### PR TITLE
Fix: Use control-plane-name and control-plane-id

### DIFF
--- a/internal/cmd/root/products/konnect/gateway/consumer/getConsumer.go
+++ b/internal/cmd/root/products/konnect/gateway/consumer/getConsumer.go
@@ -189,10 +189,21 @@ func newGetConsumerCmd(verb verbs.VerbValue,
 		addParentFlags(verb, baseCmd)
 	}
 
-	baseCmd.RunE = rv.runE
-	if parentPreRun != nil {
-		baseCmd.PreRunE = parentPreRun
+	originalPreRunE := baseCmd.PreRunE
+	baseCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if parentPreRun != nil {
+			if err := parentPreRun(cmd, args); err != nil {
+				return err
+			}
+		}
+		if originalPreRunE != nil {
+			if err := originalPreRunE(cmd, args); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
+	baseCmd.RunE = rv.runE
 
 	return &rv
 }

--- a/internal/cmd/root/products/konnect/gateway/route/getRoute.go
+++ b/internal/cmd/root/products/konnect/gateway/route/getRoute.go
@@ -302,10 +302,21 @@ func newGetRouteCmd(verb verbs.VerbValue,
 		addParentFlags(verb, baseCmd)
 	}
 
-	baseCmd.RunE = rv.runE
-	if parentPreRun != nil {
-		baseCmd.PreRunE = parentPreRun
+	originalPreRunE := baseCmd.PreRunE
+	baseCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if parentPreRun != nil {
+			if err := parentPreRun(cmd, args); err != nil {
+				return err
+			}
+		}
+		if originalPreRunE != nil {
+			if err := originalPreRunE(cmd, args); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
+	baseCmd.RunE = rv.runE
 
 	return &rv
 }

--- a/internal/cmd/root/products/konnect/gateway/service/getService.go
+++ b/internal/cmd/root/products/konnect/gateway/service/getService.go
@@ -290,8 +290,19 @@ func newGetServiceCmd(verb verbs.VerbValue,
 		addParentFlags(verb, baseCmd)
 	}
 
-	if parentPreRun != nil {
-		baseCmd.PreRunE = parentPreRun
+	originalPreRunE := baseCmd.PreRunE
+	baseCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if parentPreRun != nil {
+			if err := parentPreRun(cmd, args); err != nil {
+				return err
+			}
+		}
+		if originalPreRunE != nil {
+			if err := originalPreRunE(cmd, args); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 	baseCmd.RunE = rv.runE
 


### PR DESCRIPTION
### Summary

Fixed the issue where control plane-related flags weren't being bound.

### Full changelog

I modified `newGetServiceCmd` so that instead of overwriting `PreRunE`, it chains (concatenates) the existing `PreRunE` with the newly added `parentPreRun`.

The same change was applied to route and consumer.

### Issues resolved

Fix #96 

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
