### PR TITLE
feat: team members

### DIFF
--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -2279,5 +2279,6 @@ func createStateClient(kkClient helpers.SDKAPI) *state.Client {
 
 		// Organization APIs
 		OrganizationTeamAPI: kkClient.GetOrganizationTeamAPI(),
+		TeamMembershipAPI:   kkClient.GetTeamMembershipAPI(),
 	})
 }

--- a/internal/cmd/root/products/konnect/organization/team/getTeam.go
+++ b/internal/cmd/root/products/konnect/organization/team/getTeam.go
@@ -12,6 +12,9 @@ import (
 	cmdCommon "github.com/kong/kongctl/internal/cmd/common"
 	"github.com/kong/kongctl/internal/cmd/output/tableview"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/organization/team/members"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/organization/team/members/systemaccounts"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/organization/team/members/users"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	"github.com/kong/kongctl/internal/config"
 	"github.com/kong/kongctl/internal/konnect/helpers"
@@ -48,6 +51,12 @@ func newGetTeamCmd(
 	cmd.Flags().Bool(skipSystemTeamsFlagName, false, "Skip system teams in the output")
 
 	cmd.RunE = cmd.runE
+
+	// Wire in the members sub-command and its sub-sub-commands.
+	membersCmd := members.NewMembersCmd(verb, addParentFlags, parentPreRun)
+	membersCmd.AddCommand(users.NewUsersCmd(verb, addParentFlags, parentPreRun))
+	membersCmd.AddCommand(systemaccounts.NewSystemAccountsCmd(verb, addParentFlags, parentPreRun))
+	cmd.AddCommand(membersCmd)
 
 	return cmd
 }

--- a/internal/cmd/root/products/konnect/organization/team/members/getMembers.go
+++ b/internal/cmd/root/products/konnect/organization/team/members/getMembers.go
@@ -1,0 +1,254 @@
+package members
+
+import (
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/charmbracelet/bubbles/table"
+	"github.com/kong/kongctl/internal/cmd"
+	"github.com/kong/kongctl/internal/cmd/output/tableview"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
+	"github.com/kong/kongctl/internal/config"
+	"github.com/kong/kongctl/internal/konnect/helpers"
+	"github.com/kong/kongctl/internal/util"
+	"github.com/segmentio/cli"
+	"github.com/spf13/cobra"
+)
+
+// teamMemberRecord is the generic JSON/YAML/table record for a single team member.
+type teamMemberRecord struct {
+	Type       string `json:"type"`
+	ID         string `json:"id"`
+	Identifier string `json:"identifier"`
+}
+
+type getMembersHandler struct {
+	cmd *cobra.Command
+}
+
+func newGetMembersHandler(c *cobra.Command) getMembersHandler {
+	return getMembersHandler{cmd: c}
+}
+
+func (h getMembersHandler) run(args []string) error {
+	helper := cmd.BuildHelper(h.cmd, args)
+
+	if len(args) > 0 {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf(
+				"org team member does not accept positional arguments; " +
+					"use 'members users' or 'members system-accounts' for filtered listing",
+			),
+		}
+	}
+
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+
+	outType, err := helper.GetOutputFormat()
+	if err != nil {
+		return err
+	}
+
+	printer, err := cli.Format(outType.String(), helper.GetStreams().Out)
+	if err != nil {
+		return err
+	}
+	defer printer.Flush()
+
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return err
+	}
+
+	teamIDFlag, teamNameFlag := GetTeamIdentifiers(h.cmd)
+
+	membershipAPI := sdk.GetTeamMembershipAPI()
+	if membershipAPI == nil {
+		return &cmd.ExecutionError{
+			Msg: "Team membership client is not available",
+			Err: fmt.Errorf("team membership client not configured"),
+		}
+	}
+
+	teamID, teamName, err := ResolveOrgTeamID(
+		helper.GetContext(),
+		teamIDFlag,
+		teamNameFlag,
+		sdk.GetOrganizationTeamAPI(),
+		cfg,
+	)
+	if err != nil {
+		return &cmd.ConfigurationError{Err: err}
+	}
+
+	users, err := ListTeamUsers(helper, membershipAPI, teamID, cfg, nil)
+	if err != nil {
+		return err
+	}
+
+	systemAccounts, err := ListTeamSystemAccounts(helper, membershipAPI, teamID, cfg, nil)
+	if err != nil {
+		return err
+	}
+
+	records := make([]teamMemberRecord, 0, len(users)+len(systemAccounts))
+	for i := range users {
+		records = append(records, userToMemberRecord(&users[i]))
+	}
+	for i := range systemAccounts {
+		records = append(records, systemAccountToMemberRecord(&systemAccounts[i]))
+	}
+
+	tableRows := make([]table.Row, 0, len(records))
+	for _, r := range records {
+		tableRows = append(tableRows, table.Row{r.Type, r.ID, r.Identifier})
+	}
+
+	rootLabel := helper.GetCmd().Name()
+	if teamName != "" && teamName != teamID {
+		rootLabel = fmt.Sprintf("%s (%s)", rootLabel, teamName)
+	}
+
+	return tableview.RenderForFormat(
+		helper,
+		false,
+		outType,
+		printer,
+		helper.GetStreams(),
+		records,
+		records,
+		"",
+		tableview.WithCustomTable([]string{"TYPE", "ID", "NAME/EMAIL"}, tableRows),
+		tableview.WithRootLabel(rootLabel),
+	)
+}
+
+// ListTeamUsers fetches all users belonging to the given team. The optional
+// filter parameter constrains results server-side.
+func ListTeamUsers(
+	helper cmd.Helper,
+	membershipAPI helpers.TeamMembershipAPI,
+	teamID string,
+	cfg config.Hook,
+	filter *kkOps.ListTeamUsersQueryParamFilter,
+) ([]kkComps.User, error) {
+	var pageNumber int64 = 1
+	requestPageSize := int64(cfg.GetInt(common.RequestPageSizeConfigPath))
+	if requestPageSize < 1 {
+		requestPageSize = int64(common.DefaultRequestPageSize)
+	}
+
+	var allUsers []kkComps.User
+	var totalFetched int
+
+	for {
+		req := kkOps.ListTeamUsersRequest{
+			TeamID:     teamID,
+			PageSize:   &requestPageSize,
+			PageNumber: &pageNumber,
+			Filter:     filter,
+		}
+		res, err := membershipAPI.ListTeamUsers(helper.GetContext(), req)
+		if err != nil {
+			attrs := cmd.TryConvertErrorToAttrs(err)
+			return nil, cmd.PrepareExecutionError("Failed to list team users", err, helper.GetCmd(), attrs...)
+		}
+
+		col := res.GetUserCollection()
+		data := col.Data
+		allUsers = append(allUsers, data...)
+		totalFetched += len(data)
+
+		if col.Meta == nil || totalFetched >= int(col.Meta.Page.Total) {
+			break
+		}
+		pageNumber++
+	}
+
+	return allUsers, nil
+}
+
+// ListTeamSystemAccounts fetches all system accounts belonging to the given team.
+func ListTeamSystemAccounts(
+	helper cmd.Helper,
+	membershipAPI helpers.TeamMembershipAPI,
+	teamID string,
+	cfg config.Hook,
+	filter *kkOps.GetTeamsTeamIDSystemAccountsQueryParamFilter,
+) ([]kkComps.SystemAccount, error) {
+	var pageNumber int64 = 1
+	requestPageSize := int64(cfg.GetInt(common.RequestPageSizeConfigPath))
+	if requestPageSize < 1 {
+		requestPageSize = int64(common.DefaultRequestPageSize)
+	}
+
+	var allSAs []kkComps.SystemAccount
+	var totalFetched int
+
+	for {
+		req := kkOps.GetTeamsTeamIDSystemAccountsRequest{
+			TeamID:     teamID,
+			PageSize:   &requestPageSize,
+			PageNumber: &pageNumber,
+			Filter:     filter,
+		}
+		res, err := membershipAPI.ListTeamSystemAccounts(helper.GetContext(), req)
+		if err != nil {
+			attrs := cmd.TryConvertErrorToAttrs(err)
+			return nil, cmd.PrepareExecutionError("Failed to list team system accounts", err, helper.GetCmd(), attrs...)
+		}
+
+		col := res.GetSystemAccountCollection()
+		data := col.Data
+		allSAs = append(allSAs, data...)
+		totalFetched += len(data)
+
+		if col.Meta == nil || totalFetched >= int(col.Meta.Page.Total) {
+			break
+		}
+		pageNumber++
+	}
+
+	return allSAs, nil
+}
+
+// userToMemberRecord converts a User to a generic teamMemberRecord.
+func userToMemberRecord(u *kkComps.User) teamMemberRecord {
+	const missing = "n/a"
+	r := teamMemberRecord{Type: "user", ID: missing, Identifier: missing}
+	if u == nil {
+		return r
+	}
+	if id := u.GetID(); id != nil && *id != "" {
+		r.ID = util.AbbreviateUUID(*id)
+	}
+	if email := u.GetEmail(); email != nil && *email != "" {
+		r.Identifier = *email
+	}
+	return r
+}
+
+// systemAccountToMemberRecord converts a SystemAccount to a generic teamMemberRecord.
+func systemAccountToMemberRecord(sa *kkComps.SystemAccount) teamMemberRecord {
+	const missing = "n/a"
+	r := teamMemberRecord{Type: "system-account", ID: missing, Identifier: missing}
+	if sa == nil {
+		return r
+	}
+	if id := sa.GetID(); id != nil && *id != "" {
+		r.ID = util.AbbreviateUUID(*id)
+	}
+	if name := sa.GetName(); name != nil && *name != "" {
+		r.Identifier = *name
+	}
+	return r
+}

--- a/internal/cmd/root/products/konnect/organization/team/members/members.go
+++ b/internal/cmd/root/products/konnect/organization/team/members/members.go
@@ -1,0 +1,178 @@
+package members
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
+	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/kong/kongctl/internal/config"
+	"github.com/kong/kongctl/internal/konnect/helpers"
+	"github.com/kong/kongctl/internal/meta"
+	"github.com/kong/kongctl/internal/util/i18n"
+	"github.com/kong/kongctl/internal/util/normalizers"
+	"github.com/spf13/cobra"
+)
+
+const (
+	CommandName = "member"
+
+	// TeamIDFlagName is the flag for providing a team identifier by UUID.
+	TeamIDFlagName = "team-id"
+	// TeamNameFlagName is the flag for providing a team identifier by name.
+	TeamNameFlagName = "team-name"
+)
+
+var (
+	membersUse   = CommandName
+	membersShort = i18n.T("root.products.konnect.organization.team.membersShort",
+		"List members of a Konnect organization team")
+	membersLong = normalizers.LongDesc(i18n.T("root.products.konnect.organization.team.membersLong",
+		`Use the member command to list users and system accounts that
+belong to a specific Konnect organization team.`))
+	membersExample = normalizers.Examples(i18n.T("root.products.konnect.organization.team.membersExamples",
+		fmt.Sprintf(`
+# List all members of a team by team ID
+%[1]s get org team member --team-id <team-id>
+# List all members of a team by team name
+%[1]s get org team member --team-name my-team
+# List only users in a team
+%[1]s get org team member users --team-name my-team
+# List only system accounts in a team
+%[1]s get org team member system-accounts --team-name my-team
+`, meta.CLIName)))
+)
+
+// AddTeamFlags adds --team-id and --team-name flags to cmd.
+func AddTeamFlags(cmd *cobra.Command) {
+	cmd.Flags().String(TeamIDFlagName, "", "Team ID (UUID) to list members for")
+	cmd.Flags().String(TeamNameFlagName, "", "Team name to list members for")
+}
+
+// GetTeamIdentifiers reads the --team-id and --team-name flag values from cmd.
+func GetTeamIdentifiers(cmd *cobra.Command) (teamID, teamName string) {
+	if f := cmd.Flags().Lookup(TeamIDFlagName); f != nil {
+		teamID = strings.TrimSpace(f.Value.String())
+	}
+	if f := cmd.Flags().Lookup(TeamNameFlagName); f != nil {
+		teamName = strings.TrimSpace(f.Value.String())
+	}
+	return teamID, teamName
+}
+
+// ResolveOrgTeamID resolves the team UUID from either the teamID or teamName
+// arguments. Exactly one must be non-empty. Returns the resolved UUID and the
+// canonical team name (which equals teamID if only the ID was provided).
+func ResolveOrgTeamID(
+	ctx context.Context,
+	teamIDFlag string,
+	teamNameFlag string,
+	orgTeamAPI helpers.OrganizationTeamAPI,
+	cfg config.Hook,
+) (resolvedID string, resolvedName string, err error) {
+	if teamIDFlag != "" && teamNameFlag != "" {
+		return "", "", fmt.Errorf("only one of --%s or --%s can be provided", TeamIDFlagName, TeamNameFlagName)
+	}
+	if teamIDFlag == "" && teamNameFlag == "" {
+		return "", "", fmt.Errorf(
+			"a team identifier is required. Provide --%s or --%s",
+			TeamIDFlagName, TeamNameFlagName,
+		)
+	}
+	if teamIDFlag != "" {
+		return teamIDFlag, teamIDFlag, nil
+	}
+	// Resolve by name
+	team, err := lookupTeamByName(ctx, teamNameFlag, orgTeamAPI, cfg)
+	if err != nil {
+		return "", "", err
+	}
+	id := ""
+	if team.GetID() != nil {
+		id = *team.GetID()
+	}
+	name := teamNameFlag
+	if team.GetName() != nil && *team.GetName() != "" {
+		name = *team.GetName()
+	}
+	return id, name, nil
+}
+
+// lookupTeamByName fetches all teams matching the given name (eq filter) and
+// returns the first match. Returns an error when no match is found.
+func lookupTeamByName(
+	ctx context.Context,
+	name string,
+	orgTeamAPI helpers.OrganizationTeamAPI,
+	cfg config.Hook,
+) (kkComps.Team, error) {
+	var pageNumber int64 = 1
+	requestPageSize := int64(cfg.GetInt(common.RequestPageSizeConfigPath))
+	if requestPageSize < 1 {
+		requestPageSize = int64(common.DefaultRequestPageSize)
+	}
+
+	for {
+		req := kkOps.ListTeamsRequest{
+			PageSize:   &requestPageSize,
+			PageNumber: &pageNumber,
+			Filter: &kkOps.ListTeamsQueryParamFilter{
+				Name: &kkComps.LegacyStringFieldFilter{
+					Eq: &name,
+				},
+			},
+		}
+		res, err := orgTeamAPI.ListOrganizationTeams(ctx, req)
+		if err != nil {
+			return kkComps.Team{}, fmt.Errorf("failed to list teams: %w", err)
+		}
+
+		col := res.GetTeamCollection()
+		for _, t := range col.Data {
+			if t.GetName() != nil && *t.GetName() == name {
+				return t, nil
+			}
+		}
+
+		totalFetched := int(res.GetTeamCollection().Meta.Page.Total)
+		if int(pageNumber)*int(requestPageSize) >= totalFetched {
+			break
+		}
+		pageNumber++
+	}
+
+	return kkComps.Team{}, fmt.Errorf("team with name %q not found", name)
+}
+
+// NewMembersCmd creates the members sub-command for the given verb, wiring in
+// the users and system-accounts sub-sub-commands.
+func NewMembersCmd(
+	verb verbs.VerbValue,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) *cobra.Command {
+	membersCmd := &cobra.Command{
+		Use:     membersUse,
+		Short:   membersShort,
+		Long:    membersLong,
+		Example: membersExample,
+		Aliases: []string{"members", "Member", "Members"},
+		PreRunE: parentPreRun,
+	}
+
+	AddTeamFlags(membersCmd)
+
+	if addParentFlags != nil {
+		addParentFlags(verb, membersCmd)
+	}
+
+	membersCmd.RunE = func(c *cobra.Command, args []string) error {
+		h := newGetMembersHandler(c)
+		return h.run(args)
+	}
+
+	return membersCmd
+}

