### PR TITLE
feat: adopt command for teams

### DIFF
--- a/internal/cmd/root/products/konnect/adopt/team.go
+++ b/internal/cmd/root/products/konnect/adopt/team.go
@@ -1,0 +1,197 @@
+package adopt
+
+import (
+	"fmt"
+	"strings"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	cmdpkg "github.com/kong/kongctl/internal/cmd"
+	cmdCommon "github.com/kong/kongctl/internal/cmd/common"
+	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/kong/kongctl/internal/config"
+	"github.com/kong/kongctl/internal/declarative/labels"
+	"github.com/kong/kongctl/internal/declarative/validator"
+	"github.com/kong/kongctl/internal/konnect/helpers"
+	"github.com/kong/kongctl/internal/util"
+	"github.com/segmentio/cli"
+	"github.com/spf13/cobra"
+)
+
+func NewTeamCmd(
+	verb verbs.VerbValue,
+	baseCmd *cobra.Command,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) (*cobra.Command, error) {
+	cmd := baseCmd
+	if cmd == nil {
+		cmd = &cobra.Command{}
+	}
+
+	cmd.Use = "team team-id"
+	cmd.Short = "Adopt an existing Konnect team into namespace management"
+	cmd.Long = "Apply the KONGCTL-namespace label to an existing Konnect team " +
+		"that is not currently managed by kongctl."
+	cmd.Args = func(_ *cobra.Command, args []string) error {
+		if len(args) != 1 {
+			return fmt.Errorf("exactly one team identifier (ID) is required")
+		}
+		if trimmed := strings.TrimSpace(args[0]); trimmed == "" {
+			return fmt.Errorf("team identifier cannot be empty")
+		}
+		return nil
+	}
+
+	if addParentFlags != nil {
+		addParentFlags(verb, cmd)
+	}
+
+	if parentPreRun != nil {
+		cmd.PreRunE = parentPreRun
+	}
+
+	cmd.Flags().String(NamespaceFlagName, "", "Namespace label to apply to the resource")
+	if err := cmd.MarkFlagRequired(NamespaceFlagName); err != nil {
+		return nil, err
+	}
+
+	cmd.RunE = func(cobraCmd *cobra.Command, args []string) error {
+		helper := cmdpkg.BuildHelper(cobraCmd, args)
+
+		namespace, err := cobraCmd.Flags().GetString(NamespaceFlagName)
+		if err != nil {
+			return err
+		}
+
+		nsValidator := validator.NewNamespaceValidator()
+		if err := nsValidator.ValidateNamespace(namespace); err != nil {
+			return &cmdpkg.ConfigurationError{Err: err}
+		}
+
+		outType, err := helper.GetOutputFormat()
+		if err != nil {
+			return err
+		}
+
+		cfg, err := helper.GetConfig()
+		if err != nil {
+			return err
+		}
+
+		logger, err := helper.GetLogger()
+		if err != nil {
+			return err
+		}
+
+		sdk, err := helper.GetKonnectSDK(cfg, logger)
+		if err != nil {
+			return err
+		}
+
+		result, err := adoptTeam(helper, sdk.GetTeamAPI(), cfg, namespace, strings.TrimSpace(args[0]))
+		if err != nil {
+			return err
+		}
+
+		streams := helper.GetStreams()
+		if outType == cmdCommon.TEXT {
+			name := result.Name
+			if name == "" {
+				name = result.ID
+			}
+			fmt.Fprintf(streams.Out, "Adopted team %q (%s) into namespace %q\n", name, result.ID, result.Namespace)
+			return nil
+		}
+
+		printer, err := cli.Format(outType.String(), streams.Out)
+		if err != nil {
+			return err
+		}
+		defer printer.Flush()
+		printer.Print(result)
+		return nil
+	}
+
+	return cmd, nil
+}
+
+func adoptTeam(
+	helper cmdpkg.Helper,
+	teamAPI helpers.TeamAPI,
+	cfg config.Hook,
+	namespace string,
+	identifier string,
+) (*adoptResult, error) {
+	team, err := resolveTeam(helper, teamAPI, cfg, identifier)
+	if err != nil {
+		return nil, err
+	}
+
+	if existing := team.Labels; existing != nil {
+		if currentNamespace, ok := existing[labels.NamespaceKey]; ok && currentNamespace != "" {
+			return nil, &cmdpkg.ConfigurationError{
+				Err: fmt.Errorf("team %q already has namespace label %q", *team.Name, currentNamespace),
+			}
+		}
+	}
+
+	updateReq := kkComps.UpdateTeam{
+		Name:        team.Name,
+		Description: team.Description,
+		Labels:      pointerLabelMap(team.Labels, namespace),
+	}
+
+	ctx := ensureContext(helper.GetContext())
+
+	resp, err := teamAPI.UpdateTeam(ctx, identifier, &updateReq)
+	if err != nil {
+		fmt.Println("Failed to update team labels:", updateReq.Labels, err)
+		attrs := cmdpkg.TryConvertErrorToAttrs(err)
+		return nil, cmdpkg.PrepareExecutionError("failed to update team", err, helper.GetCmd(), attrs...)
+	}
+
+	updated := resp.GetTeam()
+	if updated == nil {
+		return nil, fmt.Errorf("update team response missing team data")
+	}
+
+	ns := namespace
+	if updated.Labels != nil {
+		if v, ok := updated.Labels[labels.NamespaceKey]; ok && v != "" {
+			ns = v
+		}
+	}
+
+	return &adoptResult{
+		ResourceType: "team",
+		ID:           *updated.ID,
+		Name:         *updated.Name,
+		Namespace:    ns,
+	}, nil
+}
+
+func resolveTeam(
+	helper cmdpkg.Helper,
+	teamAPI helpers.TeamAPI,
+	cfg config.Hook,
+	identifier string,
+) (*kkComps.Team, error) {
+	ctx := ensureContext(helper.GetContext())
+
+	if !util.IsValidUUID(identifier) {
+		return nil, &cmdpkg.ConfigurationError{
+			Err: fmt.Errorf("identifier %q is not a valid UUID", identifier),
+		}
+	}
+
+	resp, err := teamAPI.GetTeam(ctx, identifier)
+	if err != nil {
+		attrs := cmdpkg.TryConvertErrorToAttrs(err)
+		return nil, cmdpkg.PrepareExecutionError("failed to retrieve team", err, helper.GetCmd(), attrs...)
+	}
+	team := resp.GetTeam()
+	if team == nil {
+		return nil, fmt.Errorf("team %s not found", identifier)
+	}
+	return team, nil
+}

