### PR TITLE
tests: added filtering logic for resetting orgs

### DIFF
--- a/test/e2e/harness/reset.go
+++ b/test/e2e/harness/reset.go
@@ -144,14 +144,14 @@ func deleteAll(client *http.Client, baseURL, token, apiVersion, endpoint string,
 		if attempt == 0 {
 			total = len(items)
 			if skipped > 0 {
-				Infof("Skipping %d konnect-managed %s", skipped, endpoint)
+				Infof("Skipping %d filtered %s resources", skipped, endpoint)
 			}
 		} else if len(items)+deleted > total {
 			total = len(items) + deleted
 		}
 
 		if len(idsToDelete) == 0 {
-			Infof("No deletable %s remaining (all are konnect-managed or already deleted)", endpoint)
+			Infof("No %s matched deletion filter; nothing to delete", endpoint)
 			return total, deleted, nil
 		}
 


### PR DESCRIPTION
### Summary

A default filter is added that allows us
to skip resources that are marked with
konnect_managed: true. This ensures that
we do not get errors while trying to
reset an org.

Additionally, we can pass filterFuncs for
other entities as required. This would be
useful for entities like teams and roles
that have some predefined resources always
present.

Discovery: resetOrg command in test harness
attempted to delete a konnect-managed
system account, which is not allowed by the API.

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
