### PR TITLE
Fix: Removed clipboard build time dependencies no longer required

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -51,11 +51,6 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Install clipboard build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libx11-dev
-
       - name: Setup deck
         uses: kong/setup-deck@c379e0f67ec1f1363247484a0c3142ae6168f811 # v1.6.0
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,10 +27,6 @@ jobs:
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version-file: go.mod
-      - name: Install clipboard build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libx11-dev
       - name: Setup golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:


### PR DESCRIPTION
atotto/clipboard is not a CGO/X11 binding so the libx11-dev is not longer needed