### PR TITLE
Feat: event gateway consume policy

### DIFF
--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -2289,6 +2289,7 @@ func createStateClient(kkClient helpers.SDKAPI) *state.Client {
 		EventGatewayDataPlaneCertificateAPI: kkClient.GetEventGatewayDataPlaneCertificateAPI(),
 		EventGatewayClusterPolicyAPI:        kkClient.GetEventGatewayClusterPolicyAPI(),
 		EventGatewayProducePolicyAPI:        kkClient.GetEventGatewayProducePolicyAPI(),
+		EventGatewayConsumePolicyAPI:        kkClient.GetEventGatewayConsumePolicyAPI(),
 		// Organization APIs
 		OrganizationTeamAPI: kkClient.GetOrganizationTeamAPI(),
 	})

--- a/internal/cmd/root/products/konnect/eventgateway/consume-policies.go
+++ b/internal/cmd/root/products/konnect/eventgateway/consume-policies.go
@@ -527,3 +527,112 @@ func consumePolicyToRecord(policy kkComps.EventGatewayPolicy) consumePolicySumma
 		LocalUpdatedTime: policy.UpdatedAt.In(time.Local).Format("2006-01-02 15:04:05"),
 	}
 }
+
+func consumePolicyWithConfigToRecord(policy consumePolicyWithConfig) consumePolicySummaryRecord {
+	id := policy.ID
+	if id != "" {
+		id = util.AbbreviateUUID(id)
+	} else {
+		id = valueNA
+	}
+
+	name := valueNA
+	if policy.Name != nil && *policy.Name != "" {
+		name = *policy.Name
+	}
+
+	policyType := policy.Type
+	if policyType == "" {
+		policyType = valueNA
+	}
+
+	desc := valueNA
+	if policy.Description != nil && *policy.Description != "" {
+		desc = *policy.Description
+	}
+
+	return consumePolicySummaryRecord{
+		ID:               id,
+		Name:             name,
+		Type:             policyType,
+		Description:      desc,
+		Enabled:          formatEnabledBool(policy.Enabled),
+		LocalCreatedTime: policy.CreatedAt.In(time.Local).Format("2006-01-02 15:04:05"),
+		LocalUpdatedTime: policy.UpdatedAt.In(time.Local).Format("2006-01-02 15:04:05"),
+	}
+}
+
+func consumePolicyWithConfigDetailView(policy *consumePolicyWithConfig) string {
+	if policy == nil {
+		return ""
+	}
+
+	id := strings.TrimSpace(policy.ID)
+	if id == "" {
+		id = valueNA
+	}
+
+	policyType := strings.TrimSpace(policy.Type)
+	if policyType == "" {
+		policyType = valueNA
+	}
+
+	name := valueNA
+	if policy.Name != nil && strings.TrimSpace(*policy.Name) != "" {
+		name = strings.TrimSpace(*policy.Name)
+	}
+
+	description := valueNA
+	if policy.Description != nil && strings.TrimSpace(*policy.Description) != "" {
+		description = strings.TrimSpace(*policy.Description)
+	}
+
+	enabled := formatEnabledBool(policy.Enabled)
+	labels := formatLabelPairs(policy.Labels)
+	config := formatJSONValue(policy.Config)
+
+	createdAt := policy.CreatedAt.In(time.Local).Format("2006-01-02 15:04:05")
+	updatedAt := policy.UpdatedAt.In(time.Local).Format("2006-01-02 15:04:05")
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "id: %s\n", id)
+	fmt.Fprintf(&b, "type: %s\n", policyType)
+	fmt.Fprintf(&b, "name: %s\n", name)
+	fmt.Fprintf(&b, "description: %s\n", description)
+	fmt.Fprintf(&b, "enabled: %s\n", enabled)
+	fmt.Fprintf(&b, "labels: %s\n", labels)
+	fmt.Fprintf(&b, "config: %s\n", config)
+	fmt.Fprintf(&b, "created_at: %s\n", createdAt)
+	fmt.Fprintf(&b, "updated_at: %s\n", updatedAt)
+
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func buildConsumePolicyChildView(policies []consumePolicyWithConfig) tableview.ChildView {
+	tableRows := make([]table.Row, 0, len(policies))
+	for i := range policies {
+		record := consumePolicyWithConfigToRecord(policies[i])
+		tableRows = append(tableRows, table.Row{record.ID, record.Name, record.Type})
+	}
+
+	detailFn := func(index int) string {
+		if index < 0 || index >= len(policies) {
+			return ""
+		}
+		return consumePolicyWithConfigDetailView(&policies[index])
+	}
+
+	return tableview.ChildView{
+		Headers:        []string{"ID", "NAME", "TYPE"},
+		Rows:           tableRows,
+		DetailRenderer: detailFn,
+		Title:          "Consume Policies",
+		ParentType:     "consume-policy",
+		DetailContext: func(index int) any {
+			if index < 0 || index >= len(policies) {
+				return nil
+			}
+			return &policies[index]
+		},
+	}
+}