--- a/internal/cmd/root/products/konnect/organization/team/members/systemaccounts/getSystemAccounts.go
+++ b/internal/cmd/root/products/konnect/organization/team/members/systemaccounts/getSystemAccounts.go
@@ -1,0 +1,177 @@
+package systemaccounts
+
+import (
+	"fmt"
+	"strings"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/charmbracelet/bubbles/table"
+	"github.com/kong/kongctl/internal/cmd"
+	"github.com/kong/kongctl/internal/cmd/output/tableview"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/organization/team/members"
+	"github.com/kong/kongctl/internal/util"
+	"github.com/segmentio/cli"
+	"github.com/spf13/cobra"
+)
+
+// systemAccountRecord is the structured record for displaying a team system account.
+type systemAccountRecord struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type getSystemAccountsHandler struct {
+	cmd *cobra.Command
+}
+
+func newGetSystemAccountsHandler(c *cobra.Command) getSystemAccountsHandler {
+	return getSystemAccountsHandler{cmd: c}
+}
+
+func (h getSystemAccountsHandler) run(args []string) error {
+	helper := cmd.BuildHelper(h.cmd, args)
+
+	if len(args) > 1 {
+		return fmt.Errorf("too many arguments; expected at most one filter value")
+	}
+
+	filter := ""
+	if len(args) == 1 {
+		filter = strings.TrimSpace(args[0])
+	}
+
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+
+	outType, err := helper.GetOutputFormat()
+	if err != nil {
+		return err
+	}
+
+	printer, err := cli.Format(outType.String(), helper.GetStreams().Out)
+	if err != nil {
+		return err
+	}
+	defer printer.Flush()
+
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return err
+	}
+
+	teamIDFlag, teamNameFlag := members.GetTeamIdentifiers(h.cmd)
+
+	membershipAPI := sdk.GetTeamMembershipAPI()
+	if membershipAPI == nil {
+		return &cmd.ExecutionError{
+			Msg: "Team membership client is not available",
+			Err: fmt.Errorf("team membership client not configured"),
+		}
+	}
+
+	teamID, teamName, err := members.ResolveOrgTeamID(
+		helper.GetContext(),
+		teamIDFlag,
+		teamNameFlag,
+		sdk.GetOrganizationTeamAPI(),
+		cfg,
+	)
+	if err != nil {
+		return &cmd.ConfigurationError{Err: err}
+	}
+
+	// Build server-side filter when a search argument is provided.
+	var reqFilter *kkOps.GetTeamsTeamIDSystemAccountsQueryParamFilter
+	if filter != "" && !util.IsValidUUID(filter) {
+		reqFilter = &kkOps.GetTeamsTeamIDSystemAccountsQueryParamFilter{
+			Name: &kkComps.LegacyStringFieldFilter{Eq: &filter},
+		}
+	}
+
+	allSAs, err := members.ListTeamSystemAccounts(helper, membershipAPI, teamID, cfg, reqFilter)
+	if err != nil {
+		return err
+	}
+
+	// Client-side filter by ID (UUID case) or additional name narrowing.
+	if filter != "" {
+		allSAs = clientFilterSAs(allSAs, filter)
+	}
+
+	records := make([]systemAccountRecord, 0, len(allSAs))
+	for i := range allSAs {
+		records = append(records, saToRecord(&allSAs[i]))
+	}
+
+	tableRows := make([]table.Row, 0, len(records))
+	for _, r := range records {
+		tableRows = append(tableRows, table.Row{r.ID, r.Name, r.Description})
+	}
+
+	rootLabel := helper.GetCmd().Name()
+	if teamName != "" && teamName != teamID {
+		rootLabel = fmt.Sprintf("%s (%s)", rootLabel, teamName)
+	}
+
+	return tableview.RenderForFormat(
+		helper,
+		false,
+		outType,
+		printer,
+		helper.GetStreams(),
+		records,
+		allSAs,
+		"",
+		tableview.WithCustomTable([]string{"ID", "NAME", "DESCRIPTION"}, tableRows),
+		tableview.WithRootLabel(rootLabel),
+	)
+}
+
+// clientFilterSAs filters system accounts by ID (exact UUID) or name (contains).
+func clientFilterSAs(sas []kkComps.SystemAccount, filter string) []kkComps.SystemAccount {
+	var result []kkComps.SystemAccount
+	for _, sa := range sas {
+		if matchesSA(&sa, filter) {
+			result = append(result, sa)
+		}
+	}
+	return result
+}
+
+func matchesSA(sa *kkComps.SystemAccount, filter string) bool {
+	if id := sa.GetID(); id != nil && strings.EqualFold(*id, filter) {
+		return true
+	}
+	if name := sa.GetName(); name != nil && strings.EqualFold(*name, filter) {
+		return true
+	}
+	return false
+}
+
+// saToRecord converts a SystemAccount to a displayable systemAccountRecord.
+func saToRecord(sa *kkComps.SystemAccount) systemAccountRecord {
+	const missing = "n/a"
+	r := systemAccountRecord{ID: missing, Name: missing, Description: missing}
+	if sa == nil {
+		return r
+	}
+	if id := sa.GetID(); id != nil && *id != "" {
+		r.ID = util.AbbreviateUUID(*id)
+	}
+	if name := sa.GetName(); name != nil {
+		r.Name = *name
+	}
+	if desc := sa.GetDescription(); desc != nil {
+		r.Description = *desc
+	}
+	return r
+}

--- a/internal/cmd/root/products/konnect/organization/team/members/systemaccounts/systemaccounts.go
+++ b/internal/cmd/root/products/konnect/organization/team/members/systemaccounts/systemaccounts.go
@@ -1,0 +1,68 @@
+package systemaccounts
+
+import (
+	"fmt"
+
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/organization/team/members"
+	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/kong/kongctl/internal/meta"
+	"github.com/kong/kongctl/internal/util/i18n"
+	"github.com/kong/kongctl/internal/util/normalizers"
+	"github.com/spf13/cobra"
+)
+
+const (
+	CommandName = "system-account"
+)
+
+var (
+	systemAccountsUse   = CommandName
+	systemAccountsShort = i18n.T(
+		"root.products.konnect.organization.team.members.systemAccountsShort",
+		"List system accounts in a Konnect organization team")
+	systemAccountsLong = normalizers.LongDesc(i18n.T(
+		"root.products.konnect.organization.team.members.systemAccountsLong",
+		`Use the system-account command to list system accounts that belong to a
+specific Konnect organization team. An optional positional argument filters
+results: a UUID matches by ID, any other value is matched against the system
+account name.`))
+	systemAccountsExample = normalizers.Examples(i18n.T(
+		"root.products.konnect.organization.team.members.systemAccountsExamples",
+		fmt.Sprintf(`
+# List all system accounts in a team by team ID
+%[1]s get org team member system-accounts --team-id <team-id>
+# List all system accounts in a team by team name
+%[1]s get org team member system-accounts --team-name my-team
+# Filter by name
+%[1]s get org team member system-accounts --team-name my-team gateway-sa
+`, meta.CLIName)))
+)
+
+// NewSystemAccountsCmd creates the system-accounts sub-command.
+func NewSystemAccountsCmd(
+	verb verbs.VerbValue,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) *cobra.Command {
+	systemAccountsCmd := &cobra.Command{
+		Use:     systemAccountsUse,
+		Short:   systemAccountsShort,
+		Long:    systemAccountsLong,
+		Example: systemAccountsExample,
+		Aliases: []string{"system-accounts", "systemaccount", "systemaccounts",
+			"system_account", "system_accounts", "sa", "sas", "SA", "SAS"},
+		PreRunE: parentPreRun,
+		RunE: func(c *cobra.Command, args []string) error {
+			h := newGetSystemAccountsHandler(c)
+			return h.run(args)
+		},
+	}
+
+	members.AddTeamFlags(systemAccountsCmd)
+
+	if addParentFlags != nil {
+		addParentFlags(verb, systemAccountsCmd)
+	}
+
+	return systemAccountsCmd
+}

--- a/internal/cmd/root/products/konnect/organization/team/members/users/getUsers.go
+++ b/internal/cmd/root/products/konnect/organization/team/members/users/getUsers.go
@@ -1,0 +1,205 @@
+package users
+
+import (
+	"fmt"
+	"strings"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/charmbracelet/bubbles/table"
+	"github.com/kong/kongctl/internal/cmd"
+	"github.com/kong/kongctl/internal/cmd/output/tableview"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/organization/team/members"
+	"github.com/kong/kongctl/internal/util"
+	"github.com/segmentio/cli"
+	"github.com/spf13/cobra"
+)
+
+// userRecord is the structured record for displaying a team user.
+type userRecord struct {
+	ID       string `json:"id"`
+	Email    string `json:"email"`
+	FullName string `json:"full_name"`
+	Active   string `json:"active"`
+}
+
+type getUsersHandler struct {
+	cmd *cobra.Command
+}
+
+func newGetUsersHandler(c *cobra.Command) getUsersHandler {
+	return getUsersHandler{cmd: c}
+}
+
+func (h getUsersHandler) run(args []string) error {
+	helper := cmd.BuildHelper(h.cmd, args)
+
+	if len(args) > 1 {
+		return fmt.Errorf("too many arguments; expected at most one filter value")
+	}
+
+	filter := ""
+	if len(args) == 1 {
+		filter = strings.TrimSpace(args[0])
+	}
+
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+
+	outType, err := helper.GetOutputFormat()
+	if err != nil {
+		return err
+	}
+
+	printer, err := cli.Format(outType.String(), helper.GetStreams().Out)
+	if err != nil {
+		return err
+	}
+	defer printer.Flush()
+
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return err
+	}
+
+	teamIDFlag, teamNameFlag := members.GetTeamIdentifiers(h.cmd)
+
+	membershipAPI := sdk.GetTeamMembershipAPI()
+	if membershipAPI == nil {
+		return &cmd.ExecutionError{
+			Msg: "Team membership client is not available",
+			Err: fmt.Errorf("team membership client not configured"),
+		}
+	}
+
+	teamID, teamName, err := members.ResolveOrgTeamID(
+		helper.GetContext(),
+		teamIDFlag,
+		teamNameFlag,
+		sdk.GetOrganizationTeamAPI(),
+		cfg,
+	)
+	if err != nil {
+		return &cmd.ConfigurationError{Err: err}
+	}
+
+	// Build server-side filter when a search argument is provided.
+	var reqFilter *kkOps.ListTeamUsersQueryParamFilter
+	if filter != "" {
+		reqFilter = buildUserFilter(filter)
+	}
+
+	allUsers, err := members.ListTeamUsers(helper, membershipAPI, teamID, cfg, reqFilter)
+	if err != nil {
+		return err
+	}
+
+	// Client-side filter for cases where the argument can't map to a single
+	// server-side predicate.
+	if filter != "" {
+		allUsers = clientFilterUsers(allUsers, filter)
+	}
+
+	records := make([]userRecord, 0, len(allUsers))
+	for i := range allUsers {
+		records = append(records, userToRecord(&allUsers[i]))
+	}
+
+	tableRows := make([]table.Row, 0, len(records))
+	for _, r := range records {
+		tableRows = append(tableRows, table.Row{r.ID, r.Email, r.FullName, r.Active})
+	}
+
+	rootLabel := helper.GetCmd().Name()
+	if teamName != "" && teamName != teamID {
+		rootLabel = fmt.Sprintf("%s (%s)", rootLabel, teamName)
+	}
+
+	return tableview.RenderForFormat(
+		helper,
+		false,
+		outType,
+		printer,
+		helper.GetStreams(),
+		records,
+		allUsers,
+		"",
+		tableview.WithCustomTable([]string{"ID", "EMAIL", "FULL NAME", "ACTIVE"}, tableRows),
+		tableview.WithRootLabel(rootLabel),
+	)
+}
+
+// buildUserFilter constructs a server-side filter that covers ID (exact),
+// email (contains), and full_name (contains) based on the raw filter string.
+// We send all three and let the server resolve whichever is relevant. When the
+// argument looks like a UUID we use only the ID equals filter.
+func buildUserFilter(filter string) *kkOps.ListTeamUsersQueryParamFilter {
+	f := &kkOps.ListTeamUsersQueryParamFilter{}
+	if util.IsValidUUID(filter) {
+		f.ID = &kkComps.StringFieldEqualsFilter{Eq: &filter}
+		return f
+	}
+	// Use email filter when the argument contains '@'.
+	if strings.Contains(filter, "@") {
+		f.Email = &kkComps.LegacyStringFieldFilter{Eq: &filter}
+		return f
+	}
+	// Generic string: filter on full_name
+	f.FullName = &kkComps.LegacyStringFieldFilter{Eq: &filter}
+	return f
+}
+
+// clientFilterUsers performs an additional client-side pass over users in case
+// the server didn't narrow results sufficiently (e.g. when the server applies
+// OR semantics across multiple filter fields).
+func clientFilterUsers(users []kkComps.User, filter string) []kkComps.User {
+	var result []kkComps.User
+	for _, u := range users {
+		if matchesUser(&u, filter) {
+			result = append(result, u)
+		}
+	}
+	return result
+}
+
+func matchesUser(u *kkComps.User, filter string) bool {
+	if id := u.GetID(); id != nil && strings.EqualFold(*id, filter) {
+		return true
+	}
+	if email := u.GetEmail(); email != nil && strings.EqualFold(*email, filter) {
+		return true
+	}
+	if name := u.GetFullName(); name != nil && strings.EqualFold(*name, filter) {
+		return true
+	}
+	return false
+}
+
+// userToRecord converts a User to a displayable userRecord.
+func userToRecord(u *kkComps.User) userRecord {
+	const missing = "n/a"
+	r := userRecord{ID: missing, Email: missing, FullName: missing, Active: missing}
+	if u == nil {
+		return r
+	}
+	if id := u.GetID(); id != nil && *id != "" {
+		r.ID = util.AbbreviateUUID(*id)
+	}
+	if email := u.GetEmail(); email != nil {
+		r.Email = *email
+	}
+	if name := u.GetFullName(); name != nil {
+		r.FullName = *name
+	}
+	if active := u.GetActive(); active != nil {
+		r.Active = fmt.Sprintf("%t", *active)
+	}
+	return r
+}

