### PR TITLE
task: Temporarily disables create verb

### DIFF
--- a/docs/declarative-configuration.md
+++ b/docs/declarative-configuration.md
@@ -51,12 +51,7 @@ kongctl apply -f api-config.yaml
 
 #### Imperative (traditional CLI commands):
 
-_Note: Imperative command support is currently limited. The following 
-is conceptual._
-
-```bash
-kongctl create portal developer-portal
-```
+_Note: Imperative command support is currently focused on inspection workflows. Use declarative commands to provision or update Konnect resources._
 
 #### Declarative (configuration as code):
 ```yaml

--- a/internal/cmd/root/products/konnect/gateway/controlplane/controlplane.go
+++ b/internal/cmd/root/products/konnect/gateway/controlplane/controlplane.go
@@ -27,8 +27,8 @@ var (
 	%[1]s get konnect gateway control-planes
 	# Get a specific Konnect control plane
 	%[1]s get konnect gateway control-plane <id|name>
-	# Create a new Konnect control plane
-	%[1]s create konnect gateway control-plane <name>
+	# Use declarative workflows to provision new resources
+	%[1]s apply -f <config-file>
 	`, meta.CLIName)))
 )
 

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -12,7 +12,6 @@ import (
 	"github.com/kong/kongctl/internal/cmd"
 	"github.com/kong/kongctl/internal/cmd/common"
 	"github.com/kong/kongctl/internal/cmd/root/verbs/apply"
-	"github.com/kong/kongctl/internal/cmd/root/verbs/create"
 	"github.com/kong/kongctl/internal/cmd/root/verbs/del"
 	"github.com/kong/kongctl/internal/cmd/root/verbs/diff"
 	"github.com/kong/kongctl/internal/cmd/root/verbs/dump"
@@ -134,12 +133,6 @@ func addCommands() error {
 	rootCmd.AddCommand(c)
 
 	c, e = list.NewListCmd()
-	if e != nil {
-		return e
-	}
-	rootCmd.AddCommand(c)
-
-	c, e = create.NewCreateCmd()
 	if e != nil {
 		return e
 	}


### PR DESCRIPTION
Until broader support is provided, the existence of create is confusing. Users will utilize declarative configuration capabilities for the write side of resource management. get and list operations support reading imperatively.

resolves #76 
