### PR TITLE
Fix: release workflow shas

### DIFF
--- a/.github/workflows/release.md
+++ b/.github/workflows/release.md
@@ -268,12 +268,12 @@ jobs:
             -e HOST_UID="${HOST_UID}" \
             -e HOST_GID="${HOST_GID}" \
             --entrypoint /bin/sh \
-            goreleaser/goreleaser-cross:v1.25.3 \
+            goreleaser/goreleaser-cross:v1.25.3@sha256:f37a98cb1f3543c595e6d70808044f0f221ae5522911357d40cbde81d05e3786 \
             -c "set -e; git config --global --add safe.directory /work; goreleaser release --clean; if [ -d /work/dist ]; then chown -R \${HOST_UID:-0}:\${HOST_GID:-0} /work/dist; fi"
 
       - name: Set up Homebrew
         if: env.RELEASE_BUILD_MODE == 'full'
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@cced187498280712e078aaba62dc13a3e9cd80bf
 
       - name: Fetch Homebrew tap
         if: env.RELEASE_BUILD_MODE == 'full'


### PR DESCRIPTION
 1. Docker image digest pinning (line 271) — the primary flagged concern:
  # Before (mutable tag — vulnerable to tag overwrite):
  goreleaser/goreleaser-cross:v1.25.3

  # After (immutable digest — content-addressed):
  goreleaser/goreleaser-cross:v1.25.3@sha256:f37a98cb1f3543c595e6d70808044f0f221ae5522911357d40cbde81d05e3786
  The tag is kept for readability, but Docker will use the digest to pull. Even if the tag is later overwritten upstream, the workflow will continue to pull the exact same image bytes.

  2. Homebrew action SHA pinning (line 276) — same supply-chain risk pattern:
  # Before (mutable branch ref):
  uses: Homebrew/actions/setup-homebrew@master

  # After (immutable commit SHA):
  uses: Homebrew/actions/setup-homebrew@cced187498280712e078aaba62dc13a3e9cd80bf

  Maintenance note: When you intentionally upgrade either dependency, update both the human-readable tag/ref and the digest/SHA together. For the Docker image, run docker manifest inspect
  goreleaser/goreleaser-cross:<new-tag> --verbose to get the new digest. For the GitHub Action, use gh api repos/Homebrew/actions/commits/master --jq '.sha'.
