### PR TITLE
Initialize the SDK with the correct base URL

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,7 @@ linters:
   - dogsled
   - durationcheck
   - exhaustive
-  - exportloopref
+  - copyloopvar
   - gci
   - goconst
   - gofmt

--- a/internal/cmd/helper.go
+++ b/internal/cmd/helper.go
@@ -34,7 +34,7 @@ type Helper interface {
 	GetLogger() (*slog.Logger, error)
 	GetBuildInfo() (*build.Info, error)
 	GetContext() context.Context
-	GetKonnectSDKFactory() helpers.SDKFactory
+	GetKonnectSDKFactory() helpers.SDKAPIFactory
 }
 
 type CommandHelper struct {
@@ -117,8 +117,8 @@ func (r *CommandHelper) GetContext() context.Context {
 	return r.Cmd.Context()
 }
 
-func (r *CommandHelper) GetKonnectSDKFactory() helpers.SDKFactory {
-	return r.Cmd.Context().Value(helpers.SDKFactoryKey).(helpers.SDKFactory)
+func (r *CommandHelper) GetKonnectSDKFactory() helpers.SDKAPIFactory {
+	return r.Cmd.Context().Value(helpers.SDKAPIFactoryKey).(helpers.SDKAPIFactory)
 }
 
 func BuildHelper(cmd *cobra.Command, args []string) Helper {

--- a/internal/cmd/helper.go
+++ b/internal/cmd/helper.go
@@ -34,7 +34,7 @@ type Helper interface {
 	GetLogger() (*slog.Logger, error)
 	GetBuildInfo() (*build.Info, error)
 	GetContext() context.Context
-	GetKonnectSDKFactory() helpers.SDKAPIFactory
+	GetKonnectSDK(cfg config.Hook, logger *slog.Logger) (helpers.SDKAPI, error)
 }
 
 type CommandHelper struct {
@@ -117,8 +117,8 @@ func (r *CommandHelper) GetContext() context.Context {
 	return r.Cmd.Context()
 }
 
-func (r *CommandHelper) GetKonnectSDKFactory() helpers.SDKAPIFactory {
-	return r.Cmd.Context().Value(helpers.SDKAPIFactoryKey).(helpers.SDKAPIFactory)
+func (r *CommandHelper) GetKonnectSDK(cfg config.Hook, logger *slog.Logger) (helpers.SDKAPI, error) {
+	return r.Cmd.Context().Value(helpers.SDKAPIFactoryKey).(helpers.SDKAPIFactory)(cfg, logger)
 }
 
 func BuildHelper(cmd *cobra.Command, args []string) Helper {

--- a/internal/cmd/helper_mock.go
+++ b/internal/cmd/helper_mock.go
@@ -294,19 +294,19 @@ func (_c *MockHelper_GetContext_Call) RunAndReturn(run func() context.Context) *
 }
 
 // GetKonnectSDKFactory provides a mock function with given fields:
-func (_m *MockHelper) GetKonnectSDKFactory() helpers.SDKFactory {
+func (_m *MockHelper) GetKonnectSDKFactory() helpers.SDKAPIFactory {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetKonnectSDKFactory")
 	}
 
-	var r0 helpers.SDKFactory
-	if rf, ok := ret.Get(0).(func() helpers.SDKFactory); ok {
+	var r0 helpers.SDKAPIFactory
+	if rf, ok := ret.Get(0).(func() helpers.SDKAPIFactory); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(helpers.SDKFactory)
+			r0 = ret.Get(0).(helpers.SDKAPIFactory)
 		}
 	}
 
@@ -330,12 +330,12 @@ func (_c *MockHelper_GetKonnectSDKFactory_Call) Run(run func()) *MockHelper_GetK
 	return _c
 }
 
-func (_c *MockHelper_GetKonnectSDKFactory_Call) Return(_a0 helpers.SDKFactory) *MockHelper_GetKonnectSDKFactory_Call {
+func (_c *MockHelper_GetKonnectSDKFactory_Call) Return(_a0 helpers.SDKAPIFactory) *MockHelper_GetKonnectSDKFactory_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockHelper_GetKonnectSDKFactory_Call) RunAndReturn(run func() helpers.SDKFactory) *MockHelper_GetKonnectSDKFactory_Call {
+func (_c *MockHelper_GetKonnectSDKFactory_Call) RunAndReturn(run func() helpers.SDKAPIFactory) *MockHelper_GetKonnectSDKFactory_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/cmd/helper_mock.go
+++ b/internal/cmd/helper_mock.go
@@ -293,49 +293,61 @@ func (_c *MockHelper_GetContext_Call) RunAndReturn(run func() context.Context) *
 	return _c
 }
 
-// GetKonnectSDKFactory provides a mock function with given fields:
-func (_m *MockHelper) GetKonnectSDKFactory() helpers.SDKAPIFactory {
-	ret := _m.Called()
+// GetKonnectSDK provides a mock function with given fields: cfg, logger
+func (_m *MockHelper) GetKonnectSDK(cfg config.Hook, logger *slog.Logger) (helpers.SDKAPI, error) {
+	ret := _m.Called(cfg, logger)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetKonnectSDKFactory")
+		panic("no return value specified for GetKonnectSDK")
 	}
 
-	var r0 helpers.SDKAPIFactory
-	if rf, ok := ret.Get(0).(func() helpers.SDKAPIFactory); ok {
-		r0 = rf()
+	var r0 helpers.SDKAPI
+	var r1 error
+	if rf, ok := ret.Get(0).(func(config.Hook, *slog.Logger) (helpers.SDKAPI, error)); ok {
+		return rf(cfg, logger)
+	}
+	if rf, ok := ret.Get(0).(func(config.Hook, *slog.Logger) helpers.SDKAPI); ok {
+		r0 = rf(cfg, logger)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(helpers.SDKAPIFactory)
+			r0 = ret.Get(0).(helpers.SDKAPI)
 		}
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(config.Hook, *slog.Logger) error); ok {
+		r1 = rf(cfg, logger)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
-// MockHelper_GetKonnectSDKFactory_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetKonnectSDKFactory'
-type MockHelper_GetKonnectSDKFactory_Call struct {
+// MockHelper_GetKonnectSDK_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetKonnectSDK'
+type MockHelper_GetKonnectSDK_Call struct {
 	*mock.Call
 }
 
-// GetKonnectSDKFactory is a helper method to define mock.On call
-func (_e *MockHelper_Expecter) GetKonnectSDKFactory() *MockHelper_GetKonnectSDKFactory_Call {
-	return &MockHelper_GetKonnectSDKFactory_Call{Call: _e.mock.On("GetKonnectSDKFactory")}
+// GetKonnectSDK is a helper method to define mock.On call
+//   - cfg config.Hook
+//   - logger *slog.Logger
+func (_e *MockHelper_Expecter) GetKonnectSDK(cfg interface{}, logger interface{}) *MockHelper_GetKonnectSDK_Call {
+	return &MockHelper_GetKonnectSDK_Call{Call: _e.mock.On("GetKonnectSDK", cfg, logger)}
 }
 
-func (_c *MockHelper_GetKonnectSDKFactory_Call) Run(run func()) *MockHelper_GetKonnectSDKFactory_Call {
+func (_c *MockHelper_GetKonnectSDK_Call) Run(run func(cfg config.Hook, logger *slog.Logger)) *MockHelper_GetKonnectSDK_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(config.Hook), args[1].(*slog.Logger))
 	})
 	return _c
 }
 
-func (_c *MockHelper_GetKonnectSDKFactory_Call) Return(_a0 helpers.SDKAPIFactory) *MockHelper_GetKonnectSDKFactory_Call {
-	_c.Call.Return(_a0)
+func (_c *MockHelper_GetKonnectSDK_Call) Return(_a0 helpers.SDKAPI, _a1 error) *MockHelper_GetKonnectSDK_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockHelper_GetKonnectSDKFactory_Call) RunAndReturn(run func() helpers.SDKAPIFactory) *MockHelper_GetKonnectSDKFactory_Call {
+func (_c *MockHelper_GetKonnectSDK_Call) RunAndReturn(run func(config.Hook, *slog.Logger) (helpers.SDKAPI, error)) *MockHelper_GetKonnectSDK_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/cmd/root/products/konnect/gateway/consumer/consumer.go
+++ b/internal/cmd/root/products/konnect/gateway/consumer/consumer.go
@@ -26,7 +26,10 @@ var (
 	`, meta.CLIName)))
 )
 
-func NewConsumerCmd(verb verbs.VerbValue) (*cobra.Command, error) {
+func NewConsumerCmd(verb verbs.VerbValue,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) (*cobra.Command, error) {
 	baseCmd := cobra.Command{
 		Use:     routeUse,
 		Short:   routeShort,
@@ -38,10 +41,15 @@ func NewConsumerCmd(verb verbs.VerbValue) (*cobra.Command, error) {
 		},
 	}
 
-	common.AddControlPlaneFlags(&baseCmd)
+	addFlagsFunc := func(verb verbs.VerbValue, cmd *cobra.Command) {
+		common.AddControlPlaneFlags(cmd)
+		if addParentFlags != nil {
+			addParentFlags(verb, cmd)
+		}
+	}
 
 	if verb == verbs.Get || verb == verbs.List {
-		return newGetConsumerCmd(&baseCmd).Command, nil
+		return newGetConsumerCmd(verb, &baseCmd, addFlagsFunc, parentPreRun).Command, nil
 	}
 
 	return &baseCmd, nil

--- a/internal/cmd/root/products/konnect/gateway/consumer/getConsumer.go
+++ b/internal/cmd/root/products/konnect/gateway/consumer/getConsumer.go
@@ -133,7 +133,7 @@ func (c *getConsumerCmd) runE(cobraCmd *cobra.Command, args []string) error {
 			meta.CLIName)
 	}
 
-	kkClient, err := auth.GetAuthenticatedClient(token)
+	kkClient, err := auth.GetAuthenticatedClient(cfg, token)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/root/products/konnect/gateway/controlplane/controlplane.go
+++ b/internal/cmd/root/products/konnect/gateway/controlplane/controlplane.go
@@ -32,7 +32,10 @@ var (
 	`, meta.CLIName)))
 )
 
-func NewControlPlaneCmd(verb verbs.VerbValue) (*cobra.Command, error) {
+func NewControlPlaneCmd(verb verbs.VerbValue,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) (*cobra.Command, error) {
 	baseCmd := cobra.Command{
 		Use:     controlPlanesUse,
 		Short:   controlPlanesShort,
@@ -42,11 +45,11 @@ func NewControlPlaneCmd(verb verbs.VerbValue) (*cobra.Command, error) {
 	}
 
 	if verb == verbs.Get || verb == verbs.List {
-		return newGetControlPlaneCmd(&baseCmd).Command, nil
+		return newGetControlPlaneCmd(verb, &baseCmd, addParentFlags, parentPreRun).Command, nil
 	} else if verb == verbs.Create {
-		return newCreateControlPlaneCmd(&baseCmd).Command, nil
+		return newCreateControlPlaneCmd(verb, &baseCmd, addParentFlags, parentPreRun).Command, nil
 	} else if verb == verbs.Delete {
-		return newDeleteControlPlaneCmd(&baseCmd).Command, nil
+		return newDeleteControlPlaneCmd(verb, &baseCmd, addParentFlags, parentPreRun).Command, nil
 	}
 
 	return &baseCmd, nil

--- a/internal/cmd/root/products/konnect/gateway/controlplane/createControlPlane.go
+++ b/internal/cmd/root/products/konnect/gateway/controlplane/createControlPlane.go
@@ -192,7 +192,7 @@ func (c *createControlPlaneCmd) run(helper cmd.Helper) error {
 		return e
 	}
 
-	sdk, e := helper.GetKonnectSDKFactory()(token)
+	sdk, e := helper.GetKonnectSDKFactory()(cfg, token)
 	if e != nil {
 		return e
 	}

--- a/internal/cmd/root/products/konnect/gateway/controlplane/createControlPlane.go
+++ b/internal/cmd/root/products/konnect/gateway/controlplane/createControlPlane.go
@@ -10,7 +10,6 @@ import (
 	kk "github.com/Kong/sdk-konnect-go" // kk = Kong Konnect
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/kong/kongctl/internal/cmd"
-	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
 	"github.com/kong/kongctl/internal/meta"
 	"github.com/kong/kongctl/internal/util/i18n"
 	"github.com/kong/kongctl/internal/util/normalizers"
@@ -187,12 +186,7 @@ func (c *createControlPlaneCmd) run(helper cmd.Helper) error {
 		Labels:       labels,
 	}
 
-	token, e := common.GetAccessToken(cfg, logger)
-	if e != nil {
-		return e
-	}
-
-	sdk, e := helper.GetKonnectSDKFactory()(cfg, token)
+	sdk, e := helper.GetKonnectSDKFactory()(cfg, logger)
 	if e != nil {
 		return e
 	}

--- a/internal/cmd/root/products/konnect/gateway/controlplane/deleteControlPlane.go
+++ b/internal/cmd/root/products/konnect/gateway/controlplane/deleteControlPlane.go
@@ -37,7 +37,7 @@ func (c *deleteControlPlaneCmd) run(helper cmd.Helper) error {
 		return e
 	}
 
-	sdk, err := helper.GetKonnectSDKFactory()(token)
+	sdk, err := helper.GetKonnectSDKFactory()(cfg, token)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/root/products/konnect/gateway/controlplane/deleteControlPlane.go
+++ b/internal/cmd/root/products/konnect/gateway/controlplane/deleteControlPlane.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/kong/kongctl/internal/cmd"
-	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
 	"github.com/segmentio/cli"
 	"github.com/spf13/cobra"
 )
@@ -32,12 +31,7 @@ func (c *deleteControlPlaneCmd) run(helper cmd.Helper) error {
 		return e
 	}
 
-	token, e := common.GetAccessToken(cfg, logger)
-	if e != nil {
-		return e
-	}
-
-	sdk, err := helper.GetKonnectSDKFactory()(cfg, token)
+	sdk, err := helper.GetKonnectSDKFactory()(cfg, logger)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/root/products/konnect/gateway/controlplane/getControlPlane.go
+++ b/internal/cmd/root/products/konnect/gateway/controlplane/getControlPlane.go
@@ -249,7 +249,7 @@ func (c *getControlPlaneCmd) runE(cobraCmd *cobra.Command, args []string) error 
 			meta.CLIName)
 	}
 
-	sdk, e := helper.GetKonnectSDKFactory()(token)
+	sdk, e := helper.GetKonnectSDKFactory()(cfg, token)
 	if e != nil {
 		return e
 	}

--- a/internal/cmd/root/products/konnect/gateway/controlplane/getControlPlane.go
+++ b/internal/cmd/root/products/konnect/gateway/controlplane/getControlPlane.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kong/kongctl/internal/cmd"
 	cmdCommon "github.com/kong/kongctl/internal/cmd/common"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
+	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	"github.com/kong/kongctl/internal/config"
 	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/meta"
@@ -242,7 +243,7 @@ func (c *getControlPlaneCmd) runE(cobraCmd *cobra.Command, args []string) error 
 		return e
 	}
 
-	sdk, e := helper.GetKonnectSDKFactory()(cfg, logger)
+	sdk, e := helper.GetKonnectSDK(cfg, logger)
 	if e != nil {
 		return e
 	}
@@ -291,15 +292,26 @@ func (c *getControlPlaneCmd) runE(cobraCmd *cobra.Command, args []string) error 
 	return e
 }
 
-func newGetControlPlaneCmd(baseCmd *cobra.Command) *getControlPlaneCmd {
+func newGetControlPlaneCmd(verb verbs.VerbValue,
+	baseCmd *cobra.Command,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) *getControlPlaneCmd {
 	rv := getControlPlaneCmd{
 		Command: baseCmd,
 	}
 
-	baseCmd.Short = getControlPlanesShort
-	baseCmd.Long = getControlPlanesLong
-	baseCmd.Example = getControlPlanesExample
-	baseCmd.RunE = rv.runE
+	rv.Short = getControlPlanesShort
+	rv.Long = getControlPlanesLong
+	rv.Example = getControlPlanesExample
+	if parentPreRun != nil {
+		rv.PreRunE = parentPreRun
+	}
+	rv.RunE = rv.runE
+
+	if addParentFlags != nil {
+		addParentFlags(verb, rv.Command)
+	}
 
 	return &rv
 }

--- a/internal/cmd/root/products/konnect/gateway/controlplane/getControlPlane.go
+++ b/internal/cmd/root/products/konnect/gateway/controlplane/getControlPlane.go
@@ -242,14 +242,7 @@ func (c *getControlPlaneCmd) runE(cobraCmd *cobra.Command, args []string) error 
 		return e
 	}
 
-	token, e := common.GetAccessToken(cfg, logger)
-	if e != nil {
-		return fmt.Errorf(
-			`no access token available. Use "%s login konnect" to authenticate or provide a Konnect PAT using the --pat flag`,
-			meta.CLIName)
-	}
-
-	sdk, e := helper.GetKonnectSDKFactory()(cfg, token)
+	sdk, e := helper.GetKonnectSDKFactory()(cfg, logger)
 	if e != nil {
 		return e
 	}

--- a/internal/cmd/root/products/konnect/gateway/controlplane/getControlPlane_test.go
+++ b/internal/cmd/root/products/konnect/gateway/controlplane/getControlPlane_test.go
@@ -219,8 +219,8 @@ func TestGetControlPlaneCmd(t *testing.T) {
 		{
 			Name: "get-by-id",
 			Cmd: func() *cobra.Command {
-				baseCmd, _ := NewControlPlaneCmd(verbs.Get)
-				newGetControlPlaneCmd(baseCmd)
+				baseCmd, _ := NewControlPlaneCmd(verbs.Get, nil, nil)
+				newGetControlPlaneCmd(verbs.Get, baseCmd, nil, nil)
 				return baseCmd
 			}(),
 			Setup: func() (context.Context, *helpers.MockControlPlaneAPI) {

--- a/internal/cmd/root/products/konnect/gateway/controlplane/getControlPlane_test.go
+++ b/internal/cmd/root/products/konnect/gateway/controlplane/getControlPlane_test.go
@@ -265,9 +265,11 @@ func TestGetControlPlaneCmd(t *testing.T) {
 					},
 				}
 
-				ctx = context.WithValue(ctx, helpers.SDKFactoryKey, helpers.SDKFactory(func(config.Hook, string) (helpers.SDKAPI, error) {
-					return &mockSDK, nil
-				}))
+				ctx = context.WithValue(ctx,
+					helpers.SDKAPIFactoryKey,
+					helpers.SDKAPIFactory(func(config.Hook, *slog.Logger) (helpers.SDKAPI, error) {
+						return &mockSDK, nil
+					}))
 
 				return ctx, mockCPAPI
 			},

--- a/internal/cmd/root/products/konnect/gateway/controlplane/getControlPlane_test.go
+++ b/internal/cmd/root/products/konnect/gateway/controlplane/getControlPlane_test.go
@@ -265,7 +265,7 @@ func TestGetControlPlaneCmd(t *testing.T) {
 					},
 				}
 
-				ctx = context.WithValue(ctx, helpers.SDKFactoryKey, helpers.SDKFactory(func(string) (helpers.SDKAPI, error) {
+				ctx = context.WithValue(ctx, helpers.SDKFactoryKey, helpers.SDKFactory(func(config.Hook, string) (helpers.SDKAPI, error) {
 					return &mockSDK, nil
 				}))
 

--- a/internal/cmd/root/products/konnect/gateway/gateway.go
+++ b/internal/cmd/root/products/konnect/gateway/gateway.go
@@ -18,7 +18,10 @@ var (
 		`The gateway command allows you to manage Konnect Kong Gateway resources.`))
 )
 
-func NewGatewayCmd(verb verbs.VerbValue) (*cobra.Command, error) {
+func NewGatewayCmd(verb verbs.VerbValue,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:     gatewayUse,
 		Short:   gatewayShort,
@@ -26,25 +29,25 @@ func NewGatewayCmd(verb verbs.VerbValue) (*cobra.Command, error) {
 		Aliases: []string{"gw", "GW"},
 	}
 
-	c, e := controlplane.NewControlPlaneCmd(verb)
+	c, e := controlplane.NewControlPlaneCmd(verb, addParentFlags, parentPreRun)
 	if e != nil {
 		return nil, e
 	}
 	cmd.AddCommand(c)
 
-	c, e = service.NewServiceCmd(verb)
+	c, e = service.NewServiceCmd(verb, addParentFlags, parentPreRun)
 	if e != nil {
 		return nil, e
 	}
 	cmd.AddCommand(c)
 
-	c, e = route.NewRouteCmd(verb)
+	c, e = route.NewRouteCmd(verb, addParentFlags, parentPreRun)
 	if e != nil {
 		return nil, e
 	}
 	cmd.AddCommand(c)
 
-	c, e = consumer.NewConsumerCmd(verb)
+	c, e = consumer.NewConsumerCmd(verb, addParentFlags, parentPreRun)
 	if e != nil {
 		return nil, e
 	}

--- a/internal/cmd/root/products/konnect/gateway/route/getRoute.go
+++ b/internal/cmd/root/products/konnect/gateway/route/getRoute.go
@@ -13,7 +13,6 @@ import (
 	kkCommon "github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/gateway/common"
 	"github.com/kong/kongctl/internal/config"
-	"github.com/kong/kongctl/internal/konnect/auth"
 	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/meta"
 	"github.com/kong/kongctl/internal/util/i18n"
@@ -230,14 +229,8 @@ func (c *getRouteCmd) runE(cobraCmd *cobra.Command, args []string) error {
 
 	defer printer.Flush()
 
-	token, e := kkCommon.GetAccessToken(cfg, logger)
-	if e != nil {
-		return fmt.Errorf(
-			`no access token available. Use "%s login konnect" to authenticate or provide a Konnect PAT using the --pat flag`,
-			meta.CLIName)
-	}
-
-	kkClient, err := auth.GetAuthenticatedClient(cfg, token)
+	kkFactory := helper.GetKonnectSDKFactory()
+	kkClient, err := kkFactory(cfg, logger)
 	if err != nil {
 		return err
 	}
@@ -251,12 +244,15 @@ func (c *getRouteCmd) runE(cobraCmd *cobra.Command, args []string) error {
 			}
 		}
 		var err error
-		cpID, err = helpers.GetControlPlaneID(helper.GetContext(), kkClient, cpName)
+		cpID, err = helpers.GetControlPlaneID(helper.GetContext(), kkClient.GetControlPlaneAPI(), cpName)
 		if err != nil {
 			attrs := cmd.TryConvertErrorToAttrs(err)
 			return cmd.PrepareExecutionError("Failed to get Control Plane ID", err, helper.GetCmd(), attrs...)
 		}
 	}
+
+	// TODO!: Fix up the below casting to Konnect SDKs, as it will fail in testing once that is written.
+	//         A service API needs to be added to our internal SDK API interfaces
 
 	// 'get konnect gateway routes ' can be run like various ways:
 	//	> get konnect gateway routes <id>    # Get by UUID
@@ -271,13 +267,13 @@ func (c *getRouteCmd) runE(cobraCmd *cobra.Command, args []string) error {
 		if !isUUID {
 			// If the ID is not a UUID, then it is a name
 			// search for the control plane by name
-			return c.runListByName(cpID, id, kkClient, helper, cfg, printer, outType)
+			return c.runListByName(cpID, id, kkClient.(*helpers.KonnectSDK).SDK, helper, cfg, printer, outType)
 		}
 
-		return c.runGet(cpID, id, kkClient, helper, printer, outType)
+		return c.runGet(cpID, id, kkClient.(*helpers.KonnectSDK).SDK, helper, printer, outType)
 	}
 
-	return c.runList(cpID, kkClient, helper, cfg, printer, outType)
+	return c.runList(cpID, kkClient.(*helpers.KonnectSDK).SDK, helper, cfg, printer, outType)
 }
 
 func newGetRouteCmd(baseCmd *cobra.Command) *getRouteCmd {

--- a/internal/cmd/root/products/konnect/gateway/route/getRoute.go
+++ b/internal/cmd/root/products/konnect/gateway/route/getRoute.go
@@ -237,7 +237,7 @@ func (c *getRouteCmd) runE(cobraCmd *cobra.Command, args []string) error {
 			meta.CLIName)
 	}
 
-	kkClient, err := auth.GetAuthenticatedClient(token)
+	kkClient, err := auth.GetAuthenticatedClient(cfg, token)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/root/products/konnect/gateway/route/route.go
+++ b/internal/cmd/root/products/konnect/gateway/route/route.go
@@ -26,7 +26,10 @@ var (
 	`, meta.CLIName)))
 )
 
-func NewRouteCmd(verb verbs.VerbValue) (*cobra.Command, error) {
+func NewRouteCmd(verb verbs.VerbValue,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) (*cobra.Command, error) {
 	baseCmd := cobra.Command{
 		Use:     routeUse,
 		Short:   routeShort,
@@ -38,10 +41,15 @@ func NewRouteCmd(verb verbs.VerbValue) (*cobra.Command, error) {
 		},
 	}
 
-	common.AddControlPlaneFlags(&baseCmd)
+	addFlagsFunc := func(verb verbs.VerbValue, cmd *cobra.Command) {
+		common.AddControlPlaneFlags(cmd)
+		if addParentFlags != nil {
+			addParentFlags(verb, cmd)
+		}
+	}
 
 	if verb == verbs.Get || verb == verbs.List {
-		return newGetRouteCmd(&baseCmd).Command, nil
+		return newGetRouteCmd(verb, &baseCmd, addFlagsFunc, parentPreRun).Command, nil
 	}
 
 	return &baseCmd, nil

--- a/internal/cmd/root/products/konnect/gateway/service/getService.go
+++ b/internal/cmd/root/products/konnect/gateway/service/getService.go
@@ -234,7 +234,7 @@ func (c *getServiceCmd) runE(cobraCmd *cobra.Command, args []string) error {
 			meta.CLIName)
 	}
 
-	kkClient, err := auth.GetAuthenticatedClient(token)
+	kkClient, err := auth.GetAuthenticatedClient(cfg, token)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/root/products/konnect/gateway/service/getService.go
+++ b/internal/cmd/root/products/konnect/gateway/service/getService.go
@@ -13,7 +13,6 @@ import (
 	kkCommon "github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/gateway/common"
 	"github.com/kong/kongctl/internal/config"
-	"github.com/kong/kongctl/internal/konnect/auth"
 	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/meta"
 	"github.com/kong/kongctl/internal/util/i18n"
@@ -227,14 +226,8 @@ func (c *getServiceCmd) runE(cobraCmd *cobra.Command, args []string) error {
 
 	defer printer.Flush()
 
-	token, e := kkCommon.GetAccessToken(cfg, logger)
-	if e != nil {
-		return fmt.Errorf(
-			`no access token available. Use "%s login konnect" to authenticate or provide a Konnect PAT using the --pat flag`,
-			meta.CLIName)
-	}
-
-	kkClient, err := auth.GetAuthenticatedClient(cfg, token)
+	kkFactory := helper.GetKonnectSDKFactory()
+	kkClient, err := kkFactory(cfg, logger)
 	if err != nil {
 		return err
 	}
@@ -248,12 +241,15 @@ func (c *getServiceCmd) runE(cobraCmd *cobra.Command, args []string) error {
 			}
 		}
 		var err error
-		cpID, err = helpers.GetControlPlaneID(helper.GetContext(), kkClient, cpName)
+		cpID, err = helpers.GetControlPlaneID(helper.GetContext(), kkClient.GetControlPlaneAPI(), cpName)
 		if err != nil {
 			attrs := cmd.TryConvertErrorToAttrs(err)
 			return cmd.PrepareExecutionError("Failed to get Control Plane ID", err, helper.GetCmd(), attrs...)
 		}
 	}
+
+	// TODO!: Fix up the below casting to Konnect SDKs, as it will fail in testing once that is written.
+	//         A service API needs to be added to our internal SDK API interfaces
 
 	// 'get konnect gateway services' can be run like various ways:
 	//	> get konnect gateway services <id>    # Get by UUID
@@ -268,13 +264,13 @@ func (c *getServiceCmd) runE(cobraCmd *cobra.Command, args []string) error {
 		if !isUUID {
 			// If the ID is not a UUID, then it is a name
 			// search for the control plane by name
-			return c.runListByName(cpID, id, kkClient, helper, cfg, printer, outType)
+			return c.runListByName(cpID, id, kkClient.(*helpers.KonnectSDK).SDK, helper, cfg, printer, outType)
 		}
 
-		return c.runGet(cpID, id, kkClient, helper, printer, outType)
+		return c.runGet(cpID, id, kkClient.(*helpers.KonnectSDK).SDK, helper, printer, outType)
 	}
 
-	return c.runList(cpID, kkClient, helper, cfg, printer, outType)
+	return c.runList(cpID, kkClient.(*helpers.KonnectSDK).SDK, helper, cfg, printer, outType)
 }
 
 func newGetServiceCmd(baseCmd *cobra.Command) *getServiceCmd {

--- a/internal/cmd/root/products/konnect/gateway/service/service.go
+++ b/internal/cmd/root/products/konnect/gateway/service/service.go
@@ -26,7 +26,10 @@ var (
 	`, meta.CLIName)))
 )
 
-func NewServiceCmd(verb verbs.VerbValue) (*cobra.Command, error) {
+func NewServiceCmd(verb verbs.VerbValue,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) (*cobra.Command, error) {
 	baseCmd := cobra.Command{
 		Use:     serviceUse,
 		Short:   serviceShort,
@@ -38,10 +41,15 @@ func NewServiceCmd(verb verbs.VerbValue) (*cobra.Command, error) {
 		Aliases: []string{"services", "svc", "svcs"},
 	}
 
-	common.AddControlPlaneFlags(&baseCmd)
+	addFlagsFunc := func(verb verbs.VerbValue, cmd *cobra.Command) {
+		common.AddControlPlaneFlags(cmd)
+		if addParentFlags != nil {
+			addParentFlags(verb, cmd)
+		}
+	}
 
 	if verb == verbs.Get || verb == verbs.List {
-		return newGetServiceCmd(&baseCmd).Command, nil
+		return newGetServiceCmd(verb, &baseCmd, addFlagsFunc, parentPreRun).Command, nil
 	}
 
 	return &baseCmd, nil

--- a/internal/cmd/root/products/konnect/konnect.go
+++ b/internal/cmd/root/products/konnect/konnect.go
@@ -30,50 +30,53 @@ var (
 		 %[1]s get konnect gateway control-planes`, meta.CLIName)))
 )
 
+func addFlags(verb verbs.VerbValue, cmd *cobra.Command) {
+	cmd.Flags().String(common.BaseURLFlagName, common.BaseURLDefault,
+		fmt.Sprintf(`Base URL for Konnect API requests.
+- Config path: [ %s ]`,
+			common.BaseURLConfigPath))
+
+	if verb != verbs.Login {
+		cmd.Flags().String(common.PATFlagName, "",
+			fmt.Sprintf(`Konnect Personal Access Token (PAT) used to authenticate the CLI. 
+Setting this value overrides tokens obtained from the login command.
+- Config path: [ %s ]`,
+				common.PATConfigPath))
+	}
+
+	if verb == verbs.Get || verb == verbs.List {
+		cmd.Flags().Int(
+			common.RequestPageSizeFlagName,
+			common.DefaultRequestPageSize,
+			fmt.Sprintf(`Max number of results to include per response page for get and list operations.
+- Config path: [ %s ]`,
+				common.RequestPageSizeConfigPath))
+	}
+}
+
 func bindFlags(c *cobra.Command, args []string) error {
 	helper := cmd.BuildHelper(c, args)
 	cfg, err := helper.GetConfig()
 	if err != nil {
 		return err
 	}
-	f := c.Flags().Lookup(common.PATFlagName)
-	err = cfg.BindFlag(common.PATConfigPath, f)
-	if err != nil {
-		return err
-	}
 
-	f = c.Flags().Lookup(common.BaseURLFlagName)
+	f := c.Flags().Lookup(common.BaseURLFlagName)
 	err = cfg.BindFlag(common.BaseURLConfigPath, f)
 	if err != nil {
 		return err
 	}
 
-	f = c.Flags().Lookup(common.AuthPathFlagName)
-	err = cfg.BindFlag(common.AuthPathConfigPath, f)
-	if err != nil {
-		return err
-	}
-
-	f = c.Flags().Lookup(common.RefreshPathFlagName)
-	err = cfg.BindFlag(common.RefreshPathConfigPath, f)
-	if err != nil {
-		return err
-	}
-
-	f = c.Flags().Lookup(common.TokenPathFlagName)
-	err = cfg.BindFlag(common.TokenURLPathConfigPath, f)
-	if err != nil {
-		return err
-	}
-
-	f = c.Flags().Lookup(common.MachineClientIDFlagName)
-	err = cfg.BindFlag(common.MachineClientIDConfigPath, f)
-	if err != nil {
-		return err
+	f = c.Flags().Lookup(common.PATFlagName)
+	if f != nil { // might not be present depending on verb
+		err = cfg.BindFlag(common.PATConfigPath, f)
+		if err != nil {
+			return err
+		}
 	}
 
 	f = c.Flags().Lookup(common.RequestPageSizeFlagName)
-	if f != nil {
+	if f != nil { // might not be present depending on verb
 		err = cfg.BindFlag(common.RequestPageSizeConfigPath, f)
 		if err != nil {
 			return err
@@ -81,6 +84,14 @@ func bindFlags(c *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func preRunE(c *cobra.Command, args []string) error {
+	c.SetContext(context.WithValue(c.Context(),
+		products.Product, Product))
+	c.SetContext(context.WithValue(c.Context(),
+		helpers.SDKAPIFactoryKey, helpers.SDKAPIFactory(common.KonnectSDKFactory)))
+	return bindFlags(c, args)
 }
 
 func NewKonnectCmd(verb verbs.VerbValue) (*cobra.Command, error) {
@@ -99,76 +110,11 @@ func NewKonnectCmd(verb verbs.VerbValue) (*cobra.Command, error) {
 		},
 	}
 
-	cmd.PersistentFlags().String(common.PATFlagName, "",
-		fmt.Sprintf(`Konnect Personal Access Token (PAT) used to authenticate the CLI. 
-Setting this value overrides tokens obtained from the login command.
-- Config path: [ %s ]`,
-			common.PATConfigPath))
-
-	cmd.PersistentFlags().String(common.BaseURLFlagName, common.BaseURLDefault,
-		fmt.Sprintf(`Base URL used to initiate Konnect Authorization.
-- Config path: [ %s ]
--`, // (default ...)
-			common.BaseURLConfigPath))
-	e := cmd.PersistentFlags().MarkHidden(common.BaseURLFlagName)
-	if e != nil {
-		return nil, e
-	}
-
-	cmd.PersistentFlags().String(common.AuthPathFlagName, common.AuthPathDefault,
-		fmt.Sprintf(`URL path used to initiate Konnect Authorization.
-- Config path: [ %s ]
--`, // (default ...)
-			common.AuthPathConfigPath))
-	e = cmd.PersistentFlags().MarkHidden(common.AuthPathFlagName)
-	if e != nil {
-		return nil, e
-	}
-
-	cmd.PersistentFlags().String(common.RefreshPathFlagName, common.RefreshPathDefault,
-		fmt.Sprintf(`URL path used to refresh the Konnect auth token.
-- Config path: [ %s ]
--`, // (default ...)
-			common.RefreshPathConfigPath))
-	e = cmd.PersistentFlags().MarkHidden(common.RefreshPathFlagName)
-	if e != nil {
-		return nil, e
-	}
-
-	cmd.PersistentFlags().String(common.MachineClientIDFlagName, common.MachineClientIDDefault,
-		fmt.Sprintf(`Machine Client ID used to identify the application for Konnect Authorization.
-- Config path: [ %s ]
--`, // (default ...)
-			common.MachineClientIDConfigPath))
-	e = cmd.PersistentFlags().MarkHidden(common.MachineClientIDFlagName)
-	if e != nil {
-		return nil, e
-	}
-
-	cmd.PersistentFlags().String(common.TokenPathFlagName, common.TokenPathDefault,
-		fmt.Sprintf(`URL path used to poll for the Konnect Authorization response token.
-- Config path: [ %s ]
--`, // (default ...)
-			common.TokenURLPathConfigPath))
-	e = cmd.PersistentFlags().MarkHidden(common.TokenPathFlagName)
-	if e != nil {
-		return nil, e
-	}
-
-	if verb == verbs.Get || verb == verbs.List {
-		cmd.PersistentFlags().Int(
-			common.RequestPageSizeFlagName,
-			common.DefaultRequestPageSize,
-			fmt.Sprintf(
-				"Max number of results to include per response page for get and list operations.\n (config path = '%s')",
-				common.RequestPageSizeConfigPath))
-	}
-
 	if verb == verbs.Login {
-		return newLoginKonnectCmd(cmd).Command, nil
+		return newLoginKonnectCmd(verb, cmd, addFlags, preRunE).Command, nil
 	}
 
-	c, e := gateway.NewGatewayCmd(verb)
+	c, e := gateway.NewGatewayCmd(verb, addFlags, preRunE)
 	if e != nil {
 		return nil, e
 	}

--- a/internal/cmd/root/products/konnect/konnect.go
+++ b/internal/cmd/root/products/konnect/konnect.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/gateway"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/meta"
 	"github.com/kong/kongctl/internal/util/i18n"
 	"github.com/kong/kongctl/internal/util/normalizers"
@@ -90,7 +91,10 @@ func NewKonnectCmd(verb verbs.VerbValue) (*cobra.Command, error) {
 		Example: konnectExamples,
 		Aliases: []string{"k", "K"},
 		PersistentPreRunE: func(c *cobra.Command, args []string) error {
-			c.SetContext(context.WithValue(c.Context(), products.Product, Product))
+			c.SetContext(context.WithValue(c.Context(),
+				products.Product, Product))
+			c.SetContext(context.WithValue(c.Context(),
+				helpers.SDKAPIFactoryKey, helpers.SDKAPIFactory(common.KonnectSDKFactory)))
 			return bindFlags(c, args)
 		},
 	}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -19,7 +19,6 @@ import (
 	"github.com/kong/kongctl/internal/cmd/root/version"
 	"github.com/kong/kongctl/internal/config"
 	"github.com/kong/kongctl/internal/iostreams"
-	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/log"
 	"github.com/kong/kongctl/internal/meta"
 	"github.com/kong/kongctl/internal/profile"
@@ -82,7 +81,6 @@ func newRootCmd() *cobra.Command {
 			ctx = context.WithValue(ctx, profile.ProfileManagerKey, pMgr)
 			ctx = context.WithValue(ctx, build.InfoKey, buildInfo)
 			ctx = context.WithValue(ctx, log.LoggerKey, logger)
-			ctx = context.WithValue(ctx, helpers.SDKFactoryKey, helpers.SDKFactory(helpers.KonnectSDKFactory))
 			cmd.SetContext(ctx)
 		},
 	}

--- a/internal/cmd/root/verbs/apply/apply.go
+++ b/internal/cmd/root/verbs/apply/apply.go
@@ -1,0 +1,57 @@
+package apply
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect"
+	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/kong/kongctl/internal/meta"
+	"github.com/kong/kongctl/internal/util/i18n"
+	"github.com/kong/kongctl/internal/util/normalizers"
+	"github.com/spf13/cobra"
+)
+
+const (
+	Verb = verbs.Apply
+)
+
+var (
+	applyUse = Verb.String()
+
+	applyShort = i18n.T("root.verbs.apply.applyShort", "Apply configurations")
+
+	applyLong = normalizers.LongDesc(i18n.T("root.verbs.apply.applyLong",
+		`Use apply to apply a configuration to a system.
+
+Further sub-commands are required to determine which remote system is contacted. 
+The command will apply a given configuration and report a result depending on further arguments.
+Output can be formatted in multiple ways to aid in further processing.`))
+
+	applyExamples = normalizers.Examples(i18n.T("root.verbs.apply.applyExamples",
+		fmt.Sprintf(`
+		# Apply a configuration to a Konnect Kong Gateway control plane
+		%[1]s apply konnect gateway --control-plane <cp-name> <path-to-config.yaml>
+		`, meta.CLIName)))
+)
+
+func NewApplyCmd() (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:     applyUse,
+		Short:   applyShort,
+		Long:    applyLong,
+		Example: applyExamples,
+		Aliases: []string{"a", "A"},
+		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
+			cmd.SetContext(context.WithValue(cmd.Context(), verbs.Verb, Verb))
+		},
+	}
+
+	c, e := konnect.NewKonnectCmd(Verb)
+	if e != nil {
+		return nil, e
+	}
+
+	cmd.AddCommand(c)
+	return cmd, nil
+}

--- a/internal/konnect/auth/auth.go
+++ b/internal/konnect/auth/auth.go
@@ -300,14 +300,9 @@ func saveAccessTokenToDisk(path string, token *AccessToken) error {
 	return nil
 }
 
-type AuthenticatedClientFactory func(token string) (*kk.SDK, error)
-
-func GetAuthenticatedClient(cfg config.Hook, token string) (*kk.SDK, error) {
-	// TODO: This is a temporary workaround to avoid circular dependencies
-	url := cfg.GetString("konnect.base-url")
-
+func GetAuthenticatedClient(baseURL string, token string) (*kk.SDK, error) {
 	return kk.New(
-		kk.WithServerURL(url),
+		kk.WithServerURL(baseURL),
 		kk.WithSecurity(kkComps.Security{
 			PersonalAccessToken: kk.String(token),
 		}),

--- a/internal/konnect/auth/auth.go
+++ b/internal/konnect/auth/auth.go
@@ -302,8 +302,12 @@ func saveAccessTokenToDisk(path string, token *AccessToken) error {
 
 type AuthenticatedClientFactory func(token string) (*kk.SDK, error)
 
-func GetAuthenticatedClient(token string) (*kk.SDK, error) {
+func GetAuthenticatedClient(cfg config.Hook, token string) (*kk.SDK, error) {
+	// TODO: This is a temporary workaround to avoid circular dependencies
+	url := cfg.GetString("konnect.base-url")
+
 	return kk.New(
+		kk.WithServerURL(url),
 		kk.WithSecurity(kkComps.Security{
 			PersonalAccessToken: kk.String(token),
 		}),

--- a/internal/konnect/helpers/controlplanes.go
+++ b/internal/konnect/helpers/controlplanes.go
@@ -22,7 +22,7 @@ type ControlPlaneAPI interface {
 		opts ...kkOPS.Option) (*kkOPS.DeleteControlPlaneResponse, error)
 }
 
-func GetControlPlaneID(ctx context.Context, kkClient *kkSDK.SDK, cpName string) (string, error) {
+func GetControlPlaneID(ctx context.Context, kkClient ControlPlaneAPI, cpName string) (string, error) {
 	var pageNumber, requestPageSize int64 = 1, 1
 
 	req := kkOPS.ListControlPlanesRequest{
@@ -31,7 +31,7 @@ func GetControlPlaneID(ctx context.Context, kkClient *kkSDK.SDK, cpName string) 
 		FilterNameEq: kkSDK.String(cpName),
 	}
 
-	res, err := kkClient.ControlPlanes.ListControlPlanes(ctx, req)
+	res, err := kkClient.ListControlPlanes(ctx, req)
 	if err != nil {
 		return "", err
 	}

--- a/internal/konnect/helpers/sdk.go
+++ b/internal/konnect/helpers/sdk.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	kkSDK "github.com/Kong/sdk-konnect-go" // kk = Kong Konnect
+	"github.com/kong/kongctl/internal/config"
 	"github.com/kong/kongctl/internal/konnect/auth"
 )
 
@@ -26,7 +27,7 @@ func (k *KonnectSDK) GetControlPlaneAPI() ControlPlaneAPI {
 
 // A function that can build an SDKAPI with a given
 // authorization token
-type SDKFactory func(token string) (SDKAPI, error)
+type SDKFactory func(cfg config.Hook, token string) (SDKAPI, error)
 
 type Key struct{}
 
@@ -35,8 +36,8 @@ var SDKFactoryKey = Key{}
 
 // THis is the real implementation of the SDKFactory,
 // It creates an Authenticated SDK instance from the adjacent auth package
-func KonnectSDKFactory(token string) (SDKAPI, error) {
-	sdk, err := auth.GetAuthenticatedClient(token)
+func KonnectSDKFactory(cfg config.Hook, token string) (SDKAPI, error) {
+	sdk, err := auth.GetAuthenticatedClient(cfg, token)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/konnect/helpers/sdk.go
+++ b/internal/konnect/helpers/sdk.go
@@ -1,9 +1,10 @@
 package helpers
 
 import (
+	"log/slog"
+
 	kkSDK "github.com/Kong/sdk-konnect-go" // kk = Kong Konnect
 	"github.com/kong/kongctl/internal/config"
-	"github.com/kong/kongctl/internal/konnect/auth"
 )
 
 // Provides an interface for the Konnect Go SDK
@@ -16,33 +17,19 @@ type SDKAPI interface {
 // This is the real implementation of the SDKAPI
 // which wraps the actual SDK implmentation
 type KonnectSDK struct {
-	*kkSDK.SDK
+	SDK *kkSDK.SDK
 }
 
 // Returns the real implementation of the GetControlPlaneAPI
 // from the Konnect SDK
 func (k *KonnectSDK) GetControlPlaneAPI() ControlPlaneAPI {
-	return k.ControlPlanes
+	return k.SDK.ControlPlanes
 }
 
-// A function that can build an SDKAPI with a given
-// authorization token
-type SDKFactory func(cfg config.Hook, token string) (SDKAPI, error)
+// A function that can build an SDKAPI with a given configuration
+type SDKAPIFactory func(cfg config.Hook, logger *slog.Logger) (SDKAPI, error)
 
 type Key struct{}
 
 // A Key used to store the SDKFactory in a Context
-var SDKFactoryKey = Key{}
-
-// THis is the real implementation of the SDKFactory,
-// It creates an Authenticated SDK instance from the adjacent auth package
-func KonnectSDKFactory(cfg config.Hook, token string) (SDKAPI, error) {
-	sdk, err := auth.GetAuthenticatedClient(cfg, token)
-	if err != nil {
-		return nil, err
-	}
-
-	return &KonnectSDK{
-		sdk,
-	}, nil
-}
+var SDKAPIFactoryKey = Key{}

--- a/test/cmd/helpertest.go
+++ b/test/cmd/helpertest.go
@@ -15,17 +15,17 @@ import (
 )
 
 type MockHelper struct {
-	GetCmdMock               func() *cobra.Command
-	GetArgsMock              func() []string
-	GetVerbMock              func() (verbs.VerbValue, error)
-	GetProductMock           func() (products.ProductValue, error)
-	GetStreamsMock           func() *iostreams.IOStreams
-	GetConfigMock            func() (config.Hook, error)
-	GetOutputFormatMock      func() (common.OutputFormat, error)
-	GetLoggerMock            func() (*slog.Logger, error)
-	GetBuildInfoMock         func() (*build.Info, error)
-	GetContextMock           func() context.Context
-	GetKonnectSDKFactoryMock func() helpers.SDKAPIFactory
+	GetCmdMock          func() *cobra.Command
+	GetArgsMock         func() []string
+	GetVerbMock         func() (verbs.VerbValue, error)
+	GetProductMock      func() (products.ProductValue, error)
+	GetStreamsMock      func() *iostreams.IOStreams
+	GetConfigMock       func() (config.Hook, error)
+	GetOutputFormatMock func() (common.OutputFormat, error)
+	GetLoggerMock       func() (*slog.Logger, error)
+	GetBuildInfoMock    func() (*build.Info, error)
+	GetContextMock      func() context.Context
+	GetKonnectSDKMock   func(config.Hook, *slog.Logger) (helpers.SDKAPI, error)
 }
 
 func (m *MockHelper) GetCmd() *cobra.Command {
@@ -52,8 +52,8 @@ func (m *MockHelper) GetConfig() (config.Hook, error) {
 	return m.GetConfigMock()
 }
 
-func (m *MockHelper) GetKonnectSDKFactory() helpers.SDKAPIFactory {
-	return m.GetKonnectSDKFactoryMock()
+func (m *MockHelper) GetKonnectSDK(cfg config.Hook, logger *slog.Logger) (helpers.SDKAPI, error) {
+	return m.GetKonnectSDKMock(cfg, logger)
 }
 
 func (m *MockHelper) GetOutputFormat() (common.OutputFormat, error) {

--- a/test/cmd/helpertest.go
+++ b/test/cmd/helpertest.go
@@ -25,7 +25,7 @@ type MockHelper struct {
 	GetLoggerMock            func() (*slog.Logger, error)
 	GetBuildInfoMock         func() (*build.Info, error)
 	GetContextMock           func() context.Context
-	GetKonnectSDKFactoryMock func() helpers.SDKFactory
+	GetKonnectSDKFactoryMock func() helpers.SDKAPIFactory
 }
 
 func (m *MockHelper) GetCmd() *cobra.Command {
@@ -52,7 +52,7 @@ func (m *MockHelper) GetConfig() (config.Hook, error) {
 	return m.GetConfigMock()
 }
 
-func (m *MockHelper) GetKonnectSDKFactory() helpers.SDKFactory {
+func (m *MockHelper) GetKonnectSDKFactory() helpers.SDKAPIFactory {
 	return m.GetKonnectSDKFactoryMock()
 }
 


### PR DESCRIPTION
### Summary

Read `base-url` from config when initializing the SDK

### Full changelog

* Respect the `--base-url` and `konnect.base-url` configuration options
