### PR TITLE
feat: Updates CP management in decl configuration

### DIFF
--- a/docs/declarative-configuration.md
+++ b/docs/declarative-configuration.md
@@ -204,6 +204,26 @@ portals:
     display_name: "Developer Portal"
     description: "API documentation hub"
 
+# Define control planes
+control_planes:
+  - ref: prod-cp
+    name: "prod-control-plane"
+    description: "Production runtime group"
+    cluster_type: "CLUSTER_TYPE_CONTROL_PLANE"
+    auth_type: "pinned_client_certs"
+    proxy_urls:
+      - host: runtime.prod.example.com
+        port: 443
+        protocol: https
+    kongctl:
+      namespace: platform-prod
+      protected: true
+
+Control planes describe Konnect runtime control planes. 
+You can specify the cluster type (`CLUSTER_TYPE_CONTROL_PLANE`,`CLUSTER_TYPE_K8S_INGRESS_CONTROLLER`, etc.), 
+the mutual‑TLS authentication mode, whether the runtime should be marked as `cloud_gateway`, and optional `proxy_urls` entries for data plane
+connectivity. Like other parent resources, control planes support the full `kongctl` metadata block for namespace isolation and protection enforcement.
+
 # Define APIs
 apis:
   - ref: users-api

--- a/docs/examples/declarative/control-plane/README.md
+++ b/docs/examples/declarative/control-plane/README.md
@@ -1,0 +1,33 @@
+# Control Plane Example
+
+This example demonstrates how to manage Konnect control planes with `kongctl`
+declarative configuration. It shows how to provision them with different `kongctl`
+metadata and configuration details.
+
+## Files
+
+- `control-plane.yaml` – defines a production control plane and a staging control plane. The
+  example highlights:
+  - `cluster_type` and `auth_type` fields for runtime configuration
+  - optional `proxy_urls` entries that describe data plane endpoints
+  - use of `kongctl` metadata for namespaces and protection settings
+
+## Usage
+
+Preview the change set:
+
+```bash
+kongctl diff -f control-plane.yaml
+```
+
+Apply the configuration:
+
+```bash
+kongctl apply -f control-plane.yaml
+```
+
+Run in sync mode to delete unmanaged control planes in the namespace (use with caution):
+
+```bash
+kongctl sync -f control-plane.yaml
+```

--- a/docs/examples/declarative/control-plane/basic.yaml
+++ b/docs/examples/declarative/control-plane/basic.yaml
@@ -1,0 +1,5 @@
+control_planes:
+  - ref: e2e-cp
+    name: "kongctl-e2e-cp"
+    description: "Test Control Plane for E2E testing via kongctl"
+    cluster_type: "CLUSTER_TYPE_CONTROL_PLANE"

--- a/docs/examples/declarative/control-plane/control-plane.yaml
+++ b/docs/examples/declarative/control-plane/control-plane.yaml
@@ -1,0 +1,32 @@
+_defaults:
+  kongctl:
+    namespace: platform-shared
+    protected: false
+
+control_planes:
+  - ref: prod-cp
+    name: "production-control-plane"
+    description: "Production Konnect runtime group"
+    cluster_type: "CLUSTER_TYPE_CONTROL_PLANE"
+    auth_type: "pinned_client_certs"
+    proxy_urls:
+      - host: control.prod.example.com
+        port: 443
+        protocol: https
+    labels:
+      environment: production
+    kongctl:
+      namespace: platform-prod
+      protected: true
+
+  - ref: staging-cp
+    name: "staging-control-plane"
+    description: "Staging environment runtime group"
+    cluster_type: "CLUSTER_TYPE_CONTROL_PLANE"
+    cloud_gateway: true
+    proxy_urls:
+      - host: control.staging.example.com
+        port: 8443
+        protocol: https
+    labels:
+      environment: staging