--- a/internal/cmd/root/products/konnect/organization/team/members/users/users.go
+++ b/internal/cmd/root/products/konnect/organization/team/members/users/users.go
@@ -1,0 +1,66 @@
+package users
+
+import (
+	"fmt"
+
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/organization/team/members"
+	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/kong/kongctl/internal/meta"
+	"github.com/kong/kongctl/internal/util/i18n"
+	"github.com/kong/kongctl/internal/util/normalizers"
+	"github.com/spf13/cobra"
+)
+
+const (
+	CommandName = "user"
+)
+
+var (
+	usersUse   = CommandName
+	usersShort = i18n.T("root.products.konnect.organization.team.members.usersShort",
+		"List users in a Konnect organization team")
+	usersLong = normalizers.LongDesc(i18n.T("root.products.konnect.organization.team.members.usersLong",
+		`Use the user command to list users that belong to a specific Konnect
+organization team. An optional positional argument filters results: a UUID
+matches users by ID, a value containing '@' is matched against email, and any
+other value matches against the user's full name.`))
+	usersExample = normalizers.Examples(i18n.T("root.products.konnect.organization.team.members.usersExamples",
+		fmt.Sprintf(`
+# List all users in a team by team ID
+%[1]s get org team member users --team-id <team-id>
+# List all users in a team by team name
+%[1]s get org team member users --team-name my-team
+# Filter users by email
+%[1]s get org team member users --team-name my-team user@example.com
+# Filter users by name
+%[1]s get org team member users --team-name my-team "John Doe"
+`, meta.CLIName)))
+)
+
+// NewUsersCmd creates the users sub-command.
+func NewUsersCmd(
+	verb verbs.VerbValue,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) *cobra.Command {
+	usersCmd := &cobra.Command{
+		Use:     usersUse,
+		Short:   usersShort,
+		Long:    usersLong,
+		Example: usersExample,
+		Aliases: []string{"users", "User", "Users"},
+		PreRunE: parentPreRun,
+		RunE: func(c *cobra.Command, args []string) error {
+			h := newGetUsersHandler(c)
+			return h.run(args)
+		},
+	}
+
+	members.AddTeamFlags(usersCmd)
+
+	if addParentFlags != nil {
+		addParentFlags(verb, usersCmd)
+	}
+
+	return usersCmd
+}

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -78,6 +78,10 @@ type Executor struct {
 	// API implementation is not yet supported by SDK but we include adapter for completeness
 	apiImplementationExecutor *BaseCreateDeleteExecutor[kkComps.APIImplementation]
 
+	// Organization team child resource executors
+	organizationTeamUserExecutor          *BaseCreateDeleteExecutor[kkComps.AddUserToTeam]
+	organizationTeamSystemAccountExecutor *BaseCreateDeleteExecutor[kkComps.AddSystemAccountToTeam]
+
 	deckRunner     deck.Runner
 	konnectToken   string
 	konnectBaseURL string
@@ -266,6 +270,16 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 
 	e.apiImplementationExecutor = NewBaseCreateDeleteExecutor[kkComps.APIImplementation](
 		NewAPIImplementationAdapter(client),
+		dryRun,
+	)
+
+	// Initialize organization team child resource executors
+	e.organizationTeamUserExecutor = NewBaseCreateDeleteExecutor[kkComps.AddUserToTeam](
+		NewOrganizationTeamUserAdapter(client),
+		dryRun,
+	)
+	e.organizationTeamSystemAccountExecutor = NewBaseCreateDeleteExecutor[kkComps.AddSystemAccountToTeam](
+		NewOrganizationTeamSystemAccountAdapter(client),
 		dryRun,
 	)
 
@@ -730,6 +744,40 @@ func (e *Executor) resolvePortalTeamRef(
 	}
 
 	return "", fmt.Errorf("portal team not found: ref=%s, looked up by name=%s", refInfo.Ref, lookupValue)
+}
+
+// resolveOrganizationTeamRef resolves an organization team reference to its Konnect ID.
+func (e *Executor) resolveOrganizationTeamRef(
+	ctx context.Context,
+	refInfo planner.ReferenceInfo,
+) (string, error) {
+	if orgTeams, ok := e.refToID["organization_team"]; ok {
+		if id, found := orgTeams[refInfo.Ref]; found && id != "" {
+			return id, nil
+		}
+	}
+
+	lookupValue := refInfo.Ref
+	if refInfo.LookupFields != nil {
+		if name, hasName := refInfo.LookupFields["name"]; hasName && name != "" {
+			lookupValue = name
+		}
+	}
+
+	// Fall back to looking up in the state client
+	team, err := e.client.GetOrganizationTeamByName(ctx, lookupValue)
+	if err != nil {
+		return "", fmt.Errorf("failed to look up organization team %q: %w", lookupValue, err)
+	}
+	if team == nil {
+		return "", fmt.Errorf("organization team not found: ref=%s, lookup=%s", refInfo.Ref, lookupValue)
+	}
+
+	if team.ID == nil || *team.ID == "" {
+		return "", fmt.Errorf("organization team %q found but has no ID", lookupValue)
+	}
+
+	return *team.ID, nil
 }
 
 func (e *Executor) resolveControlPlaneRef(ctx context.Context, refInfo planner.ReferenceInfo) (string, error) {
@@ -1782,6 +1830,36 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 		return e.eventGatewayVirtualClusterExecutor.Create(ctx, *change)
 	case "organization_team":
 		return e.organizationTeamExecutor.Create(ctx, *change)
+	case planner.ResourceTypeOrganizationTeamUser:
+		if teamRef, ok := change.References["team_id"]; ok && teamRef.ID == "" {
+			teamID, err := e.resolveOrganizationTeamRef(ctx, teamRef)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve organization team reference: %w", err)
+			}
+			teamRef.ID = teamID
+			change.References["team_id"] = teamRef
+		}
+		if change.Parent != nil && change.Parent.ID == "" {
+			if teamRef, ok := change.References["team_id"]; ok {
+				change.Parent.ID = teamRef.ID
+			}
+		}
+		return e.organizationTeamUserExecutor.Create(ctx, *change)
+	case planner.ResourceTypeOrganizationTeamSystemAccount:
+		if teamRef, ok := change.References["team_id"]; ok && teamRef.ID == "" {
+			teamID, err := e.resolveOrganizationTeamRef(ctx, teamRef)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve organization team reference: %w", err)
+			}
+			teamRef.ID = teamID
+			change.References["team_id"] = teamRef
+		}
+		if change.Parent != nil && change.Parent.ID == "" {
+			if teamRef, ok := change.References["team_id"]; ok {
+				change.Parent.ID = teamRef.ID
+			}
+		}
+		return e.organizationTeamSystemAccountExecutor.Create(ctx, *change)
 
 	case planner.ResourceTypeEventGatewayListener:
 		// Resolve event gateway reference if needed
@@ -2272,6 +2350,36 @@ func (e *Executor) deleteResource(ctx context.Context, change *planner.PlannedCh
 		return e.eventGatewayDataPlaneCertificateExecutor.Delete(ctx, *change)
 	case "organization_team":
 		return e.organizationTeamExecutor.Delete(ctx, *change)
+	case planner.ResourceTypeOrganizationTeamUser:
+		if teamRef, ok := change.References["team_id"]; ok && teamRef.ID == "" {
+			teamID, err := e.resolveOrganizationTeamRef(ctx, teamRef)
+			if err != nil {
+				return fmt.Errorf("failed to resolve organization team reference: %w", err)
+			}
+			teamRef.ID = teamID
+			change.References["team_id"] = teamRef
+		}
+		if change.Parent != nil && change.Parent.ID == "" {
+			if teamRef, ok := change.References["team_id"]; ok {
+				change.Parent.ID = teamRef.ID
+			}
+		}
+		return e.organizationTeamUserExecutor.Delete(ctx, *change)
+	case planner.ResourceTypeOrganizationTeamSystemAccount:
+		if teamRef, ok := change.References["team_id"]; ok && teamRef.ID == "" {
+			teamID, err := e.resolveOrganizationTeamRef(ctx, teamRef)
+			if err != nil {
+				return fmt.Errorf("failed to resolve organization team reference: %w", err)
+			}
+			teamRef.ID = teamID
+			change.References["team_id"] = teamRef
+		}
+		if change.Parent != nil && change.Parent.ID == "" {
+			if teamRef, ok := change.References["team_id"]; ok {
+				change.Parent.ID = teamRef.ID
+			}
+		}
+		return e.organizationTeamSystemAccountExecutor.Delete(ctx, *change)
 	default:
 		return fmt.Errorf("delete operation not yet implemented for %s", change.ResourceType)
 	}

--- a/internal/declarative/executor/organization_team_system_account_adapter.go
+++ b/internal/declarative/executor/organization_team_system_account_adapter.go
@@ -1,0 +1,173 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/log"
+)
+
+// OrganizationTeamSystemAccountAdapter implements CreateDeleteOperations for organization team
+// system account memberships. Memberships only support add and remove operations, not updates.
+type OrganizationTeamSystemAccountAdapter struct {
+	client *state.Client
+}
+
+// NewOrganizationTeamSystemAccountAdapter creates a new organization team system account adapter.
+func NewOrganizationTeamSystemAccountAdapter(client *state.Client) *OrganizationTeamSystemAccountAdapter {
+	return &OrganizationTeamSystemAccountAdapter{client: client}
+}
+
+// MapCreateFields maps the planned change fields to an AddSystemAccountToTeam request.
+func (a *OrganizationTeamSystemAccountAdapter) MapCreateFields(
+	_ context.Context,
+	execCtx *ExecutionContext,
+	fields map[string]any,
+	create *kkComps.AddSystemAccountToTeam,
+) error {
+	// Prefer the resolved account_id from References over raw fields
+	if execCtx != nil && execCtx.PlannedChange != nil {
+		if ref, ok := execCtx.PlannedChange.References["account_id"]; ok && ref.ID != "" {
+			create.AccountID = &ref.ID
+			return nil
+		}
+	}
+
+	accountID, _ := fields["account_id"].(string)
+	if accountID == "" {
+		return fmt.Errorf("account_id is required for organization_team_system_account membership")
+	}
+
+	create.AccountID = &accountID
+	return nil
+}
+
+// Create adds a system account to an organization team.
+func (a *OrganizationTeamSystemAccountAdapter) Create(
+	ctx context.Context,
+	req kkComps.AddSystemAccountToTeam,
+	_ string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	teamID, err := a.getTeamID(execCtx)
+	if err != nil {
+		return "", err
+	}
+
+	if req.AccountID == nil || *req.AccountID == "" {
+		return "", fmt.Errorf("account_id is required to add system account to team")
+	}
+
+	accountID := *req.AccountID
+
+	logger := orgTeamSALogger(ctx)
+	if logger != nil {
+		logger.LogAttrs(ctx, slog.LevelDebug, "Adding system account to organization team",
+			slog.String("team_id", teamID),
+			slog.String("account_id", accountID))
+	}
+
+	if err := a.client.AddSystemAccountToTeam(ctx, teamID, accountID); err != nil {
+		return "", err
+	}
+
+	if logger != nil {
+		logger.LogAttrs(ctx, slog.LevelDebug, "Added system account to organization team",
+			slog.String("team_id", teamID),
+			slog.String("account_id", accountID))
+	}
+
+	// Membership has no separate ID; use the system account's Konnect ID as the resource ID.
+	return accountID, nil
+}
+
+// Delete removes a system account from an organization team.
+func (a *OrganizationTeamSystemAccountAdapter) Delete(
+	ctx context.Context,
+	id string,
+	execCtx *ExecutionContext,
+) error {
+	teamID, err := a.getTeamID(execCtx)
+	if err != nil {
+		return err
+	}
+
+	accountID := id
+	if accountID == "" {
+		if execCtx != nil && execCtx.PlannedChange != nil {
+			if aid, ok := execCtx.PlannedChange.Fields["account_id"].(string); ok {
+				accountID = aid
+			}
+		}
+	}
+
+	if accountID == "" {
+		return fmt.Errorf("account_id is required to remove system account from team")
+	}
+
+	logger := orgTeamSALogger(ctx)
+	if logger != nil {
+		logger.LogAttrs(ctx, slog.LevelDebug, "Removing system account from organization team",
+			slog.String("team_id", teamID),
+			slog.String("account_id", accountID))
+	}
+
+	if err := a.client.RemoveSystemAccountFromTeam(ctx, teamID, accountID); err != nil {
+		return err
+	}
+
+	if logger != nil {
+		logger.LogAttrs(ctx, slog.LevelDebug, "Removed system account from organization team",
+			slog.String("team_id", teamID),
+			slog.String("account_id", accountID))
+	}
+
+	return nil
+}
+
+// GetByName is not supported for team system account memberships.
+func (a *OrganizationTeamSystemAccountAdapter) GetByName(_ context.Context, _ string) (ResourceInfo, error) {
+	return nil, nil
+}
+
+// ResourceType returns the resource type name.
+func (a *OrganizationTeamSystemAccountAdapter) ResourceType() string {
+	return "organization_team_system_account"
+}
+
+// RequiredFields returns the required fields for creation.
+func (a *OrganizationTeamSystemAccountAdapter) RequiredFields() []string {
+	return []string{"account_id"}
+}
+
+// getTeamID extracts the team Konnect ID from the execution context.
+func (a *OrganizationTeamSystemAccountAdapter) getTeamID(execCtx *ExecutionContext) (string, error) {
+	if execCtx == nil || execCtx.PlannedChange == nil {
+		return "", fmt.Errorf(
+			"execution context is required for organization_team_system_account operations",
+		)
+	}
+
+	change := *execCtx.PlannedChange
+
+	if ref, ok := change.References["team_id"]; ok && ref.ID != "" {
+		return ref.ID, nil
+	}
+
+	if change.Parent != nil && change.Parent.ID != "" {
+		return change.Parent.ID, nil
+	}
+
+	return "", fmt.Errorf("team ID is required for organization_team_system_account operations")
+}
+
+func orgTeamSALogger(ctx context.Context) *slog.Logger {
+	if ctx == nil {
+		return nil
+	}
+	logger, _ := ctx.Value(log.LoggerKey).(*slog.Logger)
+	return logger
+}