--- a/internal/cmd/root/verbs/adopt/adopt.go
+++ b/internal/cmd/root/verbs/adopt/adopt.go
@@ -103,5 +103,11 @@ Setting this value overrides tokens obtained from the login command.
 	}
 	cmd.AddCommand(eventGatewayCmd)
 
+	teamCmd, err := NewDirectTeamCmd()
+	if err != nil {
+		return nil, err
+	}
+	cmd.AddCommand(teamCmd)
+
 	return cmd, nil
 }

--- a/internal/cmd/root/verbs/adopt/direct.go
+++ b/internal/cmd/root/verbs/adopt/direct.go
@@ -181,6 +181,43 @@ Setting this value overrides tokens obtained from the login command.
 	return cmd, nil
 }
 
+func NewDirectTeamCmd() (*cobra.Command, error) {
+	addFlags := func(_ verbs.VerbValue, cmd *cobra.Command) {
+		cmd.Flags().String(common.BaseURLFlagName, "",
+			fmt.Sprintf(`Base URL for Konnect API requests.
+- Config path: [ %s ]
+- Default   : [ %s ]`,
+				common.BaseURLConfigPath, common.BaseURLDefault))
+
+		cmd.Flags().String(common.PATFlagName, "",
+			fmt.Sprintf(`Konnect Personal Access Token (PAT) used to authenticate the CLI. 
+Setting this value overrides tokens obtained from the login command.
+- Config path: [ %s ]`,
+				common.PATConfigPath))
+	}
+
+	preRunE := func(c *cobra.Command, args []string) error {
+		ctx := c.Context()
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		ctx = context.WithValue(ctx, products.Product, konnect.Product)
+		ctx = context.WithValue(ctx, helpers.SDKAPIFactoryKey, common.GetSDKFactory())
+		c.SetContext(ctx)
+		return bindKonnectFlags(c, args)
+	}
+
+	cmd, err := konnectadopt.NewTeamCmd(Verb, &cobra.Command{}, addFlags, preRunE)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd.Example = `  # Adopt a team by id
+  kongctl adopt team 123e4567-e89b-12d3-a456-426614174000 --namespace team-alpha`
+
+	return cmd, nil
+}
+
 func NewDirectAuthStrategyCmd() (*cobra.Command, error) {
 	addFlags := func(_ verbs.VerbValue, cmd *cobra.Command) {
 		cmd.Flags().String(common.BaseURLFlagName, "",


### PR DESCRIPTION
### Summary

This command lets us adopt a team created
otherwise to be managed by kongctl under a
namespace. Other team commands (get, list)
fall under org but this one is directly
under adopt. It follows the same pattern
as control-planes.

### Issues resolved

For https://github.com/Kong/kongctl/issues/260

### Documentation

- [ ] Link to the website [documentation PR](https://github.com/Kong/docs.konghq.com/pull/XXX)

### Testing

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes
