### PR TITLE
api_docs: Adds parent-child relationship to API documents

### DIFF
--- a/internal/declarative/executor/api_document_adapter.go
+++ b/internal/declarative/executor/api_document_adapter.go
@@ -20,7 +20,7 @@ func NewAPIDocumentAdapter(client *state.Client) *APIDocumentAdapter {
 
 // MapCreateFields maps fields to CreateAPIDocumentRequest
 func (a *APIDocumentAdapter) MapCreateFields(
-	_ context.Context, _ *ExecutionContext, fields map[string]any,
+	_ context.Context, execCtx *ExecutionContext, fields map[string]any,
 	create *kkComps.CreateAPIDocumentRequest,
 ) error {
 	// Required fields
@@ -46,11 +46,25 @@ func (a *APIDocumentAdapter) MapCreateFields(
 		create.Status = &status
 	}
 
+	if execCtx != nil && execCtx.PlannedChange != nil {
+		if parentRef, ok := execCtx.PlannedChange.References["parent_document_id"]; ok {
+			if parentRef.ID != "" && parentRef.ID != "[unknown]" {
+				create.ParentDocumentID = &parentRef.ID
+			}
+		}
+	}
+
+	if create.ParentDocumentID == nil {
+		if parentID, ok := fields["parent_document_id"].(string); ok && parentID != "" {
+			create.ParentDocumentID = &parentID
+		}
+	}
+
 	return nil
 }
 
 // MapUpdateFields maps fields to APIDocument
-func (a *APIDocumentAdapter) MapUpdateFields(_ context.Context, _ *ExecutionContext, fields map[string]any,
+func (a *APIDocumentAdapter) MapUpdateFields(_ context.Context, execCtx *ExecutionContext, fields map[string]any,
 	update *kkComps.APIDocument, _ map[string]string,
 ) error {
 	// Optional fields - all fields are optional for updates
@@ -69,6 +83,20 @@ func (a *APIDocumentAdapter) MapUpdateFields(_ context.Context, _ *ExecutionCont
 	if statusStr, ok := fields["status"].(string); ok {
 		status := kkComps.APIDocumentStatus(statusStr)
 		update.Status = &status
+	}
+
+	if execCtx != nil && execCtx.PlannedChange != nil {
+		if parentRef, ok := execCtx.PlannedChange.References["parent_document_id"]; ok {
+			if parentRef.ID != "" && parentRef.ID != "[unknown]" {
+				update.ParentDocumentID = &parentRef.ID
+			}
+		}
+	}
+
+	if update.ParentDocumentID == nil {
+		if parentID, ok := fields["parent_document_id"].(string); ok && parentID != "" {
+			update.ParentDocumentID = &parentID
+		}
 	}
 
 	return nil

--- a/internal/declarative/loader/ref_resolver.go
+++ b/internal/declarative/loader/ref_resolver.go
@@ -194,6 +194,13 @@ func ResolveReferences(ctx context.Context, rs *resources.ResourceSet) error {
 		processCount++
 	}
 
+	for i := range rs.APIDocuments {
+		if err := resolveResourceFields(ctx, &rs.APIDocuments[i], rs, resolver, resolutionPath, logger); err != nil {
+			return fmt.Errorf("resolving api document %s: %w", rs.APIDocuments[i].GetRef(), err)
+		}
+		processCount++
+	}
+
 	logger.LogAttrs(ctx, slog.LevelDebug, "Reference resolution completed",
 		slog.Int("resources_processed", processCount),
 	)

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -279,6 +279,12 @@ func (l *Loader) validateCrossReferences(rs *resources.ResourceSet) error {
 		}
 	}
 
+	for i := range rs.APIDocuments {
+		if err := l.validateResourceReferences(&rs.APIDocuments[i], rs); err != nil {
+			return err
+		}
+	}
+
 	// Note: API versions don't have outbound references, so no validation needed
 
 	return nil

--- a/internal/declarative/resources/api_document.go
+++ b/internal/declarative/resources/api_document.go
@@ -61,9 +61,6 @@ func (d APIDocumentResource) GetReferenceFieldMappings() map[string]string {
 	if d.API != "" {
 		mappings["api"] = "api"
 	}
-	if d.ParentDocumentID != "" {
-		mappings["parent_document_id"] = "api_document"
-	}
 	if d.ParentDocumentRef != "" {
 		mappings["parent_document_ref"] = "api_document"
 	}

--- a/test/e2e/scenarios/portal/api_docs_with_children/expect/001-initial-apply/change-api-document-sms-errors.json
+++ b/test/e2e/scenarios/portal/api_docs_with_children/expect/001-initial-apply/change-api-document-sms-errors.json
@@ -1,0 +1,29 @@
+{
+  "resource_type": "api_document",
+  "resource_ref": "sms-errors",
+  "action": "CREATE",
+  "fields": {
+    "slug": "sms-errors",
+    "status": "published",
+    "title": "SMS API: Error Handling"
+  },
+  "references": {
+    "api_id": {
+      "ref": "sms",
+      "lookup_fields": {
+        "name": "SMS API"
+      }
+    },
+    "parent_document_id": {
+      "ref": "sms-webhooks",
+      "lookup_fields": {
+        "slug": "sms-errors",
+        "slug_path": "sms-webhooks"
+      }
+    }
+  },
+  "parent": {
+    "ref": "sms"
+  },
+  "namespace": "default"
+}

--- a/test/e2e/scenarios/portal/api_docs_with_children/expect/001-initial-apply/change-api-document-voice-authentication.json
+++ b/test/e2e/scenarios/portal/api_docs_with_children/expect/001-initial-apply/change-api-document-voice-authentication.json
@@ -1,25 +1,25 @@
 {
   "resource_type": "api_document",
-  "resource_ref": "sms-errors",
+  "resource_ref": "voice-authentication",
   "action": "CREATE",
   "fields": {
-    "slug": "sms-errors",
+    "slug": "voice-authentication",
     "status": "published",
-    "title": "SMS API: Error Handling"
+    "title": "Voice API: Authentication Guide"
   },
   "references": {
     "api_id": {
-      "ref": "sms",
+      "ref": "voice",
       "lookup_fields": {
-        "name": "SMS API"
+        "name": "Voice API"
       }
     },
     "parent_document_id": {
-      "ref": "sms-webhooks"
+      "ref": "voice-errors"
     }
   },
   "parent": {
-    "ref": "sms"
+    "ref": "voice"
   },
   "namespace": "default"
 }

--- a/test/e2e/scenarios/portal/api_docs_with_children/overlays/001-initial-apply/apis.yaml
+++ b/test/e2e/scenarios/portal/api_docs_with_children/overlays/001-initial-apply/apis.yaml
@@ -1,0 +1,90 @@
+apis:
+  - ref: sms
+    name: !file apis/sms/openapi.yaml#info.title
+    description: !file apis/sms/openapi.yaml#info.description
+    version: "3.2.0"
+    labels:
+      category: messaging
+      protocol: rest
+    
+    versions:
+      - ref: sms-v1
+        version: !file apis/sms/openapi.yaml#info.version
+        spec: !file apis/sms/openapi.yaml
+      - ref: sms-v2
+        version: !file apis/sms/openapi-v3.yaml#info.version
+        spec: !file apis/sms/openapi-v3.yaml
+       
+       
+    documents:
+      - ref: sms-getting-started
+        title: "SMS API: Getting Started"
+        slug: sms-getting-started
+        status: published
+        content: !file apis/sms/docs/getting-started.md
+        
+      - ref: sms-authentication
+        title: "SMS API: Authentication Guide"
+        slug: sms-authentication
+        status: published
+        content: !file apis/sms/docs/authentication.md
+        
+      - ref: sms-webhooks
+        title: "SMS API: Webhooks"
+        slug: sms-webhooks
+        status: published
+        content: !file apis/sms/docs/webhooks.md
+        children:
+          - ref: sms-errors
+            title: "SMS API: Error Handling"
+            slug: sms-errors
+            status: published
+            content: !file apis/sms/docs/errors.md
+        
+        
+    publications:
+      - ref: sms-api-to-getting-started
+        portal_id: !ref getting-started-portal#id
+        visibility: public
+
+  - ref: voice
+    name: !file apis/voice/openapi.yaml#info.title
+    description: !file apis/voice/openapi.yaml#info.description
+    labels:
+      category: voice
+      protocol: rest
+    
+    versions:
+      - ref: voice-api-v1
+        version: !file apis/voice/openapi.yaml#info.version
+        spec: !file apis/voice/openapi.yaml
+        
+    documents:
+      - ref: voice-getting-started
+        title: "Voice API: Getting Started"
+        slug: voice-getting-started
+        status: published
+        content: !file apis/voice/docs/getting-started.md
+      - ref: voice-ncco
+        title: "Voice API: NCCO Reference"
+        slug: voice-ncco
+        status: published
+        content: !file apis/voice/docs/ncco.md
+        children:
+        - ref: voice-errors
+          title: "Voice API: Error Handling"
+          slug: voice-errors
+          status: published
+          content: !file apis/voice/docs/errors.md
+          children:
+            - ref: voice-authentication
+              title: "Voice API: Authentication Guide"
+              slug: voice-authentication
+              status: published
+              content: !file apis/voice/docs/authentication.md
+        
+        
+    publications:
+      - ref: voice-api-to-getting-started
+        portal_id: !ref getting-started-portal#id
+        visibility: public

--- a/test/e2e/scenarios/portal/api_docs_with_children/scenario.yaml
+++ b/test/e2e/scenarios/portal/api_docs_with_children/scenario.yaml
@@ -1,0 +1,34 @@
+baseInputsPath: ../../../testdata/declarative/portal/full
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-initial-apply
+    inputOverlayDirs:
+      - overlays/001-initial-apply
+    commands:
+      - name: 000-apply
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - -f
+          - "{{ .workdir }}/apis.yaml"
+          - --auto-approve
+        assertions:
+          - select: >-
+              plan.changes[?resource_type=='api_document' &&
+                            resource_ref=='sms-errors'] | [0]
+            mask:
+              dropKeys:
+                - depends_on
+                - content
+                - id
+                - parent.id
+                - references.api_id
+                - references.parent_document_id.id
+            expect:
+              file: "expect/001-initial-apply/change-api-document-sms-errors.json" 

--- a/test/e2e/scenarios/portal/api_docs_with_children/scenario.yaml
+++ b/test/e2e/scenarios/portal/api_docs_with_children/scenario.yaml
@@ -18,17 +18,22 @@ steps:
           - -f
           - "{{ .workdir }}/apis.yaml"
           - --auto-approve
+        mask:
+          dropKeys:
+            - depends_on
+            - content
+            - id
+            - parent.id
+            - references.api_id
+            - references.parent_document_id.id
         assertions:
           - select: >-
               plan.changes[?resource_type=='api_document' &&
                             resource_ref=='sms-errors'] | [0]
-            mask:
-              dropKeys:
-                - depends_on
-                - content
-                - id
-                - parent.id
-                - references.api_id
-                - references.parent_document_id.id
             expect:
               file: "expect/001-initial-apply/change-api-document-sms-errors.json" 
+          - select: >-
+              plan.changes[?resource_type=='api_document' &&
+                            resource_ref=='voice-authentication'] | [0]
+            expect:
+              file: "expect/001-initial-apply/change-api-document-voice-authentication.json" 


### PR DESCRIPTION
## Summary

  - Enable declarative API documents to mirror portal page hierarchy by allowing nested children, flattening them during load, and tracking parent refs for validation.
  - Update planning to build slug-path indexes, add parent/child dependencies, and surface lookup metadata so multi-level document trees plan correctly.
  - Teach executor/state layers to cache API document trees, resolve parent document references before create/update, and propagate resolved IDs into adapter calls.

##  Technical Notes

  - APIDocumentResource now carries children and a parent_document_ref, with recursive validation/defaulting and custom unmarshal support.
  - Loader extracts nested docs from API blocks and root sections via extractAPIDocuments, pushes them through reference resolution, and expands validation.
  - Planner computes hierarchical slug paths (buildAPIDocumentPaths), enriches ReferenceInfo, and adds parent dependency edges when scheduling doc changes.
  - Executor populates cached API document trees, introduces resolveAPIDocumentRef, and ensures adapters map resolved parent IDs into SDK requests.

## Testing

- Adds e2d scenario which applies both single and multi-layer API document structures

Resolves #70 
