### PR TITLE
feat: Stage 8 - External Resources Planning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ dist/
 
 # Local development context
 CLAUDE.local.md
+
+.serena/

--- a/planning/008-external-resources/description.md
+++ b/planning/008-external-resources/description.md
@@ -1,0 +1,92 @@
+# Stage 8: External Resources
+
+## Overview
+
+Implement external resource references to enable kongctl to integrate with 
+resources managed by other Kong declarative configuration tools (decK, Kong 
+Operator, Terraform provider). This feature allows users to reference 
+existing resources without taking ownership, enabling gradual migration and 
+parallel workflows during transition periods.
+
+## Problem Statement
+
+Kong customers have existing investments in multiple declarative tools:
+- **decK**: Manages Kong Gateway core entities (services, routes, plugins)
+- **Kong Operator**: Kubernetes-native resource management
+- **Terraform Provider**: Infrastructure-as-code for Konnect
+
+As kongctl expands capabilities, users need:
+- Migration paths that don't require abandoning existing tools immediately
+- Ability to operate multiple tools in parallel
+- Ways to reference externally-managed resources in kongctl configurations
+- Gradual adoption strategy for comprehensive Konnect resource management
+
+## Solution
+
+Introduce `external_resources` blocks that:
+- Define references to resources managed by external tools
+- Use selectors to query and identify specific resources
+- Resolve to resource IDs and data during planning
+- Enable dependencies between kongctl-managed and externally-managed resources
+
+## Important Limitations
+
+### Phase 1 Limitations
+- Only `matchFields` selectors (simple equality matching)
+- No complex query expressions or operators
+- Must resolve to exactly one resource (no optional or multiple matches)
+- Limited to resource types with SDK support
+
+### Not Supported
+- Direct management or modification of external resources
+- Cascade operations on external resources
+- Import of external resources into kongctl management
+- Provider-specific features or optimizations
+
+## Key Features
+
+1. **Direct ID Reference**: Reference resources by UUID when known
+2. **Field Selectors**: Query resources by field values
+3. **Parent Relationships**: Support hierarchical resource structures
+4. **Implicit ID Resolution**: Automatic resolution of ID fields
+5. **Type Safety**: Resource-type-aware validation and resolution
+
+## Success Criteria
+
+- Users can reference any supported Konnect resource managed externally
+- Clear error messages for ambiguous or missing resources
+- Seamless integration in dependency chains
+- Intuitive configuration syntax
+
+## Example Use Case
+
+A team using decK for gateway configuration wants to adopt kongctl for API 
+management. They can reference their existing control planes and services 
+while managing APIs and API implementations through kongctl:
+
+```yaml
+external_resources:
+  - ref: prod-cp
+    resource_type: control_plane
+    selector:
+      matchFields:
+        name: production-control-plane
+  - ref: user-service
+    resource_type: ce_service # core entity service
+    control_plane: prod-cp    # Parent reference
+    selector:
+      matchFields:
+        name: user-service
+
+apis:
+  - ref: user-api
+    name: User Management API
+    
+api_implementations:
+  - ref: impl
+    api:
+      ref: user-api
+    service:
+      control_plane_id: prod-cp  # Resolves to ID of external resource
+      id: user-service           # Resolves to ID of external resource
+```

