### PR TITLE
Fix: normalize app auth strategy config keys for key_auth/oidc

### DIFF
--- a/internal/declarative/resources/auth_strategy.go
+++ b/internal/declarative/resources/auth_strategy.go
@@ -234,10 +234,10 @@ func normalizeOIDCConfig(config any) any {
 
 	normalized := maps.Clone(configMap)
 	if _, ok := normalized["credential_claim"]; !ok {
-		normalized["credential_claim"] = []string{}
+		normalized["credential_claim"] = []string(nil)
 	}
 	if _, ok := normalized["auth_methods"]; !ok {
-		normalized["auth_methods"] = []string{}
+		normalized["auth_methods"] = []string(nil)
 	}
 
 	return normalized

--- a/internal/declarative/resources/auth_strategy_unmarshal_test.go
+++ b/internal/declarative/resources/auth_strategy_unmarshal_test.go
@@ -1,0 +1,151 @@
+package resources
+
+import (
+	"fmt"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+)
+
+func TestApplicationAuthStrategyResource_UnmarshalJSON_KeyAuthConfigAliases(t *testing.T) {
+	tests := []struct {
+		name      string
+		configKey string
+	}{
+		{
+			name:      "underscore config key",
+			configKey: "key_auth",
+		},
+		{
+			name:      "hyphen config key",
+			configKey: "key-auth",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := fmt.Sprintf(`
+ref: key-auth
+name: key-auth
+display_name: Key Auth
+strategy_type: key_auth
+configs:
+  %s:
+    key_names:
+      - X-API-Key
+      - Api-Key
+`, tt.configKey)
+
+			var strategy ApplicationAuthStrategyResource
+			err := yaml.Unmarshal([]byte(input), &strategy)
+			require.NoError(t, err)
+
+			assert.Equal(t, kkComps.CreateAppAuthStrategyRequestTypeKeyAuth, strategy.Type)
+			require.NotNil(t, strategy.AppAuthStrategyKeyAuthRequest)
+			assert.Equal(
+				t,
+				[]string{"X-API-Key", "Api-Key"},
+				strategy.AppAuthStrategyKeyAuthRequest.Configs.KeyAuth.KeyNames,
+			)
+		})
+	}
+}
+
+func TestApplicationAuthStrategyResource_UnmarshalJSON_OIDCConfigAliases(t *testing.T) {
+	tests := []struct {
+		name      string
+		configKey string
+	}{
+		{
+			name:      "underscore config key",
+			configKey: "openid_connect",
+		},
+		{
+			name:      "hyphen config key",
+			configKey: "openid-connect",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := fmt.Sprintf(`
+ref: oidc
+name: oidc
+display_name: OIDC
+strategy_type: openid_connect
+configs:
+  %s:
+    issuer: https://issuer.example.com
+    credential_claim:
+      - sub
+    auth_methods:
+      - bearer
+    scopes:
+      - openid
+      - profile
+`, tt.configKey)
+
+			var strategy ApplicationAuthStrategyResource
+			err := yaml.Unmarshal([]byte(input), &strategy)
+			require.NoError(t, err)
+
+			assert.Equal(t, kkComps.CreateAppAuthStrategyRequestTypeOpenidConnect, strategy.Type)
+			require.NotNil(t, strategy.AppAuthStrategyOpenIDConnectRequest)
+			assert.Equal(
+				t,
+				"https://issuer.example.com",
+				strategy.AppAuthStrategyOpenIDConnectRequest.Configs.OpenidConnect.Issuer,
+			)
+			assert.Equal(
+				t,
+				[]string{"openid", "profile"},
+				strategy.AppAuthStrategyOpenIDConnectRequest.Configs.OpenidConnect.Scopes,
+			)
+		})
+	}
+}
+
+func TestApplicationAuthStrategyResource_UnmarshalJSON_OIDCMissingOptionalSlicesRemainNil(t *testing.T) {
+	tests := []struct {
+		name      string
+		configKey string
+	}{
+		{
+			name:      "underscore config key",
+			configKey: "openid_connect",
+		},
+		{
+			name:      "hyphen config key",
+			configKey: "openid-connect",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := fmt.Sprintf(`
+ref: oidc
+name: oidc
+display_name: OIDC
+strategy_type: openid_connect
+configs:
+  %s:
+    issuer: https://issuer.example.com
+    scopes:
+      - openid
+`, tt.configKey)
+
+			var strategy ApplicationAuthStrategyResource
+			err := yaml.Unmarshal([]byte(input), &strategy)
+			require.NoError(t, err)
+
+			require.NotNil(t, strategy.AppAuthStrategyOpenIDConnectRequest)
+			cfg := strategy.AppAuthStrategyOpenIDConnectRequest.Configs.OpenidConnect
+			assert.Nil(t, cfg.CredentialClaim)
+			assert.Nil(t, cfg.AuthMethods)
+			assert.Equal(t, []string{"openid"}, cfg.Scopes)
+		})
+	}
+}

--- a/test/e2e/scenarios/portal/app-auth-strategy/expect/001-plan-auth-strategy/auth-strategy-fields.json
+++ b/test/e2e/scenarios/portal/app-auth-strategy/expect/001-plan-auth-strategy/auth-strategy-fields.json
@@ -1,0 +1,13 @@
+{
+  "name": "key-auth-strategy-e2e",
+  "display_name": "E2E Key Auth Strategy",
+  "strategy_type": "key_auth",
+  "configs": {
+    "key-auth": {
+      "key_names": [
+        "X-API-Key",
+        "Api-Key"
+      ]
+    }
+  }
+}

--- a/test/e2e/scenarios/portal/app-auth-strategy/scenario.yaml
+++ b/test/e2e/scenarios/portal/app-auth-strategy/scenario.yaml
@@ -1,0 +1,45 @@
+baseInputsPath: testdata
+
+env:
+  KONGCTL_LOG_LEVEL: debug
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-plan-key-auth-strategy
+    commands:
+      - name: 000-plan
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/app-auth-strategy.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+
+          - select: >-
+              changes[?resource_type=='application_auth_strategy' &&
+                resource_ref=='key-auth-strategy-e2e'] | [0]
+            expect:
+              fields:
+                action: CREATE
+
+          - select: >-
+              changes[?resource_type=='application_auth_strategy' &&
+                resource_ref=='key-auth-strategy-e2e'] | [0].fields
+            expect:
+              file: expect/001-plan-auth-strategy/auth-strategy-fields.json

--- a/test/e2e/scenarios/portal/app-auth-strategy/testdata/app-auth-strategy.yaml
+++ b/test/e2e/scenarios/portal/app-auth-strategy/testdata/app-auth-strategy.yaml
@@ -1,0 +1,10 @@
+application_auth_strategies:
+  - ref: key-auth-strategy-e2e
+    name: key-auth-strategy-e2e
+    display_name: E2E Key Auth Strategy
+    strategy_type: key_auth
+    configs:
+      key_auth:
+        key_names:
+          - X-API-Key
+          - Api-Key


### PR DESCRIPTION
  - fix ApplicationAuthStrategyResource.UnmarshalJSON to accept both underscore and hyphen config keys: - key_auth and key-auth - openid_connect and openid-connect
  - normalize aliases into existing internal canonical shape so planner/executor keep emitting configs.key-auth / configs.openid-connect
  - add OIDC config normalization to supply empty credential_claim and auth_methods when omitted, matching SDK unmarshal requirements
  - add focused unit tests covering alias handling for both key auth and OIDC
  - add e2e scenario portal/app-auth-strategy with colocated testdata/ proving the key_names regression path and validating expected plan fields

Fixes
- #533 