### PR TITLE
fix: exit apply command with error if execution errors encountered

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: test-all
-test-all: fmt lint test
+test-all: fmt lint test test-integration
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
### Summary

Fixes #57 

If there are individual apply errors detected, the `apply` command should return an exit indicating this failure.

As a result, CI runners should consider the job execution to be a failure, which is better than the current false positives that happen

### Issues resolved

Fix false positive exit status when apply errors happen