--- a/planning/008-external-resources/execution-plan-adrs.md
+++ b/planning/008-external-resources/execution-plan-adrs.md
@@ -1,0 +1,388 @@
+# Architecture Decision Records (ADRs)
+
+## ADR-001: Core External Resource Design
+
+### Status
+Accepted
+
+### Decision
+- Use `external_resources` (plural) blocks containing arrays of external resource definitions
+- Each resource requires `ref` and `resource_type` fields
+- Support both direct ID reference and selector-based queries
+- External resources are read-only references, not managed resources
+
+### Rationale
+- Consistent with existing kongctl patterns (plural resource blocks)
+- Clear separation between managed and external resources
+- Flexibility for different identification methods
+
+## ADR-002: Selector Design - Phase 1
+
+### Status
+Accepted
+
+### Decision
+Start with `matchFields` only for simple equality matching:
+```yaml
+selector:
+  matchFields:
+    name: production-cp
+    environment: prod
+```
+
+### Rationale
+- Simpler initial implementation
+- Covers majority of use cases
+- Foundation for future enhancements
+- Clear, intuitive syntax
+
+### Future Consideration
+matchExpressions with operators for complex queries (deferred to Phase 2)
+
+## ADR-003: Direct ID Reference
+
+### Status
+Accepted
+
+### Decision
+Support direct UUID reference as peer to selector:
+```yaml
+external_resources:
+  - ref: my-resource
+    resource_type: control_plane
+    id: "550e8400-e29b-41d4-a716-446655440000"
+```
+
+### Rationale
+- Most efficient resolution method
+- Clear precedence (ID overrides selector)
+- Common use case when IDs are known
+
+## ADR-004: Selector Matching Requirements
+
+### Status
+Accepted
+
+### Decision
+- Selectors must match exactly one resource
+- Zero matches: fail fast with clear error
+- Multiple matches: fail fast with list of matches
+
+### Rationale
+- External resources are dependencies
+- Ambiguity should block operations
+- Clear error messages guide users to fix selectors
+
+## ADR-005: Parent Relationships
+
+### Status
+Accepted
+
+### Decision
+Use typed parent fields based on resource type knowledge:
+```yaml
+external_resources:
+  - ref: user-service
+    resource_type: gw_service
+    control_plane: prod-cp  # Parent reference
+```
+
+### Rationale
+- Leverages resource type knowledge
+- Clean syntax without unnecessary nesting
+- Consistent with resource hierarchies
+
+## ADR-006: External Resource Storage and Field Resolution
+
+### Status
+Accepted
+
+### Decision
+- External resources are fully resolved during planning
+- Complete resource objects are stored in memory
+- All fields are available for potential use
+- For Phase 1: Only ID fields are extracted for dependencies
+- Field extraction based on type knowledge, not string patterns
+
+### Implementation
+```yaml
+# External resource provides complete object
+external_resources:
+  - ref: prod-cp
+    # Resolves to complete object with id, name, config, labels, etc.
+
+# Dependent resource extracts needed field (ID for now)
+api_implementations:
+  service:
+    control_plane_id: prod-cp  # System knows to extract prod-cp.id
+    id: user-service          # System knows to extract user-service.id
+```
+
+### Rationale
+- Storing complete objects enables future field access
+- Type knowledge ensures correct field extraction
+- Consistent with existing reference patterns
+- Extensible for future needs without breaking changes
+
+### Future Capability
+Since complete objects are stored, future phases could:
+- Extract other fields (name, endpoint, labels)
+- Use JQ-like syntax for complex field access
+- Add more type mappings as needed
+
+## ADR-007: Resolution Timing
+
+### Status
+Accepted
+
+### Decision
+Resolve ALL external resources during planning phase, following existing pattern:
+1. Parse external_resources blocks first (before other resources)
+2. Resolve in dependency order (parents before children)
+3. Execute selectors via SDK to fetch complete resource data
+4. Store resolved data in memory for the duration of the planning/execution
+5. Populate PlannedChange.References with resolved IDs
+6. Fail immediately if any external resource cannot be resolved
+
+### Implementation Pattern
+Follows existing two-phase resolution used for API publications:
+- **Planning phase**: External resources fully resolved, IDs available
+- **Execution phase**: Uses pre-resolved IDs, no additional lookups needed
+
+### Rationale
+- Consistent with existing reference resolution pattern
+- Fail fast on missing/ambiguous external resources
+- No runtime surprises during execution
+- Clear error messages guide users to fix selectors
+- Simplifies executor implementation (IDs always available)
+
+## ADR-008: Caching Strategy
+
+### Status
+Accepted
+
+### Decision
+- No persistent caching between CLI invocations
+- Resolved external resource data stored in memory during planning/execution only
+- Each CLI command fetches fresh data from Konnect
+
+### Rationale
+- Avoids premature optimization
+- Consistent with current CLI behavior (fetches data each operation)
+- Prevents stale data issues
+- Simplifies implementation
+- Can add caching in future if performance requires
+
+## ADR-009: No Provider Attribution
+
+### Status
+Accepted
+
+### Decision
+Do not include provider/tool attribution fields
+
+### Rationale
+- External resources are tool-agnostic
+- Reduces complexity
+- Avoids coupling to specific tools
+- Focus on resource identity, not management tool
+
+## ADR-010: Namespace Handling
+
+### Status
+Accepted
+
+### Decision
+- External resources are namespace-agnostic
+- No namespace field on external_resources
+- Can be referenced from any namespace
+- Not included in namespace filtering operations
+
+### Rationale
+- Namespaces identify sets of "managed" resources
+- External resources are by definition not managed
+- External resources are shared references available to all namespaces
+- Simplifies cross-team resource sharing
+
+## ADR-011: Plan Output Representation
+
+### Status
+Accepted
+
+### Decision
+Display external resources in a separate section of plan output:
+```
+External Resources (read-only):
+  ✓ control_plane "prod-cp" (id: abc-123...)
+  ✓ ce_service "user-service" (id: def-456...)
+
+Changes to apply:
+  + api_implementation "impl"
+```
+
+### Rationale
+- Clear distinction between external and managed resources
+- Shows successful resolution status
+- Provides visibility into external dependencies
+
+## ADR-012: SDK Error Handling
+
+### Status
+Accepted
+
+### Decision
+- Fail fast on any SDK errors during external resource resolution
+- Provide clear error messages for:
+  - Network failures
+  - Authentication errors
+  - Rate limiting
+  - API errors
+
+### Rationale
+- External resources are critical dependencies
+- Better to fail early with clear errors
+- Users must fix connectivity/auth before proceeding
+
+## ADR-013: Dry Run Behavior
+
+### Status
+Accepted
+
+### Decision
+- External resources are resolved during dry-run operations
+- Validates configuration without making changes
+- Same resolution behavior as normal planning
+
+### Rationale
+- Allows validation of external references
+- Catches configuration errors early
+- Consistent behavior across modes
+
+## ADR-014: Complex Selectors (Future)
+
+### Status
+Proposed (Phase 2)
+
+### Options Considered
+1. **matchExpressions with operators**
+   ```yaml
+   matchExpressions:
+     name:
+       operator: StartsWith
+       value: "api-"
+   ```
+
+2. **JQ filter expressions**
+   ```yaml
+   selector:
+     jq: '.[] | select(.name | startswith("api-"))'
+   ```
+
+3. **JSONPath syntax**
+   ```yaml
+   selector:
+     jsonpath: '$[?(@.name =~ /^api-/)]'
+   ```
+
+### Recommendation
+Option 1 (matchExpressions) for Phase 2:
+- Progressive complexity from matchFields
+- Structured and validatable
+- Better IDE support
+- Consistent with Kubernetes patterns
+
+## ADR-015: Core Entity Resource Naming
+
+### Status
+Accepted
+
+### Decision
+Use `ce_` prefix for Gateway core entity resource types:
+- `ce_service` - Gateway service
+- `ce_route` - Gateway route
+- `ce_consumer` - Gateway consumer
+- `ce_plugin` - Gateway plugin
+- `ce_upstream` - Gateway upstream
+- `ce_target` - Gateway target
+
+### Rationale
+- Maps directly to API path structure (`/core-entities/`)
+- Consistent pattern across all core entities
+- Distinguishes from Service Catalog "service" resource
+- Technical alignment with Konnect API structure
+- Acronym concern addressed through documentation and error messages
+
+### Mitigation for Learning Curve
+- Clear error messages: "Unknown resource type 'service'. Did you mean 'ce_service' (Gateway core entity)?"
+- Documentation explains convention once
+- Consistent usage across all examples
+
+## ADR-016: Parent Validation
+
+### Status
+Accepted
+
+### Decision
+Validate parent field requirements at configuration parse time:
+- Validate before any SDK calls
+- Check required parent fields based on resource type
+- Validate parent resource type compatibility
+
+### Validation Rules
+```yaml
+# Required parent fields by resource type:
+ce_service: requires control_plane
+ce_route: requires control_plane (service parent optional)
+ce_plugin: requires control_plane (service/route parent optional)
+ce_consumer: requires control_plane
+ce_upstream: requires control_plane
+ce_target: requires control_plane and ce_upstream
+```
+
+### Error Examples
+```
+Error: Invalid external resource configuration
+  Resource: "user-service" (type: ce_service)
+  Missing required parent field: control_plane
+  
+Error: Invalid external resource configuration  
+  Resource: "my-route" (type: ce_route)
+  Invalid parent type: expected 'control_plane', got 'portal'
+```
+
+### Rationale
+- Immediate feedback on configuration errors
+- Prevents invalid SDK calls
+- Consistent with existing validation patterns
+- Better user experience with early error detection
+
+## ADR-017: Phase 1 Resource Types
+
+### Status
+Accepted
+
+### Decision
+Phase 1 supports only essential resource types for api_implementation:
+- `control_plane` - Kong Gateway control plane
+- `ce_service` - Gateway service (core entity)
+
+### Rationale
+- Minimal scope for initial implementation
+- Covers immediate use case (API implementations)
+- Proves the pattern before expanding
+- Additional types can be added incrementally
+
+## ADR-018: Testing Strategy
+
+### Status
+Accepted
+
+### Decision
+- Unit tests with mocked SDK responses
+- Integration tests with real Konnect resources
+- Manual validation for edge cases
+
+### Rationale
+- Unit tests ensure logic correctness
+- Integration tests validate SDK integration
+- Manual testing catches user experience issues

