### PR TITLE
Test: Improve E2E as a valid gate check for PRs

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -51,6 +51,9 @@ jobs:
       - name: Detect whether E2E is required
         id: detect
         shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          BASE_REF: ${{ github.base_ref || '' }}
         run: |
           set -euo pipefail
 
@@ -60,9 +63,14 @@ jobs:
             exit 0
           fi
 
-          base_branch="${{ github.event.repository.default_branch }}"
-          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
-            base_branch="${{ github.base_ref }}"
+          base_branch="${DEFAULT_BRANCH}"
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ] && [ -n "${BASE_REF}" ]; then
+            base_branch="${BASE_REF}"
+          fi
+
+          if ! git check-ref-format --branch "${base_branch}" >/dev/null 2>&1; then
+            echo "::error::Invalid base branch ref: ${base_branch}"
+            exit 1
           fi
 
           git fetch --no-tags --prune --depth=1 origin "${base_branch}"


### PR DESCRIPTION
## Summary
- make `E2E Verify` fail when any selected shard exits non-zero
- make `E2E Verify` fail when any scenarios are reported as failed
- surface malformed shard result files and non-zero shard exits in the workflow summary

## Why
PR 628 showed that `E2E Verify` could pass even when `E2E (kongctl-acceptance)` was cancelled. That leaves the PR green without a passing acceptance result.

## Testing
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/e2e.yaml', aliases: true); puts 'yaml-ok'"`