### PR TITLE
fix(executor): implement API version update operations

### DIFF
--- a/docs/examples/declarative/portal/apis.yaml
+++ b/docs/examples/declarative/portal/apis.yaml
@@ -14,9 +14,19 @@ apis:
       - ref: sms-v1
         version: !file apis/sms/openapi.yaml#info.version
         spec: !file apis/sms/openapi.yaml
-      - ref: sms-v2
-        version: !file apis/sms/openapi-v3.yaml#info.version
-        spec: !file apis/sms/openapi-v3.yaml
+      - ref: sms-v1-3
+        version: "1.3.0"
+        spec: | 
+          openapi: 3.0.0
+          info:
+            title: SMS API
+            version: "1.3.0"
+          paths:
+            /ping:
+              get:
+                responses:
+                  "200":
+                    description: OK
        
        
     documents:
@@ -47,7 +57,7 @@ apis:
     publications:
       - ref: sms-api-to-getting-started
         portal_id: getting-started-portal
-        visibility: public
+        visibility: private
 
   - ref: voice
     name: !file apis/voice/openapi.yaml#info.title

--- a/docs/examples/declarative/portal/apis.yaml
+++ b/docs/examples/declarative/portal/apis.yaml
@@ -14,19 +14,9 @@ apis:
       - ref: sms-v1
         version: !file apis/sms/openapi.yaml#info.version
         spec: !file apis/sms/openapi.yaml
-      - ref: sms-v1-3
-        version: "1.3.0"
-        spec: | 
-          openapi: 3.0.0
-          info:
-            title: SMS API
-            version: "1.3.0"
-          paths:
-            /ping:
-              get:
-                responses:
-                  "200":
-                    description: OK
+      - ref: sms-v2
+        version: !file apis/sms/openapi-v3.yaml#info.version
+        spec: !file apis/sms/openapi-v3.yaml
        
        
     documents:
@@ -57,7 +47,7 @@ apis:
     publications:
       - ref: sms-api-to-getting-started
         portal_id: getting-started-portal
-        visibility: private
+        visibility: public
 
   - ref: voice
     name: !file apis/voice/openapi.yaml#info.title

--- a/internal/declarative/executor/api_adapter.go
+++ b/internal/declarative/executor/api_adapter.go
@@ -125,7 +125,7 @@ func (p *APIAdapter) GetByName(ctx context.Context, name string) (ResourceInfo, 
 }
 
 // GetByID gets an API by ID