--- a/planning/008-external-resources/execution-plan-overview.md
+++ b/planning/008-external-resources/execution-plan-overview.md
@@ -1,0 +1,282 @@
+# External Resources Execution Plan Overview
+
+## Objective
+
+Implement external resource references in kongctl to enable integration with 
+resources managed by other Kong declarative tools (decK, Terraform, Kong 
+Operator) without taking ownership.
+
+## Scope
+
+### In Scope (Phase 1)
+- Basic external resource definition syntax
+- Direct ID references
+- Simple field-based selectors (matchFields)
+- Parent relationship handling
+- Implicit ID resolution for dependencies
+- Planning-phase resolution
+
+### Out of Scope (Future Phases)
+- Complex query expressions (matchExpressions)
+- Resource import/adoption
+- Modification of external resources
+- Cross-namespace external references
+
+## Technical Approach
+
+### 1. Configuration Schema
+
+#### External Resource Definition
+```yaml
+external_resources:
+  # Direct ID reference
+  - ref: specific-cp
+    resource_type: control_plane
+    id: "550e8400-e29b-41d4-a716-446655440000"
+    
+  # Selector-based reference
+  - ref: prod-cp
+    resource_type: control_plane
+    selector:
+      matchFields:
+        name: production-control-plane
+        
+  # Core entity with parent (ce_ prefix for Gateway core entities)
+  - ref: user-service
+    resource_type: ce_service  # Gateway service (core entity)
+    control_plane: prod-cp      # Required parent reference
+    selector:
+      matchFields:
+        name: user-api-service
+```
+
+#### Using External Resources
+```yaml
+api_implementations:
+  - ref: impl
+    api:
+      ref: user-api
+    service:
+      control_plane_id: prod-cp  # Implicit ID resolution
+      id: user-service          # Implicit ID resolution
+```
+
+### 2. Resolution Process
+
+```
+PLANNING PHASE:
+┌─────────────────────┐
+│ Parse Configuration │
+└──────────┬──────────┘
+           │
+           ▼
+┌─────────────────────┐
+│ Parse External      │ ◄── Process external_resources first
+│ Resources           │
+└──────────┬──────────┘
+           │
+           ▼
+┌─────────────────────┐
+│ Resolve Parents     │ ◄── Resolve in dependency order
+└──────────┬──────────┘
+           │
+           ▼
+┌─────────────────────┐
+│ Execute Selectors   │ ◄── Query via SDK
+└──────────┬──────────┘
+           │
+           ▼
+┌─────────────────────┐
+│ Validate Matches    │ ◄── Fail if != 1 match
+└──────────┬──────────┘
+           │
+           ▼
+┌─────────────────────┐
+│ Store in Memory     │ ◄── Keep for planning duration
+└──────────┬──────────┘
+           │
+           ▼
+┌─────────────────────┐
+│ Process Other       │ ◄── APIs, Portals, etc.
+│ Resources           │
+└──────────┬──────────┘
+           │
+           ▼
+┌─────────────────────┐
+│ Build PlannedChanges│ ◄── References contain resolved IDs
+└──────────┬──────────┘
+           │
+           ▼
+EXECUTION PHASE:
+┌─────────────────────┐
+│ Execute Changes     │ ◄── Uses pre-resolved IDs
+└─────────────────────┘
+```
+
+### 3. Resource Type Registry
+
+Maintain registry of supported external resource types:
+```go
+type ExternalResourceType struct {
+    Name            string
+    RequiredParents []string  // e.g., ["control_plane"] for ce_service
+    OptionalParents []string  // e.g., ["service"] for ce_route
+    SDKListFunc     func()    // SDK function to list resources
+    SDKGetFunc      func()    // SDK function to get by ID
+}
+
+// Example registry entries:
+registry["control_plane"] = ExternalResourceType{
+    Name:            "control_plane",
+    RequiredParents: nil,  // Top-level resource
+}
+
+registry["ce_service"] = ExternalResourceType{
+    Name:            "ce_service",
+    RequiredParents: []string{"control_plane"},
+}
+
+registry["ce_route"] = ExternalResourceType{
+    Name:            "ce_route",
+    RequiredParents: []string{"control_plane"},
+    OptionalParents: []string{"ce_service"},
+}
+```
+
+### 4. Implementation Components
+
+#### ExternalResourceResolver
+- Parses external_resources blocks before other resources
+- Manages resolution order (parents first)
+- Executes SDK queries based on resource type
+- Validates exactly one match per selector
+- **Stores complete resource objects in memory** (not just IDs)
+- Provides full resource data to planner
+
+#### Resource Storage
+```go
+type ResolvedExternalResource struct {
+    Ref          string
+    ResourceType string
+    FullObject   interface{}  // Complete resource from SDK
+    ID           string        // Extracted for convenience
+}
+
+// In-memory storage during planning/execution
+externalResources map[string]ResolvedExternalResource
+```
+
+#### Integration with Planner
+- Planner calls ExternalResourceResolver first
+- When building PlannedChange for resources with external refs:
+  - Uses type knowledge to determine which field to extract
+  - For `_id` fields, extracts the ID from stored object
+  - Populates References map with extracted values
+  - No runtime SDK calls needed (already resolved)
+
+#### Field Extraction Logic
+- **Phase 1**: Type-based knowledge for ID extraction
+  - `control_plane_id` → extract `control_plane.id`
+  - `service.id` → extract `ce_service.id`
+- **Future**: Could add field mapping or JQ-like syntax
+
+#### Executor Changes
+- Minimal changes required
+- External references already resolved in PlannedChange.References
+- Uses existing reference resolution logic
+
+#### Validation
+- Schema validation for external_resources
+- Resource type validation
+- Parent relationship validation
+- Match uniqueness validation
+
+### 5. Error Handling
+
+#### Resolution Failures (Planning Phase)
+```
+Error: External resource 'prod-cp' selector matched 0 resources
+  Resource type: control_plane
+  Selector: 
+    matchFields:
+      name: "production-cp"
+  Suggestion: Verify the resource exists in Konnect
+  
+Error: External resource 'user-service' selector matched 3 resources:
+  Resource type: ce_service (Gateway core entity)
+  Parent: control_plane 'prod-cp'
+  Matched resources:
+    1. service "api-service-1" (id: abc123...)
+    2. service "api-service-2" (id: def456...)
+    3. service "api-service-3" (id: ghi789...)
+  Suggestion: Refine selector to match exactly one resource
+
+Error: External resource 'user-service' parent 'prod-cp' not found
+  Resource type: ce_service
+  Parent reference: prod-cp
+  Suggestion: Ensure parent external resource is defined first
+```
+
+#### Validation Errors (Parse Time)
+```
+Error: Unknown resource type 'service'
+  Did you mean 'ce_service' (Gateway core entity)?
+  Valid resource types: control_plane, portal, api, ce_service, ce_route, ce_consumer, ce_plugin
+
+Error: Invalid external resource configuration
+  Resource: "user-service" (type: ce_service)
+  Missing required parent field: control_plane
+  
+Error: Invalid parent type for external resource
+  Resource: "my-route" (type: ce_route)
+  Parent field 'portal' is not valid for resource type 'ce_route'
+  Valid parent types: control_plane, ce_service
+  
+Error: Circular dependency detected
+  Resource dependency chain: A → B → C → A
+```
+
+## Success Metrics
+
+1. **Functionality**
+   - All external resource types resolvable
+   - Parent relationships properly handled
+   - ID resolution working for all dependency types
+
+2. **Reliability**
+   - Clear error messages for all failure cases
+   - No silent failures
+   - Consistent resolution behavior
+
+3. **Performance**
+   - Minimal SDK calls (batch where possible)
+   - Efficient caching
+   - Fast resolution for direct ID references
+
+4. **Usability**
+   - Intuitive configuration syntax
+   - Clear documentation
+   - Helpful error messages
+
+## Migration Strategy
+
+### Phase 1: Core Implementation (Current)
+- Basic external_resources support
+- matchFields selectors only
+- Two resource types only:
+  - `control_plane`
+  - `ce_service`
+- ID field extraction only
+- Complete object storage for future use
+
+### Phase 2: Extended Support (Future)
+- Additional core entity types (ce_route, ce_plugin, etc.)
+- Additional Konnect resource types (portal, api, etc.)
+- matchExpressions for complex queries
+- Field extraction beyond IDs (if needed)
+
+### Phase 3: Advanced Features (Future)
+- Resource adoption/import via export command
+- Bulk external resource operations
+- Cross-organization references
+- JQ-like field extraction syntax

