### PR TITLE
fix: enable cross-namespace portal references in API publications

### DIFF
--- a/internal/declarative/planner/api_planner.go
+++ b/internal/declarative/planner/api_planner.go
@@ -46,7 +46,9 @@ func (a *apiPlannerImpl) PlanChanges(ctx context.Context, plannerCtx *Config, pl
 		return err
 	}
 	
-	if err := a.planner.planAPIPublicationsChanges(ctx, plannerCtx, a.GetDesiredAPIPublications(namespace), plan); err != nil {
+	if err := a.planner.planAPIPublicationsChanges(
+		ctx, plannerCtx, a.GetDesiredAPIPublications(namespace), plan,
+	); err != nil {
 		return err
 	}
 	

--- a/internal/declarative/planner/api_planner.go
+++ b/internal/declarative/planner/api_planner.go
@@ -29,8 +29,11 @@ func NewAPIPlanner(base *BasePlanner) APIPlanner {
 
 // PlanChanges generates changes for API resources and their child resources
 func (a *apiPlannerImpl) PlanChanges(ctx context.Context, plannerCtx *Config, plan *Plan) error {
+	// Get namespace from planner context
+	namespace := plannerCtx.Namespace
+	
 	// Debug logging
-	desiredAPIs := a.GetDesiredAPIs()
+	desiredAPIs := a.GetDesiredAPIs(namespace)
 	a.planner.logger.Debug("apiPlannerImpl.PlanChanges called", "desiredAPIs", len(desiredAPIs))
 	
 	// Plan API resources
@@ -39,21 +42,21 @@ func (a *apiPlannerImpl) PlanChanges(ctx context.Context, plannerCtx *Config, pl
 	}
 	
 	// Plan child resources that are defined separately
-	if err := a.planner.planAPIVersionsChanges(ctx, plannerCtx, a.GetDesiredAPIVersions(), plan); err != nil {
+	if err := a.planner.planAPIVersionsChanges(ctx, plannerCtx, a.GetDesiredAPIVersions(namespace), plan); err != nil {
 		return err
 	}
 	
-	if err := a.planner.planAPIPublicationsChanges(ctx, plannerCtx, a.GetDesiredAPIPublications(), plan); err != nil {
+	if err := a.planner.planAPIPublicationsChanges(ctx, plannerCtx, a.GetDesiredAPIPublications(namespace), plan); err != nil {
 		return err
 	}
 	
 	if err := a.planner.planAPIImplementationsChanges(
-		ctx, plannerCtx, a.GetDesiredAPIImplementations(), plan,
+		ctx, plannerCtx, a.GetDesiredAPIImplementations(namespace), plan,
 	); err != nil {
 		return err
 	}
 	
-	if err := a.planner.planAPIDocumentsChanges(ctx, plannerCtx, a.GetDesiredAPIDocuments(), plan); err != nil {
+	if err := a.planner.planAPIDocumentsChanges(ctx, plannerCtx, a.GetDesiredAPIDocuments(namespace), plan); err != nil {
 		return err
 	}
 	
@@ -552,7 +555,7 @@ func (p *Planner) planAPIVersionChanges(
 	if plan.Metadata.Mode == PlanModeSync {
 		// Check if there are extracted versions for this API that will be processed later
 		hasExtractedVersions := false
-		for _, ver := range p.desiredAPIVersions {
+		for _, ver := range p.resources.GetAPIVersionsByNamespace(parentNamespace) {
 			if ver.API == apiRef {
 				hasExtractedVersions = true
 				break
@@ -631,11 +634,8 @@ func (p *Planner) planAPIVersionCreate(
 	// Set API reference for executor - find the API name for lookup
 	if apiRef != "" {
 		var apiName string
-		for _, api := range p.desiredAPIs {
-			if api.Ref == apiRef {
-				apiName = api.Name
-				break
-			}
+		if api := p.resources.GetAPIByRef(apiRef); api != nil {
+			apiName = api.Name
 		}
 		
 		change.References = map[string]ReferenceInfo{
@@ -698,11 +698,11 @@ func (p *Planner) planAPIPublicationChanges(
 	portalIDToRef := make(map[string]string) // Reverse mapping for deletion display
 	
 	p.logger.Debug("Building portal reference mapping",
-		slog.Int("desired_portals", len(p.desiredPortals)),
+		slog.Int("desired_portals", len(p.resources.Portals)),
 	)
 	
-	// First, add desired portals to the mapping
-	for _, portal := range p.desiredPortals {
+	// First, add desired portals to the mapping (search all namespaces)
+	for _, portal := range p.resources.Portals {
 		if resolvedID := portal.GetKonnectID(); resolvedID != "" {
 			portalRefToID[portal.Ref] = resolvedID
 			portalIDToRef[resolvedID] = portal.Ref
@@ -726,7 +726,7 @@ func (p *Planner) planAPIPublicationChanges(
 				// Try to find the ref by matching name with desired portals
 				// If not found, use the portal name as a fallback ref
 				portalRef := portal.Name
-				for _, desiredPortal := range p.desiredPortals {
+				for _, desiredPortal := range p.resources.Portals {
 					if desiredPortal.Name == portal.Name {
 						portalRef = desiredPortal.Ref
 						break
@@ -789,7 +789,7 @@ func (p *Planner) planAPIPublicationChanges(
 	if plan.Metadata.Mode == PlanModeSync {
 		// Check if there are extracted publications for this API that will be processed later
 		hasExtractedPublications := false
-		for _, pub := range p.desiredAPIPublications {
+		for _, pub := range p.resources.GetAPIPublicationsByNamespace(parentNamespace) {
 			if pub.API == apiRef {
 				hasExtractedPublications = true
 				break
@@ -879,13 +879,10 @@ func (p *Planner) planAPIPublicationCreate(
 		Namespace:    parentNamespace,
 	}
 
-	// Look up portal name for reference resolution
+	// Look up portal name for reference resolution using global lookup
 	var portalName string
-	for _, portal := range p.desiredPortals {
-		if portal.Ref == publication.PortalID {
-			portalName = portal.Name
-			break
-		}
+	if portal := p.resources.GetPortalByRef(publication.PortalID); portal != nil {
+		portalName = portal.Name
 	}
 
 	// Set up references with lookup fields
@@ -894,11 +891,8 @@ func (p *Planner) planAPIPublicationCreate(
 	// Set API reference for executor - find the API name for lookup
 	if apiRef != "" {
 		var apiName string
-		for _, api := range p.desiredAPIs {
-			if api.Ref == apiRef {
-				apiName = api.Name
-				break
-			}
+		if api := p.resources.GetAPIByRef(apiRef); api != nil {
+			apiName = api.Name
 		}
 		
 		change.References["api_id"] = ReferenceInfo{
@@ -925,13 +919,10 @@ func (p *Planner) planAPIPublicationCreate(
 		// Look up names for each auth strategy reference
 		var authStrategyNames []string
 		for _, ref := range publication.AuthStrategyIds {
-			// Find the auth strategy in desired state
+			// Find the auth strategy in desired state using global lookup
 			var strategyName string
-			for _, strategy := range p.desiredAuthStrategies {
-				if strategy.Ref == ref {
-					strategyName = p.getAuthStrategyName(strategy)
-					break
-				}
+			if strategy := p.resources.GetAuthStrategyByRef(ref); strategy != nil {
+				strategyName = p.getAuthStrategyName(*strategy)
 			}
 			authStrategyNames = append(authStrategyNames, strategyName)
 		}
@@ -1007,13 +998,10 @@ func (p *Planner) planAPIPublicationUpdate(
 		Namespace:    parentNamespace,
 	}
 
-	// Look up portal name for reference resolution
+	// Look up portal name for reference resolution using global lookup
 	var portalName string
-	for _, portal := range p.desiredPortals {
-		if portal.Ref == desired.PortalID {
-			portalName = portal.Name
-			break
-		}
+	if portal := p.resources.GetPortalByRef(desired.PortalID); portal != nil {
+		portalName = portal.Name
 	}
 
 	// Set up references with lookup fields
@@ -1022,11 +1010,8 @@ func (p *Planner) planAPIPublicationUpdate(
 	// Set API reference
 	if apiRef != "" {
 		var apiName string
-		for _, api := range p.desiredAPIs {
-			if api.Ref == apiRef {
-				apiName = api.Name
-				break
-			}
+		if api := p.resources.GetAPIByRef(apiRef); api != nil {
+			apiName = api.Name
 		}
 		
 		change.References["api_id"] = ReferenceInfo{
@@ -1054,12 +1039,9 @@ func (p *Planner) planAPIPublicationUpdate(
 		// Extract auth strategy names for lookup
 		authStrategyNames := make([]string, 0, len(authStrategyIDs))
 		for _, strategyRef := range authStrategyIDs {
-			// Find the auth strategy by ref to get its name
-			for _, strategy := range p.desiredAuthStrategies {
-				if strategy.GetRef() == strategyRef {
-					authStrategyNames = append(authStrategyNames, p.getAuthStrategyName(strategy))
-					break
-				}
+			// Find the auth strategy by ref to get its name using global lookup
+			if strategy := p.resources.GetAuthStrategyByRef(strategyRef); strategy != nil {
+				authStrategyNames = append(authStrategyNames, p.getAuthStrategyName(*strategy))
 			}
 		}
 		
@@ -1220,11 +1202,8 @@ func (p *Planner) planAPIImplementationCreate(
 	// Set API reference for executor - find the API name for lookup
 	if apiRef != "" {
 		var apiName string
-		for _, api := range p.desiredAPIs {
-			if api.Ref == apiRef {
-				apiName = api.Name
-				break
-			}
+		if api := p.resources.GetAPIByRef(apiRef); api != nil {
+			apiName = api.Name
 		}
 		
 		change.References = map[string]ReferenceInfo{
@@ -1399,11 +1378,8 @@ func (p *Planner) planAPIVersionUpdate(
 	if apiRef != "" {
 		// Find the API to get its name for lookup
 		var apiName string
-		for _, api := range p.desiredAPIs {
-			if api.Ref == apiRef {
-				apiName = api.Name
-				break
-			}
+		if api := p.resources.GetAPIByRef(apiRef); api != nil {
+			apiName = api.Name
 		}
 		
 		change.References = map[string]ReferenceInfo{
@@ -1459,11 +1435,8 @@ func (p *Planner) planAPIDocumentCreate(
 	if apiRef != "" {
 		// Find the API to get its name for lookup
 		var apiName string
-		for _, api := range p.desiredAPIs {
-			if api.Ref == apiRef {
-				apiName = api.Name
-				break
-			}
+		if api := p.resources.GetAPIByRef(apiRef); api != nil {
+			apiName = api.Name
 		}
 		
 		change.References = map[string]ReferenceInfo{
@@ -1515,11 +1488,8 @@ func (p *Planner) planAPIDocumentUpdate(
 	if apiRef != "" {
 		// Find the API to get its name for lookup
 		var apiName string
-		for _, api := range p.desiredAPIs {
-			if api.Ref == apiRef {
-				apiName = api.Name
-				break
-			}
+		if api := p.resources.GetAPIByRef(apiRef); api != nil {
+			apiName = api.Name
 		}
 		
 		change.References = map[string]ReferenceInfo{
@@ -1556,11 +1526,8 @@ func (p *Planner) planAPIDocumentDelete(apiRef string, apiID string, documentID 
 	if apiRef != "" {
 		// Find the API to get its name for lookup
 		var apiName string
-		for _, api := range p.desiredAPIs {
-			if api.Ref == apiRef {
-				apiName = api.Name
-				break
-			}
+		if api := p.resources.GetAPIByRef(apiRef); api != nil {
+			apiName = api.Name
 		}
 		
 		change.References = map[string]ReferenceInfo{

--- a/internal/declarative/planner/auth_strategy_planner.go
+++ b/internal/declarative/planner/auth_strategy_planner.go
@@ -24,15 +24,14 @@ func NewAuthStrategyPlanner(base *BasePlanner) AuthStrategyPlanner {
 
 // PlanChanges generates changes for auth strategy resources
 func (p *authStrategyPlannerImpl) PlanChanges(ctx context.Context, plannerCtx *Config, plan *Plan) error {
-	desired := p.GetDesiredAuthStrategies()
+	// Get namespace from planner context
+	namespace := plannerCtx.Namespace
+	desired := p.GetDesiredAuthStrategies(namespace)
 	
 	// Skip if no auth strategies to plan and not in sync mode
 	if len(desired) == 0 && plan.Metadata.Mode != PlanModeSync {
 		return nil
 	}
-
-	// Get namespace from planner context
-	namespace := plannerCtx.Namespace
 	
 	// Fetch current managed auth strategies from the specific namespace
 	namespaceFilter := []string{namespace}

--- a/internal/declarative/planner/base_planner.go
+++ b/internal/declarative/planner/base_planner.go
@@ -54,59 +54,59 @@ func (b *BasePlanner) GetClient() *state.Client {
 	return b.planner.client
 }
 
-// GetDesiredPortals returns desired portal resources
-func (b *BasePlanner) GetDesiredPortals() []resources.PortalResource {
-	return b.planner.desiredPortals
+// GetDesiredPortals returns desired portal resources from the specified namespace
+func (b *BasePlanner) GetDesiredPortals(namespace string) []resources.PortalResource {
+	return b.planner.resources.GetPortalsByNamespace(namespace)
 }
 
-// GetDesiredAuthStrategies returns desired auth strategy resources
-func (b *BasePlanner) GetDesiredAuthStrategies() []resources.ApplicationAuthStrategyResource {
-	return b.planner.desiredAuthStrategies
+// GetDesiredAuthStrategies returns desired auth strategy resources from the specified namespace
+func (b *BasePlanner) GetDesiredAuthStrategies(namespace string) []resources.ApplicationAuthStrategyResource {
+	return b.planner.resources.GetAuthStrategiesByNamespace(namespace)
 }
 
-// GetDesiredAPIs returns desired API resources
-func (b *BasePlanner) GetDesiredAPIs() []resources.APIResource {
-	return b.planner.desiredAPIs
+// GetDesiredAPIs returns desired API resources from the specified namespace
+func (b *BasePlanner) GetDesiredAPIs(namespace string) []resources.APIResource {
+	return b.planner.resources.GetAPIsByNamespace(namespace)
 }
 
-// GetDesiredAPIVersions returns desired API version resources
-func (b *BasePlanner) GetDesiredAPIVersions() []resources.APIVersionResource {
-	return b.planner.desiredAPIVersions
+// GetDesiredAPIVersions returns desired API version resources from the specified namespace
+func (b *BasePlanner) GetDesiredAPIVersions(namespace string) []resources.APIVersionResource {
+	return b.planner.resources.GetAPIVersionsByNamespace(namespace)
 }
 
-// GetDesiredAPIPublications returns desired API publication resources
-func (b *BasePlanner) GetDesiredAPIPublications() []resources.APIPublicationResource {
-	return b.planner.desiredAPIPublications
+// GetDesiredAPIPublications returns desired API publication resources from the specified namespace
+func (b *BasePlanner) GetDesiredAPIPublications(namespace string) []resources.APIPublicationResource {
+	return b.planner.resources.GetAPIPublicationsByNamespace(namespace)
 }
 
-// GetDesiredAPIImplementations returns desired API implementation resources
-func (b *BasePlanner) GetDesiredAPIImplementations() []resources.APIImplementationResource {
-	return b.planner.desiredAPIImplementations
+// GetDesiredAPIImplementations returns desired API implementation resources from the specified namespace
+func (b *BasePlanner) GetDesiredAPIImplementations(namespace string) []resources.APIImplementationResource {
+	return b.planner.resources.GetAPIImplementationsByNamespace(namespace)
 }
 
-// GetDesiredAPIDocuments returns desired API document resources
-func (b *BasePlanner) GetDesiredAPIDocuments() []resources.APIDocumentResource {
-	return b.planner.desiredAPIDocuments
+// GetDesiredAPIDocuments returns desired API document resources from the specified namespace
+func (b *BasePlanner) GetDesiredAPIDocuments(namespace string) []resources.APIDocumentResource {
+	return b.planner.resources.GetAPIDocumentsByNamespace(namespace)
 }
 
-// GetDesiredPortalCustomizations returns desired portal customization resources
-func (b *BasePlanner) GetDesiredPortalCustomizations() []resources.PortalCustomizationResource {
-	return b.planner.desiredPortalCustomizations
+// GetDesiredPortalCustomizations returns desired portal customization resources from the specified namespace
+func (b *BasePlanner) GetDesiredPortalCustomizations(namespace string) []resources.PortalCustomizationResource {
+	return b.planner.resources.GetPortalCustomizationsByNamespace(namespace)
 }
 
-// GetDesiredPortalCustomDomains returns desired portal custom domain resources
-func (b *BasePlanner) GetDesiredPortalCustomDomains() []resources.PortalCustomDomainResource {
-	return b.planner.desiredPortalCustomDomains
+// GetDesiredPortalCustomDomains returns desired portal custom domain resources from the specified namespace
+func (b *BasePlanner) GetDesiredPortalCustomDomains(namespace string) []resources.PortalCustomDomainResource {
+	return b.planner.resources.GetPortalCustomDomainsByNamespace(namespace)
 }
 
-// GetDesiredPortalPages returns desired portal page resources
-func (b *BasePlanner) GetDesiredPortalPages() []resources.PortalPageResource {
-	return b.planner.desiredPortalPages
+// GetDesiredPortalPages returns desired portal page resources from the specified namespace
+func (b *BasePlanner) GetDesiredPortalPages(namespace string) []resources.PortalPageResource {
+	return b.planner.resources.GetPortalPagesByNamespace(namespace)
 }
 
-// GetDesiredPortalSnippets returns desired portal snippet resources
-func (b *BasePlanner) GetDesiredPortalSnippets() []resources.PortalSnippetResource {
-	return b.planner.desiredPortalSnippets
+// GetDesiredPortalSnippets returns desired portal snippet resources from the specified namespace
+func (b *BasePlanner) GetDesiredPortalSnippets(namespace string) []resources.PortalSnippetResource {
+	return b.planner.resources.GetPortalSnippetsByNamespace(namespace)
 }
 
 // GetGenericPlanner returns the generic planner instance

--- a/internal/declarative/planner/portal_planner.go
+++ b/internal/declarative/planner/portal_planner.go
@@ -23,15 +23,14 @@ func NewPortalPlanner(base *BasePlanner) PortalPlanner {
 
 // PlanChanges generates changes for portal resources
 func (p *portalPlannerImpl) PlanChanges(ctx context.Context, plannerCtx *Config, plan *Plan) error {
-	desired := p.GetDesiredPortals()
+	// Get namespace from planner context
+	namespace := plannerCtx.Namespace
+	desired := p.GetDesiredPortals(namespace)
 	
 	// Skip if no portals to plan and not in sync mode
 	if len(desired) == 0 && plan.Metadata.Mode != PlanModeSync {
 		return nil
 	}
-
-	// Get namespace from planner context
-	namespace := plannerCtx.Namespace
 	
 	// Fetch current managed portals from the specific namespace
 	namespaceFilter := []string{namespace}

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -166,3 +166,174 @@ func (rs *ResourceSet) GetResourceTypeByRef(ref string) (ResourceType, bool) {
 	return res.GetType(), true
 }
 
+// Global lookup methods - search across all namespaces
+
+// GetPortalByRef returns a portal resource by its ref from any namespace
+func (rs *ResourceSet) GetPortalByRef(ref string) *PortalResource {
+	for i := range rs.Portals {
+		if rs.Portals[i].GetRef() == ref {
+			return &rs.Portals[i]
+		}
+	}
+	return nil
+}
+
+// GetAPIByRef returns an API resource by its ref from any namespace
+func (rs *ResourceSet) GetAPIByRef(ref string) *APIResource {
+	for i := range rs.APIs {
+		if rs.APIs[i].GetRef() == ref {
+			return &rs.APIs[i]
+		}
+	}
+	return nil
+}
+
+// GetAuthStrategyByRef returns an auth strategy resource by its ref from any namespace
+func (rs *ResourceSet) GetAuthStrategyByRef(ref string) *ApplicationAuthStrategyResource {
+	for i := range rs.ApplicationAuthStrategies {
+		if rs.ApplicationAuthStrategies[i].GetRef() == ref {
+			return &rs.ApplicationAuthStrategies[i]
+		}
+	}
+	return nil
+}
+
+// Namespace-filtered access methods
+
+// GetPortalsByNamespace returns all portal resources from the specified namespace
+func (rs *ResourceSet) GetPortalsByNamespace(namespace string) []PortalResource {
+	var filtered []PortalResource
+	for _, portal := range rs.Portals {
+		if GetNamespace(portal.Kongctl) == namespace {
+			filtered = append(filtered, portal)
+		}
+	}
+	return filtered
+}
+
+// GetAPIsByNamespace returns all API resources from the specified namespace
+func (rs *ResourceSet) GetAPIsByNamespace(namespace string) []APIResource {
+	var filtered []APIResource
+	for _, api := range rs.APIs {
+		if GetNamespace(api.Kongctl) == namespace {
+			filtered = append(filtered, api)
+		}
+	}
+	return filtered
+}
+
+// GetAuthStrategiesByNamespace returns all auth strategy resources from the specified namespace
+func (rs *ResourceSet) GetAuthStrategiesByNamespace(namespace string) []ApplicationAuthStrategyResource {
+	var filtered []ApplicationAuthStrategyResource
+	for _, strategy := range rs.ApplicationAuthStrategies {
+		if GetNamespace(strategy.Kongctl) == namespace {
+			filtered = append(filtered, strategy)
+		}
+	}
+	return filtered
+}
+
+// GetAPIVersionsByNamespace returns all API version resources from the specified namespace
+func (rs *ResourceSet) GetAPIVersionsByNamespace(namespace string) []APIVersionResource {
+	var filtered []APIVersionResource
+	for _, version := range rs.APIVersions {
+		// Check if parent API is in the namespace
+		if api := rs.GetAPIByRef(version.API); api != nil && GetNamespace(api.Kongctl) == namespace {
+			filtered = append(filtered, version)
+		}
+	}
+	return filtered
+}
+
+// GetAPIPublicationsByNamespace returns all API publication resources from the specified namespace
+func (rs *ResourceSet) GetAPIPublicationsByNamespace(namespace string) []APIPublicationResource {
+	var filtered []APIPublicationResource
+	for _, pub := range rs.APIPublications {
+		// Check if parent API is in the namespace
+		if api := rs.GetAPIByRef(pub.API); api != nil && GetNamespace(api.Kongctl) == namespace {
+			filtered = append(filtered, pub)
+		}
+	}
+	return filtered
+}
+
+// GetAPIImplementationsByNamespace returns all API implementation resources from the specified namespace
+func (rs *ResourceSet) GetAPIImplementationsByNamespace(namespace string) []APIImplementationResource {
+	var filtered []APIImplementationResource
+	for _, impl := range rs.APIImplementations {
+		// Check if parent API is in the namespace
+		if api := rs.GetAPIByRef(impl.API); api != nil && GetNamespace(api.Kongctl) == namespace {
+			filtered = append(filtered, impl)
+		}
+	}
+	return filtered
+}
+
+// GetAPIDocumentsByNamespace returns all API document resources from the specified namespace
+func (rs *ResourceSet) GetAPIDocumentsByNamespace(namespace string) []APIDocumentResource {
+	var filtered []APIDocumentResource
+	for _, doc := range rs.APIDocuments {
+		// Check if parent API is in the namespace
+		if api := rs.GetAPIByRef(doc.API); api != nil && GetNamespace(api.Kongctl) == namespace {
+			filtered = append(filtered, doc)
+		}
+	}
+	return filtered
+}
+
+// GetPortalCustomizationsByNamespace returns all portal customization resources from the specified namespace
+func (rs *ResourceSet) GetPortalCustomizationsByNamespace(namespace string) []PortalCustomizationResource {
+	var filtered []PortalCustomizationResource
+	for _, custom := range rs.PortalCustomizations {
+		// Check if parent portal is in the namespace
+		if portal := rs.GetPortalByRef(custom.Portal); portal != nil && GetNamespace(portal.Kongctl) == namespace {
+			filtered = append(filtered, custom)
+		}
+	}
+	return filtered
+}
+
+// GetPortalCustomDomainsByNamespace returns all portal custom domain resources from the specified namespace
+func (rs *ResourceSet) GetPortalCustomDomainsByNamespace(namespace string) []PortalCustomDomainResource {
+	var filtered []PortalCustomDomainResource
+	for _, domain := range rs.PortalCustomDomains {
+		// Check if parent portal is in the namespace
+		if portal := rs.GetPortalByRef(domain.Portal); portal != nil && GetNamespace(portal.Kongctl) == namespace {
+			filtered = append(filtered, domain)
+		}
+	}
+	return filtered
+}
+
+// GetPortalPagesByNamespace returns all portal page resources from the specified namespace
+func (rs *ResourceSet) GetPortalPagesByNamespace(namespace string) []PortalPageResource {
+	var filtered []PortalPageResource
+	for _, page := range rs.PortalPages {
+		// Check if parent portal is in the namespace
+		if portal := rs.GetPortalByRef(page.Portal); portal != nil && GetNamespace(portal.Kongctl) == namespace {
+			filtered = append(filtered, page)
+		}
+	}
+	return filtered
+}
+
+// GetPortalSnippetsByNamespace returns all portal snippet resources from the specified namespace
+func (rs *ResourceSet) GetPortalSnippetsByNamespace(namespace string) []PortalSnippetResource {
+	var filtered []PortalSnippetResource
+	for _, snippet := range rs.PortalSnippets {
+		// Check if parent portal is in the namespace
+		if portal := rs.GetPortalByRef(snippet.Portal); portal != nil && GetNamespace(portal.Kongctl) == namespace {
+			filtered = append(filtered, snippet)
+		}
+	}
+	return filtered
+}
+
+// GetNamespace safely extracts namespace from kongctl metadata
+func GetNamespace(kongctl *KongctlMeta) string {
+	if kongctl == nil || kongctl.Namespace == nil {
+		return "default"
+	}
+	return *kongctl.Namespace
+}
+


### PR DESCRIPTION
## Summary

Fixes issue #58 where API publications fail when referencing portals in different namespaces.

## Problem

When creating API publications that reference portals in different namespaces, the planner would fail with "portal with ref 'test-portal' not found" even though the portal existed. This occurred because the planner only had access to namespace-filtered resources and couldn't see portals from other namespaces.

## Root Cause

The `planAPIPublicationCreate` function in `api_planner.go` was using namespace-filtered portal resources (`p.desiredPortals`) to look up portal references. When the referenced portal was in a different namespace, the lookup would fail.

## Solution

- Added global lookup methods to `ResourceSet` that search across all namespaces
- Added namespace-filtered access methods to `ResourceSet` for existing functionality  
- Updated planner to use single `ResourceSet` with both global and filtered capabilities
- Fixed portal reference resolution to use global lookup while maintaining namespace isolation for planning operations

## Changes

- **internal/declarative/resources/types.go**: Added global and namespace-filtered resource access methods
- **internal/declarative/planner/api_planner.go**: Fixed portal lookup to use global method
- **internal/declarative/planner/planner.go**: Refactored to use single ResourceSet
- **internal/declarative/planner/base_planner.go**: Updated methods to support namespace filtering
- **internal/declarative/planner/portal_planner.go**: Updated to use public GetNamespace function
- **internal/declarative/planner/auth_strategy_planner.go**: Updated to use public GetNamespace function

## Testing

- All existing tests pass
- Build succeeds with no compilation errors
- Solution is general enough to support cross-namespace references for all resource types

Resolves #58