### PR TITLE
Feat: Event gateway schema registry

### DIFF
--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -2290,6 +2290,7 @@ func createStateClient(kkClient helpers.SDKAPI) *state.Client {
 		EventGatewayClusterPolicyAPI:        kkClient.GetEventGatewayClusterPolicyAPI(),
 		EventGatewayProducePolicyAPI:        kkClient.GetEventGatewayProducePolicyAPI(),
 		EventGatewayConsumePolicyAPI:        kkClient.GetEventGatewayConsumePolicyAPI(),
+		EventGatewaySchemaRegistryAPI:       kkClient.GetEventGatewaySchemaRegistryAPI(),
 		// Organization APIs
 		OrganizationTeamAPI: kkClient.GetOrganizationTeamAPI(),
 	})

--- a/internal/cmd/root/products/konnect/eventgateway/child_common.go
+++ b/internal/cmd/root/products/konnect/eventgateway/child_common.go
@@ -41,6 +41,12 @@ const (
 	dataPlaneCertIDConfigPath   = "konnect.event-gateway.data-plane-certificate.id"
 	dataPlaneCertNameConfigPath = "konnect.event-gateway.data-plane-certificate.name"
 
+	schemaRegistryIDFlagName   = "schema-registry-id"
+	schemaRegistryNameFlagName = "schema-registry-name"
+
+	schemaRegistryIDConfigPath   = "konnect.event-gateway.schema-registry.id"
+	schemaRegistryNameConfigPath = "konnect.event-gateway.schema-registry.name"
+
 	valueNA = "n/a"
 )
 
@@ -233,6 +239,42 @@ func bindDataPlaneCertChildFlags(c *cobra.Command, args []string) error {
 
 func getDataPlaneCertIdentifiers(cfg config.Hook) (id string, name string) {
 	return cfg.GetString(dataPlaneCertIDConfigPath), cfg.GetString(dataPlaneCertNameConfigPath)
+}
+
+func addSchemaRegistryChildFlags(cmd *cobra.Command) {
+	cmd.Flags().String(schemaRegistryIDFlagName, "",
+		fmt.Sprintf(`The ID of the schema registry to retrieve.
+- Config path: [ %s ]`, schemaRegistryIDConfigPath))
+	cmd.Flags().String(schemaRegistryNameFlagName, "",
+		fmt.Sprintf(`The name of the schema registry to retrieve.
+- Config path: [ %s ]`, schemaRegistryNameConfigPath))
+	cmd.MarkFlagsMutuallyExclusive(schemaRegistryIDFlagName, schemaRegistryNameFlagName)
+}
+
+func bindSchemaRegistryChildFlags(c *cobra.Command, args []string) error {
+	helper := cmd.BuildHelper(c, args)
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	if flag := c.Flags().Lookup(schemaRegistryIDFlagName); flag != nil {
+		if err := cfg.BindFlag(schemaRegistryIDConfigPath, flag); err != nil {
+			return err
+		}
+	}
+
+	if flag := c.Flags().Lookup(schemaRegistryNameFlagName); flag != nil {
+		if err := cfg.BindFlag(schemaRegistryNameConfigPath, flag); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getSchemaRegistryIdentifiers(cfg config.Hook) (id string, name string) {
+	return cfg.GetString(schemaRegistryIDConfigPath), cfg.GetString(schemaRegistryNameConfigPath)
 }
 
 func resolveEventGatewayIDByName(

--- a/internal/cmd/root/products/konnect/eventgateway/getEventGateway.go
+++ b/internal/cmd/root/products/konnect/eventgateway/getEventGateway.go
@@ -520,6 +520,11 @@ func newGetEventGatewayControlPlaneCmd(verb verbs.VerbValue,
 		rv.AddCommand(dataPlaneCertsCmd)
 	}
 
+	schemaRegistriesCmd := newGetEventGatewaySchemaRegistriesCmd(verb, addParentFlags, parentPreRun)
+	if schemaRegistriesCmd != nil {
+		rv.AddCommand(schemaRegistriesCmd)
+	}
+
 	listenerPoliciesCmd := newGetEventGatewayListenerPoliciesCmd(verb, addParentFlags, parentPreRun)
 	if listenerPoliciesCmd != nil {
 		rv.AddCommand(listenerPoliciesCmd)

--- a/internal/cmd/root/products/konnect/eventgateway/interactive_children.go
+++ b/internal/cmd/root/products/konnect/eventgateway/interactive_children.go
@@ -19,6 +19,7 @@ func init() {
 	tableview.RegisterChildLoader("event-gateway", "virtual-clusters", loadEventGatewayVirtualClusters)
 	tableview.RegisterChildLoader("event-gateway", "data-plane-certificates", loadEventGatewayDataPlaneCertificates)
 	tableview.RegisterChildLoader("event-gateway", "listeners", loadEventGatewayListeners)
+	tableview.RegisterChildLoader("event-gateway", "schema-registries", loadEventGatewaySchemaRegistries)
 	tableview.RegisterChildLoader("listener", "policies", loadEventGatewayListenerPolicies)
 	tableview.RegisterChildLoader("virtual-cluster", "cluster-policies", loadEventGatewayVirtualClusterClusterPolicies)
 	tableview.RegisterChildLoader("virtual-cluster", "produce-policies", loadEventGatewayVirtualClusterProducePolicies)
@@ -408,4 +409,42 @@ func loadEventGatewayDataPlaneCertificates(
 	}
 
 	return buildDataPlaneCertChildView(certs), nil
+}
+
+func loadEventGatewaySchemaRegistries(
+	_ context.Context,
+	helper cmd.Helper,
+	parent any,
+) (tableview.ChildView, error) {
+	gatewayID, err := eventGatewayIDFromParent(parent)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	registryAPI := sdk.GetEventGatewaySchemaRegistryAPI()
+	if registryAPI == nil {
+		return tableview.ChildView{}, fmt.Errorf("event gateway schema registry client is not available")
+	}
+
+	registries, err := fetchSchemaRegistries(helper, registryAPI, gatewayID, cfg, "")
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	return buildSchemaRegistryChildView(registries), nil
 }

--- a/internal/cmd/root/products/konnect/eventgateway/schema_registries.go
+++ b/internal/cmd/root/products/konnect/eventgateway/schema_registries.go
@@ -1,0 +1,502 @@
+package eventgateway
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/table"
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/cmd"
+	cmdCommon "github.com/kong/kongctl/internal/cmd/common"
+	"github.com/kong/kongctl/internal/cmd/output/tableview"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
+	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/kong/kongctl/internal/config"
+	"github.com/kong/kongctl/internal/konnect/helpers"
+	"github.com/kong/kongctl/internal/meta"
+	"github.com/kong/kongctl/internal/util"
+	"github.com/kong/kongctl/internal/util/i18n"
+	"github.com/kong/kongctl/internal/util/normalizers"
+	"github.com/segmentio/cli"
+	"github.com/spf13/cobra"
+)
+
+const (
+	schemaRegistriesCommandName = "schema-registries"
+)
+
+type schemaRegistrySummaryRecord struct {
+	ID               string
+	Name             string
+	Type             string
+	Description      string
+	LocalCreatedTime string
+	LocalUpdatedTime string
+}
+
+var (
+	schemaRegistriesUse = schemaRegistriesCommandName
+
+	schemaRegistriesShort = i18n.T("root.products.konnect.eventgateway.schemaRegistriesShort",
+		"Manage schema registries for an Event Gateway")
+	schemaRegistriesLong = normalizers.LongDesc(
+		i18n.T(
+			"root.products.konnect.eventgateway.schemaRegistriesLong",
+			`Use the schema-registries command to list or retrieve schema registries for a specific Event Gateway.`,
+		),
+	)
+	schemaRegistriesExample = normalizers.Examples(
+		i18n.T("root.products.konnect.eventgateway.schemaRegistriesExamples",
+			fmt.Sprintf(`
+# List schema registries for an event gateway by ID
+%[1]s get event-gateway schema-registries --gateway-id <gateway-id>
+# List schema registries for an event gateway by name
+%[1]s get event-gateway schema-registries --gateway-name my-gateway
+# Get a specific schema registry by ID (positional argument)
+%[1]s get event-gateway schema-registries --gateway-id <gateway-id> <schema-registry-id>
+# Get a specific schema registry by name (positional argument)
+%[1]s get event-gateway schema-registries --gateway-id <gateway-id> my-registry
+# Get a specific schema registry by ID (flag)
+%[1]s get event-gateway schema-registries --gateway-id <gateway-id> --schema-registry-id <registry-id>
+# Get a specific schema registry by name (flag)
+%[1]s get event-gateway schema-registries --gateway-name my-gateway --schema-registry-name my-registry
+`, meta.CLIName)))
+)
+
+func newGetEventGatewaySchemaRegistriesCmd(
+	verb verbs.VerbValue,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     schemaRegistriesUse,
+		Short:   schemaRegistriesShort,
+		Long:    schemaRegistriesLong,
+		Example: schemaRegistriesExample,
+		Aliases: []string{"schema-registry", "sr"},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if parentPreRun != nil {
+				if err := parentPreRun(cmd, args); err != nil {
+					return err
+				}
+			}
+			if err := bindEventGatewayChildFlags(cmd, args); err != nil {
+				return err
+			}
+			return bindSchemaRegistryChildFlags(cmd, args)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			handler := schemaRegistriesHandler{cmd: cmd}
+			return handler.run(args)
+		},
+	}
+
+	addEventGatewayChildFlags(cmd)
+	addSchemaRegistryChildFlags(cmd)
+
+	if addParentFlags != nil {
+		addParentFlags(verb, cmd)
+	}
+
+	return cmd
+}
+
+type schemaRegistriesHandler struct {
+	cmd *cobra.Command
+}
+
+func (h schemaRegistriesHandler) run(args []string) error {
+	helper := cmd.BuildHelper(h.cmd, args)
+
+	if len(args) > 1 {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf(
+				"too many arguments. Listing schema registries requires 0 or 1 arguments (ID or name)"),
+		}
+	}
+
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	// Check if positional arg and flags are both provided
+	if len(args) == 1 {
+		srID, srName := getSchemaRegistryIdentifiers(cfg)
+		if srID != "" || srName != "" {
+			return &cmd.ConfigurationError{
+				Err: fmt.Errorf(
+					"cannot specify both positional argument and --%s or --%s flags",
+					schemaRegistryIDFlagName,
+					schemaRegistryNameFlagName,
+				),
+			}
+		}
+	}
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+
+	outType, err := helper.GetOutputFormat()
+	if err != nil {
+		return err
+	}
+
+	printer, err := cli.Format(outType.String(), helper.GetStreams().Out)
+	if err != nil {
+		return err
+	}
+	defer printer.Flush()
+
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return err
+	}
+
+	gatewayID, gatewayName := getEventGatewayIdentifiers(cfg)
+	if gatewayID != "" && gatewayName != "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf("only one of --%s or --%s can be provided", gatewayIDFlagName, gatewayNameFlagName),
+		}
+	}
+
+	if gatewayID == "" && gatewayName == "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf(
+				"an event gateway identifier is required. Provide --%s or --%s",
+				gatewayIDFlagName,
+				gatewayNameFlagName,
+			),
+		}
+	}
+
+	if gatewayID == "" {
+		gatewayID, err = resolveEventGatewayIDByName(gatewayName, sdk.GetEventGatewayControlPlaneAPI(), helper, cfg)
+		if err != nil {
+			return err
+		}
+	}
+
+	registryAPI := sdk.GetEventGatewaySchemaRegistryAPI()
+	if registryAPI == nil {
+		return &cmd.ExecutionError{
+			Msg: "Schema registry client is not available",
+			Err: fmt.Errorf("schema registry client not configured"),
+		}
+	}
+
+	// Validate mutual exclusivity of schema registry ID and name flags
+	srID, srName := getSchemaRegistryIdentifiers(cfg)
+	if srID != "" && srName != "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf(
+				"only one of --%s or --%s can be provided",
+				schemaRegistryIDFlagName,
+				schemaRegistryNameFlagName,
+			),
+		}
+	}
+
+	var srIdentifier string
+	if len(args) == 1 {
+		srIdentifier = strings.TrimSpace(args[0])
+	} else if srID != "" {
+		srIdentifier = srID
+	} else if srName != "" {
+		srIdentifier = srName
+	}
+
+	if srIdentifier != "" {
+		return h.getSingleSchemaRegistry(
+			helper,
+			registryAPI,
+			gatewayID,
+			srIdentifier,
+			outType,
+			printer,
+			cfg,
+		)
+	}
+
+	return h.listSchemaRegistries(helper, registryAPI, gatewayID, outType, printer, cfg)
+}
+
+func (h schemaRegistriesHandler) listSchemaRegistries(
+	helper cmd.Helper,
+	registryAPI helpers.EventGatewaySchemaRegistryAPI,
+	gatewayID string,
+	outType cmdCommon.OutputFormat,
+	printer cli.PrintFlusher,
+	cfg config.Hook,
+) error {
+	registries, err := fetchSchemaRegistries(helper, registryAPI, gatewayID, cfg, "")
+	if err != nil {
+		return err
+	}
+
+	records := make([]schemaRegistrySummaryRecord, 0, len(registries))
+	for _, sr := range registries {
+		records = append(records, schemaRegistryToRecord(sr))
+	}
+
+	tableRows := make([]table.Row, 0, len(records))
+	for _, record := range records {
+		tableRows = append(tableRows, table.Row{record.ID, record.Name, record.Type})
+	}
+
+	return tableview.RenderForFormat(
+		helper,
+		false,
+		outType,
+		printer,
+		helper.GetStreams(),
+		records,
+		registries,
+		"",
+		tableview.WithCustomTable([]string{"ID", "NAME", "TYPE"}, tableRows),
+		tableview.WithRootLabel(helper.GetCmd().Name()),
+	)
+}
+
+func (h schemaRegistriesHandler) getSingleSchemaRegistry(
+	helper cmd.Helper,
+	registryAPI helpers.EventGatewaySchemaRegistryAPI,
+	gatewayID string,
+	identifier string,
+	outType cmdCommon.OutputFormat,
+	printer cli.PrintFlusher,
+	cfg config.Hook,
+) error {
+	registryID := identifier
+	if !util.IsValidUUID(identifier) {
+		// Use name filter to optimize the list query, then match exactly
+		registries, err := fetchSchemaRegistries(helper, registryAPI, gatewayID, cfg, identifier)
+		if err != nil {
+			return err
+		}
+		match := findSchemaRegistryByName(registries, identifier)
+		if match == nil {
+			return &cmd.ConfigurationError{
+				Err: fmt.Errorf("schema registry %q not found", identifier),
+			}
+		}
+		registryID = match.ID
+	}
+
+	res, err := registryAPI.GetEventGatewaySchemaRegistry(helper.GetContext(), gatewayID, registryID)
+	if err != nil {
+		attrs := cmd.TryConvertErrorToAttrs(err)
+		return cmd.PrepareExecutionError("Failed to get schema registry", err, helper.GetCmd(), attrs...)
+	}
+
+	sr := res.GetSchemaRegistry()
+	if sr == nil {
+		return &cmd.ExecutionError{
+			Msg: "Schema registry response was empty",
+			Err: fmt.Errorf("no schema registry returned for id %s", registryID),
+		}
+	}
+
+	return tableview.RenderForFormat(
+		helper,
+		false,
+		outType,
+		printer,
+		helper.GetStreams(),
+		schemaRegistryToRecord(*sr),
+		sr,
+		"",
+		tableview.WithRootLabel(helper.GetCmd().Name()),
+	)
+}
+
+func fetchSchemaRegistries(
+	helper cmd.Helper,
+	registryAPI helpers.EventGatewaySchemaRegistryAPI,
+	gatewayID string,
+	cfg config.Hook,
+	nameFilter string,
+) ([]kkComps.SchemaRegistry, error) {
+	requestPageSize := int64(cfg.GetInt(common.RequestPageSizeConfigPath))
+	if requestPageSize < 1 {
+		requestPageSize = int64(common.DefaultRequestPageSize)
+	}
+
+	var allData []kkComps.SchemaRegistry
+	var pageAfter *string
+
+	for {
+		req := kkOps.ListEventGatewaySchemaRegistriesRequest{
+			GatewayID: gatewayID,
+			PageSize:  new(requestPageSize),
+		}
+
+		// Apply name filter if provided (fuzzy match; exact match is done client-side)
+		if nameFilter != "" {
+			req.Filter = &kkComps.EventGatewayCommonFilter{
+				Name: &kkComps.StringFieldContainsFilter{
+					Contains: nameFilter,
+				},
+			}
+		}
+
+		if pageAfter != nil {
+			req.PageAfter = pageAfter
+		}
+
+		res, err := registryAPI.ListEventGatewaySchemaRegistries(helper.GetContext(), req)
+		if err != nil {
+			attrs := cmd.TryConvertErrorToAttrs(err)
+			return nil, cmd.PrepareExecutionError(
+				"Failed to list schema registries", err, helper.GetCmd(), attrs...)
+		}
+
+		if res.GetListSchemaRegistriesResponse() == nil {
+			break
+		}
+
+		data := res.GetListSchemaRegistriesResponse().Data
+		allData = append(allData, data...)
+
+		if res.GetListSchemaRegistriesResponse().Meta == nil ||
+			res.GetListSchemaRegistriesResponse().Meta.Page.Next == nil {
+			break
+		}
+
+		u, err := url.Parse(*res.GetListSchemaRegistriesResponse().Meta.Page.Next)
+		if err != nil {
+			return nil, cmd.PrepareExecutionError(
+				"Failed to list schema registries: invalid cursor",
+				err,
+				helper.GetCmd(),
+			)
+		}
+
+		values := u.Query()
+		pageAfter = new(values.Get("page[after]"))
+	}
+
+	return allData, nil
+}
+
+func findSchemaRegistryByName(
+	registries []kkComps.SchemaRegistry,
+	name string,
+) *kkComps.SchemaRegistry {
+	lowered := strings.ToLower(name)
+	for i := range registries {
+		if strings.ToLower(registries[i].Name) == lowered {
+			return &registries[i]
+		}
+	}
+	return nil
+}
+
+func schemaRegistryToRecord(sr kkComps.SchemaRegistry) schemaRegistrySummaryRecord {
+	id := sr.ID
+	if id != "" {
+		id = util.AbbreviateUUID(id)
+	} else {
+		id = valueNA
+	}
+
+	name := sr.Name
+	if name == "" {
+		name = valueNA
+	}
+
+	srType := sr.Type
+	if srType == "" {
+		srType = valueNA
+	}
+
+	description := valueNA
+	if sr.Description != nil && *sr.Description != "" {
+		description = *sr.Description
+	}
+
+	createdAt := sr.CreatedAt.In(time.Local).Format("2006-01-02 15:04:05")
+	updatedAt := sr.UpdatedAt.In(time.Local).Format("2006-01-02 15:04:05")
+
+	return schemaRegistrySummaryRecord{
+		ID:               id,
+		Name:             name,
+		Type:             srType,
+		Description:      description,
+		LocalCreatedTime: createdAt,
+		LocalUpdatedTime: updatedAt,
+	}
+}
+
+func schemaRegistryDetailView(sr *kkComps.SchemaRegistry) string {
+	if sr == nil {
+		return ""
+	}
+
+	id := strings.TrimSpace(sr.ID)
+	if id == "" {
+		id = valueNA
+	}
+
+	name := sr.Name
+	if name == "" {
+		name = valueNA
+	}
+
+	srType := sr.Type
+	if srType == "" {
+		srType = valueNA
+	}
+
+	description := valueNA
+	if sr.Description != nil && strings.TrimSpace(*sr.Description) != "" {
+		description = strings.TrimSpace(*sr.Description)
+	}
+
+	createdAt := sr.CreatedAt.In(time.Local).Format("2006-01-02 15:04:05")
+	updatedAt := sr.UpdatedAt.In(time.Local).Format("2006-01-02 15:04:05")
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "id: %s\n", id)
+	fmt.Fprintf(&b, "name: %s\n", name)
+	fmt.Fprintf(&b, "type: %s\n", srType)
+	fmt.Fprintf(&b, "description: %s\n", description)
+	fmt.Fprintf(&b, "created_at: %s\n", createdAt)
+	fmt.Fprintf(&b, "updated_at: %s\n", updatedAt)
+
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func buildSchemaRegistryChildView(registries []kkComps.SchemaRegistry) tableview.ChildView {
+	tableRows := make([]table.Row, 0, len(registries))
+	for i := range registries {
+		record := schemaRegistryToRecord(registries[i])
+		tableRows = append(tableRows, table.Row{record.ID, record.Name, record.Type})
+	}
+
+	detailFn := func(index int) string {
+		if index < 0 || index >= len(registries) {
+			return ""
+		}
+		return schemaRegistryDetailView(&registries[index])
+	}
+
+	return tableview.ChildView{
+		Headers:        []string{"ID", "NAME", "TYPE"},
+		Rows:           tableRows,
+		DetailRenderer: detailFn,
+		Title:          "Schema Registries",
+		ParentType:     "schema-registry",
+		DetailContext: func(index int) any {
+			if index < 0 || index >= len(registries) {
+				return nil
+			}
+			return &registries[index]
+		},
+	}
+}