-func (p *APIAdapter) GetByID(ctx context.Context, id string) (ResourceInfo, error) {
+func (p *APIAdapter) GetByID(ctx context.Context, id string, _ *ExecutionContext) (ResourceInfo, error) {
 	api, err := p.client.GetAPIByID(ctx, id)
 	if err != nil {
 		return nil, err

--- a/internal/declarative/executor/api_document_adapter.go
+++ b/internal/declarative/executor/api_document_adapter.go
@@ -127,25 +127,20 @@ func (a *APIDocumentAdapter) GetByName(_ context.Context, _ string) (ResourceInf
 }
 
 // GetByID gets an API document by ID using API context
-func (a *APIDocumentAdapter) GetByID(ctx context.Context, id string) (ResourceInfo, error) {
-	// Get API ID from context (this method still uses context anti-pattern temporarily)
-	if execCtxValue := ctx.Value("executionContext"); execCtxValue != nil {
-		if execCtx, ok := execCtxValue.(*ExecutionContext); ok {
-			apiID, err := a.getAPIIDFromExecutionContext(execCtx)
-			if err == nil {
-				// Use existing client method
-				document, err := a.client.GetAPIDocument(ctx, apiID, id)
-				if err != nil {
-					return nil, fmt.Errorf("failed to get API document: %w", err)
-				}
-				if document == nil {
-					return nil, nil
-				}
-				return &APIDocumentResourceInfo{document: document}, nil
-			}
-		}
+func (a *APIDocumentAdapter) GetByID(ctx context.Context, id string, execCtx *ExecutionContext) (ResourceInfo, error) {
+	apiID, err := a.getAPIIDFromExecutionContext(execCtx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get API ID for document lookup: %w", err)
 	}
-	return nil, fmt.Errorf("failed to get API ID for document lookup: execution context not found")
+
+	document, err := a.client.GetAPIDocument(ctx, apiID, id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get API document: %w", err)
+	}
+	if document == nil {
+		return nil, nil
+	}
+	return &APIDocumentResourceInfo{document: document}, nil
 }
 
 // ResourceType returns the resource type name

--- a/internal/declarative/executor/api_implementation_adapter.go
+++ b/internal/declarative/executor/api_implementation_adapter.go
@@ -53,6 +53,11 @@ func (a *APIImplementationAdapter) GetByName(_ context.Context, _ string) (Resou
 	return nil, fmt.Errorf("API implementations are not yet supported by the SDK")
 }
 
+// GetByID gets an API implementation by ID
+func (a *APIImplementationAdapter) GetByID(_ context.Context, _ string, _ *ExecutionContext) (ResourceInfo, error) {
+	return nil, fmt.Errorf("API implementations are not yet supported by the SDK")
+}
+
 // ResourceType returns the resource type name
 func (a *APIImplementationAdapter) ResourceType() string {
 	return "api_implementation"
@@ -69,20 +74,21 @@ func (a *APIImplementationAdapter) SupportsUpdate() bool {
 	return false
 }
 
-// APIImplementationResourceInfo is a placeholder for API implementation resource info
+// APIImplementationResourceInfo implements ResourceInfo for API implementations
 type APIImplementationResourceInfo struct {
-	// Empty struct as implementations are not supported
+	implementation *state.APIImplementation
 }
 
 func (a *APIImplementationResourceInfo) GetID() string {
-	return ""
+	return a.implementation.ID
 }
 
 func (a *APIImplementationResourceInfo) GetName() string {
-	return ""
+	return a.implementation.ID // Implementations don't have names, use ID
 }
 
 func (a *APIImplementationResourceInfo) GetLabels() map[string]string {
+	// API implementations don't support labels in the SDK
 	return make(map[string]string)
 }
 

--- a/internal/declarative/executor/api_publication_adapter.go
+++ b/internal/declarative/executor/api_publication_adapter.go
@@ -106,6 +106,13 @@ func (a *APIPublicationAdapter) GetByName(_ context.Context, _ string) (Resource
 	return nil, nil
 }
 
+// GetByID gets an API publication by ID
+func (a *APIPublicationAdapter) GetByID(_ context.Context, _ string, _ *ExecutionContext) (ResourceInfo, error) {
+	// API publications don't have a direct "get by ID" method - they're singleton resources per API
+	// For now, return nil to indicate lookup by ID is not available
+	return nil, nil
+}
+
 // ResourceType returns the resource type name
 func (a *APIPublicationAdapter) ResourceType() string {
 	return "api_publication"
@@ -114,6 +121,24 @@ func (a *APIPublicationAdapter) ResourceType() string {
 // RequiredFields returns the required fields for creation
 func (a *APIPublicationAdapter) RequiredFields() []string {
 	return []string{"portal_id"}
+}
+
+// MapUpdateFields maps fields for update operations (not supported for API publications)
+func (a *APIPublicationAdapter) MapUpdateFields(
+	_ context.Context, _ *ExecutionContext, _ map[string]any,
+	_ *kkComps.APIPublication, _ map[string]string) error {
+	return fmt.Errorf("API publications do not support update operations")
+}
+
+// Update is not supported for API publications
+func (a *APIPublicationAdapter) Update(
+	_ context.Context, _ string, _ kkComps.APIPublication, _ string, _ *ExecutionContext) (string, error) {
+	return "", fmt.Errorf("API publications do not support update operations")
+}
+
+// SupportsUpdate returns false as API publications don't support updates
+func (a *APIPublicationAdapter) SupportsUpdate() bool {
+	return false
 }
 
 // getPortalIDFromExecutionContext extracts the portal ID from ExecutionContext parameter

--- a/internal/declarative/executor/auth_strategy_adapter.go
+++ b/internal/declarative/executor/auth_strategy_adapter.go
@@ -167,6 +167,13 @@ func (a *AuthStrategyAdapter) GetByName(ctx context.Context, name string) (Resou
 	return &AuthStrategyResourceInfo{strategy: strategy}, nil
 }
 
+// GetByID gets an auth strategy by ID
+func (a *AuthStrategyAdapter) GetByID(_ context.Context, _ string, _ *ExecutionContext) (ResourceInfo, error) {
+	// Use the existing GetByName approach since we don't have a direct GetByID in the client
+	// This is a fallback - the planner should handle ID lookups
+	return nil, nil
+}
+
 // ResourceType returns the resource type name
 func (a *AuthStrategyAdapter) ResourceType() string {
 	return "application_auth_strategy"

--- a/internal/declarative/executor/portal_adapter.go
+++ b/internal/declarative/executor/portal_adapter.go
@@ -176,6 +176,12 @@ func (p *PortalAdapter) GetByName(ctx context.Context, name string) (ResourceInf
 	return &PortalResourceInfo{portal: portal}, nil
 }
 
+// GetByID gets a portal by ID
+func (p *PortalAdapter) GetByID(_ context.Context, _ string, _ *ExecutionContext) (ResourceInfo, error) {
+	// Portals don't have a direct GetByID method - the planner handles ID lookups
+	return nil, nil
+}
+
 // ResourceType returns the resource type name
 func (p *PortalAdapter) ResourceType() string {
 	return "portal"

--- a/internal/declarative/executor/portal_customization_adapter.go
+++ b/internal/declarative/executor/portal_customization_adapter.go
@@ -229,3 +229,4 @@ func (p *PortalCustomizationAdapter) Update(ctx context.Context, portalID string
 func (p *PortalCustomizationAdapter) ResourceType() string {
 	return "portal_customization"
 }
+

--- a/internal/declarative/executor/portal_domain_adapter.go
+++ b/internal/declarative/executor/portal_domain_adapter.go
@@ -103,7 +103,7 @@ func (p *PortalDomainAdapter) GetByName(_ context.Context, _ string) (ResourceIn
 }
 
 // GetByID gets a portal custom domain by ID (portal ID in this case)
-func (p *PortalDomainAdapter) GetByID(_ context.Context, id string) (ResourceInfo, error) {
+func (p *PortalDomainAdapter) GetByID(_ context.Context, id string, _ *ExecutionContext) (ResourceInfo, error) {
 	// For custom domains, the ID is actually the portal ID since they're singleton resources
 	// The executor calls this with the resource ID from the planned change, which for 
 	// custom domains is the portal ID

--- a/internal/declarative/executor/portal_page_adapter.go
+++ b/internal/declarative/executor/portal_page_adapter.go
@@ -196,25 +196,20 @@ func (p *PortalPageAdapter) getPortalIDFromExecutionContext(execCtx *ExecutionCo
 }
 
 // GetByID gets a portal page by ID using portal context
-func (p *PortalPageAdapter) GetByID(ctx context.Context, id string) (ResourceInfo, error) {
-	// Get portal ID from context (this method still uses context anti-pattern temporarily)
-	if execCtxValue := ctx.Value("executionContext"); execCtxValue != nil {
-		if execCtx, ok := execCtxValue.(*ExecutionContext); ok {
-			portalID, err := p.getPortalIDFromExecutionContext(execCtx)
-			if err == nil {
-				// Use existing client method
-				page, err := p.client.GetPortalPage(ctx, portalID, id)
-				if err != nil {
-					return nil, fmt.Errorf("failed to get portal page: %w", err)
-				}
-				if page == nil {
-					return nil, nil
-				}
-				return &PortalPageResourceInfo{page: page}, nil
-			}
-		}
+func (p *PortalPageAdapter) GetByID(ctx context.Context, id string, execCtx *ExecutionContext) (ResourceInfo, error) {
+	portalID, err := p.getPortalIDFromExecutionContext(execCtx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get portal ID for page lookup: %w", err)
 	}
-	return nil, fmt.Errorf("failed to get portal ID for page lookup: execution context not found")
+
+	page, err := p.client.GetPortalPage(ctx, portalID, id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get portal page: %w", err)
+	}
+	if page == nil {
+		return nil, nil
+	}
+	return &PortalPageResourceInfo{page: page}, nil
 }
 
 // PortalPageResourceInfo implements ResourceInfo for portal pages

--- a/internal/declarative/executor/portal_snippet_adapter.go
+++ b/internal/declarative/executor/portal_snippet_adapter.go
@@ -138,26 +138,21 @@ func (p *PortalSnippetAdapter) GetByName(_ context.Context, _ string) (ResourceI
 }
 
 // GetByID gets a portal snippet by ID
-func (p *PortalSnippetAdapter) GetByID(ctx context.Context, id string) (ResourceInfo, error) {
-	// Get portal ID from context (this method still uses context anti-pattern temporarily)
-	if execCtxValue := ctx.Value("executionContext"); execCtxValue != nil {
-		if execCtx, ok := execCtxValue.(*ExecutionContext); ok {
-			portalID, err := p.getPortalID(execCtx)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get portal ID for snippet lookup: %w", err)
-			}
-			
-			snippet, err := p.client.GetPortalSnippet(ctx, portalID, id)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get portal snippet: %w", err)
-			}
-			if snippet == nil {
-				return nil, nil
-			}
-			return &PortalSnippetResourceInfo{snippet: snippet}, nil
-		}
+func (p *PortalSnippetAdapter) GetByID(
+	ctx context.Context, id string, execCtx *ExecutionContext) (ResourceInfo, error) {
+	portalID, err := p.getPortalID(execCtx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get portal ID for snippet lookup: %w", err)
 	}
-	return nil, fmt.Errorf("failed to get portal ID for snippet lookup: execution context not found")
+	
+	snippet, err := p.client.GetPortalSnippet(ctx, portalID, id)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get portal snippet: %w", err)
+	}
+	if snippet == nil {
+		return nil, nil
+	}
+	return &PortalSnippetResourceInfo{snippet: snippet}, nil
 }
 
 // ResourceType returns the resource type name

--- a/internal/declarative/resources/api_version.go
+++ b/internal/declarative/resources/api_version.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/kong/kongctl/internal/util/normalizers"
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 )
 
@@ -195,6 +196,13 @@ func (v *APIVersionResource) UnmarshalJSON(data []byte) error {
 			}
 			specContent = string(specJSON)
 		}
+		
+		// Normalize spec to JSON before storing
+		normalizedSpec, err := normalizers.SpecToJSON(specContent)
+		if err != nil {
+			return fmt.Errorf("failed to normalize spec: %w", err)
+		}
+		specContent = normalizedSpec
 		
 		sdkData["spec"] = map[string]any{
 			"content": specContent,

--- a/internal/konnect/helpers/api_versions.go
+++ b/internal/konnect/helpers/api_versions.go
@@ -20,6 +20,8 @@ type APIVersionAPI interface {
 		opts ...kkOps.Option) (*kkOps.UpdateAPIVersionResponse, error)
 	DeleteAPIVersion(ctx context.Context, apiID string, versionID string,
 		opts ...kkOps.Option) (*kkOps.DeleteAPIVersionResponse, error)
+	FetchAPIVersion(ctx context.Context, apiID string, versionID string,
+		opts ...kkOps.Option) (*kkOps.FetchAPIVersionResponse, error)
 }
 
 // APIVersionAPIImpl provides an implementation of the APIVersionAPI interface
@@ -82,6 +84,20 @@ func (a *APIVersionAPIImpl) DeleteAPIVersion(ctx context.Context, apiID string, 
 		return nil, fmt.Errorf("SDK.APIVersion is nil")
 	}
 	return a.SDK.APIVersion.DeleteAPIVersion(ctx, apiID, versionID, opts...)
+}
+
+// FetchAPIVersion implements the APIVersionAPI interface
+func (a *APIVersionAPIImpl) FetchAPIVersion(ctx context.Context, apiID string, versionID string,
+	opts ...kkOps.Option,
+) (*kkOps.FetchAPIVersionResponse, error) {
+	if a.SDK == nil {
+		return nil, fmt.Errorf("SDK is nil")
+	}
+
+	if a.SDK.APIVersion == nil {
+		return nil, fmt.Errorf("SDK.APIVersion is nil")
+	}
+	return a.SDK.APIVersion.FetchAPIVersion(ctx, apiID, versionID, opts...)
 }
 
 // GetVersionsForAPI fetches all version objects for a specific API


### PR DESCRIPTION
## Summary
- Implement API version update operations in executor 
- Fix resource validation for API version updates
- Add proper GetByID implementation using FetchAPIVersion

## Changes
- Switch APIVersionAdapter from BaseCreateDeleteExecutor to BaseExecutor
- Add api_version case to updateResource switch statement  
- Implement GetByID method in APIVersionAdapter using FetchAPIVersion
- Add NewAPIVersionResourceInfo helper function
- Include API reference resolution in update operations

## Test Plan
- [x] Build passes: `make build`
- [x] Linting passes: `make lint`
- [x] Tests pass: `make test`
- [x] Manual testing with declarative API version updates

Fixes #53
Fixes #55