### PR TITLE
Fix: Add base-url flag to required commands

### DIFF
--- a/internal/cmd/root/verbs/adopt/adopt.go
+++ b/internal/cmd/root/verbs/adopt/adopt.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	"github.com/kong/kongctl/internal/meta"
 	"github.com/kong/kongctl/internal/util/i18n"
@@ -40,10 +41,23 @@ func NewAdoptCmd() (*cobra.Command, error) {
 		Short:   adoptShort,
 		Long:    adoptLong,
 		Example: adoptExamples,
-		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
-			cmd.SetContext(context.WithValue(cmd.Context(), verbs.Verb, Verb))
+		PersistentPreRunE: func(c *cobra.Command, args []string) error {
+			c.SetContext(context.WithValue(c.Context(), verbs.Verb, Verb))
+			return bindKonnectFlags(c, args)
 		},
 	}
+
+	// Add Konnect-specific flags as persistent flags so they appear in help
+	cmd.PersistentFlags().String(common.BaseURLFlagName, common.BaseURLDefault,
+		fmt.Sprintf(`Base URL for Konnect API requests.
+- Config path: [ %s ]`,
+			common.BaseURLConfigPath))
+
+	cmd.PersistentFlags().String(common.PATFlagName, "",
+		fmt.Sprintf(`Konnect Personal Access Token (PAT) used to authenticate the CLI.
+Setting this value overrides tokens obtained from the login command.
+- Config path: [ %s ]`,
+			common.PATConfigPath))
 
 	konnectCmd, err := konnect.NewKonnectCmd(Verb)
 	if err != nil {

--- a/internal/cmd/root/verbs/create/create.go
+++ b/internal/cmd/root/verbs/create/create.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	cmdpkg "github.com/kong/kongctl/internal/cmd"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	"github.com/kong/kongctl/internal/meta"
 	"github.com/kong/kongctl/internal/util/i18n"
@@ -24,7 +26,7 @@ var (
 	createLong = normalizers.LongDesc(i18n.T("root.verbs.create.createLong",
 		`Use create to create a new object.
 
-Further sub-commands are required to determine which remote system is contacted (if necessary). 
+Further sub-commands are required to determine which remote system is contacted (if necessary).
 The command will create an object and report a result depending on further arguments.
 Output can be formatted in multiple ways to aid in further processing.`))
 
@@ -44,10 +46,23 @@ func NewCreateCmd() (*cobra.Command, error) {
 		Long:    createLong,
 		Example: createExamples,
 		Aliases: []string{"c", "C"},
-		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
-			cmd.SetContext(context.WithValue(cmd.Context(), verbs.Verb, Verb))
+		PersistentPreRunE: func(c *cobra.Command, args []string) error {
+			c.SetContext(context.WithValue(c.Context(), verbs.Verb, Verb))
+			return bindKonnectFlags(c, args)
 		},
 	}
+
+	// Add Konnect-specific flags as persistent flags so they appear in help
+	cmd.PersistentFlags().String(common.BaseURLFlagName, common.BaseURLDefault,
+		fmt.Sprintf(`Base URL for Konnect API requests.
+- Config path: [ %s ]`,
+			common.BaseURLConfigPath))
+
+	cmd.PersistentFlags().String(common.PATFlagName, "",
+		fmt.Sprintf(`Konnect Personal Access Token (PAT) used to authenticate the CLI.
+Setting this value overrides tokens obtained from the login command.
+- Config path: [ %s ]`,
+			common.PATConfigPath))
 
 	// TODO: Determine if creating profiles for the command make sense and how to implement
 	// cmd.AddCommand(profileCmd.NewProfileCmd())
@@ -66,4 +81,27 @@ func NewCreateCmd() (*cobra.Command, error) {
 	cmd.AddCommand(gatewayCmd)
 
 	return cmd, nil
+}
+
+// bindKonnectFlags binds Konnect-specific flags to configuration
+func bindKonnectFlags(c *cobra.Command, args []string) error {
+	helper := cmdpkg.BuildHelper(c, args)
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	if f := c.Flags().Lookup(common.BaseURLFlagName); f != nil {
+		if err := cfg.BindFlag(common.BaseURLConfigPath, f); err != nil {
+			return err
+		}
+	}
+
+	if f := c.Flags().Lookup(common.PATFlagName); f != nil {
+		if err := cfg.BindFlag(common.PATConfigPath, f); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/internal/cmd/root/verbs/dump/declarative.go
+++ b/internal/cmd/root/verbs/dump/declarative.go
@@ -73,6 +73,17 @@ func newDeclarativeCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.defaultNamespace, "default-namespace", "",
 		"Default namespace to include in declarative output (_defaults.kongctl.namespace).")
 
+	cmd.Flags().String(konnectCommon.BaseURLFlagName, konnectCommon.BaseURLDefault,
+		fmt.Sprintf(`Base URL for Konnect API requests.
+- Config path: [ %s ]`,
+			konnectCommon.BaseURLConfigPath))
+
+	cmd.Flags().String(konnectCommon.PATFlagName, "",
+		fmt.Sprintf(`Konnect Personal Access Token (PAT) used to authenticate the CLI.
+Setting this value overrides tokens obtained from the login command.
+- Config path: [ %s ]`,
+			konnectCommon.PATConfigPath))
+
 	cmd.Flags().Int(
 		konnectCommon.RequestPageSizeFlagName,
 		konnectCommon.DefaultRequestPageSize,
@@ -85,6 +96,19 @@ func newDeclarativeCmd() *cobra.Command {
 		if err != nil {
 			return err
 		}
+
+		if f := c.Flags().Lookup(konnectCommon.BaseURLFlagName); f != nil {
+			if err := cfg.BindFlag(konnectCommon.BaseURLConfigPath, f); err != nil {
+				return err
+			}
+		}
+
+		if f := c.Flags().Lookup(konnectCommon.PATFlagName); f != nil {
+			if err := cfg.BindFlag(konnectCommon.PATConfigPath, f); err != nil {
+				return err
+			}
+		}
+
 		return cfg.BindFlag(konnectCommon.RequestPageSizeConfigPath,
 			c.Flags().Lookup(konnectCommon.RequestPageSizeFlagName))
 	}

--- a/internal/cmd/root/verbs/dump/tfimport.go
+++ b/internal/cmd/root/verbs/dump/tfimport.go
@@ -69,6 +69,17 @@ func newTFImportCmd() *cobra.Command {
 	cmd.Flags().StringVar(&opts.outputFile, "output-file", "",
 		"File to write the output to. If not specified, output is written to stdout.")
 
+	cmd.Flags().String(konnectCommon.BaseURLFlagName, konnectCommon.BaseURLDefault,
+		fmt.Sprintf(`Base URL for Konnect API requests.
+- Config path: [ %s ]`,
+			konnectCommon.BaseURLConfigPath))
+
+	cmd.Flags().String(konnectCommon.PATFlagName, "",
+		fmt.Sprintf(`Konnect Personal Access Token (PAT) used to authenticate the CLI.
+Setting this value overrides tokens obtained from the login command.
+- Config path: [ %s ]`,
+			konnectCommon.PATConfigPath))
+
 	cmd.Flags().Int(
 		konnectCommon.RequestPageSizeFlagName,
 		konnectCommon.DefaultRequestPageSize,
@@ -81,6 +92,19 @@ func newTFImportCmd() *cobra.Command {
 		if err != nil {
 			return err
 		}
+
+		if f := c.Flags().Lookup(konnectCommon.BaseURLFlagName); f != nil {
+			if err := cfg.BindFlag(konnectCommon.BaseURLConfigPath, f); err != nil {
+				return err
+			}
+		}
+
+		if f := c.Flags().Lookup(konnectCommon.PATFlagName); f != nil {
+			if err := cfg.BindFlag(konnectCommon.PATConfigPath, f); err != nil {
+				return err
+			}
+		}
+
 		return cfg.BindFlag(konnectCommon.RequestPageSizeConfigPath,
 			c.Flags().Lookup(konnectCommon.RequestPageSizeFlagName))
 	}

--- a/internal/cmd/root/verbs/get/get.go
+++ b/internal/cmd/root/verbs/get/get.go
@@ -7,6 +7,7 @@ import (
 	cmdpkg "github.com/kong/kongctl/internal/cmd"
 	cmdCommon "github.com/kong/kongctl/internal/cmd/common"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/navigator"
 	profileCmd "github.com/kong/kongctl/internal/cmd/root/profile"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
@@ -54,10 +55,30 @@ func NewGetCmd() (*cobra.Command, error) {
 		Long:    getLong,
 		Example: getExamples,
 		Aliases: []string{"g", "G"},
-		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
-			cmd.SetContext(context.WithValue(cmd.Context(), verbs.Verb, Verb))
+		PersistentPreRunE: func(c *cobra.Command, args []string) error {
+			c.SetContext(context.WithValue(c.Context(), verbs.Verb, Verb))
+			return bindKonnectFlags(c, args)
 		},
 	}
+
+	// Add Konnect-specific flags as persistent flags so they appear in help
+	cmd.PersistentFlags().String(common.BaseURLFlagName, common.BaseURLDefault,
+		fmt.Sprintf(`Base URL for Konnect API requests.
+- Config path: [ %s ]`,
+			common.BaseURLConfigPath))
+
+	cmd.PersistentFlags().String(common.PATFlagName, "",
+		fmt.Sprintf(`Konnect Personal Access Token (PAT) used to authenticate the CLI.
+Setting this value overrides tokens obtained from the login command.
+- Config path: [ %s ]`,
+			common.PATConfigPath))
+
+	cmd.PersistentFlags().Int(
+		common.RequestPageSizeFlagName,
+		common.DefaultRequestPageSize,
+		fmt.Sprintf(`Max number of results to include per response page for get and list operations.
+- Config path: [ %s ]`,
+			common.RequestPageSizeConfigPath))
 
 	cmd.PersistentFlags().BoolP(
 		cmdCommon.InteractiveFlagName,
@@ -125,4 +146,33 @@ func NewGetCmd() (*cobra.Command, error) {
 	cmd.AddCommand(meCmd)
 
 	return cmd, nil
+}
+
+// bindKonnectFlags binds Konnect-specific flags to configuration
+func bindKonnectFlags(c *cobra.Command, args []string) error {
+	helper := cmdpkg.BuildHelper(c, args)
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	if f := c.Flags().Lookup(common.BaseURLFlagName); f != nil {
+		if err := cfg.BindFlag(common.BaseURLConfigPath, f); err != nil {
+			return err
+		}
+	}
+
+	if f := c.Flags().Lookup(common.PATFlagName); f != nil {
+		if err := cfg.BindFlag(common.PATConfigPath, f); err != nil {
+			return err
+		}
+	}
+
+	if f := c.Flags().Lookup(common.RequestPageSizeFlagName); f != nil {
+		if err := cfg.BindFlag(common.RequestPageSizeConfigPath, f); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/internal/cmd/root/verbs/list/list.go
+++ b/internal/cmd/root/verbs/list/list.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	cmdpkg "github.com/kong/kongctl/internal/cmd"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	"github.com/kong/kongctl/internal/meta"
 	"github.com/kong/kongctl/internal/util/i18n"
@@ -50,10 +52,30 @@ func NewListCmd() (*cobra.Command, error) {
 		Long:    listLong,
 		Example: listExamples,
 		Aliases: []string{"ls", "l"},
-		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
-			cmd.SetContext(context.WithValue(cmd.Context(), verbs.Verb, Verb))
+		PersistentPreRunE: func(c *cobra.Command, args []string) error {
+			c.SetContext(context.WithValue(c.Context(), verbs.Verb, Verb))
+			return bindKonnectFlags(c, args)
 		},
 	}
+
+	// Add Konnect-specific flags as persistent flags so they appear in help
+	cmd.PersistentFlags().String(common.BaseURLFlagName, common.BaseURLDefault,
+		fmt.Sprintf(`Base URL for Konnect API requests.
+- Config path: [ %s ]`,
+			common.BaseURLConfigPath))
+
+	cmd.PersistentFlags().String(common.PATFlagName, "",
+		fmt.Sprintf(`Konnect Personal Access Token (PAT) used to authenticate the CLI.
+Setting this value overrides tokens obtained from the login command.
+- Config path: [ %s ]`,
+			common.PATConfigPath))
+
+	cmd.PersistentFlags().Int(
+		common.RequestPageSizeFlagName,
+		common.DefaultRequestPageSize,
+		fmt.Sprintf(`Max number of results to include per response page for get and list operations.
+- Config path: [ %s ]`,
+			common.RequestPageSizeConfigPath))
 
 	c, e := konnect.NewKonnectCmd(Verb)
 	if e != nil {
@@ -92,4 +114,33 @@ func NewListCmd() (*cobra.Command, error) {
 	cmd.AddCommand(newThemesCmd())
 
 	return cmd, nil
+}
+
+// bindKonnectFlags binds Konnect-specific flags to configuration
+func bindKonnectFlags(c *cobra.Command, args []string) error {
+	helper := cmdpkg.BuildHelper(c, args)
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	if f := c.Flags().Lookup(common.BaseURLFlagName); f != nil {
+		if err := cfg.BindFlag(common.BaseURLConfigPath, f); err != nil {
+			return err
+		}
+	}
+
+	if f := c.Flags().Lookup(common.PATFlagName); f != nil {
+		if err := cfg.BindFlag(common.PATConfigPath, f); err != nil {
+			return err
+		}
+	}
+
+	if f := c.Flags().Lookup(common.RequestPageSizeFlagName); f != nil {
+		if err := cfg.BindFlag(common.RequestPageSizeConfigPath, f); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
This commit adds base-url and PAT flag support to the dump (and other) command's tf-import and declarative subcommands, resolving inconsistent base-url support across the CLI.

**Changes:**
- Added --base-url flag to `dump tf-import` command
- Added --base-url flag to `dump declarative` command
- Added --pat flag to both subcommands for consistency
- Added proper flag binding in PreRunE hooks

**Impact:**
Users can now override the Konnect API base URL when using dump commands, enabling usage with different regions or environments:

```bash
# Use EU region for export
kongctl dump declarative --base-url https://eu.api.konghq.com \
  --resources=portals,apis

# Use custom Konnect instance
kongctl dump tf-import --base-url https://custom.api.konghq.com \
  --resources=control_planes
```

All commands now consistently support base-url configuration either via:
- Command-line flag: --base-url
- Configuration file: konnect.base-url
- Environment variable: KONGCTL_KONNECT_BASE_URL

Resolves: Kong/kongctl#109

