### PR TITLE
test: add api publication omitted-auth no-op e2e coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ CLAUDE.local.md
 
 .serena/
 .latest-e2e
+.e2e-artifacts/
+.cache/
 
 # Python cache folders
 __pycache__/

--- a/test/e2e/scenarios/portal/publication-auth-omitted-noop/overlays/002-omit-auth-strategy-ids/apis.yaml
+++ b/test/e2e/scenarios/portal/publication-auth-omitted-noop/overlays/002-omit-auth-strategy-ids/apis.yaml
@@ -1,0 +1,12 @@
+apis:
+  - ref: sms
+    name: "E2E SMS API"
+    description: "Demo API used to verify omitted publication auth strategy fields stay unmanaged"
+    versions:
+      - ref: sms-v1
+        version: "1.0.0"
+        spec: !file ./apis/e2e-api.yaml
+    publications:
+      - ref: sms-to-e2e-portal
+        portal_id: !ref e2e-portal#id
+        visibility: public

--- a/test/e2e/scenarios/portal/publication-auth-omitted-noop/scenario.yaml
+++ b/test/e2e/scenarios/portal/publication-auth-omitted-noop/scenario.yaml
@@ -1,0 +1,129 @@
+baseInputsPath: testdata
+
+env:
+  KONGCTL_LOG_LEVEL: debug
+
+vars:
+  portalRef: e2e-portal
+  portalName: "E2E Publication Portal"
+  apiRef: sms
+  apiName: "E2E SMS API"
+  authStrategyRef: key-auth
+  publicationRef: sms-to-e2e-portal
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - created_at
+      - updated_at
+      - resource_id
+      - change_id
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-apply-managed-publication
+    commands:
+      - name: 000-apply
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - -f
+          - "{{ .workdir }}/auth-strategies.yaml"
+          - -f
+          - "{{ .workdir }}/apis.yaml"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 5
+                failed: 0
+                skipped: 0
+                status: "success"
+                total_changes: 5
+          - select: >-
+              plan.changes[?resource_type=='api_publication' &&
+                            resource_ref=='{{ .vars.publicationRef }}'] | [0]
+            expect:
+              fields:
+                action: "CREATE"
+                "fields.auth_strategy_ids | length(@)": 1
+      - name: 001-get-api-publications
+        run:
+          - get
+          - api
+          - publications
+          - --api-name
+          - "{{ .vars.apiName }}"
+        assertions:
+          - select: "[0]"
+            expect:
+              fields:
+                visibility: "public"
+                "length(auth_strategy_ids)": 1
+                "contains(auth_strategy_ids[0], '-')": true
+
+  - name: 002-omit-auth-strategy-ids
+    inputOverlayDirs:
+      - overlays/002-omit-auth-strategy-ids
+    commands:
+      - name: 000-apply-no-op
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - -f
+          - "{{ .workdir }}/auth-strategies.yaml"
+          - -f
+          - "{{ .workdir }}/apis.yaml"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 0
+                failed: 0
+                skipped: 0
+                status: "success"
+                total_changes: 0
+      - name: 001-get-api-publications
+        run:
+          - get
+          - api
+          - publications
+          - --api-name
+          - "{{ .vars.apiName }}"
+        assertions:
+          - select: "[0]"
+            expect:
+              fields:
+                visibility: "public"
+                "length(auth_strategy_ids)": 1
+                "contains(auth_strategy_ids[0], '-')": true
+      - name: 002-plan-no-op
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - -f
+          - "{{ .workdir }}/auth-strategies.yaml"
+          - -f
+          - "{{ .workdir }}/apis.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+          - select: "changes[?resource_type=='api_publication']"
+            expect:
+              fields:
+                "length(@)": 0

--- a/test/e2e/scenarios/portal/publication-auth-omitted-noop/testdata/apis.yaml
+++ b/test/e2e/scenarios/portal/publication-auth-omitted-noop/testdata/apis.yaml
@@ -1,0 +1,14 @@
+apis:
+  - ref: sms
+    name: "E2E SMS API"
+    description: "Demo API used to verify omitted publication auth strategy fields stay unmanaged"
+    versions:
+      - ref: sms-v1
+        version: "1.0.0"
+        spec: !file ./apis/e2e-api.yaml
+    publications:
+      - ref: sms-to-e2e-portal
+        portal_id: !ref e2e-portal#id
+        visibility: public
+        auth_strategy_ids:
+          - !ref key-auth#id

--- a/test/e2e/scenarios/portal/publication-auth-omitted-noop/testdata/apis/e2e-api.yaml
+++ b/test/e2e/scenarios/portal/publication-auth-omitted-noop/testdata/apis/e2e-api.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.0
+info:
+  title: E2E SMS API
+  version: "1.0.0"
+paths:
+  /messages:
+    get:
+      summary: List messages
+      responses:
+        "200":
+          description: OK

--- a/test/e2e/scenarios/portal/publication-auth-omitted-noop/testdata/auth-strategies.yaml
+++ b/test/e2e/scenarios/portal/publication-auth-omitted-noop/testdata/auth-strategies.yaml
@@ -1,0 +1,9 @@
+application_auth_strategies:
+  - ref: key-auth
+    name: key-auth
+    display_name: "Key Auth"
+    strategy_type: key_auth
+    configs:
+      key_auth:
+        key_names:
+          - X-API-Key

--- a/test/e2e/scenarios/portal/publication-auth-omitted-noop/testdata/portal.yaml
+++ b/test/e2e/scenarios/portal/publication-auth-omitted-noop/testdata/portal.yaml
@@ -1,0 +1,11 @@
+portals:
+  - ref: e2e-portal
+    name: "E2E Publication Portal"
+    display_name: "E2E Publication Portal"
+    description: "Portal used by the API publication omitted auth strategy scenario"
+    authentication_enabled: false
+    rbac_enabled: false
+    auto_approve_developers: false
+    auto_approve_applications: false
+    default_api_visibility: "public"
+    default_page_visibility: "public"


### PR DESCRIPTION
## Summary
- add an e2e scenario covering `api_publication` behavior when `auth_strategy_ids` is omitted after an initial apply
- assert that `apply` remains a no-op and `plan --mode apply` reports zero `api_publication` changes
- ignore local `.e2e-artifacts/` and `.cache/` directories generated during reproducibility work

## Why
Issue #37 reported repeated no-op `api_publication` updates after apply. I reproduced current behavior against Konnect and did not reproduce the issue on the current branch. The repository already had coverage for the `auth_strategy_ids: []` case; this PR adds the omitted-field case from the original report.

## Validation
- ran `portal/auth-strategy-link` e2e scenario against live Konnect
- ran new `portal/publication-auth-omitted-noop` e2e scenario against live Konnect

Resolved #37 