--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -1443,9 +1443,10 @@ func runSync(command *cobra.Command, args []string) error {
 func createStateClient(kkClient helpers.SDKAPI) *state.Client {
 	return state.NewClient(state.ClientConfig{
 		// Core APIs
-		PortalAPI:  kkClient.GetPortalAPI(),
-		APIAPI:     kkClient.GetAPIAPI(),
-		AppAuthAPI: kkClient.GetAppAuthStrategiesAPI(),
+		PortalAPI:       kkClient.GetPortalAPI(),
+		APIAPI:          kkClient.GetAPIAPI(),
+		AppAuthAPI:      kkClient.GetAppAuthStrategiesAPI(),
+		ControlPlaneAPI: kkClient.GetControlPlaneAPI(),
 
 		// Portal child resource APIs
 		PortalPageAPI:          kkClient.GetPortalPageAPI(),

--- a/internal/declarative/executor/control_plane_adapter.go
+++ b/internal/declarative/executor/control_plane_adapter.go
@@ -1,0 +1,271 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/common"
+	"github.com/kong/kongctl/internal/declarative/labels"
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/kong/kongctl/internal/declarative/state"
+)
+
+// ControlPlaneAdapter implements ResourceOperations for control planes
+type ControlPlaneAdapter struct {
+	client *state.Client
+}
+
+// NewControlPlaneAdapter creates a new control plane adapter
+func NewControlPlaneAdapter(client *state.Client) *ControlPlaneAdapter {
+	return &ControlPlaneAdapter{client: client}
+}
+
+// MapCreateFields maps planner fields to CreateControlPlaneRequest
+func (a *ControlPlaneAdapter) MapCreateFields(_ context.Context, execCtx *ExecutionContext,
+	fields map[string]any, create *kkComps.CreateControlPlaneRequest,
+) error {
+	create.Name = common.ExtractResourceName(fields)
+	common.MapOptionalStringFieldToPtr(&create.Description, fields, "description")
+
+	if clusterType, ok := extractString(fields["cluster_type"]); ok {
+		value := kkComps.CreateControlPlaneRequestClusterType(clusterType)
+		create.ClusterType = &value
+	}
+
+	if authType, ok := extractString(fields["auth_type"]); ok {
+		value := kkComps.AuthType(authType)
+		create.AuthType = &value
+	}
+
+	if cloudGateway, ok := extractBool(fields["cloud_gateway"]); ok {
+		create.CloudGateway = &cloudGateway
+	}
+
+	if proxyValues, ok := fields["proxy_urls"]; ok && proxyValues != nil {
+		urls, err := convertProxyURLs(proxyValues)
+		if err != nil {
+			return fmt.Errorf("invalid proxy_urls value: %w", err)
+		}
+		create.ProxyUrls = urls
+	}
+
+	userLabels := labels.ExtractLabelsFromField(fields["labels"])
+	create.Labels = labels.BuildCreateLabels(userLabels, execCtx.Namespace, execCtx.Protection)
+
+	return nil
+}
+
+// MapUpdateFields maps planner fields to UpdateControlPlaneRequest
+func (a *ControlPlaneAdapter) MapUpdateFields(_ context.Context, execCtx *ExecutionContext,
+	fields map[string]any, update *kkComps.UpdateControlPlaneRequest, currentLabels map[string]string,
+) error {
+	for field, value := range fields {
+		switch field {
+		case "name":
+			if name, ok := value.(string); ok {
+				update.Name = &name
+			}
+		case "description":
+			if desc, ok := value.(string); ok {
+				update.Description = &desc
+			}
+		case "auth_type":
+			if auth, ok := extractString(value); ok {
+				typed := kkComps.UpdateControlPlaneRequestAuthType(auth)
+				update.AuthType = &typed
+			}
+		case "proxy_urls":
+			urls, err := convertProxyURLs(value)
+			if err != nil {
+				return fmt.Errorf("invalid proxy_urls value: %w", err)
+			}
+			update.ProxyUrls = urls
+		}
+	}
+
+	desiredLabels := labels.ExtractLabelsFromField(fields["labels"])
+	if plannerLabels := labels.ExtractLabelsFromField(fields[planner.FieldCurrentLabels]); plannerLabels != nil {
+		currentLabels = plannerLabels
+	}
+
+	if desiredLabels != nil {
+		update.Labels = labels.BuildUpdateStringLabels(desiredLabels, currentLabels, execCtx.Namespace, execCtx.Protection)
+	} else if currentLabels != nil {
+		update.Labels = labels.BuildUpdateStringLabels(currentLabels, currentLabels, execCtx.Namespace, execCtx.Protection)
+	}
+
+	return nil
+}
+
+// Create issues a create call via the state client
+func (a *ControlPlaneAdapter) Create(ctx context.Context, req kkComps.CreateControlPlaneRequest,
+	namespace string, _ *ExecutionContext,
+) (string, error) {
+	resp, err := a.client.CreateControlPlane(ctx, req, namespace)
+	if err != nil {
+		return "", err
+	}
+	return resp.ID, nil
+}
+
+// Update issues an update call via the state client
+func (a *ControlPlaneAdapter) Update(ctx context.Context, id string, req kkComps.UpdateControlPlaneRequest,
+	namespace string, _ *ExecutionContext,
+) (string, error) {
+	resp, err := a.client.UpdateControlPlane(ctx, id, req, namespace)
+	if err != nil {
+		return "", err
+	}
+	return resp.ID, nil
+}
+
+// Delete removes a control plane
+func (a *ControlPlaneAdapter) Delete(ctx context.Context, id string, _ *ExecutionContext) error {
+	return a.client.DeleteControlPlane(ctx, id)
+}
+
+// GetByName resolves a control plane by name
+func (a *ControlPlaneAdapter) GetByName(ctx context.Context, name string) (ResourceInfo, error) {
+	cp, err := a.client.GetControlPlaneByName(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if cp == nil {
+		return nil, nil
+	}
+	return &ControlPlaneResourceInfo{controlPlane: cp}, nil
+}
+
+// GetByID resolves a control plane by ID
+func (a *ControlPlaneAdapter) GetByID(ctx context.Context, id string, _ *ExecutionContext) (ResourceInfo, error) {
+	cp, err := a.client.GetControlPlaneByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if cp == nil {
+		return nil, nil
+	}
+	return &ControlPlaneResourceInfo{controlPlane: cp}, nil
+}
+
+// ResourceType returns the adapter resource type
+func (a *ControlPlaneAdapter) ResourceType() string {
+	return "control_plane"
+}
+
+// RequiredFields lists required fields for create
+func (a *ControlPlaneAdapter) RequiredFields() []string {
+	return []string{"name"}
+}
+
+// SupportsUpdate indicates control planes support updates
+func (a *ControlPlaneAdapter) SupportsUpdate() bool {
+	return true
+}
+
+// ControlPlaneResourceInfo implements ResourceInfo for control planes
+type ControlPlaneResourceInfo struct {
+	controlPlane *state.ControlPlane
+}
+
+func (c *ControlPlaneResourceInfo) GetID() string {
+	return c.controlPlane.ID
+}
+
+func (c *ControlPlaneResourceInfo) GetName() string {
+	return c.controlPlane.Name
+}
+
+func (c *ControlPlaneResourceInfo) GetLabels() map[string]string {
+	return c.controlPlane.Labels
+}
+
+func (c *ControlPlaneResourceInfo) GetNormalizedLabels() map[string]string {
+	return c.controlPlane.NormalizedLabels
+}
+
+func extractString(value any) (string, bool) {
+	if value == nil {
+		return "", false
+	}
+	if str, ok := value.(string); ok {
+		return str, true
+	}
+	return "", false
+}
+
+func extractBool(value any) (bool, bool) {
+	if value == nil {
+		return false, false
+	}
+	switch v := value.(type) {
+	case bool:
+		return v, true
+	case *bool:
+		if v == nil {
+			return false, false
+		}
+		return *v, true
+	default:
+		return false, false
+	}
+}
+
+func convertProxyURLs(value any) ([]kkComps.ProxyURL, error) {
+	if value == nil {
+		return nil, nil
+	}
+	if urls, ok := value.([]kkComps.ProxyURL); ok {
+		return urls, nil
+	}
+
+	switch items := value.(type) {
+	case []any:
+		return convertProxyInterfaceSlice(items)
+	case []map[string]any:
+		converted := make([]any, len(items))
+		for i := range items {
+			converted[i] = items[i]
+		}
+		return convertProxyInterfaceSlice(converted)
+	default:
+		return nil, fmt.Errorf("unsupported proxy_urls type %T", value)
+	}
+}
+
+func convertProxyInterfaceSlice(items []any) ([]kkComps.ProxyURL, error) {
+	urls := make([]kkComps.ProxyURL, 0, len(items))
+	for _, item := range items {
+		data, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("proxy url entry must be object, got %T", item)
+		}
+
+		host, _ := data["host"].(string)
+		protocol, _ := data["protocol"].(string)
+
+		portVal, hasPort := data["port"]
+		var port int64
+		if hasPort {
+			switch pv := portVal.(type) {
+			case int64:
+				port = pv
+			case int:
+				port = int64(pv)
+			case float64:
+				port = int64(pv)
+			default:
+				return nil, fmt.Errorf("invalid proxy url port type %T", portVal)
+			}
+		}
+
+		urls = append(urls, kkComps.ProxyURL{
+			Host:     host,
+			Port:     port,
+			Protocol: protocol,
+		})
+	}
+
+	return urls, nil
+}

--- a/internal/declarative/executor/control_plane_operations_test.go
+++ b/internal/declarative/executor/control_plane_operations_test.go
@@ -1,0 +1,117 @@
+package executor
+
+import (
+	"context"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/declarative/labels"
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/konnect/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestControlPlaneAdapter_MapCreateFields(t *testing.T) {
+	adapter := NewControlPlaneAdapter(nil)
+	execCtx := NewExecutionContext(&planner.PlannedChange{
+		Namespace:  "team-a",
+		Protection: true,
+	})
+
+	fields := map[string]any{
+		"name":          "cp-create",
+		"description":   "desc",
+		"cluster_type":  string(kkComps.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
+		"auth_type":     string(kkComps.AuthTypePinnedClientCerts),
+		"cloud_gateway": true,
+		"proxy_urls": []any{
+			map[string]any{"host": "example.com", "port": float64(443), "protocol": "https"},
+		},
+		"labels": map[string]any{"env": "prod"},
+	}
+
+	var req kkComps.CreateControlPlaneRequest
+	require.NoError(t, adapter.MapCreateFields(context.Background(), execCtx, fields, &req))
+	assert.Equal(t, "cp-create", req.Name)
+	require.NotNil(t, req.ClusterType)
+	assert.Equal(t, kkComps.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane, *req.ClusterType)
+	require.NotNil(t, req.AuthType)
+	assert.Equal(t, kkComps.AuthTypePinnedClientCerts, *req.AuthType)
+	require.NotNil(t, req.CloudGateway)
+	assert.True(t, *req.CloudGateway)
+	require.Len(t, req.ProxyUrls, 1)
+	assert.Equal(t, int64(443), req.ProxyUrls[0].Port)
+	assert.Equal(t, "team-a", req.Labels[labels.NamespaceKey])
+	assert.Equal(t, labels.TrueValue, req.Labels[labels.ProtectedKey])
+	assert.Equal(t, "prod", req.Labels["env"])
+}
+
+func TestControlPlaneAdapter_MapUpdateFields(t *testing.T) {
+	adapter := NewControlPlaneAdapter(nil)
+	execCtx := NewExecutionContext(&planner.PlannedChange{
+		Namespace:  "team-a",
+		Protection: false,
+	})
+
+	fields := map[string]any{
+		"description": "updated",
+		"auth_type":   string(kkComps.UpdateControlPlaneRequestAuthTypePkiClientCerts),
+		"proxy_urls":  []kkComps.ProxyURL{{Host: "example.com", Port: 8443, Protocol: "https"}},
+		"labels":      map[string]any{"env": "staging"},
+		planner.FieldCurrentLabels: map[string]any{
+			"env":               "prod",
+			labels.NamespaceKey: "team-a",
+		},
+	}
+
+	currentLabels := map[string]string{"env": "prod"}
+	var update kkComps.UpdateControlPlaneRequest
+	require.NoError(t, adapter.MapUpdateFields(context.Background(), execCtx, fields, &update, currentLabels))
+	require.NotNil(t, update.Description)
+	assert.Equal(t, "updated", *update.Description)
+	require.NotNil(t, update.AuthType)
+	assert.Equal(t, kkComps.UpdateControlPlaneRequestAuthTypePkiClientCerts, *update.AuthType)
+	require.Len(t, update.ProxyUrls, 1)
+	assert.Equal(t, int64(8443), update.ProxyUrls[0].Port)
+	require.NotNil(t, update.Labels)
+	assert.Equal(t, "team-a", update.Labels[labels.NamespaceKey])
+	assert.Equal(t, "staging", update.Labels["env"])
+}
+
+func TestControlPlaneAdapter_CreateUpdateDelete(t *testing.T) {
+	mockAPI := helpers.NewMockControlPlaneAPI(t)
+	createReq := kkComps.CreateControlPlaneRequest{Name: "cp"}
+	updateReq := kkComps.UpdateControlPlaneRequest{}
+
+	mockAPI.EXPECT().
+		CreateControlPlane(mock.Anything, createReq).
+		Return(&kkOps.CreateControlPlaneResponse{ControlPlane: &kkComps.ControlPlane{ID: "cp-1"}}, nil).
+		Once()
+
+	mockAPI.EXPECT().
+		UpdateControlPlane(mock.Anything, "cp-1", updateReq).
+		Return(&kkOps.UpdateControlPlaneResponse{ControlPlane: &kkComps.ControlPlane{ID: "cp-1"}}, nil).
+		Once()
+
+	mockAPI.EXPECT().
+		DeleteControlPlane(mock.Anything, "cp-1").
+		Return(&kkOps.DeleteControlPlaneResponse{}, nil).
+		Once()
+
+	client := state.NewClient(state.ClientConfig{ControlPlaneAPI: mockAPI})
+	adapter := NewControlPlaneAdapter(client)
+
+	id, err := adapter.Create(testContextWithLogger(), createReq, "team-a", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "cp-1", id)
+
+	id, err = adapter.Update(testContextWithLogger(), "cp-1", updateReq, "team-a", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "cp-1", id)
+
+	require.NoError(t, adapter.Delete(testContextWithLogger(), "cp-1", nil))
+}

--- a/internal/declarative/labels/labels.go
+++ b/internal/declarative/labels/labels.go
@@ -311,6 +311,32 @@ func BuildUpdateLabels(
 	return result
 }
 
+// BuildUpdateStringLabels prepares labels for update operations that expect map[string]string
+// Nil values in the pointer-based representation are treated as deletions and thus omitted
+func BuildUpdateStringLabels(
+	desiredLabels, currentLabels map[string]string,
+	namespace string,
+	protection any,
+) map[string]string {
+	updated := BuildUpdateLabels(desiredLabels, currentLabels, namespace, protection)
+	if len(updated) == 0 {
+		return nil
+	}
+
+	result := make(map[string]string)
+	for k, v := range updated {
+		if v != nil {
+			result[k] = *v
+		}
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
+
+	return result
+}
+
 // getProtectionNewValue uses reflection to get the New field from a ProtectionChange
 // This avoids circular dependency with the planner package
 func getProtectionNewValue(protection any) bool {

--- a/internal/declarative/planner/base_planner.go
+++ b/internal/declarative/planner/base_planner.go
@@ -59,6 +59,11 @@ func (b *BasePlanner) GetDesiredPortals(namespace string) []resources.PortalReso
 	return b.planner.resources.GetPortalsByNamespace(namespace)
 }
 
+// GetDesiredControlPlanes returns desired control plane resources from the specified namespace
+func (b *BasePlanner) GetDesiredControlPlanes(namespace string) []resources.ControlPlaneResource {
+	return b.planner.resources.GetControlPlanesByNamespace(namespace)
+}
+
 // GetDesiredAuthStrategies returns desired auth strategy resources from the specified namespace
 func (b *BasePlanner) GetDesiredAuthStrategies(namespace string) []resources.ApplicationAuthStrategyResource {
 	return b.planner.resources.GetAuthStrategiesByNamespace(namespace)

--- a/internal/declarative/planner/control_plane_planner.go
+++ b/internal/declarative/planner/control_plane_planner.go
@@ -1,0 +1,381 @@
+package planner
+
+import (
+	"context"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/labels"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+)
+
+// controlPlanePlannerImpl implements planning logic for control plane resources
+type controlPlanePlannerImpl struct {
+	*BasePlanner
+}
+
+// NewControlPlanePlanner creates a new control plane planner
+func NewControlPlanePlanner(base *BasePlanner) ControlPlanePlanner {
+	return &controlPlanePlannerImpl{BasePlanner: base}
+}
+
+// PlanChanges generates changes for control plane resources
+func (p *controlPlanePlannerImpl) PlanChanges(ctx context.Context, plannerCtx *Config, plan *Plan) error {
+	namespace := plannerCtx.Namespace
+	desired := p.GetDesiredControlPlanes(namespace)
+
+	if len(desired) == 0 && plan.Metadata.Mode != PlanModeSync {
+		return nil
+	}
+
+	currentControlPlanes, err := p.GetClient().ListManagedControlPlanes(ctx, []string{namespace})
+	if err != nil {
+		if state.IsAPIClientError(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to list current control planes in namespace %s: %w", namespace, err)
+	}
+
+	currentByName := make(map[string]state.ControlPlane)
+	for _, cp := range currentControlPlanes {
+		currentByName[cp.Name] = cp
+	}
+
+	protectionErrors := &ProtectionErrorCollector{}
+
+	for _, desiredCP := range desired {
+		current, exists := currentByName[desiredCP.Name]
+		desiredProtected := isProtected(desiredCP)
+
+		if !exists {
+			p.planControlPlaneCreate(desiredCP, desiredProtected, plan)
+			continue
+		}
+
+		currentProtected := labels.IsProtectedResource(current.NormalizedLabels)
+		needsUpdate, updateFields := p.shouldUpdateControlPlane(current, desiredCP)
+
+		if currentProtected != desiredProtected {
+			protectionChange := &ProtectionChange{Old: currentProtected, New: desiredProtected}
+			err := p.ValidateProtectionWithChange(
+				"control_plane", desiredCP.Name, currentProtected, ActionUpdate, protectionChange, needsUpdate,
+			)
+			protectionErrors.Add(err)
+			if err == nil {
+				p.planControlPlaneProtectionChangeWithFields(current, desiredCP, protectionChange, updateFields, plan)
+			}
+			continue
+		}
+
+		if needsUpdate {
+			err := p.ValidateProtection("control_plane", desiredCP.Name, currentProtected, ActionUpdate)
+			protectionErrors.Add(err)
+			if err == nil {
+				p.planControlPlaneUpdate(current, desiredCP, updateFields, plan)
+			}
+		}
+	}
+
+	if plan.Metadata.Mode == PlanModeSync {
+		desiredNames := make(map[string]struct{})
+		for _, cp := range desired {
+			desiredNames[cp.Name] = struct{}{}
+		}
+
+		for name, current := range currentByName {
+			if _, ok := desiredNames[name]; ok {
+				continue
+			}
+
+			isProtected := labels.IsProtectedResource(current.NormalizedLabels)
+			err := p.ValidateProtection("control_plane", name, isProtected, ActionDelete)
+			protectionErrors.Add(err)
+			if err == nil {
+				p.planControlPlaneDelete(current, plan)
+			}
+		}
+	}
+
+	if protectionErrors.HasErrors() {
+		return protectionErrors.Error()
+	}
+
+	return nil
+}
+
+func (p *controlPlanePlannerImpl) planControlPlaneCreate(
+	desired resources.ControlPlaneResource,
+	protected bool,
+	plan *Plan,
+) {
+	fields := extractControlPlaneFields(desired)
+
+	namespace := resources.GetNamespace(desired.Kongctl)
+	config := CreateConfig{
+		ResourceType:   "control_plane",
+		ResourceName:   desired.Name,
+		ResourceRef:    desired.GetRef(),
+		RequiredFields: []string{"name"},
+		FieldExtractor: func(_ any) map[string]any { return fields },
+		Namespace:      namespace,
+	}
+
+	generic := p.GetGenericPlanner()
+	if generic != nil {
+		change, err := generic.PlanCreate(context.Background(), config)
+		if err == nil {
+			change.Protection = protected
+			plan.AddChange(change)
+			return
+		}
+
+		p.planner.logger.Error("Failed to plan control plane create", "error", err.Error())
+	}
+
+	changeID := p.NextChangeID(ActionCreate, "control_plane", desired.GetRef())
+	plan.AddChange(PlannedChange{
+		ID:           changeID,
+		ResourceType: "control_plane",
+		ResourceRef:  desired.GetRef(),
+		Action:       ActionCreate,
+		Fields:       fields,
+		Namespace:    namespace,
+		Protection:   protected,
+	})
+}
+
+func (p *controlPlanePlannerImpl) planControlPlaneUpdate(
+	current state.ControlPlane,
+	desired resources.ControlPlaneResource,
+	updateFields map[string]any,
+	plan *Plan,
+) {
+	// Always include name for identification
+	updateFields["name"] = current.Name
+
+	if _, hasLabels := updateFields["labels"]; hasLabels {
+		updateFields[FieldCurrentLabels] = current.NormalizedLabels
+	}
+
+	namespace := resources.GetNamespace(desired.Kongctl)
+	config := UpdateConfig{
+		ResourceType:   "control_plane",
+		ResourceName:   desired.Name,
+		ResourceRef:    desired.GetRef(),
+		ResourceID:     current.ID,
+		DesiredFields:  updateFields,
+		RequiredFields: []string{"name"},
+		Namespace:      namespace,
+	}
+
+	generic := p.GetGenericPlanner()
+	if generic != nil {
+		change, err := generic.PlanUpdate(context.Background(), config)
+		if err == nil {
+			if labels.IsProtectedResource(current.NormalizedLabels) {
+				change.Protection = true
+			}
+			plan.AddChange(change)
+			return
+		}
+		p.planner.logger.Error("Failed to plan control plane update", "error", err.Error())
+	}
+
+	fields := make(map[string]any)
+	for key, value := range updateFields {
+		fields[key] = value
+	}
+
+	changeID := p.NextChangeID(ActionUpdate, "control_plane", desired.GetRef())
+	change := PlannedChange{
+		ID:           changeID,
+		ResourceType: "control_plane",
+		ResourceRef:  desired.GetRef(),
+		ResourceID:   current.ID,
+		Action:       ActionUpdate,
+		Fields:       fields,
+		Namespace:    namespace,
+	}
+
+	if labels.IsProtectedResource(current.NormalizedLabels) {
+		change.Protection = true
+	}
+
+	plan.AddChange(change)
+}
+
+func (p *controlPlanePlannerImpl) planControlPlaneProtectionChangeWithFields(
+	current state.ControlPlane,
+	desired resources.ControlPlaneResource,
+	protectionChange *ProtectionChange,
+	updateFields map[string]any,
+	plan *Plan,
+) {
+	namespace := resources.GetNamespace(desired.Kongctl)
+	config := ProtectionChangeConfig{
+		ResourceType: "control_plane",
+		ResourceName: desired.Name,
+		ResourceRef:  desired.GetRef(),
+		ResourceID:   current.ID,
+		OldProtected: protectionChange.Old,
+		NewProtected: protectionChange.New,
+		Namespace:    namespace,
+	}
+
+	generic := p.GetGenericPlanner()
+	change := PlannedChange{}
+	if generic != nil {
+		change = generic.PlanProtectionChange(context.Background(), config)
+	} else {
+		changeID := p.NextChangeID(ActionUpdate, "control_plane", desired.GetRef())
+		change = PlannedChange{
+			ID:           changeID,
+			ResourceType: "control_plane",
+			ResourceRef:  desired.GetRef(),
+			ResourceID:   current.ID,
+			Action:       ActionUpdate,
+			Protection:   *protectionChange,
+			Namespace:    namespace,
+		}
+	}
+
+	fields := map[string]any{"name": current.Name}
+
+	if protectionChange.Old && !protectionChange.New && len(updateFields) > 0 {
+		for key, value := range updateFields {
+			fields[key] = value
+		}
+		if _, hasLabels := updateFields["labels"]; hasLabels {
+			fields[FieldCurrentLabels] = current.NormalizedLabels
+		}
+	}
+
+	change.Fields = fields
+	plan.AddChange(change)
+}
+
+func (p *controlPlanePlannerImpl) planControlPlaneDelete(current state.ControlPlane, plan *Plan) {
+	namespace := DefaultNamespace
+	if ns, ok := current.NormalizedLabels[labels.NamespaceKey]; ok {
+		namespace = ns
+	}
+
+	generic := p.GetGenericPlanner()
+	if generic != nil {
+		config := DeleteConfig{
+			ResourceType: "control_plane",
+			ResourceName: current.Name,
+			ResourceRef:  current.Name,
+			ResourceID:   current.ID,
+			Namespace:    namespace,
+		}
+		change := generic.PlanDelete(context.Background(), config)
+		change.Fields = map[string]any{"name": current.Name}
+		plan.AddChange(change)
+		return
+	}
+
+	changeID := p.NextChangeID(ActionDelete, "control_plane", current.Name)
+	plan.AddChange(PlannedChange{
+		ID:           changeID,
+		ResourceType: "control_plane",
+		ResourceRef:  current.Name,
+		ResourceID:   current.ID,
+		Action:       ActionDelete,
+		Fields:       map[string]any{"name": current.Name},
+		Namespace:    namespace,
+	})
+}
+
+func (p *controlPlanePlannerImpl) shouldUpdateControlPlane(
+	current state.ControlPlane,
+	desired resources.ControlPlaneResource,
+) (bool, map[string]any) {
+	updates := make(map[string]any)
+
+	if desired.Description != nil {
+		currentDesc := ""
+		if current.Description != nil {
+			currentDesc = *current.Description
+		}
+		if currentDesc != *desired.Description {
+			updates["description"] = *desired.Description
+		}
+	}
+
+	if desired.AuthType != nil {
+		desiredAuth := string(*desired.AuthType)
+		if desiredAuth != "" && desiredAuth != string(current.Config.AuthType) {
+			updates["auth_type"] = desiredAuth
+		}
+	}
+
+	if desired.ProxyUrls != nil {
+		if !proxyURLsEqual(current.Config.ProxyUrls, desired.ProxyUrls) {
+			updates["proxy_urls"] = desired.ProxyUrls
+		}
+	}
+
+	if desired.Labels != nil {
+		if labels.CompareUserLabels(current.NormalizedLabels, desired.Labels) {
+			updates["labels"] = desired.Labels
+		}
+	}
+
+	return len(updates) > 0, updates
+}
+
+func extractControlPlaneFields(cp resources.ControlPlaneResource) map[string]any {
+	fields := make(map[string]any)
+	fields["name"] = cp.Name
+
+	if cp.Description != nil {
+		fields["description"] = *cp.Description
+	}
+
+	if cp.ClusterType != nil {
+		fields["cluster_type"] = string(*cp.ClusterType)
+	}
+
+	if cp.AuthType != nil {
+		fields["auth_type"] = string(*cp.AuthType)
+	}
+
+	if cp.CloudGateway != nil {
+		fields["cloud_gateway"] = *cp.CloudGateway
+	}
+
+	if cp.ProxyUrls != nil {
+		fields["proxy_urls"] = cp.ProxyUrls
+	}
+
+	if cp.Labels != nil {
+		fields["labels"] = cp.Labels
+	}
+
+	return fields
+}
+
+func proxyURLsEqual(current, desired []kkComps.ProxyURL) bool {
+	if len(current) != len(desired) {
+		return false
+	}
+
+	for i := range current {
+		if current[i].Host != desired[i].Host ||
+			current[i].Port != desired[i].Port ||
+			current[i].Protocol != desired[i].Protocol {
+			return false
+		}
+	}
+
+	return true
+}
+
+func isProtected(cp resources.ControlPlaneResource) bool {
+	if cp.Kongctl != nil && cp.Kongctl.Protected != nil {
+		return *cp.Kongctl.Protected
+	}
+	return false
+}

--- a/internal/declarative/planner/control_plane_planner_test.go
+++ b/internal/declarative/planner/control_plane_planner_test.go
@@ -1,0 +1,231 @@
+package planner
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/declarative/labels"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/konnect/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestControlPlanePlanner_PlanCreate(t *testing.T) {
+	mockAPI := helpers.NewMockControlPlaneAPI(t)
+	mockAPI.EXPECT().
+		ListControlPlanes(mock.Anything, mock.Anything).
+		Return(newListControlPlaneResponse(nil, 0), nil).
+		Once()
+
+	client := state.NewClient(state.ClientConfig{ControlPlaneAPI: mockAPI})
+	planner := &Planner{
+		client: client,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	planner.genericPlanner = NewGenericPlanner(planner)
+	planner.resources = &resources.ResourceSet{
+		ControlPlanes: []resources.ControlPlaneResource{
+			{
+				CreateControlPlaneRequest: kkComps.CreateControlPlaneRequest{
+					Name:        "cp-create",
+					Description: strPtr("Control Plane"),
+				},
+				Ref: "cp-create",
+				Kongctl: &resources.KongctlMeta{
+					Namespace: strPtr("default"),
+				},
+			},
+		},
+	}
+
+	base := NewBasePlanner(planner)
+	cpPlanner := NewControlPlanePlanner(base)
+
+	plan := NewPlan("1.0", "test", PlanModeApply)
+	err := cpPlanner.PlanChanges(context.Background(), NewConfig("default"), plan)
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+
+	change := plan.Changes[0]
+	assert.Equal(t, ActionCreate, change.Action)
+	assert.Equal(t, "control_plane", change.ResourceType)
+	assert.Equal(t, "default", change.Namespace)
+	assert.Equal(t, "cp-create", change.Fields["name"])
+	assert.Equal(t, false, change.Protection)
+}
+
+func TestControlPlanePlanner_PlanUpdate(t *testing.T) {
+	mockAPI := helpers.NewMockControlPlaneAPI(t)
+	current := kkComps.ControlPlane{
+		ID:          "cp-1",
+		Name:        "cp-update",
+		Description: strPtr("old"),
+		Labels: map[string]string{
+			labels.NamespaceKey: "default",
+		},
+		Config: kkComps.Config{
+			AuthType:    kkComps.ControlPlaneAuthTypePinnedClientCerts,
+			ProxyUrls:   []kkComps.ProxyURL{{Host: "example.com", Port: 443, Protocol: "https"}},
+			ClusterType: kkComps.ControlPlaneClusterTypeClusterTypeControlPlane,
+		},
+	}
+
+	resp := newListControlPlaneResponse([]kkComps.ControlPlane{current}, 1)
+	mockAPI.EXPECT().
+		ListControlPlanes(mock.Anything, mock.Anything).
+		Return(resp, nil).
+		Once()
+
+	client := state.NewClient(state.ClientConfig{ControlPlaneAPI: mockAPI})
+	planner := &Planner{
+		client: client,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	planner.genericPlanner = NewGenericPlanner(planner)
+	planner.resources = &resources.ResourceSet{
+		ControlPlanes: []resources.ControlPlaneResource{
+			{
+				CreateControlPlaneRequest: kkComps.CreateControlPlaneRequest{
+					Name:        "cp-update",
+					Description: strPtr("new"),
+					ProxyUrls:   []kkComps.ProxyURL{{Host: "example.com", Port: 8443, Protocol: "https"}},
+				},
+				Ref: "cp-update",
+				Kongctl: &resources.KongctlMeta{
+					Namespace: strPtr("default"),
+				},
+			},
+		},
+	}
+
+	base := NewBasePlanner(planner)
+	cpPlanner := NewControlPlanePlanner(base)
+
+	plan := NewPlan("1.0", "test", PlanModeApply)
+	err := cpPlanner.PlanChanges(context.Background(), NewConfig("default"), plan)
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+
+	change := plan.Changes[0]
+	assert.Equal(t, ActionUpdate, change.Action)
+	assert.Equal(t, "cp-update", change.ResourceRef)
+	assert.Equal(t, "cp-1", change.ResourceID)
+	assert.Equal(t, "new", change.Fields["description"])
+	assert.Equal(t, []kkComps.ProxyURL{{Host: "example.com", Port: 8443, Protocol: "https"}}, change.Fields["proxy_urls"])
+	assert.Nil(t, change.Protection)
+}
+
+func TestControlPlanePlanner_PlanDeleteSync(t *testing.T) {
+	mockAPI := helpers.NewMockControlPlaneAPI(t)
+	current := kkComps.ControlPlane{
+		ID:   "cp-delete",
+		Name: "cp-delete",
+		Labels: map[string]string{
+			labels.NamespaceKey: "default",
+		},
+	}
+
+	resp := newListControlPlaneResponse([]kkComps.ControlPlane{current}, 1)
+	mockAPI.EXPECT().
+		ListControlPlanes(mock.Anything, mock.Anything).
+		Return(resp, nil).
+		Once()
+
+	client := state.NewClient(state.ClientConfig{ControlPlaneAPI: mockAPI})
+	planner := &Planner{
+		client: client,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	planner.genericPlanner = NewGenericPlanner(planner)
+	planner.resources = &resources.ResourceSet{ControlPlanes: []resources.ControlPlaneResource{}}
+
+	base := NewBasePlanner(planner)
+	cpPlanner := NewControlPlanePlanner(base)
+
+	plan := NewPlan("1.0", "test", PlanModeSync)
+	err := cpPlanner.PlanChanges(context.Background(), NewConfig("default"), plan)
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	assert.Equal(t, ActionDelete, plan.Changes[0].Action)
+	assert.Equal(t, "cp-delete", plan.Changes[0].ResourceRef)
+}
+
+func TestControlPlanePlanner_ProtectionChange(t *testing.T) {
+	mockAPI := helpers.NewMockControlPlaneAPI(t)
+	current := kkComps.ControlPlane{
+		ID:   "cp-protect",
+		Name: "cp-protect",
+		Labels: map[string]string{
+			labels.NamespaceKey: "default",
+		},
+	}
+
+	resp := newListControlPlaneResponse([]kkComps.ControlPlane{current}, 1)
+	mockAPI.EXPECT().
+		ListControlPlanes(mock.Anything, mock.Anything).
+		Return(resp, nil).
+		Once()
+
+	client := state.NewClient(state.ClientConfig{ControlPlaneAPI: mockAPI})
+	planner := &Planner{
+		client: client,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	planner.genericPlanner = NewGenericPlanner(planner)
+	planner.resources = &resources.ResourceSet{
+		ControlPlanes: []resources.ControlPlaneResource{
+			{
+				CreateControlPlaneRequest: kkComps.CreateControlPlaneRequest{
+					Name: "cp-protect",
+				},
+				Ref: "cp-protect",
+				Kongctl: &resources.KongctlMeta{
+					Namespace: strPtr("default"),
+					Protected: boolPtr(true),
+				},
+			},
+		},
+	}
+
+	base := NewBasePlanner(planner)
+	cpPlanner := NewControlPlanePlanner(base)
+
+	plan := NewPlan("1.0", "test", PlanModeApply)
+	err := cpPlanner.PlanChanges(context.Background(), NewConfig("default"), plan)
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+
+	change := plan.Changes[0]
+	assert.Equal(t, ActionUpdate, change.Action)
+	assert.IsType(t, ProtectionChange{}, change.Protection)
+	pc := change.Protection.(ProtectionChange)
+	assert.False(t, pc.Old)
+	assert.True(t, pc.New)
+	assert.Equal(t, "cp-protect", change.Fields["name"])
+}
+
+func newListControlPlaneResponse(data []kkComps.ControlPlane, total float64) *kkOps.ListControlPlanesResponse {
+	return &kkOps.ListControlPlanesResponse{
+		ListControlPlanesResponse: &kkComps.ListControlPlanesResponse{
+			Data: data,
+			Meta: kkComps.PaginatedMeta{
+				Page: kkComps.PageMeta{Total: total},
+			},
+		},
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/internal/declarative/planner/interfaces.go
+++ b/internal/declarative/planner/interfaces.go
@@ -17,6 +17,11 @@ type PortalPlanner interface {
 	// Additional portal-specific methods if needed
 }
 
+// ControlPlanePlanner handles planning for control plane resources
+type ControlPlanePlanner interface {
+	ResourcePlanner
+}
+
 // AuthStrategyPlanner handles planning for auth strategy resources
 type AuthStrategyPlanner interface {
 	ResourcePlanner

--- a/internal/declarative/planner/resolver.go
+++ b/internal/declarative/planner/resolver.go
@@ -219,9 +219,15 @@ func (r *ReferenceResolver) resolveAuthStrategyRef(_ context.Context, _ string) 
 }
 
 // resolveControlPlaneRef resolves control plane ref to ID
-func (r *ReferenceResolver) resolveControlPlaneRef(_ context.Context, _ string) (string, error) {
-	// TODO: Implement when control plane state client is available
-	return "", fmt.Errorf("control plane resolution not yet implemented")
+func (r *ReferenceResolver) resolveControlPlaneRef(ctx context.Context, ref string) (string, error) {
+	cp, err := r.client.GetControlPlaneByName(ctx, ref)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve control plane ref '%s': %w", ref, err)
+	}
+	if cp == nil {
+		return "", fmt.Errorf("control plane with ref '%s' not found", ref)
+	}
+	return cp.ID, nil
 }
 
 // resolvePortalRef resolves portal ref to ID

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -227,6 +227,17 @@ func (rs *ResourceSet) GetPortalsByNamespace(namespace string) []PortalResource 
 	return filtered
 }
 
+// GetControlPlanesByNamespace returns all control plane resources from the specified namespace
+func (rs *ResourceSet) GetControlPlanesByNamespace(namespace string) []ControlPlaneResource {
+	var filtered []ControlPlaneResource
+	for _, cp := range rs.ControlPlanes {
+		if GetNamespace(cp.Kongctl) == namespace {
+			filtered = append(filtered, cp)
+		}
+	}
+	return filtered
+}
+
 // GetAPIsByNamespace returns all API resources from the specified namespace
 func (rs *ResourceSet) GetAPIsByNamespace(namespace string) []APIResource {
 	var filtered []APIResource

--- a/internal/declarative/state/client_control_plane_test.go
+++ b/internal/declarative/state/client_control_plane_test.go
@@ -1,0 +1,171 @@
+package state
+
+import (
+	"errors"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/declarative/labels"
+	"github.com/kong/kongctl/internal/konnect/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func newListControlPlanesResponse(data []kkComps.ControlPlane, total float64) *kkOps.ListControlPlanesResponse {
+	return &kkOps.ListControlPlanesResponse{
+		ListControlPlanesResponse: &kkComps.ListControlPlanesResponse{
+			Data: data,
+			Meta: kkComps.PaginatedMeta{
+				Page: kkComps.PageMeta{Total: total},
+			},
+		},
+	}
+}
+
+func TestListManagedControlPlanes(t *testing.T) {
+	ctx := testContextWithLogger()
+	mockAPI := helpers.NewMockControlPlaneAPI(t)
+
+	managed := kkComps.ControlPlane{
+		ID:   "cp-managed",
+		Name: "managed-cp",
+		Labels: map[string]string{
+			labels.NamespaceKey: "team-a",
+		},
+	}
+
+	unmanaged := kkComps.ControlPlane{
+		ID:   "cp-unmanaged",
+		Name: "unmanaged",
+		Labels: map[string]string{
+			"env": "dev",
+		},
+	}
+
+	pageOne := newListControlPlanesResponse([]kkComps.ControlPlane{managed, unmanaged}, 2)
+
+	mockAPI.EXPECT().
+		ListControlPlanes(mock.Anything, mock.Anything).
+		Return(pageOne, nil).
+		Once()
+
+	client := NewClient(ClientConfig{ControlPlaneAPI: mockAPI})
+
+	result, err := client.ListManagedControlPlanes(ctx, []string{"team-a"})
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "cp-managed", result[0].ID)
+	assert.Equal(t, "team-a", result[0].NormalizedLabels[labels.NamespaceKey])
+}
+
+func TestGetControlPlaneByNameFallback(t *testing.T) {
+	ctx := testContextWithLogger()
+	mockAPI := helpers.NewMockControlPlaneAPI(t)
+
+	legacy := kkComps.ControlPlane{
+		ID:   "cp-fallback",
+		Name: "legacy-cp",
+		Labels: map[string]string{
+			labels.ProtectedKey: labels.TrueValue,
+		},
+	}
+
+	managedCall := newListControlPlanesResponse([]kkComps.ControlPlane{legacy}, 1)
+	allCall := newListControlPlanesResponse([]kkComps.ControlPlane{legacy}, 1)
+
+	mockAPI.EXPECT().
+		ListControlPlanes(mock.Anything, mock.Anything).
+		Return(managedCall, nil).
+		Once()
+
+	mockAPI.EXPECT().
+		ListControlPlanes(mock.Anything, mock.Anything).
+		Return(allCall, nil).
+		Once()
+
+	client := NewClient(ClientConfig{ControlPlaneAPI: mockAPI})
+
+	cp, err := client.GetControlPlaneByName(ctx, "legacy-cp")
+	require.NoError(t, err)
+	require.NotNil(t, cp)
+	assert.Equal(t, "cp-fallback", cp.ID)
+	assert.True(t, client.hasAnyKongctlLabels(cp.Labels))
+}
+
+func TestCreateControlPlane(t *testing.T) {
+	ctx := testContextWithLogger()
+	mockAPI := helpers.NewMockControlPlaneAPI(t)
+
+	req := kkComps.CreateControlPlaneRequest{Name: "new-cp"}
+	resp := &kkOps.CreateControlPlaneResponse{
+		ControlPlane: &kkComps.ControlPlane{ID: "cp-123", Name: "new-cp"},
+	}
+
+	mockAPI.EXPECT().
+		CreateControlPlane(mock.Anything, req).
+		Return(resp, nil).
+		Once()
+
+	client := NewClient(ClientConfig{ControlPlaneAPI: mockAPI})
+
+	created, err := client.CreateControlPlane(ctx, req, "team-a")
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	assert.Equal(t, "cp-123", created.ID)
+}
+
+func TestCreateControlPlaneError(t *testing.T) {
+	ctx := testContextWithLogger()
+	mockAPI := helpers.NewMockControlPlaneAPI(t)
+
+	req := kkComps.CreateControlPlaneRequest{Name: "broken-cp"}
+	mockAPI.EXPECT().
+		CreateControlPlane(mock.Anything, req).
+		Return(nil, errors.New("boom")).
+		Once()
+
+	client := NewClient(ClientConfig{ControlPlaneAPI: mockAPI})
+
+	created, err := client.CreateControlPlane(ctx, req, "team-a")
+	require.Error(t, err)
+	assert.Nil(t, created)
+	assert.Contains(t, err.Error(), "create control plane")
+}
+
+func TestUpdateControlPlane(t *testing.T) {
+	ctx := testContextWithLogger()
+	mockAPI := helpers.NewMockControlPlaneAPI(t)
+
+	updateReq := kkComps.UpdateControlPlaneRequest{}
+	resp := &kkOps.UpdateControlPlaneResponse{
+		ControlPlane: &kkComps.ControlPlane{ID: "cp-123", Name: "updated"},
+	}
+
+	mockAPI.EXPECT().
+		UpdateControlPlane(mock.Anything, "cp-123", updateReq).
+		Return(resp, nil).
+		Once()
+
+	client := NewClient(ClientConfig{ControlPlaneAPI: mockAPI})
+
+	updated, err := client.UpdateControlPlane(ctx, "cp-123", updateReq, "team-a")
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	assert.Equal(t, "updated", updated.Name)
+}
+
+func TestDeleteControlPlane(t *testing.T) {
+	ctx := testContextWithLogger()
+	mockAPI := helpers.NewMockControlPlaneAPI(t)
+
+	mockAPI.EXPECT().
+		DeleteControlPlane(mock.Anything, "cp-123").
+		Return(&kkOps.DeleteControlPlaneResponse{}, nil).
+		Once()
+
+	client := NewClient(ClientConfig{ControlPlaneAPI: mockAPI})
+
+	require.NoError(t, client.DeleteControlPlane(ctx, "cp-123"))
+}

--- a/planning/cp-declarative-plan.md
+++ b/planning/cp-declarative-plan.md
@@ -1,0 +1,296 @@
+# Control Plane Support Implementation Plan for Declarative Configuration
+
+## Current State Analysis
+
+### What Exists
+1. **Resource Definition**: `internal/declarative/resources/control_plane.go` contains:
+   - `ControlPlaneResource` struct with `kkComps.CreateControlPlaneRequest` embedded
+   - Standard resource interface implementations (GetRef, Validate, GetType, etc.)
+   - `ResourceTypeControlPlane` constant defined in `types.go`
+   - Control planes array in `ResourceSet` struct
+
+2. **Documentation References**:
+   - Listed as parent resource in `docs/declarative-configuration.md` (line 167)
+   - Supports kongctl metadata (namespace, protected fields)
+
+3. **Partial References**:
+   - Validator includes control plane validation (`internal/declarative/validator/namespace_validator.go:294`)
+   - Reference resolver has TODO stub (`internal/declarative/planner/resolver.go:222-224`)
+
+### What's Missing (Critical Gaps)
+1. No planner implementation for control planes
+2. No state client methods for control plane CRUD operations
+3. No executor operations/adapters
+4. Not integrated into main planner's GeneratePlan method
+5. No examples or documentation of usage
+
+## Implementation Requirements
+
+### 1. Control Plane Planner (`internal/declarative/planner/control_plane_planner.go`)
+
+Create new file following the pattern of `portal_planner.go` and `api_planner.go`:
+
+```go
+package planner
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/Kong/sdk-konnect-go/models/components"
+    "github.com/Kong/kongctl/internal/declarative/resources"
+)
+
+// Key functions to implement:
+// - planControlPlanes(ctx context.Context, desired []resources.ControlPlaneResource, plan *Plan) error
+// - planControlPlaneCreate(namespace, ref string, cp resources.ControlPlaneResource, plan *Plan)
+// - planControlPlaneUpdate(currentID string, desired resources.ControlPlaneResource, current state.ControlPlane, plan *Plan)
+// - planControlPlaneDelete(ref string, current state.ControlPlane, plan *Plan)
+```
+
+Key implementation details:
+- Follow namespace filtering pattern from `planPortals`
+- Use `p.isResourceInScope()` for namespace checking
+- Check protection status before planning deletes
+- Build field comparisons for updates (Name, Description, Config fields)
+- Add changes to plan with proper dependencies (control planes have no dependencies)
+
+### 2. State Client Methods (`internal/declarative/state/client.go`)
+
+Add these methods following the pattern of Portal/API methods:
+
+```go
+// ListManagedControlPlanes returns all KONGCTL-managed control planes in specified namespaces
+func (c *Client) ListManagedControlPlanes(ctx context.Context, namespaces []string) ([]ControlPlane, error)
+
+// GetControlPlaneByName finds a managed control plane by name
+func (c *Client) GetControlPlaneByName(ctx context.Context, name string) (*ControlPlane, error)
+
+// GetControlPlaneByFilter finds a managed control plane using filter expression
+func (c *Client) GetControlPlaneByFilter(ctx context.Context, filter string) (*ControlPlane, error)
+
+// CreateControlPlane creates a new control plane with management labels
+func (c *Client) CreateControlPlane(ctx context.Context, cp components.CreateControlPlaneRequest, namespace string) (*components.ControlPlane, error)
+
+// UpdateControlPlane updates an existing control plane
+func (c *Client) UpdateControlPlane(ctx context.Context, id string, cp components.UpdateControlPlaneRequest, namespace string) (*components.ControlPlane, error)
+
+// DeleteControlPlane deletes a control plane by ID
+func (c *Client) DeleteControlPlane(ctx context.Context, id string) error
+```
+
+Also add ControlPlane type to state package:
+```go
+type ControlPlane struct {
+    components.ControlPlane
+    NormalizedLabels map[string]string
+}
+```
+
+Implementation notes:
+- Use `c.controlPlaneAPI` (already exists in KonnectSDK)
+- Apply label management using `labels.BuildCreateLabels` and `labels.BuildUpdateLabels`
+- Follow pagination pattern with `PaginateAll` helper
+- Include fallback lookup strategy for protection changes
+
+### 3. Executor Operations (`internal/declarative/executor/control_plane_operations.go`)
+
+Create following the pattern of `portal_operations.go`:
+
+```go
+package executor
+
+// Key functions:
+// - (e *Executor) executeControlPlaneCreate(ctx context.Context, change Change) error
+// - (e *Executor) executeControlPlaneUpdate(ctx context.Context, change Change) error
+// - (e *Executor) executeControlPlaneDelete(ctx context.Context, change Change) error
+```
+
+Implementation details:
+- Extract fields from change.Fields map
+- Use state client methods for actual operations
+- Include proper error handling with context
+- Update progress tracking
+
+### 4. Executor Adapter (`internal/declarative/executor/control_plane_adapter.go`)
+
+Create adapter to convert between resource and SDK types:
+
+```go
+package executor
+
+import (
+    kkComps "github.com/Kong/sdk-konnect-go/models/components"
+    "github.com/Kong/kongctl/internal/declarative/resources"
+)
+
+func adaptControlPlaneResourceToCreate(cp resources.ControlPlaneResource, namespace string, protected bool) kkComps.CreateControlPlaneRequest {
+    // Build create request from resource
+    // Apply labels using labels.BuildCreateLabels
+}
+
+func adaptControlPlaneResourceToUpdate(cp resources.ControlPlaneResource, existingLabels map[string]string, namespace string, protected bool) kkComps.UpdateControlPlaneRequest {
+    // Build update request
+    // Use labels.BuildUpdateLabels for label management
+}
+```
+
+### 5. Main Planner Integration (`internal/declarative/planner/planner.go`)
+
+In `GeneratePlan` method, add control plane processing after auth strategies and before APIs:
+
+```go
+// Plan control planes
+if err := p.planControlPlanes(ctx, resourceSet.ControlPlanes, plan); err != nil {
+    return nil, fmt.Errorf("failed to plan control planes: %w", err)
+}
+```
+
+### 6. Executor Integration (`internal/declarative/executor/executor.go`)
+
+In `Execute` method's switch statement, add control plane cases:
+
+```go
+case resources.ResourceTypeControlPlane:
+    switch change.Action {
+    case ActionCreate:
+        return e.executeControlPlaneCreate(ctx, change)
+    case ActionUpdate:
+        return e.executeControlPlaneUpdate(ctx, change)
+    case ActionDelete:
+        return e.executeControlPlaneDelete(ctx, change)
+    }
+```
+
+### 7. Reference Resolver Update (`internal/declarative/planner/resolver.go`)
+
+Update the TODO stub at line 222:
+
+```go
+func (r *ReferenceResolver) resolveControlPlaneRef(ctx context.Context, ref string) (string, error) {
+    cp, err := r.stateClient.GetControlPlaneByName(ctx, ref)
+    if err != nil {
+        return "", fmt.Errorf("failed to resolve control plane ref '%s': %w", ref, err)
+    }
+    if cp == nil {
+        return "", fmt.Errorf("control plane with ref '%s' not found", ref)
+    }
+    return cp.ID, nil
+}
+```
+
+### 8. Documentation Updates
+
+Create `docs/examples/declarative/control-plane/control-plane.yaml`:
+
+```yaml
+_defaults:
+  kongctl:
+    namespace: infrastructure
+    protected: false
+
+control_planes:
+  - ref: prod-cp
+    name: "production-control-plane"
+    description: "Production Kong Gateway control plane"
+    cluster_type: "CLUSTER_TYPE_CONTROL_PLANE"
+    config:
+      control_plane_endpoint: "https://cp.example.com"
+      telemetry_endpoint: "https://telemetry.example.com"
+    kongctl:
+      namespace: production
+      protected: true
+
+  - ref: staging-cp
+    name: "staging-control-plane"
+    description: "Staging environment control plane"
+    cluster_type: "CLUSTER_TYPE_CONTROL_PLANE"
+    config:
+      control_plane_endpoint: "https://staging-cp.example.com"
+```
+
+Update `docs/declarative-configuration.md` to include control plane examples in the resource types section.
+
+### 9. Testing Requirements
+
+#### Unit Tests
+
+1. `internal/declarative/planner/control_plane_planner_test.go`:
+   - Test plan generation for create/update/delete
+   - Test namespace filtering
+   - Test protection checking
+   - Test field comparison logic
+
+2. `internal/declarative/state/client_control_plane_test.go`:
+   - Mock SDK responses
+   - Test CRUD operations
+   - Test label management
+   - Test pagination
+
+3. `internal/declarative/executor/control_plane_operations_test.go`:
+   - Test execution of each operation type
+   - Test error handling
+   - Test progress updates
+
+#### Integration Tests
+
+Create `test/integration/declarative/control_plane_test.go`:
+- Test full workflow: load config -> plan -> execute
+- Test sync mode with existing resources
+- Test namespace isolation
+- Test protection flags
+
+## Implementation Order
+
+1. State client methods (foundation)
+2. Control plane planner
+3. Executor operations and adapter
+4. Main planner/executor integration
+5. Reference resolver update
+6. Documentation and examples
+7. Unit tests
+8. Integration tests
+
+## Critical Implementation Notes
+
+1. **SDK Integration**: The SDK already has `ControlPlanes` API in `KonnectSDK.GetControlPlaneAPI()`. Use existing operations.
+
+2. **Label Management**: Control planes must use the same label pattern as other resources:
+   - `KONGCTL-NAMESPACE`: For namespace isolation
+   - `KONGCTL-PROTECTED`: For deletion protection
+   - `KONGCTL-MANAGED`: To identify managed resources
+
+3. **Field Mapping**: Based on `CreateControlPlaneRequest` in SDK:
+   - Name (string)
+   - Description (*string)
+   - ClusterType (*components.ClusterType)
+   - Config (*components.Config with ControlPlaneEndpoint, TelemetryEndpoint)
+   - Labels (map[string]*string)
+
+4. **Namespace Behavior**: Control planes are parent resources, so they:
+   - Support kongctl metadata section
+   - Can have namespace and protected fields
+   - Don't inherit namespace from parents (they ARE parents)
+
+5. **Dependencies**: Control planes have no dependencies on other resources, making them good to process early in the plan.
+
+6. **Error Handling**: Follow enhanced error patterns from API/Portal implementations with proper context and hints.
+
+## Validation Checklist
+
+After implementation, verify:
+- [ ] Control planes can be created via `apply`
+- [ ] Control planes can be updated with field changes
+- [ ] Control planes can be deleted via `sync` (respecting protection)
+- [ ] Namespace filtering works correctly
+- [ ] Protection flags prevent deletion
+- [ ] Reference resolution works for resources referencing control planes
+- [ ] Plan output shows correct operations
+- [ ] Diff command shows control plane changes
+- [ ] Examples work end-to-end
+
+## Known Limitations
+
+1. SDK may not support all control plane configuration fields
+2. API implementations that reference control planes are commented out (TODO in code)
+3. Control plane groups are not yet modeled

--- a/test/e2e/harness/step.go
+++ b/test/e2e/harness/step.go
@@ -446,6 +446,21 @@ func (s *Step) ResetOrg(stage string) error {
 			"error":       errorString(err3),
 		},
 	)
+	// control-planes
+	tot4, del4, err4 := deleteAll(client, baseURL, token, "v2", "control-planes")
+	if err4 != nil && firstErr == nil {
+		firstErr = err4
+	}
+	details = append(
+		details,
+		map[string]any{
+			"api_version": "v2",
+			"endpoint":    "control-planes",
+			"total":       tot4,
+			"deleted":     del4,
+			"error":       errorString(err4),
+		},
+	)
 
 	status := "ok"
 	if firstErr != nil {

--- a/test/e2e/scenarios/control-plane/apply/scenario.yaml
+++ b/test/e2e/scenarios/control-plane/apply/scenario.yaml
@@ -1,0 +1,27 @@
+baseInputsPath: ../../../testdata/declarative/control-plane/basic
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-initial-apply
+    commands:
+      - name: 001-000-apply
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/control-plane.yaml"
+          - --auto-approve
+        assertions:
+          - select: "plan.metadata"
+            expect:
+              fields:
+                mode: apply
+          - select: >-
+              plan.changes[?resource_type=='control_plane' && 
+                            resource_ref=='e2e-cp'] | [0]
+            expect:
+              fields:
+                action: CREATE

--- a/test/e2e/scenarios/control-plane/sync/overlays/002-sync-with-delete/control-plane.yaml
+++ b/test/e2e/scenarios/control-plane/sync/overlays/002-sync-with-delete/control-plane.yaml
@@ -1,0 +1,9 @@
+control_planes:
+  #- ref: e2e-cp
+  #  name: "kongctl-e2e-cp"
+  #  description: "Test Control Plane for E2E testing via kongctl"
+  #  cluster_type: "CLUSTER_TYPE_CONTROL_PLANE"
+  - ref: e2e-cp-2
+    name: "kongctl-e2e-cp-2"
+    description: "Second Test Control Plane for E2E testing via kongctl"
+    cluster_type: "CLUSTER_TYPE_CONTROL_PLANE"

--- a/test/e2e/scenarios/control-plane/sync/scenario.yaml
+++ b/test/e2e/scenarios/control-plane/sync/scenario.yaml
@@ -1,0 +1,47 @@
+baseInputsPath: ../../../testdata/declarative/control-plane/basic
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-initial-sync
+    commands:
+      - name: 000-001-sync
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/control-plane.yaml"
+          - --auto-approve
+        assertions:
+          - select: "plan.metadata"
+            expect:
+              fields:
+                mode: sync
+          - select: >-
+              plan.changes[?resource_type=='control_plane' && 
+                            resource_ref=='e2e-cp'] | [0]
+            expect:
+              fields:
+                action: CREATE
+
+  - name: 002-sync-with-delete
+    inputOverlayDirs:
+      - overlays/002-sync-with-delete
+    commands:
+      - name: 000-002-sync
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/control-plane.yaml"
+          - --auto-approve
+        assertions:
+          - select: "plan.metadata"
+            expect:
+              fields:
+                mode: sync
+          - select: "plan.changes"
+            expect:
+              fields:
+                "length(@)": 2

--- a/test/e2e/testdata/declarative/control-plane/basic/control-plane.yaml
+++ b/test/e2e/testdata/declarative/control-plane/basic/control-plane.yaml
@@ -1,0 +1,5 @@
+control_planes:
+  - ref: e2e-cp
+    name: "kongctl-e2e-cp"
+    description: "Test Control Plane for E2E testing via kongctl"
+    cluster_type: "CLUSTER_TYPE_CONTROL_PLANE"

--- a/test/e2e/tools/reset/main.go
+++ b/test/e2e/tools/reset/main.go
@@ -1,0 +1,27 @@
+//go:build e2e
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/kong/kongctl/test/e2e/harness"
+)
+
+// Usage:
+//
+//	go run -tags e2e ./test/e2e/tools/reset
+//
+// Respects KONGCTL_E2E_{KONNECT_PAT,KONNECT_BASE_URL,RESET,ARTIFACTS_DIR} like the harness.
+func main() {
+	stage := flag.String("stage", "manual-reset", "label used in log output")
+	flag.Parse()
+
+	if err := harness.ResetOrg(*stage); err != nil {
+		fmt.Fprintf(os.Stderr, "reset failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Konnect organization reset complete")
+}

--- a/test/integration/declarative/apply_test.go
+++ b/test/integration/declarative/apply_test.go
@@ -64,6 +64,11 @@ func TestApplyCommand_BasicWorkflow(t *testing.T) {
 	sdkFactory := ctx.Value(helpers.SDKAPIFactoryKey).(helpers.SDKAPIFactory)
 	konnectSDK, _ := sdkFactory(GetTestConfig(), nil)
 	mockSDK := konnectSDK.(*helpers.MockKonnectSDK)
+	if mockSDK.CPAPIFactory == nil {
+		mockSDK.CPAPIFactory = func() helpers.ControlPlaneAPI {
+			return helpers.NewMockControlPlaneAPI(t)
+		}
+	}
 	mockPortalAPI := mockSDK.GetPortalAPI().(*MockPortalAPI)
 
 	// Mock checking for existing portal (not found)


### PR DESCRIPTION
## Summary

  - wired Control Plane support into declarative apply/plan/sync so the planner can diff desired control planes,
  look them up via state, and execute CRUD operations
  - added docs + examples for declarative control planes, plus tests covering planner/executor/state behaviour and
  mock integrations
  - enhanced the e2e harness reset path to clear control planes, and provided a simple developer-only reset entry
  point (go run -tags e2e ./test/e2e/tools/reset)
  - adjusted mocks, integration helpers, and examples to keep existing tests green
