### PR TITLE
chore: bump sdk-konnect-go to v0.14.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kong/kongctl
 go 1.24.3
 
 require (
-	github.com/Kong/sdk-konnect-go v0.13.2-alpha.2
+	github.com/Kong/sdk-konnect-go v0.14.2
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/ajg/form v1.5.1
 	github.com/alecthomas/chroma/v2 v2.20.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/Kong/sdk-konnect-go v0.13.2-alpha.2 h1:edk6b8OUwAlZfycwj6jCC5WGBV5Uj8niETpmO3B5GO8=
-github.com/Kong/sdk-konnect-go v0.13.2-alpha.2/go.mod h1:LOJjA3UyX2fhmJQV10LrC72LF9vZo6pXv5VM03uBDB0=
+github.com/Kong/sdk-konnect-go v0.14.2 h1:vcF9+xcq2aCkzzJKshBqaoRFVis0CpQfgmlIAHgB1js=
+github.com/Kong/sdk-konnect-go v0.14.2/go.mod h1:LOJjA3UyX2fhmJQV10LrC72LF9vZo6pXv5VM03uBDB0=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=


### PR DESCRIPTION
### Summary
Bumping sdk-konnect-go to v0.14.2 - this is required to work with Event gateway and Catalog APIs.
https://kongstrong.slack.com/archives/C048KLCCR7T/p1764798363193999

### Full changelog

* [chore: bump sdk-konnect-go to v0.14.2](https://github.com/Kong/kongctl/commit/26e871af086d1d498231ab0682e411dd96a136f1)

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