--- a/internal/declarative/executor/organization_team_user_adapter.go
+++ b/internal/declarative/executor/organization_team_user_adapter.go
@@ -1,0 +1,166 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/log"
+)
+
+// OrganizationTeamUserAdapter implements CreateDeleteOperations for organization team user memberships.
+// User memberships only support add and remove operations, not updates.
+type OrganizationTeamUserAdapter struct {
+	client *state.Client
+}
+
+// NewOrganizationTeamUserAdapter creates a new organization team user adapter.
+func NewOrganizationTeamUserAdapter(client *state.Client) *OrganizationTeamUserAdapter {
+	return &OrganizationTeamUserAdapter{client: client}
+}
+
+// MapCreateFields maps the planned change fields to an AddUserToTeam request.
+func (a *OrganizationTeamUserAdapter) MapCreateFields(
+	_ context.Context,
+	execCtx *ExecutionContext,
+	fields map[string]any,
+	create *kkComps.AddUserToTeam,
+) error {
+	// Prefer the resolved user_id from References over raw fields
+	if execCtx != nil && execCtx.PlannedChange != nil {
+		if ref, ok := execCtx.PlannedChange.References["user_id"]; ok && ref.ID != "" {
+			create.UserID = ref.ID
+			return nil
+		}
+	}
+
+	userID, _ := fields["user_id"].(string)
+	if userID == "" {
+		return fmt.Errorf("user_id is required for organization_team_user membership")
+	}
+
+	create.UserID = userID
+	return nil
+}
+
+// Create adds a user to an organization team.
+func (a *OrganizationTeamUserAdapter) Create(
+	ctx context.Context,
+	req kkComps.AddUserToTeam,
+	_ string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	teamID, err := a.getTeamID(execCtx)
+	if err != nil {
+		return "", err
+	}
+
+	if req.UserID == "" {
+		return "", fmt.Errorf("user_id is required to add user to team")
+	}
+
+	logger := orgTeamUserLogger(ctx)
+	if logger != nil {
+		logger.LogAttrs(ctx, slog.LevelDebug, "Adding user to organization team",
+			slog.String("team_id", teamID),
+			slog.String("user_id", req.UserID))
+	}
+
+	if err := a.client.AddUserToTeam(ctx, teamID, req.UserID); err != nil {
+		return "", err
+	}
+
+	if logger != nil {
+		logger.LogAttrs(ctx, slog.LevelDebug, "Added user to organization team",
+			slog.String("team_id", teamID),
+			slog.String("user_id", req.UserID))
+	}
+
+	// Membership has no separate ID; use the user's Konnect ID as the resource ID.
+	return req.UserID, nil
+}
+
+// Delete removes a user from an organization team.
+func (a *OrganizationTeamUserAdapter) Delete(ctx context.Context, id string, execCtx *ExecutionContext) error {
+	teamID, err := a.getTeamID(execCtx)
+	if err != nil {
+		return err
+	}
+
+	userID := id
+	if userID == "" {
+		// Fall back to fields
+		if execCtx != nil && execCtx.PlannedChange != nil {
+			if uid, ok := execCtx.PlannedChange.Fields["user_id"].(string); ok {
+				userID = uid
+			}
+		}
+	}
+
+	if userID == "" {
+		return fmt.Errorf("user_id is required to remove user from team")
+	}
+
+	logger := orgTeamUserLogger(ctx)
+	if logger != nil {
+		logger.LogAttrs(ctx, slog.LevelDebug, "Removing user from organization team",
+			slog.String("team_id", teamID),
+			slog.String("user_id", userID))
+	}
+
+	if err := a.client.RemoveUserFromTeam(ctx, userID, teamID); err != nil {
+		return err
+	}
+
+	if logger != nil {
+		logger.LogAttrs(ctx, slog.LevelDebug, "Removed user from organization team",
+			slog.String("team_id", teamID),
+			slog.String("user_id", userID))
+	}
+
+	return nil
+}
+
+// GetByName is not supported for team user memberships.
+func (a *OrganizationTeamUserAdapter) GetByName(_ context.Context, _ string) (ResourceInfo, error) {
+	return nil, nil
+}
+
+// ResourceType returns the resource type name.
+func (a *OrganizationTeamUserAdapter) ResourceType() string {
+	return "organization_team_user"
+}
+
+// RequiredFields returns the required fields for creation.
+func (a *OrganizationTeamUserAdapter) RequiredFields() []string {
+	return []string{"user_id"}
+}
+
+// getTeamID extracts the team Konnect ID from the execution context.
+func (a *OrganizationTeamUserAdapter) getTeamID(execCtx *ExecutionContext) (string, error) {
+	if execCtx == nil || execCtx.PlannedChange == nil {
+		return "", fmt.Errorf("execution context is required for organization_team_user operations")
+	}
+
+	change := *execCtx.PlannedChange
+
+	if ref, ok := change.References["team_id"]; ok && ref.ID != "" {
+		return ref.ID, nil
+	}
+
+	if change.Parent != nil && change.Parent.ID != "" {
+		return change.Parent.ID, nil
+	}
+
+	return "", fmt.Errorf("team ID is required for organization_team_user operations")
+}
+
+func orgTeamUserLogger(ctx context.Context) *slog.Logger {
+	if ctx == nil {
+		return nil
+	}
+	logger, _ := ctx.Value(log.LoggerKey).(*slog.Logger)
+	return logger
+}

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -675,6 +675,26 @@ func (l *Loader) extractNestedResources(rs *resources.ResourceSet) {
 		org.Teams = nil
 	}
 
