### PR TITLE
Fix: Remove incorrect trimprefix from goreleaser version ldflags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,7 @@ builds:
       - CGO_ENABLED=1
     ldflags:
       - -s -w
-      - -X main.version={{ .Version | trimprefix "v" }}
+      - -X main.version={{.Version}}
       - -X main.commit={{.ShortCommit}}
       - -X main.date={{.Date}}
     goos:


### PR DESCRIPTION
The .goreleaser.yml was using `{{ .Version | trimprefix "v" }}` to set the main.version ldflags. However, GoReleaser automatically strips the "v" prefix from git tags when populating the .Version variable, making the trimprefix operation unnecessary and potentially problematic.

Additionally, "trimprefix" with a lowercase 'p' is not a valid Sprig template function (the correct function is "trimPrefix" with uppercase 'P'), which could cause the template to fail or behave unexpectedly.

This change removes the trimprefix operation and uses .Version directly, which already contains the version without the "v" prefix.

Resolved #229
