### PR TITLE
docs: fix command flag inaccuracies and improve documentation style

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ KONGCTL_DEFAULT_OUTPUT=yaml kongctl get apis
 
 ## Command Structure
 
-Commands generallyfollow a verb->product->resource->args pattern with `konnect` as the default product.
+Commands generally follow a verb->product->resource->args pattern with `konnect` as the default product.
 
 ```shell
 kongctl <verb> <product> <resource-type> [resource-name] [flags]

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ in the command help text with a "Config path" note that looks like this:
 ```
 
 The above help text shows a YAML key path for the `--output` flag which controls the format of output text
-from the CLI. The config path is the location in the configuration file where a flag value can be defauled. 
+from the CLI. The config path is the location in the configuration file where a flag value can be defaulted. 
 In this case it specifies that output formats can be set in the configuration file under an `output` key. 
 
 It's called a config _path_ because the key may be nested. For example this `--control-plane-flag` has this 
@@ -201,16 +201,16 @@ KONGCTL_DEFAULT_OUTPUT=yaml kongctl get apis
 
 ## Command Structure
 
-Commands follow a verb-resource pattern for Konnect resources:
+Commands generallyfollow a verb->product->resource->args pattern with `konnect` as the default product.
 
 ```shell
-kongctl <verb> <resource-type> [resource-name] [flags]
+kongctl <verb> <product> <resource-type> [resource-name] [flags]
 ```
 
 Examples:
-- `kongctl get apis` - List all APIs in Konnect
+- `kongctl get apis` - List all APIs in Konnect (`konnect` product is implicit)
+- `kongctl get konnect apis` - List all APIs in Konnect (using full product name)
 - `kongctl get api users-api` - Get specific API details
-- `kongctl create portal` - Create a new developer portal
 - `kongctl delete api my-api` - Delete an API from Konnect
 
 ## Support
