### PR TITLE
simplifier: remove auth strategy variable shadowing

### DIFF
--- a/internal/declarative/executor/auth_strategy_adapter.go
+++ b/internal/declarative/executor/auth_strategy_adapter.go
@@ -227,8 +227,8 @@ func (a *AuthStrategyAdapter) buildKeyAuthRequest(name, displayName string, labe
 	case []any:
 		names := make([]string, 0, len(keyNames))
 		for _, kn := range keyNames {
-			if name, ok := kn.(string); ok {
-				names = append(names, name)
+			if str, ok := kn.(string); ok {
+				names = append(names, str)
 			}
 		}
 		if len(names) > 0 {
@@ -299,8 +299,8 @@ func (a *AuthStrategyAdapter) buildUpdateConfigs(strategyType string,
 		keyAuth.KeyNames = extractStringSlice(keyAuthConfig["key_names"], nil)
 
 		wrapped := kkComps.UpdateAppAuthStrategyRequestKeyAuth{KeyAuth: keyAuth}
-		configs := kkComps.CreateConfigsUpdateAppAuthStrategyRequestKeyAuth(wrapped)
-		return &configs, nil
+		result := kkComps.CreateConfigsUpdateAppAuthStrategyRequestKeyAuth(wrapped)
+		return &result, nil
 
 	case "openid_connect":
 		oidcConfig, ok := configs["openid-connect"].(map[string]any)
@@ -322,8 +322,8 @@ func (a *AuthStrategyAdapter) buildUpdateConfigs(strategyType string,
 		oidc.AuthMethods = extractStringSlice(oidcConfig["auth_methods"], nil)
 
 		wrapped := kkComps.UpdateAppAuthStrategyRequestOpenIDConnect{OpenidConnect: oidc}
-		configs := kkComps.CreateConfigsUpdateAppAuthStrategyRequestOpenIDConnect(wrapped)
-		return &configs, nil
+		result := kkComps.CreateConfigsUpdateAppAuthStrategyRequestOpenIDConnect(wrapped)
+		return &result, nil
 
 	default:
 		return nil, fmt.Errorf("unsupported strategy type: %s", strategyType)

--- a/internal/declarative/resources/utils.go
+++ b/internal/declarative/resources/utils.go
@@ -9,8 +9,8 @@ import (
 func resolveStringField(v reflect.Value, fieldName string) string {
 	// Try direct field access first
 	field := v.FieldByName(fieldName)
-	//nolint: exhaustive
 	if field.IsValid() {
+		//nolint: exhaustive
 		switch field.Kind() {
 		case reflect.String:
 			return field.String()


### PR DESCRIPTION
## Summary
- rename the shadowed locals in `AuthStrategyAdapter` so the key auth and update helpers are easier to follow
- preserve existing behavior while addressing the simplifier recommendations from issue #664
- move the existing `//nolint: exhaustive` directive onto its guarded switch so lint stays green during validation

## Testing
- `make build`
- `make lint`
- `make test-all`

Closes #664