+	// Extract member resources from each organization team
+	for i := range rs.OrganizationTeams {
+		team := &rs.OrganizationTeams[i]
+		if team.Members == nil {
+			continue
+		}
+
+		for _, user := range team.Members.Users {
+			user.Team = team.Ref
+			rs.OrganizationTeamUsers = append(rs.OrganizationTeamUsers, user)
+		}
+
+		for _, sa := range team.Members.SystemAccounts {
+			sa.Team = team.Ref
+			rs.OrganizationTeamSystemAccounts = append(rs.OrganizationTeamSystemAccounts, sa)
+		}
+
+		team.Members = nil // clear after extraction to avoid double processing
+	}
+
 	for i := range rs.ControlPlanes {
 		cp := &rs.ControlPlanes[i]
 

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -692,7 +692,7 @@ func (l *Loader) extractNestedResources(rs *resources.ResourceSet) {
 			rs.OrganizationTeamSystemAccounts = append(rs.OrganizationTeamSystemAccounts, sa)
 		}
 
-		team.Members = nil // clear after extraction to avoid double processing
+		team.Members = nil
 	}
 
 	for i := range rs.ControlPlanes {

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -52,6 +52,11 @@ func (l *Loader) validateResourceSet(rs *resources.ResourceSet) error {
 		return err
 	}
 
+	// Validate separate team member resources (extracted from nested members)
+	if err := l.validateSeparateTeamMemberResources(rs); err != nil {
+		return err
+	}
+
 	// Validate cross-resource references
 	if err := l.validateCrossReferences(rs); err != nil {
 		return err
@@ -94,6 +99,43 @@ func (l *Loader) validateOrganizationTeams(teams []resources.OrganizationTeamRes
 		}
 
 		names[team.Name] = team.GetRef()
+	}
+
+	return nil
+}
+
+// validateSeparateTeamMemberResources validates team member resources extracted from nested members blocks
+func (l *Loader) validateSeparateTeamMemberResources(rs *resources.ResourceSet) error {
+	// Validate separate team user resources
+	for i := range rs.OrganizationTeamUsers {
+		user := &rs.OrganizationTeamUsers[i]
+		if err := user.Validate(); err != nil {
+			return fmt.Errorf("invalid organization_team_user %q: %w", user.GetRef(), err)
+		}
+		for j := i + 1; j < len(rs.OrganizationTeamUsers); j++ {
+			if rs.OrganizationTeamUsers[j].GetRef() == user.GetRef() {
+				return fmt.Errorf(
+					"duplicate ref '%s' (already defined as organization_team_user)",
+					user.GetRef(),
+				)
+			}
+		}
+	}
+
+	// Validate separate team system account resources
+	for i := range rs.OrganizationTeamSystemAccounts {
+		sa := &rs.OrganizationTeamSystemAccounts[i]
+		if err := sa.Validate(); err != nil {
+			return fmt.Errorf("invalid organization_team_system_account %q: %w", sa.GetRef(), err)
+		}
+		for j := i + 1; j < len(rs.OrganizationTeamSystemAccounts); j++ {
+			if rs.OrganizationTeamSystemAccounts[j].GetRef() == sa.GetRef() {
+				return fmt.Errorf(
+					"duplicate ref '%s' (already defined as organization_team_system_account)",
+					sa.GetRef(),
+				)
+			}
+		}
 	}
 
 	return nil

--- a/internal/declarative/planner/constants.go
+++ b/internal/declarative/planner/constants.go
@@ -75,6 +75,12 @@ const (
 
 	// ResourceTypeDeck represents an internal deck execution step.
 	ResourceTypeDeck = "_deck"
+
+	// ResourceTypeOrganizationTeamUser is the resource type for organization team user memberships
+	ResourceTypeOrganizationTeamUser = "organization_team_user"
+
+	// ResourceTypeOrganizationTeamSystemAccount is the resource type for organization team system account memberships
+	ResourceTypeOrganizationTeamSystemAccount = "organization_team_system_account"
 )
 
 // Default values

--- a/internal/declarative/planner/organization_team_planner.go
+++ b/internal/declarative/planner/organization_team_planner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"strings"
 
 	"github.com/kong/kongctl/internal/declarative/labels"
 	"github.com/kong/kongctl/internal/declarative/resources"
@@ -186,6 +187,11 @@ func (t *OrganizationTeamPlannerImpl) PlanChanges(ctx context.Context, plannerCt
 	// Fail fast if any protected resources would be modified
 	if protectionErrors.HasErrors() {
 		return protectionErrors.Error()
+	}
+
+	// Plan member changes for all desired teams
+	if err := t.planOrganizationTeamMembersChanges(ctx, namespace, desired, currentByName, plan); err != nil {
+		return err
 	}
 
 	return nil
@@ -497,4 +503,240 @@ func (t *OrganizationTeamPlannerImpl) planOrganizationTeamDelete(team state.Orga
 	change.Fields = map[string]any{"name": util.GetString(team.Name)}
 
 	plan.AddChange(change)
+}
+
+// planOrganizationTeamMembersChanges plans member (user and system account) changes for all desired teams.
+func (t *OrganizationTeamPlannerImpl) planOrganizationTeamMembersChanges(
+	ctx context.Context,
+	namespace string,
+	desiredTeams []resources.OrganizationTeamResource,
+	currentByName map[string]state.OrganizationTeam,
+	plan *Plan,
+) error {
+	for _, team := range desiredTeams {
+		// Resolve Konnect team ID (may be empty if team is being created in this run)
+		teamID := ""
+		if current, ok := currentByName[team.Name]; ok {
+			teamID = util.GetString(current.ID)
+		}
+
+		// If team is being created in this run, get the change ID for dependency tracking
+		teamCreateChangeID := findChangeID(plan, "organization_team", team.GetRef())
+
+		if err := t.planTeamUserMemberChanges(
+			ctx, namespace, team.GetRef(), teamID, teamCreateChangeID, plan,
+		); err != nil {
+			return err
+		}
+
+		if err := t.planTeamSystemAccountMemberChanges(
+			ctx, namespace, team.GetRef(), teamID, teamCreateChangeID, plan,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// planTeamUserMemberChanges plans CREATE/DELETE changes for user memberships within a team.
+func (t *OrganizationTeamPlannerImpl) planTeamUserMemberChanges(
+	ctx context.Context,
+	namespace string,
+	teamRef string,
+	teamID string,
+	teamChangeID string,
+	plan *Plan,
+) error {
+	desiredUsers := t.planner.resources.GetOrganizationTeamUsersByTeamRef(teamRef)
+
+	// Nothing to do if no desired users and no existing team to sync against
+	if len(desiredUsers) == 0 && teamID == "" {
+		return nil
+	}
+
+	// Fetch current team members when we have a live team ID
+	currentByID := make(map[string]string) // konnectID -> konnectID (set)
+	if teamID != "" {
+		users, err := t.GetClient().ListTeamUsers(ctx, teamID)
+		if err != nil {
+			// If team membership API is not configured, skip member planning gracefully
+			if strings.Contains(err.Error(), "team membership API") &&
+				strings.Contains(err.Error(), "not configured") {
+				return nil
+			}
+			return fmt.Errorf("failed to list users for team %s: %w", teamRef, err)
+		}
+		for _, u := range users {
+			if u.ID != nil && *u.ID != "" {
+				currentByID[*u.ID] = *u.ID
+			}
+		}
+	}
+
+	// Resolve desired user IDs and plan CREATE for any not currently in the team
+	desiredIDs := make(map[string]bool)
+	for _, desired := range desiredUsers {
+		userID, err := t.GetClient().LookupUserID(ctx, desired.ID, desired.Email, desired.Name)
+		if err != nil {
+			return fmt.Errorf("failed to resolve user identity for team %s member ref %s: %w",
+				teamRef, desired.GetRef(), err)
+		}
+
+		desiredIDs[userID] = true
+
+		if _, exists := currentByID[userID]; exists {
+			continue // already a member – no action needed
+		}
+
+		// Plan CREATE
+		var deps []string
+		if teamChangeID != "" {
+			deps = append(deps, teamChangeID)
+		}
+
+		change := PlannedChange{
+			ID:           t.NextChangeID(ActionCreate, ResourceTypeOrganizationTeamUser, desired.GetRef()),
+			ResourceType: ResourceTypeOrganizationTeamUser,
+			ResourceRef:  desired.GetRef(),
+			Action:       ActionCreate,
+			Fields: map[string]any{
+				"user_id":    userID,
+				"user_email": desired.Email,
+				"user_name":  desired.Name,
+			},
+			DependsOn: deps,
+			Namespace: namespace,
+			References: map[string]ReferenceInfo{
+				"team_id": {Ref: teamRef, ID: teamID},
+			},
+			Parent: &ParentInfo{Ref: teamRef, ID: teamID},
+		}
+		plan.AddChange(change)
+	}
+
+	// In sync mode, plan DELETE for users currently in the team but not in desired state
+	if plan.Metadata.Mode == PlanModeSync && teamID != "" {
+		for currentID := range currentByID {
+			if !desiredIDs[currentID] {
+				change := PlannedChange{
+					ID:           t.NextChangeID(ActionDelete, ResourceTypeOrganizationTeamUser, currentID),
+					ResourceType: ResourceTypeOrganizationTeamUser,
+					ResourceRef:  currentID,
+					ResourceID:   currentID,
+					Action:       ActionDelete,
+					Fields:       map[string]any{"user_id": currentID},
+					DependsOn:    []string{},
+					Namespace:    namespace,
+					References: map[string]ReferenceInfo{
+						"team_id": {Ref: teamRef, ID: teamID},
+					},
+					Parent: &ParentInfo{Ref: teamRef, ID: teamID},
+				}
+				plan.AddChange(change)
+			}
+		}
+	}
+
+	return nil
+}
+
+// planTeamSystemAccountMemberChanges plans CREATE/DELETE changes for system account memberships within a team.
+func (t *OrganizationTeamPlannerImpl) planTeamSystemAccountMemberChanges(
+	ctx context.Context,
+	namespace string,
+	teamRef string,
+	teamID string,
+	teamChangeID string,
+	plan *Plan,
+) error {
+	desiredSAs := t.planner.resources.GetOrganizationTeamSystemAccountsByTeamRef(teamRef)
+
+	if len(desiredSAs) == 0 && teamID == "" {
+		return nil
+	}
+
+	// Fetch current system account members
+	currentByID := make(map[string]string)
+	if teamID != "" {
+		accounts, err := t.GetClient().ListTeamSystemAccounts(ctx, teamID)
+		if err != nil {
+			if strings.Contains(err.Error(), "team membership API") &&
+				strings.Contains(err.Error(), "not configured") {
+				return nil
+			}
+			return fmt.Errorf("failed to list system accounts for team %s: %w", teamRef, err)
+		}
+		for _, a := range accounts {
+			if a.ID != nil && *a.ID != "" {
+				currentByID[*a.ID] = *a.ID
+			}
+		}
+	}
+
+	// Resolve desired system account IDs and plan CREATE
+	desiredIDs := make(map[string]bool)
+	for _, desired := range desiredSAs {
+		accountID, err := t.GetClient().LookupSystemAccountID(ctx, desired.ID, desired.Name)
+		if err != nil {
+			return fmt.Errorf(
+				"failed to resolve system account identity for team %s member ref %s: %w",
+				teamRef, desired.GetRef(), err,
+			)
+		}
+
+		desiredIDs[accountID] = true
+
+		if _, exists := currentByID[accountID]; exists {
+			continue
+		}
+
+		var deps []string
+		if teamChangeID != "" {
+			deps = append(deps, teamChangeID)
+		}
+
+		change := PlannedChange{
+			ID:           t.NextChangeID(ActionCreate, ResourceTypeOrganizationTeamSystemAccount, desired.GetRef()),
+			ResourceType: ResourceTypeOrganizationTeamSystemAccount,
+			ResourceRef:  desired.GetRef(),
+			Action:       ActionCreate,
+			Fields: map[string]any{
+				"account_id":  accountID,
+				"account_name": desired.Name,
+			},
+			DependsOn: deps,
+			Namespace: namespace,
+			References: map[string]ReferenceInfo{
+				"team_id": {Ref: teamRef, ID: teamID},
+			},
+			Parent: &ParentInfo{Ref: teamRef, ID: teamID},
+		}
+		plan.AddChange(change)
+	}
+
+	// In sync mode, plan DELETE for system accounts currently in the team but not in desired state
+	if plan.Metadata.Mode == PlanModeSync && teamID != "" {
+		for currentID := range currentByID {
+			if !desiredIDs[currentID] {
+				change := PlannedChange{
+					ID:           t.NextChangeID(ActionDelete, ResourceTypeOrganizationTeamSystemAccount, currentID),
+					ResourceType: ResourceTypeOrganizationTeamSystemAccount,
+					ResourceRef:  currentID,
+					ResourceID:   currentID,
+					Action:       ActionDelete,
+					Fields:       map[string]any{"account_id": currentID},
+					DependsOn:    []string{},
+					Namespace:    namespace,
+					References: map[string]ReferenceInfo{
+						"team_id": {Ref: teamRef, ID: teamID},
+					},
+					Parent: &ParentInfo{Ref: teamRef, ID: teamID},
+				}
+				plan.AddChange(change)
+			}
+		}
+	}
+
+	return nil
 }

--- a/internal/declarative/planner/organization_team_planner.go
+++ b/internal/declarative/planner/organization_team_planner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"strings"
 
 	"github.com/kong/kongctl/internal/declarative/labels"
 	"github.com/kong/kongctl/internal/declarative/resources"
@@ -556,13 +555,12 @@ func (t *OrganizationTeamPlannerImpl) planTeamUserMemberChanges(
 	}
 
 	// Fetch current team members when we have a live team ID
-	currentByID := make(map[string]string) // konnectID -> konnectID (set)
+	currentByID := make(map[string]string)
 	if teamID != "" {
 		users, err := t.GetClient().ListTeamUsers(ctx, teamID)
 		if err != nil {
 			// If team membership API is not configured, skip member planning gracefully
-			if strings.Contains(err.Error(), "team membership API") &&
-				strings.Contains(err.Error(), "not configured") {
+			if state.IsAPIClientError(err) {
 				return nil
 			}
 			return fmt.Errorf("failed to list users for team %s: %w", teamRef, err)
@@ -661,8 +659,7 @@ func (t *OrganizationTeamPlannerImpl) planTeamSystemAccountMemberChanges(
 	if teamID != "" {
 		accounts, err := t.GetClient().ListTeamSystemAccounts(ctx, teamID)
 		if err != nil {
-			if strings.Contains(err.Error(), "team membership API") &&
-				strings.Contains(err.Error(), "not configured") {
+			if state.IsAPIClientError(err) {
 				return nil
 			}
 			return fmt.Errorf("failed to list system accounts for team %s: %w", teamRef, err)
@@ -702,7 +699,7 @@ func (t *OrganizationTeamPlannerImpl) planTeamSystemAccountMemberChanges(
 			ResourceRef:  desired.GetRef(),
 			Action:       ActionCreate,
 			Fields: map[string]any{
-				"account_id":  accountID,
+				"account_id":   accountID,
 				"account_name": desired.Name,
 			},
 			DependsOn: deps,

--- a/internal/declarative/resources/organization_team.go
+++ b/internal/declarative/resources/organization_team.go
@@ -17,7 +17,7 @@ func init() {
 // It is a wrapper key under a team definition and is not itself a Konnect resource.
 type TeamMembersBlock struct {
 	Users          []OrganizationTeamUserResource          `yaml:"users,omitempty"           json:"users,omitempty"`
-	SystemAccounts []OrganizationTeamSystemAccountResource `yaml:"system_accounts,omitempty" json:"system_accounts,omitempty"`
+	SystemAccounts []OrganizationTeamSystemAccountResource `yaml:"system_accounts,omitempty" json:"system_accounts,omitempty"` //nolint:lll
 }
 
 // OrganizationTeamResource represents a team in declarative configuration

--- a/internal/declarative/resources/organization_team.go
+++ b/internal/declarative/resources/organization_team.go
@@ -13,11 +13,19 @@ func init() {
 	)
 }
 
+// TeamMembersBlock groups user and system-account membership declarations for readability.
+// It is a wrapper key under a team definition and is not itself a Konnect resource.
+type TeamMembersBlock struct {
+	Users          []OrganizationTeamUserResource          `yaml:"users,omitempty"           json:"users,omitempty"`
+	SystemAccounts []OrganizationTeamSystemAccountResource `yaml:"system_accounts,omitempty" json:"system_accounts,omitempty"`
+}
+
 // OrganizationTeamResource represents a team in declarative configuration
 type OrganizationTeamResource struct {
 	BaseResource
 	kkComps.CreateTeam `yaml:",inline" json:",inline"`
-	External           *ExternalBlock `yaml:"_external,omitempty" json:"_external,omitempty"`
+	Members            *TeamMembersBlock `yaml:"members,omitempty"   json:"members,omitempty"`
+	External           *ExternalBlock    `yaml:"_external,omitempty" json:"_external,omitempty"`
 }
 
 // GetReferenceFieldMappings returns the field mappings for reference validation
@@ -40,6 +48,31 @@ func (t OrganizationTeamResource) Validate() error {
 			return fmt.Errorf("invalid _external block: %w", err)
 		}
 	}
+
+	if t.Members != nil {
+		userRefs := make(map[string]bool)
+		for i, user := range t.Members.Users {
+			if err := user.Validate(); err != nil {
+				return fmt.Errorf("invalid member user %d: %w", i, err)
+			}
+			if userRefs[user.GetRef()] {
+				return fmt.Errorf("duplicate member user ref: %s", user.GetRef())
+			}
+			userRefs[user.GetRef()] = true
+		}
+
+		sysAccountRefs := make(map[string]bool)
+		for i, sa := range t.Members.SystemAccounts {
+			if err := sa.Validate(); err != nil {
+				return fmt.Errorf("invalid member system account %d: %w", i, err)
+			}
+			if sysAccountRefs[sa.GetRef()] {
+				return fmt.Errorf("duplicate member system account ref: %s", sa.GetRef())
+			}
+			sysAccountRefs[sa.GetRef()] = true
+		}
+	}
+
 	return nil
 }
 
@@ -48,6 +81,14 @@ func (t *OrganizationTeamResource) SetDefaults() {
 	// If Name is not set, use ref as default
 	if t.Name == "" {
 		t.Name = t.Ref
+	}
+	if t.Members != nil {
+		for i := range t.Members.Users {
+			t.Members.Users[i].SetDefaults()
+		}
+		for i := range t.Members.SystemAccounts {
+			t.Members.SystemAccounts[i].SetDefaults()
+		}
 	}
 }
 

--- a/internal/declarative/resources/organization_team_system_account.go
+++ b/internal/declarative/resources/organization_team_system_account.go
@@ -1,0 +1,109 @@
+package resources
+
+import (
+	"fmt"
+)
+
+func init() {
+	registerResourceType(
+		ResourceTypeOrganizationTeamSystemAccount,
+		func(rs *ResourceSet) *[]OrganizationTeamSystemAccountResource {
+			return &rs.OrganizationTeamSystemAccounts
+		},
+	)
+}
+
+// OrganizationTeamSystemAccountResource represents a system account member of an organization team.
+// This is a child resource of OrganizationTeamResource.
+type OrganizationTeamSystemAccountResource struct {
+	Ref string `yaml:"ref" json:"ref"`
+
+	// Team is the parent team reference
+	Team string `yaml:"team,omitempty" json:"team,omitempty"`
+
+	// Identity lookup fields — specify at least one
+	ID   string `yaml:"id,omitempty"   json:"id,omitempty"`
+	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+
+	// Resolved Konnect system account ID (not serialized)
+	konnectID string `yaml:"-" json:"-"`
+}
+
+// GetType returns the resource type
+func (s OrganizationTeamSystemAccountResource) GetType() ResourceType {
+	return ResourceTypeOrganizationTeamSystemAccount
+}
+
+// GetRef returns the reference identifier
+func (s OrganizationTeamSystemAccountResource) GetRef() string {
+	return s.Ref
+}
+
+// GetMoniker returns a human-readable moniker
+func (s OrganizationTeamSystemAccountResource) GetMoniker() string {
+	if s.Name != "" {
+		return s.Name
+	}
+	return s.ID
+}
+
+// GetDependencies returns references to other resources this system account depends on
+func (s OrganizationTeamSystemAccountResource) GetDependencies() []ResourceRef {
+	deps := []ResourceRef{}
+	if s.Team != "" {
+		deps = append(deps, ResourceRef{
+			Kind: string(ResourceTypeOrganizationTeam),
+			Ref:  s.Team,
+		})
+	}
+	return deps
+}
+
+// Validate ensures the team system account resource is valid
+func (s OrganizationTeamSystemAccountResource) Validate() error {
+	if err := ValidateRef(s.Ref); err != nil {
+		return fmt.Errorf("invalid team system account ref: %w", err)
+	}
+
+	if s.ID == "" && s.Name == "" {
+		return fmt.Errorf("at least one of id or name is required to identify the system account")
+	}
+
+	return nil
+}
+
+// SetDefaults applies default values (none for team system accounts)
+func (s *OrganizationTeamSystemAccountResource) SetDefaults() {}
+
+// GetKonnectID returns the resolved Konnect ID if available
+func (s OrganizationTeamSystemAccountResource) GetKonnectID() string {
+	return s.konnectID
+}
+
+// SetKonnectID sets the resolved Konnect ID
+func (s *OrganizationTeamSystemAccountResource) SetKonnectID(id string) {
+	s.konnectID = id
+}
+
+// GetKonnectMonikerFilter returns the filter string for Konnect API lookup
+func (s OrganizationTeamSystemAccountResource) GetKonnectMonikerFilter() string {
+	return ""
+}
+
+// TryMatchKonnectResource attempts to match this resource with a Konnect resource
+func (s *OrganizationTeamSystemAccountResource) TryMatchKonnectResource(konnectResource any) bool {
+	return false
+}
+
+// GetParentRef returns the parent team reference
+func (s OrganizationTeamSystemAccountResource) GetParentRef() *ResourceRef {
+	if s.Team != "" {
+		return &ResourceRef{Kind: string(ResourceTypeOrganizationTeam), Ref: s.Team}
+	}
+	return nil
+}
+
+// GetReferenceFieldMappings returns the field mappings for reference validation
+func (s OrganizationTeamSystemAccountResource) GetReferenceFieldMappings() map[string]string {
+	return map[string]string{}
+}

--- a/internal/declarative/resources/organization_team_system_account.go
+++ b/internal/declarative/resources/organization_team_system_account.go
@@ -91,7 +91,7 @@ func (s OrganizationTeamSystemAccountResource) GetKonnectMonikerFilter() string 
 }
 
 // TryMatchKonnectResource attempts to match this resource with a Konnect resource
-func (s *OrganizationTeamSystemAccountResource) TryMatchKonnectResource(konnectResource any) bool {
+func (s *OrganizationTeamSystemAccountResource) TryMatchKonnectResource(_ any) bool {
 	return false
 }
 

--- a/internal/declarative/resources/organization_team_user.go
+++ b/internal/declarative/resources/organization_team_user.go
@@ -93,7 +93,7 @@ func (u OrganizationTeamUserResource) GetKonnectMonikerFilter() string {
 }
 
 // TryMatchKonnectResource attempts to match this resource with a Konnect resource by user ID
-func (u *OrganizationTeamUserResource) TryMatchKonnectResource(konnectResource any) bool {
+func (u *OrganizationTeamUserResource) TryMatchKonnectResource(_ any) bool {
 	return false
 }
 

--- a/internal/declarative/resources/organization_team_user.go
+++ b/internal/declarative/resources/organization_team_user.go
@@ -1,0 +1,111 @@
+package resources
+
+import (
+	"fmt"
+)
+
+func init() {
+	registerResourceType(
+		ResourceTypeOrganizationTeamUser,
+		func(rs *ResourceSet) *[]OrganizationTeamUserResource { return &rs.OrganizationTeamUsers },
+	)
+}
+
+// OrganizationTeamUserResource represents a user member of an organization team.
+// This is a child resource of OrganizationTeamResource.
+type OrganizationTeamUserResource struct {
+	Ref string `yaml:"ref" json:"ref"`
+
+	// Team is the parent team reference
+	Team string `yaml:"team,omitempty" json:"team,omitempty"`
+
+	// Identity lookup fields — specify at least one
+	ID    string `yaml:"id,omitempty"    json:"id,omitempty"`
+	Name  string `yaml:"name,omitempty"  json:"name,omitempty"`
+	Email string `yaml:"email,omitempty" json:"email,omitempty"`
+
+	// Resolved Konnect user ID (not serialized)
+	konnectID string `yaml:"-" json:"-"`
+}
+
+// GetType returns the resource type
+func (u OrganizationTeamUserResource) GetType() ResourceType {
+	return ResourceTypeOrganizationTeamUser
+}
+
+// GetRef returns the reference identifier
+func (u OrganizationTeamUserResource) GetRef() string {
+	return u.Ref
+}
+
+// GetMoniker returns a human-readable moniker for matching purposes
+func (u OrganizationTeamUserResource) GetMoniker() string {
+	if u.Email != "" {
+		return u.Email
+	}
+	if u.Name != "" {
+		return u.Name
+	}
+	return u.ID
+}
+
+// GetDependencies returns references to other resources this user depends on
+func (u OrganizationTeamUserResource) GetDependencies() []ResourceRef {
+	deps := []ResourceRef{}
+	if u.Team != "" {
+		deps = append(deps, ResourceRef{
+			Kind: string(ResourceTypeOrganizationTeam),
+			Ref:  u.Team,
+		})
+	}
+	return deps
+}
+
+// Validate ensures the team user resource is valid
+func (u OrganizationTeamUserResource) Validate() error {
+	if err := ValidateRef(u.Ref); err != nil {
+		return fmt.Errorf("invalid team user ref: %w", err)
+	}
+
+	if u.ID == "" && u.Name == "" && u.Email == "" {
+		return fmt.Errorf("at least one of id, name, or email is required to identify the user")
+	}
+
+	return nil
+}
+
+// SetDefaults applies default values (none for team users)
+func (u *OrganizationTeamUserResource) SetDefaults() {}
+
+// GetKonnectID returns the resolved Konnect ID if available
+func (u OrganizationTeamUserResource) GetKonnectID() string {
+	return u.konnectID
+}
+
+// SetKonnectID sets the resolved Konnect ID
+func (u *OrganizationTeamUserResource) SetKonnectID(id string) {
+	u.konnectID = id
+}
+
+// GetKonnectMonikerFilter returns the filter string for Konnect API lookup
+func (u OrganizationTeamUserResource) GetKonnectMonikerFilter() string {
+	return ""
+}
+
+// TryMatchKonnectResource attempts to match this resource with a Konnect resource by user ID
+func (u *OrganizationTeamUserResource) TryMatchKonnectResource(konnectResource any) bool {
+	return false
+}
+
+// GetParentRef returns the parent team reference
+func (u OrganizationTeamUserResource) GetParentRef() *ResourceRef {
+	if u.Team != "" {
+		return &ResourceRef{Kind: string(ResourceTypeOrganizationTeam), Ref: u.Team}
+	}
+	return nil
+}
+
+// GetReferenceFieldMappings returns the field mappings for reference validation
+func (u OrganizationTeamUserResource) GetReferenceFieldMappings() map[string]string {
+	return map[string]string{}
+}

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -32,6 +32,8 @@ const (
 	ResourceTypeEventGatewayBackendCluster       ResourceType = "event_gateway_backend_cluster"
 	ResourceTypeEventGatewayVirtualCluster       ResourceType = "event_gateway_virtual_cluster"
 	ResourceTypeOrganizationTeam                 ResourceType = "organization_team"
+	ResourceTypeOrganizationTeamUser             ResourceType = "organization_team_user"
+	ResourceTypeOrganizationTeamSystemAccount    ResourceType = "organization_team_system_account"
 	ResourceTypeEventGatewayListener             ResourceType = "event_gateway_listener"
 	ResourceTypeEventGatewayListenerPolicy       ResourceType = "event_gateway_listener_policy"
 	ResourceTypeEventGatewayDataPlaneCertificate ResourceType = "event_gateway_data_plane_certificate"
@@ -83,6 +85,12 @@ type ResourceSet struct {
 	// Teams is populated internally from OrganizationTeams during loading
 	// It is not exposed in YAML/JSON to enforce the organization grouping format
 	OrganizationTeams                 []OrganizationTeamResource                 `yaml:"-" json:"-"`
+	// OrganizationTeamUsers is populated internally from OrganizationTeams.Members.Users.
+	// It is not exposed in YAML/JSON to enforce the members grouping format.
+	OrganizationTeamUsers         []OrganizationTeamUserResource         `yaml:"-" json:"-"`
+	// OrganizationTeamSystemAccounts is populated internally from OrganizationTeams.Members.SystemAccounts.
+	// It is not exposed in YAML/JSON to enforce the members grouping format.
+	OrganizationTeamSystemAccounts []OrganizationTeamSystemAccountResource `yaml:"-" json:"-"`
 	EventGatewayListeners             []EventGatewayListenerResource             `yaml:"event_gateway_listeners,omitempty" json:"event_gateway_listeners,omitempty"`                             //nolint:lll
 	EventGatewayListenerPolicies      []EventGatewayListenerPolicyResource       `yaml:"event_gateway_listener_policies,omitempty" json:"event_gateway_listener_policies,omitempty"`             //nolint:lll
 	EventGatewayDataPlaneCertificates []EventGatewayDataPlaneCertificateResource `yaml:"event_gateway_data_plane_certificates,omitempty" json:"event_gateway_data_plane_certificates,omitempty"` //nolint:lll
@@ -540,6 +548,30 @@ func (rs *ResourceSet) GetOrganizationTeamsByNamespace(namespace string) []Organ
 		}
 	}
 	return filtered
+}
+
+// GetOrganizationTeamUsersByTeamRef returns all team user resources for the specified team ref
+func (rs *ResourceSet) GetOrganizationTeamUsersByTeamRef(teamRef string) []OrganizationTeamUserResource {
+	var result []OrganizationTeamUserResource
+	for _, user := range rs.OrganizationTeamUsers {
+		if user.Team == teamRef {
+			result = append(result, user)
+		}
+	}
+	return result
+}
+
+// GetOrganizationTeamSystemAccountsByTeamRef returns all team system account resources for the specified team ref
+func (rs *ResourceSet) GetOrganizationTeamSystemAccountsByTeamRef(
+	teamRef string,
+) []OrganizationTeamSystemAccountResource {
+	var result []OrganizationTeamSystemAccountResource
+	for _, sa := range rs.OrganizationTeamSystemAccounts {
+		if sa.Team == teamRef {
+			result = append(result, sa)
+		}
+	}
+	return result
 }
 
 // GetNamespace safely extracts namespace from kongctl metadata

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -60,6 +60,7 @@ type ClientConfig struct {
 
 	// Identity resources
 	OrganizationTeamAPI helpers.OrganizationTeamAPI
+	TeamMembershipAPI   helpers.TeamMembershipAPI
 }
 
 // Client wraps Konnect SDK for state management
@@ -100,6 +101,7 @@ type Client struct {
 
 	// Organization resource APIs
 	organizationTeamAPI helpers.OrganizationTeamAPI
+	teamMembershipAPI   helpers.TeamMembershipAPI
 }
 
 // NewClient creates a new state client with the provided configuration
@@ -141,6 +143,7 @@ func NewClient(config ClientConfig) *Client {
 
 		// Identity resource APIs
 		organizationTeamAPI: config.OrganizationTeamAPI,
+		teamMembershipAPI:   config.TeamMembershipAPI,
 	}
 }
 
@@ -3742,6 +3745,246 @@ func (c *Client) DeleteOrganizationTeam(ctx context.Context, teamID string) erro
 	}
 
 	return nil
+}
+
+// ListTeamUsers returns all users belonging to the given organization team.
+func (c *Client) ListTeamUsers(ctx context.Context, teamID string) ([]kkComps.User, error) {
+	if err := ValidateAPIClient(c.teamMembershipAPI, "team membership API"); err != nil {
+		return nil, err
+	}
+
+	var (
+		allUsers   []kkComps.User
+		pageNumber int64 = 1
+		pageSize   int64 = 100
+	)
+
+	for {
+		req := kkOps.ListTeamUsersRequest{
+			TeamID:     teamID,
+			PageSize:   &pageSize,
+			PageNumber: &pageNumber,
+		}
+
+		resp, err := c.teamMembershipAPI.ListTeamUsers(ctx, req)
+		if err != nil {
+			return nil, WrapAPIError(err, "list team users", &ErrorWrapperOptions{
+				ResourceType: "organization_team_user",
+				UseEnhanced:  true,
+			})
+		}
+
+		if resp.UserCollection == nil || len(resp.UserCollection.Data) == 0 {
+			break
+		}
+
+		allUsers = append(allUsers, resp.UserCollection.Data...)
+		pageNumber++
+
+		if resp.UserCollection.Meta == nil ||
+			float64(pageSize*(pageNumber-1)) >= resp.UserCollection.Meta.Page.Total {
+			break
+		}
+	}
+
+	return allUsers, nil
+}
+
+// AddUserToTeam adds a user to an organization team.
+func (c *Client) AddUserToTeam(ctx context.Context, teamID, userID string) error {
+	if err := ValidateAPIClient(c.teamMembershipAPI, "team membership API"); err != nil {
+		return err
+	}
+
+	body := &kkComps.AddUserToTeam{UserID: userID}
+	_, err := c.teamMembershipAPI.AddUserToTeam(ctx, teamID, body)
+	if err != nil {
+		return WrapAPIError(err, "add user to team", &ErrorWrapperOptions{
+			ResourceType: "organization_team_user",
+			UseEnhanced:  true,
+		})
+	}
+
+	return nil
+}
+
+// RemoveUserFromTeam removes a user from an organization team.
+func (c *Client) RemoveUserFromTeam(ctx context.Context, userID, teamID string) error {
+	if err := ValidateAPIClient(c.teamMembershipAPI, "team membership API"); err != nil {
+		return err
+	}
+
+	_, err := c.teamMembershipAPI.RemoveUserFromTeam(ctx, userID, teamID)
+	if err != nil {
+		return WrapAPIError(err, "remove user from team", &ErrorWrapperOptions{
+			ResourceType: "organization_team_user",
+			UseEnhanced:  true,
+		})
+	}
+
+	return nil
+}
+
+// ListTeamSystemAccounts returns all system accounts belonging to the given organization team.
+func (c *Client) ListTeamSystemAccounts(
+	ctx context.Context,
+	teamID string,
+) ([]kkComps.SystemAccount, error) {
+	if err := ValidateAPIClient(c.teamMembershipAPI, "team membership API"); err != nil {
+		return nil, err
+	}
+
+	var (
+		allAccounts []kkComps.SystemAccount
+		pageNumber  int64 = 1
+		pageSize    int64 = 100
+	)
+
+	for {
+		req := kkOps.GetTeamsTeamIDSystemAccountsRequest{
+			TeamID:     teamID,
+			PageSize:   &pageSize,
+			PageNumber: &pageNumber,
+		}
+
+		resp, err := c.teamMembershipAPI.ListTeamSystemAccounts(ctx, req)
+		if err != nil {
+			return nil, WrapAPIError(err, "list team system accounts", &ErrorWrapperOptions{
+				ResourceType: "organization_team_system_account",
+				UseEnhanced:  true,
+			})
+		}
+
+		if resp.SystemAccountCollection == nil || len(resp.SystemAccountCollection.Data) == 0 {
+			break
+		}
+
+		allAccounts = append(allAccounts, resp.SystemAccountCollection.Data...)
+		pageNumber++
+
+		if resp.SystemAccountCollection.Meta == nil ||
+			float64(pageSize*(pageNumber-1)) >= resp.SystemAccountCollection.Meta.Page.Total {
+			break
+		}
+	}
+
+	return allAccounts, nil
+}
+
+// AddSystemAccountToTeam adds a system account to an organization team.
+func (c *Client) AddSystemAccountToTeam(ctx context.Context, teamID, accountID string) error {
+	if err := ValidateAPIClient(c.teamMembershipAPI, "team membership API"); err != nil {
+		return err
+	}
+
+	body := &kkComps.AddSystemAccountToTeam{AccountID: &accountID}
+	_, err := c.teamMembershipAPI.AddSystemAccountToTeam(ctx, teamID, body)
+	if err != nil {
+		return WrapAPIError(err, "add system account to team", &ErrorWrapperOptions{
+			ResourceType: "organization_team_system_account",
+			UseEnhanced:  true,
+		})
+	}
+
+	return nil
+}
+
+// RemoveSystemAccountFromTeam removes a system account from an organization team.
+func (c *Client) RemoveSystemAccountFromTeam(ctx context.Context, teamID, accountID string) error {
+	if err := ValidateAPIClient(c.teamMembershipAPI, "team membership API"); err != nil {
+		return err
+	}
+
+	_, err := c.teamMembershipAPI.RemoveSystemAccountFromTeam(ctx, teamID, accountID)
+	if err != nil {
+		return WrapAPIError(err, "remove system account from team", &ErrorWrapperOptions{
+			ResourceType: "organization_team_system_account",
+			UseEnhanced:  true,
+		})
+	}
+
+	return nil
+}
+
+// LookupUserID resolves a user's Konnect UUID from id, email, or full_name.
+// If id is non-empty it is returned directly. Otherwise email is preferred over name.
+func (c *Client) LookupUserID(ctx context.Context, id, email, name string) (string, error) {
+	if err := ValidateAPIClient(c.teamMembershipAPI, "team membership API"); err != nil {
+		return "", err
+	}
+
+	if id != "" {
+		return id, nil
+	}
+
+	filter := &kkOps.ListUsersQueryParamFilter{}
+
+	switch {
+	case email != "":
+		filter.Email = &kkComps.LegacyStringFieldFilter{Eq: &email}
+	case name != "":
+		filter.FullName = &kkComps.LegacyStringFieldFilter{Eq: &name}
+	default:
+		return "", fmt.Errorf("at least one of id, email, or name is required to look up a user")
+	}
+
+	resp, err := c.teamMembershipAPI.ListUsers(ctx, kkOps.ListUsersRequest{Filter: filter})
+	if err != nil {
+		return "", WrapAPIError(err, "look up user", nil)
+	}
+
+	if resp.UserCollection == nil || len(resp.UserCollection.Data) == 0 {
+		if email != "" {
+			return "", fmt.Errorf("user with email %q not found in the organization", email)
+		}
+		return "", fmt.Errorf("user with full_name %q not found in the organization", name)
+	}
+
+	user := resp.UserCollection.Data[0]
+	if user.ID == nil || *user.ID == "" {
+		return "", fmt.Errorf("user found but has no ID")
+	}
+
+	return *user.ID, nil
+}
+
+// LookupSystemAccountID resolves a system account's Konnect UUID from id or name.
+// If id is non-empty it is returned directly.
+func (c *Client) LookupSystemAccountID(ctx context.Context, id, name string) (string, error) {
+	if err := ValidateAPIClient(c.teamMembershipAPI, "team membership API"); err != nil {
+		return "", err
+	}
+
+	if id != "" {
+		return id, nil
+	}
+
+	if name == "" {
+		return "", fmt.Errorf("at least one of id or name is required to look up a system account")
+	}
+
+	filter := &kkOps.GetSystemAccountsQueryParamFilter{
+		Name: &kkComps.LegacyStringFieldFilter{Eq: &name},
+	}
+
+	resp, err := c.teamMembershipAPI.ListSystemAccounts(
+		ctx,
+		kkOps.GetSystemAccountsRequest{Filter: filter},
+	)
+	if err != nil {
+		return "", WrapAPIError(err, "look up system account", nil)
+	}
+
+	if resp.SystemAccountCollection == nil || len(resp.SystemAccountCollection.Data) == 0 {
+		return "", fmt.Errorf("system account with name %q not found in the organization", name)
+	}
+
+	account := resp.SystemAccountCollection.Data[0]
+	if account.ID == nil || *account.ID == "" {
+		return "", fmt.Errorf("system account found but has no ID")
+	}
+
+	return *account.ID, nil
 }
 
 func getString(value *string) string {

--- a/internal/konnect/helpers/organization_team_membership.go
+++ b/internal/konnect/helpers/organization_team_membership.go
@@ -1,0 +1,177 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+
+	kkSDK "github.com/Kong/sdk-konnect-go"
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+)
+
+// TeamMembershipAPI defines the interface for organization team membership operations
+// covering both user and system-account membership, plus identity lookup helpers.
+type TeamMembershipAPI interface {
+	// User identity lookup
+	ListUsers(
+		ctx context.Context,
+		request kkOps.ListUsersRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.ListUsersResponse, error)
+
+	// System account identity lookup
+	ListSystemAccounts(
+		ctx context.Context,
+		request kkOps.GetSystemAccountsRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.GetSystemAccountsResponse, error)
+
+	// User membership
+	ListTeamUsers(
+		ctx context.Context,
+		request kkOps.ListTeamUsersRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.ListTeamUsersResponse, error)
+
+	AddUserToTeam(
+		ctx context.Context,
+		teamID string,
+		body *kkComps.AddUserToTeam,
+		opts ...kkOps.Option,
+	) (*kkOps.AddUserToTeamResponse, error)
+
+	RemoveUserFromTeam(
+		ctx context.Context,
+		userID string,
+		teamID string,
+		opts ...kkOps.Option,
+	) (*kkOps.RemoveUserFromTeamResponse, error)
+
+	// System-account membership
+	ListTeamSystemAccounts(
+		ctx context.Context,
+		request kkOps.GetTeamsTeamIDSystemAccountsRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.GetTeamsTeamIDSystemAccountsResponse, error)
+
+	AddSystemAccountToTeam(
+		ctx context.Context,
+		teamID string,
+		body *kkComps.AddSystemAccountToTeam,
+		opts ...kkOps.Option,
+	) (*kkOps.PostTeamsTeamIDSystemAccountsResponse, error)
+
+	RemoveSystemAccountFromTeam(
+		ctx context.Context,
+		teamID string,
+		accountID string,
+		opts ...kkOps.Option,
+	) (*kkOps.DeleteTeamsTeamIDSystemAccountsAccountIDResponse, error)
+}
+
+// TeamMembershipAPIImpl provides an implementation backed by the SDK
+type TeamMembershipAPIImpl struct {
+	SDK *kkSDK.SDK
+}
+
+// ListUsers lists users in the organization, allowing filtering by id, email, or full_name
+func (t *TeamMembershipAPIImpl) ListUsers(
+	ctx context.Context,
+	request kkOps.ListUsersRequest,
+	opts ...kkOps.Option,
+) (*kkOps.ListUsersResponse, error) {
+	if t.SDK == nil {
+		return nil, fmt.Errorf("SDK is nil")
+	}
+	return t.SDK.Users.ListUsers(ctx, request, opts...)
+}
+
+// ListSystemAccounts lists system accounts in the organization, allowing filtering by name
+func (t *TeamMembershipAPIImpl) ListSystemAccounts(
+	ctx context.Context,
+	request kkOps.GetSystemAccountsRequest,
+	opts ...kkOps.Option,
+) (*kkOps.GetSystemAccountsResponse, error) {
+	if t.SDK == nil {
+		return nil, fmt.Errorf("SDK is nil")
+	}
+	return t.SDK.SystemAccounts.GetSystemAccounts(ctx, request, opts...)
+}
+
+// ListTeamUsers lists users that belong to the given team
+func (t *TeamMembershipAPIImpl) ListTeamUsers(
+	ctx context.Context,
+	request kkOps.ListTeamUsersRequest,
+	opts ...kkOps.Option,
+) (*kkOps.ListTeamUsersResponse, error) {
+	if t.SDK == nil {
+		return nil, fmt.Errorf("SDK is nil")
+	}
+	return t.SDK.TeamMembership.ListTeamUsers(ctx, request, opts...)
+}
+
+// AddUserToTeam adds a user to a team
+func (t *TeamMembershipAPIImpl) AddUserToTeam(
+	ctx context.Context,
+	teamID string,
+	body *kkComps.AddUserToTeam,
+	opts ...kkOps.Option,
+) (*kkOps.AddUserToTeamResponse, error) {
+	if t.SDK == nil {
+		return nil, fmt.Errorf("SDK is nil")
+	}
+	return t.SDK.TeamMembership.AddUserToTeam(ctx, teamID, body, opts...)
+}
+
+// RemoveUserFromTeam removes a user from a team
+func (t *TeamMembershipAPIImpl) RemoveUserFromTeam(
+	ctx context.Context,
+	userID string,
+	teamID string,
+	opts ...kkOps.Option,
+) (*kkOps.RemoveUserFromTeamResponse, error) {
+	if t.SDK == nil {
+		return nil, fmt.Errorf("SDK is nil")
+	}
+	return t.SDK.TeamMembership.RemoveUserFromTeam(ctx, userID, teamID, opts...)
+}
+
+// ListTeamSystemAccounts lists system accounts that belong to the given team
+func (t *TeamMembershipAPIImpl) ListTeamSystemAccounts(
+	ctx context.Context,
+	request kkOps.GetTeamsTeamIDSystemAccountsRequest,
+	opts ...kkOps.Option,
+) (*kkOps.GetTeamsTeamIDSystemAccountsResponse, error) {
+	if t.SDK == nil {
+		return nil, fmt.Errorf("SDK is nil")
+	}
+	return t.SDK.SystemAccountsTeamMembership.GetTeamsTeamIDSystemAccounts(ctx, request, opts...)
+}
+
+// AddSystemAccountToTeam adds a system account to a team
+func (t *TeamMembershipAPIImpl) AddSystemAccountToTeam(
+	ctx context.Context,
+	teamID string,
+	body *kkComps.AddSystemAccountToTeam,
+	opts ...kkOps.Option,
+) (*kkOps.PostTeamsTeamIDSystemAccountsResponse, error) {
+	if t.SDK == nil {
+		return nil, fmt.Errorf("SDK is nil")
+	}
+	return t.SDK.SystemAccountsTeamMembership.PostTeamsTeamIDSystemAccounts(ctx, teamID, body, opts...)
+}
+
+// RemoveSystemAccountFromTeam removes a system account from a team
+func (t *TeamMembershipAPIImpl) RemoveSystemAccountFromTeam(
+	ctx context.Context,
+	teamID string,
+	accountID string,
+	opts ...kkOps.Option,
+) (*kkOps.DeleteTeamsTeamIDSystemAccountsAccountIDResponse, error) {
+	if t.SDK == nil {
+		return nil, fmt.Errorf("SDK is nil")
+	}
+	return t.SDK.SystemAccountsTeamMembership.DeleteTeamsTeamIDSystemAccountsAccountID(ctx, teamID, accountID, opts...)
+}
+
+var _ TeamMembershipAPI = (*TeamMembershipAPIImpl)(nil)

--- a/internal/konnect/helpers/sdk.go
+++ b/internal/konnect/helpers/sdk.go
@@ -31,6 +31,7 @@ type SDKAPI interface {
 	GetGatewayServiceAPI() GatewayServiceAPI
 	GetSystemAccountAPI() SystemAccountAPI
 	GetOrganizationTeamAPI() OrganizationTeamAPI
+	GetTeamMembershipAPI() TeamMembershipAPI
 	// Portal child resource APIs
 	GetPortalPageAPI() PortalPageAPI
 	GetPortalAuthSettingsAPI() PortalAuthSettingsAPI
@@ -351,6 +352,15 @@ func (k *KonnectSDK) GetOrganizationTeamAPI() OrganizationTeamAPI {
 	}
 
 	return &OrganizationTeamAPIImpl{SDK: k.SDK}
+}
+
+// GetTeamMembershipAPI returns the implementation of the TeamMembershipAPI interface
+func (k *KonnectSDK) GetTeamMembershipAPI() TeamMembershipAPI {
+	if k.SDK == nil {
+		return nil
+	}
+
+	return &TeamMembershipAPIImpl{SDK: k.SDK}
 }
 
 // A function that can build an SDKAPI with a given configuration

--- a/internal/konnect/helpers/sdk_mock.go
+++ b/internal/konnect/helpers/sdk_mock.go
@@ -20,6 +20,7 @@ type MockKonnectSDK struct {
 	GatewayServiceFactory     func() GatewayServiceAPI
 	SystemAccountFactory      func() SystemAccountAPI
 	OrganizationTeamFactory   func() OrganizationTeamAPI
+	TeamMembershipFactory     func() TeamMembershipAPI
 	// Portal child resource factories
 	PortalPageFactory                    func() PortalPageAPI
 	PortalAuthSettingsFactory            func() PortalAuthSettingsAPI
@@ -269,6 +270,14 @@ func (m *MockKonnectSDK) GetEventGatewayBackendClusterAPI() EventGatewayBackendC
 func (m *MockKonnectSDK) GetOrganizationTeamAPI() OrganizationTeamAPI {
 	if m.OrganizationTeamFactory != nil {
 		return m.OrganizationTeamFactory()
+	}
+	return nil
+}
+
+// Returns a mock instance of the TeamMembershipAPI
+func (m *MockKonnectSDK) GetTeamMembershipAPI() TeamMembershipAPI {
+	if m.TeamMembershipFactory != nil {
+		return m.TeamMembershipFactory()
 	}
 	return nil
 }

--- a/test/e2e/scenarios/org/teams/members/apply/scenario.yaml
+++ b/test/e2e/scenarios/org/teams/members/apply/scenario.yaml
@@ -1,0 +1,146 @@
+baseInputsPath: ./testdata
+
+env:
+  KONGCTL_LOG_LEVEL: info
+
+vars:
+  namespace: team-members-apply-e2e
+  teamRef: api-platform-team
+  sa1Name: e2e-team-member-sa1
+  sa2Name: e2e-team-member-sa2
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - change_id
+      - resource_id
+      - created_at
+      - updated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-create-system-accounts
+    skipInputs: true
+    commands:
+      - name: 000-create-sa1
+        create:
+          resource: system-account
+          payload:
+            inline:
+              name: "{{ .vars.sa1Name }}"
+              description: "E2E team member SA 1"
+          recordVar:
+            name: sa1ID
+            responsePath: id
+
+      - name: 001-create-sa2
+        create:
+          resource: system-account
+          payload:
+            inline:
+              name: "{{ .vars.sa2Name }}"
+              description: "E2E team member SA 2"
+          recordVar:
+            name: sa2ID
+            responsePath: id
+
+  - name: 002-apply-create
+    commands:
+      - name: 000-apply-create
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/team-members.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 3
+                by_action.CREATE: 3
+          - select: summary
+            expect:
+              fields:
+                applied: 3
+                failed: 0
+                status: success
+          - select: "plan.changes[?resource_type=='organization_team' && resource_ref=='{{ .vars.teamRef }}'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+                fields.name: "API Platform Team"
+                fields.description: "Team for API platform management"
+          - select: "plan.changes[?resource_type=='organization_team_system_account' && resource_ref=='api-platform-sa1'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+                fields.account_name: "{{ .vars.sa1Name }}"
+                fields.account_id: "{{ .vars.sa1ID }}"
+                references.team_id.ref: "{{ .vars.teamRef }}"
+          - select: "plan.changes[?resource_type=='organization_team_system_account' && resource_ref=='api-platform-sa2'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+                fields.account_name: "{{ .vars.sa2Name }}"
+                fields.account_id: "{{ .vars.sa2ID }}"
+                references.team_id.ref: "{{ .vars.teamRef }}"
+
+  - name: 003-get-verify-members
+    skipInputs: true
+    commands:
+      - name: 000-get-all-members
+        run: ["get", "org", "team", "member", "--team-name", "API Platform Team"]
+        assertions:
+          - select: "[?type=='system-account' && identifier=='{{ .vars.sa1Name }}'] | [0]"
+            expect:
+              fields:
+                type: system-account
+                identifier: "{{ .vars.sa1Name }}"
+          - select: "[?type=='system-account' && identifier=='{{ .vars.sa2Name }}'] | [0]"
+            expect:
+              fields:
+                type: system-account
+                identifier: "{{ .vars.sa2Name }}"
+      - name: 001-get-sa-members
+        run: ["get", "org", "team", "member", "system-accounts", "--team-name", "API Platform Team"]
+        assertions:
+          - select: "[?name=='{{ .vars.sa1Name }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.sa1Name }}"
+          - select: "[?name=='{{ .vars.sa2Name }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.sa2Name }}"
+      - name: 002-get-sa-member-by-name
+        run: ["get", "org", "team", "member", "system-accounts", "--team-name", "API Platform Team", "{{ .vars.sa1Name }}"]
+        assertions:
+          - select: "[?name=='{{ .vars.sa1Name }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.sa1Name }}"
+
+  - name: 004-apply-idempotent
+    commands:
+      - name: 000-apply-no-changes
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/team-members.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 0
+          - select: summary
+            expect:
+              fields:
+                applied: 0
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/org/teams/members/apply/testdata/team-members.yaml
+++ b/test/e2e/scenarios/org/teams/members/apply/testdata/team-members.yaml
@@ -1,0 +1,16 @@
+organization:
+  teams:
+    - ref: api-platform-team
+      name: "API Platform Team"
+      description: "Team for API platform management"
+      labels:
+        department: "engineering"
+      kongctl:
+        namespace: team-members-apply-e2e
+        protected: false
+      members:
+        system_accounts:
+          - ref: api-platform-sa1
+            name: "e2e-team-member-sa1"
+          - ref: api-platform-sa2
+            name: "e2e-team-member-sa2"

--- a/test/e2e/scenarios/org/teams/members/plan/apply-workflow/scenario.yaml
+++ b/test/e2e/scenarios/org/teams/members/plan/apply-workflow/scenario.yaml
@@ -1,0 +1,143 @@
+baseInputsPath: ./testdata
+
+env:
+  KONGCTL_LOG_LEVEL: info
+
+vars:
+  namespace: team-members-plan-apply-e2e
+  teamRef: api-platform-team
+  sa1Name: e2e-team-member-plan-sa1
+  sa2Name: e2e-team-member-plan-sa2
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - change_id
+      - resource_id
+      - created_at
+      - updated_at
+      - generated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-create-system-accounts
+    skipInputs: true
+    commands:
+      - name: 000-create-sa1
+        create:
+          resource: system-account
+          payload:
+            inline:
+              name: "{{ .vars.sa1Name }}"
+              description: "E2E plan team member SA 1"
+          recordVar:
+            name: sa1ID
+            responsePath: id
+
+      - name: 001-create-sa2
+        create:
+          resource: system-account
+          payload:
+            inline:
+              name: "{{ .vars.sa2Name }}"
+              description: "E2E plan team member SA 2"
+          recordVar:
+            name: sa2ID
+            responsePath: id
+
+  - name: 002-plan-apply-create
+    commands:
+      - name: 000-plan-create
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-create.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/team-members.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 3
+                by_action.CREATE: 3
+          - select: "changes[?resource_type=='organization_team' && resource_ref=='{{ .vars.teamRef }}'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+                fields.name: "API Platform Team"
+          - select: "changes[?resource_type=='organization_team_system_account' && resource_ref=='api-platform-sa1'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+                fields.account_name: "{{ .vars.sa1Name }}"
+                fields.account_id: "{{ .vars.sa1ID }}"
+                references.team_id.ref: "{{ .vars.teamRef }}"
+          - select: "changes[?resource_type=='organization_team_system_account' && resource_ref=='api-platform-sa2'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+                fields.account_name: "{{ .vars.sa2Name }}"
+                fields.account_id: "{{ .vars.sa2ID }}"
+                references.team_id.ref: "{{ .vars.teamRef }}"
+
+      - name: 001-diff-plan-text
+        outputFormat: text
+        parseAs: raw
+        run:
+          - diff
+          - --plan
+          - "{{ .workdir }}/plan-create.json"
+        assertions:
+          - select: stdout
+            expect:
+              fields:
+                "contains(@, 'Plan: 3 to add')": true
+                "contains(@, 'team \"api-platform-team\" will be created')": true
+                "contains(@, 'organization_team_system_account \"api-platform-sa1\" will be created')": true
+                "contains(@, 'organization_team_system_account \"api-platform-sa2\" will be created')": true
+
+      - name: 002-apply-plan
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-create.json"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                applied: 3
+                failed: 0
+                status: success
+
+  - name: 003-plan-apply-no-changes
+    commands:
+      - name: 000-plan-no-changes
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/team-members.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0

--- a/test/e2e/scenarios/org/teams/members/plan/apply-workflow/testdata/team-members.yaml
+++ b/test/e2e/scenarios/org/teams/members/plan/apply-workflow/testdata/team-members.yaml
@@ -1,0 +1,16 @@
+organization:
+  teams:
+    - ref: api-platform-team
+      name: "API Platform Team"
+      description: "Team for API platform management"
+      labels:
+        department: "engineering"
+      kongctl:
+        namespace: team-members-plan-apply-e2e
+        protected: false
+      members:
+        system_accounts:
+          - ref: api-platform-sa1
+            name: "e2e-team-member-plan-sa1"
+          - ref: api-platform-sa2
+            name: "e2e-team-member-plan-sa2"

--- a/test/e2e/scenarios/org/teams/members/plan/sync-workflow/overlays/003-remove-member/team-members.yaml
+++ b/test/e2e/scenarios/org/teams/members/plan/sync-workflow/overlays/003-remove-member/team-members.yaml
@@ -1,0 +1,17 @@
+organization:
+  teams:
+    - ref: api-platform-team
+      name: "API Platform Team"
+      description: "Team for API platform management"
+      labels:
+        department: "engineering"
+      kongctl:
+        namespace: team-members-plan-sync-e2e
+        protected: false
+      members:
+        system_accounts:
+          - ref: api-platform-sa1
+            name: "e2e-team-member-ps-sa1"
+            # removed api-platform-sa2 and added api-platform-sa3
+          - ref: api-platform-sa3
+            name: "e2e-team-member-ps-sa3"

--- a/test/e2e/scenarios/org/teams/members/plan/sync-workflow/scenario.yaml
+++ b/test/e2e/scenarios/org/teams/members/plan/sync-workflow/scenario.yaml
@@ -1,0 +1,151 @@
+baseInputsPath: ./testdata
+
+env:
+  KONGCTL_LOG_LEVEL: info
+
+vars:
+  namespace: team-members-plan-sync-e2e
+  teamRef: api-platform-team
+  sa1Name: e2e-team-member-ps-sa1
+  sa2Name: e2e-team-member-ps-sa2
+  sa3Name: e2e-team-member-ps-sa3
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - change_id
+      - resource_id
+      - created_at
+      - updated_at
+      - generated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-create-system-accounts
+    skipInputs: true
+    commands:
+      - name: 000-create-sa1
+        create:
+          resource: system-account
+          payload:
+            inline:
+              name: "{{ .vars.sa1Name }}"
+              description: "E2E plan-sync team member SA 1"
+          recordVar:
+            name: sa1ID
+            responsePath: id
+
+      - name: 001-create-sa2
+        create:
+          resource: system-account
+          payload:
+            inline:
+              name: "{{ .vars.sa2Name }}"
+              description: "E2E plan-sync team member SA 2"
+          recordVar:
+            name: sa2ID
+            responsePath: id
+
+      - name: 002-create-sa3
+        create:
+          resource: system-account
+          payload:
+            inline:
+              name: "{{ .vars.sa3Name }}"
+              description: "E2E plan-sync team member SA 3"
+          recordVar:
+            name: sa3ID
+            responsePath: id
+
+  - name: 002-bootstrap-sync-state
+    commands:
+      - name: 000-sync-initial
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/team-members.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: sync
+          - select: summary
+            expect:
+              fields:
+                applied: 3
+                failed: 0
+
+  - name: 003-plan-sync-remove-member
+    inputOverlayDirs:
+      - overlays/003-remove-member
+    commands:
+      - name: 000-plan-sync
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-sync.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/team-members.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: sync
+          - select: summary
+            expect:
+              fields:
+                total_changes: 2
+                by_action.DELETE: 1
+                by_action.CREATE: 1
+          - select: "changes[?resource_type=='organization_team_system_account' && action=='DELETE'] | [0]"
+            expect:
+              fields:
+                resource_ref: "{{ .vars.sa2ID }}"
+                references.team_id.ref: "{{ .vars.teamRef }}"
+          - select: "changes[?resource_type=='organization_team_system_account' && resource_ref=='api-platform-sa3'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+                fields.account_name: "{{ .vars.sa3Name }}"
+                fields.account_id: "{{ .vars.sa3ID }}"
+
+      - name: 001-apply-plan
+        outputFormat: json
+        run:
+          - sync
+          - --plan
+          - "{{ .workdir }}/plan-sync.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 2
+                failed: 0
+                status: success
+
+  - name: 004-plan-sync-no-changes
+    inputOverlayDirs:
+      - overlays/003-remove-member
+    commands:
+      - name: 000-plan-no-changes
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/team-members.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0

--- a/test/e2e/scenarios/org/teams/members/plan/sync-workflow/testdata/team-members.yaml
+++ b/test/e2e/scenarios/org/teams/members/plan/sync-workflow/testdata/team-members.yaml
@@ -1,0 +1,16 @@
+organization:
+  teams:
+    - ref: api-platform-team
+      name: "API Platform Team"
+      description: "Team for API platform management"
+      labels:
+        department: "engineering"
+      kongctl:
+        namespace: team-members-plan-sync-e2e
+        protected: false
+      members:
+        system_accounts:
+          - ref: api-platform-sa1
+            name: "e2e-team-member-ps-sa1"
+          - ref: api-platform-sa2
+            name: "e2e-team-member-ps-sa2"

--- a/test/e2e/scenarios/org/teams/members/sync/overlays/003-sync-remove-member/team-members.yaml
+++ b/test/e2e/scenarios/org/teams/members/sync/overlays/003-sync-remove-member/team-members.yaml
@@ -1,0 +1,17 @@
+organization:
+  teams:
+    - ref: api-platform-team
+      name: "API Platform Team"
+      description: "Team for API platform management"
+      labels:
+        department: "engineering"
+      kongctl:
+        namespace: team-members-sync-e2e
+        protected: false
+      members:
+        system_accounts:
+          - ref: api-platform-sa1
+            name: "e2e-team-member-sync-sa1"
+            # removed api-platform-sa2 and added api-platform-sa3
+          - ref: api-platform-sa3
+            name: "e2e-team-member-sync-sa3"

--- a/test/e2e/scenarios/org/teams/members/sync/scenario.yaml
+++ b/test/e2e/scenarios/org/teams/members/sync/scenario.yaml
@@ -1,0 +1,226 @@
+baseInputsPath: ./testdata
+
+env:
+  KONGCTL_LOG_LEVEL: info
+
+vars:
+  namespace: team-members-sync-e2e
+  teamRef: api-platform-team
+  sa1Name: e2e-team-member-sync-sa1
+  sa2Name: e2e-team-member-sync-sa2
+  sa3Name: e2e-team-member-sync-sa3
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - change_id
+      - resource_id
+      - created_at
+      - updated_at
+      - generated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-create-system-accounts
+    skipInputs: true
+    commands:
+      - name: 000-create-sa1
+        create:
+          resource: system-account
+          payload:
+            inline:
+              name: "{{ .vars.sa1Name }}"
+              description: "E2E sync team member SA 1"
+          recordVar:
+            name: sa1ID
+            responsePath: id
+
+      - name: 001-create-sa2
+        create:
+          resource: system-account
+          payload:
+            inline:
+              name: "{{ .vars.sa2Name }}"
+              description: "E2E sync team member SA 2"
+          recordVar:
+            name: sa2ID
+            responsePath: id
+
+      - name: 002-create-sa3
+        create:
+          resource: system-account
+          payload:
+            inline:
+              name: "{{ .vars.sa3Name }}"
+              description: "E2E sync team member SA 3"
+          recordVar:
+            name: sa3ID
+            responsePath: id
+
+  - name: 002-sync-initial
+    commands:
+      - name: 000-sync-create
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/team-members.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: sync
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 3
+                by_action.CREATE: 3
+          - select: summary
+            expect:
+              fields:
+                applied: 3
+                failed: 0
+                status: success
+          - select: "plan.changes[?resource_type=='organization_team' && resource_ref=='{{ .vars.teamRef }}'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+                fields.name: "API Platform Team"
+          - select: "plan.changes[?resource_type=='organization_team_system_account' && resource_ref=='api-platform-sa1'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+                fields.account_name: "{{ .vars.sa1Name }}"
+                fields.account_id: "{{ .vars.sa1ID }}"
+          - select: "plan.changes[?resource_type=='organization_team_system_account' && resource_ref=='api-platform-sa2'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+                fields.account_name: "{{ .vars.sa2Name }}"
+                fields.account_id: "{{ .vars.sa2ID }}"
+
+  - name: 003-get-verify-initial-members
+    skipInputs: true
+    commands:
+      - name: 000-get-all-members
+        run: ["get", "org", "team", "member", "--team-name", "API Platform Team"]
+        assertions:
+          - select: "[?type=='system-account' && identifier=='{{ .vars.sa1Name }}'] | [0]"
+            expect:
+              fields:
+                type: system-account
+                identifier: "{{ .vars.sa1Name }}"
+          - select: "[?type=='system-account' && identifier=='{{ .vars.sa2Name }}'] | [0]"
+            expect:
+              fields:
+                type: system-account
+                identifier: "{{ .vars.sa2Name }}"
+      - name: 001-get-sa-members
+        run: ["get", "org", "team", "member", "system-accounts", "--team-name", "API Platform Team"]
+        assertions:
+          - select: "[?name=='{{ .vars.sa1Name }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.sa1Name }}"
+          - select: "[?name=='{{ .vars.sa2Name }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.sa2Name }}"
+
+  - name: 004-sync-remove-member
+    inputOverlayDirs:
+      - overlays/003-sync-remove-member
+    commands:
+      - name: 000-sync-update-members
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/team-members.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 2
+                by_action.CREATE: 1
+                by_action.DELETE: 1
+          - select: summary
+            expect:
+              fields:
+                applied: 2
+                failed: 0
+                status: success
+          - select: "plan.changes[?resource_type=='organization_team_system_account' && action=='DELETE'] | [0]"
+            expect:
+              fields:
+                resource_ref: "{{ .vars.sa2ID }}"
+                references.team_id.ref: "{{ .vars.teamRef }}"
+          - select: "plan.changes[?resource_type=='organization_team_system_account' && resource_ref=='api-platform-sa3'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+                fields.account_name: "{{ .vars.sa3Name }}"
+                fields.account_id: "{{ .vars.sa3ID }}"
+
+  - name: 005-get-verify-members-after-swap
+    skipInputs: true
+    commands:
+      - name: 000-get-all-members
+        run: ["get", "org", "team", "member", "--team-name", "API Platform Team"]
+        assertions:
+          - select: "[?type=='system-account' && identifier=='{{ .vars.sa1Name }}'] | [0]"
+            expect:
+              fields:
+                type: system-account
+                identifier: "{{ .vars.sa1Name }}"
+          - select: "[?type=='system-account' && identifier=='{{ .vars.sa3Name }}'] | [0]"
+            expect:
+              fields:
+                type: system-account
+                identifier: "{{ .vars.sa3Name }}"
+          - select: "@"
+            expect:
+              fields:
+                "length([?identifier=='{{ .vars.sa2Name }}'])": 0
+      - name: 001-get-sa-members
+        run: ["get", "org", "team", "member", "system-accounts", "--team-name", "API Platform Team"]
+        assertions:
+          - select: "[?name=='{{ .vars.sa1Name }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.sa1Name }}"
+          - select: "[?name=='{{ .vars.sa3Name }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.sa3Name }}"
+          - select: "@"
+            expect:
+              fields:
+                "length([?name=='{{ .vars.sa2Name }}'])": 0
+
+  - name: 006-sync-no-changes
+    inputOverlayDirs:
+      - overlays/003-sync-remove-member
+    commands:
+      - name: 000-sync-idempotent
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/team-members.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 0
+          - select: summary
+            expect:
+              fields:
+                applied: 0
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/org/teams/members/sync/testdata/team-members.yaml
+++ b/test/e2e/scenarios/org/teams/members/sync/testdata/team-members.yaml
@@ -1,0 +1,16 @@
+organization:
+  teams:
+    - ref: api-platform-team
+      name: "API Platform Team"
+      description: "Team for API platform management"
+      labels:
+        department: "engineering"
+      kongctl:
+        namespace: team-members-sync-e2e
+        protected: false
+      members:
+        system_accounts:
+          - ref: api-platform-sa1
+            name: "e2e-team-member-sync-sa1"
+          - ref: api-platform-sa2
+            name: "e2e-team-member-sync-sa2"


### PR DESCRIPTION
This PR adds support for member additions in a team.
We can add a pre-existing user or a system-account to a team.

This is what the declarative UX looks like:
```
organization:
  teams:
    - ref: backend-team
      name: "Backend Team"

      members: # a grouping concept for better readability and collapsing yaml needs
        users:
         - ref: alice
           name: Alice # we can also support id, email for lookups  

        system_accounts:
         - ref: bot-account
           name: Bot # we can also support id for lookup
```

Get and list commands follow the same heirarchy.

The following commands would output all members of a team - users and system-accounts
- kongctl get org teams members --team-name teamA
- kongctl get org teams members --team-id <some-uuid>

We can classify them more into specific members and filter based on names, ids and emails (in case of users).
- kongctl get org teams members users --team-name teamA alice
- kongctl get org teams members users --team-name teamA alice@gmail.com
- kongctl get org teams members system-account --team-name teamA bot

For tests, I have used system-accounts in the scenarios as we can't readily create and delete users. 
So, I am testing all functionalities using system-accounts.

Support for adopt and dump would be added in a separate PR.