@@ -219,4 +219,5 @@ Examples:
 - **Documentation**: [Kong Docs](https://developer.konghq.com)
 - **Community**: [Kong Nation](https://discuss.konghq.com)
 
-Remember: This is tech preview software. Please report bugs and provide feedback through GitHub Issues.
+Remember: This is tech preview software. Please report bugs and provide feedback through GitHub 
+Issues or the [Kong Nation](https://discuss.konghq.com/) community.

--- a/docs/declarative-ci-cd.md
+++ b/docs/declarative-ci-cd.md
@@ -37,7 +37,7 @@ graph LR
 
 ## Plan Artifacts in CI/CD
 
-Plan artifacts optional, but can be useful for CI/CD workflows. A plan filei enables separation 
+Plan artifacts optional, but can be useful for CI/CD workflows. A plan file enables separation 
 between planning and execution, allowing for additional review and approval processes of changes.
 
 ### Benefits of Plan Artifacts

--- a/docs/declarative-ci-cd.md
+++ b/docs/declarative-ci-cd.md
@@ -482,11 +482,13 @@ apis:
 
 Create separate PATs for each environment:
 
+Development PAT with read/write to dev resources:
 ```bash
-# Development - read/write to dev resources
 KONG_PAT_DEV="kpat_dev_xxxxx"
+```
 
-# Production - read/write to prod resources, requires 2FA
+Production PAT with read/write to prod resources (requires 2FA):
+```bash
 KONG_PAT_PROD="kpat_prod_xxxxx"
 ```
 
@@ -513,9 +515,11 @@ apis:
   - ref: payment-api
     name: "Payment Processing API"
     kongctl:
-      protected: true  # Prevents accidental changes
+      protected: true
       namespace: production
 ```
+
+Note: The `protected: true` flag prevents accidental changes through kongctl operations.
 
 ## Advanced Patterns
 
@@ -554,25 +558,32 @@ jobs:
 
 ### 2. Canary Deployments
 
+Create a canary deployment script:
+
 ```bash
 #!/bin/bash
-# canary-deploy.sh
+```
 
-# Deploy canary configuration
+Filename: canary-deploy.sh
+
+Deploy canary configuration:
+```bash
 kongctl apply -f configs/canary/ \
   --auto-approve
+```
 
-# Monitor metrics
+Monitor metrics for 5 minutes:
+```bash
 sleep 300
+```
 
-# Check error rate
+Check error rate and decide on deployment:
+```bash
 ERROR_RATE=$(curl -s metrics.example.com/error_rate)
 if [ "$ERROR_RATE" -lt "0.01" ]; then
-  # Deploy to production
   kongctl apply -f configs/production/ \
     --auto-approve
 else
-  # Rollback canary
   kongctl sync -f configs/canary-stable/ \
     --auto-approve
   exit 1
@@ -603,7 +614,6 @@ jobs:
           
           if [ -s drift.json ]; then
             echo "Drift detected!"
-            # Send alert
             curl -X POST ${{ secrets.SLACK_WEBHOOK }} \
               -d '{"text":"Kong configuration drift detected"}'
           fi

--- a/docs/declarative-ci-cd.md
+++ b/docs/declarative-ci-cd.md
@@ -80,19 +80,14 @@ aws s3 cp plan.json s3://kong-plans/$(date +%Y/%m/%d)/plan-${BUILD_ID}.json
 
 ### Plan Review Best Practices
 
-1. **Always generate diffs from plans** for human review:
+1. **Generate diffs from plans for human review:
    ```shell
    kongctl diff --plan plan.json
    ```
 
 2. **Include plan summary in PR comments** for visibility
 
-3. **Validate plans before storing** to ensure they're valid:
-   ```shell
-   kongctl apply --plan plan.json --dry-run
-   ```
-
-4. **Tag plans with metadata** for easier tracking:
+3. **Tag plans with metadata** for easier tracking:
    - Commit SHA
    - Timestamp
    - Author

--- a/docs/declarative-ci-cd.md
+++ b/docs/declarative-ci-cd.md
@@ -673,8 +673,7 @@ jobs:
 Enable verbose logging in CI:
 
 ```bash
-export KONGCTL_LOG_LEVEL=debug
-kongctl apply -f configs/ --auto-approve
+kongctl apply -f configs/ --auto-approve --log-level debug
 ```
 
 ## Further Reading

--- a/docs/declarative-ci-cd.md
+++ b/docs/declarative-ci-cd.md
@@ -80,7 +80,7 @@ aws s3 cp plan.json s3://kong-plans/$(date +%Y/%m/%d)/plan-${BUILD_ID}.json
 
 ### Plan Review Best Practices
 
-1. **Generate diffs from plans for human review:
+1. **Generate diffs from plans for human review:**
    ```shell
    kongctl diff --plan plan.json
    ```

--- a/docs/declarative-configuration.md
+++ b/docs/declarative-configuration.md
@@ -299,20 +299,31 @@ Use `_defaults` to set default values for all resources in a file:
 ```yaml
 _defaults:
   kongctl:
-    namespace: platform-team    # Default namespace for resources in this file
-    protected: true            # Default protection status
+    namespace: platform-team
+    protected: true
+```
 
+In this example:
+- Default namespace for resources in this file: `platform-team`
+- Default protection status: `true`
+
+```yaml
 portals:
   - ref: api-portal
     name: "API Portal"
-    # Inherits namespace: platform-team and protected: true
-    
+```
+
+The `api-portal` inherits `namespace: platform-team` and `protected: true` from defaults.
+
+```yaml
   - ref: test-portal
     name: "Test Portal"
     kongctl:
-      namespace: qa-team      # Overrides default namespace
-      protected: false        # Overrides default protected
+      namespace: qa-team
+      protected: false
 ```
+
+The `test-portal` overrides the default namespace with `qa-team` and protected status with `false`.
 
 ### Namespace and Protected Field Behavior
 
@@ -638,6 +649,8 @@ kongctl sync --plan plans/last-known-good.json --auto-approve
 ### Common Mistakes to Avoid
 
 ❌ **Setting kongctl on child resources**:
+
+Wrong - kongctl section not supported on child resources:
 ```yaml
 # WRONG
 apis:
@@ -646,7 +659,7 @@ apis:
       namespace: team-a
     versions:
       - ref: v1
-        kongctl:  # ERROR: Not supported on child
+        kongctl:  # ERROR
           protected: true
 ```
 
@@ -657,26 +670,31 @@ apis:
   - ref: my-api
     kongctl:
       namespace: team-a
-      protected: true  # Set on parent only
+      protected: true
     versions:
       - ref: v1
-        # No kongctl here
 ```
 
+Note: Set kongctl metadata on parent only. Child resources don't support kongctl sections.
+
 ❌ **Using name as identifier**:
+
+Wrong - using display name:
 ```yaml
 # WRONG
 api_publications:
   - ref: pub1
-    api: "Users API"  # Using display name
+    api: "Users API"
 ```
 
 ✅ **Use ref for references**:
+
+Correct - using ref:
 ```yaml
 # RIGHT
 api_publications:
   - ref: pub1
-    api: users-api  # Using ref
+    api: users-api
 ```
 
 ## Migration Guide
@@ -720,8 +738,10 @@ apis:
     name: "Users API"
     kongctl:
       namespace: production
-      protected: true  # Protect during migration
+      protected: true
 ```
+
+Note: Enable protection during migration to prevent accidental changes.
 
 #### Step 5: Test Migration
 

--- a/docs/declarative-getting-started.md
+++ b/docs/declarative-getting-started.md
@@ -16,9 +16,9 @@ and an API and apply them to your Kong Konnect account.
   and Auth Strategies. 
 - **References (ref)**: Identifier string _in the declarative configuration_ which 
   uniquely identifies each resource
-- **Plan**: Plans are artifacts that contain desired changes to resources. Plans 
-  are the foundation to the declarative configuration feature, but using them 
-  directly is optional
+- **Plan**: A plan is a JSON artifact that captures the exact changes to be made 
+  to your resources. While `apply` and `sync` generate plans internally, you can 
+  create explicit plan artifacts for review, audit, and deferred execution
 - **Apply**: Execute changes to resources (create and update only)
 - **Sync**: Full declarative reconciliation (create, update and delete). Not used in this guide
 

--- a/docs/examples/declarative/plan-artifacts/README.md
+++ b/docs/examples/declarative/plan-artifacts/README.md
@@ -1,0 +1,243 @@
+# Plan Artifact Workflow Example
+
+This example demonstrates the complete workflow of using plan artifacts for safe, 
+reviewable deployments to Kong Konnect.
+
+## Overview
+
+Plan artifacts enable a two-phase deployment process:
+1. **Planning Phase**: Generate a plan artifact that captures all changes
+2. **Execution Phase**: Apply the plan artifact after review and approval
+
+## Directory Structure
+
+```
+plan-artifacts/
+├── README.md           # This file
+├── config/            # Configuration files
+│   ├── api.yaml       # API definitions
+│   └── portal.yaml    # Portal configuration
+├── plans/             # Generated plan artifacts (git-ignored)
+└── scripts/           # Workflow automation scripts
+    ├── generate-plan.sh
+    └── apply-plan.sh
+```
+
+## Workflow Steps
+
+### Step 1: Generate a Plan Artifact
+
+```bash
+# Generate a timestamped plan
+./scripts/generate-plan.sh
+
+# This creates: plans/plan-2024-01-15-143025.json
+```
+
+### Step 2: Review the Plan
+
+View human-readable diff:
+```bash
+kongctl diff --plan plans/plan-2024-01-15-143025.json
+```
+
+Inspect plan details:
+```bash
+jq '.summary' plans/plan-2024-01-15-143025.json
+```
+
+Check specific changes:
+```bash
+jq '.changes[] | select(.resource_type == "api")' plans/plan-2024-01-15-143025.json
+```
+
+### Step 3: Share for Approval
+
+Option 1: Attach to Pull Request
+The plan file can be committed or attached as a PR artifact
+
+Option 2: Upload to shared storage
+```bash
+aws s3 cp plans/plan-2024-01-15-143025.json \
+  s3://team-bucket/kong-plans/pending-review/
+```
+
+### Step 4: Apply the Plan
+
+After approval, apply the specific plan:
+```bash
+./scripts/apply-plan.sh plans/plan-2024-01-15-143025.json
+```
+
+## Example Configuration
+
+### config/api.yaml
+```yaml
+apis:
+  - ref: example-api
+    name: "Example API"
+    description: "API managed via plan artifacts"
+    version: "v1.0.0"
+```
+
+### config/portal.yaml
+```yaml
+portals:
+  - ref: dev-portal
+    name: "developer-portal"
+    display_name: "Developer Portal"
+    authentication_enabled: false
+    
+api_publications:
+  - ref: example-api-pub
+    api: example-api
+    portal: dev-portal
+```
+
+## Scripts
+
+### scripts/generate-plan.sh
+```bash
+#!/bin/bash
+set -e
+
+# Create plans directory if it doesn't exist
+mkdir -p plans
+
+# Generate timestamp
+TIMESTAMP=$(date +%Y-%m-%d-%H%M%S)
+PLAN_FILE="plans/plan-${TIMESTAMP}.json"
+
+echo "Generating plan artifact..."
+kongctl plan -f config/ --output-file "$PLAN_FILE"
+
+echo "Plan created: $PLAN_FILE"
+echo ""
+echo "Review with: kongctl diff --plan $PLAN_FILE"
+```
+
+### scripts/apply-plan.sh
+```bash
+#!/bin/bash
+set -e
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <plan-file>"
+  exit 1
+fi
+
+PLAN_FILE="$1"
+
+if [ ! -f "$PLAN_FILE" ]; then
+  echo "Error: Plan file not found: $PLAN_FILE"
+  exit 1
+fi
+
+echo "Applying plan: $PLAN_FILE"
+echo ""
+
+# Show summary
+echo "Plan summary:"
+jq '.summary' "$PLAN_FILE"
+echo ""
+
+# Confirm before applying
+read -p "Apply this plan? (y/N) " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  echo "Aborted"
+  exit 1
+fi
+
+# Apply the plan
+kongctl apply --plan "$PLAN_FILE"
+
+# Archive the applied plan
+ARCHIVE_DIR="plans/applied"
+mkdir -p "$ARCHIVE_DIR"
+mv "$PLAN_FILE" "$ARCHIVE_DIR/"
+
+echo "Plan applied and archived to $ARCHIVE_DIR"
+```
+
+## CI/CD Integration
+
+### GitHub Actions Example
+
+```yaml
+name: Kong Deployment
+
+on:
+  pull_request:
+    paths:
+      - 'config/**'
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Generate Plan
+        run: |
+          kongctl plan -f config/ --output-file plan.json
+          
+      - name: Comment PR
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs');
+            const plan = JSON.parse(fs.readFileSync('plan.json'));
+            
+            const body = `## Kong Configuration Plan
+            
+            **Summary:**
+            - Create: ${plan.summary.create}
+            - Update: ${plan.summary.update}
+            - Delete: ${plan.summary.delete}
+            
+            Review the plan artifact: [plan.json](${artifactUrl})`;
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
+```
+
+## Best Practices
+
+1. **Always review diffs**: Use `kongctl diff --plan` before applying
+2. **Version your plans**: Include timestamps or version numbers
+3. **Archive applied plans**: Keep a history of what was deployed
+4. **Validate before applying**: Use `--dry-run` to validate plans
+5. **Document plan contents**: Include comments about what changed
+
+## Troubleshooting
+
+### Plan is out of date
+
+Regenerate the plan with current state:
+```bash
+kongctl plan -f config/ --output-file new-plan.json
+```
+
+### Viewing plan details
+
+Full plan content:
+```bash
+jq . plan.json
+```
+
+Just the changes:
+```bash
+jq '.changes[]' plan.json | less
+```
+
+### Comparing plans
+
+See what's different between two plans:
+```bash
+diff <(jq -S . plan1.json) <(jq -S . plan2.json)
+```

--- a/docs/examples/declarative/plan-artifacts/README.md
+++ b/docs/examples/declarative/plan-artifacts/README.md
@@ -97,14 +97,15 @@ api_publications:
 ## Scripts
 
 ### scripts/generate-plan.sh
+
+This script creates a timestamped plan artifact:
+
 ```bash
 #!/bin/bash
 set -e
 
-# Create plans directory if it doesn't exist
 mkdir -p plans
 
-# Generate timestamp
 TIMESTAMP=$(date +%Y-%m-%d-%H%M%S)
 PLAN_FILE="plans/plan-${TIMESTAMP}.json"
 
@@ -117,6 +118,9 @@ echo "Review with: kongctl diff --plan $PLAN_FILE"
 ```
 
 ### scripts/apply-plan.sh
+
+This script applies a plan artifact with confirmation:
+
 ```bash
 #!/bin/bash
 set -e
@@ -136,12 +140,10 @@ fi
 echo "Applying plan: $PLAN_FILE"
 echo ""
 
-# Show summary
 echo "Plan summary:"
 jq '.summary' "$PLAN_FILE"
 echo ""
 
-# Confirm before applying
 read -p "Apply this plan? (y/N) " -n 1 -r
 echo
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
@@ -149,10 +151,8 @@ if [[ ! $REPLY =~ ^[Yy]$ ]]; then
   exit 1
 fi
 
-# Apply the plan
 kongctl apply --plan "$PLAN_FILE"
 
-# Archive the applied plan
 ARCHIVE_DIR="plans/applied"
 mkdir -p "$ARCHIVE_DIR"
 mv "$PLAN_FILE" "$ARCHIVE_DIR/"

--- a/docs/examples/declarative/protected/README.md
+++ b/docs/examples/declarative/protected/README.md
@@ -43,8 +43,9 @@ To test the protection, try commenting out the `order-api` resource in the confi
   #- ref: order-api
   #  name: "Order Management API"
   #  description: "Production API for order processing"
-  #  # Inherits protected: true from defaults
 ```
+
+Note: This resource inherits `protected: true` from the defaults section.
 
 And run the sync command again:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -333,10 +333,15 @@ Error: resource "my-api" references unknown portal: unknown-portal
 **Common causes:**
 
 1. **Typo in reference**:
+   
+   Note the exact ref value:
    ```yaml
    portals:
-     - ref: developer-portal  # Note the exact ref
+     - ref: developer-portal
+   ```
    
+   Wrong ref value:
+   ```yaml
    api_publications:
      - ref: api-pub
        portal: dev-portal     # ❌ Wrong ref


### PR DESCRIPTION
- Replace --force with --auto-approve for sync command
- Replace -o with --output-file for plan command output
- Remove invalid --namespace flag references
- Remove --dry-run from plan command (not supported)
- Clarify plan command creates artifacts, not just previews
- Add comprehensive Plan Artifacts documentation section
- Update all command examples to remove inline comments
- Add descriptive text before commands for better UX
- Create plan artifact workflow example with scripts
- Improve troubleshooting guide with plan debugging section