--- a/internal/cmd/root/products/konnect/eventgateway/schema_registries.go
+++ b/internal/cmd/root/products/konnect/eventgateway/schema_registries.go
@@ -1,7 +1,9 @@
 package eventgateway
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/url"
 	"strings"
 	"time"
@@ -35,6 +37,13 @@ type schemaRegistrySummaryRecord struct {
 	Description      string
 	LocalCreatedTime string
 	LocalUpdatedTime string
+}
+
+// schemaRegistryEntry wraps the SDK SchemaRegistry with raw config data from the API
+// response (the SDK Config struct is empty/opaque).
+type schemaRegistryEntry struct {
+	kkComps.SchemaRegistry
+	RawConfig map[string]any
 }
 
 var (
@@ -249,6 +258,12 @@ func (h schemaRegistriesHandler) listSchemaRegistries(
 		tableRows = append(tableRows, table.Row{record.ID, record.Name, record.Type})
 	}
 
+	// Extract base SDK types for JSON/YAML serialization.
+	rawRegistries := make([]kkComps.SchemaRegistry, 0, len(registries))
+	for _, sr := range registries {
+		rawRegistries = append(rawRegistries, sr.SchemaRegistry)
+	}
+
 	return tableview.RenderForFormat(
 		helper,
 		false,
@@ -256,7 +271,7 @@ func (h schemaRegistriesHandler) listSchemaRegistries(
 		printer,
 		helper.GetStreams(),
 		records,
-		registries,
+		rawRegistries,
 		"",
 		tableview.WithCustomTable([]string{"ID", "NAME", "TYPE"}, tableRows),
 		tableview.WithRootLabel(helper.GetCmd().Name()),
@@ -302,13 +317,27 @@ func (h schemaRegistriesHandler) getSingleSchemaRegistry(
 		}
 	}
 
+	// Parse raw response to retrieve the config (SDK Config struct is opaque).
+	entry := schemaRegistryEntry{SchemaRegistry: *sr}
+	if res.RawResponse != nil && res.RawResponse.Body != nil {
+		bodyBytes, readErr := io.ReadAll(res.RawResponse.Body)
+		if readErr == nil && len(bodyBytes) > 0 {
+			var rawResp struct {
+				Config map[string]any `json:"config"`
+			}
+			if jsonErr := json.Unmarshal(bodyBytes, &rawResp); jsonErr == nil {
+				entry.RawConfig = rawResp.Config
+			}
+		}
+	}
+
 	return tableview.RenderForFormat(
 		helper,
 		false,
 		outType,
 		printer,
 		helper.GetStreams(),
-		schemaRegistryToRecord(*sr),
+		schemaRegistryToRecord(entry),
 		sr,
 		"",
 		tableview.WithRootLabel(helper.GetCmd().Name()),
@@ -321,13 +350,14 @@ func fetchSchemaRegistries(
 	gatewayID string,
 	cfg config.Hook,
 	nameFilter string,
-) ([]kkComps.SchemaRegistry, error) {
+) ([]schemaRegistryEntry, error) {
 	requestPageSize := int64(cfg.GetInt(common.RequestPageSizeConfigPath))
 	if requestPageSize < 1 {
 		requestPageSize = int64(common.DefaultRequestPageSize)
 	}
 
 	var allData []kkComps.SchemaRegistry
+	rawConfigByID := make(map[string]map[string]any)
 	var pageAfter *string
 
 	for {
@@ -360,6 +390,26 @@ func fetchSchemaRegistries(
 			break
 		}
 
+		// Parse the raw response body to extract full config (SDK Config struct is opaque).
+		if res.RawResponse != nil && res.RawResponse.Body != nil {
+			bodyBytes, readErr := io.ReadAll(res.RawResponse.Body)
+			if readErr == nil && len(bodyBytes) > 0 {
+				var rawResp struct {
+					Data []struct {
+						ID     string         `json:"id"`
+						Config map[string]any `json:"config"`
+					} `json:"data"`
+				}
+				if jsonErr := json.Unmarshal(bodyBytes, &rawResp); jsonErr == nil {
+					for _, item := range rawResp.Data {
+						if item.ID != "" && item.Config != nil {
+							rawConfigByID[item.ID] = item.Config
+						}
+					}
+				}
+			}
+		}
+
 		data := res.GetListSchemaRegistriesResponse().Data
 		allData = append(allData, data...)
 
@@ -381,13 +431,21 @@ func fetchSchemaRegistries(
 		pageAfter = new(values.Get("page[after]"))
 	}
 
-	return allData, nil
+	entries := make([]schemaRegistryEntry, 0, len(allData))
+	for _, sr := range allData {
+		entries = append(entries, schemaRegistryEntry{
+			SchemaRegistry: sr,
+			RawConfig:      rawConfigByID[sr.ID],
+		})
+	}
+
+	return entries, nil
 }
 
 func findSchemaRegistryByName(
-	registries []kkComps.SchemaRegistry,
+	registries []schemaRegistryEntry,
 	name string,
-) *kkComps.SchemaRegistry {
+) *schemaRegistryEntry {
 	lowered := strings.ToLower(name)
 	for i := range registries {
 		if strings.ToLower(registries[i].Name) == lowered {
@@ -397,7 +455,7 @@ func findSchemaRegistryByName(
 	return nil
 }
 
-func schemaRegistryToRecord(sr kkComps.SchemaRegistry) schemaRegistrySummaryRecord {
+func schemaRegistryToRecord(sr schemaRegistryEntry) schemaRegistrySummaryRecord {
 	id := sr.ID
 	if id != "" {
 		id = util.AbbreviateUUID(id)
@@ -433,7 +491,7 @@ func schemaRegistryToRecord(sr kkComps.SchemaRegistry) schemaRegistrySummaryReco
 	}
 }
 
-func schemaRegistryDetailView(sr *kkComps.SchemaRegistry) string {
+func schemaRegistryDetailView(sr *schemaRegistryEntry) string {
 	if sr == nil {
 		return ""
 	}
@@ -469,10 +527,32 @@ func schemaRegistryDetailView(sr *kkComps.SchemaRegistry) string {
 	fmt.Fprintf(&b, "created_at: %s\n", createdAt)
 	fmt.Fprintf(&b, "updated_at: %s\n", updatedAt)
 
+	if len(sr.RawConfig) > 0 {
+		fmt.Fprintf(&b, "config:\n")
+		if v, ok := sr.RawConfig["schema_type"]; ok {
+			fmt.Fprintf(&b, "  schema_type: %v\n", v)
+		}
+		if v, ok := sr.RawConfig["endpoint"]; ok {
+			fmt.Fprintf(&b, "  endpoint: %v\n", v)
+		}
+		if v, ok := sr.RawConfig["timeout_seconds"]; ok {
+			fmt.Fprintf(&b, "  timeout_seconds: %v\n", v)
+		}
+		if auth, ok := sr.RawConfig["authentication"].(map[string]any); ok {
+			fmt.Fprintf(&b, "  authentication:\n")
+			if t, ok := auth["type"]; ok {
+				fmt.Fprintf(&b, "    type: %v\n", t)
+			}
+			if u, ok := auth["username"]; ok {
+				fmt.Fprintf(&b, "    username: %v\n", u)
+			}
+		}
+	}
+
 	return strings.TrimRight(b.String(), "\n")
 }
 
-func buildSchemaRegistryChildView(registries []kkComps.SchemaRegistry) tableview.ChildView {
+func buildSchemaRegistryChildView(registries []schemaRegistryEntry) tableview.ChildView {
 	tableRows := make([]table.Row, 0, len(registries))
 	for i := range registries {
 		record := schemaRegistryToRecord(registries[i])

--- a/internal/cmd/root/products/konnect/eventgateway/schema_registries.go
+++ b/internal/cmd/root/products/konnect/eventgateway/schema_registries.go
@@ -1,9 +1,7 @@
 package eventgateway
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/url"
 	"strings"
 	"time"
@@ -39,11 +37,18 @@ type schemaRegistrySummaryRecord struct {
 	LocalUpdatedTime string
 }
 
-// schemaRegistryEntry wraps the SDK SchemaRegistry with raw config data from the API
-// response (the SDK Config struct is empty/opaque).
+// schemaRegistryEntry holds a schema registry with full config from the raw API
+// response. The SDK's SchemaRegistryConfig struct is opaque/empty, so we parse
+// the raw response body directly, keeping Config as map[string]any.
 type schemaRegistryEntry struct {
-	kkComps.SchemaRegistry
-	RawConfig map[string]any
+	ID          string            `json:"id"                    yaml:"id"`
+	Name        string            `json:"name"                  yaml:"name"`
+	Type        string            `json:"type"                  yaml:"type"`
+	Description *string           `json:"description,omitempty" yaml:"description,omitempty"`
+	Config      map[string]any    `json:"config"                yaml:"config"`
+	Labels      map[string]string `json:"labels,omitempty"      yaml:"labels,omitempty"`
+	CreatedAt   time.Time         `json:"created_at"            yaml:"created_at"`
+	UpdatedAt   time.Time         `json:"updated_at"            yaml:"updated_at"`
 }
 
 var (
@@ -258,12 +263,6 @@ func (h schemaRegistriesHandler) listSchemaRegistries(
 		tableRows = append(tableRows, table.Row{record.ID, record.Name, record.Type})
 	}
 
-	// Extract base SDK types for JSON/YAML serialization.
-	rawRegistries := make([]kkComps.SchemaRegistry, 0, len(registries))
-	for _, sr := range registries {
-		rawRegistries = append(rawRegistries, sr.SchemaRegistry)
-	}
-
 	return tableview.RenderForFormat(
 		helper,
 		false,
@@ -271,7 +270,7 @@ func (h schemaRegistriesHandler) listSchemaRegistries(
 		printer,
 		helper.GetStreams(),
 		records,
-		rawRegistries,
+		registries,
 		"",
 		tableview.WithCustomTable([]string{"ID", "NAME", "TYPE"}, tableRows),
 		tableview.WithRootLabel(helper.GetCmd().Name()),
@@ -309,25 +308,26 @@ func (h schemaRegistriesHandler) getSingleSchemaRegistry(
 		return cmd.PrepareExecutionError("Failed to get schema registry", err, helper.GetCmd(), attrs...)
 	}
 
-	sr := res.GetSchemaRegistry()
-	if sr == nil {
+	if res.GetSchemaRegistry() == nil {
 		return &cmd.ExecutionError{
 			Msg: "Schema registry response was empty",
 			Err: fmt.Errorf("no schema registry returned for id %s", registryID),
 		}
 	}
 
-	// Parse raw response to retrieve the config (SDK Config struct is opaque).
-	entry := schemaRegistryEntry{SchemaRegistry: *sr}
-	if res.RawResponse != nil && res.RawResponse.Body != nil {
-		bodyBytes, readErr := io.ReadAll(res.RawResponse.Body)
-		if readErr == nil && len(bodyBytes) > 0 {
-			var rawResp struct {
-				Config map[string]any `json:"config"`
-			}
-			if jsonErr := json.Unmarshal(bodyBytes, &rawResp); jsonErr == nil {
-				entry.RawConfig = rawResp.Config
-			}
+	// Parse raw response to get full config (SDK SchemaRegistryConfig is opaque/empty).
+	var entry schemaRegistryEntry
+	if !parseRawPolicyResponse(helper, res, &entry) {
+		// Fallback: populate from SDK type (Config will be empty).
+		sr := res.GetSchemaRegistry()
+		entry = schemaRegistryEntry{
+			ID:          sr.ID,
+			Name:        sr.Name,
+			Type:        sr.Type,
+			Description: sr.Description,
+			Labels:      sr.Labels,
+			CreatedAt:   sr.CreatedAt,
+			UpdatedAt:   sr.UpdatedAt,
 		}
 	}
 
@@ -338,7 +338,7 @@ func (h schemaRegistriesHandler) getSingleSchemaRegistry(
 		printer,
 		helper.GetStreams(),
 		schemaRegistryToRecord(entry),
-		sr,
+		&entry,
 		"",
 		tableview.WithRootLabel(helper.GetCmd().Name()),
 	)
@@ -356,8 +356,7 @@ func fetchSchemaRegistries(
 		requestPageSize = int64(common.DefaultRequestPageSize)
 	}
 
-	var allData []kkComps.SchemaRegistry
-	rawConfigByID := make(map[string]map[string]any)
+	var allEntries []schemaRegistryEntry
 	var pageAfter *string
 
 	for {
@@ -390,28 +389,26 @@ func fetchSchemaRegistries(
 			break
 		}
 
-		// Parse the raw response body to extract full config (SDK Config struct is opaque).
-		if res.RawResponse != nil && res.RawResponse.Body != nil {
-			bodyBytes, readErr := io.ReadAll(res.RawResponse.Body)
-			if readErr == nil && len(bodyBytes) > 0 {
-				var rawResp struct {
-					Data []struct {
-						ID     string         `json:"id"`
-						Config map[string]any `json:"config"`
-					} `json:"data"`
-				}
-				if jsonErr := json.Unmarshal(bodyBytes, &rawResp); jsonErr == nil {
-					for _, item := range rawResp.Data {
-						if item.ID != "" && item.Config != nil {
-							rawConfigByID[item.ID] = item.Config
-						}
-					}
-				}
+		// Parse raw response to get entries with full config (SDK SchemaRegistryConfig is opaque/empty).
+		var rawPage struct {
+			Data []schemaRegistryEntry `json:"data"`
+		}
+		if parseRawPolicyResponse(helper, res, &rawPage) && len(rawPage.Data) > 0 {
+			allEntries = append(allEntries, rawPage.Data...)
+		} else {
+			// Fallback: use SDK types (Config will be empty).
+			for _, sr := range res.GetListSchemaRegistriesResponse().Data {
+				allEntries = append(allEntries, schemaRegistryEntry{
+					ID:          sr.ID,
+					Name:        sr.Name,
+					Type:        sr.Type,
+					Description: sr.Description,
+					Labels:      sr.Labels,
+					CreatedAt:   sr.CreatedAt,
+					UpdatedAt:   sr.UpdatedAt,
+				})
 			}
 		}
-
-		data := res.GetListSchemaRegistriesResponse().Data
-		allData = append(allData, data...)
 
 		if res.GetListSchemaRegistriesResponse().Meta == nil ||
 			res.GetListSchemaRegistriesResponse().Meta.Page.Next == nil {
@@ -431,15 +428,7 @@ func fetchSchemaRegistries(
 		pageAfter = new(values.Get("page[after]"))
 	}
 
-	entries := make([]schemaRegistryEntry, 0, len(allData))
-	for _, sr := range allData {
-		entries = append(entries, schemaRegistryEntry{
-			SchemaRegistry: sr,
-			RawConfig:      rawConfigByID[sr.ID],
-		})
-	}
-
-	return entries, nil
+	return allEntries, nil
 }
 
 func findSchemaRegistryByName(
@@ -526,28 +515,7 @@ func schemaRegistryDetailView(sr *schemaRegistryEntry) string {
 	fmt.Fprintf(&b, "description: %s\n", description)
 	fmt.Fprintf(&b, "created_at: %s\n", createdAt)
 	fmt.Fprintf(&b, "updated_at: %s\n", updatedAt)
-
-	if len(sr.RawConfig) > 0 {
-		fmt.Fprintf(&b, "config:\n")
-		if v, ok := sr.RawConfig["schema_type"]; ok {
-			fmt.Fprintf(&b, "  schema_type: %v\n", v)
-		}
-		if v, ok := sr.RawConfig["endpoint"]; ok {
-			fmt.Fprintf(&b, "  endpoint: %v\n", v)
-		}
-		if v, ok := sr.RawConfig["timeout_seconds"]; ok {
-			fmt.Fprintf(&b, "  timeout_seconds: %v\n", v)
-		}
-		if auth, ok := sr.RawConfig["authentication"].(map[string]any); ok {
-			fmt.Fprintf(&b, "  authentication:\n")
-			if t, ok := auth["type"]; ok {
-				fmt.Fprintf(&b, "    type: %v\n", t)
-			}
-			if u, ok := auth["username"]; ok {
-				fmt.Fprintf(&b, "    username: %v\n", u)
-			}
-		}
-	}
+	fmt.Fprintf(&b, "config:\n")
 
 	return strings.TrimRight(b.String(), "\n")
 }

--- a/internal/cmd/root/products/konnect/eventgateway/schema_registries.go
+++ b/internal/cmd/root/products/konnect/eventgateway/schema_registries.go
@@ -513,9 +513,11 @@ func schemaRegistryDetailView(sr *schemaRegistryEntry) string {
 	fmt.Fprintf(&b, "name: %s\n", name)
 	fmt.Fprintf(&b, "type: %s\n", srType)
 	fmt.Fprintf(&b, "description: %s\n", description)
+	config := formatJSONValue(sr.Config)
+
 	fmt.Fprintf(&b, "created_at: %s\n", createdAt)
 	fmt.Fprintf(&b, "updated_at: %s\n", updatedAt)
-	fmt.Fprintf(&b, "config:\n")
+	fmt.Fprintf(&b, "config: %s\n", config)
 
 	return strings.TrimRight(b.String(), "\n")
 }

--- a/internal/cmd/root/products/konnect/eventgateway/schema_registries_test.go
+++ b/internal/cmd/root/products/konnect/eventgateway/schema_registries_test.go
@@ -1,0 +1,105 @@
+package eventgateway
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/kong/kongctl/internal/cmd/common"
+	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/kong/kongctl/internal/config"
+	"github.com/kong/kongctl/internal/iostreams"
+	"github.com/kong/kongctl/internal/log"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSchemaRegistryFlagValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "both gateway flags mutually exclusive",
+			args:    []string{"--gateway-id", "gw-1", "--gateway-name", "gw"},
+			wantErr: "if any flags in the group [gateway-id gateway-name] are set none of the others can be",
+		},
+		{
+			name: "both schema registry flags mutually exclusive",
+			args: []string{
+				"--gateway-id", "gw-1",
+				"--schema-registry-id", "sr-1",
+				"--schema-registry-name", "sr",
+			},
+			wantErr: "if any flags in the group [schema-registry-id schema-registry-name] are set none of the others can be",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.BuildProfiledConfig("default", "", viper.New())
+			cfg.Set(common.OutputConfigPath, "text")
+
+			ctx := context.Background()
+			ctx = context.WithValue(ctx, config.ConfigKey, cfg)
+			ctx = context.WithValue(ctx, log.LoggerKey, slog.Default())
+			ctx = context.WithValue(ctx, iostreams.StreamsKey, iostreams.NewTestIOStreamsOnly())
+
+			cmd := newGetEventGatewaySchemaRegistriesCmd(verbs.Get, nil, nil)
+			cmd.SetArgs(tc.args)
+
+			err := cmd.ExecuteContext(ctx)
+
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestSchemaRegistryPositionalArgConflictWithFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "positional arg conflicts with schema-registry-id flag",
+			args: []string{
+				"--gateway-id", "gw-1",
+				"--schema-registry-id", "sr-1",
+				"my-registry",
+			},
+			wantErr: "cannot specify both positional argument",
+		},
+		{
+			name: "positional arg conflicts with schema-registry-name flag",
+			args: []string{
+				"--gateway-id", "gw-1",
+				"--schema-registry-name", "sr",
+				"my-registry",
+			},
+			wantErr: "cannot specify both positional argument",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config.BuildProfiledConfig("default", "", viper.New())
+			cfg.Set(common.OutputConfigPath, "text")
+
+			ctx := context.Background()
+			ctx = context.WithValue(ctx, config.ConfigKey, cfg)
+			ctx = context.WithValue(ctx, log.LoggerKey, slog.Default())
+			ctx = context.WithValue(ctx, iostreams.StreamsKey, iostreams.NewTestIOStreamsOnly())
+
+			cmd := newGetEventGatewaySchemaRegistriesCmd(verbs.Get, nil, nil)
+			cmd.SetArgs(tc.args)
+
+			err := cmd.ExecuteContext(ctx)
+
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}

--- a/internal/cmd/root/verbs/dump/declarative.go
+++ b/internal/cmd/root/verbs/dump/declarative.go
@@ -194,6 +194,7 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 			EventGatewayProducePolicyAPI:        sdk.GetEventGatewayProducePolicyAPI(),
 			EventGatewayClusterPolicyAPI:        sdk.GetEventGatewayClusterPolicyAPI(),
 			EventGatewayConsumePolicyAPI:        sdk.GetEventGatewayConsumePolicyAPI(),
+			EventGatewaySchemaRegistryAPI:       sdk.GetEventGatewaySchemaRegistryAPI(),
 			OrganizationTeamAPI:                 sdk.GetOrganizationTeamAPI(),
 		})
 	}

--- a/internal/cmd/root/verbs/dump/declarative_children.go
+++ b/internal/cmd/root/verbs/dump/declarative_children.go
@@ -198,6 +198,12 @@ func populateEventGatewayChildren(
 		} else if len(certs) > 0 {
 			gateway.DataPlaneCertificates = certs
 		}
+
+		if regs, err := buildEventGatewaySchemaRegistries(ctx, logger, client, gatewayID, gateway.Name); err != nil {
+			logWarn(logger, "failed to load event gateway schema registries", gatewayID, gateway.Name, err)
+		} else if len(regs) > 0 {
+			gateway.SchemaRegistries = regs
+		}
 	}
 }
 
@@ -234,6 +240,67 @@ func buildEventGatewayDataPlaneCertificates(
 				Description: cert.Description,
 			},
 			Ref: cert.ID,
+		}
+
+		results = append(results, res)
+	}
+
+	return results, nil
+}
+
+func buildEventGatewaySchemaRegistries(
+	ctx context.Context,
+	logger *slog.Logger,
+	client *declstate.Client,
+	gatewayID string,
+	gatewayName string,
+) ([]declresources.EventGatewaySchemaRegistryResource, error) {
+	registries, err := client.ListEventGatewaySchemaRegistries(ctx, gatewayID)
+	if err != nil {
+		return nil, err
+	}
+	if len(registries) == 0 {
+		return nil, nil
+	}
+
+	results := make([]declresources.EventGatewaySchemaRegistryResource, 0, len(registries))
+	for _, sr := range registries {
+		if strings.TrimSpace(sr.ID) == "" {
+			logWarn(logger, "schema registry missing ID", gatewayID, gatewayName, nil)
+			continue
+		}
+
+		// Build the create union using a JSON round-trip (same approach as cluster/listener policies)
+		// because the SDK response Config field is an opaque empty struct.
+		regMap := map[string]any{
+			"name": sr.Name,
+			"type": sr.Type,
+		}
+		if sr.Description != nil {
+			regMap["description"] = *sr.Description
+		}
+		if len(sr.Labels) > 0 {
+			regMap["labels"] = sr.Labels
+		}
+		if sr.RawConfig != nil {
+			regMap["config"] = sr.RawConfig
+		}
+
+		data, marshalErr := json.Marshal(regMap)
+		if marshalErr != nil {
+			logWarn(logger, "failed to marshal schema registry", sr.ID, gatewayName, marshalErr)
+			continue
+		}
+
+		var createReq kkComps.SchemaRegistryCreate
+		if unmarshalErr := json.Unmarshal(data, &createReq); unmarshalErr != nil {
+			logWarn(logger, "failed to unmarshal schema registry create", sr.ID, gatewayName, unmarshalErr)
+			continue
+		}
+
+		res := declresources.EventGatewaySchemaRegistryResource{
+			SchemaRegistryCreate: createReq,
+			Ref:                  sr.ID,
 		}
 
 		results = append(results, res)

--- a/internal/declarative/executor/event_gateway_schema_registry_adapter.go
+++ b/internal/declarative/executor/event_gateway_schema_registry_adapter.go
@@ -1,0 +1,430 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/kong/kongctl/internal/declarative/state"
+)
+
+// EventGatewaySchemaRegistryAdapter implements ResourceOperations for Event Gateway Schema Registries.
+type EventGatewaySchemaRegistryAdapter struct {
+	client *state.Client
+}
+
+// NewEventGatewaySchemaRegistryAdapter creates a new adapter for Event Gateway Schema Registries.
+func NewEventGatewaySchemaRegistryAdapter(client *state.Client) *EventGatewaySchemaRegistryAdapter {
+	return &EventGatewaySchemaRegistryAdapter{client: client}
+}
+
+// MapCreateFields maps plan fields to a SchemaRegistryCreate request.
+func (a *EventGatewaySchemaRegistryAdapter) MapCreateFields(
+	_ context.Context,
+	_ *ExecutionContext,
+	fields map[string]any,
+	create *kkComps.SchemaRegistryCreate,
+) error {
+	confluent, err := buildConfluentCreate(fields)
+	if err != nil {
+		return err
+	}
+	*create = kkComps.CreateSchemaRegistryCreateConfluent(confluent)
+	return nil
+}
+
+// MapUpdateFields maps plan fields to a SchemaRegistryUpdate request.
+func (a *EventGatewaySchemaRegistryAdapter) MapUpdateFields(
+	_ context.Context,
+	_ *ExecutionContext,
+	fields map[string]any,
+	update *kkComps.SchemaRegistryUpdate,
+	_ map[string]string,
+) error {
+	confluent, err := buildConfluentUpdate(fields)
+	if err != nil {
+		return err
+	}
+	*update = kkComps.CreateSchemaRegistryUpdateConfluent(confluent)
+	return nil
+}
+
+// Create creates a new schema registry.
+func (a *EventGatewaySchemaRegistryAdapter) Create(
+	ctx context.Context,
+	req kkComps.SchemaRegistryCreate,
+	namespace string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	gatewayID, err := a.getGatewayIDFromContext(execCtx)
+	if err != nil {
+		return "", err
+	}
+	return a.client.CreateEventGatewaySchemaRegistry(ctx, gatewayID, req, namespace)
+}
+
+// Update updates an existing schema registry.
+func (a *EventGatewaySchemaRegistryAdapter) Update(
+	ctx context.Context,
+	id string,
+	req kkComps.SchemaRegistryUpdate,
+	namespace string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	gatewayID, err := a.getGatewayIDFromContext(execCtx)
+	if err != nil {
+		return "", err
+	}
+	return a.client.UpdateEventGatewaySchemaRegistry(ctx, gatewayID, id, req, namespace)
+}
+
+// Delete deletes a schema registry.
+func (a *EventGatewaySchemaRegistryAdapter) Delete(
+	ctx context.Context,
+	id string,
+	execCtx *ExecutionContext,
+) error {
+	gatewayID, err := a.getGatewayIDFromContext(execCtx)
+	if err != nil {
+		return err
+	}
+	return a.client.DeleteEventGatewaySchemaRegistry(ctx, gatewayID, id)
+}
+
+// GetByID gets a schema registry by ID.
+func (a *EventGatewaySchemaRegistryAdapter) GetByID(
+	ctx context.Context,
+	id string,
+	execCtx *ExecutionContext,
+) (ResourceInfo, error) {
+	gatewayID, err := a.getGatewayIDFromContext(execCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	sr, err := a.client.GetEventGatewaySchemaRegistryByID(ctx, gatewayID, id)
+	if err != nil {
+		return nil, err
+	}
+	if sr == nil {
+		return nil, nil
+	}
+
+	return &EventGatewaySchemaRegistryResourceInfo{sr: sr}, nil
+}
+
+// GetByName is not directly supported; schema registries are identified by name via list.
+func (a *EventGatewaySchemaRegistryAdapter) GetByName(
+	_ context.Context,
+	_ string,
+) (ResourceInfo, error) {
+	return nil, fmt.Errorf("GetByName not supported for event gateway schema registries")
+}
+
+// ResourceType returns the resource type string.
+func (a *EventGatewaySchemaRegistryAdapter) ResourceType() string {
+	return planner.ResourceTypeEventGatewaySchemaRegistry
+}
+
+// RequiredFields returns the list of required fields for this resource.
+func (a *EventGatewaySchemaRegistryAdapter) RequiredFields() []string {
+	return []string{"name", "type", "config"}
+}
+
+// SupportsUpdate indicates whether this resource supports update operations.
+func (a *EventGatewaySchemaRegistryAdapter) SupportsUpdate() bool {
+	return true
+}
+
+// getGatewayIDFromContext extracts the event gateway ID from the execution context.
+func (a *EventGatewaySchemaRegistryAdapter) getGatewayIDFromContext(
+	execCtx *ExecutionContext,
+) (string, error) {
+	if execCtx == nil || execCtx.PlannedChange == nil {
+		return "", fmt.Errorf("execution context required")
+	}
+
+	change := *execCtx.PlannedChange
+
+	// Priority 1: References (for new parent)
+	if gatewayRef, ok := change.References["event_gateway_id"]; ok && gatewayRef.ID != "" {
+		return gatewayRef.ID, nil
+	}
+
+	// Priority 2: Parent field (for existing parent)
+	if change.Parent != nil && change.Parent.ID != "" {
+		return change.Parent.ID, nil
+	}
+
+	return "", fmt.Errorf("event gateway ID required for schema registry operations")
+}
+
+// buildConfluentCreate converts a field map to a SchemaRegistryConfluent create struct.
+func buildConfluentCreate(fields map[string]any) (kkComps.SchemaRegistryConfluent, error) {
+	var confluent kkComps.SchemaRegistryConfluent
+
+	name, ok := fields["name"].(string)
+	if !ok || name == "" {
+		return confluent, fmt.Errorf("name is required for schema registry")
+	}
+	confluent.Name = name
+
+	if desc, ok := fields["description"].(string); ok {
+		confluent.Description = &desc
+	}
+
+	config, err := extractConfluentConfig(fields)
+	if err != nil {
+		return confluent, err
+	}
+	confluent.Config = config
+
+	if labelsRaw, ok := fields["labels"]; ok {
+		switch v := labelsRaw.(type) {
+		case map[string]string:
+			confluent.Labels = v
+		case map[string]any:
+			m := make(map[string]string, len(v))
+			for k, val := range v {
+				if s, ok := val.(string); ok {
+					m[k] = s
+				}
+			}
+			confluent.Labels = m
+		}
+	}
+
+	return confluent, nil
+}
+
+// buildConfluentUpdate converts a field map to a SchemaRegistryConfluentSensitiveDataAware struct.
+func buildConfluentUpdate(fields map[string]any) (kkComps.SchemaRegistryConfluentSensitiveDataAware, error) {
+	var confluent kkComps.SchemaRegistryConfluentSensitiveDataAware
+
+	name, ok := fields["name"].(string)
+	if !ok || name == "" {
+		return confluent, fmt.Errorf("name is required for schema registry update")
+	}
+	confluent.Name = name
+
+	if desc, ok := fields["description"].(string); ok {
+		confluent.Description = &desc
+	}
+
+	configSDA, err := extractConfluentConfigSensitiveDataAware(fields)
+	if err != nil {
+		return confluent, err
+	}
+	confluent.Config = configSDA
+
+	if labelsRaw, ok := fields["labels"]; ok {
+		switch v := labelsRaw.(type) {
+		case map[string]string:
+			confluent.Labels = v
+		case map[string]any:
+			m := make(map[string]string, len(v))
+			for k, val := range v {
+				if s, ok := val.(string); ok {
+					m[k] = s
+				}
+			}
+			confluent.Labels = m
+		}
+	}
+
+	return confluent, nil
+}
+
+// extractConfluentConfig extracts SchemaRegistryConfluentConfig from the fields map.
+func extractConfluentConfig(fields map[string]any) (kkComps.SchemaRegistryConfluentConfig, error) {
+	var cfg kkComps.SchemaRegistryConfluentConfig
+
+	// Accept pre-built SDK struct
+	if sdkCfg, ok := fields["config"].(kkComps.SchemaRegistryConfluentConfig); ok {
+		return sdkCfg, nil
+	}
+
+	// Accept a map
+	cfgRaw, ok := fields["config"]
+	if !ok {
+		return cfg, fmt.Errorf("config is required for schema registry")
+	}
+
+	cfgMap, ok := cfgRaw.(map[string]any)
+	if !ok {
+		return cfg, fmt.Errorf("config must be an object")
+	}
+
+	endpoint, ok := cfgMap["endpoint"].(string)
+	if !ok || endpoint == "" {
+		return cfg, fmt.Errorf("config.endpoint is required")
+	}
+	cfg.Endpoint = endpoint
+
+	schemaType, ok := cfgMap["schema_type"].(string)
+	if !ok || schemaType == "" {
+		return cfg, fmt.Errorf("config.schema_type is required (avro or json)")
+	}
+	cfg.SchemaType = kkComps.SchemaType(schemaType)
+
+	if timeout, ok := cfgMap["timeout_seconds"].(int64); ok {
+		cfg.TimeoutSeconds = &timeout
+	} else if timeout, ok := cfgMap["timeout_seconds"].(float64); ok {
+		t := int64(timeout)
+		cfg.TimeoutSeconds = &t
+	}
+
+	// Authentication is optional
+	if authRaw, ok := cfgMap["authentication"]; ok {
+		auth, err := extractSchemaRegistryAuth(authRaw)
+		if err != nil {
+			return cfg, fmt.Errorf("config.authentication: %w", err)
+		}
+		cfg.Authentication = &auth
+	}
+
+	return cfg, nil
+}
+
+// extractConfluentConfigSensitiveDataAware extracts the sensitive-data-aware config variant.
+func extractConfluentConfigSensitiveDataAware(
+	fields map[string]any,
+) (kkComps.SchemaRegistryConfluentConfigSensitiveDataAware, error) {
+	var cfg kkComps.SchemaRegistryConfluentConfigSensitiveDataAware
+
+	if sdkCfg, ok := fields["config"].(kkComps.SchemaRegistryConfluentConfigSensitiveDataAware); ok {
+		return sdkCfg, nil
+	}
+
+	cfgRaw, ok := fields["config"]
+	if !ok {
+		return cfg, fmt.Errorf("config is required for schema registry update")
+	}
+
+	cfgMap, ok := cfgRaw.(map[string]any)
+	if !ok {
+		// Accept a pre-built base config and convert it
+		if baseCfg, ok := cfgRaw.(kkComps.SchemaRegistryConfluentConfig); ok {
+			cfg.Endpoint = baseCfg.Endpoint
+			cfg.SchemaType = kkComps.SchemaRegistryConfluentConfigSensitiveDataAwareSchemaType(baseCfg.SchemaType)
+			cfg.TimeoutSeconds = baseCfg.TimeoutSeconds
+			if baseCfg.Authentication != nil {
+				sdaAuth, err := convertAuthToSDA(*baseCfg.Authentication)
+				if err != nil {
+					return cfg, err
+				}
+				cfg.Authentication = &sdaAuth
+			}
+			return cfg, nil
+		}
+		return cfg, fmt.Errorf("config must be an object")
+	}
+
+	endpoint, ok := cfgMap["endpoint"].(string)
+	if !ok || endpoint == "" {
+		return cfg, fmt.Errorf("config.endpoint is required")
+	}
+	cfg.Endpoint = endpoint
+
+	schemaType, ok := cfgMap["schema_type"].(string)
+	if !ok || schemaType == "" {
+		return cfg, fmt.Errorf("config.schema_type is required (avro or json)")
+	}
+	cfg.SchemaType = kkComps.SchemaRegistryConfluentConfigSensitiveDataAwareSchemaType(schemaType)
+
+	if timeout, ok := cfgMap["timeout_seconds"].(int64); ok {
+		cfg.TimeoutSeconds = &timeout
+	} else if timeout, ok := cfgMap["timeout_seconds"].(float64); ok {
+		t := int64(timeout)
+		cfg.TimeoutSeconds = &t
+	}
+
+	if authRaw, ok := cfgMap["authentication"]; ok {
+		auth, err := extractSchemaRegistryAuth(authRaw)
+		if err != nil {
+			return cfg, fmt.Errorf("config.authentication: %w", err)
+		}
+		sdaAuth, err := convertAuthToSDA(auth)
+		if err != nil {
+			return cfg, err
+		}
+		cfg.Authentication = &sdaAuth
+	}
+
+	return cfg, nil
+}
+
+// extractSchemaRegistryAuth builds SchemaRegistryAuthenticationScheme from a raw map or SDK type.
+func extractSchemaRegistryAuth(raw any) (kkComps.SchemaRegistryAuthenticationScheme, error) {
+	var auth kkComps.SchemaRegistryAuthenticationScheme
+
+	if sdkAuth, ok := raw.(kkComps.SchemaRegistryAuthenticationScheme); ok {
+		return sdkAuth, nil
+	}
+
+	authMap, ok := raw.(map[string]any)
+	if !ok {
+		return auth, fmt.Errorf("authentication must be an object")
+	}
+
+	authType, _ := authMap["type"].(string)
+	if authType == "" {
+		return auth, fmt.Errorf("authentication.type is required (currently only 'basic')")
+	}
+
+	switch authType {
+	case string(kkComps.SchemaRegistryAuthenticationSchemeTypeBasic):
+		username, _ := authMap["username"].(string)
+		password, _ := authMap["password"].(string)
+		basic := kkComps.SchemaRegistryAuthenticationBasic{
+			Username: username,
+			Password: password,
+		}
+		auth = kkComps.CreateSchemaRegistryAuthenticationSchemeBasic(basic)
+	default:
+		return auth, fmt.Errorf("unsupported authentication type %q (currently only 'basic')", authType)
+	}
+
+	return auth, nil
+}
+
+// convertAuthToSDA converts authentication to the sensitive-data-aware variant.
+func convertAuthToSDA(
+	auth kkComps.SchemaRegistryAuthenticationScheme,
+) (kkComps.SchemaRegistryAuthenticationSensitiveDataAwareScheme, error) {
+	var sda kkComps.SchemaRegistryAuthenticationSensitiveDataAwareScheme
+
+	if auth.SchemaRegistryAuthenticationBasic == nil {
+		return sda, fmt.Errorf("unsupported authentication type for update")
+	}
+
+	basic := auth.SchemaRegistryAuthenticationBasic
+	sdaBasic := kkComps.SchemaRegistryAuthenticationBasicSensitiveDataAware{
+		Username: basic.Username,
+		Password: &basic.Password,
+	}
+	sda = kkComps.CreateSchemaRegistryAuthenticationSensitiveDataAwareSchemeBasic(sdaBasic)
+	return sda, nil
+}
+
+// EventGatewaySchemaRegistryResourceInfo wraps an Event Gateway Schema Registry to implement ResourceInfo.
+type EventGatewaySchemaRegistryResourceInfo struct {
+	sr *state.EventGatewaySchemaRegistry
+}
+
+func (e *EventGatewaySchemaRegistryResourceInfo) GetID() string {
+	return e.sr.ID
+}
+
+func (e *EventGatewaySchemaRegistryResourceInfo) GetName() string {
+	return e.sr.Name
+}
+
+func (e *EventGatewaySchemaRegistryResourceInfo) GetLabels() map[string]string {
+	return e.sr.Labels
+}
+
+func (e *EventGatewaySchemaRegistryResourceInfo) GetNormalizedLabels() map[string]string {
+	return e.sr.NormalizedLabels
+}

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -61,6 +61,8 @@ type Executor struct {
 	eventGatewayDataPlaneCertificateExecutor *BaseExecutor[
 		kkComps.CreateEventGatewayDataPlaneCertificateRequest,
 		kkComps.UpdateEventGatewayDataPlaneCertificateRequest]
+	eventGatewaySchemaRegistryExecutor *BaseExecutor[
+		kkComps.SchemaRegistryCreate, kkComps.SchemaRegistryUpdate]
 
 	// Portal child resource executors
 	portalCustomizationExecutor *BaseSingletonExecutor[kkComps.PortalCustomization]
@@ -215,6 +217,13 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 		kkComps.CreateEventGatewayDataPlaneCertificateRequest,
 		kkComps.UpdateEventGatewayDataPlaneCertificateRequest](
 		NewEventGatewayDataPlaneCertificateAdapter(client),
+		client,
+		dryRun,
+	)
+
+	e.eventGatewaySchemaRegistryExecutor = NewBaseExecutor[
+		kkComps.SchemaRegistryCreate, kkComps.SchemaRegistryUpdate](
+		NewEventGatewaySchemaRegistryAdapter(client),
 		client,
 		dryRun,
 	)
@@ -1889,6 +1898,17 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 			change.References["event_gateway_id"] = gatewayRef
 		}
 		return e.eventGatewayDataPlaneCertificateExecutor.Create(ctx, *change)
+	case planner.ResourceTypeEventGatewaySchemaRegistry:
+		// Resolve event gateway reference if needed
+		if gatewayRef, ok := change.References["event_gateway_id"]; ok && gatewayRef.ID == "" {
+			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
+			}
+			gatewayRef.ID = gatewayID
+			change.References["event_gateway_id"] = gatewayRef
+		}
+		return e.eventGatewaySchemaRegistryExecutor.Create(ctx, *change)
 	case planner.ResourceTypeEventGatewayClusterPolicy:
 		// Resolve event gateway reference if needed
 		if gatewayRef, ok := change.References["event_gateway_id"]; ok && gatewayRef.ID == "" {
@@ -2242,6 +2262,17 @@ func (e *Executor) updateResource(ctx context.Context, change *planner.PlannedCh
 			change.References["event_gateway_id"] = gatewayRef
 		}
 		return e.eventGatewayDataPlaneCertificateExecutor.Update(ctx, *change)
+	case planner.ResourceTypeEventGatewaySchemaRegistry:
+		// Resolve event gateway reference if needed (typically should already be in Parent)
+		if gatewayRef, ok := change.References["event_gateway_id"]; ok && gatewayRef.ID == "" {
+			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
+			}
+			gatewayRef.ID = gatewayID
+			change.References["event_gateway_id"] = gatewayRef
+		}
+		return e.eventGatewaySchemaRegistryExecutor.Update(ctx, *change)
 	case planner.ResourceTypeEventGatewayClusterPolicy:
 		// Resolve event gateway reference if needed
 		if gatewayRef, ok := change.References["event_gateway_id"]; ok && gatewayRef.ID == "" {
@@ -2450,6 +2481,9 @@ func (e *Executor) deleteResource(ctx context.Context, change *planner.PlannedCh
 	case planner.ResourceTypeEventGatewayDataPlaneCertificate:
 		// No need to resolve event gateway reference for delete - parent ID should be in Parent field
 		return e.eventGatewayDataPlaneCertificateExecutor.Delete(ctx, *change)
+	case planner.ResourceTypeEventGatewaySchemaRegistry:
+		// No need to resolve event gateway reference for delete - parent ID should be in Parent field
+		return e.eventGatewaySchemaRegistryExecutor.Delete(ctx, *change)
 	case planner.ResourceTypeEventGatewayClusterPolicy:
 		// Both gateway ID and virtual cluster ID should be in References for delete
 		return e.eventGatewayClusterPolicyExecutor.Delete(ctx, *change)

--- a/internal/declarative/planner/constants.go
+++ b/internal/declarative/planner/constants.go
@@ -78,8 +78,13 @@ const (
 
 	// ResourceTypeEventGatewayProducePolicy is the resource type for event gateway produce policies
 	ResourceTypeEventGatewayProducePolicy = "event_gateway_virtual_cluster_produce_policy"
+<<<<<<< HEAD
 	// ResourceTypeEventGatewayConsumePolicy is the resource type for event gateway virtual cluster consume policies
 	ResourceTypeEventGatewayConsumePolicy = "event_gateway_virtual_cluster_consume_policy"
+=======
+	// ResourceTypeEventGatewaySchemaRegistry is the resource type for event gateway schema registries
+	ResourceTypeEventGatewaySchemaRegistry = "event_gateway_schema_registry"
+>>>>>>> c52f661 (feat: bootstrap event gateway schema registry)
 
 	// ResourceTypeDeck represents an internal deck execution step.
 	ResourceTypeDeck = "_deck"

--- a/internal/declarative/planner/constants.go
+++ b/internal/declarative/planner/constants.go
@@ -78,13 +78,10 @@ const (
 
 	// ResourceTypeEventGatewayProducePolicy is the resource type for event gateway produce policies
 	ResourceTypeEventGatewayProducePolicy = "event_gateway_virtual_cluster_produce_policy"
-<<<<<<< HEAD
 	// ResourceTypeEventGatewayConsumePolicy is the resource type for event gateway virtual cluster consume policies
 	ResourceTypeEventGatewayConsumePolicy = "event_gateway_virtual_cluster_consume_policy"
-=======
 	// ResourceTypeEventGatewaySchemaRegistry is the resource type for event gateway schema registries
 	ResourceTypeEventGatewaySchemaRegistry = "event_gateway_schema_registry"
->>>>>>> c52f661 (feat: bootstrap event gateway schema registry)
 
 	// ResourceTypeDeck represents an internal deck execution step.
 	ResourceTypeDeck = "_deck"

--- a/internal/declarative/planner/egw_control_plane_planner.go
+++ b/internal/declarative/planner/egw_control_plane_planner.go
@@ -233,6 +233,18 @@ func (p *Planner) planEGWControlPlaneChanges(
 				return err
 			}
 		}
+
+		// Plan schema registries for this gateway (whether it exists or is being created)
+		schemaRegistries := p.resources.GetSchemaRegistriesForGateway(desiredEGWCP.Ref)
+
+		if len(schemaRegistries) > 0 || plan.Metadata.Mode == PlanModeSync {
+			if err := p.planEventGatewaySchemaRegistryChanges(
+				ctx, plannerCtx, namespace, desiredEGWCP.Name, gatewayID, desiredEGWCP.Ref,
+				gatewayChangeID, schemaRegistries, plan,
+			); err != nil {
+				return err
+			}
+		}
 	}
 
 	// Check for managed resources to delete (sync mode only)

--- a/internal/declarative/planner/event_gateway_schema_registry_planner.go
+++ b/internal/declarative/planner/event_gateway_schema_registry_planner.go
@@ -95,7 +95,7 @@ func (p *Planner) planSchemaRegistryChangesForExistingGateway(
 				"registry_id", current.ID,
 			)
 
-			needsUpdate, updateFields := p.shouldUpdateSchemaRegistry(current, desiredSR)
+			needsUpdate, updateFields, changedFields := p.shouldUpdateSchemaRegistry(current, desiredSR)
 			if needsUpdate {
 				p.logger.Debug("Planning schema registry UPDATE",
 					"registry_name", name,
@@ -103,8 +103,8 @@ func (p *Planner) planSchemaRegistryChangesForExistingGateway(
 					"update_fields", updateFields,
 				)
 				p.planSchemaRegistryUpdate(
-					namespace, gatewayRef, gatewayName, gatewayID,
-					current.ID, desiredSR, updateFields, plan)
+					namespace, gatewayRef, gatewayID,
+					current.ID, desiredSR, updateFields, changedFields, plan)
 			}
 		}
 	}
@@ -197,11 +197,11 @@ func (p *Planner) planSchemaRegistryCreate(
 func (p *Planner) planSchemaRegistryUpdate(
 	namespace string,
 	gatewayRef string,
-	gatewayName string,
 	gatewayID string,
 	registryID string,
 	sr resources.EventGatewaySchemaRegistryResource,
 	updateFields map[string]any,
+	changedFields map[string]FieldChange,
 	plan *Plan,
 ) {
 	change := PlannedChange{
@@ -216,9 +216,9 @@ func (p *Planner) planSchemaRegistryUpdate(
 			Ref: gatewayRef,
 			ID:  gatewayID,
 		},
-		ChangedFields: map[string]FieldChange{
-			"updated": {Old: gatewayName, New: ""},
-		},
+	}
+	if len(changedFields) > 0 {
+		change.ChangedFields = changedFields
 	}
 
 	plan.AddChange(change)
@@ -249,23 +249,24 @@ func (p *Planner) planSchemaRegistryDelete(
 }
 
 // shouldUpdateSchemaRegistry compares current and desired schema registry state.
-// It returns whether an update is needed and the fields to send in the PUT request.
+// It returns whether an update is needed, the fields to send in the PUT request,
+// and a map of which specific fields changed.
 func (p *Planner) shouldUpdateSchemaRegistry(
 	current state.EventGatewaySchemaRegistry,
 	desired resources.EventGatewaySchemaRegistryResource,
-) (bool, map[string]any) {
+) (bool, map[string]any, map[string]FieldChange) {
 	updates := make(map[string]any)
-	needsUpdate := false
+	changes := make(map[string]FieldChange)
 
 	// Only the confluent variant is currently supported.
 	conf := desired.SchemaRegistryConfluent
 	if conf == nil {
-		return false, nil
+		return false, nil, nil
 	}
 
 	// Compare name
 	if current.Name != conf.Name {
-		needsUpdate = true
+		changes["name"] = FieldChange{Old: current.Name, New: conf.Name}
 	}
 
 	// Compare description
@@ -278,12 +279,12 @@ func (p *Planner) shouldUpdateSchemaRegistry(
 		desiredDesc = *conf.Description
 	}
 	if currentDesc != desiredDesc {
-		needsUpdate = true
+		changes["description"] = FieldChange{Old: currentDesc, New: desiredDesc}
 	}
 
 	// Compare type (structural)
 	if current.Type != conf.GetType() {
-		needsUpdate = true
+		changes["type"] = FieldChange{Old: current.Type, New: conf.GetType()}
 	}
 
 	// Compare config fields using RawConfig (SDK Config struct is opaque/empty).
@@ -291,12 +292,12 @@ func (p *Planner) shouldUpdateSchemaRegistry(
 	desiredConf := conf.Config
 	currentSchemaType, _ := current.RawConfig["schema_type"].(string)
 	if currentSchemaType != string(desiredConf.SchemaType) {
-		needsUpdate = true
+		changes["config.schema_type"] = FieldChange{Old: currentSchemaType, New: string(desiredConf.SchemaType)}
 	}
 
 	currentEndpoint, _ := current.RawConfig["endpoint"].(string)
 	if currentEndpoint != desiredConf.Endpoint {
-		needsUpdate = true
+		changes["config.endpoint"] = FieldChange{Old: currentEndpoint, New: desiredConf.Endpoint}
 	}
 
 	// JSON numbers unmarshal as float64.
@@ -309,7 +310,7 @@ func (p *Planner) shouldUpdateSchemaRegistry(
 		desiredTimeout = *desiredConf.TimeoutSeconds
 	}
 	if currentTimeout != desiredTimeout {
-		needsUpdate = true
+		changes["config.timeout_seconds"] = FieldChange{Old: currentTimeout, New: desiredTimeout}
 	}
 
 	// Compare authentication fields (skip password — write-only).
@@ -318,32 +319,32 @@ func (p *Planner) shouldUpdateSchemaRegistry(
 		if currentAuth, ok := current.RawConfig["authentication"].(map[string]any); ok {
 			currentAuthType, _ := currentAuth["type"].(string)
 			if currentAuthType != desiredAuth.GetType() {
-				needsUpdate = true
+				changes["config.authentication.type"] = FieldChange{Old: currentAuthType, New: desiredAuth.GetType()}
 			}
 
 			currentUsername, _ := currentAuth["username"].(string)
 			if currentUsername != desiredAuth.Username {
-				needsUpdate = true
+				changes["config.authentication.username"] = FieldChange{Old: currentUsername, New: desiredAuth.Username}
 			}
 		} else {
-			needsUpdate = true
+			changes["config.authentication"] = FieldChange{Old: nil, New: desiredConf.Authentication}
 		}
 	} else if desiredConf.Authentication == nil {
 		if _, hasAuth := current.RawConfig["authentication"]; hasAuth {
-			needsUpdate = true
+			changes["config.authentication"] = FieldChange{Old: current.RawConfig["authentication"], New: nil}
 		}
 	}
 
 	// Compare labels
 	if !labelsEqual(current.NormalizedLabels, conf.Labels) {
-		needsUpdate = true
+		changes["labels"] = FieldChange{Old: current.NormalizedLabels, New: conf.Labels}
 	}
 
-	if needsUpdate {
+	if len(changes) > 0 {
 		updates = buildSchemaRegistryFields(desired)
 	}
 
-	return needsUpdate, updates
+	return len(changes) > 0, updates, changes
 }
 
 // labelsEqual returns true iff two label maps are identical.

--- a/internal/declarative/planner/event_gateway_schema_registry_planner.go
+++ b/internal/declarative/planner/event_gateway_schema_registry_planner.go
@@ -117,7 +117,7 @@ func (p *Planner) planSchemaRegistryChangesForExistingGateway(
 					"registry_name", name,
 					"registry_id", current.ID,
 				)
-				p.planSchemaRegistryDelete(gatewayRef, gatewayName, gatewayID, current.ID, name, plan)
+				p.planSchemaRegistryDelete(gatewayRef, gatewayID, current.ID, name, plan)
 			}
 		}
 	}
@@ -227,7 +227,6 @@ func (p *Planner) planSchemaRegistryUpdate(
 // planSchemaRegistryDelete plans a DELETE change for a schema registry.
 func (p *Planner) planSchemaRegistryDelete(
 	gatewayRef string,
-	gatewayName string,
 	gatewayID string,
 	registryID string,
 	registryName string,
@@ -259,7 +258,7 @@ func (p *Planner) shouldUpdateSchemaRegistry(
 	needsUpdate := false
 
 	// Only the confluent variant is currently supported.
-	conf := desired.SchemaRegistryCreate.SchemaRegistryConfluent
+	conf := desired.SchemaRegistryConfluent
 	if conf == nil {
 		return false, nil
 	}
@@ -364,7 +363,7 @@ func labelsEqual(a map[string]string, b map[string]string) bool {
 func buildSchemaRegistryFields(sr resources.EventGatewaySchemaRegistryResource) map[string]any {
 	fields := make(map[string]any)
 
-	conf := sr.SchemaRegistryCreate.SchemaRegistryConfluent
+	conf := sr.SchemaRegistryConfluent
 	if conf == nil {
 		return fields
 	}

--- a/internal/declarative/planner/event_gateway_schema_registry_planner.go
+++ b/internal/declarative/planner/event_gateway_schema_registry_planner.go
@@ -1,0 +1,350 @@
+package planner
+
+import (
+	"context"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+)
+
+// planEventGatewaySchemaRegistryChanges plans changes for Event Gateway Schema Registries
+// for a specific gateway.
+func (p *Planner) planEventGatewaySchemaRegistryChanges(
+	ctx context.Context,
+	_ *Config,
+	namespace string,
+	gatewayName string,
+	gatewayID string,
+	gatewayRef string,
+	gatewayChangeID string,
+	desired []resources.EventGatewaySchemaRegistryResource,
+	plan *Plan,
+) error {
+	p.logger.Debug("Planning Event Gateway Schema Registry changes",
+		"gateway_name", gatewayName,
+		"gateway_id", gatewayID,
+		"gateway_ref", gatewayRef,
+		"gateway_change_id", gatewayChangeID,
+		"desired_count", len(desired),
+		"namespace", namespace,
+	)
+
+	if gatewayID != "" {
+		return p.planSchemaRegistryChangesForExistingGateway(
+			ctx, namespace, gatewayID, gatewayRef, gatewayName, desired, plan,
+		)
+	}
+
+	// Gateway doesn't exist yet: plan creates only with dependency on gateway creation
+	p.planSchemaRegistryCreatesForNewGateway(
+		namespace, gatewayRef, gatewayName, gatewayChangeID, desired, plan)
+	return nil
+}
+
+// planSchemaRegistryChangesForExistingGateway handles full diff for schema registries of
+// an existing gateway.
+func (p *Planner) planSchemaRegistryChangesForExistingGateway(
+	ctx context.Context,
+	namespace string,
+	gatewayID string,
+	gatewayRef string,
+	gatewayName string,
+	desired []resources.EventGatewaySchemaRegistryResource,
+	plan *Plan,
+) error {
+	p.logger.Debug("Planning changes for existing gateway schema registries",
+		"gateway_id", gatewayID,
+		"gateway_ref", gatewayRef,
+		"desired_count", len(desired),
+	)
+
+	currentRegistries, err := p.client.ListEventGatewaySchemaRegistries(ctx, gatewayID)
+	if err != nil {
+		return fmt.Errorf("failed to list schema registries for gateway %s: %w", gatewayID, err)
+	}
+
+	p.logger.Debug("Fetched current schema registries",
+		"gateway_id", gatewayID,
+		"current_count", len(currentRegistries),
+	)
+
+	currentByName := make(map[string]state.EventGatewaySchemaRegistry)
+	for _, sr := range currentRegistries {
+		currentByName[sr.Name] = sr
+	}
+
+	desiredNames := make(map[string]bool)
+
+	for _, desiredSR := range desired {
+		name := desiredSR.GetMoniker()
+		desiredNames[name] = true
+
+		current, exists := currentByName[name]
+
+		if !exists {
+			p.logger.Debug("Planning schema registry CREATE",
+				"registry_name", name,
+				"gateway_ref", gatewayRef,
+			)
+			p.planSchemaRegistryCreate(namespace, gatewayRef, gatewayName, gatewayID, desiredSR, []string{}, plan)
+		} else {
+			p.logger.Debug("Checking if schema registry needs update",
+				"registry_name", name,
+				"registry_id", current.ID,
+			)
+
+			needsUpdate, updateFields := p.shouldUpdateSchemaRegistry(current, desiredSR)
+			if needsUpdate {
+				p.logger.Debug("Planning schema registry UPDATE",
+					"registry_name", name,
+					"registry_id", current.ID,
+					"update_fields", updateFields,
+				)
+				p.planSchemaRegistryUpdate(
+					namespace, gatewayRef, gatewayName, gatewayID,
+					current.ID, desiredSR, updateFields, plan)
+			}
+		}
+	}
+
+	// SYNC MODE: Delete unmanaged registries
+	if plan.Metadata.Mode == PlanModeSync {
+		for name, current := range currentByName {
+			if !desiredNames[name] {
+				p.logger.Debug("Planning schema registry DELETE (sync mode)",
+					"registry_name", name,
+					"registry_id", current.ID,
+				)
+				p.planSchemaRegistryDelete(gatewayRef, gatewayName, gatewayID, current.ID, name, plan)
+			}
+		}
+	}
+
+	return nil
+}
+
+// planSchemaRegistryCreatesForNewGateway plans creates for schema registries when the gateway
+// doesn't exist yet.
+func (p *Planner) planSchemaRegistryCreatesForNewGateway(
+	namespace string,
+	gatewayRef string,
+	gatewayName string,
+	gatewayChangeID string,
+	registries []resources.EventGatewaySchemaRegistryResource,
+	plan *Plan,
+) {
+	p.logger.Debug("Planning schema registry creates for new gateway",
+		"gateway_ref", gatewayRef,
+		"gateway_change_id", gatewayChangeID,
+		"registry_count", len(registries),
+	)
+
+	var dependsOn []string
+	if gatewayChangeID != "" {
+		dependsOn = []string{gatewayChangeID}
+	}
+
+	for _, sr := range registries {
+		p.planSchemaRegistryCreate(namespace, gatewayRef, gatewayName, "", sr, dependsOn, plan)
+	}
+}
+
+// planSchemaRegistryCreate plans a CREATE change for a schema registry.
+func (p *Planner) planSchemaRegistryCreate(
+	namespace string,
+	gatewayRef string,
+	gatewayName string,
+	gatewayID string,
+	sr resources.EventGatewaySchemaRegistryResource,
+	dependsOn []string,
+	plan *Plan,
+) {
+	fields := buildSchemaRegistryFields(sr)
+
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionCreate, ResourceTypeEventGatewaySchemaRegistry, sr.Ref),
+		ResourceType: ResourceTypeEventGatewaySchemaRegistry,
+		ResourceRef:  sr.Ref,
+		Action:       ActionCreate,
+		Fields:       fields,
+		Namespace:    namespace,
+		DependsOn:    dependsOn,
+	}
+
+	if gatewayID != "" {
+		change.Parent = &ParentInfo{
+			Ref: gatewayRef,
+			ID:  gatewayID,
+		}
+	} else {
+		change.References = map[string]ReferenceInfo{
+			"event_gateway_id": {
+				Ref: gatewayRef,
+				ID:  "", // to be resolved at runtime
+				LookupFields: map[string]string{
+					"name": gatewayName,
+				},
+			},
+		}
+	}
+
+	plan.AddChange(change)
+}
+
+// planSchemaRegistryUpdate plans an UPDATE change for a schema registry.
+func (p *Planner) planSchemaRegistryUpdate(
+	namespace string,
+	gatewayRef string,
+	gatewayName string,
+	gatewayID string,
+	registryID string,
+	sr resources.EventGatewaySchemaRegistryResource,
+	updateFields map[string]any,
+	plan *Plan,
+) {
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionUpdate, ResourceTypeEventGatewaySchemaRegistry, sr.Ref),
+		ResourceType: ResourceTypeEventGatewaySchemaRegistry,
+		ResourceRef:  sr.Ref,
+		ResourceID:   registryID,
+		Action:       ActionUpdate,
+		Fields:       updateFields,
+		Namespace:    namespace,
+		Parent: &ParentInfo{
+			Ref: gatewayRef,
+			ID:  gatewayID,
+		},
+		ChangedFields: map[string]FieldChange{
+			"updated": {Old: gatewayName, New: ""},
+		},
+	}
+
+	plan.AddChange(change)
+}
+
+// planSchemaRegistryDelete plans a DELETE change for a schema registry.
+func (p *Planner) planSchemaRegistryDelete(
+	gatewayRef string,
+	gatewayName string,
+	gatewayID string,
+	registryID string,
+	registryName string,
+	plan *Plan,
+) {
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionDelete, ResourceTypeEventGatewaySchemaRegistry, registryName),
+		ResourceType: ResourceTypeEventGatewaySchemaRegistry,
+		ResourceRef:  registryName,
+		ResourceID:   registryID,
+		Action:       ActionDelete,
+		Namespace:    "",
+		Parent: &ParentInfo{
+			Ref: gatewayRef,
+			ID:  gatewayID,
+		},
+	}
+
+	plan.AddChange(change)
+}
+
+// shouldUpdateSchemaRegistry compares current and desired schema registry state.
+// It returns whether an update is needed and the fields to send in the PUT request.
+func (p *Planner) shouldUpdateSchemaRegistry(
+	current state.EventGatewaySchemaRegistry,
+	desired resources.EventGatewaySchemaRegistryResource,
+) (bool, map[string]any) {
+	updates := make(map[string]any)
+	needsUpdate := false
+
+	// Only the confluent variant is currently supported.
+	conf := desired.SchemaRegistryCreate.SchemaRegistryConfluent
+	if conf == nil {
+		return false, nil
+	}
+
+	// Compare name
+	if current.Name != conf.Name {
+		needsUpdate = true
+	}
+
+	// Compare description
+	currentDesc := ""
+	if current.Description != nil {
+		currentDesc = *current.Description
+	}
+	desiredDesc := ""
+	if conf.Description != nil {
+		desiredDesc = *conf.Description
+	}
+	if currentDesc != desiredDesc {
+		needsUpdate = true
+	}
+
+	// Compare type (structural)
+	if current.Type != conf.GetType() {
+		needsUpdate = true
+	}
+
+	// For the confluent type compare config fields using the SDK struct
+	// (endpoint, schema_type, timeout, labels)
+	if current.Config != nil {
+		// Can't deep-compare the opaque SchemaRegistryConfig reliably;
+		// use the full config fields from the SDK struct instead.
+	}
+
+	// Compare labels
+	if !labelsEqual(current.NormalizedLabels, conf.Labels) {
+		needsUpdate = true
+	}
+
+	if needsUpdate {
+		updates = buildSchemaRegistryFields(desired)
+	}
+
+	return needsUpdate, updates
+}
+
+// labelsEqual returns true iff two label maps are identical.
+func labelsEqual(a map[string]string, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// buildSchemaRegistryFields builds the field map used in PlannedChange.Fields.
+func buildSchemaRegistryFields(sr resources.EventGatewaySchemaRegistryResource) map[string]any {
+	fields := make(map[string]any)
+
+	conf := sr.SchemaRegistryCreate.SchemaRegistryConfluent
+	if conf == nil {
+		return fields
+	}
+
+	fields["name"] = conf.Name
+	fields["type"] = conf.GetType()
+
+	if conf.Description != nil {
+		fields["description"] = *conf.Description
+	}
+
+	fields["config"] = kkComps.SchemaRegistryConfluentConfig{
+		SchemaType:     conf.Config.SchemaType,
+		Endpoint:       conf.Config.Endpoint,
+		TimeoutSeconds: conf.Config.TimeoutSeconds,
+		Authentication: conf.Config.Authentication,
+	}
+
+	if len(conf.Labels) > 0 {
+		fields["labels"] = conf.Labels
+	}
+
+	return fields
+}

--- a/internal/declarative/planner/event_gateway_schema_registry_planner.go
+++ b/internal/declarative/planner/event_gateway_schema_registry_planner.go
@@ -287,11 +287,52 @@ func (p *Planner) shouldUpdateSchemaRegistry(
 		needsUpdate = true
 	}
 
-	// For the confluent type compare config fields using the SDK struct
-	// (endpoint, schema_type, timeout, labels)
-	if current.Config != nil {
-		// Can't deep-compare the opaque SchemaRegistryConfig reliably;
-		// use the full config fields from the SDK struct instead.
+	// Compare config fields using RawConfig (SDK Config struct is opaque/empty).
+	// password is write-only and is never returned by the API, so it is skipped.
+	desiredConf := conf.Config
+	currentSchemaType, _ := current.RawConfig["schema_type"].(string)
+	if currentSchemaType != string(desiredConf.SchemaType) {
+		needsUpdate = true
+	}
+
+	currentEndpoint, _ := current.RawConfig["endpoint"].(string)
+	if currentEndpoint != desiredConf.Endpoint {
+		needsUpdate = true
+	}
+
+	// JSON numbers unmarshal as float64.
+	currentTimeout := int64(10) // API default
+	if t, ok := current.RawConfig["timeout_seconds"].(float64); ok {
+		currentTimeout = int64(t)
+	}
+	desiredTimeout := int64(10)
+	if desiredConf.TimeoutSeconds != nil {
+		desiredTimeout = *desiredConf.TimeoutSeconds
+	}
+	if currentTimeout != desiredTimeout {
+		needsUpdate = true
+	}
+
+	// Compare authentication fields (skip password — write-only).
+	if desiredConf.Authentication != nil && desiredConf.Authentication.SchemaRegistryAuthenticationBasic != nil {
+		desiredAuth := desiredConf.Authentication.SchemaRegistryAuthenticationBasic
+		if currentAuth, ok := current.RawConfig["authentication"].(map[string]any); ok {
+			currentAuthType, _ := currentAuth["type"].(string)
+			if currentAuthType != desiredAuth.GetType() {
+				needsUpdate = true
+			}
+
+			currentUsername, _ := currentAuth["username"].(string)
+			if currentUsername != desiredAuth.Username {
+				needsUpdate = true
+			}
+		} else {
+			needsUpdate = true
+		}
+	} else if desiredConf.Authentication == nil {
+		if _, hasAuth := current.RawConfig["authentication"]; hasAuth {
+			needsUpdate = true
+		}
 	}
 
 	// Compare labels

--- a/internal/declarative/protection/lookup.go
+++ b/internal/declarative/protection/lookup.go
@@ -117,7 +117,8 @@ func IsManagedResourceProtected(
 		resources.ResourceTypeEventGatewayListener,
 		resources.ResourceTypeEventGatewayListenerPolicy,
 		resources.ResourceTypeEventGatewayDataPlaneCertificate,
-		resources.ResourceTypeEventGatewayProducePolicy:
+		resources.ResourceTypeEventGatewayProducePolicy,
+		resources.ResourceTypeEventGatewaySchemaRegistry:
 		return false, nil
 	}
 

--- a/internal/declarative/resources/event_gateway_control_plane.go
+++ b/internal/declarative/resources/event_gateway_control_plane.go
@@ -23,6 +23,7 @@ type EventGatewayControlPlaneResource struct {
 	VirtualClusters       []EventGatewayVirtualClusterResource       `yaml:"virtual_clusters,omitempty"        json:"virtual_clusters,omitempty"`        //nolint:lll
 	Listeners             []EventGatewayListenerResource             `yaml:"listeners,omitempty"               json:"listeners,omitempty"`               //nolint:lll
 	DataPlaneCertificates []EventGatewayDataPlaneCertificateResource `yaml:"data_plane_certificates,omitempty" json:"data_plane_certificates,omitempty"` //nolint:lll
+	SchemaRegistries      []EventGatewaySchemaRegistryResource       `yaml:"schema_registries,omitempty"       json:"schema_registries,omitempty"`       //nolint:lll
 }
 
 func (e EventGatewayControlPlaneResource) GetType() ResourceType {
@@ -99,6 +100,18 @@ func (e EventGatewayControlPlaneResource) Validate() error {
 		dataPlaneCertRefs[dpc.GetRef()] = true
 	}
 
+	// Validate schema registries
+	schemaRegistryRefs := make(map[string]bool)
+	for i, sr := range e.SchemaRegistries {
+		if err := sr.Validate(); err != nil {
+			return fmt.Errorf("invalid schema registry %d: %w", i, err)
+		}
+		if schemaRegistryRefs[sr.GetRef()] {
+			return fmt.Errorf("duplicate schema registry ref: %s", sr.GetRef())
+		}
+		schemaRegistryRefs[sr.GetRef()] = true
+	}
+
 	return nil
 }
 
@@ -121,6 +134,10 @@ func (e *EventGatewayControlPlaneResource) SetDefaults() {
 
 	for i := range e.DataPlaneCertificates {
 		e.DataPlaneCertificates[i].SetDefaults()
+	}
+
+	for i := range e.SchemaRegistries {
+		e.SchemaRegistries[i].SetDefaults()
 	}
 }
 

--- a/internal/declarative/resources/event_gateway_schema_registry.go
+++ b/internal/declarative/resources/event_gateway_schema_registry.go
@@ -1,0 +1,181 @@
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+)
+
+func init() {
+	registerResourceType(
+		ResourceTypeEventGatewaySchemaRegistry,
+		func(rs *ResourceSet) *[]EventGatewaySchemaRegistryResource {
+			return &rs.EventGatewaySchemaRegistries
+		},
+		AutoExplain[EventGatewaySchemaRegistryResource](),
+	)
+}
+
+// EventGatewaySchemaRegistryResource represents a schema registry in declarative configuration.
+// The SDK represents schema registries as a union type (SchemaRegistryCreate) with the
+// "confluent" variant (SchemaRegistryConfluent).
+type EventGatewaySchemaRegistryResource struct {
+	kkComps.SchemaRegistryCreate `yaml:",inline" json:",inline"`
+	Ref                          string `yaml:"ref"                            json:"ref"`
+	// Parent Event Gateway reference (for root-level definitions)
+	EventGateway string `yaml:"event_gateway,omitempty" json:"event_gateway,omitempty"`
+
+	// Resolved Konnect ID (not serialized)
+	konnectID string `yaml:"-" json:"-"`
+}
+
+func (e EventGatewaySchemaRegistryResource) GetType() ResourceType {
+	return ResourceTypeEventGatewaySchemaRegistry
+}
+
+func (e EventGatewaySchemaRegistryResource) GetRef() string {
+	return e.Ref
+}
+
+// GetMoniker returns the name of the schema registry from whichever union variant is set.
+func (e EventGatewaySchemaRegistryResource) GetMoniker() string {
+	if e.SchemaRegistryConfluent != nil {
+		return e.SchemaRegistryConfluent.Name
+	}
+	return e.Ref
+}
+
+func (e EventGatewaySchemaRegistryResource) GetDependencies() []ResourceRef {
+	deps := []ResourceRef{}
+	if e.EventGateway != "" {
+		// Dependency on parent Event Gateway when defined at root level
+		deps = append(deps, ResourceRef{Kind: "event_gateway", Ref: e.EventGateway})
+	}
+	return deps
+}
+
+func (e EventGatewaySchemaRegistryResource) GetKonnectID() string {
+	return e.konnectID
+}
+
+func (e EventGatewaySchemaRegistryResource) Validate() error {
+	if err := ValidateRef(e.Ref); err != nil {
+		return fmt.Errorf("invalid schema registry ref: %w", err)
+	}
+
+	// Ensure exactly one union variant is set and that it's confluent
+	if e.SchemaRegistryConfluent == nil {
+		return fmt.Errorf("schema registry must specify the 'confluent' type")
+	}
+
+	return nil
+}
+
+func (e *EventGatewaySchemaRegistryResource) SetDefaults() {
+	// Name defaults are managed inside the union variant.
+	// If the confluent variant has no name, use ref.
+	if e.SchemaRegistryConfluent != nil && e.SchemaRegistryConfluent.Name == "" {
+		e.SchemaRegistryConfluent.Name = e.Ref
+	}
+}
+
+func (e EventGatewaySchemaRegistryResource) GetKonnectMonikerFilter() string {
+	return "" // TODO: The API does not support server-side filtering by name for schema registries.
+}
+
+func (e *EventGatewaySchemaRegistryResource) TryMatchKonnectResource(konnectResource any) bool {
+	if id := tryMatchByField(konnectResource, "Name", e.GetMoniker()); id != "" {
+		e.konnectID = id
+		return true
+	}
+	return false
+}
+
+// REQUIRED: Implement ResourceWithParent
+func (e EventGatewaySchemaRegistryResource) GetParentRef() *ResourceRef {
+	if e.EventGateway != "" {
+		return &ResourceRef{Kind: "event_gateway", Ref: e.EventGateway}
+	}
+	return nil
+}
+
+// MarshalJSON ensures schema registry metadata (ref, event_gateway) are included along with
+// the union body. Without this, the embedded SchemaRegistryCreate's MarshalJSON is promoted
+// and drops our metadata fields.
+func (e EventGatewaySchemaRegistryResource) MarshalJSON() ([]byte, error) {
+	// Marshal the embedded union type first to get the registry body
+	registryBytes, err := json.Marshal(e.SchemaRegistryCreate)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal schema registry: %w", err)
+	}
+
+	// Unmarshal into a generic map so we can add metadata fields
+	var result map[string]any
+	if err := json.Unmarshal(registryBytes, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal schema registry body: %w", err)
+	}
+
+	result["ref"] = e.Ref
+	if e.EventGateway != "" {
+		result["event_gateway"] = e.EventGateway
+	}
+
+	return json.Marshal(result)
+}
+
+// UnmarshalJSON handles the union type correctly.
+// It rejects kongctl metadata and delegates to the SDK union type for the registry body.
+// The SDK union type requires a "type" discriminator field to determine which variant to use.
+// Currently only "confluent" type is supported.
+func (e *EventGatewaySchemaRegistryResource) UnmarshalJSON(data []byte) error {
+	// First extract our metadata fields
+	var meta struct {
+		Ref          string `json:"ref"`
+		EventGateway string `json:"event_gateway,omitempty"`
+		Kongctl      any    `json:"kongctl,omitempty"`
+	}
+
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return err
+	}
+
+	if meta.Kongctl != nil {
+		return fmt.Errorf("kongctl metadata not supported on child resources")
+	}
+
+	e.Ref = meta.Ref
+	e.EventGateway = meta.EventGateway
+
+	// Validate required type discriminator field
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if err := validateSchemaRegistryType(raw); err != nil {
+		return err
+	}
+
+	// Delegate the registry-specific fields to the SDK union type's UnmarshalJSON.
+	if err := json.Unmarshal(data, &e.SchemaRegistryCreate); err != nil {
+		return fmt.Errorf("failed to unmarshal schema registry: %w", err)
+	}
+
+	return nil
+}
+
+// validateSchemaRegistryType ensures the required type discriminator is present.
+func validateSchemaRegistryType(raw map[string]any) error {
+	typeVal, ok := raw["type"]
+	if !ok {
+		return fmt.Errorf("schema registry must specify a 'type' field (currently only 'confluent' is supported)")
+	}
+
+	allowedType := string(kkComps.SchemaRegistryCreateTypeConfluent)
+	typStr, _ := typeVal.(string)
+	if typStr != allowedType {
+		return fmt.Errorf("unsupported schema registry type %q (currently only %q is supported)", typStr, allowedType)
+	}
+
+	return nil
+}

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -38,6 +38,7 @@ const (
 	ResourceTypeEventGatewayClusterPolicy        ResourceType = "event_gateway_virtual_cluster_cluster_policy"
 	ResourceTypeEventGatewayProducePolicy        ResourceType = "event_gateway_virtual_cluster_produce_policy"
 	ResourceTypeEventGatewayConsumePolicy        ResourceType = "event_gateway_virtual_cluster_consume_policy"
+	ResourceTypeEventGatewaySchemaRegistry       ResourceType = "event_gateway_schema_registry"
 )
 
 const (
@@ -92,6 +93,7 @@ type ResourceSet struct {
 	EventGatewayProducePolicies       []EventGatewayProducePolicyResource        `yaml:"event_gateway_virtual_cluster_produce_policies,omitempty" json:"event_gateway_virtual_cluster_produce_policies,omitempty"` //nolint:lll
 	EventGatewayConsumePolicies       []EventGatewayConsumePolicyResource        `yaml:"event_gateway_virtual_cluster_consume_policies,omitempty" json:"event_gateway_virtual_cluster_consume_policies,omitempty"` //nolint:lll
 	EventGatewayDataPlaneCertificates []EventGatewayDataPlaneCertificateResource `yaml:"event_gateway_data_plane_certificates,omitempty" json:"event_gateway_data_plane_certificates,omitempty"`                   //nolint:lll
+	EventGatewaySchemaRegistries      []EventGatewaySchemaRegistryResource       `yaml:"event_gateway_schema_registries,omitempty"       json:"event_gateway_schema_registries,omitempty"`                         //nolint:lll
 	// DefaultNamespace tracks namespace from _defaults when no resources are present
 	// This is used by the planner to determine which namespace to check for deletions
 	DefaultNamespace  string   `yaml:"-"                                               json:"-"`
@@ -760,6 +762,35 @@ func (rs *ResourceSet) GetDataPlaneCertificatesForGateway(
 	}
 
 	return certs
+}
+
+// GetSchemaRegistriesForGateway returns all schema registries (nested + root-level)
+// for a specific event gateway
+func (rs *ResourceSet) GetSchemaRegistriesForGateway(
+	gatewayRef string,
+) []EventGatewaySchemaRegistryResource {
+	var regs []EventGatewaySchemaRegistryResource
+
+	// Add nested schema registries from the event gateway
+	for _, gateway := range rs.EventGatewayControlPlanes {
+		if gateway.Ref == gatewayRef {
+			for _, reg := range gateway.SchemaRegistries {
+				regCopy := reg
+				regCopy.EventGateway = gatewayRef
+				regs = append(regs, regCopy)
+			}
+			break
+		}
+	}
+
+	// Add root-level schema registries for this gateway
+	for _, reg := range rs.EventGatewaySchemaRegistries {
+		if reg.EventGateway == gatewayRef {
+			regs = append(regs, reg)
+		}
+	}
+
+	return regs
 }
 
 // GetClusterPoliciesForVirtualCluster returns all cluster policies (nested + root-level)

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -60,6 +60,7 @@ type ClientConfig struct {
 	EventGatewayProducePolicyAPI        helpers.EventGatewayProducePolicyAPI
 	EventGatewayConsumePolicyAPI        helpers.EventGatewayConsumePolicyAPI
 	EventGatewayDataPlaneCertificateAPI helpers.EventGatewayDataPlaneCertificateAPI
+	EventGatewaySchemaRegistryAPI       helpers.EventGatewaySchemaRegistryAPI
 
 	// Identity resources
 	OrganizationTeamAPI helpers.OrganizationTeamAPI
@@ -103,6 +104,7 @@ type Client struct {
 	eventGatewayProducePolicyAPI        helpers.EventGatewayProducePolicyAPI
 	eventGatewayConsumePolicyAPI        helpers.EventGatewayConsumePolicyAPI
 	eventGatewayDataPlaneCertificateAPI helpers.EventGatewayDataPlaneCertificateAPI
+	eventGatewaySchemaRegistryAPI       helpers.EventGatewaySchemaRegistryAPI
 
 	// Organization resource APIs
 	organizationTeamAPI helpers.OrganizationTeamAPI
@@ -147,6 +149,7 @@ func NewClient(config ClientConfig) *Client {
 		eventGatewayProducePolicyAPI:        config.EventGatewayProducePolicyAPI,
 		eventGatewayConsumePolicyAPI:        config.EventGatewayConsumePolicyAPI,
 		eventGatewayDataPlaneCertificateAPI: config.EventGatewayDataPlaneCertificateAPI,
+		eventGatewaySchemaRegistryAPI:       config.EventGatewaySchemaRegistryAPI,
 
 		// Identity resource APIs
 		organizationTeamAPI: config.OrganizationTeamAPI,
@@ -296,6 +299,13 @@ type EventGatewayListener struct {
 // EventGatewayDataPlaneCertificate represents a data plane certificate for internal use
 type EventGatewayDataPlaneCertificate struct {
 	kkComps.EventGatewayDataPlaneCertificate
+}
+
+// EventGatewaySchemaRegistry represents a schema registry for internal use
+type EventGatewaySchemaRegistry struct {
+	kkComps.SchemaRegistry
+	NormalizedLabels map[string]string // Non-pointer labels
+	RawConfig        map[string]any    // Full config from raw API response
 }
 
 // ListManagedPortals returns all KONGCTL-managed portals in the specified namespaces
@@ -5088,6 +5098,196 @@ func (c *Client) DeleteEventGatewayDataPlaneCertificate(
 		ctx, gatewayID, certificateID)
 	if err != nil {
 		return WrapAPIError(err, "delete event gateway data plane certificate", nil)
+	}
+	return nil
+}
+
+// ListEventGatewaySchemaRegistries returns all schema registries for a given event gateway.
+// It uses cursor-based pagination to retrieve all pages.
+func (c *Client) ListEventGatewaySchemaRegistries(
+	ctx context.Context,
+	gatewayID string,
+) ([]EventGatewaySchemaRegistry, error) {
+	if err := ValidateAPIClient(c.eventGatewaySchemaRegistryAPI, "event gateway schema registry API"); err != nil {
+		return nil, err
+	}
+
+	var allData []kkComps.SchemaRegistry
+	var rawConfigByID map[string]map[string]any
+	var pageAfter *string
+
+	for {
+		req := kkOps.ListEventGatewaySchemaRegistriesRequest{
+			GatewayID: gatewayID,
+		}
+
+		if pageAfter != nil {
+			req.PageAfter = pageAfter
+		}
+
+		res, err := c.eventGatewaySchemaRegistryAPI.ListEventGatewaySchemaRegistries(ctx, req)
+		if err != nil {
+			return nil, WrapAPIError(err, "list event gateway schema registries", nil)
+		}
+
+		if res.ListSchemaRegistriesResponse == nil {
+			return []EventGatewaySchemaRegistry{}, nil
+		}
+
+		// Try to parse raw response to get full config data (SDK config struct is opaque)
+		if rawConfigByID == nil {
+			rawConfigByID = make(map[string]map[string]any)
+		}
+		if res.RawResponse != nil && res.RawResponse.Body != nil {
+			bodyBytes, readErr := io.ReadAll(res.RawResponse.Body)
+			if readErr == nil && len(bodyBytes) > 0 {
+				var rawResp struct {
+					Data []struct {
+						ID     string         `json:"id"`
+						Config map[string]any `json:"config"`
+					} `json:"data"`
+				}
+				if jsonErr := json.Unmarshal(bodyBytes, &rawResp); jsonErr == nil {
+					for _, item := range rawResp.Data {
+						if item.ID != "" && item.Config != nil {
+							rawConfigByID[item.ID] = item.Config
+						}
+					}
+				}
+			}
+		}
+
+		allData = append(allData, res.ListSchemaRegistriesResponse.Data...)
+
+		if res.ListSchemaRegistriesResponse.Meta == nil ||
+			res.ListSchemaRegistriesResponse.Meta.Page.Next == nil {
+			break
+		}
+
+		u, err := url.Parse(*res.ListSchemaRegistriesResponse.Meta.Page.Next)
+		if err != nil {
+			return nil, WrapAPIError(err, "list event gateway schema registries: invalid cursor", nil)
+		}
+
+		values := u.Query()
+		pageAfter = new(values.Get("page[after]"))
+	}
+
+	registries := make([]EventGatewaySchemaRegistry, 0, len(allData))
+	for _, sr := range allData {
+		normalized := sr.Labels
+		if normalized == nil {
+			normalized = make(map[string]string)
+		}
+		registries = append(registries, EventGatewaySchemaRegistry{
+			SchemaRegistry:   sr,
+			NormalizedLabels: normalized,
+			RawConfig:        rawConfigByID[sr.ID],
+		})
+	}
+
+	return registries, nil
+}
+
+// GetEventGatewaySchemaRegistryByID retrieves a single schema registry by ID.
+func (c *Client) GetEventGatewaySchemaRegistryByID(
+	ctx context.Context,
+	gatewayID string,
+	schemaRegistryID string,
+) (*EventGatewaySchemaRegistry, error) {
+	if err := ValidateAPIClient(c.eventGatewaySchemaRegistryAPI, "event gateway schema registry API"); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.eventGatewaySchemaRegistryAPI.GetEventGatewaySchemaRegistry(ctx, gatewayID, schemaRegistryID)
+	if err != nil {
+		return nil, WrapAPIError(err, "get event gateway schema registry", nil)
+	}
+
+	if resp.SchemaRegistry == nil {
+		return nil, nil
+	}
+
+	normalized := resp.SchemaRegistry.Labels
+	if normalized == nil {
+		normalized = make(map[string]string)
+	}
+
+	return &EventGatewaySchemaRegistry{
+		SchemaRegistry:   *resp.SchemaRegistry,
+		NormalizedLabels: normalized,
+	}, nil
+}
+
+// GetEventGatewaySchemaRegistryByName looks up a schema registry by name.
+func (c *Client) GetEventGatewaySchemaRegistryByName(
+	ctx context.Context,
+	gatewayID string,
+	name string,
+) (*EventGatewaySchemaRegistry, error) {
+	registries, err := c.ListEventGatewaySchemaRegistries(ctx, gatewayID)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range registries {
+		if registries[i].Name == name {
+			return &registries[i], nil
+		}
+	}
+
+	return nil, nil
+}
+
+// CreateEventGatewaySchemaRegistry creates a new schema registry for an event gateway.
+func (c *Client) CreateEventGatewaySchemaRegistry(
+	ctx context.Context,
+	gatewayID string,
+	req kkComps.SchemaRegistryCreate,
+	_ string, // namespace (not applicable to schema registry, which has no management labels)
+) (string, error) {
+	resp, err := c.eventGatewaySchemaRegistryAPI.CreateEventGatewaySchemaRegistry(ctx, gatewayID, req)
+	if err != nil {
+		return "", WrapAPIError(err, "create event gateway schema registry", nil)
+	}
+
+	if err := ValidateResponse(resp.SchemaRegistry, "create event gateway schema registry"); err != nil {
+		return "", err
+	}
+
+	return resp.SchemaRegistry.ID, nil
+}
+
+// UpdateEventGatewaySchemaRegistry updates an existing schema registry.
+func (c *Client) UpdateEventGatewaySchemaRegistry(
+	ctx context.Context,
+	gatewayID string,
+	schemaRegistryID string,
+	req kkComps.SchemaRegistryUpdate,
+	_ string, // namespace
+) (string, error) {
+	resp, err := c.eventGatewaySchemaRegistryAPI.UpdateEventGatewaySchemaRegistry(
+		ctx, gatewayID, schemaRegistryID, req)
+	if err != nil {
+		return "", WrapAPIError(err, "update event gateway schema registry", nil)
+	}
+
+	if err := ValidateResponse(resp.SchemaRegistry, "update event gateway schema registry"); err != nil {
+		return "", err
+	}
+
+	return resp.SchemaRegistry.ID, nil
+}
+
+// DeleteEventGatewaySchemaRegistry deletes a schema registry by ID.
+func (c *Client) DeleteEventGatewaySchemaRegistry(
+	ctx context.Context,
+	gatewayID string,
+	schemaRegistryID string,
+) error {
+	_, err := c.eventGatewaySchemaRegistryAPI.DeleteEventGatewaySchemaRegistry(ctx, gatewayID, schemaRegistryID)
+	if err != nil {
+		return WrapAPIError(err, "delete event gateway schema registry", nil)
 	}
 	return nil
 }

--- a/internal/konnect/helpers/event_gateway_schema_registries.go
+++ b/internal/konnect/helpers/event_gateway_schema_registries.go
@@ -1,0 +1,105 @@
+package helpers
+
+import (
+	"context"
+
+	kkSDK "github.com/Kong/sdk-konnect-go"
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+)
+
+// EventGatewaySchemaRegistryAPI defines operations for Event Gateway Schema Registries.
+type EventGatewaySchemaRegistryAPI interface {
+	ListEventGatewaySchemaRegistries(
+		ctx context.Context,
+		request kkOps.ListEventGatewaySchemaRegistriesRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.ListEventGatewaySchemaRegistriesResponse, error)
+
+	GetEventGatewaySchemaRegistry(
+		ctx context.Context,
+		gatewayID string,
+		schemaRegistryID string,
+		opts ...kkOps.Option,
+	) (*kkOps.GetEventGatewaySchemaRegistryResponse, error)
+
+	CreateEventGatewaySchemaRegistry(
+		ctx context.Context,
+		gatewayID string,
+		request kkComps.SchemaRegistryCreate,
+		opts ...kkOps.Option,
+	) (*kkOps.CreateEventGatewaySchemaRegistryResponse, error)
+
+	UpdateEventGatewaySchemaRegistry(
+		ctx context.Context,
+		gatewayID string,
+		schemaRegistryID string,
+		request kkComps.SchemaRegistryUpdate,
+		opts ...kkOps.Option,
+	) (*kkOps.UpdateEventGatewaySchemaRegistryResponse, error)
+
+	DeleteEventGatewaySchemaRegistry(
+		ctx context.Context,
+		gatewayID string,
+		schemaRegistryID string,
+		opts ...kkOps.Option,
+	) (*kkOps.DeleteEventGatewaySchemaRegistryResponse, error)
+}
+
+// EventGatewaySchemaRegistryAPIImpl implements EventGatewaySchemaRegistryAPI using the Konnect SDK.
+type EventGatewaySchemaRegistryAPIImpl struct {
+	SDK *kkSDK.SDK
+}
+
+func (a *EventGatewaySchemaRegistryAPIImpl) ListEventGatewaySchemaRegistries(
+	ctx context.Context,
+	request kkOps.ListEventGatewaySchemaRegistriesRequest,
+	opts ...kkOps.Option,
+) (*kkOps.ListEventGatewaySchemaRegistriesResponse, error) {
+	return a.SDK.EventGatewaySchemaRegistries.ListEventGatewaySchemaRegistries(ctx, request, opts...)
+}
+
+func (a *EventGatewaySchemaRegistryAPIImpl) GetEventGatewaySchemaRegistry(
+	ctx context.Context,
+	gatewayID string,
+	schemaRegistryID string,
+	opts ...kkOps.Option,
+) (*kkOps.GetEventGatewaySchemaRegistryResponse, error) {
+	return a.SDK.EventGatewaySchemaRegistries.GetEventGatewaySchemaRegistry(
+		ctx, gatewayID, schemaRegistryID, opts...)
+}
+
+func (a *EventGatewaySchemaRegistryAPIImpl) CreateEventGatewaySchemaRegistry(
+	ctx context.Context,
+	gatewayID string,
+	request kkComps.SchemaRegistryCreate,
+	opts ...kkOps.Option,
+) (*kkOps.CreateEventGatewaySchemaRegistryResponse, error) {
+	return a.SDK.EventGatewaySchemaRegistries.CreateEventGatewaySchemaRegistry(
+		ctx, gatewayID, &request, opts...)
+}
+
+func (a *EventGatewaySchemaRegistryAPIImpl) UpdateEventGatewaySchemaRegistry(
+	ctx context.Context,
+	gatewayID string,
+	schemaRegistryID string,
+	request kkComps.SchemaRegistryUpdate,
+	opts ...kkOps.Option,
+) (*kkOps.UpdateEventGatewaySchemaRegistryResponse, error) {
+	req := kkOps.UpdateEventGatewaySchemaRegistryRequest{
+		GatewayID:            gatewayID,
+		SchemaRegistryID:     schemaRegistryID,
+		SchemaRegistryUpdate: &request,
+	}
+	return a.SDK.EventGatewaySchemaRegistries.UpdateEventGatewaySchemaRegistry(ctx, req, opts...)
+}
+
+func (a *EventGatewaySchemaRegistryAPIImpl) DeleteEventGatewaySchemaRegistry(
+	ctx context.Context,
+	gatewayID string,
+	schemaRegistryID string,
+	opts ...kkOps.Option,
+) (*kkOps.DeleteEventGatewaySchemaRegistryResponse, error) {
+	return a.SDK.EventGatewaySchemaRegistries.DeleteEventGatewaySchemaRegistry(
+		ctx, gatewayID, schemaRegistryID, opts...)
+}

--- a/internal/konnect/helpers/sdk.go
+++ b/internal/konnect/helpers/sdk.go
@@ -54,6 +54,7 @@ type SDKAPI interface {
 	GetEventGatewayProducePolicyAPI() EventGatewayProducePolicyAPI
 	GetEventGatewayConsumePolicyAPI() EventGatewayConsumePolicyAPI
 	GetEventGatewayDataPlaneCertificateAPI() EventGatewayDataPlaneCertificateAPI
+	GetEventGatewaySchemaRegistryAPI() EventGatewaySchemaRegistryAPI
 }
 
 // This is the real implementation of the SDKAPI
@@ -381,6 +382,15 @@ func (k *KonnectSDK) GetEventGatewayConsumePolicyAPI() EventGatewayConsumePolicy
 	}
 
 	return &EventGatewayConsumePolicyAPIImpl{SDK: k.SDK}
+}
+
+// GetEventGatewaySchemaRegistryAPI returns the implementation of the EventGatewaySchemaRegistryAPI interface.
+func (k *KonnectSDK) GetEventGatewaySchemaRegistryAPI() EventGatewaySchemaRegistryAPI {
+	if k.SDK == nil {
+		return nil
+	}
+
+	return &EventGatewaySchemaRegistryAPIImpl{SDK: k.SDK}
 }
 
 func (k *KonnectSDK) GetOrganizationTeamAPI() OrganizationTeamAPI {

--- a/internal/konnect/helpers/sdk_mock.go
+++ b/internal/konnect/helpers/sdk_mock.go
@@ -45,6 +45,7 @@ type MockKonnectSDK struct {
 	EventGatewayProducePolicyFactory        func() EventGatewayProducePolicyAPI
 	EventGatewayConsumePolicyFactory        func() EventGatewayConsumePolicyAPI
 	EventGatewayDataPlaneCertificateFactory func() EventGatewayDataPlaneCertificateAPI
+	EventGatewaySchemaRegistryFactory       func() EventGatewaySchemaRegistryAPI
 }
 
 // Returns a mock instance of the ControlPlaneAPI
@@ -328,6 +329,14 @@ func (m *MockKonnectSDK) GetEventGatewayConsumePolicyAPI() EventGatewayConsumePo
 func (m *MockKonnectSDK) GetEventGatewayDataPlaneCertificateAPI() EventGatewayDataPlaneCertificateAPI {
 	if m.EventGatewayDataPlaneCertificateFactory != nil {
 		return m.EventGatewayDataPlaneCertificateFactory()
+	}
+	return nil
+}
+
+// Returns a mock instance of the EventGatewaySchemaRegistryAPI
+func (m *MockKonnectSDK) GetEventGatewaySchemaRegistryAPI() EventGatewaySchemaRegistryAPI {
+	if m.EventGatewaySchemaRegistryFactory != nil {
+		return m.EventGatewaySchemaRegistryFactory()
 	}
 	return nil
 }

--- a/test/e2e/scenarios/event-gateway/dump/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/dump/scenario.yaml
@@ -46,7 +46,7 @@ steps:
           - select: summary
             expect:
               fields:
-                applied: 5
+                applied: 6
                 failed: 0
 
   # Dump event_gateways with child resources and validate the output structure.

--- a/test/e2e/scenarios/event-gateway/dump/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/dump/scenario.yaml
@@ -17,6 +17,8 @@ vars:
   vcRef: default-virtual-cluster
   producePolicyName: default-produce-policy-name-for-dump-test
   consumePolicyName: default-consume-policy-name-for-dump-test
+  schemaRegistryRef: default-schema-registry
+  schemaRegistryName: default-schema-registry-name-for-dump-test
 
 defaults:
   mask:
@@ -96,6 +98,12 @@ steps:
                 name: "{{ .vars.consumePolicyName }}"
                 type: schema_validation
                 enabled: true
+          - name: schema-registry-present
+            select: >-
+              event_gateways[?name=='{{ .vars.egwName }}'] | [0].schema_registries[?name=='{{ .vars.schemaRegistryName }}'] | [0]
+            expect:
+              fields:
+                name: "{{ .vars.schemaRegistryName }}"
           - name: namespace-label-preserved
             select: "_defaults.kongctl"
             expect:

--- a/test/e2e/scenarios/event-gateway/dump/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/dump/testdata/config.yaml
@@ -55,3 +55,16 @@ event_gateways:
             name: default-consume-policy-name-for-dump-test
             ref: default-consume-policy
             type: schema_validation
+    schema_registries:
+      - ref: default-schema-registry
+        name: default-schema-registry-name-for-dump-test
+        description: "Default Schema Registry description for Dump Test"
+        type: confluent
+        config:
+          schema_type: json
+          endpoint: https://schema-registry.example.com
+          timeout_seconds: 30
+          authentication:
+            type: basic
+            username: testuser
+            password: "${env[\"KAFKA_PASSWORD\"]}"

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/010-schema-registry/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/010-schema-registry/config.yaml
@@ -1,0 +1,116 @@
+_defaults:
+  kongctl:
+    namespace: egw-plan-apply
+
+event_gateways:
+  - ref: plan-apply-egw
+    name: plan-apply-egw
+    description: "Updated description for plan apply workflow"
+    backend_clusters:
+      - ref: plan-apply-backend-cluster
+        name: plan-apply-backend-cluster
+        description: "Updated description for plan apply backend cluster"
+        bootstrap_servers:
+          - "egw-backend-1-updated.example.com:9092"
+        authentication:
+          type: anonymous
+        tls:
+          enabled: true
+          skip_verify: false
+          tls_versions:
+            - tls12
+            - tls13
+    virtual_clusters:
+      - ref: plan-apply-virtual-cluster
+        name: plan-apply-virtual-cluster
+        description: "Virtual cluster for plan apply workflow"
+        destination:
+          name: plan-apply-backend-cluster
+        authentication:
+          - type: sasl_scram
+            algorithm: sha512
+        acl_mode: enforce_on_gateway
+        dns_label: vc-default
+        cluster_policies:
+          - ref: plan-apply-cluster-policy
+            name: plan-apply-cluster-policy-name-for-test
+            description: Plan Apply Cluster Policy description
+            type: acls
+            enabled: true
+            config:
+              rules:
+                - action: "deny"
+                  operations:
+                  - name: "describe_configs"
+                  resource_names:
+                  - match: "*"
+                  resource_type: "transactional_id"
+        produce_policies:
+          - ref: plan-apply-produce-policy
+            name: plan-apply-produce-policy-name-for-test
+            description: Plan Apply Produce Policy description
+            type: modify_headers
+            enabled: true
+            labels:
+              env: staging
+              team: streaming
+            config:
+              actions:
+                - op: set
+                  key: x-producer-id
+                  value: "${client_id}"
+                - op: remove
+                  key: x-original-header
+    schema_registries:
+      - ref: plan-apply-schema-registry
+        name: plan-apply-schema-registry-name
+        description: "Plan Apply Schema Registry description"
+        type: confluent
+        config:
+          schema_type: json
+          endpoint: https://schema-registry.example.com
+          timeout_seconds: 30
+          authentication:
+            type: basic
+            username: testuser
+            password: testpassword
+    listeners:
+      - ref: plan-apply-listener
+        name: plan-apply-listener
+        description: "Listener for plan apply workflow"
+        ports:
+          - "9093-9095"
+        addresses:
+          - localhost
+        policies:
+          - ref: plan-apply-listener-1-policy-1-ref
+            name: plan-apply-listener-1-policy-1-name
+            type: forward_to_virtual_cluster
+            description: "Plan Apply Listener 1 Policy 1"
+            enabled: true
+            condition: "${ssl_sni} == \"example.com\""
+            labels:
+              env: staging
+              team: payments
+            config:
+              type: sni
+              advertised_port: 9092
+              sni_suffix: ".example.com"
+    data_plane_certificates:
+      - ref: plan-apply-dataplane-certificate-ref
+        name: plan-apply-dataplane-certificate-name
+        description: "Plan Apply Dataplane Certificate description"
+        certificate: |-
+          -----BEGIN CERTIFICATE-----
+          MIIB4TCCAYugAwIBAgIUAenxUyPjkSLCe2BQXoBMBacqgLowDQYJKoZIhvcNAQEL
+          BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+          GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yNDEwMjgyMDA3NDlaFw0zNDEw
+          MjYyMDA3NDlaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+          HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwXDANBgkqhkiG9w0BAQEF
+          AANLADBIAkEAyzipjrbAaLO/yPg7lL1dLWzhqNdc3S4YNR7f1RG9whWhbsPE2z42
+          e6WGFf9hggP6xjG4qbU8jFVczpd1UPwGbQIDAQABo1MwUTAdBgNVHQ4EFgQUkPPB
+          ghj+iHOHAKJlC1gLbKT/ZHQwHwYDVR0jBBgwFoAUkPPBghj+iHOHAKJlC1gLbKT/
+          ZHQwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAANBALfy49GvA2ld+u+G
+          Koxa8kCt7uywoqu0hfbBfUT4HqmXPvsuhz8RinE5ltxId108vtDNlD/+bKl+N5Ub
+          qKjBs0k=
+          -----END CERTIFICATE-----

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/010-schema-registry/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/010-schema-registry/config.yaml
@@ -61,6 +61,13 @@ event_gateways:
                   value: "${client_id}"
                 - op: remove
                   key: x-original-header
+        consume_policies:
+          - condition: ""
+            description: description
+            enabled: true
+            name: skip-record-policy
+            ref: plan-apply-consume-policy
+            type: skip_record
     schema_registries:
       - ref: plan-apply-schema-registry
         name: plan-apply-schema-registry-name

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/scenario.yaml
@@ -34,6 +34,9 @@ vars:
   producePolicyDesc: "Plan Apply Produce Policy description"
   consumePolicyRef: plan-apply-consume-policy
   consumePolicyName: skip-record-policy
+  schemaRegistryRef: plan-apply-schema-registry
+  schemaRegistryName: plan-apply-schema-registry-name
+  schemaRegistryDesc: "Plan Apply Schema Registry description"
 
 defaults:
   mask:
@@ -794,4 +797,79 @@ steps:
               fields:
                 name: "{{ .vars.consumePolicyName }}"
                 type: skip_record
-                enabled: true 
+                enabled: true
+  - name: 011-plan-apply-schema-registry
+    inputOverlayDirs:
+      - overlays/010-schema-registry
+    commands:
+      - name: 000-plan-create-schema-registry
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-schema-registry.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_schema_registry' && resource_ref=='{{ .vars.schemaRegistryRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.schemaRegistryRef }}"
+      - name: 001-diff-plan-text
+        outputFormat: text
+        parseAs: raw
+        run:
+          - diff
+          - --plan
+          - "{{ .workdir }}/plan-schema-registry.json"
+        assertions:
+          - select: stdout
+            expect:
+              fields:
+                "contains(@, 'Plan: 1 to add')": true
+                "contains(@, 'event_gateway_schema_registry \"plan-apply-schema-registry\" will be created')": true
+      - name: 002-apply-plan
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-schema-registry.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 003-verify-schema-registry
+        run:
+          - get
+          - event-gateway
+          - schema-registries
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 1
+          - select: "[0]"
+            expect:
+              fields:
+                name: "{{ .vars.schemaRegistryName }}"
+                description: "{{ .vars.schemaRegistryDesc }}"
+                type: confluent

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/010-schema-registry/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/010-schema-registry/config.yaml
@@ -60,6 +60,17 @@ event_gateways:
                   value: "${client_id}"
                 - op: remove
                   key: x-original-header
+        consume_policies:
+          - condition: ""
+            config:
+              key_validation_action: mark
+              type: json
+              value_validation_action: skip
+            description: ""
+            enabled: true
+            name: plan-sync-consume-policy-name-for-test
+            ref: plan-sync-consume-policy
+            type: schema_validation
     schema_registries:
       - ref: plan-sync-schema-registry
         name: plan-sync-schema-registry-name

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/010-schema-registry/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/010-schema-registry/config.yaml
@@ -1,0 +1,116 @@
+_defaults:
+  kongctl:
+    namespace: egw-plan-sync
+
+event_gateways:
+  - ref: plan-sync-egw
+    name: plan-sync-egw
+    description: "Updated description for plan sync workflow"
+    backend_clusters:
+      - ref: plan-sync-backend-cluster
+        name: plan-sync-backend-cluster
+        description: "Updated description for plan apply backend cluster"
+        bootstrap_servers:
+          - "egw-backend-1-updated.example.com:9092"
+        authentication:
+          type: anonymous
+        tls:
+          enabled: true
+          skip_verify: false
+          tls_versions:
+            - tls12
+            - tls13
+    virtual_clusters:
+      - ref: plan-sync-virtual-cluster
+        name: plan-sync-virtual-cluster
+        description: "Virtual cluster for plan sync workflow"
+        destination:
+          id: !ref plan-sync-backend-cluster#id
+        authentication:
+          - type: anonymous
+        acl_mode: enforce_on_gateway
+        dns_label: vc-default
+        cluster_policies:
+          - ref: plan-sync-cluster-policy
+            name: plan-sync-cluster-policy-name-for-test
+            description: Plan Sync Cluster Policy description
+            type: acls
+            enabled: true
+            config:
+              rules:
+                - action: "deny"
+                  operations:
+                  - name: "describe_configs"
+                  resource_names:
+                  - match: "*"
+                  resource_type: "transactional_id"
+        produce_policies:
+          - ref: plan-sync-produce-policy
+            name: plan-sync-produce-policy-name-for-test
+            description: Plan Sync Produce Policy description
+            type: modify_headers
+            enabled: true
+            labels:
+              env: staging
+              team: streaming
+            config:
+              actions:
+                - op: set
+                  key: x-producer-id
+                  value: "${client_id}"
+                - op: remove
+                  key: x-original-header
+    schema_registries:
+      - ref: plan-sync-schema-registry
+        name: plan-sync-schema-registry-name
+        description: "Plan Sync Schema Registry description"
+        type: confluent
+        config:
+          schema_type: json
+          endpoint: https://schema-registry.example.com
+          timeout_seconds: 30
+          authentication:
+            type: basic
+            username: testuser
+            password: testpassword
+    listeners:
+      - ref: plan-sync-listener
+        name: plan-sync-listener
+        description: "Listener for plan sync workflow"
+        ports:
+          - 9092
+        addresses:
+          - localhost
+        policies:
+          - ref: plan-sync-listener-1-policy-1-ref
+            name: plan-sync-listener-1-policy-1-name
+            type: forward_to_virtual_cluster
+            description: "Plan Sync Listener 1 Policy 1"
+            enabled: true
+            condition: "${ssl_sni} == \"example.com\""
+            labels:
+              env: staging
+              team: payments
+            config:
+              type: port_mapping
+              destination:
+                id: !ref plan-sync-virtual-cluster#id
+              advertised_host: "example.com"
+    data_plane_certificates:
+      - ref: plan-sync-dataplane-certificate-ref
+        name: plan-sync-dataplane-certificate-name
+        description: "Plan Sync Dataplane Certificate description"
+        certificate: |-
+          -----BEGIN CERTIFICATE-----
+          MIIB4TCCAYugAwIBAgIUAenxUyPjkSLCe2BQXoBMBacqgLowDQYJKoZIhvcNAQEL
+          BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+          GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yNDEwMjgyMDA3NDlaFw0zNDEw
+          MjYyMDA3NDlaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+          HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwXDANBgkqhkiG9w0BAQEF
+          AANLADBIAkEAyzipjrbAaLO/yPg7lL1dLWzhqNdc3S4YNR7f1RG9whWhbsPE2z42
+          e6WGFf9hggP6xjG4qbU8jFVczpd1UPwGbQIDAQABo1MwUTAdBgNVHQ4EFgQUkPPB
+          ghj+iHOHAKJlC1gLbKT/ZHQwHwYDVR0jBBgwFoAUkPPBghj+iHOHAKJlC1gLbKT/
+          ZHQwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAANBALfy49GvA2ld+u+G
+          Koxa8kCt7uywoqu0hfbBfUT4HqmXPvsuhz8RinE5ltxId108vtDNlD/+bKl+N5Ub
+          qKjBs0k=
+          -----END CERTIFICATE-----

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/scenario.yaml
@@ -34,6 +34,9 @@ vars:
   producePolicyDesc: "Plan Sync Produce Policy description"
   consumePolicyRef: plan-sync-consume-policy
   consumePolicyName: plan-sync-consume-policy-name-for-test
+  schemaRegistryRef: plan-sync-schema-registry
+  schemaRegistryName: plan-sync-schema-registry-name
+  schemaRegistryDesc: "Plan Sync Schema Registry description"
 
 defaults:
   mask:
@@ -891,3 +894,91 @@ steps:
             expect:
               fields:
                 "contains(@, 'No changes detected. Konnect is up to date.')": true
+  - name: 011-plan-sync-schema-registry
+    inputOverlayDirs:
+      - overlays/010-schema-registry
+    commands:
+      - name: 000-plan-create-schema-registry
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-schema-registry.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: sync
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_schema_registry' && resource_ref=='{{ .vars.schemaRegistryRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.schemaRegistryRef }}"
+      - name: 001-diff-plan-text
+        outputFormat: text
+        parseAs: raw
+        run:
+          - diff
+          - --plan
+          - "{{ .workdir }}/plan-schema-registry.json"
+        assertions:
+          - select: stdout
+            expect:
+              fields:
+                "contains(@, 'Plan: 1 to add')": true
+                "contains(@, 'event_gateway_schema_registry \"plan-sync-schema-registry\" will be created')": true
+      - name: 002-sync-plan
+        outputFormat: json
+        run:
+          - sync
+          - --plan
+          - "{{ .workdir }}/plan-schema-registry.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 003-verify-schema-registry
+        run:
+          - get
+          - event-gateway
+          - schema-registries
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 1
+          - select: "[0]"
+            expect:
+              fields:
+                name: "{{ .vars.schemaRegistryName }}"
+                description: "{{ .vars.schemaRegistryDesc }}"
+                type: confluent
+      - name: 004-diff-no-changes
+        outputFormat: text
+        parseAs: raw
+        run:
+          - diff
+          - -f
+          - "{{ .workdir }}/config.yaml"
+        assertions:
+          - select: stdout
+            expect:
+              fields:
+                "contains(@, 'No changes detected. Konnect is up to date.')": true
+

--- a/test/e2e/scenarios/event-gateway/schema-registry/overlays/001-update-fields/config.yaml
+++ b/test/e2e/scenarios/event-gateway/schema-registry/overlays/001-update-fields/config.yaml
@@ -1,0 +1,21 @@
+_defaults:
+  kongctl:
+    namespace: event-gateways-schema-registry-test
+
+event_gateways:
+  - ref: egw-cp-for-schema-registry-test-ref
+    name: egw-cp-for-schema-registry-test-name
+    description: "EGW CP for Schema Registry Test"
+    schema_registries:
+      - ref: default-schema-registry-ref
+        name: default-schema-registry-name
+        description: "Updated Schema Registry description"
+        type: confluent
+        config:
+          schema_type: avro
+          endpoint: https://schema-registry-updated.example.com
+          timeout_seconds: 60
+          authentication:
+            type: basic
+            username: updateduser
+            password: updatedpassword

--- a/test/e2e/scenarios/event-gateway/schema-registry/overlays/002-sync-delete/config.yaml
+++ b/test/e2e/scenarios/event-gateway/schema-registry/overlays/002-sync-delete/config.yaml
@@ -1,0 +1,9 @@
+_defaults:
+  kongctl:
+    namespace: event-gateways-schema-registry-test
+
+event_gateways:
+  - ref: egw-cp-for-schema-registry-test-ref
+    name: egw-cp-for-schema-registry-test-name
+    description: "EGW CP for Schema Registry Test"
+    schema_registries: []

--- a/test/e2e/scenarios/event-gateway/schema-registry/overlays/003-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/schema-registry/overlays/003-root-level-declaration/config.yaml
@@ -2,6 +2,11 @@ _defaults:
   kongctl:
     namespace: event-gateways-schema-registry-test
 
+event_gateways:
+  - ref: egw-cp-for-schema-registry-test-ref
+    name: egw-cp-for-schema-registry-test-name
+    description: "EGW CP for Schema Registry Test"
+
 event_gateway_schema_registries:
   - ref: default-schema-registry-ref
     event_gateway: egw-cp-for-schema-registry-test-ref

--- a/test/e2e/scenarios/event-gateway/schema-registry/overlays/003-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/schema-registry/overlays/003-root-level-declaration/config.yaml
@@ -1,0 +1,18 @@
+_defaults:
+  kongctl:
+    namespace: event-gateways-schema-registry-test
+
+event_gateway_schema_registries:
+  - ref: default-schema-registry-ref
+    event_gateway: egw-cp-for-schema-registry-test-ref
+    name: default-schema-registry-name
+    description: "Default root level Schema Registry description"
+    type: confluent
+    config:
+      schema_type: json
+      endpoint: https://schema-registry.example.com
+      timeout_seconds: 30
+      authentication:
+        type: basic
+        username: rootuser
+        password: rootpassword

--- a/test/e2e/scenarios/event-gateway/schema-registry/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/schema-registry/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -2,4 +2,9 @@ _defaults:
   kongctl:
     namespace: event-gateways-schema-registry-test
 
+event_gateways:
+  - ref: egw-cp-for-schema-registry-test-ref
+    name: egw-cp-for-schema-registry-test-name
+    description: "EGW CP for Schema Registry Test"
+
 event_gateway_schema_registries: []

--- a/test/e2e/scenarios/event-gateway/schema-registry/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/schema-registry/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -1,0 +1,5 @@
+_defaults:
+  kongctl:
+    namespace: event-gateways-schema-registry-test
+
+event_gateway_schema_registries: []

--- a/test/e2e/scenarios/event-gateway/schema-registry/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/schema-registry/scenario.yaml
@@ -1,0 +1,325 @@
+baseInputsPath: testdata
+
+env:
+  KONGCTL_LOG_LEVEL: info
+
+test:
+  enabledByEnvVar: KONGCTL_ENABLE_EVENT_GATEWAY
+
+vars:
+  egwName: egw-cp-for-schema-registry-test-name
+  schemaRegistryRef: default-schema-registry-ref
+  schemaRegistryName: default-schema-registry-name
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - created_at
+      - updated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+  - name: 001-plan-apply-create
+    commands:
+      - name: 001-plan-create
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-create.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 2
+                by_action.CREATE: 2
+          - select: >-
+              changes[?resource_type=='event_gateway' && resource_ref=='egw-cp-for-schema-registry-test-ref'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "egw-cp-for-schema-registry-test-ref"
+          - select: >-
+              changes[?resource_type=='event_gateway_schema_registry' && resource_ref=='{{ .vars.schemaRegistryRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.schemaRegistryRef }}"
+      - name: 002-apply-create
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-create.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 2
+                failed: 0
+
+      - name: 003-verify-create
+        run:
+          - get
+          - event-gateway
+          - schema-registries
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 1
+          - select: "[0]"
+            expect:
+              fields:
+                Name: default-schema-registry-name
+                Description: "Default Schema Registry description"
+  - name: 002-plan-apply-update
+    inputOverlayDirs:
+      - overlays/001-update-fields
+    commands:
+      - name: 001-plan-update
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-update.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_schema_registry' && resource_ref=='{{ .vars.schemaRegistryRef }}'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                resource_ref: "{{ .vars.schemaRegistryRef }}"
+      - name: 002-apply-update
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-update.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 003-verify-update
+        run:
+          - get
+          - event-gateway
+          - schema-registries
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 1
+          - select: "[0]"
+            expect:
+              fields:
+                Name: "{{ .vars.schemaRegistryName }}"
+                Description: "Updated Schema Registry description"
+  - name: 003-sync-delete
+    inputOverlayDirs:
+      - overlays/002-sync-delete
+    commands:
+      - name: 001-plan-sync-delete
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-sync-delete.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: sync
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_schema_registry' && resource_ref=='{{ .vars.schemaRegistryName }}'] | [0]
+            expect:
+              fields:
+                action: DELETE
+                resource_ref: "{{ .vars.schemaRegistryName }}"
+      - name: 002-sync-delete
+        outputFormat: json
+        run:
+          - sync
+          - --plan
+          - "{{ .workdir }}/plan-sync-delete.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 003-verify-delete
+        run:
+          - get
+          - event-gateway
+          - schema-registries
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 0
+  - name: 004-root-level-declaration
+    inputOverlayDirs:
+      - overlays/003-root-level-declaration
+    commands:
+      - name: 001-plan-root-level
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-root-level.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_schema_registry' && resource_ref=='{{ .vars.schemaRegistryRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.schemaRegistryRef }}"
+      - name: 002-apply-create
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-root-level.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 003-verify-create
+        run:
+          - get
+          - event-gateway
+          - schema-registries
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 1
+          - select: "[0]"
+            expect:
+              fields:
+                Name: default-schema-registry-name
+                Description: "Default root level Schema Registry description"
+  - name: 005-sync-delete-root-level
+    inputOverlayDirs:
+      - overlays/004-sync-delete-root-level-declaration
+    commands:
+      - name: 001-plan-sync-delete-root-level
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-sync-delete-root-level.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: sync
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_schema_registry' && resource_ref=='{{ .vars.schemaRegistryName }}'] | [0]
+            expect:
+              fields:
+                action: DELETE
+                resource_ref: "{{ .vars.schemaRegistryName }}"
+      - name: 002-sync-delete-root-level
+        outputFormat: json
+        run:
+          - sync
+          - --plan
+          - "{{ .workdir }}/plan-sync-delete-root-level.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 003-verify-delete-root-level
+        run:
+          - get
+          - event-gateway
+          - schema-registries
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 0

--- a/test/e2e/scenarios/event-gateway/schema-registry/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/schema-registry/scenario.yaml
@@ -87,8 +87,8 @@ steps:
           - select: "[0]"
             expect:
               fields:
-                Name: default-schema-registry-name
-                Description: "Default Schema Registry description"
+                name: "{{ .vars.schemaRegistryName }}"
+                description: "Default Schema Registry description"
   - name: 002-plan-apply-update
     inputOverlayDirs:
       - overlays/001-update-fields
@@ -148,8 +148,8 @@ steps:
           - select: "[0]"
             expect:
               fields:
-                Name: "{{ .vars.schemaRegistryName }}"
-                Description: "Updated Schema Registry description"
+                name: "{{ .vars.schemaRegistryName }}"
+                description: "Updated Schema Registry description"
   - name: 003-sync-delete
     inputOverlayDirs:
       - overlays/002-sync-delete
@@ -265,8 +265,8 @@ steps:
           - select: "[0]"
             expect:
               fields:
-                Name: default-schema-registry-name
-                Description: "Default root level Schema Registry description"
+                name: default-schema-registry-name
+                description: "Default root level Schema Registry description"
   - name: 005-sync-delete-root-level
     inputOverlayDirs:
       - overlays/004-sync-delete-root-level-declaration

--- a/test/e2e/scenarios/event-gateway/schema-registry/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/schema-registry/testdata/config.yaml
@@ -1,0 +1,21 @@
+_defaults:
+  kongctl:
+    namespace: event-gateways-schema-registry-test
+
+event_gateways:
+  - ref: egw-cp-for-schema-registry-test-ref
+    name: egw-cp-for-schema-registry-test-name
+    description: "EGW CP for Schema Registry Test"
+    schema_registries:
+      - ref: default-schema-registry-ref
+        name: default-schema-registry-name
+        description: "Default Schema Registry description"
+        type: confluent
+        config:
+          schema_type: json
+          endpoint: https://schema-registry.example.com
+          timeout_seconds: 30
+          authentication:
+            type: basic
+            username: testuser
+            password: testpassword


### PR DESCRIPTION
## Summary
In this PR, we are adding support for
1. Declarative management of Event Gateway Schema Registry
2. Imperative GET for Schema Registry
3. Dump for Schema Registry
4. View for Schema Registry

Example for GET
```
./kongctl get egw schema-registry --gateway-id $EGW_ID
./kongctl get egw schema-registry --gateway-id $EGW_ID --schema-registry-id $SRID
./kongctl get konnect egw sr --gateway-name $EGW_NAME --schema-registry-name $SRNAME
```

