### PR TITLE
fix: renovate config json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "Kong/public-shared-renovate"
-  ],
+  ]
 }


### PR DESCRIPTION
### Summary

The renovate.json had an extra trailing comma (oops)