--- a/internal/cmd/root/products/konnect/eventgateway/consume-policies.go
+++ b/internal/cmd/root/products/konnect/eventgateway/consume-policies.go
@@ -1,0 +1,529 @@
+package eventgateway
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/table"
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/cmd"
+	cmdCommon "github.com/kong/kongctl/internal/cmd/common"
+	"github.com/kong/kongctl/internal/cmd/output/tableview"
+	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/kong/kongctl/internal/config"
+	"github.com/kong/kongctl/internal/konnect/helpers"
+	"github.com/kong/kongctl/internal/meta"
+	"github.com/kong/kongctl/internal/util"
+	"github.com/kong/kongctl/internal/util/i18n"
+	"github.com/kong/kongctl/internal/util/normalizers"
+	"github.com/segmentio/cli"
+	"github.com/spf13/cobra"
+)
+
+const (
+	consumePoliciesCommandName = "consume-policies"
+
+	consumePolicyIDFlagName   = "consume-policy-id"
+	consumePolicyNameFlagName = "consume-policy-name"
+
+	consumePolicyIDConfigPath   = "konnect.event-gateway.consume-policy.id"
+	consumePolicyNameConfigPath = "konnect.event-gateway.consume-policy.name"
+)
+
+type consumePolicySummaryRecord struct {
+	ID               string
+	Name             string
+	Type             string
+	Description      string
+	Enabled          string
+	LocalCreatedTime string
+	LocalUpdatedTime string
+}
+
+// consumePolicyWithConfig is a wrapper that includes the full config from raw API response.
+// The SDK's EventGatewayPolicyConfig struct is empty, so we use map[string]any to capture actual config.
+type consumePolicyWithConfig struct {
+	Type        string            `json:"type" yaml:"type"`
+	Name        *string           `json:"name,omitempty" yaml:"name,omitempty"`
+	Description *string           `json:"description,omitempty" yaml:"description,omitempty"`
+	Enabled     *bool             `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	ID          string            `json:"id" yaml:"id"`
+	Config      map[string]any    `json:"config" yaml:"config"`
+	CreatedAt   time.Time         `json:"created_at" yaml:"created_at"`
+	UpdatedAt   time.Time         `json:"updated_at" yaml:"updated_at"`
+}
+
+var (
+	consumePoliciesUse = consumePoliciesCommandName
+
+	consumePoliciesShort = i18n.T("root.products.konnect.eventgateway.consumePoliciesShort",
+		"Manage consume policies for an Event Gateway Virtual Cluster")
+	consumePoliciesLong = normalizers.LongDesc(i18n.T("root.products.konnect.eventgateway.consumePoliciesLong",
+		`Use the consume-policies command to list or retrieve consume policies for a specific Event Gateway Virtual Cluster.`)) //nolint:lll
+	consumePoliciesExample = normalizers.Examples(
+		i18n.T("root.products.konnect.eventgateway.consumePoliciesExamples",
+			fmt.Sprintf(`
+# List consume policies for a virtual cluster by ID
+%[1]s get event-gateway virtual-clusters consume-policies --gateway-id <gw-id> --virtual-cluster-id <vc-id>
+# List consume policies for a virtual cluster by name
+%[1]s get event-gateway vc consume-policies --gateway-name my-gw --virtual-cluster-name my-vc
+# Get a specific consume policy by ID (positional argument)
+%[1]s get event-gateway vc consume-policies --gateway-id <gw-id> --virtual-cluster-id <vc-id> <policy-id>
+# Get a specific consume policy by name
+%[1]s get event-gateway vc consume-policies --gateway-id <gw-id> --virtual-cluster-id <vc-id> my-policy
+# Get a specific consume policy by ID (flag)
+%[1]s get event-gateway vc consume-policies --gateway-id <id> --virtual-cluster-id <id> --consume-policy-id <id>
+# Get a specific consume policy by name (flag)
+%[1]s get event-gateway vc consume-policies --gateway-name gw --virtual-cluster-name vc --consume-policy-name p
+`, meta.CLIName)))
+)
+
+func newGetEventGatewayConsumePoliciesCmd(
+	verb verbs.VerbValue,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) *cobra.Command {
+	c := &cobra.Command{
+		Use:     consumePoliciesUse,
+		Short:   consumePoliciesShort,
+		Long:    consumePoliciesLong,
+		Example: consumePoliciesExample,
+		Aliases: []string{"consume-policy", "consumes"},
+		PreRunE: func(c *cobra.Command, args []string) error {
+			if parentPreRun != nil {
+				if err := parentPreRun(c, args); err != nil {
+					return err
+				}
+			}
+			if err := bindEventGatewayChildFlags(c, args); err != nil {
+				return err
+			}
+			if err := bindVirtualClusterChildFlags(c, args); err != nil {
+				return err
+			}
+			return bindConsumePolicyChildFlags(c, args)
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			handler := consumePoliciesHandler{cmd: c}
+			return handler.run(args)
+		},
+	}
+
+	addEventGatewayChildFlags(c)
+	addVirtualClusterChildFlags(c)
+	addConsumePolicyChildFlags(c)
+
+	if addParentFlags != nil {
+		addParentFlags(verb, c)
+	}
+
+	return c
+}
+
+func addConsumePolicyChildFlags(c *cobra.Command) {
+	c.Flags().String(consumePolicyIDFlagName, "",
+		fmt.Sprintf(`The ID of the consume policy to retrieve.
+- Config path: [ %s ]`, consumePolicyIDConfigPath))
+	c.Flags().String(consumePolicyNameFlagName, "",
+		fmt.Sprintf(`The name of the consume policy to retrieve.
+- Config path: [ %s ]`, consumePolicyNameConfigPath))
+	c.MarkFlagsMutuallyExclusive(consumePolicyIDFlagName, consumePolicyNameFlagName)
+}
+
+func bindConsumePolicyChildFlags(c *cobra.Command, args []string) error {
+	helper := cmd.BuildHelper(c, args)
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	if flag := c.Flags().Lookup(consumePolicyIDFlagName); flag != nil {
+		if err := cfg.BindFlag(consumePolicyIDConfigPath, flag); err != nil {
+			return err
+		}
+	}
+
+	if flag := c.Flags().Lookup(consumePolicyNameFlagName); flag != nil {
+		if err := cfg.BindFlag(consumePolicyNameConfigPath, flag); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getConsumePolicyIdentifiers(cfg config.Hook) (id string, name string) {
+	return cfg.GetString(consumePolicyIDConfigPath), cfg.GetString(consumePolicyNameConfigPath)
+}
+
+type consumePoliciesHandler struct {
+	cmd *cobra.Command
+}
+
+func (h consumePoliciesHandler) run(args []string) error {
+	helper := cmd.BuildHelper(h.cmd, args)
+
+	if len(args) > 1 {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf("too many arguments. Listing consume policies requires 0 or 1 arguments (ID or name)"),
+		}
+	}
+
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	// Check if positional arg and flags are both provided
+	if len(args) == 1 {
+		policyID, policyName := getConsumePolicyIdentifiers(cfg)
+		if policyID != "" || policyName != "" {
+			return &cmd.ConfigurationError{
+				Err: fmt.Errorf(
+					"cannot specify both positional argument and --%s or --%s flags",
+					consumePolicyIDFlagName,
+					consumePolicyNameFlagName,
+				),
+			}
+		}
+	}
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+
+	outType, err := helper.GetOutputFormat()
+	if err != nil {
+		return err
+	}
+
+	printer, err := cli.Format(outType.String(), helper.GetStreams().Out)
+	if err != nil {
+		return err
+	}
+	defer printer.Flush()
+
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return err
+	}
+
+	// Resolve gateway ID
+	gatewayID, gatewayName := getEventGatewayIdentifiers(cfg)
+	if gatewayID != "" && gatewayName != "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf("only one of --%s or --%s can be provided", gatewayIDFlagName, gatewayNameFlagName),
+		}
+	}
+
+	if gatewayID == "" && gatewayName == "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf(
+				"an event gateway identifier is required. Provide --%s or --%s",
+				gatewayIDFlagName,
+				gatewayNameFlagName,
+			),
+		}
+	}
+
+	if gatewayID == "" {
+		gatewayID, err = resolveEventGatewayIDByName(gatewayName, sdk.GetEventGatewayControlPlaneAPI(), helper, cfg)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Resolve virtual cluster ID
+	virtualClusterID, virtualClusterName := getVirtualClusterIdentifiers(cfg)
+	if virtualClusterID != "" && virtualClusterName != "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf(
+				"only one of --%s or --%s can be provided",
+				virtualClusterIDFlagName,
+				virtualClusterNameFlagName,
+			),
+		}
+	}
+
+	if virtualClusterID == "" && virtualClusterName == "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf(
+				"a virtual cluster identifier is required. Provide --%s or --%s",
+				virtualClusterIDFlagName,
+				virtualClusterNameFlagName,
+			),
+		}
+	}
+
+	virtualClusterAPI := sdk.GetEventGatewayVirtualClusterAPI()
+	if virtualClusterAPI == nil {
+		return &cmd.ExecutionError{
+			Msg: "Virtual Clusters client is not available",
+			Err: fmt.Errorf("virtual clusters client not configured"),
+		}
+	}
+
+	if virtualClusterID == "" {
+		virtualClusterID, err = resolveVirtualClusterIDByName(
+			virtualClusterName,
+			virtualClusterAPI,
+			gatewayID,
+			helper,
+			cfg,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	policyAPI := sdk.GetEventGatewayConsumePolicyAPI()
+	if policyAPI == nil {
+		return &cmd.ExecutionError{
+			Msg: "Consume Policies client is not available",
+			Err: fmt.Errorf("consume policies client not configured"),
+		}
+	}
+
+	// Determine if we're getting a single policy or listing all
+	policyID, policyName := getConsumePolicyIdentifiers(cfg)
+	var policyIdentifier string
+
+	if len(args) == 1 {
+		policyIdentifier = strings.TrimSpace(args[0])
+	} else if policyID != "" {
+		policyIdentifier = policyID
+	} else if policyName != "" {
+		policyIdentifier = policyName
+	}
+
+	if policyIdentifier != "" {
+		return h.getSinglePolicy(
+			helper,
+			policyAPI,
+			gatewayID,
+			virtualClusterID,
+			policyIdentifier,
+			outType,
+			printer,
+			cfg,
+		)
+	}
+
+	return h.listPolicies(helper, policyAPI, gatewayID, virtualClusterID, outType, printer, cfg)
+}
+
+func (h consumePoliciesHandler) listPolicies(
+	helper cmd.Helper,
+	policyAPI helpers.EventGatewayConsumePolicyAPI,
+	gatewayID string,
+	virtualClusterID string,
+	outType cmdCommon.OutputFormat,
+	printer cli.PrintFlusher,
+	_ config.Hook,
+) error {
+	policies, rawPolicies, err := fetchConsumePolicies(helper, policyAPI, gatewayID, virtualClusterID)
+	if err != nil {
+		return err
+	}
+
+	records := make([]consumePolicySummaryRecord, 0, len(policies))
+	for _, policy := range policies {
+		records = append(records, consumePolicyToRecord(policy))
+	}
+
+	tableRows := make([]table.Row, 0, len(records))
+	for _, record := range records {
+		tableRows = append(tableRows, table.Row{record.ID, record.Name, record.Type})
+	}
+
+	// Use raw policies with full config for JSON/YAML output if available
+	var outputData any = policies
+	if len(rawPolicies) > 0 {
+		outputData = rawPolicies
+	}
+
+	return tableview.RenderForFormat(
+		helper,
+		false,
+		outType,
+		printer,
+		helper.GetStreams(),
+		records,
+		outputData,
+		"",
+		tableview.WithCustomTable([]string{"ID", "NAME", "TYPE"}, tableRows),
+		tableview.WithRootLabel(helper.GetCmd().Name()),
+	)
+}
+
+func (h consumePoliciesHandler) getSinglePolicy(
+	helper cmd.Helper,
+	policyAPI helpers.EventGatewayConsumePolicyAPI,
+	gatewayID string,
+	virtualClusterID string,
+	identifier string,
+	outType cmdCommon.OutputFormat,
+	printer cli.PrintFlusher,
+	_ config.Hook,
+) error {
+	policyID := identifier
+	if !util.IsValidUUID(identifier) {
+		policies, _, err := fetchConsumePolicies(helper, policyAPI, gatewayID, virtualClusterID)
+		if err != nil {
+			return err
+		}
+		match := findConsumePolicyByName(policies, identifier)
+		if match == nil {
+			return &cmd.ConfigurationError{
+				Err: fmt.Errorf("consume policy %q not found", identifier),
+			}
+		}
+		if match.ID != "" {
+			policyID = match.ID
+		} else {
+			return &cmd.ConfigurationError{
+				Err: fmt.Errorf("consume policy %q does not have an ID", identifier),
+			}
+		}
+	}
+
+	req := kkOps.GetEventGatewayVirtualClusterConsumePolicyRequest{
+		GatewayID:        gatewayID,
+		VirtualClusterID: virtualClusterID,
+		PolicyID:         policyID,
+	}
+
+	res, err := policyAPI.GetEventGatewayVirtualClusterConsumePolicy(helper.GetContext(), req)
+	if err != nil {
+		attrs := cmd.TryConvertErrorToAttrs(err)
+		return cmd.PrepareExecutionError("Failed to get consume policy", err, helper.GetCmd(), attrs...)
+	}
+
+	policy := res.EventGatewayPolicy
+	if policy == nil {
+		return &cmd.ExecutionError{
+			Msg: "Consume policy response was empty",
+			Err: fmt.Errorf("no consume policy returned for id %s", policyID),
+		}
+	}
+
+	// Parse raw response to get full config (SDK's EventGatewayPolicyConfig is empty)
+	var policyWithConfig *consumePolicyWithConfig
+	var parsed consumePolicyWithConfig
+	if parseRawConsumePolicyResponse(helper, res, &parsed) {
+		policyWithConfig = &parsed
+	}
+
+	// If we successfully parsed the raw response with config, use that
+	if policyWithConfig != nil {
+		return tableview.RenderForFormat(
+			helper,
+			false,
+			outType,
+			printer,
+			helper.GetStreams(),
+			consumePolicyToRecord(*policy),
+			policyWithConfig,
+			"",
+			tableview.WithRootLabel(helper.GetCmd().Name()),
+		)
+	}
+
+	return tableview.RenderForFormat(
+		helper,
+		false,
+		outType,
+		printer,
+		helper.GetStreams(),
+		consumePolicyToRecord(*policy),
+		policy,
+		"",
+		tableview.WithRootLabel(helper.GetCmd().Name()),
+	)
+}
+
+// parseRawConsumePolicyResponse parses the raw HTTP response body to extract consume policies with full config.
+// The SDK's EventGatewayPolicyConfig struct is empty, so we use this to capture actual config.
+func parseRawConsumePolicyResponse[T any](helper cmd.Helper, sdkResponse sdkResponseWithRawBody, target *T) bool {
+	return parseRawPolicyResponse(helper, sdkResponse, target)
+}
+
+func fetchConsumePolicies(
+	helper cmd.Helper,
+	policyAPI helpers.EventGatewayConsumePolicyAPI,
+	gatewayID string,
+	virtualClusterID string,
+) ([]kkComps.EventGatewayPolicy, []consumePolicyWithConfig, error) {
+	req := kkOps.ListEventGatewayVirtualClusterConsumePoliciesRequest{
+		GatewayID:        gatewayID,
+		VirtualClusterID: virtualClusterID,
+	}
+
+	res, err := policyAPI.ListEventGatewayVirtualClusterConsumePolicies(helper.GetContext(), req)
+	if err != nil {
+		attrs := cmd.TryConvertErrorToAttrs(err)
+		return nil, nil, cmd.PrepareExecutionError("Failed to list consume policies", err, helper.GetCmd(), attrs...)
+	}
+
+	if res.ListConsumePoliciesResponse == nil {
+		return []kkComps.EventGatewayPolicy{}, nil, nil
+	}
+
+	// Parse raw response to get full config (SDK's EventGatewayPolicyConfig is empty)
+	var rawPolicies []consumePolicyWithConfig
+	parseRawPolicyResponse(helper, res, &rawPolicies)
+
+	return res.ListConsumePoliciesResponse, rawPolicies, nil
+}
+
+func findConsumePolicyByName(
+	policies []kkComps.EventGatewayPolicy,
+	identifier string,
+) *kkComps.EventGatewayPolicy {
+	lowered := strings.ToLower(identifier)
+	for _, policy := range policies {
+		if policy.Name != nil && strings.ToLower(*policy.Name) == lowered {
+			policyCopy := policy
+			return &policyCopy
+		}
+	}
+	return nil
+}
+
+func consumePolicyToRecord(policy kkComps.EventGatewayPolicy) consumePolicySummaryRecord {
+	recordID := policy.ID
+	if recordID != "" {
+		recordID = util.AbbreviateUUID(recordID)
+	} else {
+		recordID = valueNA
+	}
+
+	recordName := valueNA
+	if policy.Name != nil && *policy.Name != "" {
+		recordName = *policy.Name
+	}
+
+	recordType := policy.Type
+	if recordType == "" {
+		recordType = valueNA
+	}
+
+	recordDesc := valueNA
+	if policy.Description != nil && *policy.Description != "" {
+		recordDesc = *policy.Description
+	}
+
+	return consumePolicySummaryRecord{
+		ID:               recordID,
+		Name:             recordName,
+		Type:             recordType,
+		Description:      recordDesc,
+		Enabled:          formatEnabledBool(policy.Enabled),
+		LocalCreatedTime: policy.CreatedAt.In(time.Local).Format("2006-01-02 15:04:05"),
+		LocalUpdatedTime: policy.UpdatedAt.In(time.Local).Format("2006-01-02 15:04:05"),
+	}
+}

--- a/internal/cmd/root/products/konnect/eventgateway/consume-policies_test.go
+++ b/internal/cmd/root/products/konnect/eventgateway/consume-policies_test.go
@@ -1,0 +1,142 @@
+package eventgateway
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/cmd/common"
+	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/kong/kongctl/internal/config"
+	"github.com/kong/kongctl/internal/iostreams"
+	"github.com/kong/kongctl/internal/log"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+// ptr is a helper to create string pointers in tests.
+func ptr(s string) *string { return &s }
+
+// boolPtr is a helper to create bool pointers in tests.
+func boolPtr(b bool) *bool { return &b }
+
+func TestConsumePolicyFlagValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "both gateway flags mutually exclusive",
+			args:    []string{"--gateway-id", "gw-1", "--gateway-name", "gw"},
+			wantErr: "if any flags in the group [gateway-id gateway-name] are set none of the others can be",
+		},
+		{
+			name: "both virtual cluster flags mutually exclusive",
+			args: []string{
+				"--gateway-id", "gw-1",
+				"--virtual-cluster-id", "vc-1",
+				"--virtual-cluster-name", "vc",
+			},
+			wantErr: "if any flags in the group [virtual-cluster-id virtual-cluster-name] are set none of the others can be",
+		},
+		{
+			name: "both consume policy flags mutually exclusive",
+			args: []string{
+				"--gateway-id", "gw-1",
+				"--virtual-cluster-id", "vc-1",
+				"--consume-policy-id", "policy-1",
+				"--consume-policy-name", "my-policy",
+			},
+			wantErr: "if any flags in the group [consume-policy-id consume-policy-name] are set none of the others can be",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.BuildProfiledConfig("default", "", viper.New())
+			cfg.Set(common.OutputConfigPath, "text")
+
+			ctx := context.Background()
+			ctx = context.WithValue(ctx, config.ConfigKey, cfg)
+			ctx = context.WithValue(ctx, log.LoggerKey, slog.Default())
+			ctx = context.WithValue(ctx, iostreams.StreamsKey, iostreams.NewTestIOStreamsOnly())
+
+			cmd := newGetEventGatewayConsumePoliciesCmd(verbs.Get, nil, nil)
+			cmd.SetArgs(tc.args)
+
+			err := cmd.ExecuteContext(ctx)
+
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestFindConsumePolicyByName(t *testing.T) {
+	name1 := "Decrypt-Policy"
+	policies := []kkComps.EventGatewayPolicy{
+		{ID: "policy-1", Name: &name1, Type: "decrypt"},
+		{ID: "policy-2", Name: nil, Type: "schema_validation"},
+	}
+
+	// Case-insensitive match
+	result := findConsumePolicyByName(policies, "decrypt-policy")
+	assert.NotNil(t, result)
+	assert.Equal(t, "policy-1", result.ID)
+
+	// Not found
+	assert.Nil(t, findConsumePolicyByName(policies, "missing"))
+
+	// No name set
+	assert.Nil(t, findConsumePolicyByName(policies, ""))
+}
+
+func TestConsumePolicyToRecord(t *testing.T) {
+	now := time.Now()
+	name := "my-consume-policy"
+	desc := "test description"
+	enabled := true
+
+	policy := kkComps.EventGatewayPolicy{
+		ID:          "00000000-0000-0000-0000-000000000001",
+		Name:        &name,
+		Type:        "decrypt",
+		Description: &desc,
+		Enabled:     &enabled,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	record := consumePolicyToRecord(policy)
+
+	// ID is abbreviated
+	assert.NotEmpty(t, record.ID)
+	assert.Equal(t, name, record.Name)
+	assert.Equal(t, "decrypt", record.Type)
+	assert.Equal(t, desc, record.Description)
+	assert.Equal(t, "true", record.Enabled)
+	assert.NotEmpty(t, record.LocalCreatedTime)
+	assert.NotEmpty(t, record.LocalUpdatedTime)
+}
+
+func TestConsumePolicyToRecordNilFields(t *testing.T) {
+	policy := kkComps.EventGatewayPolicy{
+		ID:        "",
+		Name:      nil,
+		Type:      "",
+		Enabled:   nil,
+		CreatedAt: time.Time{},
+		UpdatedAt: time.Time{},
+	}
+
+	record := consumePolicyToRecord(policy)
+
+	assert.Equal(t, valueNA, record.ID)
+	assert.Equal(t, valueNA, record.Name)
+	assert.Equal(t, valueNA, record.Type)
+	assert.Equal(t, valueNA, record.Description)
+	assert.Equal(t, valueNA, record.Enabled)
+}

--- a/internal/cmd/root/products/konnect/eventgateway/consume-policies_test.go
+++ b/internal/cmd/root/products/konnect/eventgateway/consume-policies_test.go
@@ -16,12 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// ptr is a helper to create string pointers in tests.
-func ptr(s string) *string { return &s }
-
-// boolPtr is a helper to create bool pointers in tests.
-func boolPtr(b bool) *bool { return &b }
-
 func TestConsumePolicyFlagValidation(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/cmd/root/products/konnect/eventgateway/interactive_children.go
+++ b/internal/cmd/root/products/konnect/eventgateway/interactive_children.go
@@ -22,6 +22,7 @@ func init() {
 	tableview.RegisterChildLoader("listener", "policies", loadEventGatewayListenerPolicies)
 	tableview.RegisterChildLoader("virtual-cluster", "cluster-policies", loadEventGatewayVirtualClusterClusterPolicies)
 	tableview.RegisterChildLoader("virtual-cluster", "produce-policies", loadEventGatewayVirtualClusterProducePolicies)
+	tableview.RegisterChildLoader("virtual-cluster", "consume-policies", loadEventGatewayVirtualClusterConsumePolicies)
 }
 
 func loadEventGatewayBackendClusters(_ context.Context, helper cmd.Helper, parent any) (tableview.ChildView, error) {
@@ -294,6 +295,44 @@ func loadEventGatewayVirtualClusterProducePolicies(
 	}
 
 	return buildProducePolicyChildView(rawPolicies), nil
+}
+
+func loadEventGatewayVirtualClusterConsumePolicies(
+	_ context.Context,
+	helper cmd.Helper,
+	parent any,
+) (tableview.ChildView, error) {
+	gatewayID, virtualClusterID, err := virtualClusterIDsFromParent(parent)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	policyAPI := sdk.GetEventGatewayConsumePolicyAPI()
+	if policyAPI == nil {
+		return tableview.ChildView{}, fmt.Errorf("event gateway consume policy client is not available")
+	}
+
+	_, rawPolicies, err := fetchConsumePolicies(helper, policyAPI, gatewayID, virtualClusterID)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	return buildConsumePolicyChildView(rawPolicies), nil
 }
 
 func virtualClusterIDsFromParent(parent any) (string, string, error) {

--- a/internal/cmd/root/products/konnect/eventgateway/virtual_clusters.go
+++ b/internal/cmd/root/products/konnect/eventgateway/virtual_clusters.go
@@ -112,6 +112,7 @@ func newGetEventGatewayVirtualClustersCmd(
 	producePoliciesCmd := newGetEventGatewayProducePoliciesCmd(verb, addParentFlags, parentPreRun)
 	if producePoliciesCmd != nil {
 		cmd.AddCommand(producePoliciesCmd)
+	}
 	consumePoliciesCmd := newGetEventGatewayConsumePoliciesCmd(verb, addParentFlags, parentPreRun)
 	if consumePoliciesCmd != nil {
 		cmd.AddCommand(consumePoliciesCmd)

--- a/internal/cmd/root/products/konnect/eventgateway/virtual_clusters.go
+++ b/internal/cmd/root/products/konnect/eventgateway/virtual_clusters.go
@@ -112,6 +112,9 @@ func newGetEventGatewayVirtualClustersCmd(
 	producePoliciesCmd := newGetEventGatewayProducePoliciesCmd(verb, addParentFlags, parentPreRun)
 	if producePoliciesCmd != nil {
 		cmd.AddCommand(producePoliciesCmd)
+	consumePoliciesCmd := newGetEventGatewayConsumePoliciesCmd(verb, addParentFlags, parentPreRun)
+	if consumePoliciesCmd != nil {
+		cmd.AddCommand(consumePoliciesCmd)
 	}
 
 	return cmd

--- a/internal/cmd/root/verbs/dump/declarative.go
+++ b/internal/cmd/root/verbs/dump/declarative.go
@@ -193,8 +193,8 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 			EventGatewayDataPlaneCertificateAPI: sdk.GetEventGatewayDataPlaneCertificateAPI(),
 			EventGatewayProducePolicyAPI:        sdk.GetEventGatewayProducePolicyAPI(),
 			EventGatewayClusterPolicyAPI:        sdk.GetEventGatewayClusterPolicyAPI(),
-
-			OrganizationTeamAPI: sdk.GetOrganizationTeamAPI(),
+			EventGatewayConsumePolicyAPI:        sdk.GetEventGatewayConsumePolicyAPI(),
+			OrganizationTeamAPI:                 sdk.GetOrganizationTeamAPI(),
 		})
 	}
 

--- a/internal/cmd/root/verbs/dump/declarative_children.go
+++ b/internal/cmd/root/verbs/dump/declarative_children.go
@@ -1109,8 +1109,19 @@ func buildEventGatewayVirtualClusters(
 		// Fetch produce policies for this virtual cluster
 		if policies, err := buildEventGatewayProducePolicies(ctx, logger, client, gatewayID, cluster.ID); err != nil {
 			logWarn(logger, "failed to load produce policies", cluster.ID, cluster.Name, err)
+		}  err != nil {
+			logWarn(logger, "failed to load produce policies", cluster.ID, cluster.Name, err)
 		} else if len(policies) > 0 {
 			res.ProducePolicies = policies
+		}
+
+		// Fetch consume policies for this virtual cluster
+		if consumePolicies, err := buildEventGatewayConsumePolicies(
+			ctx, logger, client, gatewayID, cluster.ID,
+		); err != nil {
+			logWarn(logger, "failed to load consume policies", cluster.ID, cluster.Name, err)
+		} else if len(consumePolicies) > 0 {
+			res.ConsumePolicies = consumePolicies
 		}
 
 		results = append(results, res)
@@ -1383,6 +1394,76 @@ func convertProducePolicyToResource(
 
 	return declresources.EventGatewayProducePolicyResource{
 		EventGatewayProducePolicyCreate: createPolicy,
+		Ref:                             policy.ID,
+	}, nil
+}
+
+func buildEventGatewayConsumePolicies(
+	ctx context.Context,
+	logger *slog.Logger,
+	client *declstate.Client,
+	gatewayID string,
+	virtualClusterID string,
+) ([]declresources.EventGatewayConsumePolicyResource, error) {
+	policies, err := client.ListEventGatewayConsumePolicies(ctx, gatewayID, virtualClusterID)
+	if err != nil {
+		return nil, err
+	}
+	if len(policies) == 0 {
+		return nil, nil
+	}
+
+	results := make([]declresources.EventGatewayConsumePolicyResource, 0, len(policies))
+	for _, policy := range policies {
+		res, err := convertConsumePolicyToResource(policy.EventGatewayPolicy, policy.RawConfig)
+		if err != nil {
+			logWarn(logger, "failed to convert consume policy", policy.ID, "", err)
+			continue
+		}
+		results = append(results, res)
+	}
+
+	return results, nil
+}
+
+// convertConsumePolicyToResource converts an EventGatewayPolicy (response type)
+// to an EventGatewayConsumePolicyResource (which embeds the Create union type).
+// We use rawConfig from the raw API response because the SDK's EventGatewayPolicyConfig
+// is an empty struct that doesn't capture the actual config data.
+func convertConsumePolicyToResource(
+	policy kkComps.EventGatewayPolicy,
+	rawConfig map[string]any,
+) (declresources.EventGatewayConsumePolicyResource, error) {
+	policyMap := map[string]any{
+		"type":   policy.Type,
+		"config": rawConfig,
+	}
+	if policy.Name != nil {
+		policyMap["name"] = *policy.Name
+	}
+	if policy.Description != nil {
+		policyMap["description"] = *policy.Description
+	}
+	if policy.Enabled != nil {
+		policyMap["enabled"] = *policy.Enabled
+	}
+	if policy.Labels != nil {
+		policyMap["labels"] = policy.Labels
+	}
+
+	data, err := json.Marshal(policyMap)
+	if err != nil {
+		return declresources.EventGatewayConsumePolicyResource{}, fmt.Errorf("failed to marshal consume policy: %w", err)
+	}
+
+	var createPolicy kkComps.EventGatewayConsumePolicyCreate
+	if err := json.Unmarshal(data, &createPolicy); err != nil {
+		return declresources.EventGatewayConsumePolicyResource{},
+			fmt.Errorf("failed to unmarshal consume policy: %w", err)
+	}
+
+	return declresources.EventGatewayConsumePolicyResource{
+		EventGatewayConsumePolicyCreate: createPolicy,
 		Ref:                             policy.ID,
 	}, nil
 }

--- a/internal/cmd/root/verbs/dump/declarative_children.go
+++ b/internal/cmd/root/verbs/dump/declarative_children.go
@@ -1109,7 +1109,7 @@ func buildEventGatewayVirtualClusters(
 		// Fetch produce policies for this virtual cluster
 		if policies, err := buildEventGatewayProducePolicies(ctx, logger, client, gatewayID, cluster.ID); err != nil {
 			logWarn(logger, "failed to load produce policies", cluster.ID, cluster.Name, err)
-		}  err != nil {
+		} else if err != nil {
 			logWarn(logger, "failed to load produce policies", cluster.ID, cluster.Name, err)
 		} else if len(policies) > 0 {
 			res.ProducePolicies = policies

--- a/internal/cmd/root/verbs/dump/declarative_children.go
+++ b/internal/cmd/root/verbs/dump/declarative_children.go
@@ -1109,8 +1109,6 @@ func buildEventGatewayVirtualClusters(
 		// Fetch produce policies for this virtual cluster
 		if policies, err := buildEventGatewayProducePolicies(ctx, logger, client, gatewayID, cluster.ID); err != nil {
 			logWarn(logger, "failed to load produce policies", cluster.ID, cluster.Name, err)
-		} else if err != nil {
-			logWarn(logger, "failed to load produce policies", cluster.ID, cluster.Name, err)
 		} else if len(policies) > 0 {
 			res.ProducePolicies = policies
 		}

--- a/internal/declarative/executor/event_gateway_consume_policy_adapter.go
+++ b/internal/declarative/executor/event_gateway_consume_policy_adapter.go
@@ -1,0 +1,225 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/kong/kongctl/internal/declarative/state"
+)
+
+// EventGatewayConsumePolicyAdapter implements ResourceOperations for Event Gateway Consume Policy resources.
+// Consume policies are grandchildren: Event Gateway → Virtual Cluster → Consume Policy.
+// Both the gateway ID and virtual cluster ID are required for all operations.
+type EventGatewayConsumePolicyAdapter struct {
+	client *state.Client
+}
+
+// NewEventGatewayConsumePolicyAdapter creates a new EventGatewayConsumePolicyAdapter
+func NewEventGatewayConsumePolicyAdapter(client *state.Client) *EventGatewayConsumePolicyAdapter {
+	return &EventGatewayConsumePolicyAdapter{
+		client: client,
+	}
+}
+
+// MapCreateFields maps fields to EventGatewayConsumePolicyCreate (union type).
+// The fields map should contain the full union-typed policy body (serialized from the resource).
+func (a *EventGatewayConsumePolicyAdapter) MapCreateFields(
+	_ context.Context,
+	_ *ExecutionContext,
+	fields map[string]any,
+	create *kkComps.EventGatewayConsumePolicyCreate,
+) error {
+	// The consume policy is a union type. We serialize the fields to JSON
+	// and delegate unmarshaling to the SDK union type which handles discriminating
+	// based on the "type" field.
+	data, err := json.Marshal(fields)
+	if err != nil {
+		return fmt.Errorf("failed to marshal consume policy fields: %w", err)
+	}
+
+	if err := json.Unmarshal(data, create); err != nil {
+		return fmt.Errorf("failed to unmarshal consume policy create request: %w", err)
+	}
+
+	return nil
+}
+
+// MapUpdateFields maps the fields into an EventGatewayConsumePolicyUpdate (union type).
+// The update type has the same discriminator as the create type but may use different struct names.
+func (a *EventGatewayConsumePolicyAdapter) MapUpdateFields(
+	_ context.Context,
+	_ *ExecutionContext,
+	fieldsToUpdate map[string]any,
+	update *kkComps.EventGatewayConsumePolicyUpdate,
+	_ map[string]string,
+) error {
+	// Serialize fields to JSON and delegate to the SDK union type unmarshaler.
+	data, err := json.Marshal(fieldsToUpdate)
+	if err != nil {
+		return fmt.Errorf("failed to marshal consume policy update fields: %w", err)
+	}
+
+	if err := json.Unmarshal(data, update); err != nil {
+		return fmt.Errorf("failed to unmarshal consume policy update request: %w", err)
+	}
+
+	return nil
+}
+
+// Create creates a new consume policy
+func (a *EventGatewayConsumePolicyAdapter) Create(
+	ctx context.Context,
+	req kkComps.EventGatewayConsumePolicyCreate,
+	namespace string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	gatewayID, virtualClusterID, err := a.getGatewayAndVirtualClusterIDs(execCtx)
+	if err != nil {
+		return "", err
+	}
+
+	return a.client.CreateEventGatewayConsumePolicy(ctx, gatewayID, virtualClusterID, req, namespace)
+}
+
+// Update updates an existing consume policy
+func (a *EventGatewayConsumePolicyAdapter) Update(
+	ctx context.Context,
+	id string,
+	req kkComps.EventGatewayConsumePolicyUpdate,
+	namespace string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	gatewayID, virtualClusterID, err := a.getGatewayAndVirtualClusterIDs(execCtx)
+	if err != nil {
+		return "", err
+	}
+
+	return a.client.UpdateEventGatewayConsumePolicy(ctx, gatewayID, virtualClusterID, id, req, namespace)
+}
+
+// Delete deletes a consume policy
+func (a *EventGatewayConsumePolicyAdapter) Delete(
+	ctx context.Context,
+	id string,
+	execCtx *ExecutionContext,
+) error {
+	gatewayID, virtualClusterID, err := a.getGatewayAndVirtualClusterIDs(execCtx)
+	if err != nil {
+		return err
+	}
+
+	return a.client.DeleteEventGatewayConsumePolicy(ctx, gatewayID, virtualClusterID, id)
+}
+
+// GetByID gets a consume policy by ID
+func (a *EventGatewayConsumePolicyAdapter) GetByID(
+	ctx context.Context,
+	id string,
+	execCtx *ExecutionContext,
+) (ResourceInfo, error) {
+	gatewayID, virtualClusterID, err := a.getGatewayAndVirtualClusterIDs(execCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	policy, err := a.client.GetEventGatewayConsumePolicy(ctx, gatewayID, virtualClusterID, id)
+	if err != nil {
+		return nil, err
+	}
+	if policy == nil {
+		return nil, nil
+	}
+
+	return &EventGatewayConsumePolicyResourceInfo{policy: policy}, nil
+}
+
+// GetByName is not supported for consume policies
+func (a *EventGatewayConsumePolicyAdapter) GetByName(
+	_ context.Context,
+	_ string,
+) (ResourceInfo, error) {
+	return nil, fmt.Errorf("GetByName not supported for event gateway consume policies")
+}
+
+// ResourceType returns the resource type string
+func (a *EventGatewayConsumePolicyAdapter) ResourceType() string {
+	return planner.ResourceTypeEventGatewayConsumePolicy
+}
+
+// RequiredFields returns the list of required fields for this resource.
+// For union types, the required fields depend on which variant is set,
+// so validation is delegated to the SDK type.
+func (a *EventGatewayConsumePolicyAdapter) RequiredFields() []string {
+	return []string{"type"}
+}
+
+// SupportsUpdate indicates whether this resource supports update operations
+func (a *EventGatewayConsumePolicyAdapter) SupportsUpdate() bool {
+	return true
+}
+
+// getGatewayAndVirtualClusterIDs extracts both the event gateway ID and virtual cluster ID
+// from the execution context.
+// Consume policies are grandchildren and require both parent IDs.
+// The virtual cluster ID comes from Parent or References["event_gateway_virtual_cluster_id"].
+// The gateway ID comes from References["event_gateway_id"].
+func (a *EventGatewayConsumePolicyAdapter) getGatewayAndVirtualClusterIDs(
+	execCtx *ExecutionContext,
+) (string, string, error) {
+	if execCtx == nil || execCtx.PlannedChange == nil {
+		return "", "", fmt.Errorf("execution context required")
+	}
+
+	change := *execCtx.PlannedChange
+
+	var gatewayID, virtualClusterID string
+
+	// Resolve virtual cluster ID: Priority 1 = References, Priority 2 = Parent
+	if vcRef, ok := change.References["event_gateway_virtual_cluster_id"]; ok && vcRef.ID != "" {
+		virtualClusterID = vcRef.ID
+	}
+	if virtualClusterID == "" && change.Parent != nil && change.Parent.ID != "" {
+		virtualClusterID = change.Parent.ID
+	}
+	if virtualClusterID == "" {
+		return "", "", fmt.Errorf("event gateway virtual cluster ID required for consume policy operations")
+	}
+
+	// Resolve gateway ID from References
+	if gatewayRef, ok := change.References["event_gateway_id"]; ok && gatewayRef.ID != "" {
+		gatewayID = gatewayRef.ID
+	}
+	if gatewayID == "" {
+		return "", "", fmt.Errorf("event gateway ID required for consume policy operations")
+	}
+
+	return gatewayID, virtualClusterID, nil
+}
+
+// EventGatewayConsumePolicyResourceInfo wraps a Consume Policy to implement ResourceInfo
+type EventGatewayConsumePolicyResourceInfo struct {
+	policy *state.EventGatewayConsumePolicyInfo
+}
+
+func (e *EventGatewayConsumePolicyResourceInfo) GetID() string {
+	return e.policy.ID
+}
+
+func (e *EventGatewayConsumePolicyResourceInfo) GetName() string {
+	if e.policy.Name != nil {
+		return *e.policy.Name
+	}
+	return ""
+}
+
+func (e *EventGatewayConsumePolicyResourceInfo) GetLabels() map[string]string {
+	return e.policy.Labels
+}
+
+func (e *EventGatewayConsumePolicyResourceInfo) GetNormalizedLabels() map[string]string {
+	return e.policy.NormalizedLabels
+}

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -56,6 +56,8 @@ type Executor struct {
 		kkComps.EventGatewayClusterPolicyModify, kkComps.EventGatewayClusterPolicyModify]
 	eventGatewayProducePolicyExecutor *BaseExecutor[
 		kkComps.EventGatewayProducePolicyCreate, kkComps.EventGatewayProducePolicyUpdate]
+	eventGatewayConsumePolicyExecutor *BaseExecutor[
+		kkComps.EventGatewayConsumePolicyCreate, kkComps.EventGatewayConsumePolicyUpdate]
 	eventGatewayDataPlaneCertificateExecutor *BaseExecutor[
 		kkComps.CreateEventGatewayDataPlaneCertificateRequest,
 		kkComps.UpdateEventGatewayDataPlaneCertificateRequest]
@@ -199,6 +201,9 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 	e.eventGatewayProducePolicyExecutor = NewBaseExecutor[
 		kkComps.EventGatewayProducePolicyCreate, kkComps.EventGatewayProducePolicyUpdate](
 		NewEventGatewayProducePolicyAdapter(client),
+	e.eventGatewayConsumePolicyExecutor = NewBaseExecutor[
+		kkComps.EventGatewayConsumePolicyCreate, kkComps.EventGatewayConsumePolicyUpdate](
+		NewEventGatewayConsumePolicyAdapter(client),
 		client,
 		dryRun,
 	)
@@ -1923,6 +1928,27 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 			change.References["event_gateway_virtual_cluster_id"] = virtualClusterRef
 		}
 		return e.eventGatewayProducePolicyExecutor.Create(ctx, *change)
+	case planner.ResourceTypeEventGatewayConsumePolicy:
+		// Resolve event gateway reference if needed
+		if gatewayRef, ok := change.References["event_gateway_id"]; ok && gatewayRef.ID == "" {
+			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
+			}
+			gatewayRef.ID = gatewayID
+			change.References["event_gateway_id"] = gatewayRef
+		}
+		// Resolve event gateway virtual cluster reference if needed
+		if virtualClusterRef, ok := change.References["event_gateway_virtual_cluster_id"]; ok && virtualClusterRef.ID == "" {
+			gatewayID := change.References["event_gateway_id"].ID
+			virtualClusterID, err := e.resolveEventGatewayVirtualClusterRef(ctx, gatewayID, virtualClusterRef)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve event gateway virtual cluster reference: %w", err)
+			}
+			virtualClusterRef.ID = virtualClusterID
+			change.References["event_gateway_virtual_cluster_id"] = virtualClusterRef
+		}
+		return e.eventGatewayConsumePolicyExecutor.Create(ctx, *change)
 	default:
 		return "", fmt.Errorf("create operation not yet implemented for %s", change.ResourceType)
 	}
@@ -2255,6 +2281,27 @@ func (e *Executor) updateResource(ctx context.Context, change *planner.PlannedCh
 			change.References["event_gateway_virtual_cluster_id"] = virtualClusterRef
 		}
 		return e.eventGatewayProducePolicyExecutor.Update(ctx, *change)
+	case planner.ResourceTypeEventGatewayConsumePolicy:
+		// Resolve event gateway reference if needed
+		if gatewayRef, ok := change.References["event_gateway_id"]; ok && gatewayRef.ID == "" {
+			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
+			}
+			gatewayRef.ID = gatewayID
+			change.References["event_gateway_id"] = gatewayRef
+		}
+		// Resolve event gateway virtual cluster reference if needed
+		if virtualClusterRef, ok := change.References["event_gateway_virtual_cluster_id"]; ok && virtualClusterRef.ID == "" {
+			gatewayID := change.References["event_gateway_id"].ID
+			virtualClusterID, err := e.resolveEventGatewayVirtualClusterRef(ctx, gatewayID, virtualClusterRef)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve event gateway virtual cluster reference: %w", err)
+			}
+			virtualClusterRef.ID = virtualClusterID
+			change.References["event_gateway_virtual_cluster_id"] = virtualClusterRef
+		}
+		return e.eventGatewayConsumePolicyExecutor.Update(ctx, *change)
 	default:
 		return "", fmt.Errorf("update operation not yet implemented for %s", change.ResourceType)
 	}
@@ -2406,6 +2453,9 @@ func (e *Executor) deleteResource(ctx context.Context, change *planner.PlannedCh
 	case planner.ResourceTypeEventGatewayProducePolicy:
 		// Both gateway ID and virtual cluster ID should be in References for delete
 		return e.eventGatewayProducePolicyExecutor.Delete(ctx, *change)
+	case planner.ResourceTypeEventGatewayConsumePolicy:
+		// Both gateway ID and virtual cluster ID should be in References for delete
+		return e.eventGatewayConsumePolicyExecutor.Delete(ctx, *change)
 	case "organization_team":
 		return e.organizationTeamExecutor.Delete(ctx, *change)
 	default:

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -201,6 +201,9 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 	e.eventGatewayProducePolicyExecutor = NewBaseExecutor[
 		kkComps.EventGatewayProducePolicyCreate, kkComps.EventGatewayProducePolicyUpdate](
 		NewEventGatewayProducePolicyAdapter(client),
+		client,
+		dryRun,
+	)
 	e.eventGatewayConsumePolicyExecutor = NewBaseExecutor[
 		kkComps.EventGatewayConsumePolicyCreate, kkComps.EventGatewayConsumePolicyUpdate](
 		NewEventGatewayConsumePolicyAdapter(client),

--- a/internal/declarative/planner/constants.go
+++ b/internal/declarative/planner/constants.go
@@ -78,6 +78,8 @@ const (
 
 	// ResourceTypeEventGatewayProducePolicy is the resource type for event gateway produce policies
 	ResourceTypeEventGatewayProducePolicy = "event_gateway_virtual_cluster_produce_policy"
+	// ResourceTypeEventGatewayConsumePolicy is the resource type for event gateway virtual cluster consume policies
+	ResourceTypeEventGatewayConsumePolicy = "event_gateway_virtual_cluster_consume_policy"
 
 	// ResourceTypeDeck represents an internal deck execution step.
 	ResourceTypeDeck = "_deck"

--- a/internal/declarative/planner/event_gateway_consume_policy_planner.go
+++ b/internal/declarative/planner/event_gateway_consume_policy_planner.go
@@ -1,0 +1,493 @@
+package planner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+)
+
+// planEventGatewayConsumePolicyChanges plans changes for Event Gateway Consume Policies
+// for a specific virtual cluster within a specific gateway.
+func (p *Planner) planEventGatewayConsumePolicyChanges(
+	ctx context.Context,
+	_ *Config,
+	namespace string,
+	gatewayID string,
+	gatewayRef string,
+	virtualClusterName string,
+	virtualClusterID string,
+	virtualClusterRef string,
+	virtualClusterChangeID string,
+	desired []resources.EventGatewayConsumePolicyResource,
+	plan *Plan,
+) error {
+	p.logger.Debug("Planning Event Gateway Consume Policy changes",
+		"gateway_id", gatewayID,
+		"gateway_ref", gatewayRef,
+		"virtual_cluster_name", virtualClusterName,
+		"virtual_cluster_id", virtualClusterID,
+		"virtual_cluster_ref", virtualClusterRef,
+		"virtual_cluster_change_id", virtualClusterChangeID,
+		"desired_count", len(desired),
+		"namespace", namespace,
+	)
+
+	if virtualClusterID != "" && gatewayID != "" {
+		return p.planConsumePolicyChangesForExistingVirtualCluster(
+			ctx, namespace, gatewayID, gatewayRef, virtualClusterID, virtualClusterRef, virtualClusterName,
+			desired, plan,
+		)
+	}
+
+	// Virtual cluster doesn't exist yet: plan creates only, with dependency on virtual cluster creation
+	p.planConsumePolicyCreatesForNewVirtualCluster(
+		namespace, gatewayRef, virtualClusterRef, virtualClusterName, virtualClusterChangeID, desired, plan,
+	)
+	return nil
+}
+
+// planConsumePolicyChangesForExistingVirtualCluster handles full diff for consume policies
+// when both the gateway and virtual cluster already exist.
+func (p *Planner) planConsumePolicyChangesForExistingVirtualCluster(
+	ctx context.Context,
+	namespace string,
+	gatewayID string,
+	gatewayRef string,
+	virtualClusterID string,
+	virtualClusterRef string,
+	virtualClusterName string,
+	desired []resources.EventGatewayConsumePolicyResource,
+	plan *Plan,
+) error {
+	p.logger.Debug("Planning changes for existing virtual cluster consume policies",
+		"gateway_id", gatewayID,
+		"virtual_cluster_id", virtualClusterID,
+		"virtual_cluster_ref", virtualClusterRef,
+		"desired_count", len(desired),
+	)
+
+	// 1. List current consume policies for this virtual cluster
+	currentPolicies, err := p.client.ListEventGatewayConsumePolicies(ctx, gatewayID, virtualClusterID)
+	if err != nil {
+		return fmt.Errorf("failed to list consume policies for virtual cluster %s: %w", virtualClusterID, err)
+	}
+
+	p.logger.Debug("Fetched current consume policies",
+		"virtual_cluster_id", virtualClusterID,
+		"current_count", len(currentPolicies),
+	)
+
+	// 2. Index current policies by name
+	currentByName := make(map[string]state.EventGatewayConsumePolicyInfo)
+	for _, policy := range currentPolicies {
+		if policy.Name != nil {
+			currentByName[*policy.Name] = policy
+		}
+	}
+
+	// 3. Compare desired vs current
+	desiredNames := make(map[string]bool)
+	for _, desiredPolicy := range desired {
+		policyName := desiredPolicy.GetMoniker()
+		desiredNames[policyName] = true
+		current, exists := currentByName[policyName]
+		if !exists {
+			p.logger.Debug("Planning consume policy CREATE",
+				"policy_name", policyName,
+				"virtual_cluster_ref", virtualClusterRef,
+			)
+			p.planConsumePolicyCreate(
+				namespace, gatewayID, gatewayRef, virtualClusterID, virtualClusterRef, virtualClusterName,
+				desiredPolicy, []string{}, plan,
+			)
+		} else {
+			p.logger.Debug("Checking if consume policy needs update",
+				"policy_name", policyName,
+				"policy_id", current.ID,
+			)
+
+			needsUpdate, updateFields, changedFields := p.shouldUpdateConsumePolicy(current, desiredPolicy)
+			if needsUpdate {
+				p.logger.Debug("Planning consume policy UPDATE",
+					"policy_name", policyName,
+					"policy_id", current.ID,
+					"changed_fields", changedFields,
+				)
+				p.planConsumePolicyUpdate(
+					namespace, gatewayID, gatewayRef, virtualClusterID, virtualClusterRef,
+					current.ID, desiredPolicy, updateFields, changedFields, plan,
+				)
+			}
+		}
+	}
+
+	// 4. SYNC MODE: Delete policies no longer in desired state
+	if plan.Metadata.Mode == PlanModeSync {
+		for name, current := range currentByName {
+			if !desiredNames[name] {
+				p.logger.Debug("Planning consume policy DELETE (sync mode)",
+					"policy_name", name,
+					"policy_id", current.ID,
+				)
+				p.planConsumePolicyDelete(
+					gatewayID, gatewayRef, virtualClusterID, virtualClusterRef,
+					current.ID, name, plan,
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
+// planConsumePolicyCreatesForNewVirtualCluster plans creates for consume policies
+// when the parent virtual cluster doesn't exist yet.
+func (p *Planner) planConsumePolicyCreatesForNewVirtualCluster(
+	namespace string,
+	gatewayRef string,
+	virtualClusterRef string,
+	virtualClusterName string,
+	virtualClusterChangeID string,
+	policies []resources.EventGatewayConsumePolicyResource,
+	plan *Plan,
+) {
+	p.logger.Debug("Planning consume policy creates for new virtual cluster",
+		"virtual_cluster_ref", virtualClusterRef,
+		"virtual_cluster_change_id", virtualClusterChangeID,
+		"policy_count", len(policies),
+	)
+
+	var dependsOn []string
+	if virtualClusterChangeID != "" {
+		dependsOn = []string{virtualClusterChangeID}
+	}
+
+	for _, policy := range policies {
+		p.planConsumePolicyCreate(
+			namespace, "", gatewayRef, "", virtualClusterRef, virtualClusterName,
+			policy, dependsOn, plan,
+		)
+	}
+}
+
+// planConsumePolicyCreate plans a CREATE change for a consume policy.
+func (p *Planner) planConsumePolicyCreate(
+	namespace string,
+	gatewayID string,
+	gatewayRef string,
+	virtualClusterID string,
+	virtualClusterRef string,
+	virtualClusterName string,
+	policy resources.EventGatewayConsumePolicyResource,
+	dependsOn []string,
+	plan *Plan,
+) {
+	fields := p.consumePolicyToFields(policy)
+
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionCreate, ResourceTypeEventGatewayConsumePolicy, policy.Ref),
+		ResourceType: ResourceTypeEventGatewayConsumePolicy,
+		ResourceRef:  policy.Ref,
+		Action:       ActionCreate,
+		Fields:       fields,
+		Namespace:    namespace,
+		DependsOn:    dependsOn,
+	}
+
+	if virtualClusterID != "" {
+		change.Parent = &ParentInfo{
+			Ref: virtualClusterRef,
+			ID:  virtualClusterID,
+		}
+	}
+
+	change.References = map[string]ReferenceInfo{
+		"event_gateway_id": {
+			Ref: gatewayRef,
+			ID:  gatewayID,
+		},
+		"event_gateway_virtual_cluster_id": {
+			Ref: virtualClusterRef,
+			ID:  virtualClusterID,
+			LookupFields: map[string]string{
+				"name": virtualClusterName,
+			},
+		},
+	}
+
+	p.logger.Debug("Enqueuing consume policy CREATE",
+		"policy_ref", policy.Ref,
+		"policy_name", policy.GetMoniker(),
+		"virtual_cluster_ref", virtualClusterRef,
+		"gateway_ref", gatewayRef,
+	)
+	plan.AddChange(change)
+}
+
+// planConsumePolicyUpdate plans an UPDATE change for a consume policy.
+func (p *Planner) planConsumePolicyUpdate(
+	namespace string,
+	gatewayID string,
+	gatewayRef string,
+	virtualClusterID string,
+	virtualClusterRef string,
+	policyID string,
+	policy resources.EventGatewayConsumePolicyResource,
+	updateFields map[string]any,
+	changedFields map[string]FieldChange,
+	plan *Plan,
+) {
+	if len(updateFields) == 0 {
+		return
+	}
+
+	change := PlannedChange{
+		ID:            p.nextChangeID(ActionUpdate, ResourceTypeEventGatewayConsumePolicy, policy.Ref),
+		ResourceType:  ResourceTypeEventGatewayConsumePolicy,
+		ResourceRef:   policy.Ref,
+		ResourceID:    policyID,
+		Action:        ActionUpdate,
+		Fields:        updateFields,
+		ChangedFields: changedFields,
+		Namespace:     namespace,
+		Parent: &ParentInfo{
+			Ref: virtualClusterRef,
+			ID:  virtualClusterID,
+		},
+		References: map[string]ReferenceInfo{
+			"event_gateway_id": {
+				Ref: gatewayRef,
+				ID:  gatewayID,
+			},
+			"event_gateway_virtual_cluster_id": {
+				Ref: virtualClusterRef,
+				ID:  virtualClusterID,
+			},
+		},
+	}
+
+	p.logger.Debug("Enqueuing consume policy UPDATE",
+		"policy_ref", policy.Ref,
+		"policy_name", policy.GetMoniker(),
+		"policy_id", policyID,
+	)
+	plan.AddChange(change)
+}
+
+// planConsumePolicyDelete plans a DELETE change for a consume policy.
+func (p *Planner) planConsumePolicyDelete(
+	gatewayID string,
+	gatewayRef string,
+	virtualClusterID string,
+	virtualClusterRef string,
+	policyID string,
+	policyName string,
+	plan *Plan,
+) {
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionDelete, ResourceTypeEventGatewayConsumePolicy, policyName),
+		ResourceType: ResourceTypeEventGatewayConsumePolicy,
+		ResourceRef:  policyName,
+		ResourceID:   policyID,
+		Action:       ActionDelete,
+		Parent: &ParentInfo{
+			Ref: virtualClusterRef,
+			ID:  virtualClusterID,
+		},
+		References: map[string]ReferenceInfo{
+			"event_gateway_id": {
+				Ref: gatewayRef,
+				ID:  gatewayID,
+			},
+			"event_gateway_virtual_cluster_id": {
+				Ref: virtualClusterRef,
+				ID:  virtualClusterID,
+			},
+		},
+	}
+
+	p.logger.Debug("Enqueuing consume policy DELETE",
+		"policy_name", policyName,
+		"policy_id", policyID,
+	)
+	plan.AddChange(change)
+}
+
+// consumePolicyToFields converts a consume policy resource to a fields map
+// by serializing the embedded union type to JSON.
+func (p *Planner) consumePolicyToFields(policy resources.EventGatewayConsumePolicyResource) map[string]any {
+	data, err := json.Marshal(policy.EventGatewayConsumePolicyCreate)
+	if err != nil {
+		p.logger.Warn("Failed to marshal consume policy to fields", "error", err)
+		return map[string]any{}
+	}
+
+	var fields map[string]any
+	if err := json.Unmarshal(data, &fields); err != nil {
+		p.logger.Warn("Failed to unmarshal consume policy fields", "error", err)
+		return map[string]any{}
+	}
+
+	return fields
+}
+
+// extractConsumePolicyLabels extracts labels from whichever union variant is set.
+func (p *Planner) extractConsumePolicyLabels(
+	policy resources.EventGatewayConsumePolicyResource,
+) map[string]string {
+	v := reflect.ValueOf(policy.EventGatewayConsumePolicyCreate)
+	for i := range v.NumField() {
+		field := v.Field(i)
+		if field.Kind() != reflect.Pointer || field.IsNil() {
+			continue
+		}
+		labelsField := field.Elem().FieldByName("Labels")
+		if labelsField.IsValid() && !labelsField.IsNil() {
+			if labels, ok := labelsField.Interface().(map[string]string); ok {
+				return labels
+			}
+		}
+	}
+	return nil
+}
+
+// extractConsumePolicyDescription extracts description from whichever union variant is set.
+func (p *Planner) extractConsumePolicyDescription(
+	policy resources.EventGatewayConsumePolicyResource,
+) string {
+	v := reflect.ValueOf(policy.EventGatewayConsumePolicyCreate)
+	for i := range v.NumField() {
+		field := v.Field(i)
+		if field.Kind() != reflect.Pointer || field.IsNil() {
+			continue
+		}
+		descField := field.Elem().FieldByName("Description")
+		if descField.IsValid() && descField.Kind() == reflect.Pointer && !descField.IsNil() {
+			return descField.Elem().String()
+		}
+	}
+	return ""
+}
+
+// extractConsumePolicyEnabled extracts the enabled flag from whichever union variant is set.
+func (p *Planner) extractConsumePolicyEnabled(
+	policy resources.EventGatewayConsumePolicyResource,
+) bool {
+	v := reflect.ValueOf(policy.EventGatewayConsumePolicyCreate)
+	for i := range v.NumField() {
+		field := v.Field(i)
+		if field.Kind() != reflect.Pointer || field.IsNil() {
+			continue
+		}
+		enabledField := field.Elem().FieldByName("Enabled")
+		if enabledField.IsValid() && enabledField.Kind() == reflect.Pointer && !enabledField.IsNil() {
+			return enabledField.Elem().Bool()
+		}
+	}
+	return true // default is enabled
+}
+
+// extractConsumePolicyConfig extracts config from whichever union variant is set.
+func (p *Planner) extractConsumePolicyConfig(
+	policy resources.EventGatewayConsumePolicyResource,
+) map[string]any {
+	v := reflect.ValueOf(policy.EventGatewayConsumePolicyCreate)
+	for i := range v.NumField() {
+		field := v.Field(i)
+		if field.Kind() != reflect.Pointer || field.IsNil() {
+			continue
+		}
+		configField := field.Elem().FieldByName("Config")
+		if !configField.IsValid() {
+			continue
+		}
+
+		data, err := json.Marshal(configField.Interface())
+		if err != nil {
+			continue
+		}
+
+		var config map[string]any
+		if err := json.Unmarshal(data, &config); err != nil {
+			continue
+		}
+
+		if len(config) > 0 {
+			return config
+		}
+	}
+	return nil
+}
+
+// shouldUpdateConsumePolicy compares current and desired consume policy state.
+func (p *Planner) shouldUpdateConsumePolicy(
+	current state.EventGatewayConsumePolicyInfo,
+	desired resources.EventGatewayConsumePolicyResource,
+) (bool, map[string]any, map[string]FieldChange) {
+	var needsUpdate bool
+	changes := make(map[string]FieldChange)
+
+	// Compare name
+	desiredName := desired.GetMoniker()
+	currentName := ""
+	if current.Name != nil {
+		currentName = *current.Name
+	}
+	if currentName != desiredName {
+		needsUpdate = true
+		changes["name"] = FieldChange{Old: currentName, New: desiredName}
+	}
+
+	// Compare description
+	currentDesc := ""
+	if current.Description != nil {
+		currentDesc = *current.Description
+	}
+	desiredDesc := p.extractConsumePolicyDescription(desired)
+	if currentDesc != desiredDesc {
+		needsUpdate = true
+		changes["description"] = FieldChange{Old: currentDesc, New: desiredDesc}
+	}
+
+	// Compare enabled
+	currentEnabled := true
+	if current.Enabled != nil {
+		currentEnabled = *current.Enabled
+	}
+	desiredEnabled := p.extractConsumePolicyEnabled(desired)
+	if currentEnabled != desiredEnabled {
+		needsUpdate = true
+		changes["enabled"] = FieldChange{Old: currentEnabled, New: desiredEnabled}
+	}
+
+	// Compare labels
+	desiredLabels := p.extractConsumePolicyLabels(desired)
+	if desiredLabels != nil {
+		if !compareMaps(current.NormalizedLabels, desiredLabels) {
+			needsUpdate = true
+			changes["labels"] = FieldChange{Old: current.NormalizedLabels, New: desiredLabels}
+		}
+	} else if len(current.NormalizedLabels) > 0 {
+		needsUpdate = true
+		changes["labels"] = FieldChange{Old: current.NormalizedLabels, New: map[string]string{}}
+	}
+
+	// Compare config
+	desiredConfig := p.extractConsumePolicyConfig(desired)
+	if desiredConfig != nil && !configFieldsMatch(current.RawConfig, desiredConfig) {
+		needsUpdate = true
+		changes["config"] = FieldChange{Old: current.RawConfig, New: desiredConfig}
+	}
+
+	var updateFields map[string]any
+	if needsUpdate {
+		updateFields = p.consumePolicyToFields(desired)
+		updateFields[FieldCurrentLabels] = current.NormalizedLabels
+	}
+
+	return needsUpdate, updateFields, changes
+}

--- a/internal/declarative/planner/event_gateway_consume_policy_planner_test.go
+++ b/internal/declarative/planner/event_gateway_consume_policy_planner_test.go
@@ -1,0 +1,155 @@
+package planner
+
+import (
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldUpdateConsumePolicy_NoChanges(t *testing.T) {
+	name := "test-consume-policy"
+	desc := "test description"
+	enabled := true
+	keyAction := kkComps.ConsumeKeyValidationActionMark
+	valueAction := kkComps.ConsumeValueValidationActionSkip
+
+	current := state.EventGatewayConsumePolicyInfo{
+		EventGatewayPolicy: kkComps.EventGatewayPolicy{
+			ID:          "policy-123",
+			Name:        &name,
+			Description: &desc,
+			Enabled:     &enabled,
+			Type:        "schema_validation",
+		},
+		NormalizedLabels: map[string]string{
+			"env":  "prod",
+			"team": "platform",
+		},
+		RawConfig: map[string]any{
+			"type":                    "json",
+			"key_validation_action":   "mark",
+			"value_validation_action": "skip",
+		},
+	}
+
+	desired := resources.EventGatewayConsumePolicyResource{
+		EventGatewayConsumePolicyCreate: kkComps.CreateEventGatewayConsumePolicyCreateSchemaValidation(
+			kkComps.EventGatewayConsumeSchemaValidationPolicy{
+				Name:        &name,
+				Description: &desc,
+				Enabled:     &enabled,
+				Labels: map[string]string{
+					"env":  "prod",
+					"team": "platform",
+				},
+				Config: kkComps.EventGatewayConsumeSchemaValidationPolicyConfig{
+					Type:                  kkComps.SchemaValidationTypeJSON,
+					KeyValidationAction:   &keyAction,
+					ValueValidationAction: &valueAction,
+				},
+			},
+		),
+		Ref: "test-consume-policy-ref",
+	}
+
+	p := &Planner{}
+	needsUpdate, updateFields, changedFields := p.shouldUpdateConsumePolicy(current, desired)
+
+	assert.False(t, needsUpdate, "no update should be needed when all fields match")
+	assert.Nil(t, updateFields, "updateFields should be nil when no update needed")
+	assert.Empty(t, changedFields, "changedFields should be empty when no update needed")
+}
+
+func TestShouldUpdateConsumePolicy_DescriptionChanged(t *testing.T) {
+	name := "test-consume-policy"
+	oldDesc := "old description"
+	newDesc := "new description"
+	enabled := true
+
+	current := state.EventGatewayConsumePolicyInfo{
+		EventGatewayPolicy: kkComps.EventGatewayPolicy{
+			ID:          "policy-123",
+			Name:        &name,
+			Description: &oldDesc,
+			Enabled:     &enabled,
+			Type:        "schema_validation",
+		},
+		NormalizedLabels: map[string]string{},
+		RawConfig: map[string]any{
+			"type": "json",
+		},
+	}
+
+	desired := resources.EventGatewayConsumePolicyResource{
+		EventGatewayConsumePolicyCreate: kkComps.CreateEventGatewayConsumePolicyCreateSchemaValidation(
+			kkComps.EventGatewayConsumeSchemaValidationPolicy{
+				Name:        &name,
+				Description: &newDesc,
+				Enabled:     &enabled,
+				Config: kkComps.EventGatewayConsumeSchemaValidationPolicyConfig{
+					Type: kkComps.SchemaValidationTypeJSON,
+				},
+			},
+		),
+		Ref: "test-consume-policy-ref",
+	}
+
+	p := &Planner{}
+	needsUpdate, updateFields, changedFields := p.shouldUpdateConsumePolicy(current, desired)
+
+	require.True(t, needsUpdate, "update should be needed when description changes")
+	require.Contains(t, changedFields, "description")
+	assert.Equal(t, oldDesc, changedFields["description"].Old)
+	assert.Equal(t, newDesc, changedFields["description"].New)
+	assert.NotNil(t, updateFields)
+	assert.NotContains(t, changedFields, "name")
+}
+
+func TestShouldUpdateConsumePolicy_ConfigChangedNestedField(t *testing.T) {
+	name := "test-consume-policy"
+	desc := "test description"
+	enabled := true
+	oldKeyAction := kkComps.ConsumeKeyValidationActionMark
+	newKeyAction := kkComps.ConsumeKeyValidationActionSkip
+
+	current := state.EventGatewayConsumePolicyInfo{
+		EventGatewayPolicy: kkComps.EventGatewayPolicy{
+			ID:          "policy-123",
+			Name:        &name,
+			Description: &desc,
+			Enabled:     &enabled,
+			Type:        "schema_validation",
+		},
+		NormalizedLabels: map[string]string{},
+		RawConfig: map[string]any{
+			"type":                  "json",
+			"key_validation_action": string(oldKeyAction),
+		},
+	}
+
+	desired := resources.EventGatewayConsumePolicyResource{
+		EventGatewayConsumePolicyCreate: kkComps.CreateEventGatewayConsumePolicyCreateSchemaValidation(
+			kkComps.EventGatewayConsumeSchemaValidationPolicy{
+				Name:        &name,
+				Description: &desc,
+				Enabled:     &enabled,
+				Config: kkComps.EventGatewayConsumeSchemaValidationPolicyConfig{
+					Type:                kkComps.SchemaValidationTypeJSON,
+					KeyValidationAction: &newKeyAction,
+				},
+			},
+		),
+		Ref: "test-consume-policy-ref",
+	}
+
+	p := &Planner{}
+	needsUpdate, updateFields, changedFields := p.shouldUpdateConsumePolicy(current, desired)
+
+	require.True(t, needsUpdate, "update should be needed when config changes")
+	assert.NotNil(t, updateFields, "updateFields should contain the new config")
+	require.Contains(t, changedFields, "config", "config should be in changed fields")
+}

--- a/internal/declarative/planner/event_gateway_virtual_cluster_planner.go
+++ b/internal/declarative/planner/event_gateway_virtual_cluster_planner.go
@@ -115,6 +115,17 @@ func (p *Planner) planVirtualClusterChangesForExistingGateway(
 					return err
 				}
 			}
+			// Plan consume policies for this new virtual cluster (depends on virtual cluster creation)
+			consumePolicies := p.resources.GetConsumePoliciesForVirtualCluster(desiredCluster.Ref)
+			if len(consumePolicies) > 0 {
+				if err := p.planEventGatewayConsumePolicyChanges(
+					ctx, nil, namespace, gatewayID, gatewayRef,
+					desiredCluster.Name, "", desiredCluster.Ref,
+					virtualClusterChangeID, consumePolicies, plan,
+				); err != nil {
+					return err
+				}
+			}
 		} else {
 			// CHECK UPDATE
 			p.logger.Debug("Checking if virtual cluster needs update",
@@ -160,6 +171,17 @@ func (p *Planner) planVirtualClusterChangesForExistingGateway(
 					ctx, nil, namespace, gatewayID, gatewayRef,
 					desiredCluster.Name, current.ID, desiredCluster.Ref,
 					"", producePolicies, plan,
+				); err != nil {
+					return err
+				}
+			}
+			// Plan consume policies for this existing virtual cluster
+			consumePolicies := p.resources.GetConsumePoliciesForVirtualCluster(desiredCluster.Ref)
+			if len(consumePolicies) > 0 || plan.Metadata.Mode == PlanModeSync {
+				if err := p.planEventGatewayConsumePolicyChanges(
+					ctx, nil, namespace, gatewayID, gatewayRef,
+					desiredCluster.Name, current.ID, desiredCluster.Ref,
+					"", consumePolicies, plan,
 				); err != nil {
 					return err
 				}
@@ -229,6 +251,17 @@ func (p *Planner) planVirtualClusterCreatesForNewGateway(
 				ctx, nil, namespace, "", gatewayRef,
 				cluster.Name, "", cluster.Ref,
 				virtualClusterChangeID, producePolicies, plan,
+			); err != nil {
+				return err
+			}
+		}
+		// Plan consume policies for this new virtual cluster (depends on virtual cluster creation)
+		consumePolicies := p.resources.GetConsumePoliciesForVirtualCluster(cluster.Ref)
+		if len(consumePolicies) > 0 {
+			if err := p.planEventGatewayConsumePolicyChanges(
+				ctx, nil, namespace, "", gatewayRef,
+				cluster.Name, "", cluster.Ref,
+				virtualClusterChangeID, consumePolicies, plan,
 			); err != nil {
 				return err
 			}

--- a/internal/declarative/protection/lookup.go
+++ b/internal/declarative/protection/lookup.go
@@ -113,6 +113,7 @@ func IsManagedResourceProtected(
 		resources.ResourceTypeEventGatewayBackendCluster,
 		resources.ResourceTypeEventGatewayVirtualCluster,
 		resources.ResourceTypeEventGatewayClusterPolicy,
+		resources.ResourceTypeEventGatewayConsumePolicy,
 		resources.ResourceTypeEventGatewayListener,
 		resources.ResourceTypeEventGatewayListenerPolicy,
 		resources.ResourceTypeEventGatewayDataPlaneCertificate,

--- a/internal/declarative/resources/event_gateway_consume_policy.go
+++ b/internal/declarative/resources/event_gateway_consume_policy.go
@@ -1,0 +1,242 @@
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+)
+
+func init() {
+	registerResourceType(
+		ResourceTypeEventGatewayConsumePolicy,
+		func(rs *ResourceSet) *[]EventGatewayConsumePolicyResource {
+			return &rs.EventGatewayConsumePolicies
+		},
+		AutoExplain[EventGatewayConsumePolicyResource](),
+	)
+}
+
+// EventGatewayConsumePolicyResource represents a consume policy in declarative configuration.
+// Consume policies are grandchildren: Event Gateway → Virtual Cluster → Consume Policy.
+// The SDK represents consume policies as a discriminated union type (EventGatewayConsumePolicyCreate)
+// with four variants: modify_headers, schema_validation, decrypt, skip_record.
+// The "type" discriminator field is required.
+type EventGatewayConsumePolicyResource struct {
+	kkComps.EventGatewayConsumePolicyCreate `yaml:",inline" json:",inline"`
+	Ref                                     string `yaml:"ref" json:"ref"`
+	// Parent Virtual Cluster reference (for root-level definitions)
+	VirtualCluster string `yaml:"virtual_cluster,omitempty" json:"virtual_cluster,omitempty"`
+	EventGateway   string `yaml:"event_gateway,omitempty"   json:"event_gateway,omitempty"`
+
+	// Resolved Konnect ID (not serialized)
+	konnectID string `yaml:"-" json:"-"`
+}
+
+func (e EventGatewayConsumePolicyResource) GetType() ResourceType {
+	return ResourceTypeEventGatewayConsumePolicy
+}
+
+func (e EventGatewayConsumePolicyResource) GetRef() string {
+	return e.Ref
+}
+
+// GetMoniker returns the name of the policy from whichever union variant is set.
+func (e EventGatewayConsumePolicyResource) GetMoniker() string {
+	if e.EventGatewayModifyHeadersPolicyCreate != nil && e.EventGatewayModifyHeadersPolicyCreate.Name != nil {
+		return *e.EventGatewayModifyHeadersPolicyCreate.Name
+	}
+	if e.EventGatewayConsumeSchemaValidationPolicy != nil &&
+		e.EventGatewayConsumeSchemaValidationPolicy.Name != nil {
+		return *e.EventGatewayConsumeSchemaValidationPolicy.Name
+	}
+	if e.EventGatewayDecryptPolicy != nil && e.EventGatewayDecryptPolicy.Name != nil {
+		return *e.EventGatewayDecryptPolicy.Name
+	}
+	if e.EventGatewaySkipRecordPolicyCreate != nil && e.EventGatewaySkipRecordPolicyCreate.Name != nil {
+		return *e.EventGatewaySkipRecordPolicyCreate.Name
+	}
+	return e.Ref
+}
+
+func (e EventGatewayConsumePolicyResource) GetDependencies() []ResourceRef {
+	deps := []ResourceRef{}
+	if e.VirtualCluster != "" {
+		deps = append(deps, ResourceRef{Kind: "event_gateway_virtual_cluster", Ref: e.VirtualCluster})
+	}
+	return deps
+}
+
+func (e EventGatewayConsumePolicyResource) GetKonnectID() string {
+	return e.konnectID
+}
+
+func (e EventGatewayConsumePolicyResource) Validate() error {
+	if err := ValidateRef(e.Ref); err != nil {
+		return fmt.Errorf("invalid consume policy ref: %w", err)
+	}
+
+	// Exactly one union variant must be set — the SDK's UnmarshalJSON enforces the discriminator,
+	// so here we just verify one variant is present after unmarshaling.
+	hasVariant := e.EventGatewayModifyHeadersPolicyCreate != nil ||
+		e.EventGatewayConsumeSchemaValidationPolicy != nil ||
+		e.EventGatewayDecryptPolicy != nil ||
+		e.EventGatewaySkipRecordPolicyCreate != nil
+	if !hasVariant {
+		return fmt.Errorf(
+			"consume policy must specify 'type' field (one of: modify_headers, schema_validation, decrypt, skip_record)",
+		)
+	}
+
+	return nil
+}
+
+func (e *EventGatewayConsumePolicyResource) SetDefaults() {
+	// Names for union types are managed inside the variants; nothing to propagate.
+}
+
+func (e EventGatewayConsumePolicyResource) GetKonnectMonikerFilter() string {
+	return "" // TODO: the API does not support filtering by name for consume policies.
+}
+
+func (e *EventGatewayConsumePolicyResource) TryMatchKonnectResource(konnectResource any) bool {
+	v := reflect.ValueOf(konnectResource)
+	if v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return false
+	}
+
+	nameField := v.FieldByName("Name")
+	idField := v.FieldByName("ID")
+
+	if nameField.IsValid() && idField.IsValid() {
+		var konnectName string
+		if nameField.Kind() == reflect.Pointer && !nameField.IsNil() {
+			konnectName = nameField.Elem().String()
+		} else if nameField.Kind() == reflect.String {
+			konnectName = nameField.String()
+		}
+
+		if idField.Kind() == reflect.String && konnectName != "" && konnectName == e.GetMoniker() {
+			e.konnectID = idField.String()
+			return true
+		}
+	}
+
+	return false
+}
+
+// REQUIRED: Implement ResourceWithParent
+func (e EventGatewayConsumePolicyResource) GetParentRef() *ResourceRef {
+	if e.VirtualCluster != "" {
+		return &ResourceRef{Kind: "event_gateway_virtual_cluster", Ref: e.VirtualCluster}
+	}
+	return nil
+}
+
+// MarshalJSON ensures consume policy metadata (ref, virtual_cluster, event_gateway)
+// are included in the serialized output.
+func (e EventGatewayConsumePolicyResource) MarshalJSON() ([]byte, error) {
+	// Marshal the embedded union type first to get the policy body
+	policyBytes, err := json.Marshal(e.EventGatewayConsumePolicyCreate)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal consume policy: %w", err)
+	}
+
+	// Unmarshal into a generic map so we can add metadata fields
+	var result map[string]any
+	if err := json.Unmarshal(policyBytes, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal consume policy body: %w", err)
+	}
+
+	result["ref"] = e.Ref
+	if e.VirtualCluster != "" {
+		result["virtual_cluster"] = e.VirtualCluster
+	}
+	if e.EventGateway != "" {
+		result["event_gateway"] = e.EventGateway
+	}
+
+	return json.Marshal(result)
+}
+
+// UnmarshalJSON handles the union type correctly.
+// It rejects kongctl metadata and delegates to the SDK union type for the policy body.
+// The SDK union type requires a "type" discriminator field to determine which variant to use:
+//   - "modify_headers" → EventGatewayModifyHeadersPolicyCreate
+//   - "schema_validation" → EventGatewayConsumeSchemaValidationPolicy
+//   - "decrypt" → EventGatewayDecryptPolicy
+//   - "skip_record" → EventGatewaySkipRecordPolicyCreate
+func (e *EventGatewayConsumePolicyResource) UnmarshalJSON(data []byte) error {
+	// Extract our metadata fields
+	var meta struct {
+		Ref            string `json:"ref"`
+		VirtualCluster string `json:"virtual_cluster,omitempty"`
+		EventGateway   string `json:"event_gateway,omitempty"`
+		Kongctl        any    `json:"kongctl,omitempty"`
+	}
+
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return err
+	}
+
+	if meta.Kongctl != nil {
+		return fmt.Errorf("kongctl metadata not supported on child resources")
+	}
+
+	e.Ref = meta.Ref
+	e.VirtualCluster = meta.VirtualCluster
+	e.EventGateway = meta.EventGateway
+
+	// Validate required type discriminator
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if err := validateConsumePolicyType(raw); err != nil {
+		return err
+	}
+
+	// The SDK union type's UnmarshalJSON handles discriminating based on "type".
+	if err := json.Unmarshal(data, &e.EventGatewayConsumePolicyCreate); err != nil {
+		return fmt.Errorf("failed to unmarshal consume policy: %w", err)
+	}
+
+	return nil
+}
+
+// validateConsumePolicyType ensures the required type discriminator is present and valid.
+func validateConsumePolicyType(raw map[string]any) error {
+	validTypes := []string{
+		string(kkComps.EventGatewayConsumePolicyCreateTypeModifyHeaders),
+		string(kkComps.EventGatewayConsumePolicyCreateTypeSchemaValidation),
+		string(kkComps.EventGatewayConsumePolicyCreateTypeDecrypt),
+		string(kkComps.EventGatewayConsumePolicyCreateTypeSkipRecord),
+	}
+
+	policyType, hasType := raw["type"]
+	if !hasType {
+		return fmt.Errorf(
+			"consume policy requires 'type' field (one of: modify_headers, schema_validation, decrypt, skip_record)",
+		)
+	}
+
+	policyTypeStr, ok := policyType.(string)
+	if !ok {
+		return fmt.Errorf("consume policy 'type' must be a string")
+	}
+
+	for _, v := range validTypes {
+		if policyTypeStr == v {
+			return nil
+		}
+	}
+
+	return fmt.Errorf(
+		"consume policy 'type' must be one of [modify_headers, schema_validation, decrypt, skip_record], got %q",
+		policyTypeStr,
+	)
+}

--- a/internal/declarative/resources/event_gateway_virtual_cluster.go
+++ b/internal/declarative/resources/event_gateway_virtual_cluster.go
@@ -22,8 +22,8 @@ type EventGatewayVirtualClusterResource struct {
 	EventGateway string `yaml:"event_gateway,omitempty" json:"event_gateway,omitempty"`
 
 	// Nested child resources
-	ClusterPolicies []EventGatewayClusterPolicyResource `yaml:"cluster_policies,omitempty" json:"cluster_policies,omitempty"` //nolint:lll
-	ProducePolicies []EventGatewayProducePolicyResource `yaml:"produce_policies,omitempty" json:"produce_policies,omitempty"` //nolint:lll
+	ClusterPolicies []EventGatewayClusterPolicyResource `yaml:"cluster_policies,omitempty" json:"cluster_policies,omitempty"`  //nolint:lll
+	ProducePolicies []EventGatewayProducePolicyResource `yaml:"produce_policies,omitempty" json:"produce_policies,omitempty"`  //nolint:lll
 	ConsumePolicies []EventGatewayConsumePolicyResource `yaml:"consume_policies,omitempty"  json:"consume_policies,omitempty"` //nolint:lll
 
 	// Resolved Konnect ID (not serialized)
@@ -82,6 +82,7 @@ func (e EventGatewayVirtualClusterResource) Validate() error {
 			return fmt.Errorf("duplicate produce policy ref: %s", pp.GetRef())
 		}
 		producePolicyRefs[pp.GetRef()] = true
+	}
 	// Validate consume policies
 	consumePolicyRefs := make(map[string]bool)
 	for i, cp := range e.ConsumePolicies {

--- a/internal/declarative/resources/event_gateway_virtual_cluster.go
+++ b/internal/declarative/resources/event_gateway_virtual_cluster.go
@@ -24,6 +24,7 @@ type EventGatewayVirtualClusterResource struct {
 	// Nested child resources
 	ClusterPolicies []EventGatewayClusterPolicyResource `yaml:"cluster_policies,omitempty" json:"cluster_policies,omitempty"` //nolint:lll
 	ProducePolicies []EventGatewayProducePolicyResource `yaml:"produce_policies,omitempty" json:"produce_policies,omitempty"` //nolint:lll
+	ConsumePolicies []EventGatewayConsumePolicyResource `yaml:"consume_policies,omitempty"  json:"consume_policies,omitempty"` //nolint:lll
 
 	// Resolved Konnect ID (not serialized)
 	konnectID string `yaml:"-" json:"-"`
@@ -81,6 +82,16 @@ func (e EventGatewayVirtualClusterResource) Validate() error {
 			return fmt.Errorf("duplicate produce policy ref: %s", pp.GetRef())
 		}
 		producePolicyRefs[pp.GetRef()] = true
+	// Validate consume policies
+	consumePolicyRefs := make(map[string]bool)
+	for i, cp := range e.ConsumePolicies {
+		if err := cp.Validate(); err != nil {
+			return fmt.Errorf("invalid consume policy %d: %w", i, err)
+		}
+		if consumePolicyRefs[cp.GetRef()] {
+			return fmt.Errorf("duplicate consume policy ref: %s", cp.GetRef())
+		}
+		consumePolicyRefs[cp.GetRef()] = true
 	}
 
 	return nil
@@ -100,6 +111,10 @@ func (e *EventGatewayVirtualClusterResource) SetDefaults() {
 	// Apply defaults to produce policies
 	for i := range e.ProducePolicies {
 		e.ProducePolicies[i].SetDefaults()
+	}
+	// Apply defaults to consume policies
+	for i := range e.ConsumePolicies {
+		e.ConsumePolicies[i].SetDefaults()
 	}
 }
 
@@ -143,6 +158,7 @@ func (e EventGatewayVirtualClusterResource) MarshalJSON() ([]byte, error) {
 		// Nested child resources
 		ClusterPolicies []EventGatewayClusterPolicyResource `json:"cluster_policies,omitempty"`
 		ProducePolicies []EventGatewayProducePolicyResource `json:"produce_policies,omitempty"`
+		ConsumePolicies []EventGatewayConsumePolicyResource `json:"consume_policies,omitempty"`
 	}
 
 	payload := alias{
@@ -158,6 +174,7 @@ func (e EventGatewayVirtualClusterResource) MarshalJSON() ([]byte, error) {
 		Labels:          e.Labels,
 		ClusterPolicies: e.ClusterPolicies,
 		ProducePolicies: e.ProducePolicies,
+		ConsumePolicies: e.ConsumePolicies,
 	}
 
 	return json.Marshal(payload)
@@ -185,6 +202,7 @@ func (e *EventGatewayVirtualClusterResource) UnmarshalJSON(data []byte) error {
 		// Nested child resources
 		ClusterPolicies []EventGatewayClusterPolicyResource `json:"cluster_policies,omitempty"`
 		ProducePolicies []EventGatewayProducePolicyResource `json:"produce_policies,omitempty"`
+		ConsumePolicies []EventGatewayConsumePolicyResource `json:"consume_policies,omitempty"`
 	}
 
 	if err := json.Unmarshal(data, &temp); err != nil {
@@ -212,6 +230,7 @@ func (e *EventGatewayVirtualClusterResource) UnmarshalJSON(data []byte) error {
 	// Populate nested child resources
 	e.ClusterPolicies = temp.ClusterPolicies
 	e.ProducePolicies = temp.ProducePolicies
+	e.ConsumePolicies = temp.ConsumePolicies
 
 	return nil
 }

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -37,6 +37,7 @@ const (
 	ResourceTypeEventGatewayDataPlaneCertificate ResourceType = "event_gateway_data_plane_certificate"
 	ResourceTypeEventGatewayClusterPolicy        ResourceType = "event_gateway_virtual_cluster_cluster_policy"
 	ResourceTypeEventGatewayProducePolicy        ResourceType = "event_gateway_virtual_cluster_produce_policy"
+	ResourceTypeEventGatewayConsumePolicy        ResourceType = "event_gateway_virtual_cluster_consume_policy"
 )
 
 const (
@@ -89,6 +90,7 @@ type ResourceSet struct {
 	EventGatewayListenerPolicies      []EventGatewayListenerPolicyResource       `yaml:"event_gateway_listener_policies,omitempty" json:"event_gateway_listener_policies,omitempty"`                               //nolint:lll
 	EventGatewayClusterPolicies       []EventGatewayClusterPolicyResource        `yaml:"event_gateway_virtual_cluster_cluster_policies,omitempty" json:"event_gateway_virtual_cluster_cluster_policies,omitempty"` //nolint:lll
 	EventGatewayProducePolicies       []EventGatewayProducePolicyResource        `yaml:"event_gateway_virtual_cluster_produce_policies,omitempty" json:"event_gateway_virtual_cluster_produce_policies,omitempty"` //nolint:lll
+	EventGatewayConsumePolicies       []EventGatewayConsumePolicyResource        `yaml:"event_gateway_virtual_cluster_consume_policies,omitempty" json:"event_gateway_virtual_cluster_consume_policies,omitempty"` //nolint:lll
 	EventGatewayDataPlaneCertificates []EventGatewayDataPlaneCertificateResource `yaml:"event_gateway_data_plane_certificates,omitempty" json:"event_gateway_data_plane_certificates,omitempty"`                   //nolint:lll
 	// DefaultNamespace tracks namespace from _defaults when no resources are present
 	// This is used by the planner to determine which namespace to check for deletions
@@ -835,6 +837,47 @@ func (rs *ResourceSet) GetProducePoliciesForVirtualCluster(
 
 	// Add root-level produce policies for this virtual cluster
 	for _, policy := range rs.EventGatewayProducePolicies {
+		if policy.VirtualCluster == virtualClusterRef {
+			policies = append(policies, policy)
+		}
+	}
+
+	return policies
+}
+
+// GetConsumePoliciesForVirtualCluster returns all consume policies (nested + root-level)
+// for a specific virtual cluster.
+func (rs *ResourceSet) GetConsumePoliciesForVirtualCluster(
+	virtualClusterRef string,
+) []EventGatewayConsumePolicyResource {
+	var policies []EventGatewayConsumePolicyResource
+
+	// Add nested consume policies from virtual clusters inside event gateways
+	for _, gateway := range rs.EventGatewayControlPlanes {
+		for _, vc := range gateway.VirtualClusters {
+			if vc.Ref == virtualClusterRef {
+				for _, policy := range vc.ConsumePolicies {
+					policyCopy := policy
+					policyCopy.VirtualCluster = virtualClusterRef
+					policies = append(policies, policyCopy)
+				}
+			}
+		}
+	}
+
+	// Check root-level virtual clusters
+	for _, vc := range rs.EventGatewayVirtualClusters {
+		if vc.Ref == virtualClusterRef {
+			for _, policy := range vc.ConsumePolicies {
+				policyCopy := policy
+				policyCopy.VirtualCluster = virtualClusterRef
+				policies = append(policies, policyCopy)
+			}
+		}
+	}
+
+	// Add root-level consume policies for this virtual cluster
+	for _, policy := range rs.EventGatewayConsumePolicies {
 		if policy.VirtualCluster == virtualClusterRef {
 			policies = append(policies, policy)
 		}

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -58,6 +58,7 @@ type ClientConfig struct {
 	EventGatewayListenerPolicyAPI       helpers.EventGatewayListenerPolicyAPI
 	EventGatewayClusterPolicyAPI        helpers.EventGatewayClusterPolicyAPI
 	EventGatewayProducePolicyAPI        helpers.EventGatewayProducePolicyAPI
+	EventGatewayConsumePolicyAPI        helpers.EventGatewayConsumePolicyAPI
 	EventGatewayDataPlaneCertificateAPI helpers.EventGatewayDataPlaneCertificateAPI
 
 	// Identity resources
@@ -100,6 +101,7 @@ type Client struct {
 	eventGatewayListenerPolicyAPI       helpers.EventGatewayListenerPolicyAPI
 	eventGatewayClusterPolicyAPI        helpers.EventGatewayClusterPolicyAPI
 	eventGatewayProducePolicyAPI        helpers.EventGatewayProducePolicyAPI
+	eventGatewayConsumePolicyAPI        helpers.EventGatewayConsumePolicyAPI
 	eventGatewayDataPlaneCertificateAPI helpers.EventGatewayDataPlaneCertificateAPI
 
 	// Organization resource APIs
@@ -143,6 +145,7 @@ func NewClient(config ClientConfig) *Client {
 		eventGatewayListenerPolicyAPI:       config.EventGatewayListenerPolicyAPI,
 		eventGatewayClusterPolicyAPI:        config.EventGatewayClusterPolicyAPI,
 		eventGatewayProducePolicyAPI:        config.EventGatewayProducePolicyAPI,
+		eventGatewayConsumePolicyAPI:        config.EventGatewayConsumePolicyAPI,
 		eventGatewayDataPlaneCertificateAPI: config.EventGatewayDataPlaneCertificateAPI,
 
 		// Identity resource APIs
@@ -4749,6 +4752,194 @@ func (c *Client) GetEventGatewayVirtualClusterProducePolicy(
 	return &EventGatewayVirtualClusterProducePolicyInfo{
 		EventGatewayPolicy: *resp.EventGatewayPolicy,
 		RawConfig:          nil,
+	}, nil
+}
+
+// ---- Event Gateway Consume Policy operations ----
+
+// EventGatewayConsumePolicyInfo wraps an Event Gateway Consume Policy for internal use.
+// RawConfig contains the full config from the raw API response since the SDK's
+// EventGatewayPolicyConfig struct is empty and doesn't capture actual config data.
+type EventGatewayConsumePolicyInfo struct {
+	kkComps.EventGatewayPolicy
+	NormalizedLabels map[string]string
+	RawConfig        map[string]any
+}
+
+// consumePolicyRawResponse is used to parse the raw API response to get full config.
+type consumePolicyRawResponse struct {
+	Type           string            `json:"type"`
+	Name           *string           `json:"name,omitempty"`
+	Description    *string           `json:"description,omitempty"`
+	Enabled        *bool             `json:"enabled,omitempty"`
+	Labels         map[string]string `json:"labels,omitempty"`
+	ID             string            `json:"id"`
+	Config         map[string]any    `json:"config"`
+	CreatedAt      string            `json:"created_at"`
+	UpdatedAt      string            `json:"updated_at"`
+	ParentPolicyID *string           `json:"parent_policy_id,omitempty"`
+	Condition      *string           `json:"condition,omitempty"`
+}
+
+func (c *Client) ListEventGatewayConsumePolicies(
+	ctx context.Context,
+	gatewayID string,
+	virtualClusterID string,
+) ([]EventGatewayConsumePolicyInfo, error) {
+	if err := ValidateAPIClient(c.eventGatewayConsumePolicyAPI, "event gateway consume policy API"); err != nil {
+		return nil, err
+	}
+
+	req := kkOps.ListEventGatewayVirtualClusterConsumePoliciesRequest{
+		GatewayID:        gatewayID,
+		VirtualClusterID: virtualClusterID,
+	}
+
+	res, err := c.eventGatewayConsumePolicyAPI.ListEventGatewayVirtualClusterConsumePolicies(ctx, req)
+	if err != nil {
+		return nil, WrapAPIError(err, "list event gateway consume policies", nil)
+	}
+
+	if res.ListConsumePoliciesResponse == nil {
+		return []EventGatewayConsumePolicyInfo{}, nil
+	}
+
+	// Try to parse raw response to get full config data
+	rawConfigByID := make(map[string]map[string]any)
+	if res.RawResponse != nil && res.RawResponse.Body != nil {
+		bodyBytes, readErr := io.ReadAll(res.RawResponse.Body)
+		if readErr == nil && len(bodyBytes) > 0 {
+			var rawPolicies []consumePolicyRawResponse
+			if jsonErr := json.Unmarshal(bodyBytes, &rawPolicies); jsonErr == nil {
+				for _, rp := range rawPolicies {
+					if rp.ID != "" && rp.Config != nil {
+						rawConfigByID[rp.ID] = rp.Config
+					}
+				}
+			}
+		}
+	}
+
+	var policies []EventGatewayConsumePolicyInfo
+	for _, p := range res.ListConsumePoliciesResponse {
+		normalized := p.Labels
+		if normalized == nil {
+			normalized = make(map[string]string)
+		}
+		policies = append(policies, EventGatewayConsumePolicyInfo{
+			EventGatewayPolicy: p,
+			NormalizedLabels:   normalized,
+			RawConfig:          rawConfigByID[p.ID],
+		})
+	}
+
+	return policies, nil
+}
+
+func (c *Client) CreateEventGatewayConsumePolicy(
+	ctx context.Context,
+	gatewayID string,
+	virtualClusterID string,
+	req kkComps.EventGatewayConsumePolicyCreate,
+	namespace string,
+) (string, error) {
+	createReq := kkOps.CreateEventGatewayVirtualClusterConsumePolicyRequest{
+		GatewayID:                       gatewayID,
+		VirtualClusterID:                virtualClusterID,
+		EventGatewayConsumePolicyCreate: &req,
+	}
+
+	resp, err := c.eventGatewayConsumePolicyAPI.CreateEventGatewayVirtualClusterConsumePolicy(ctx, createReq)
+	if err != nil {
+		return "", WrapAPIError(err, "create event gateway consume policy", &ErrorWrapperOptions{
+			ResourceType: "event_gateway_virtual_cluster_consume_policy",
+			Namespace:    namespace,
+			UseEnhanced:  true,
+		})
+	}
+
+	if err := ValidateResponse(resp.EventGatewayPolicy, "create event gateway consume policy"); err != nil {
+		return "", err
+	}
+
+	return resp.EventGatewayPolicy.ID, nil
+}
+
+func (c *Client) UpdateEventGatewayConsumePolicy(
+	ctx context.Context,
+	gatewayID string,
+	virtualClusterID string,
+	policyID string,
+	req kkComps.EventGatewayConsumePolicyUpdate,
+	namespace string,
+) (string, error) {
+	updateReq := kkOps.UpdateEventGatewayVirtualClusterConsumePolicyRequest{
+		GatewayID:                       gatewayID,
+		VirtualClusterID:                virtualClusterID,
+		PolicyID:                        policyID,
+		EventGatewayConsumePolicyUpdate: &req,
+	}
+
+	resp, err := c.eventGatewayConsumePolicyAPI.UpdateEventGatewayVirtualClusterConsumePolicy(ctx, updateReq)
+	if err != nil {
+		return "", WrapAPIError(err, "update event gateway consume policy", &ErrorWrapperOptions{
+			ResourceType: "event_gateway_virtual_cluster_consume_policy",
+			Namespace:    namespace,
+			UseEnhanced:  true,
+		})
+	}
+
+	return resp.EventGatewayPolicy.ID, nil
+}
+
+func (c *Client) DeleteEventGatewayConsumePolicy(
+	ctx context.Context,
+	gatewayID string,
+	virtualClusterID string,
+	policyID string,
+) error {
+	deleteReq := kkOps.DeleteEventGatewayVirtualClusterConsumePolicyRequest{
+		GatewayID:        gatewayID,
+		VirtualClusterID: virtualClusterID,
+		PolicyID:         policyID,
+	}
+
+	_, err := c.eventGatewayConsumePolicyAPI.DeleteEventGatewayVirtualClusterConsumePolicy(ctx, deleteReq)
+	if err != nil {
+		return WrapAPIError(err, "delete event gateway consume policy", nil)
+	}
+	return nil
+}
+
+func (c *Client) GetEventGatewayConsumePolicy(
+	ctx context.Context,
+	gatewayID string,
+	virtualClusterID string,
+	policyID string,
+) (*EventGatewayConsumePolicyInfo, error) {
+	req := kkOps.GetEventGatewayVirtualClusterConsumePolicyRequest{
+		GatewayID:        gatewayID,
+		VirtualClusterID: virtualClusterID,
+		PolicyID:         policyID,
+	}
+
+	resp, err := c.eventGatewayConsumePolicyAPI.GetEventGatewayVirtualClusterConsumePolicy(ctx, req)
+	if err != nil {
+		return nil, WrapAPIError(err, "get event gateway consume policy", nil)
+	}
+
+	if resp.EventGatewayPolicy == nil {
+		return nil, nil
+	}
+
+	normalized := resp.EventGatewayPolicy.Labels
+	if normalized == nil {
+		normalized = make(map[string]string)
+	}
+
+	return &EventGatewayConsumePolicyInfo{
+		EventGatewayPolicy: *resp.EventGatewayPolicy,
+		NormalizedLabels:   normalized,
 	}, nil
 }
 

--- a/internal/konnect/helpers/event_gateway_consume_policies.go
+++ b/internal/konnect/helpers/event_gateway_consume_policies.go
@@ -1,0 +1,90 @@
+package helpers
+
+import (
+	"context"
+
+	kkSDK "github.com/Kong/sdk-konnect-go"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+)
+
+// EventGatewayConsumePolicyAPI defines the interface for Event Gateway Virtual Cluster Consume Policy operations.
+type EventGatewayConsumePolicyAPI interface {
+	ListEventGatewayVirtualClusterConsumePolicies(
+		ctx context.Context,
+		request kkOps.ListEventGatewayVirtualClusterConsumePoliciesRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.ListEventGatewayVirtualClusterConsumePoliciesResponse, error)
+	GetEventGatewayVirtualClusterConsumePolicy(
+		ctx context.Context,
+		request kkOps.GetEventGatewayVirtualClusterConsumePolicyRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.GetEventGatewayVirtualClusterConsumePolicyResponse, error)
+	CreateEventGatewayVirtualClusterConsumePolicy(
+		ctx context.Context,
+		request kkOps.CreateEventGatewayVirtualClusterConsumePolicyRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.CreateEventGatewayVirtualClusterConsumePolicyResponse, error)
+	UpdateEventGatewayVirtualClusterConsumePolicy(
+		ctx context.Context,
+		request kkOps.UpdateEventGatewayVirtualClusterConsumePolicyRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.UpdateEventGatewayVirtualClusterConsumePolicyResponse, error)
+	DeleteEventGatewayVirtualClusterConsumePolicy(
+		ctx context.Context,
+		request kkOps.DeleteEventGatewayVirtualClusterConsumePolicyRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.DeleteEventGatewayVirtualClusterConsumePolicyResponse, error)
+}
+
+// EventGatewayConsumePolicyAPIImpl provides an implementation of the EventGatewayConsumePolicyAPI interface.
+type EventGatewayConsumePolicyAPIImpl struct {
+	SDK *kkSDK.SDK
+}
+
+func (a *EventGatewayConsumePolicyAPIImpl) ListEventGatewayVirtualClusterConsumePolicies(
+	ctx context.Context,
+	request kkOps.ListEventGatewayVirtualClusterConsumePoliciesRequest,
+	opts ...kkOps.Option,
+) (*kkOps.ListEventGatewayVirtualClusterConsumePoliciesResponse, error) {
+	return a.SDK.EventGatewayVirtualClusterConsumePolicies.ListEventGatewayVirtualClusterConsumePolicies(
+		ctx, request, opts...)
+}
+
+func (a *EventGatewayConsumePolicyAPIImpl) GetEventGatewayVirtualClusterConsumePolicy(
+	ctx context.Context,
+	request kkOps.GetEventGatewayVirtualClusterConsumePolicyRequest,
+	opts ...kkOps.Option,
+) (*kkOps.GetEventGatewayVirtualClusterConsumePolicyResponse, error) {
+	return a.SDK.EventGatewayVirtualClusterConsumePolicies.GetEventGatewayVirtualClusterConsumePolicy(
+		ctx, request, opts...)
+}
+
+func (a *EventGatewayConsumePolicyAPIImpl) CreateEventGatewayVirtualClusterConsumePolicy(
+	ctx context.Context,
+	request kkOps.CreateEventGatewayVirtualClusterConsumePolicyRequest,
+	opts ...kkOps.Option,
+) (*kkOps.CreateEventGatewayVirtualClusterConsumePolicyResponse, error) {
+	return a.SDK.EventGatewayVirtualClusterConsumePolicies.CreateEventGatewayVirtualClusterConsumePolicy(
+		ctx, request, opts...)
+}
+
+func (a *EventGatewayConsumePolicyAPIImpl) UpdateEventGatewayVirtualClusterConsumePolicy(
+	ctx context.Context,
+	request kkOps.UpdateEventGatewayVirtualClusterConsumePolicyRequest,
+	opts ...kkOps.Option,
+) (*kkOps.UpdateEventGatewayVirtualClusterConsumePolicyResponse, error) {
+	return a.SDK.EventGatewayVirtualClusterConsumePolicies.UpdateEventGatewayVirtualClusterConsumePolicy(
+		ctx, request, opts...)
+}
+
+func (a *EventGatewayConsumePolicyAPIImpl) DeleteEventGatewayVirtualClusterConsumePolicy(
+	ctx context.Context,
+	request kkOps.DeleteEventGatewayVirtualClusterConsumePolicyRequest,
+	opts ...kkOps.Option,
+) (*kkOps.DeleteEventGatewayVirtualClusterConsumePolicyResponse, error) {
+	return a.SDK.EventGatewayVirtualClusterConsumePolicies.DeleteEventGatewayVirtualClusterConsumePolicy(
+		ctx, request, opts...)
+}
+
+// Compile-time interface assertion
+var _ EventGatewayConsumePolicyAPI = &EventGatewayConsumePolicyAPIImpl{}

--- a/internal/konnect/helpers/sdk.go
+++ b/internal/konnect/helpers/sdk.go
@@ -367,13 +367,19 @@ func (k *KonnectSDK) GetEventGatewayClusterPolicyAPI() EventGatewayClusterPolicy
 
 // Returns the implementation of the EventGatewayProducePolicyAPI interface
 func (k *KonnectSDK) GetEventGatewayProducePolicyAPI() EventGatewayProducePolicyAPI {
+	if k.SDK == nil {
+		return nil
+	}
+
+	return &EventGatewayProducePolicyAPIImpl{SDK: k.SDK}
+}
+
 // Returns the implementation of the EventGatewayConsumePolicyAPI interface
 func (k *KonnectSDK) GetEventGatewayConsumePolicyAPI() EventGatewayConsumePolicyAPI {
 	if k.SDK == nil {
 		return nil
 	}
 
-	return &EventGatewayProducePolicyAPIImpl{SDK: k.SDK}
 	return &EventGatewayConsumePolicyAPIImpl{SDK: k.SDK}
 }
 

--- a/internal/konnect/helpers/sdk.go
+++ b/internal/konnect/helpers/sdk.go
@@ -52,6 +52,7 @@ type SDKAPI interface {
 	GetEventGatewayListenerPolicyAPI() EventGatewayListenerPolicyAPI
 	GetEventGatewayClusterPolicyAPI() EventGatewayClusterPolicyAPI
 	GetEventGatewayProducePolicyAPI() EventGatewayProducePolicyAPI
+	GetEventGatewayConsumePolicyAPI() EventGatewayConsumePolicyAPI
 	GetEventGatewayDataPlaneCertificateAPI() EventGatewayDataPlaneCertificateAPI
 }
 
@@ -366,11 +367,14 @@ func (k *KonnectSDK) GetEventGatewayClusterPolicyAPI() EventGatewayClusterPolicy
 
 // Returns the implementation of the EventGatewayProducePolicyAPI interface
 func (k *KonnectSDK) GetEventGatewayProducePolicyAPI() EventGatewayProducePolicyAPI {
+// Returns the implementation of the EventGatewayConsumePolicyAPI interface
+func (k *KonnectSDK) GetEventGatewayConsumePolicyAPI() EventGatewayConsumePolicyAPI {
 	if k.SDK == nil {
 		return nil
 	}
 
 	return &EventGatewayProducePolicyAPIImpl{SDK: k.SDK}
+	return &EventGatewayConsumePolicyAPIImpl{SDK: k.SDK}
 }
 
 func (k *KonnectSDK) GetOrganizationTeamAPI() OrganizationTeamAPI {

--- a/internal/konnect/helpers/sdk_mock.go
+++ b/internal/konnect/helpers/sdk_mock.go
@@ -43,6 +43,7 @@ type MockKonnectSDK struct {
 	EventGatewayListenerPolicyFactory       func() EventGatewayListenerPolicyAPI
 	EventGatewayClusterPolicyFactory        func() EventGatewayClusterPolicyAPI
 	EventGatewayProducePolicyFactory        func() EventGatewayProducePolicyAPI
+	EventGatewayConsumePolicyFactory        func() EventGatewayConsumePolicyAPI
 	EventGatewayDataPlaneCertificateFactory func() EventGatewayDataPlaneCertificateAPI
 }
 
@@ -311,6 +312,10 @@ func (m *MockKonnectSDK) GetEventGatewayClusterPolicyAPI() EventGatewayClusterPo
 func (m *MockKonnectSDK) GetEventGatewayProducePolicyAPI() EventGatewayProducePolicyAPI {
 	if m.EventGatewayProducePolicyFactory != nil {
 		return m.EventGatewayProducePolicyFactory()
+// Returns a mock instance of the EventGatewayConsumePolicyAPI
+func (m *MockKonnectSDK) GetEventGatewayConsumePolicyAPI() EventGatewayConsumePolicyAPI {
+	if m.EventGatewayConsumePolicyFactory != nil {
+		return m.EventGatewayConsumePolicyFactory()
 	}
 	return nil
 }

--- a/internal/konnect/helpers/sdk_mock.go
+++ b/internal/konnect/helpers/sdk_mock.go
@@ -312,6 +312,10 @@ func (m *MockKonnectSDK) GetEventGatewayClusterPolicyAPI() EventGatewayClusterPo
 func (m *MockKonnectSDK) GetEventGatewayProducePolicyAPI() EventGatewayProducePolicyAPI {
 	if m.EventGatewayProducePolicyFactory != nil {
 		return m.EventGatewayProducePolicyFactory()
+	}
+	return nil
+}
+
 // Returns a mock instance of the EventGatewayConsumePolicyAPI
 func (m *MockKonnectSDK) GetEventGatewayConsumePolicyAPI() EventGatewayConsumePolicyAPI {
 	if m.EventGatewayConsumePolicyFactory != nil {

--- a/internal/processes/runtime.go
+++ b/internal/processes/runtime.go
@@ -13,6 +13,13 @@ import (
 	"time"
 )
 
+const (
+	defaultStopTimeout        = 15 * time.Second
+	defaultStartProbeWait     = 500 * time.Millisecond
+	defaultProbeInterval      = 100 * time.Millisecond
+	defaultStartProbeInterval = 20 * time.Millisecond
+)
+
 // Inspect evaluates whether a recorded process is still running.
 func Inspect(record Record) RuntimeState {
 	state := RuntimeState{

--- a/internal/processes/runtime.go
+++ b/internal/processes/runtime.go
@@ -13,13 +13,6 @@ import (
 	"time"
 )
 
-const (
-	defaultStopTimeout        = 15 * time.Second
-	defaultStartProbeWait     = 500 * time.Millisecond
-	defaultProbeInterval      = 100 * time.Millisecond
-	defaultStartProbeInterval = 20 * time.Millisecond
-)
-
 // Inspect evaluates whether a recorded process is still running.
 func Inspect(record Record) RuntimeState {
 	state := RuntimeState{

--- a/test/e2e/scenarios/event-gateway/consume-policy/overlays/001-update-fields/config.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/overlays/001-update-fields/config.yaml
@@ -1,0 +1,47 @@
+_defaults:
+  kongctl:
+    namespace: event-gateways-vc-consume-policy-comprehensive-test
+
+event_gateways:
+  - ref: egw-cp-for-vc-consume-policy-test
+    name: egw-cp-for-vc-consume-policy-test
+    description: "EGW for Virtual Cluster Consume Policy Test"
+    backend_clusters:
+      - ref: default-backend-cluster
+        name: default-backend-cluster
+        description: "Backend Cluster for Test"
+        bootstrap_servers:
+          - "egw-backend-1.example.com:9092"
+          - "egw-backend-2.example.com:9092"
+        authentication:
+          type: anonymous
+        tls:
+          enabled: true
+          skip_verify: false
+          tls_versions:
+            - tls12
+            - tls13
+    virtual_clusters:
+      - ref: default-virtual-cluster-for-consume-policy-test
+        name: default-virtual-cluster-name-for-consume-policy-test
+        description: "Virtual Cluster for Consume Policy Test"
+        destination:
+          name: default-backend-cluster
+        authentication:
+         - type: anonymous
+        acl_mode: enforce_on_gateway
+        dns_label: vc-default
+        consume_policies:
+          - ref: default-consume-policy
+            name: default-consume-policy-name-for-test
+            description: Default Consume Policy description updated
+            type: modify_headers
+            enabled: false
+            labels:
+              env: production
+              version: v2
+            config:
+              actions:
+                - op: set
+                  key: x-env-updated
+                  value: production

--- a/test/e2e/scenarios/event-gateway/consume-policy/overlays/002-sync-delete/config.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/overlays/002-sync-delete/config.yaml
@@ -1,0 +1,34 @@
+_defaults:
+  kongctl:
+    namespace: event-gateways-vc-consume-policy-comprehensive-test
+
+event_gateways:
+  - ref: egw-cp-for-vc-consume-policy-test
+    name: egw-cp-for-vc-consume-policy-test
+    description: "EGW for Virtual Cluster Consume Policy Test"
+    backend_clusters:
+      - ref: default-backend-cluster
+        name: default-backend-cluster
+        description: "Backend Cluster for Test"
+        bootstrap_servers:
+          - "egw-backend-1.example.com:9092"
+          - "egw-backend-2.example.com:9092"
+        authentication:
+          type: anonymous
+        tls:
+          enabled: true
+          skip_verify: false
+          tls_versions:
+            - tls12
+            - tls13
+    virtual_clusters:
+      - ref: default-virtual-cluster-for-consume-policy-test
+        name: default-virtual-cluster-name-for-consume-policy-test
+        description: "Virtual Cluster for Consume Policy Test"
+        destination:
+          name: default-backend-cluster
+        authentication:
+         - type: anonymous
+        acl_mode: enforce_on_gateway
+        dns_label: vc-default
+        consume_policies: []

--- a/test/e2e/scenarios/event-gateway/consume-policy/overlays/003-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/overlays/003-root-level-declaration/config.yaml
@@ -1,0 +1,49 @@
+_defaults:
+  kongctl:
+    namespace: event-gateways-vc-consume-policy-comprehensive-test
+
+event_gateways:
+  - ref: egw-cp-for-vc-consume-policy-test
+    name: egw-cp-for-vc-consume-policy-test
+    description: "EGW for Virtual Cluster Consume Policy Test"
+    backend_clusters:
+      - ref: default-backend-cluster
+        name: default-backend-cluster
+        description: "Backend Cluster for Test"
+        bootstrap_servers:
+          - "egw-backend-1.example.com:9092"
+          - "egw-backend-2.example.com:9092"
+        authentication:
+          type: anonymous
+        tls:
+          enabled: true
+          skip_verify: false
+          tls_versions:
+            - tls12
+            - tls13
+    virtual_clusters:
+      - ref: default-virtual-cluster-for-consume-policy-test
+        name: default-virtual-cluster-name-for-consume-policy-test
+        description: "Virtual Cluster for Consume Policy Test"
+        destination:
+          name: default-backend-cluster
+        authentication:
+         - type: anonymous
+        acl_mode: enforce_on_gateway
+        dns_label: vc-default
+event_gateway_virtual_cluster_consume_policies:
+  - ref: default-consume-policy
+    name: default-consume-policy-name-for-test
+    description: Default Consume Policy description
+    event_gateway: egw-cp-for-vc-consume-policy-test
+    virtual_cluster: default-virtual-cluster-for-consume-policy-test
+    type: modify_headers
+    enabled: true
+    labels:
+      env: staging
+      team: payments
+    config:
+      actions:
+        - op: set
+          key: x-env
+          value: staging

--- a/test/e2e/scenarios/event-gateway/consume-policy/overlays/003-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/overlays/003-root-level-declaration/config.yaml
@@ -37,13 +37,14 @@ event_gateway_virtual_cluster_consume_policies:
     description: Default Consume Policy description
     event_gateway: egw-cp-for-vc-consume-policy-test
     virtual_cluster: default-virtual-cluster-for-consume-policy-test
-    type: modify_headers
+    type: decrypt
     enabled: true
     labels:
       env: staging
       team: payments
     config:
-      actions:
-        - op: set
-          key: x-env
-          value: staging
+      failure_mode: passthrough
+      part_of_record:
+      - key
+      key_sources:
+        - type: aws

--- a/test/e2e/scenarios/event-gateway/consume-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -1,0 +1,34 @@
+_defaults:
+  kongctl:
+    namespace: event-gateways-vc-consume-policy-comprehensive-test
+
+event_gateways:
+  - ref: egw-cp-for-vc-consume-policy-test
+    name: egw-cp-for-vc-consume-policy-test
+    description: "EGW for Virtual Cluster Consume Policy Test"
+    backend_clusters:
+      - ref: default-backend-cluster
+        name: default-backend-cluster
+        description: "Backend Cluster for Test"
+        bootstrap_servers:
+          - "egw-backend-1.example.com:9092"
+          - "egw-backend-2.example.com:9092"
+        authentication:
+          type: anonymous
+        tls:
+          enabled: true
+          skip_verify: false
+          tls_versions:
+            - tls12
+            - tls13
+    virtual_clusters:
+      - ref: default-virtual-cluster-for-consume-policy-test
+        name: default-virtual-cluster-name-for-consume-policy-test
+        description: "Virtual Cluster for Consume Policy Test"
+        destination:
+          name: default-backend-cluster
+        authentication:
+         - type: anonymous
+        acl_mode: enforce_on_gateway
+        dns_label: vc-default
+event_gateway_virtual_cluster_consume_policies: []

--- a/test/e2e/scenarios/event-gateway/consume-policy/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/scenario.yaml
@@ -310,6 +310,7 @@ steps:
                 name: "{{ .vars.consumePolicyName }}"
                 description: "{{ .vars.consumePolicyDescription }}"
                 enabled: true
+                type: decrypt
                 labels:
                   env: staging
                   team: payments

--- a/test/e2e/scenarios/event-gateway/consume-policy/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/scenario.yaml
@@ -1,0 +1,374 @@
+baseInputsPath: testdata
+
+env:
+  KONGCTL_LOG_LEVEL: info
+
+test:
+  enabledByEnvVar: KONGCTL_ENABLE_EVENT_GATEWAY
+
+vars:
+  egwName: egw-cp-for-vc-consume-policy-test
+  egwRef: egw-cp-for-vc-consume-policy-test
+  backendClusterRef: default-backend-cluster
+  backendClusterName: default-backend-cluster
+  virtualClusterRef: default-virtual-cluster-for-consume-policy-test
+  virtualClusterName: default-virtual-cluster-name-for-consume-policy-test
+  consumePolicyRef: default-consume-policy
+  consumePolicyName: default-consume-policy-name-for-test
+  consumePolicyDescription: Default Consume Policy description
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - created_at
+      - updated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+  - name: 001-plan-apply-create
+    commands:
+      - name: 001-plan-create
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-create.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 4
+                by_action.CREATE: 4
+          - select: >-
+              changes[?resource_type=='event_gateway' && resource_ref=='{{ .vars.egwRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.egwRef }}"
+          - select: >-
+              changes[?resource_type=='event_gateway_backend_cluster' && resource_ref=='{{ .vars.backendClusterRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.backendClusterRef }}"
+          - select: >-
+              changes[?resource_type=='event_gateway_virtual_cluster' && resource_ref=='{{ .vars.virtualClusterRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.virtualClusterRef }}"
+          - select: >-
+              changes[?resource_type=='event_gateway_virtual_cluster_consume_policy' && resource_ref=='{{ .vars.consumePolicyRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.consumePolicyRef }}"
+      - name: 002-apply-create
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-create.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 4
+                failed: 0
+
+      - name: 003-verify-create
+        run:
+          - get
+          - event-gateway
+          - virtual-cluster
+          - consume-policies
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - --virtual-cluster-name
+          - "{{ .vars.virtualClusterName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 1
+          - select: "[0]"
+            expect:
+              fields:
+                name: "{{ .vars.consumePolicyName }}"
+                description: "Default Consume Policy description"
+  - name: 002-plan-apply-update
+    inputOverlayDirs:
+      - overlays/001-update-fields
+    commands:
+      - name: 001-plan-update
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-update.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_virtual_cluster_consume_policy' && resource_ref=='{{ .vars.consumePolicyRef }}'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                resource_ref: "{{ .vars.consumePolicyRef }}"
+      - name: 002-apply-update
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-update.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 003-verify-update
+        run:
+          - get
+          - event-gateway
+          - virtual-cluster
+          - consume-policies
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - --virtual-cluster-name
+          - "{{ .vars.virtualClusterName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 1
+          - select: "[0]"
+            expect:
+              fields:
+                name: "{{ .vars.consumePolicyName }}"
+                type: modify_headers
+                description: Default Consume Policy description updated
+                enabled: false
+                labels:
+                  env: production
+                  version: v2
+                config:
+                  actions:
+                    - op: set
+                      key: x-env-updated
+                      value: production
+
+  - name: 003-sync-delete
+    inputOverlayDirs:
+      - overlays/002-sync-delete
+    commands:
+      - name: 001-plan-sync-delete
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-sync-delete.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: sync
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_virtual_cluster_consume_policy' && resource_ref=='{{ .vars.consumePolicyName }}'] | [0]
+            expect:
+              fields:
+                action: DELETE
+                resource_ref: "{{ .vars.consumePolicyName }}"
+      - name: 002-sync-delete
+        outputFormat: json
+        run:
+          - sync
+          - --plan
+          - "{{ .workdir }}/plan-sync-delete.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 003-verify-delete
+        run:
+          - get
+          - event-gateway
+          - virtual-cluster
+          - consume-policies
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - --virtual-cluster-name
+          - "{{ .vars.virtualClusterName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 0
+
+  - name: 004-root-level-consume-policy
+    inputOverlayDirs:
+      - overlays/003-root-level-declaration
+    commands:
+      - name: 001-plan-create
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-root-level.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_virtual_cluster_consume_policy' && resource_ref=='{{ .vars.consumePolicyRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.consumePolicyRef }}"
+      - name: 002-apply-create
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-root-level.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 003-verify-create
+        run:
+          - get
+          - event-gateway
+          - virtual-cluster
+          - consume-policies
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - --virtual-cluster-name
+          - "{{ .vars.virtualClusterName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 1
+          - select: "[0]"
+            expect:
+              fields:
+                name: "{{ .vars.consumePolicyName }}"
+                description: "{{ .vars.consumePolicyDescription }}"
+                enabled: true
+                labels:
+                  env: staging
+                  team: payments
+  - name: 005-sync-delete-root-level
+    inputOverlayDirs:
+      - overlays/004-sync-delete-root-level-declaration
+    commands:
+      - name: 001-plan-sync-delete-root-level
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-sync-delete-root-level.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: sync
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_virtual_cluster_consume_policy' && resource_ref=='{{ .vars.consumePolicyName }}'] | [0]
+            expect:
+              fields:
+                action: DELETE
+                resource_ref: "{{ .vars.consumePolicyName }}"
+      - name: 002-sync-delete-root-level
+        outputFormat: json
+        run:
+          - sync
+          - --plan
+          - "{{ .workdir }}/plan-sync-delete-root-level.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 003-verify-delete-root-level
+        run:
+          - get
+          - event-gateway
+          - virtual-cluster
+          - consume-policies
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - --virtual-cluster-name
+          - "{{ .vars.virtualClusterName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 0

--- a/test/e2e/scenarios/event-gateway/consume-policy/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/testdata/config.yaml
@@ -1,0 +1,47 @@
+_defaults:
+  kongctl:
+    namespace: event-gateways-vc-consume-policy-comprehensive-test
+
+event_gateways:
+  - ref: egw-cp-for-vc-consume-policy-test
+    name: egw-cp-for-vc-consume-policy-test
+    description: "EGW for Virtual Cluster Consume Policy Test"
+    backend_clusters:
+      - ref: default-backend-cluster
+        name: default-backend-cluster
+        description: "Backend Cluster for Test"
+        bootstrap_servers:
+          - "egw-backend-1.example.com:9092"
+          - "egw-backend-2.example.com:9092"
+        authentication:
+          type: anonymous
+        tls:
+          enabled: true
+          skip_verify: false
+          tls_versions:
+            - tls12
+            - tls13
+    virtual_clusters:
+      - ref: default-virtual-cluster-for-consume-policy-test
+        name: default-virtual-cluster-name-for-consume-policy-test
+        description: "Virtual Cluster for Consume Policy Test"
+        destination:
+          name: default-backend-cluster
+        authentication:
+         - type: anonymous
+        acl_mode: enforce_on_gateway
+        dns_label: vc-default
+        consume_policies:
+          - ref: default-consume-policy
+            name: default-consume-policy-name-for-test
+            description: Default Consume Policy description
+            type: modify_headers
+            enabled: true
+            labels:
+              env: staging
+              team: payments
+            config:
+              actions:
+                - op: set
+                  key: x-env
+                  value: staging

--- a/test/e2e/scenarios/event-gateway/dump/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/dump/scenario.yaml
@@ -16,6 +16,7 @@ vars:
   bcRef: default-backend-cluster
   vcRef: default-virtual-cluster
   producePolicyName: default-produce-policy-name-for-dump-test
+  consumePolicyName: default-consume-policy-name-for-dump-test
 
 defaults:
   mask:
@@ -43,7 +44,7 @@ steps:
           - select: summary
             expect:
               fields:
-                applied: 4
+                applied: 5
                 failed: 0
 
   # Dump event_gateways with child resources and validate the output structure.
@@ -86,6 +87,14 @@ steps:
               fields:
                 name: "{{ .vars.producePolicyName }}"
                 type: modify_headers
+                enabled: true
+          - name: consume-policy-present
+            select: >-
+              event_gateways[?name=='{{ .vars.egwName }}'] | [0].virtual_clusters[?name=='{{ .vars.vcRef }}'] | [0].consume_policies[?name=='{{ .vars.consumePolicyName }}'] | [0]
+            expect:
+              fields:
+                name: "{{ .vars.consumePolicyName }}"
+                type: schema_validation
                 enabled: true
           - name: namespace-label-preserved
             select: "_defaults.kongctl"

--- a/test/e2e/scenarios/event-gateway/dump/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/dump/testdata/config.yaml
@@ -45,13 +45,13 @@ event_gateways:
                   - op: remove
                     key: x-original-header
         consume_policies:
-        - condition: ""
-          config:
-            key_validation_action: mark
-            type: json
-            value_validation_action: skip
-          description: ""
-          enabled: true
-          name: default-consume-policy-name-for-dump-test
-          ref: default-consume-policy
-          type: schema_validation
+          - condition: ""
+            config:
+              key_validation_action: mark
+              type: json
+              value_validation_action: skip
+            description: ""
+            enabled: true
+            name: default-consume-policy-name-for-dump-test
+            ref: default-consume-policy
+            type: schema_validation

--- a/test/e2e/scenarios/event-gateway/dump/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/dump/testdata/config.yaml
@@ -44,3 +44,14 @@ event_gateways:
                     value: "${client_id}"
                   - op: remove
                     key: x-original-header
+        consume_policies:
+        - condition: ""
+          config:
+            key_validation_action: mark
+            type: json
+            value_validation_action: skip
+          description: ""
+          enabled: true
+          name: default-consume-policy-name-for-dump-test
+          ref: default-consume-policy
+          type: schema_validation

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/009-consume-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/009-consume-policy/config.yaml
@@ -1,0 +1,94 @@
+_defaults:
+  kongctl:
+    namespace: egw-plan-apply
+
+event_gateways:
+  - ref: plan-apply-egw
+    name: plan-apply-egw
+    description: "Updated description for plan apply workflow"
+    backend_clusters:
+      - ref: plan-apply-backend-cluster
+        name: plan-apply-backend-cluster
+        description: "Updated description for plan apply backend cluster"
+        bootstrap_servers:
+          - "egw-backend-1-updated.example.com:9092"
+        authentication:
+          type: anonymous
+        tls:
+          enabled: true
+          skip_verify: false
+          tls_versions:
+            - tls12
+            - tls13
+    virtual_clusters:
+      - ref: plan-apply-virtual-cluster
+        name: plan-apply-virtual-cluster
+        description: "Virtual cluster for plan apply workflow"
+        destination:
+          name: plan-apply-backend-cluster #id: !ref plan-apply-backend-cluster#id
+        authentication:
+          - type: sasl_scram
+            algorithm: sha512
+        acl_mode: enforce_on_gateway
+        dns_label: vc-default
+        consume_policies:
+        - condition: ""
+          description: description
+          enabled: true
+          name: skip-record-policy
+          ref: 019d62bd-e0fd-79e3-b523-9e2fcbe6284f
+          type: skip_record
+        cluster_policies:
+          - ref: plan-apply-cluster-policy
+            name: plan-apply-cluster-policy-name-for-test
+            description: Plan Apply Cluster Policy description
+            type: acls
+            enabled: true
+            config:
+              rules:
+                - action: "deny"
+                  operations:
+                  - name: "describe_configs"
+                  resource_names:
+                  - match: "*"
+                  resource_type: "transactional_id"
+    listeners:
+      - ref: plan-apply-listener
+        name: plan-apply-listener
+        description: "Listener for plan apply workflow"
+        ports:
+          - "9093-9095"
+        addresses:
+          - localhost
+        policies:
+          - ref: plan-apply-listener-1-policy-1-ref
+            name: plan-apply-listener-1-policy-1-name
+            type: forward_to_virtual_cluster
+            description: "Plan Apply Listener 1 Policy 1"
+            enabled: true
+            condition: "${ssl_sni} == \"example.com\""
+            labels:
+              env: staging
+              team: payments
+            config:
+              type: sni
+              advertised_port: 9092
+              sni_suffix: ".example.com"
+    data_plane_certificates:
+      - ref: plan-apply-dataplane-certificate-ref
+        name: plan-apply-dataplane-certificate-name
+        description: "Plan Apply Dataplane Certificate description"
+        certificate: |-
+          -----BEGIN CERTIFICATE-----
+          MIIB4TCCAYugAwIBAgIUAenxUyPjkSLCe2BQXoBMBacqgLowDQYJKoZIhvcNAQEL
+          BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+          GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yNDEwMjgyMDA3NDlaFw0zNDEw
+          MjYyMDA3NDlaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+          HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwXDANBgkqhkiG9w0BAQEF
+          AANLADBIAkEAyzipjrbAaLO/yPg7lL1dLWzhqNdc3S4YNR7f1RG9whWhbsPE2z42
+          e6WGFf9hggP6xjG4qbU8jFVczpd1UPwGbQIDAQABo1MwUTAdBgNVHQ4EFgQUkPPB
+          ghj+iHOHAKJlC1gLbKT/ZHQwHwYDVR0jBBgwFoAUkPPBghj+iHOHAKJlC1gLbKT/
+          ZHQwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAANBALfy49GvA2ld+u+G
+          Koxa8kCt7uywoqu0hfbBfUT4HqmXPvsuhz8RinE5ltxId108vtDNlD/+bKl+N5Ub
+          qKjBs0k=
+          -----END CERTIFICATE-----

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/009-consume-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/009-consume-policy/config.yaml
@@ -32,12 +32,12 @@ event_gateways:
         acl_mode: enforce_on_gateway
         dns_label: vc-default
         consume_policies:
-        - condition: ""
-          description: description
-          enabled: true
-          name: skip-record-policy
-          ref: plan-apply-consume-policy
-          type: skip_record
+          - condition: ""
+            description: description
+            enabled: true
+            name: skip-record-policy
+            ref: plan-apply-consume-policy
+            type: skip_record
         cluster_policies:
           - ref: plan-apply-cluster-policy
             name: plan-apply-cluster-policy-name-for-test

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/009-consume-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/009-consume-policy/config.yaml
@@ -36,7 +36,7 @@ event_gateways:
           description: description
           enabled: true
           name: skip-record-policy
-          ref: 019d62bd-e0fd-79e3-b523-9e2fcbe6284f
+          ref: plan-apply-consume-policy
           type: skip_record
         cluster_policies:
           - ref: plan-apply-cluster-policy

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/009-consume-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/009-consume-policy/config.yaml
@@ -31,6 +31,22 @@ event_gateways:
             algorithm: sha512
         acl_mode: enforce_on_gateway
         dns_label: vc-default
+        produce_policies:
+          - ref: plan-apply-produce-policy
+            name: plan-apply-produce-policy-name-for-test
+            description: Plan Apply Produce Policy description
+            type: modify_headers
+            enabled: true
+            labels:
+              env: staging
+              team: streaming
+            config:
+              actions:
+                - op: set
+                  key: x-producer-id
+                  value: "${client_id}"
+                - op: remove
+                  key: x-original-header
         consume_policies:
           - condition: ""
             description: description

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/scenario.yaml
@@ -32,7 +32,7 @@ vars:
   producePolicyRef: plan-apply-produce-policy
   producePolicyName: plan-apply-produce-policy-name-for-test
   producePolicyDesc: "Plan Apply Produce Policy description"
-  consumePolicyRef: 019d62bd-e0fd-79e3-b523-9e2fcbe6284f
+  consumePolicyRef: plan-apply-consume-policy
   consumePolicyName: skip-record-policy
 
 defaults:

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/scenario.yaml
@@ -32,6 +32,8 @@ vars:
   producePolicyRef: plan-apply-produce-policy
   producePolicyName: plan-apply-produce-policy-name-for-test
   producePolicyDesc: "Plan Apply Produce Policy description"
+  consumePolicyRef: 019d62bd-e0fd-79e3-b523-9e2fcbe6284f
+  consumePolicyName: skip-record-policy
 
 defaults:
   mask:
@@ -715,3 +717,81 @@ steps:
                 name: "{{ .vars.producePolicyName }}"
                 description: "{{ .vars.producePolicyDesc }}"
                 enabled: true
+  - name: 010-plan-apply-consume-policy
+    inputOverlayDirs:
+      - overlays/009-consume-policy
+    commands:
+      - name: 000-plan-create-consume-policy
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-consume-policy.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_virtual_cluster_consume_policy' && resource_ref=='{{ .vars.consumePolicyRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.consumePolicyRef }}"
+      - name: 001-diff-plan-text
+        outputFormat: text
+        parseAs: raw
+        run:
+          - diff
+          - --plan
+          - "{{ .workdir }}/plan-consume-policy.json"
+        assertions:
+          - select: stdout
+            expect:
+              fields:
+                "contains(@, 'Plan: 1 to add')": true
+                "contains(@, 'event_gateway_virtual_cluster_consume_policy \"plan-apply-consume-policy\" will be created')": true
+      - name: 002-apply-plan
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-consume-policy.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 003-verify-consume-policy
+        run:
+          - get
+          - event-gateway
+          - virtual-cluster
+          - consume-policies
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - --virtual-cluster-name
+          - "{{ .vars.vcName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 1
+          - select: "[0]"
+            expect:
+              fields:
+                name: "{{ .vars.consumePolicyName }}"
+                type: skip_record
+                enabled: true 

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/009-consume-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/009-consume-policy/config.yaml
@@ -30,6 +30,22 @@ event_gateways:
           - type: anonymous
         acl_mode: enforce_on_gateway
         dns_label: vc-default
+        produce_policies:
+          - ref: plan-sync-produce-policy
+            name: plan-sync-produce-policy-name-for-test
+            description: Plan Sync Produce Policy description
+            type: modify_headers
+            enabled: true
+            labels:
+              env: staging
+              team: streaming
+            config:
+              actions:
+                - op: set
+                  key: x-producer-id
+                  value: "${client_id}"
+                - op: remove
+                  key: x-original-header
         consume_policies:
           - condition: ""
             config:

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/009-consume-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/009-consume-policy/config.yaml
@@ -31,16 +31,16 @@ event_gateways:
         acl_mode: enforce_on_gateway
         dns_label: vc-default
         consume_policies:
-        - condition: ""
-          config:
-            key_validation_action: mark
-            type: json
-            value_validation_action: skip
-          description: ""
-          enabled: true
-          name: plan-sync-consume-policy-name-for-test
-          ref: plan-sync-consume-policy
-          type: schema_validation
+          - condition: ""
+            config:
+              key_validation_action: mark
+              type: json
+              value_validation_action: skip
+            description: ""
+            enabled: true
+            name: plan-sync-consume-policy-name-for-test
+            ref: plan-sync-consume-policy
+            type: schema_validation
         cluster_policies:
           - ref: plan-sync-cluster-policy
             name: plan-sync-cluster-policy-name-for-test

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/009-consume-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/009-consume-policy/config.yaml
@@ -1,0 +1,98 @@
+_defaults:
+  kongctl:
+    namespace: egw-plan-sync
+
+event_gateways:
+  - ref: plan-sync-egw
+    name: plan-sync-egw
+    description: "Updated description for plan sync workflow"
+    backend_clusters:
+      - ref: plan-sync-backend-cluster
+        name: plan-sync-backend-cluster
+        description: "Updated description for plan apply backend cluster"
+        bootstrap_servers:
+          - "egw-backend-1-updated.example.com:9092"
+        authentication:
+          type: anonymous
+        tls:
+          enabled: true
+          skip_verify: false
+          tls_versions:
+            - tls12
+            - tls13
+    virtual_clusters:
+      - ref: plan-sync-virtual-cluster
+        name: plan-sync-virtual-cluster
+        description: "Virtual cluster for plan sync workflow"
+        destination:
+          id: !ref plan-sync-backend-cluster#id
+        authentication:
+          - type: anonymous
+        acl_mode: enforce_on_gateway
+        dns_label: vc-default
+        consume_policies:
+        - condition: ""
+          config:
+            key_validation_action: mark
+            type: json
+            value_validation_action: skip
+          description: ""
+          enabled: true
+          name: plan-sync-consume-policy-name-for-test
+          ref: plan-sync-consume-policy
+          type: schema_validation
+        cluster_policies:
+          - ref: plan-sync-cluster-policy
+            name: plan-sync-cluster-policy-name-for-test
+            description: Plan Sync Cluster Policy description
+            type: acls
+            enabled: true
+            config:
+              rules:
+                - action: "deny"
+                  operations:
+                  - name: "describe_configs"
+                  resource_names:
+                  - match: "*"
+                  resource_type: "transactional_id"
+    listeners:
+      - ref: plan-sync-listener
+        name: plan-sync-listener
+        description: "Listener for plan sync workflow"
+        ports:
+          - 9092
+        addresses:
+          - localhost
+        policies:
+          - ref: plan-sync-listener-1-policy-1-ref
+            name: plan-sync-listener-1-policy-1-name
+            type: forward_to_virtual_cluster
+            description: "Plan Sync Listener 1 Policy 1"
+            enabled: true
+            condition: "${ssl_sni} == \"example.com\""
+            labels:
+              env: staging
+              team: payments
+            config:
+              type: port_mapping
+              destination:
+                id: !ref plan-sync-virtual-cluster#id
+              advertised_host: "example.com"
+    data_plane_certificates:
+      - ref: plan-sync-dataplane-certificate-ref
+        name: plan-sync-dataplane-certificate-name
+        description: "Plan Sync Dataplane Certificate description"
+        certificate: |-
+          -----BEGIN CERTIFICATE-----
+          MIIB4TCCAYugAwIBAgIUAenxUyPjkSLCe2BQXoBMBacqgLowDQYJKoZIhvcNAQEL
+          BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+          GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yNDEwMjgyMDA3NDlaFw0zNDEw
+          MjYyMDA3NDlaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+          HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwXDANBgkqhkiG9w0BAQEF
+          AANLADBIAkEAyzipjrbAaLO/yPg7lL1dLWzhqNdc3S4YNR7f1RG9whWhbsPE2z42
+          e6WGFf9hggP6xjG4qbU8jFVczpd1UPwGbQIDAQABo1MwUTAdBgNVHQ4EFgQUkPPB
+          ghj+iHOHAKJlC1gLbKT/ZHQwHwYDVR0jBBgwFoAUkPPBghj+iHOHAKJlC1gLbKT/
+          ZHQwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAANBALfy49GvA2ld+u+G
+          Koxa8kCt7uywoqu0hfbBfUT4HqmXPvsuhz8RinE5ltxId108vtDNlD/+bKl+N5Ub
+          qKjBs0k=
+          -----END CERTIFICATE-----

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/scenario.yaml
@@ -32,6 +32,8 @@ vars:
   producePolicyRef: plan-sync-produce-policy
   producePolicyName: plan-sync-produce-policy-name-for-test
   producePolicyDesc: "Plan Sync Produce Policy description"
+  consumePolicyRef: plan-sync-consume-policy
+  consumePolicyName: plan-sync-consume-policy-name-for-test
 
 defaults:
   mask:
@@ -786,6 +788,96 @@ steps:
                 name: "{{ .vars.producePolicyName }}"
                 description: "{{ .vars.producePolicyDesc }}"
                 type: modify_headers
+                enabled: true
+      - name: 004-diff-no-changes
+        outputFormat: text
+        parseAs: raw
+        run:
+          - diff
+          - -f
+          - "{{ .workdir }}/config.yaml"
+        assertions:
+          - select: stdout
+            expect:
+              fields:
+                "contains(@, 'No changes detected. Konnect is up to date.')": true
+  - name: 010-plan-sync-consume-policy
+    inputOverlayDirs:
+      - overlays/009-consume-policy
+    commands:
+      - name: 000-plan-create-consume-policy
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-consume-policy.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: sync
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_virtual_cluster_consume_policy' && resource_ref=='{{ .vars.consumePolicyRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.consumePolicyRef }}"
+      - name: 001-diff-plan-text
+        outputFormat: text
+        parseAs: raw
+        run:
+          - diff
+          - --plan
+          - "{{ .workdir }}/plan-consume-policy.json"
+        assertions:
+          - select: stdout
+            expect:
+              fields:
+                "contains(@, 'Plan: 1 to add')": true
+                "contains(@, 'event_gateway_virtual_cluster_consume_policy \"plan-sync-consume-policy\" will be created')": true
+      - name: 002-sync-plan
+        outputFormat: json
+        run:
+          - sync
+          - --plan
+          - "{{ .workdir }}/plan-consume-policy.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 003-verify-consume-policy
+        run:
+          - get
+          - event-gateway
+          - virtual-cluster
+          - consume-policies
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - --virtual-cluster-name
+          - "{{ .vars.vcName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 1
+          - select: "[0]"
+            expect:
+              fields:
+                name: "{{ .vars.consumePolicyName }}"
+                type: schema_validation
                 enabled: true
       - name: 004-diff-no-changes
         outputFormat: text


### PR DESCRIPTION
## Summary
In this PR, we are adding support for Event Gateway Virtual Cluster Consume Policy - 
1. Declarative Management
2. Imperative Get
3. Dump
4. View

Note:
Resource key is `consume_policies` when nested under `virtual_clusters`, and `event_gateway_virtual_cluster_consume_policies` when declared at root level.


Example for imperative Get:
```
kongctl get egw vc consume-policies --gateway-id $EGW_ID --virtual-cluster-id $VC_ID --pat $PAT

kongctl get egw vc consume-policies $POLICY_ID --gateway-id $EGW_ID --virtual-cluster-id $VC_ID --pat $PAT
```

## Full changelog
[Implement https://github.com/Kong/kongctl/issues/215](https://github.com/Kong/kongctl/issues/215)

## Testing
- [x] Unit tests
- [x] E2E tests
- [ ] Manual testing on Universal
- [ ] Manual testing on Kubernetes

