### PR TITLE
pre-release: sdk-konnect-go: v0.13.2-alpha.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kong/kongctl
 go 1.24.3
 
 require (
-	github.com/Kong/sdk-konnect-go v0.13.1
+	github.com/Kong/sdk-konnect-go v0.13.2-alpha.1
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/ajg/form v1.5.1
 	github.com/alecthomas/chroma/v2 v2.20.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Kong/sdk-konnect-go v0.13.1 h1:c1WGaOlUt7b/eDsdsmxMFLWRYgroSqvJ7nr2/uCheG4=
-github.com/Kong/sdk-konnect-go v0.13.1/go.mod h1:LOJjA3UyX2fhmJQV10LrC72LF9vZo6pXv5VM03uBDB0=
+github.com/Kong/sdk-konnect-go v0.13.2-alpha.1 h1:IJPQtCoRigNvI5vcLZSpGZXB5q6Q1JatjAO+a+pKPCA=
+github.com/Kong/sdk-konnect-go v0.13.2-alpha.1/go.mod h1:LOJjA3UyX2fhmJQV10LrC72LF9vZo6pXv5VM03uBDB0=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=


### PR DESCRIPTION
## Preview: sdk-konnect-go v0.13.2-alpha.1
- Release: [v0.13.2-alpha.1](https://github.com/Kong/sdk-konnect-go/releases/tag/v0.13.2-alpha.1)
- Published: 2025-11-05T16:52:03Z

### Notes
- Dependency bump staged for automated preview validation.
- Standard PR workflows (lint/unit/e2e) will run on this branch.