--- a/planning/008-external-resources/execution-plan-steps.md
+++ b/planning/008-external-resources/execution-plan-steps.md
@@ -1,0 +1,161 @@
+# External Resources Implementation Steps
+
+## Phase 1: Core Implementation
+
+### Step 1: Schema and Configuration (2 days)
+- [ ] Define external_resources schema in configuration types
+- [ ] Add validation for external resource blocks
+- [ ] Support both direct ID and selector patterns
+- [ ] Add parent field support for hierarchical resources
+
+### Step 2: Resource Type Registry (1 day)
+- [ ] Create registry for supported external resource types
+- [ ] Map resource types to SDK operations
+- [ ] Define parent-child relationships
+- [ ] Add resource type validation
+
+### Step 3: External Resource Resolver (3 days)
+- [ ] Implement ExternalResourceResolver struct
+- [ ] Parse external_resources from configuration
+- [ ] Build dependency graph for resolution order
+- [ ] Implement direct ID resolution
+- [ ] Implement matchFields selector logic
+- [ ] Add SDK query execution
+- [ ] Implement match validation (exactly one)
+- [ ] Add resource caching mechanism
+
+### Step 4: Reference Resolution (2 days)
+- [ ] Implement ReferenceResolver for dependency handling
+- [ ] Detect external resource references in configurations
+- [ ] Implement implicit ID resolution for _id fields
+- [ ] Handle mixed internal/external references
+- [ ] Add reference validation
+
+### Step 5: Error Handling (1 day)
+- [ ] Implement clear error messages for zero matches
+- [ ] Implement error messages for multiple matches
+- [ ] Add validation errors for invalid configurations
+- [ ] Handle SDK errors gracefully
+- [ ] Add detailed error context
+
+### Step 6: Integration with Planning (2 days)
+- [ ] Integrate external resolution into planning phase
+- [ ] Ensure resolution happens before plan generation
+- [ ] Update plan output to show external resources
+- [ ] Add external resource status to plan
+
+### Step 7: Testing (3 days)
+- [ ] Unit tests for resolver components
+- [ ] Integration tests with mock SDK responses
+- [ ] Test error scenarios (0 matches, multiple matches)
+- [ ] Test parent-child resolution
+- [ ] Test implicit ID resolution
+- [ ] End-to-end tests with real resources
+
+### Step 8: Documentation (1 day)
+- [ ] User guide for external resources
+- [ ] Migration guide from other tools
+- [ ] Configuration examples
+- [ ] Troubleshooting guide
+
+## Phase 2: Extended Support (Future)
+
+### Step 9: Additional Resource Types
+- [ ] Add support for all SDK-supported resource types
+- [ ] Implement resource-specific validation
+- [ ] Add complex parent relationships
+
+### Step 10: matchExpressions Support
+- [ ] Design operator system
+- [ ] Implement comparison operators
+- [ ] Implement string operators
+- [ ] Implement array operators
+- [ ] Add operator validation
+
+### Step 11: Performance Optimization
+- [ ] Batch SDK calls where possible
+- [ ] Implement parallel resolution
+- [ ] Optimize caching strategy
+- [ ] Add resolution metrics
+
+## Testing Strategy
+
+### Unit Tests
+- Schema validation
+- Selector matching logic
+- Reference resolution
+- Error handling
+
+### Integration Tests
+- SDK integration
+- Parent-child resolution
+- Mixed references
+- Planning integration
+
+### E2E Tests
+- Real Konnect resources
+- Migration scenarios
+- Complex dependencies
+- Error scenarios
+
+## Rollout Plan
+
+### Alpha Release
+- Internal testing
+- Limited resource types
+- Basic documentation
+
+### Beta Release
+- Customer preview
+- Core resource types
+- Full documentation
+- Migration examples
+
+### GA Release
+- All planned resource types
+- Performance optimized
+- Production ready
+- Complete documentation
+
+## Risk Mitigation
+
+### Risk: SDK Changes
+**Mitigation**: Abstract SDK operations behind interfaces
+
+### Risk: Performance Issues
+**Mitigation**: Implement caching and batch operations early
+
+### Risk: Complex Selectors
+**Mitigation**: Start with simple matchFields, extend gradually
+
+### Risk: Breaking Changes
+**Mitigation**: Design extensible schema from the start
+
+## Success Criteria
+
+- [ ] External resources resolve correctly
+- [ ] Clear error messages for all failure cases
+- [ ] No performance regression
+- [ ] Positive user feedback
+- [ ] Successful migration stories
+
+## Dependencies
+
+- Konnect Go SDK
+- Existing resource type system
+- Planning phase implementation
+- Configuration management system
+
+## Estimated Timeline
+
+**Phase 1**: 15 days
+- Core implementation: 11 days
+- Testing: 3 days
+- Documentation: 1 day
+
+**Phase 2**: 10 days (future)
+- Extended features: 7 days
+- Testing: 2 days
+- Documentation: 1 day
+
+Total: 25 days across two phases

