### PR TITLE
Fix: kai command now displays errors during setup/validation

### DIFF
--- a/internal/cmd/root/products/konnect/common/common.go
+++ b/internal/cmd/root/products/konnect/common/common.go
@@ -68,12 +68,16 @@ func GetAccessToken(cfg config.Hook, logger *slog.Logger) (string, error) {
 		envVar := fmt.Sprintf("KONGCTL_%s_KONNECT_PAT", strings.ToUpper(profile))
 
 		return "", fmt.Errorf(
-			"authentication token not available. Use '%s login' to authenticate, "+
-				"provide a token via the --%s flag, set the %s environment variable, "+
-				"or configure '%s' in your config file",
+			"authentication token not available. Use one of the following to authorize %s:\n"+
+				"  - '%s login' to authenticate via the web\n"+
+				"  - provide a token via the --%s flag\n"+
+				"  - set the %s environment variable\n"+
+				"  - configure a token value in the '%s.%s' path of your configuration file",
+			meta.CLIName,
 			meta.CLIName,
 			PATFlagName,
 			envVar,
+			profile,
 			PATConfigPath,
 		)
 	}

--- a/internal/cmd/root/products/konnect/common/common.go
+++ b/internal/cmd/root/products/konnect/common/common.go
@@ -70,10 +70,11 @@ func GetAccessToken(cfg config.Hook, logger *slog.Logger) (string, error) {
 		return "", fmt.Errorf(
 			"authentication token not available. Use '%s login' to authenticate, "+
 				"provide a token via the --%s flag, set the %s environment variable, "+
-				"or configure 'konnect.pat' in your config file",
+				"or configure '%s' in your config file",
 			meta.CLIName,
 			PATFlagName,
 			envVar,
+			PATConfigPath,
 		)
 	}
 	return tok.Token.AuthToken, nil

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -91,12 +91,6 @@ func newRootCmd() *cobra.Command {
 		Short: rootShort,
 		Long:  rootLong,
 		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
-			if isKaiCommand(cmd) {
-				log.DisableErrorMirroring()
-			} else {
-				log.EnableErrorMirroring()
-			}
-
 			ctx := context.WithValue(cmd.Context(), config.ConfigKey, currConfig)
 			ctx = context.WithValue(ctx, iostreams.StreamsKey, streams)
 			ctx = context.WithValue(ctx, profile.ProfileManagerKey, pMgr)
@@ -255,20 +249,6 @@ func addCommands() error {
 	rootCmd.AddCommand(help.NewHelpCmd())
 
 	return nil
-}
-
-func isKaiCommand(cmd *cobra.Command) bool {
-	if cmd == nil {
-		return false
-	}
-
-	for current := cmd; current != nil; current = current.Parent() {
-		if current.Name() == kai.Verb.String() {
-			return true
-		}
-	}
-
-	return false
 }
 
 func sampleThemeNames() []string {

--- a/internal/cmd/root/verbs/kai/kai.go
+++ b/internal/cmd/root/verbs/kai/kai.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kong/kongctl/internal/kai/render"
 	kaistui "github.com/kong/kongctl/internal/kai/tui"
 	"github.com/kong/kongctl/internal/konnect/helpers"
+	"github.com/kong/kongctl/internal/log"
 	"github.com/kong/kongctl/internal/meta"
 	"github.com/kong/kongctl/internal/theme"
 	"github.com/kong/kongctl/internal/util/i18n"
@@ -277,6 +278,11 @@ func runInteractiveCore(
 		}
 		initialTasks = tasks
 	}
+
+	// Disable error mirroring while the TUI is running to prevent errors from
+	// interfering with the UI. Re-enable it after the TUI exits.
+	log.DisableErrorMirroring()
+	defer log.EnableErrorMirroring()
 
 	return kaistui.Run(ctx, streams, kaistui.Options{
 		BaseURL:            baseURL,


### PR DESCRIPTION
Fixes an issue where the kai command would exit with code 1 but not show any error message when setup/validation failed (e.g., missing PAT token).

The error mirroring was being disabled too early in the command lifecycle, before setup/validation operations could complete. This meant errors from operations like GetAccessToken() were suppressed even though they occurred before the TUI launched.

Changes:
- Moved error mirroring control from root command to kai command
- Error mirroring now disabled only when TUI launches, not during setup
- Re-enabled via defer to ensure proper cleanup
- Removed isKaiCommand() helper function as it's no longer needed

This ensures:
- Setup/validation errors are visible to users
- TUI operation doesn't interfere with stderr output
- Error mirroring is properly restored after command completes

Fixes #193