--- a/planning/008-external-resources/overview.md
+++ b/planning/008-external-resources/overview.md
@@ -1,0 +1,71 @@
+# External Resources Feature Overview
+
+## Purpose
+
+The External Resources feature enables kongctl to reference and integrate with
+resources managed by other Kong declarative configuration tools (decK, Kong
+Operator, Terraform provider). This allows users to maintain existing workflows
+and investments while gradually adopting kongctl for comprehensive Konnect
+resource management.
+
+## Problem Statement
+
+Kong customers currently use multiple declarative configuration tools:
+- **decK**: Manages Kong Gateway "core entities" (services, routes, plugins,
+  consumers) via YAML configuration
+- **Kong Operator**: Kubernetes-native operator for reconciling K8s resources
+  to Konnect
+- **Terraform Provider**: Infrastructure-as-code management for Konnect
+
+As kongctl expands its capabilities, users need a migration path that doesn't
+require abandoning existing tools immediately. They need to operate multiple
+tools in parallel during transition periods.
+
+## Solution Overview
+
+External Resources allows kongctl to:
+1. Reference resources managed by external tools without taking ownership
+2. Query and retrieve identity information (IDs, names, composite keys) for
+   these external resources
+3. Use external resource data in relationships and dependencies within kongctl
+   configurations
+4. Enable gradual migration from other tools to kongctl
+
+## Key Capabilities
+
+### External Resource Declaration
+Users define `external_resource` blocks in kongctl configuration that:
+- Specify the resource type and identifying attributes
+- Indicate which external tool manages the resource
+- Provide sufficient information for kongctl to query the resource via SDK
+
+### Resource Information Retrieval
+kongctl will:
+- Use the Konnect SDK to query external resources based on provided identifiers
+- Cache retrieved information for use within the configuration lifecycle
+- Validate that external resources exist and are accessible
+
+### Integration Points
+External resources can be referenced in:
+- Relationship definitions (e.g., linking an API to an externally-managed
+  Control Plane)
+- Dependency declarations
+- Resource associations
+
+## Benefits
+
+1. **Gradual Migration**: Users can adopt kongctl incrementally without
+   disrupting existing workflows
+2. **Tool Interoperability**: Enables mixed-tool environments during transition
+   periods
+3. **Investment Protection**: Preserves existing configuration investments in
+   decK, Terraform, or Kong Operator
+4. **Flexibility**: Supports various migration strategies based on customer needs
+
+## Success Criteria
+
+- Users can reference any Konnect resource managed by external tools
+- External resource data is accurately retrieved and usable within kongctl
+- Clear error messages when external resources are unavailable or misconfigured
+- Minimal performance impact from external resource queries
+- Documentation clearly explains usage patterns and migration strategies


### PR DESCRIPTION
## Summary

This PR adds comprehensive planning documentation for Stage 8: External Resources feature.

## Overview

The External Resources feature enables kongctl to reference resources managed by other Kong declarative tools (decK, Terraform, Kong Operator) without taking ownership. This allows gradual migration and parallel tool usage during transition periods.

## Key Design Decisions

- **Structure**: `external_resources` (plural) blocks with array of resources
- **Identification**: Direct UUID reference or selector-based queries
- **Resolution**: All during planning phase with fail-fast semantics
- **Resource Naming**: `ce_` prefix for Gateway core entities
- **Scope**: Phase 1 limited to `control_plane` and `ce_service` types
- **Storage**: Complete resource objects stored for future field extraction

## Documentation Included

- **18 ADRs** documenting all design decisions
- **Execution plan** with technical approach
- **Implementation steps** with timeline estimates
- **Complete examples** showing configuration syntax

## Implementation Focus

Phase 1 focuses on the minimal scope needed for API implementations:
- Support for control planes and Gateway services only
- Simple matchFields selectors
- ID field extraction for dependencies
- Foundation for future expansion

## Test Plan

- [ ] Review planning documentation for completeness
- [ ] Validate design decisions align with existing patterns
- [ ] Confirm scope is appropriate for Phase 1
- [ ] Implementation to follow in subsequent PRs