### PR TITLE
feat: event gateway static keys

### DIFF
--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -2291,6 +2291,7 @@ func createStateClient(kkClient helpers.SDKAPI) *state.Client {
 		EventGatewayProducePolicyAPI:        kkClient.GetEventGatewayProducePolicyAPI(),
 		EventGatewayConsumePolicyAPI:        kkClient.GetEventGatewayConsumePolicyAPI(),
 		EventGatewaySchemaRegistryAPI:       kkClient.GetEventGatewaySchemaRegistryAPI(),
+		EventGatewayStaticKeyAPI:            kkClient.GetEventGatewayStaticKeyAPI(),
 		// Organization APIs
 		OrganizationTeamAPI: kkClient.GetOrganizationTeamAPI(),
 	})

--- a/internal/cmd/root/products/konnect/eventgateway/child_common.go
+++ b/internal/cmd/root/products/konnect/eventgateway/child_common.go
@@ -47,6 +47,12 @@ const (
 	schemaRegistryIDConfigPath   = "konnect.event-gateway.schema-registry.id"
 	schemaRegistryNameConfigPath = "konnect.event-gateway.schema-registry.name"
 
+	staticKeyIDFlagName   = "static-key-id"
+	staticKeyNameFlagName = "static-key-name"
+
+	staticKeyIDConfigPath   = "konnect.event-gateway.static-key.id"
+	staticKeyNameConfigPath = "konnect.event-gateway.static-key.name"
+
 	valueNA = "n/a"
 )
 
@@ -275,6 +281,42 @@ func bindSchemaRegistryChildFlags(c *cobra.Command, args []string) error {
 
 func getSchemaRegistryIdentifiers(cfg config.Hook) (id string, name string) {
 	return cfg.GetString(schemaRegistryIDConfigPath), cfg.GetString(schemaRegistryNameConfigPath)
+}
+
+func addStaticKeyChildFlags(cmd *cobra.Command) {
+	cmd.Flags().String(staticKeyIDFlagName, "",
+		fmt.Sprintf(`The ID of the static key to retrieve.
+- Config path: [ %s ]`, staticKeyIDConfigPath))
+	cmd.Flags().String(staticKeyNameFlagName, "",
+		fmt.Sprintf(`The name of the static key to retrieve.
+- Config path: [ %s ]`, staticKeyNameConfigPath))
+	cmd.MarkFlagsMutuallyExclusive(staticKeyIDFlagName, staticKeyNameFlagName)
+}
+
+func bindStaticKeyChildFlags(c *cobra.Command, args []string) error {
+	helper := cmd.BuildHelper(c, args)
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	if flag := c.Flags().Lookup(staticKeyIDFlagName); flag != nil {
+		if err := cfg.BindFlag(staticKeyIDConfigPath, flag); err != nil {
+			return err
+		}
+	}
+
+	if flag := c.Flags().Lookup(staticKeyNameFlagName); flag != nil {
+		if err := cfg.BindFlag(staticKeyNameConfigPath, flag); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getStaticKeyIdentifiers(cfg config.Hook) (id string, name string) {
+	return cfg.GetString(staticKeyIDConfigPath), cfg.GetString(staticKeyNameConfigPath)
 }
 
 func resolveEventGatewayIDByName(

--- a/internal/cmd/root/products/konnect/eventgateway/getEventGateway.go
+++ b/internal/cmd/root/products/konnect/eventgateway/getEventGateway.go
@@ -525,6 +525,11 @@ func newGetEventGatewayControlPlaneCmd(verb verbs.VerbValue,
 		rv.AddCommand(schemaRegistriesCmd)
 	}
 
+	staticKeysCmd := newGetEventGatewayStaticKeysCmd(verb, addParentFlags, parentPreRun)
+	if staticKeysCmd != nil {
+		rv.AddCommand(staticKeysCmd)
+	}
+
 	listenerPoliciesCmd := newGetEventGatewayListenerPoliciesCmd(verb, addParentFlags, parentPreRun)
 	if listenerPoliciesCmd != nil {
 		rv.AddCommand(listenerPoliciesCmd)

--- a/internal/cmd/root/products/konnect/eventgateway/interactive_children.go
+++ b/internal/cmd/root/products/konnect/eventgateway/interactive_children.go
@@ -20,6 +20,7 @@ func init() {
 	tableview.RegisterChildLoader("event-gateway", "data-plane-certificates", loadEventGatewayDataPlaneCertificates)
 	tableview.RegisterChildLoader("event-gateway", "listeners", loadEventGatewayListeners)
 	tableview.RegisterChildLoader("event-gateway", "schema-registries", loadEventGatewaySchemaRegistries)
+	tableview.RegisterChildLoader("event-gateway", "static-keys", loadEventGatewayStaticKeys)
 	tableview.RegisterChildLoader("listener", "policies", loadEventGatewayListenerPolicies)
 	tableview.RegisterChildLoader("virtual-cluster", "cluster-policies", loadEventGatewayVirtualClusterClusterPolicies)
 	tableview.RegisterChildLoader("virtual-cluster", "produce-policies", loadEventGatewayVirtualClusterProducePolicies)
@@ -447,4 +448,42 @@ func loadEventGatewaySchemaRegistries(
 	}
 
 	return buildSchemaRegistryChildView(registries), nil
+}
+
+func loadEventGatewayStaticKeys(
+	_ context.Context,
+	helper cmd.Helper,
+	parent any,
+) (tableview.ChildView, error) {
+	gatewayID, err := eventGatewayIDFromParent(parent)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	staticKeyAPI := sdk.GetEventGatewayStaticKeyAPI()
+	if staticKeyAPI == nil {
+		return tableview.ChildView{}, fmt.Errorf("event gateway static key client is not available")
+	}
+
+	keys, err := fetchStaticKeys(helper, staticKeyAPI, gatewayID, cfg, "")
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	return buildStaticKeyChildView(keys), nil
 }

--- a/internal/cmd/root/products/konnect/eventgateway/static_keys.go
+++ b/internal/cmd/root/products/konnect/eventgateway/static_keys.go
@@ -1,0 +1,488 @@
+package eventgateway
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/table"
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/cmd"
+	cmdCommon "github.com/kong/kongctl/internal/cmd/common"
+	"github.com/kong/kongctl/internal/cmd/output/tableview"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
+	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/kong/kongctl/internal/config"
+	"github.com/kong/kongctl/internal/konnect/helpers"
+	"github.com/kong/kongctl/internal/meta"
+	"github.com/kong/kongctl/internal/util"
+	"github.com/kong/kongctl/internal/util/i18n"
+	"github.com/kong/kongctl/internal/util/normalizers"
+	"github.com/segmentio/cli"
+	"github.com/spf13/cobra"
+)
+
+const (
+	staticKeysCommandName = "static-keys"
+)
+
+type staticKeySummaryRecord struct {
+	ID               string
+	Name             string
+	Description      string
+	LocalCreatedTime string
+	LocalUpdatedTime string
+}
+
+var (
+	staticKeysUse = staticKeysCommandName
+
+	staticKeysShort = i18n.T("root.products.konnect.eventgateway.staticKeysShort",
+		"Manage static keys for an Event Gateway")
+	staticKeysLong = normalizers.LongDesc(
+		i18n.T(
+			"root.products.konnect.eventgateway.staticKeysLong",
+			`Use the static-keys command to list or retrieve static keys for a specific Event Gateway.`,
+		),
+	)
+	staticKeysExample = normalizers.Examples(
+		i18n.T("root.products.konnect.eventgateway.staticKeysExamples",
+			fmt.Sprintf(`
+# List static keys for an event gateway by name
+%[1]s get event-gateway static-keys --gateway-name my-gateway
+# List static keys for an event gateway by ID
+%[1]s get event-gateway static-keys --gateway-id <gateway-id>
+# Get a specific static key by name (positional argument)
+%[1]s get event-gateway static-keys --gateway-name my-gateway my-static-key
+# Get a specific static key by ID (positional argument)
+%[1]s get event-gateway static-keys --gateway-id <gateway-id> <static-key-id>
+# Get a specific static key by name (flag)
+%[1]s get event-gateway static-keys --gateway-name my-gateway --static-key-name my-static-key
+# Get a specific static key by ID (flag)
+%[1]s get event-gateway static-keys --gateway-id <gateway-id> --static-key-id <static-key-id>
+`, meta.CLIName)))
+)
+
+func newGetEventGatewayStaticKeysCmd(
+	verb verbs.VerbValue,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     staticKeysUse,
+		Short:   staticKeysShort,
+		Long:    staticKeysLong,
+		Example: staticKeysExample,
+		Aliases: []string{"static-key", "sk"},
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if parentPreRun != nil {
+				if err := parentPreRun(cmd, args); err != nil {
+					return err
+				}
+			}
+			if err := bindEventGatewayChildFlags(cmd, args); err != nil {
+				return err
+			}
+			return bindStaticKeyChildFlags(cmd, args)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			handler := staticKeysHandler{cmd: cmd}
+			return handler.run(args)
+		},
+	}
+
+	addEventGatewayChildFlags(cmd)
+	addStaticKeyChildFlags(cmd)
+
+	if addParentFlags != nil {
+		addParentFlags(verb, cmd)
+	}
+
+	return cmd
+}
+
+type staticKeysHandler struct {
+	cmd *cobra.Command
+}
+
+func (h staticKeysHandler) run(args []string) error {
+	helper := cmd.BuildHelper(h.cmd, args)
+
+	if len(args) > 1 {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf(
+				"too many arguments. Listing static keys requires 0 or 1 arguments (ID or name)"),
+		}
+	}
+
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	// Check if positional arg and flags are both provided
+	if len(args) == 1 {
+		skID, skName := getStaticKeyIdentifiers(cfg)
+		if skID != "" || skName != "" {
+			return &cmd.ConfigurationError{
+				Err: fmt.Errorf(
+					"cannot specify both positional argument and --%s or --%s flags",
+					staticKeyIDFlagName,
+					staticKeyNameFlagName,
+				),
+			}
+		}
+	}
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+
+	outType, err := helper.GetOutputFormat()
+	if err != nil {
+		return err
+	}
+
+	printer, err := cli.Format(outType.String(), helper.GetStreams().Out)
+	if err != nil {
+		return err
+	}
+	defer printer.Flush()
+
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return err
+	}
+
+	gatewayID, gatewayName := getEventGatewayIdentifiers(cfg)
+	if gatewayID != "" && gatewayName != "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf("only one of --%s or --%s can be provided", gatewayIDFlagName, gatewayNameFlagName),
+		}
+	}
+
+	if gatewayID == "" && gatewayName == "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf(
+				"an event gateway identifier is required. Provide --%s or --%s",
+				gatewayIDFlagName,
+				gatewayNameFlagName,
+			),
+		}
+	}
+
+	if gatewayID == "" {
+		gatewayID, err = resolveEventGatewayIDByName(gatewayName, sdk.GetEventGatewayControlPlaneAPI(), helper, cfg)
+		if err != nil {
+			return err
+		}
+	}
+
+	staticKeyAPI := sdk.GetEventGatewayStaticKeyAPI()
+	if staticKeyAPI == nil {
+		return &cmd.ExecutionError{
+			Msg: "Static key client is not available",
+			Err: fmt.Errorf("static key client not configured"),
+		}
+	}
+
+	// Validate mutual exclusivity of static key ID and name flags
+	skID, skName := getStaticKeyIdentifiers(cfg)
+	if skID != "" && skName != "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf(
+				"only one of --%s or --%s can be provided",
+				staticKeyIDFlagName,
+				staticKeyNameFlagName,
+			),
+		}
+	}
+
+	var skIdentifier string
+	if len(args) == 1 {
+		skIdentifier = strings.TrimSpace(args[0])
+	} else if skID != "" {
+		skIdentifier = skID
+	} else if skName != "" {
+		skIdentifier = skName
+	}
+
+	if skIdentifier != "" {
+		return h.getSingleStaticKey(helper, staticKeyAPI, gatewayID, skIdentifier, outType, printer, cfg)
+	}
+
+	return h.listStaticKeys(helper, staticKeyAPI, gatewayID, outType, printer, cfg)
+}
+
+func (h staticKeysHandler) listStaticKeys(
+	helper cmd.Helper,
+	staticKeyAPI helpers.EventGatewayStaticKeyAPI,
+	gatewayID string,
+	outType cmdCommon.OutputFormat,
+	printer cli.PrintFlusher,
+	cfg config.Hook,
+) error {
+	keys, err := fetchStaticKeys(helper, staticKeyAPI, gatewayID, cfg, "")
+	if err != nil {
+		return err
+	}
+
+	records := make([]staticKeySummaryRecord, 0, len(keys))
+	for _, sk := range keys {
+		records = append(records, staticKeyToRecord(sk))
+	}
+
+	tableRows := make([]table.Row, 0, len(records))
+	for _, record := range records {
+		tableRows = append(tableRows, table.Row{record.ID, record.Name, record.Description})
+	}
+
+	return tableview.RenderForFormat(
+		helper,
+		false,
+		outType,
+		printer,
+		helper.GetStreams(),
+		records,
+		keys,
+		"",
+		tableview.WithCustomTable([]string{"ID", "NAME", "DESCRIPTION"}, tableRows),
+		tableview.WithRootLabel(helper.GetCmd().Name()),
+	)
+}
+
+func (h staticKeysHandler) getSingleStaticKey(
+	helper cmd.Helper,
+	staticKeyAPI helpers.EventGatewayStaticKeyAPI,
+	gatewayID string,
+	identifier string,
+	outType cmdCommon.OutputFormat,
+	printer cli.PrintFlusher,
+	cfg config.Hook,
+) error {
+	staticKeyID := identifier
+	if !util.IsValidUUID(identifier) {
+		// Resolve name to ID by listing and matching exactly
+		keys, err := fetchStaticKeys(helper, staticKeyAPI, gatewayID, cfg, identifier)
+		if err != nil {
+			return err
+		}
+		match := findStaticKeyByName(keys, identifier)
+		if match == nil {
+			return &cmd.ConfigurationError{
+				Err: fmt.Errorf("static key %q not found", identifier),
+			}
+		}
+		staticKeyID = match.ID
+	}
+
+	res, err := staticKeyAPI.GetEventGatewayStaticKey(helper.GetContext(), kkOps.GetEventGatewayStaticKeyRequest{
+		GatewayID:   gatewayID,
+		StaticKeyID: staticKeyID,
+	})
+	if err != nil {
+		attrs := cmd.TryConvertErrorToAttrs(err)
+		return cmd.PrepareExecutionError("Failed to get static key", err, helper.GetCmd(), attrs...)
+	}
+
+	if res.GetEventGatewayStaticKey() == nil {
+		return &cmd.ExecutionError{
+			Msg: "Static key response was empty",
+			Err: fmt.Errorf("no static key returned for id %s", staticKeyID),
+		}
+	}
+
+	sk := res.GetEventGatewayStaticKey()
+
+	return tableview.RenderForFormat(
+		helper,
+		false,
+		outType,
+		printer,
+		helper.GetStreams(),
+		staticKeyToRecord(*sk),
+		sk,
+		"",
+		tableview.WithRootLabel(helper.GetCmd().Name()),
+	)
+}
+
+func fetchStaticKeys(
+	helper cmd.Helper,
+	staticKeyAPI helpers.EventGatewayStaticKeyAPI,
+	gatewayID string,
+	cfg config.Hook,
+	nameFilter string,
+) ([]kkComps.EventGatewayStaticKey, error) {
+	requestPageSize := int64(cfg.GetInt(common.RequestPageSizeConfigPath))
+	if requestPageSize < 1 {
+		requestPageSize = int64(common.DefaultRequestPageSize)
+	}
+
+	var allKeys []kkComps.EventGatewayStaticKey
+	var pageAfter *string
+
+	for {
+		req := kkOps.ListEventGatewayStaticKeysRequest{
+			GatewayID: gatewayID,
+			PageSize:  new(requestPageSize),
+		}
+
+		if nameFilter != "" {
+			req.Filter = &kkComps.EventGatewayCommonFilter{
+				Name: &kkComps.StringFieldContainsFilter{
+					Contains: nameFilter,
+				},
+			}
+		}
+
+		if pageAfter != nil {
+			req.PageAfter = pageAfter
+		}
+
+		res, err := staticKeyAPI.ListEventGatewayStaticKeys(helper.GetContext(), req)
+		if err != nil {
+			attrs := cmd.TryConvertErrorToAttrs(err)
+			return nil, cmd.PrepareExecutionError("Failed to list static keys", err, helper.GetCmd(), attrs...)
+		}
+
+		if res.GetListEventGatewayStaticKeysResponse() == nil {
+			break
+		}
+
+		allKeys = append(allKeys, res.GetListEventGatewayStaticKeysResponse().Data...)
+
+		if res.GetListEventGatewayStaticKeysResponse().Meta == nil ||
+			res.GetListEventGatewayStaticKeysResponse().Meta.Page.Next == nil {
+			break
+		}
+
+		u, err := url.Parse(*res.GetListEventGatewayStaticKeysResponse().Meta.Page.Next)
+		if err != nil {
+			return nil, cmd.PrepareExecutionError(
+				"Failed to list static keys: invalid cursor",
+				err,
+				helper.GetCmd(),
+			)
+		}
+
+		values := u.Query()
+		pageAfter = new(values.Get("page[after]"))
+	}
+
+	return allKeys, nil
+}
+
+func findStaticKeyByName(
+	keys []kkComps.EventGatewayStaticKey,
+	name string,
+) *kkComps.EventGatewayStaticKey {
+	lowered := strings.ToLower(name)
+	for i := range keys {
+		if strings.ToLower(keys[i].Name) == lowered {
+			return &keys[i]
+		}
+	}
+	return nil
+}
+
+func staticKeyToRecord(sk kkComps.EventGatewayStaticKey) staticKeySummaryRecord {
+	id := sk.ID
+	if id != "" {
+		id = util.AbbreviateUUID(id)
+	} else {
+		id = valueNA
+	}
+
+	name := sk.Name
+	if name == "" {
+		name = valueNA
+	}
+
+	description := valueNA
+	if sk.Description != nil && *sk.Description != "" {
+		description = *sk.Description
+	}
+
+	createdAt := sk.CreatedAt.In(time.Local).Format("2006-01-02 15:04:05")
+	updatedAt := sk.UpdatedAt.In(time.Local).Format("2006-01-02 15:04:05")
+
+	return staticKeySummaryRecord{
+		ID:               id,
+		Name:             name,
+		Description:      description,
+		LocalCreatedTime: createdAt,
+		LocalUpdatedTime: updatedAt,
+	}
+}
+
+func staticKeyDetailView(sk *kkComps.EventGatewayStaticKey) string {
+	if sk == nil {
+		return ""
+	}
+
+	id := strings.TrimSpace(sk.ID)
+	if id == "" {
+		id = valueNA
+	}
+
+	name := sk.Name
+	if name == "" {
+		name = valueNA
+	}
+
+	description := valueNA
+	if sk.Description != nil && strings.TrimSpace(*sk.Description) != "" {
+		description = strings.TrimSpace(*sk.Description)
+	}
+
+	value := valueNA
+	if sk.Value != nil && strings.TrimSpace(*sk.Value) != "" {
+		value = strings.TrimSpace(*sk.Value)
+	}
+
+	createdAt := sk.CreatedAt.In(time.Local).Format("2006-01-02 15:04:05")
+	updatedAt := sk.UpdatedAt.In(time.Local).Format("2006-01-02 15:04:05")
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "id: %s\n", id)
+	fmt.Fprintf(&b, "name: %s\n", name)
+	fmt.Fprintf(&b, "description: %s\n", description)
+	fmt.Fprintf(&b, "value: %s\n", value)
+	fmt.Fprintf(&b, "created_at: %s\n", createdAt)
+	fmt.Fprintf(&b, "updated_at: %s\n", updatedAt)
+
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func buildStaticKeyChildView(keys []kkComps.EventGatewayStaticKey) tableview.ChildView {
+	tableRows := make([]table.Row, 0, len(keys))
+	for i := range keys {
+		record := staticKeyToRecord(keys[i])
+		tableRows = append(tableRows, table.Row{record.ID, record.Name, record.Description})
+	}
+
+	detailFn := func(index int) string {
+		if index < 0 || index >= len(keys) {
+			return ""
+		}
+		return staticKeyDetailView(&keys[index])
+	}
+
+	return tableview.ChildView{
+		Headers:        []string{"ID", "NAME", "DESCRIPTION"},
+		Rows:           tableRows,
+		DetailRenderer: detailFn,
+		Title:          "Static Keys",
+		ParentType:     "static-key",
+		DetailContext: func(index int) any {
+			if index < 0 || index >= len(keys) {
+				return nil
+			}
+			return &keys[index]
+		},
+	}
+}

--- a/internal/cmd/root/verbs/dump/declarative.go
+++ b/internal/cmd/root/verbs/dump/declarative.go
@@ -195,6 +195,7 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 			EventGatewayClusterPolicyAPI:        sdk.GetEventGatewayClusterPolicyAPI(),
 			EventGatewayConsumePolicyAPI:        sdk.GetEventGatewayConsumePolicyAPI(),
 			EventGatewaySchemaRegistryAPI:       sdk.GetEventGatewaySchemaRegistryAPI(),
+			EventGatewayStaticKeyAPI:            sdk.GetEventGatewayStaticKeyAPI(),
 			OrganizationTeamAPI:                 sdk.GetOrganizationTeamAPI(),
 		})
 	}

--- a/internal/cmd/root/verbs/dump/declarative_children.go
+++ b/internal/cmd/root/verbs/dump/declarative_children.go
@@ -343,7 +343,7 @@ func buildEventGatewayStaticKeys(
 				Name:        sk.Name,
 				Description: sk.Description,
 				Labels:      sk.Labels,
-				// Value intentionally omitted – the API never returns it.
+				Value:       *sk.Value,
 			},
 			Ref: sk.ID,
 		}

--- a/internal/cmd/root/verbs/dump/declarative_children.go
+++ b/internal/cmd/root/verbs/dump/declarative_children.go
@@ -204,6 +204,12 @@ func populateEventGatewayChildren(
 		} else if len(regs) > 0 {
 			gateway.SchemaRegistries = regs
 		}
+
+		if keys, err := buildEventGatewayStaticKeys(ctx, logger, client, gatewayID, gateway.Name); err != nil {
+			logWarn(logger, "failed to load event gateway static keys", gatewayID, gateway.Name, err)
+		} else if len(keys) > 0 {
+			gateway.StaticKeys = keys
+		}
 	}
 }
 
@@ -301,6 +307,45 @@ func buildEventGatewaySchemaRegistries(
 		res := declresources.EventGatewaySchemaRegistryResource{
 			SchemaRegistryCreate: createReq,
 			Ref:                  sr.ID,
+		}
+
+		results = append(results, res)
+	}
+
+	return results, nil
+}
+
+func buildEventGatewayStaticKeys(
+	ctx context.Context,
+	logger *slog.Logger,
+	client *declstate.Client,
+	gatewayID string,
+	gatewayName string,
+) ([]declresources.EventGatewayStaticKeyResource, error) {
+	keys, err := client.ListEventGatewayStaticKeys(ctx, gatewayID)
+	if err != nil {
+		return nil, err
+	}
+	if len(keys) == 0 {
+		return nil, nil
+	}
+
+	results := make([]declresources.EventGatewayStaticKeyResource, 0, len(keys))
+	for _, sk := range keys {
+		if strings.TrimSpace(sk.ID) == "" {
+			logWarn(logger, "static key missing ID", gatewayID, gatewayName, nil)
+			continue
+		}
+
+		// Value is write-only and not returned by the API; omit it from the dump.
+		res := declresources.EventGatewayStaticKeyResource{
+			EventGatewayStaticKeyCreate: kkComps.EventGatewayStaticKeyCreate{
+				Name:        sk.Name,
+				Description: sk.Description,
+				Labels:      sk.Labels,
+				// Value intentionally omitted – the API never returns it.
+			},
+			Ref: sk.ID,
 		}
 
 		results = append(results, res)

--- a/internal/cmd/root/verbs/dump/declarative_children.go
+++ b/internal/cmd/root/verbs/dump/declarative_children.go
@@ -337,13 +337,18 @@ func buildEventGatewayStaticKeys(
 			continue
 		}
 
-		// Value is write-only and not returned by the API; omit it from the dump.
+		// Include the value if the API returned it (vault/template references are echoed
+		// back verbatim; plain-text secrets are omitted by the API and sk.Value will be nil).
+		value := ""
+		if sk.Value != nil {
+			value = *sk.Value
+		}
 		res := declresources.EventGatewayStaticKeyResource{
 			EventGatewayStaticKeyCreate: kkComps.EventGatewayStaticKeyCreate{
 				Name:        sk.Name,
 				Description: sk.Description,
 				Labels:      sk.Labels,
-				Value:       *sk.Value,
+				Value:       value,
 			},
 			Ref: sk.ID,
 		}

--- a/internal/declarative/executor/event_gateway_static_key_adapter.go
+++ b/internal/declarative/executor/event_gateway_static_key_adapter.go
@@ -1,0 +1,200 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/kong/kongctl/internal/declarative/state"
+)
+
+// EventGatewayStaticKeyAdapter implements ResourceOperations for Event Gateway Static Key resources.
+// Static keys do not support update operations – use delete + create instead.
+type EventGatewayStaticKeyAdapter struct {
+	client *state.Client
+}
+
+// NewEventGatewayStaticKeyAdapter creates a new EventGatewayStaticKeyAdapter.
+func NewEventGatewayStaticKeyAdapter(client *state.Client) *EventGatewayStaticKeyAdapter {
+	return &EventGatewayStaticKeyAdapter{client: client}
+}
+
+// MapCreateFields maps fields to EventGatewayStaticKeyCreate.
+func (a *EventGatewayStaticKeyAdapter) MapCreateFields(
+	_ context.Context,
+	_ *ExecutionContext,
+	fields map[string]any,
+	create *kkComps.EventGatewayStaticKeyCreate,
+) error {
+	name, ok := fields["name"].(string)
+	if !ok || name == "" {
+		return fmt.Errorf("name is required")
+	}
+	create.Name = name
+
+	value, ok := fields["value"].(string)
+	if !ok || value == "" {
+		return fmt.Errorf("value is required")
+	}
+	create.Value = value
+
+	if desc, ok := fields["description"].(string); ok {
+		create.Description = &desc
+	}
+
+	if labelsRaw, ok := fields["labels"].(map[string]any); ok {
+		labels := make(map[string]string, len(labelsRaw))
+		for k, v := range labelsRaw {
+			if sv, ok := v.(string); ok {
+				labels[k] = sv
+			}
+		}
+		create.Labels = labels
+	} else if labels, ok := fields["labels"].(map[string]string); ok {
+		create.Labels = labels
+	}
+
+	return nil
+}
+
+// MapUpdateFields is not supported for static keys.
+func (a *EventGatewayStaticKeyAdapter) MapUpdateFields(
+	_ context.Context,
+	_ *ExecutionContext,
+	_ map[string]any,
+	_ *kkComps.EventGatewayStaticKeyCreate, // reuse create type as sentinel
+	_ map[string]string,
+) error {
+	return fmt.Errorf("event gateway static keys do not support update operations")
+}
+
+// Create creates a new static key.
+func (a *EventGatewayStaticKeyAdapter) Create(
+	ctx context.Context,
+	req kkComps.EventGatewayStaticKeyCreate,
+	namespace string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	gatewayID, err := a.getEventGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return "", err
+	}
+
+	return a.client.CreateEventGatewayStaticKey(ctx, gatewayID, req, namespace)
+}
+
+// Update is not supported for static keys.
+func (a *EventGatewayStaticKeyAdapter) Update(
+	_ context.Context,
+	_ string,
+	_ kkComps.EventGatewayStaticKeyCreate,
+	_ string,
+	_ *ExecutionContext,
+) (string, error) {
+	return "", fmt.Errorf("event gateway static keys do not support update operations")
+}
+
+// Delete deletes a static key.
+func (a *EventGatewayStaticKeyAdapter) Delete(
+	ctx context.Context,
+	id string,
+	execCtx *ExecutionContext,
+) error {
+	gatewayID, err := a.getEventGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return err
+	}
+
+	return a.client.DeleteEventGatewayStaticKey(ctx, gatewayID, id)
+}
+
+// GetByID retrieves a static key by ID.
+func (a *EventGatewayStaticKeyAdapter) GetByID(
+	ctx context.Context,
+	id string,
+	execCtx *ExecutionContext,
+) (ResourceInfo, error) {
+	gatewayID, err := a.getEventGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	sk, err := a.client.GetEventGatewayStaticKey(ctx, gatewayID, id)
+	if err != nil {
+		return nil, err
+	}
+	if sk == nil {
+		return nil, nil
+	}
+
+	return &EventGatewayStaticKeyResourceInfo{key: sk}, nil
+}
+
+// GetByName is not supported for static keys (no direct name-based lookup).
+func (a *EventGatewayStaticKeyAdapter) GetByName(
+	_ context.Context,
+	_ string,
+) (ResourceInfo, error) {
+	return nil, fmt.Errorf("GetByName not supported for event gateway static keys")
+}
+
+// ResourceType returns the resource type string.
+func (a *EventGatewayStaticKeyAdapter) ResourceType() string {
+	return planner.ResourceTypeEventGatewayStaticKey
+}
+
+// RequiredFields returns the list of required fields for this resource.
+func (a *EventGatewayStaticKeyAdapter) RequiredFields() []string {
+	return []string{"name", "value"}
+}
+
+// SupportsUpdate returns false – static keys must be deleted and re-created on change.
+func (a *EventGatewayStaticKeyAdapter) SupportsUpdate() bool {
+	return false
+}
+
+// getEventGatewayIDFromExecutionContext extracts the event gateway ID from the execution context.
+func (a *EventGatewayStaticKeyAdapter) getEventGatewayIDFromExecutionContext(
+	execCtx *ExecutionContext,
+) (string, error) {
+	if execCtx == nil || execCtx.PlannedChange == nil {
+		return "", fmt.Errorf("execution context required")
+	}
+
+	change := *execCtx.PlannedChange
+
+	// Priority 1: Check References (for new parent)
+	if gatewayRef, ok := change.References["event_gateway_id"]; ok && gatewayRef.ID != "" {
+		return gatewayRef.ID, nil
+	}
+
+	// Priority 2: Check Parent field (for existing parent)
+	if change.Parent != nil && change.Parent.ID != "" {
+		return change.Parent.ID, nil
+	}
+
+	return "", fmt.Errorf("event gateway ID required for static key operations")
+}
+
+// EventGatewayStaticKeyResourceInfo wraps an Event Gateway Static Key to implement ResourceInfo.
+type EventGatewayStaticKeyResourceInfo struct {
+	key *state.EventGatewayStaticKey
+}
+
+func (e *EventGatewayStaticKeyResourceInfo) GetID() string {
+	return e.key.ID
+}
+
+func (e *EventGatewayStaticKeyResourceInfo) GetName() string {
+	return e.key.Name
+}
+
+func (e *EventGatewayStaticKeyResourceInfo) GetLabels() map[string]string {
+	return e.key.Labels
+}
+
+func (e *EventGatewayStaticKeyResourceInfo) GetNormalizedLabels() map[string]string {
+	return e.key.Labels
+}

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -63,6 +63,8 @@ type Executor struct {
 		kkComps.UpdateEventGatewayDataPlaneCertificateRequest]
 	eventGatewaySchemaRegistryExecutor *BaseExecutor[
 		kkComps.SchemaRegistryCreate, kkComps.SchemaRegistryUpdate]
+	eventGatewayStaticKeyExecutor *BaseExecutor[
+		kkComps.EventGatewayStaticKeyCreate, kkComps.EventGatewayStaticKeyCreate]
 
 	// Portal child resource executors
 	portalCustomizationExecutor *BaseSingletonExecutor[kkComps.PortalCustomization]
@@ -224,6 +226,13 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 	e.eventGatewaySchemaRegistryExecutor = NewBaseExecutor[
 		kkComps.SchemaRegistryCreate, kkComps.SchemaRegistryUpdate](
 		NewEventGatewaySchemaRegistryAdapter(client),
+		client,
+		dryRun,
+	)
+
+	e.eventGatewayStaticKeyExecutor = NewBaseExecutor[
+		kkComps.EventGatewayStaticKeyCreate, kkComps.EventGatewayStaticKeyCreate](
+		NewEventGatewayStaticKeyAdapter(client),
 		client,
 		dryRun,
 	)
@@ -1909,6 +1918,17 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 			change.References["event_gateway_id"] = gatewayRef
 		}
 		return e.eventGatewaySchemaRegistryExecutor.Create(ctx, *change)
+	case planner.ResourceTypeEventGatewayStaticKey:
+		// Resolve event gateway reference if needed
+		if gatewayRef, ok := change.References["event_gateway_id"]; ok && gatewayRef.ID == "" {
+			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
+			}
+			gatewayRef.ID = gatewayID
+			change.References["event_gateway_id"] = gatewayRef
+		}
+		return e.eventGatewayStaticKeyExecutor.Create(ctx, *change)
 	case planner.ResourceTypeEventGatewayClusterPolicy:
 		// Resolve event gateway reference if needed
 		if gatewayRef, ok := change.References["event_gateway_id"]; ok && gatewayRef.ID == "" {
@@ -2484,6 +2504,9 @@ func (e *Executor) deleteResource(ctx context.Context, change *planner.PlannedCh
 	case planner.ResourceTypeEventGatewaySchemaRegistry:
 		// No need to resolve event gateway reference for delete - parent ID should be in Parent field
 		return e.eventGatewaySchemaRegistryExecutor.Delete(ctx, *change)
+	case planner.ResourceTypeEventGatewayStaticKey:
+		// No need to resolve event gateway reference for delete - parent ID should be in Parent field
+		return e.eventGatewayStaticKeyExecutor.Delete(ctx, *change)
 	case planner.ResourceTypeEventGatewayClusterPolicy:
 		// Both gateway ID and virtual cluster ID should be in References for delete
 		return e.eventGatewayClusterPolicyExecutor.Delete(ctx, *change)

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -885,6 +885,44 @@ func (l *Loader) extractNestedResources(rs *resources.ResourceSet) {
 		portal.EmailConfig = nil
 		portal.EmailTemplates = nil
 	}
+
+	// Extract nested Event Gateway child resources so that deferred !env
+	// placeholders on their fields are tracked per child resource ref (not
+	// per gateway ref).  Each nested type already has a root-level slice in
+	// ResourceSet and a GetXxxForGateway helper that reads from both.
+	for i := range rs.EventGatewayControlPlanes {
+		egw := &rs.EventGatewayControlPlanes[i]
+
+		for _, sk := range egw.StaticKeys {
+			sk.EventGateway = egw.Ref
+			rs.EventGatewayStaticKeys = append(rs.EventGatewayStaticKeys, sk)
+		}
+		egw.StaticKeys = nil
+
+		for _, sr := range egw.SchemaRegistries {
+			sr.EventGateway = egw.Ref
+			rs.EventGatewaySchemaRegistries = append(rs.EventGatewaySchemaRegistries, sr)
+		}
+		egw.SchemaRegistries = nil
+
+		for _, bc := range egw.BackendClusters {
+			bc.EventGateway = egw.Ref
+			rs.EventGatewayBackendClusters = append(rs.EventGatewayBackendClusters, bc)
+		}
+		egw.BackendClusters = nil
+
+		for _, l := range egw.Listeners {
+			l.EventGateway = egw.Ref
+			rs.EventGatewayListeners = append(rs.EventGatewayListeners, l)
+		}
+		egw.Listeners = nil
+
+		for _, dp := range egw.DataPlaneCertificates {
+			dp.EventGateway = egw.Ref
+			rs.EventGatewayDataPlaneCertificates = append(rs.EventGatewayDataPlaneCertificates, dp)
+		}
+		egw.DataPlaneCertificates = nil
+	}
 }
 
 // extractAPIDocuments recursively extracts and flattens nested API documents

--- a/internal/declarative/planner/constants.go
+++ b/internal/declarative/planner/constants.go
@@ -83,6 +83,10 @@ const (
 	// ResourceTypeEventGatewaySchemaRegistry is the resource type for event gateway schema registries
 	ResourceTypeEventGatewaySchemaRegistry = "event_gateway_schema_registry"
 
+	// ResourceTypeEventGatewayStaticKey is the resource type for event gateway static keys.
+	// Static keys do not support update – changes are applied as delete + create.
+	ResourceTypeEventGatewayStaticKey = "event_gateway_static_key"
+
 	// ResourceTypeDeck represents an internal deck execution step.
 	ResourceTypeDeck = "_deck"
 )

--- a/internal/declarative/planner/egw_control_plane_planner.go
+++ b/internal/declarative/planner/egw_control_plane_planner.go
@@ -245,6 +245,18 @@ func (p *Planner) planEGWControlPlaneChanges(
 				return err
 			}
 		}
+
+		// Plan static keys for this gateway (whether it exists or is being created)
+		staticKeys := p.resources.GetStaticKeysForGateway(desiredEGWCP.Ref)
+
+		if len(staticKeys) > 0 || plan.Metadata.Mode == PlanModeSync {
+			if err := p.planEventGatewayStaticKeyChanges(
+				ctx, plannerCtx, namespace, desiredEGWCP.Name, gatewayID, desiredEGWCP.Ref,
+				gatewayChangeID, staticKeys, plan,
+			); err != nil {
+				return err
+			}
+		}
 	}
 
 	// Check for managed resources to delete (sync mode only)

--- a/internal/declarative/planner/event_gateway_static_key_planner.go
+++ b/internal/declarative/planner/event_gateway_static_key_planner.go
@@ -243,13 +243,23 @@ func (p *Planner) planStaticKeyDelete(
 }
 
 // doesStaticKeyNeedChange checks whether a static key needs to be replaced.
-// The value field is write-only (API never returns it), so we compare name, description and labels.
-// Any change in description or labels triggers a replace.
-// Changes to value are not detectable (write-only), so value changes are never detected.
+// The API returns the stored value when it is a vault reference, but does not return plaintext. We compare
+// it directly against the desired value anyway.
+//
+// Any change triggers a replace (static keys do not support update).
 func (p *Planner) doesStaticKeyNeedChange(
 	current state.EventGatewayStaticKey,
 	desired resources.EventGatewayStaticKeyResource,
 ) bool {
+	// Compare value
+	currentVal := ""
+	if current.Value != nil {
+		currentVal = *current.Value
+	}
+	if currentVal != desired.Value {
+		return true
+	}
+
 	// Compare description
 	currentDesc := ""
 	if current.Description != nil {

--- a/internal/declarative/planner/event_gateway_static_key_planner.go
+++ b/internal/declarative/planner/event_gateway_static_key_planner.go
@@ -1,0 +1,272 @@
+package planner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+)
+
+// planEventGatewayStaticKeyChanges plans changes for Event Gateway Static Keys for a specific gateway.
+// Static keys do not support update – detected changes are planned as DELETE + CREATE.
+func (p *Planner) planEventGatewayStaticKeyChanges(
+	ctx context.Context,
+	_ *Config,
+	namespace string,
+	gatewayName string,
+	gatewayID string,
+	gatewayRef string,
+	gatewayChangeID string,
+	desired []resources.EventGatewayStaticKeyResource,
+	plan *Plan,
+) error {
+	p.logger.Debug("Planning Event Gateway Static Key changes",
+		"gateway_name", gatewayName,
+		"gateway_id", gatewayID,
+		"gateway_ref", gatewayRef,
+		"gateway_change_id", gatewayChangeID,
+		"desired_count", len(desired),
+		"namespace", namespace,
+	)
+
+	if gatewayID != "" {
+		// Gateway exists: full diff
+		return p.planStaticKeyChangesForExistingGateway(
+			ctx, namespace, gatewayID, gatewayRef, gatewayName, desired, plan,
+		)
+	}
+
+	// Gateway doesn't exist yet: plan creates only with dependency on gateway creation
+	p.planStaticKeyCreatesForNewGateway(namespace, gatewayRef, gatewayName, gatewayChangeID, desired, plan)
+	return nil
+}
+
+// planStaticKeyChangesForExistingGateway handles full diff for static keys of an existing gateway.
+func (p *Planner) planStaticKeyChangesForExistingGateway(
+	ctx context.Context,
+	namespace string,
+	gatewayID string,
+	gatewayRef string,
+	gatewayName string,
+	desired []resources.EventGatewayStaticKeyResource,
+	plan *Plan,
+) error {
+	p.logger.Debug("Planning changes for existing gateway static keys",
+		"gateway_id", gatewayID,
+		"gateway_ref", gatewayRef,
+		"desired_count", len(desired),
+	)
+
+	// 1. List current static keys for this gateway
+	currentKeys, err := p.client.ListEventGatewayStaticKeys(ctx, gatewayID)
+	if err != nil {
+		return fmt.Errorf("failed to list static keys for gateway %s: %w", gatewayID, err)
+	}
+
+	p.logger.Debug("Fetched current static keys",
+		"gateway_id", gatewayID,
+		"current_count", len(currentKeys),
+	)
+
+	// 2. Index current by name
+	currentByName := make(map[string]state.EventGatewayStaticKey)
+	for _, sk := range currentKeys {
+		currentByName[sk.Name] = sk
+	}
+
+	desiredNames := make(map[string]bool)
+
+	// 3. Compare desired vs current
+	for _, desiredKey := range desired {
+		desiredNames[desiredKey.Name] = true
+
+		current, exists := currentByName[desiredKey.Name]
+
+		if !exists {
+			// CREATE
+			p.logger.Debug("Planning static key CREATE",
+				"key_name", desiredKey.Name,
+				"gateway_ref", gatewayRef,
+			)
+			p.planStaticKeyCreate(namespace, gatewayRef, gatewayName, gatewayID, desiredKey, []string{}, plan)
+		} else {
+			// Static keys do not support update – detect changes and plan DELETE + CREATE instead.
+			needsChange := p.doesStaticKeyNeedChange(current, desiredKey)
+			if needsChange {
+				p.logger.Debug("Planning static key DELETE+CREATE (no update supported)",
+					"key_name", desiredKey.Name,
+					"key_id", current.ID,
+					"gateway_ref", gatewayRef,
+				)
+				deleteChangeID := p.planStaticKeyDelete(gatewayRef, gatewayName, gatewayID, current.ID, desiredKey.Name, plan)
+				// CREATE depends on the DELETE being applied first
+				p.planStaticKeyCreate(namespace, gatewayRef, gatewayName, gatewayID, desiredKey,
+					[]string{deleteChangeID}, plan)
+			}
+		}
+	}
+
+	// 4. SYNC MODE: Delete unmanaged static keys
+	if plan.Metadata.Mode == PlanModeSync {
+		for name, current := range currentByName {
+			if !desiredNames[name] {
+				p.logger.Debug("Planning static key DELETE (sync mode)",
+					"key_name", name,
+					"key_id", current.ID,
+				)
+				p.planStaticKeyDelete(gatewayRef, gatewayName, gatewayID, current.ID, name, plan)
+			}
+		}
+	}
+
+	return nil
+}
+
+// planStaticKeyCreatesForNewGateway plans creates for static keys when the gateway doesn't exist yet.
+func (p *Planner) planStaticKeyCreatesForNewGateway(
+	namespace string,
+	gatewayRef string,
+	gatewayName string,
+	gatewayChangeID string,
+	keys []resources.EventGatewayStaticKeyResource,
+	plan *Plan,
+) {
+	p.logger.Debug("Planning static key creates for new gateway",
+		"gateway_ref", gatewayRef,
+		"gateway_change_id", gatewayChangeID,
+		"key_count", len(keys),
+	)
+
+	var dependsOn []string
+	if gatewayChangeID != "" {
+		dependsOn = []string{gatewayChangeID}
+	}
+
+	for _, key := range keys {
+		p.planStaticKeyCreate(namespace, gatewayRef, gatewayName, "", key, dependsOn, plan)
+	}
+}
+
+// planStaticKeyCreate plans a CREATE change for a static key.
+func (p *Planner) planStaticKeyCreate(
+	namespace string,
+	gatewayRef string,
+	gatewayName string,
+	gatewayID string,
+	key resources.EventGatewayStaticKeyResource,
+	dependsOn []string,
+	plan *Plan,
+) {
+	fields := make(map[string]any)
+	fields["name"] = key.Name
+	fields["value"] = key.Value
+
+	if key.Description != nil {
+		fields["description"] = *key.Description
+	}
+
+	if len(key.Labels) > 0 {
+		fields["labels"] = key.Labels
+	}
+
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionCreate, ResourceTypeEventGatewayStaticKey, key.Ref),
+		ResourceType: ResourceTypeEventGatewayStaticKey,
+		ResourceRef:  key.Ref,
+		Action:       ActionCreate,
+		Fields:       fields,
+		Namespace:    namespace,
+		DependsOn:    dependsOn,
+	}
+
+	if gatewayID != "" {
+		change.Parent = &ParentInfo{
+			Ref: gatewayRef,
+			ID:  gatewayID,
+		}
+	} else {
+		// Gateway doesn't exist yet, add reference for runtime resolution
+		change.References = map[string]ReferenceInfo{
+			"event_gateway_id": {
+				Ref: gatewayRef,
+				ID:  "", // to be resolved at runtime
+				LookupFields: map[string]string{
+					"name": gatewayName,
+				},
+			},
+		}
+	}
+
+	p.logger.Debug("Enqueuing static key CREATE",
+		"key_ref", key.Ref,
+		"key_name", key.Name,
+		"gateway_ref", gatewayRef,
+	)
+
+	plan.AddChange(change)
+}
+
+// planStaticKeyDelete plans a DELETE change for a static key and returns the change ID.
+func (p *Planner) planStaticKeyDelete(
+	gatewayRef string,
+	_ string, // gatewayName - unused but kept for API consistency
+	gatewayID string,
+	keyID string,
+	keyName string,
+	plan *Plan,
+) string {
+	changeID := p.nextChangeID(ActionDelete, ResourceTypeEventGatewayStaticKey, keyName)
+
+	change := PlannedChange{
+		ID:           changeID,
+		ResourceType: ResourceTypeEventGatewayStaticKey,
+		ResourceRef:  keyName,
+		ResourceID:   keyID,
+		Action:       ActionDelete,
+		Fields:       map[string]any{},
+		Parent: &ParentInfo{
+			Ref: gatewayRef,
+			ID:  gatewayID,
+		},
+	}
+
+	p.logger.Debug("Enqueuing static key DELETE",
+		"key_name", keyName,
+		"key_id", keyID,
+		"gateway_ref", gatewayRef,
+	)
+
+	plan.AddChange(change)
+
+	return changeID
+}
+
+// doesStaticKeyNeedChange checks whether a static key needs to be replaced.
+// The value field is write-only (API never returns it), so we compare name, description and labels.
+// Any change in description or labels triggers a replace.
+// Changes to value are not detectable (write-only), so value changes are never detected.
+func (p *Planner) doesStaticKeyNeedChange(
+	current state.EventGatewayStaticKey,
+	desired resources.EventGatewayStaticKeyResource,
+) bool {
+	// Compare description
+	currentDesc := ""
+	if current.Description != nil {
+		currentDesc = *current.Description
+	}
+	desiredDesc := ""
+	if desired.Description != nil {
+		desiredDesc = *desired.Description
+	}
+	if currentDesc != desiredDesc {
+		return true
+	}
+
+	// Compare labels
+	if !compareStringMaps(current.Labels, desired.Labels) {
+		return true
+	}
+
+	return false
+}

--- a/internal/declarative/planner/event_gateway_static_key_planner_test.go
+++ b/internal/declarative/planner/event_gateway_static_key_planner_test.go
@@ -9,20 +9,12 @@ import (
 	"github.com/kong/kongctl/internal/declarative/resources"
 	"github.com/kong/kongctl/internal/declarative/state"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // newTestStaticKeyPlanner returns a minimal Planner suitable for unit tests.
 func newTestStaticKeyPlanner() *Planner {
 	return &Planner{
 		logger: slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
-	}
-}
-
-// newTestStaticKeyPlan returns a minimal Plan with the given mode.
-func newTestStaticKeyPlan() *Plan {
-	return &Plan{
-		Metadata: PlanMetadata{Mode: "apply"},
 	}
 }
 
@@ -36,12 +28,14 @@ func TestDoesStaticKeyNeedChange_NoChanges(t *testing.T) {
 	p := newTestStaticKeyPlanner()
 
 	desc := "a description"
+	val := "secret"
 	current := state.EventGatewayStaticKey{
 		EventGatewayStaticKey: kkComps.EventGatewayStaticKey{
 			ID:          "key-123",
 			Name:        "my-key",
 			Description: &desc,
 			Labels:      map[string]string{"env": "prod"},
+			Value:       &val,
 		},
 	}
 	desired := resources.EventGatewayStaticKeyResource{
@@ -107,169 +101,50 @@ func TestDoesStaticKeyNeedChange_LabelsChanged(t *testing.T) {
 	assert.True(t, p.doesStaticKeyNeedChange(current, desired))
 }
 
-func TestDoesStaticKeyNeedChange_ValueChangedNotDetected(t *testing.T) {
+func TestDoesStaticKeyNeedChange_ValueChanged(t *testing.T) {
 	t.Parallel()
 
-	// The value field is write-only; the API never returns it.
-	// A value change cannot be detected and must NOT trigger a replace.
 	p := newTestStaticKeyPlanner()
 
+	oldVal := "old-secret"
 	current := state.EventGatewayStaticKey{
 		EventGatewayStaticKey: kkComps.EventGatewayStaticKey{
-			ID:   "key-123",
-			Name: "my-key",
+			ID:    "key-123",
+			Name:  "my-key",
+			Value: &oldVal,
 		},
 	}
 	desired := resources.EventGatewayStaticKeyResource{
 		EventGatewayStaticKeyCreate: kkComps.EventGatewayStaticKeyCreate{
 			Name:  "my-key",
-			Value: "changed-secret",
+			Value: "new-secret",
 		},
 		Ref: "my-key-ref",
 	}
 
-	assert.False(t, p.doesStaticKeyNeedChange(current, desired),
-		"value changes are undetectable and must not trigger a replace")
+	assert.True(t, p.doesStaticKeyNeedChange(current, desired))
 }
 
-// ---------------------------------------------------------------------------
-// planStaticKeyCreate
-// ---------------------------------------------------------------------------
-
-func TestPlanStaticKeyCreate_WithExistingGateway(t *testing.T) {
+func TestDoesStaticKeyNeedChange_VaultRefChanged(t *testing.T) {
 	t.Parallel()
 
 	p := newTestStaticKeyPlanner()
-	plan := newTestStaticKeyPlan()
 
-	desc := "key description"
-	key := resources.EventGatewayStaticKeyResource{
-		EventGatewayStaticKeyCreate: kkComps.EventGatewayStaticKeyCreate{
-			Name:        "my-key",
-			Value:       "s3cr3t",
-			Description: &desc,
-			Labels:      map[string]string{"team": "platform"},
+	oldRef := `${env["OLD_KEY"]}`
+	current := state.EventGatewayStaticKey{
+		EventGatewayStaticKey: kkComps.EventGatewayStaticKey{
+			ID:    "key-123",
+			Name:  "my-key",
+			Value: &oldRef,
 		},
-		Ref: "my-key-ref",
 	}
-
-	p.planStaticKeyCreate("default", "gw-ref", "my-gateway", "gw-id", key, nil, plan)
-
-	require.Len(t, plan.Changes, 1)
-	c := plan.Changes[0]
-	assert.Equal(t, ActionCreate, c.Action)
-	assert.Equal(t, ResourceTypeEventGatewayStaticKey, c.ResourceType)
-	assert.Equal(t, "my-key-ref", c.ResourceRef)
-	assert.Equal(t, "my-key", c.Fields["name"])
-	assert.Equal(t, "s3cr3t", c.Fields["value"])
-	assert.Equal(t, "key description", c.Fields["description"])
-	assert.Equal(t, map[string]string{"team": "platform"}, c.Fields["labels"])
-	require.NotNil(t, c.Parent)
-	assert.Equal(t, "gw-id", c.Parent.ID)
-	assert.Equal(t, "gw-ref", c.Parent.Ref)
-}
-
-func TestPlanStaticKeyCreate_ForNewGateway_HasReference(t *testing.T) {
-	t.Parallel()
-
-	p := newTestStaticKeyPlanner()
-	plan := newTestStaticKeyPlan()
-
-	key := resources.EventGatewayStaticKeyResource{
+	desired := resources.EventGatewayStaticKeyResource{
 		EventGatewayStaticKeyCreate: kkComps.EventGatewayStaticKeyCreate{
 			Name:  "my-key",
-			Value: "val",
+			Value: `${env["NEW_KEY"]}`,
 		},
 		Ref: "my-key-ref",
 	}
 
-	// gatewayID="" signals gateway doesn't exist yet
-	p.planStaticKeyCreate("default", "gw-ref", "my-gateway", "", key, []string{"dep-1"}, plan)
-
-	require.Len(t, plan.Changes, 1)
-	c := plan.Changes[0]
-	assert.Nil(t, c.Parent, "parent should not be set when gateway doesn't exist yet")
-	require.Contains(t, c.References, "event_gateway_id")
-	assert.Equal(t, "gw-ref", c.References["event_gateway_id"].Ref)
-	assert.Contains(t, c.DependsOn, "dep-1")
-}
-
-// ---------------------------------------------------------------------------
-// planStaticKeyDelete
-// ---------------------------------------------------------------------------
-
-func TestPlanStaticKeyDelete_ReturnsChangeID(t *testing.T) {
-	t.Parallel()
-
-	p := newTestStaticKeyPlanner()
-	plan := newTestStaticKeyPlan()
-
-	changeID := p.planStaticKeyDelete("gw-ref", "my-gateway", "gw-id", "key-id-1", "my-key", plan)
-
-	require.NotEmpty(t, changeID)
-	require.Len(t, plan.Changes, 1)
-	c := plan.Changes[0]
-	assert.Equal(t, ActionDelete, c.Action)
-	assert.Equal(t, ResourceTypeEventGatewayStaticKey, c.ResourceType)
-	assert.Equal(t, "key-id-1", c.ResourceID)
-	assert.Equal(t, changeID, c.ID)
-}
-
-// ---------------------------------------------------------------------------
-// planStaticKeyCreatesForNewGateway
-// ---------------------------------------------------------------------------
-
-func TestPlanStaticKeyCreatesForNewGateway_WithGatewayDependency(t *testing.T) {
-	t.Parallel()
-
-	p := newTestStaticKeyPlanner()
-	plan := newTestStaticKeyPlan()
-
-	keys := []resources.EventGatewayStaticKeyResource{
-		{
-			EventGatewayStaticKeyCreate: kkComps.EventGatewayStaticKeyCreate{
-				Name:  "key-a",
-				Value: "val-a",
-			},
-			Ref: "key-a",
-		},
-		{
-			EventGatewayStaticKeyCreate: kkComps.EventGatewayStaticKeyCreate{
-				Name:  "key-b",
-				Value: "val-b",
-			},
-			Ref: "key-b",
-		},
-	}
-
-	p.planStaticKeyCreatesForNewGateway("ns", "gw-ref", "my-gateway", "gw-change-id", keys, plan)
-
-	require.Len(t, plan.Changes, 2)
-	for _, c := range plan.Changes {
-		assert.Equal(t, ActionCreate, c.Action)
-		assert.Contains(t, c.DependsOn, "gw-change-id",
-			"each static key create must depend on gateway create")
-	}
-}
-
-func TestPlanStaticKeyCreatesForNewGateway_NoGatewayChangeID(t *testing.T) {
-	t.Parallel()
-
-	p := newTestStaticKeyPlanner()
-	plan := newTestStaticKeyPlan()
-
-	key := resources.EventGatewayStaticKeyResource{
-		EventGatewayStaticKeyCreate: kkComps.EventGatewayStaticKeyCreate{
-			Name:  "key-a",
-			Value: "val",
-		},
-		Ref: "key-a",
-	}
-
-	p.planStaticKeyCreatesForNewGateway(
-		"ns", "gw-ref", "my-gateway", "",
-		[]resources.EventGatewayStaticKeyResource{key}, plan)
-
-	require.Len(t, plan.Changes, 1)
-	assert.Empty(t, plan.Changes[0].DependsOn)
+	assert.True(t, p.doesStaticKeyNeedChange(current, desired))
 }

--- a/internal/declarative/planner/event_gateway_static_key_planner_test.go
+++ b/internal/declarative/planner/event_gateway_static_key_planner_test.go
@@ -1,0 +1,275 @@
+package planner
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestStaticKeyPlanner returns a minimal Planner suitable for unit tests.
+func newTestStaticKeyPlanner() *Planner {
+	return &Planner{
+		logger: slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+	}
+}
+
+// newTestStaticKeyPlan returns a minimal Plan with the given mode.
+func newTestStaticKeyPlan() *Plan {
+	return &Plan{
+		Metadata: PlanMetadata{Mode: "apply"},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// doesStaticKeyNeedChange
+// ---------------------------------------------------------------------------
+
+func TestDoesStaticKeyNeedChange_NoChanges(t *testing.T) {
+	t.Parallel()
+
+	p := newTestStaticKeyPlanner()
+
+	desc := "a description"
+	current := state.EventGatewayStaticKey{
+		EventGatewayStaticKey: kkComps.EventGatewayStaticKey{
+			ID:          "key-123",
+			Name:        "my-key",
+			Description: &desc,
+			Labels:      map[string]string{"env": "prod"},
+		},
+	}
+	desired := resources.EventGatewayStaticKeyResource{
+		EventGatewayStaticKeyCreate: kkComps.EventGatewayStaticKeyCreate{
+			Name:        "my-key",
+			Value:       "secret",
+			Description: &desc,
+			Labels:      map[string]string{"env": "prod"},
+		},
+		Ref: "my-key-ref",
+	}
+
+	assert.False(t, p.doesStaticKeyNeedChange(current, desired))
+}
+
+func TestDoesStaticKeyNeedChange_DescriptionChanged(t *testing.T) {
+	t.Parallel()
+
+	p := newTestStaticKeyPlanner()
+
+	oldDesc := "old description"
+	newDesc := "new description"
+	current := state.EventGatewayStaticKey{
+		EventGatewayStaticKey: kkComps.EventGatewayStaticKey{
+			ID:          "key-123",
+			Name:        "my-key",
+			Description: &oldDesc,
+		},
+	}
+	desired := resources.EventGatewayStaticKeyResource{
+		EventGatewayStaticKeyCreate: kkComps.EventGatewayStaticKeyCreate{
+			Name:        "my-key",
+			Value:       "secret",
+			Description: &newDesc,
+		},
+		Ref: "my-key-ref",
+	}
+
+	assert.True(t, p.doesStaticKeyNeedChange(current, desired))
+}
+
+func TestDoesStaticKeyNeedChange_LabelsChanged(t *testing.T) {
+	t.Parallel()
+
+	p := newTestStaticKeyPlanner()
+
+	current := state.EventGatewayStaticKey{
+		EventGatewayStaticKey: kkComps.EventGatewayStaticKey{
+			ID:     "key-123",
+			Name:   "my-key",
+			Labels: map[string]string{"env": "staging"},
+		},
+	}
+	desired := resources.EventGatewayStaticKeyResource{
+		EventGatewayStaticKeyCreate: kkComps.EventGatewayStaticKeyCreate{
+			Name:   "my-key",
+			Value:  "secret",
+			Labels: map[string]string{"env": "prod"},
+		},
+		Ref: "my-key-ref",
+	}
+
+	assert.True(t, p.doesStaticKeyNeedChange(current, desired))
+}
+
+func TestDoesStaticKeyNeedChange_ValueChangedNotDetected(t *testing.T) {
+	t.Parallel()
+
+	// The value field is write-only; the API never returns it.
+	// A value change cannot be detected and must NOT trigger a replace.
+	p := newTestStaticKeyPlanner()
+
+	current := state.EventGatewayStaticKey{
+		EventGatewayStaticKey: kkComps.EventGatewayStaticKey{
+			ID:   "key-123",
+			Name: "my-key",
+		},
+	}
+	desired := resources.EventGatewayStaticKeyResource{
+		EventGatewayStaticKeyCreate: kkComps.EventGatewayStaticKeyCreate{
+			Name:  "my-key",
+			Value: "changed-secret",
+		},
+		Ref: "my-key-ref",
+	}
+
+	assert.False(t, p.doesStaticKeyNeedChange(current, desired),
+		"value changes are undetectable and must not trigger a replace")
+}
+
+// ---------------------------------------------------------------------------
+// planStaticKeyCreate
+// ---------------------------------------------------------------------------
+
+func TestPlanStaticKeyCreate_WithExistingGateway(t *testing.T) {
+	t.Parallel()
+
+	p := newTestStaticKeyPlanner()
+	plan := newTestStaticKeyPlan()
+
+	desc := "key description"
+	key := resources.EventGatewayStaticKeyResource{
+		EventGatewayStaticKeyCreate: kkComps.EventGatewayStaticKeyCreate{
+			Name:        "my-key",
+			Value:       "s3cr3t",
+			Description: &desc,
+			Labels:      map[string]string{"team": "platform"},
+		},
+		Ref: "my-key-ref",
+	}
+
+	p.planStaticKeyCreate("default", "gw-ref", "my-gateway", "gw-id", key, nil, plan)
+
+	require.Len(t, plan.Changes, 1)
+	c := plan.Changes[0]
+	assert.Equal(t, ActionCreate, c.Action)
+	assert.Equal(t, ResourceTypeEventGatewayStaticKey, c.ResourceType)
+	assert.Equal(t, "my-key-ref", c.ResourceRef)
+	assert.Equal(t, "my-key", c.Fields["name"])
+	assert.Equal(t, "s3cr3t", c.Fields["value"])
+	assert.Equal(t, "key description", c.Fields["description"])
+	assert.Equal(t, map[string]string{"team": "platform"}, c.Fields["labels"])
+	require.NotNil(t, c.Parent)
+	assert.Equal(t, "gw-id", c.Parent.ID)
+	assert.Equal(t, "gw-ref", c.Parent.Ref)
+}
+
+func TestPlanStaticKeyCreate_ForNewGateway_HasReference(t *testing.T) {
+	t.Parallel()
+
+	p := newTestStaticKeyPlanner()
+	plan := newTestStaticKeyPlan()
+
+	key := resources.EventGatewayStaticKeyResource{
+		EventGatewayStaticKeyCreate: kkComps.EventGatewayStaticKeyCreate{
+			Name:  "my-key",
+			Value: "val",
+		},
+		Ref: "my-key-ref",
+	}
+
+	// gatewayID="" signals gateway doesn't exist yet
+	p.planStaticKeyCreate("default", "gw-ref", "my-gateway", "", key, []string{"dep-1"}, plan)
+
+	require.Len(t, plan.Changes, 1)
+	c := plan.Changes[0]
+	assert.Nil(t, c.Parent, "parent should not be set when gateway doesn't exist yet")
+	require.Contains(t, c.References, "event_gateway_id")
+	assert.Equal(t, "gw-ref", c.References["event_gateway_id"].Ref)
+	assert.Contains(t, c.DependsOn, "dep-1")
+}
+
+// ---------------------------------------------------------------------------
+// planStaticKeyDelete
+// ---------------------------------------------------------------------------
+
+func TestPlanStaticKeyDelete_ReturnsChangeID(t *testing.T) {
+	t.Parallel()
+
+	p := newTestStaticKeyPlanner()
+	plan := newTestStaticKeyPlan()
+
+	changeID := p.planStaticKeyDelete("gw-ref", "my-gateway", "gw-id", "key-id-1", "my-key", plan)
+
+	require.NotEmpty(t, changeID)
+	require.Len(t, plan.Changes, 1)
+	c := plan.Changes[0]
+	assert.Equal(t, ActionDelete, c.Action)
+	assert.Equal(t, ResourceTypeEventGatewayStaticKey, c.ResourceType)
+	assert.Equal(t, "key-id-1", c.ResourceID)
+	assert.Equal(t, changeID, c.ID)
+}
+
+// ---------------------------------------------------------------------------
+// planStaticKeyCreatesForNewGateway
+// ---------------------------------------------------------------------------
+
+func TestPlanStaticKeyCreatesForNewGateway_WithGatewayDependency(t *testing.T) {
+	t.Parallel()
+
+	p := newTestStaticKeyPlanner()
+	plan := newTestStaticKeyPlan()
+
+	keys := []resources.EventGatewayStaticKeyResource{
+		{
+			EventGatewayStaticKeyCreate: kkComps.EventGatewayStaticKeyCreate{
+				Name:  "key-a",
+				Value: "val-a",
+			},
+			Ref: "key-a",
+		},
+		{
+			EventGatewayStaticKeyCreate: kkComps.EventGatewayStaticKeyCreate{
+				Name:  "key-b",
+				Value: "val-b",
+			},
+			Ref: "key-b",
+		},
+	}
+
+	p.planStaticKeyCreatesForNewGateway("ns", "gw-ref", "my-gateway", "gw-change-id", keys, plan)
+
+	require.Len(t, plan.Changes, 2)
+	for _, c := range plan.Changes {
+		assert.Equal(t, ActionCreate, c.Action)
+		assert.Contains(t, c.DependsOn, "gw-change-id",
+			"each static key create must depend on gateway create")
+	}
+}
+
+func TestPlanStaticKeyCreatesForNewGateway_NoGatewayChangeID(t *testing.T) {
+	t.Parallel()
+
+	p := newTestStaticKeyPlanner()
+	plan := newTestStaticKeyPlan()
+
+	key := resources.EventGatewayStaticKeyResource{
+		EventGatewayStaticKeyCreate: kkComps.EventGatewayStaticKeyCreate{
+			Name:  "key-a",
+			Value: "val",
+		},
+		Ref: "key-a",
+	}
+
+	p.planStaticKeyCreatesForNewGateway(
+		"ns", "gw-ref", "my-gateway", "",
+		[]resources.EventGatewayStaticKeyResource{key}, plan)
+
+	require.Len(t, plan.Changes, 1)
+	assert.Empty(t, plan.Changes[0].DependsOn)
+}

--- a/internal/declarative/protection/lookup.go
+++ b/internal/declarative/protection/lookup.go
@@ -118,7 +118,8 @@ func IsManagedResourceProtected(
 		resources.ResourceTypeEventGatewayListenerPolicy,
 		resources.ResourceTypeEventGatewayDataPlaneCertificate,
 		resources.ResourceTypeEventGatewayProducePolicy,
-		resources.ResourceTypeEventGatewaySchemaRegistry:
+		resources.ResourceTypeEventGatewaySchemaRegistry,
+		resources.ResourceTypeEventGatewayStaticKey:
 		return false, nil
 	}
 

--- a/internal/declarative/resources/event_gateway_control_plane.go
+++ b/internal/declarative/resources/event_gateway_control_plane.go
@@ -24,6 +24,7 @@ type EventGatewayControlPlaneResource struct {
 	Listeners             []EventGatewayListenerResource             `yaml:"listeners,omitempty"               json:"listeners,omitempty"`               //nolint:lll
 	DataPlaneCertificates []EventGatewayDataPlaneCertificateResource `yaml:"data_plane_certificates,omitempty" json:"data_plane_certificates,omitempty"` //nolint:lll
 	SchemaRegistries      []EventGatewaySchemaRegistryResource       `yaml:"schema_registries,omitempty"       json:"schema_registries,omitempty"`       //nolint:lll
+	StaticKeys            []EventGatewayStaticKeyResource            `yaml:"static_keys,omitempty"             json:"static_keys,omitempty"`             //nolint:lll
 }
 
 func (e EventGatewayControlPlaneResource) GetType() ResourceType {
@@ -112,6 +113,18 @@ func (e EventGatewayControlPlaneResource) Validate() error {
 		schemaRegistryRefs[sr.GetRef()] = true
 	}
 
+	// Validate static keys
+	staticKeyRefs := make(map[string]bool)
+	for i, sk := range e.StaticKeys {
+		if err := sk.Validate(); err != nil {
+			return fmt.Errorf("invalid static key %d: %w", i, err)
+		}
+		if staticKeyRefs[sk.GetRef()] {
+			return fmt.Errorf("duplicate static key ref: %s", sk.GetRef())
+		}
+		staticKeyRefs[sk.GetRef()] = true
+	}
+
 	return nil
 }
 
@@ -138,6 +151,10 @@ func (e *EventGatewayControlPlaneResource) SetDefaults() {
 
 	for i := range e.SchemaRegistries {
 		e.SchemaRegistries[i].SetDefaults()
+	}
+
+	for i := range e.StaticKeys {
+		e.StaticKeys[i].SetDefaults()
 	}
 }
 

--- a/internal/declarative/resources/event_gateway_static_key.go
+++ b/internal/declarative/resources/event_gateway_static_key.go
@@ -58,6 +58,12 @@ func (e EventGatewayStaticKeyResource) Validate() error {
 	if err := ValidateRef(e.Ref); err != nil {
 		return fmt.Errorf("invalid static key ref: %w", err)
 	}
+	if e.Name == "" {
+		return fmt.Errorf("static key %q is missing required field: name", e.Ref)
+	}
+	if e.Value == "" {
+		return fmt.Errorf("static key %q is missing required field: value", e.Ref)
+	}
 	return nil
 }
 

--- a/internal/declarative/resources/event_gateway_static_key.go
+++ b/internal/declarative/resources/event_gateway_static_key.go
@@ -1,0 +1,143 @@
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+)
+
+func init() {
+	registerResourceType(
+		ResourceTypeEventGatewayStaticKey,
+		func(rs *ResourceSet) *[]EventGatewayStaticKeyResource { return &rs.EventGatewayStaticKeys },
+		AutoExplain[EventGatewayStaticKeyResource](),
+	)
+}
+
+// EventGatewayStaticKeyResource represents an Event Gateway Static Key resource.
+// Static keys are used by Encrypt and Decrypt policies to encrypt data at rest.
+// This resource does not support update operations – changes are implemented as
+// delete + create.
+type EventGatewayStaticKeyResource struct {
+	kkComps.EventGatewayStaticKeyCreate `yaml:",inline" json:",inline"`
+	Ref                                 string `yaml:"ref"                     json:"ref"`
+	// Parent Event Gateway reference (for root-level definitions)
+	EventGateway string `yaml:"event_gateway,omitempty" json:"event_gateway,omitempty"`
+
+	// Resolved Konnect ID (not serialized)
+	konnectID string `yaml:"-" json:"-"`
+}
+
+func (e EventGatewayStaticKeyResource) GetType() ResourceType {
+	return ResourceTypeEventGatewayStaticKey
+}
+
+func (e EventGatewayStaticKeyResource) GetRef() string {
+	return e.Ref
+}
+
+func (e EventGatewayStaticKeyResource) GetMoniker() string {
+	return e.Name
+}
+
+func (e EventGatewayStaticKeyResource) GetDependencies() []ResourceRef {
+	deps := []ResourceRef{}
+	if e.EventGateway != "" {
+		// Dependency on parent Event Gateway when defined at root level
+		deps = append(deps, ResourceRef{Kind: "event_gateway", Ref: e.EventGateway})
+	}
+	return deps
+}
+
+func (e EventGatewayStaticKeyResource) GetKonnectID() string {
+	return e.konnectID
+}
+
+func (e EventGatewayStaticKeyResource) Validate() error {
+	if err := ValidateRef(e.Ref); err != nil {
+		return fmt.Errorf("invalid static key ref: %w", err)
+	}
+	return nil
+}
+
+func (e *EventGatewayStaticKeyResource) SetDefaults() {
+	if e.Name == "" {
+		e.Name = e.Ref
+	}
+}
+
+func (e EventGatewayStaticKeyResource) GetKonnectMonikerFilter() string {
+	return fmt.Sprintf("name[eq]=%s", e.Name) // TODO: the API does not support filtering by name.
+}
+
+func (e *EventGatewayStaticKeyResource) TryMatchKonnectResource(konnectResource any) bool {
+	if id := tryMatchByField(konnectResource, "Name", e.Name); id != "" {
+		e.konnectID = id
+		return true
+	}
+	return false
+}
+
+// GetParentRef REQUIRED: marks resource as a child of Event Gateway.
+func (e EventGatewayStaticKeyResource) GetParentRef() *ResourceRef {
+	if e.EventGateway != "" {
+		return &ResourceRef{Kind: "event_gateway", Ref: e.EventGateway}
+	}
+	return nil
+}
+
+// MarshalJSON ensures static key metadata (ref, event_gateway) are included.
+// Without this, the embedded EventGatewayStaticKeyCreate's MarshalJSON is promoted and
+// drops metadata fields.
+func (e EventGatewayStaticKeyResource) MarshalJSON() ([]byte, error) {
+	type alias struct {
+		Ref          string            `json:"ref"`
+		EventGateway string            `json:"event_gateway,omitempty"`
+		Name         string            `json:"name"`
+		Description  *string           `json:"description,omitempty"`
+		Labels       map[string]string `json:"labels,omitempty"`
+		Value        string            `json:"value"`
+	}
+
+	payload := alias{
+		Ref:          e.Ref,
+		EventGateway: e.EventGateway,
+		Name:         e.Name,
+		Description:  e.Description,
+		Labels:       e.Labels,
+		Value:        e.Value,
+	}
+
+	return json.Marshal(payload)
+}
+
+// UnmarshalJSON rejects kongctl metadata (not supported on child resources).
+func (e *EventGatewayStaticKeyResource) UnmarshalJSON(data []byte) error {
+	var temp struct {
+		Ref          string            `json:"ref"`
+		EventGateway string            `json:"event_gateway,omitempty"`
+		Kongctl      any               `json:"kongctl,omitempty"`
+		Name         string            `json:"name"`
+		Description  *string           `json:"description,omitempty"`
+		Labels       map[string]string `json:"labels,omitempty"`
+		Value        string            `json:"value"`
+	}
+
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return err
+	}
+
+	if temp.Kongctl != nil {
+		return fmt.Errorf("kongctl metadata not supported on child resources")
+	}
+
+	e.Ref = temp.Ref
+	e.EventGateway = temp.EventGateway
+	e.Name = temp.Name
+	e.Description = temp.Description
+	e.Labels = temp.Labels
+	e.Value = temp.Value
+
+	return nil
+}

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -39,6 +39,7 @@ const (
 	ResourceTypeEventGatewayProducePolicy        ResourceType = "event_gateway_virtual_cluster_produce_policy"
 	ResourceTypeEventGatewayConsumePolicy        ResourceType = "event_gateway_virtual_cluster_consume_policy"
 	ResourceTypeEventGatewaySchemaRegistry       ResourceType = "event_gateway_schema_registry"
+	ResourceTypeEventGatewayStaticKey            ResourceType = "event_gateway_static_key"
 )
 
 const (
@@ -94,6 +95,7 @@ type ResourceSet struct {
 	EventGatewayConsumePolicies       []EventGatewayConsumePolicyResource        `yaml:"event_gateway_virtual_cluster_consume_policies,omitempty" json:"event_gateway_virtual_cluster_consume_policies,omitempty"` //nolint:lll
 	EventGatewayDataPlaneCertificates []EventGatewayDataPlaneCertificateResource `yaml:"event_gateway_data_plane_certificates,omitempty" json:"event_gateway_data_plane_certificates,omitempty"`                   //nolint:lll
 	EventGatewaySchemaRegistries      []EventGatewaySchemaRegistryResource       `yaml:"event_gateway_schema_registries,omitempty"       json:"event_gateway_schema_registries,omitempty"`                         //nolint:lll
+	EventGatewayStaticKeys            []EventGatewayStaticKeyResource            `yaml:"event_gateway_static_keys,omitempty"              json:"event_gateway_static_keys,omitempty"`                              //nolint:lll
 	// DefaultNamespace tracks namespace from _defaults when no resources are present
 	// This is used by the planner to determine which namespace to check for deletions
 	DefaultNamespace  string   `yaml:"-"                                               json:"-"`
@@ -915,4 +917,33 @@ func (rs *ResourceSet) GetConsumePoliciesForVirtualCluster(
 	}
 
 	return policies
+}
+
+// GetStaticKeysForGateway returns all static keys (nested + root-level)
+// for a specific event gateway
+func (rs *ResourceSet) GetStaticKeysForGateway(
+	gatewayRef string,
+) []EventGatewayStaticKeyResource {
+	var keys []EventGatewayStaticKeyResource
+
+	// Add nested static keys from the event gateway
+	for _, gateway := range rs.EventGatewayControlPlanes {
+		if gateway.Ref == gatewayRef {
+			for _, sk := range gateway.StaticKeys {
+				skCopy := sk
+				skCopy.EventGateway = gatewayRef
+				keys = append(keys, skCopy)
+			}
+			break
+		}
+	}
+
+	// Add root-level static keys for this gateway
+	for _, sk := range rs.EventGatewayStaticKeys {
+		if sk.EventGateway == gatewayRef {
+			keys = append(keys, sk)
+		}
+	}
+
+	return keys
 }

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -61,6 +61,7 @@ type ClientConfig struct {
 	EventGatewayConsumePolicyAPI        helpers.EventGatewayConsumePolicyAPI
 	EventGatewayDataPlaneCertificateAPI helpers.EventGatewayDataPlaneCertificateAPI
 	EventGatewaySchemaRegistryAPI       helpers.EventGatewaySchemaRegistryAPI
+	EventGatewayStaticKeyAPI            helpers.EventGatewayStaticKeyAPI
 
 	// Identity resources
 	OrganizationTeamAPI helpers.OrganizationTeamAPI
@@ -105,6 +106,7 @@ type Client struct {
 	eventGatewayConsumePolicyAPI        helpers.EventGatewayConsumePolicyAPI
 	eventGatewayDataPlaneCertificateAPI helpers.EventGatewayDataPlaneCertificateAPI
 	eventGatewaySchemaRegistryAPI       helpers.EventGatewaySchemaRegistryAPI
+	eventGatewayStaticKeyAPI            helpers.EventGatewayStaticKeyAPI
 
 	// Organization resource APIs
 	organizationTeamAPI helpers.OrganizationTeamAPI
@@ -150,6 +152,7 @@ func NewClient(config ClientConfig) *Client {
 		eventGatewayConsumePolicyAPI:        config.EventGatewayConsumePolicyAPI,
 		eventGatewayDataPlaneCertificateAPI: config.EventGatewayDataPlaneCertificateAPI,
 		eventGatewaySchemaRegistryAPI:       config.EventGatewaySchemaRegistryAPI,
+		eventGatewayStaticKeyAPI:            config.EventGatewayStaticKeyAPI,
 
 		// Identity resource APIs
 		organizationTeamAPI: config.OrganizationTeamAPI,
@@ -5289,5 +5292,149 @@ func (c *Client) DeleteEventGatewaySchemaRegistry(
 	if err != nil {
 		return WrapAPIError(err, "delete event gateway schema registry", nil)
 	}
+	return nil
+}
+
+// EventGatewayStaticKey represents an event gateway static key for internal use.
+type EventGatewayStaticKey struct {
+	kkComps.EventGatewayStaticKey
+}
+
+// ListEventGatewayStaticKeys lists all static keys for a gateway using cursor-based pagination.
+func (c *Client) ListEventGatewayStaticKeys(
+	ctx context.Context,
+	gatewayID string,
+) ([]EventGatewayStaticKey, error) {
+	if err := ValidateAPIClient(c.eventGatewayStaticKeyAPI, "event gateway static key API"); err != nil {
+		return nil, err
+	}
+
+	var allData []kkComps.EventGatewayStaticKey
+	var pageAfter *string
+
+	for {
+		req := kkOps.ListEventGatewayStaticKeysRequest{
+			GatewayID: gatewayID,
+		}
+
+		if pageAfter != nil {
+			req.PageAfter = pageAfter
+		}
+
+		res, err := c.eventGatewayStaticKeyAPI.ListEventGatewayStaticKeys(ctx, req)
+		if err != nil {
+			return nil, WrapAPIError(err, "list event gateway static keys", nil)
+		}
+
+		if res.ListEventGatewayStaticKeysResponse == nil {
+			return []EventGatewayStaticKey{}, nil
+		}
+
+		allData = append(allData, res.ListEventGatewayStaticKeysResponse.Data...)
+
+		if res.ListEventGatewayStaticKeysResponse.Meta.Page.Next == nil {
+			break
+		}
+
+		u, err := url.Parse(*res.ListEventGatewayStaticKeysResponse.Meta.Page.Next)
+		if err != nil {
+			return nil, WrapAPIError(err, "list event gateway static keys: invalid cursor", nil)
+		}
+
+		values := u.Query()
+		after := values.Get("page[after]")
+		pageAfter = &after
+	}
+
+	result := make([]EventGatewayStaticKey, 0, len(allData))
+	for _, sk := range allData {
+		result = append(result, EventGatewayStaticKey{EventGatewayStaticKey: sk})
+	}
+
+	return result, nil
+}
+
+// CreateEventGatewayStaticKey creates a new static key for an event gateway.
+func (c *Client) CreateEventGatewayStaticKey(
+	ctx context.Context,
+	gatewayID string,
+	req kkComps.EventGatewayStaticKeyCreate,
+	_ string, // namespace
+) (string, error) {
+	if err := ValidateAPIClient(c.eventGatewayStaticKeyAPI, "event gateway static key API"); err != nil {
+		return "", err
+	}
+
+	createReq := kkOps.CreateEventGatewayStaticKeyRequest{
+		GatewayID:                   gatewayID,
+		EventGatewayStaticKeyCreate: &req,
+	}
+
+	resp, err := c.eventGatewayStaticKeyAPI.CreateEventGatewayStaticKey(ctx, createReq)
+	if err != nil {
+		return "", WrapAPIError(err, "create event gateway static key", &ErrorWrapperOptions{
+			ResourceType: "event_gateway_static_key",
+			ResourceName: req.Name,
+			UseEnhanced:  true,
+		})
+	}
+
+	if err := ValidateResponse(resp.EventGatewayStaticKey, "create event gateway static key"); err != nil {
+		return "", err
+	}
+
+	return resp.EventGatewayStaticKey.ID, nil
+}
+
+// GetEventGatewayStaticKey retrieves a static key by ID.
+func (c *Client) GetEventGatewayStaticKey(
+	ctx context.Context,
+	gatewayID string,
+	staticKeyID string,
+) (*EventGatewayStaticKey, error) {
+	if err := ValidateAPIClient(c.eventGatewayStaticKeyAPI, "event gateway static key API"); err != nil {
+		return nil, err
+	}
+
+	req := kkOps.GetEventGatewayStaticKeyRequest{
+		GatewayID:   gatewayID,
+		StaticKeyID: staticKeyID,
+	}
+
+	resp, err := c.eventGatewayStaticKeyAPI.GetEventGatewayStaticKey(ctx, req)
+	if err != nil {
+		return nil, WrapAPIError(err, "get event gateway static key", &ErrorWrapperOptions{
+			ResourceType: "event_gateway_static_key",
+			UseEnhanced:  true,
+		})
+	}
+
+	if resp.EventGatewayStaticKey == nil {
+		return nil, nil
+	}
+
+	return &EventGatewayStaticKey{EventGatewayStaticKey: *resp.EventGatewayStaticKey}, nil
+}
+
+// DeleteEventGatewayStaticKey deletes a static key by ID.
+func (c *Client) DeleteEventGatewayStaticKey(
+	ctx context.Context,
+	gatewayID string,
+	staticKeyID string,
+) error {
+	if err := ValidateAPIClient(c.eventGatewayStaticKeyAPI, "event gateway static key API"); err != nil {
+		return err
+	}
+
+	deleteReq := kkOps.DeleteEventGatewayStaticKeyRequest{
+		GatewayID:   gatewayID,
+		StaticKeyID: staticKeyID,
+	}
+
+	_, err := c.eventGatewayStaticKeyAPI.DeleteEventGatewayStaticKey(ctx, deleteReq)
+	if err != nil {
+		return WrapAPIError(err, "delete event gateway static key", nil)
+	}
+
 	return nil
 }

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -5332,7 +5332,8 @@ func (c *Client) ListEventGatewayStaticKeys(
 
 		allData = append(allData, res.ListEventGatewayStaticKeysResponse.Data...)
 
-		if res.ListEventGatewayStaticKeysResponse.Meta.Page.Next == nil {
+		if res.ListEventGatewayStaticKeysResponse.Meta == nil ||
+			res.ListEventGatewayStaticKeysResponse.Meta.Page.Next == nil {
 			break
 		}
 

--- a/internal/konnect/helpers/event_gateway_static_keys.go
+++ b/internal/konnect/helpers/event_gateway_static_keys.go
@@ -1,0 +1,63 @@
+package helpers
+
+import (
+	"context"
+
+	kkSDK "github.com/Kong/sdk-konnect-go"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+)
+
+// EventGatewayStaticKeyAPI defines the interface for Event Gateway Static Key operations.
+type EventGatewayStaticKeyAPI interface {
+	ListEventGatewayStaticKeys(ctx context.Context,
+		request kkOps.ListEventGatewayStaticKeysRequest,
+		opts ...kkOps.Option) (*kkOps.ListEventGatewayStaticKeysResponse, error)
+	GetEventGatewayStaticKey(ctx context.Context,
+		request kkOps.GetEventGatewayStaticKeyRequest,
+		opts ...kkOps.Option) (*kkOps.GetEventGatewayStaticKeyResponse, error)
+	CreateEventGatewayStaticKey(ctx context.Context,
+		request kkOps.CreateEventGatewayStaticKeyRequest,
+		opts ...kkOps.Option) (*kkOps.CreateEventGatewayStaticKeyResponse, error)
+	DeleteEventGatewayStaticKey(ctx context.Context,
+		request kkOps.DeleteEventGatewayStaticKeyRequest,
+		opts ...kkOps.Option) (*kkOps.DeleteEventGatewayStaticKeyResponse, error)
+}
+
+// EventGatewayStaticKeyAPIImpl provides an implementation of the EventGatewayStaticKeyAPI interface.
+type EventGatewayStaticKeyAPIImpl struct {
+	SDK *kkSDK.SDK
+}
+
+func (a *EventGatewayStaticKeyAPIImpl) ListEventGatewayStaticKeys(
+	ctx context.Context,
+	request kkOps.ListEventGatewayStaticKeysRequest,
+	opts ...kkOps.Option,
+) (*kkOps.ListEventGatewayStaticKeysResponse, error) {
+	return a.SDK.EventGatewayStaticKeys.ListEventGatewayStaticKeys(ctx, request, opts...)
+}
+
+func (a *EventGatewayStaticKeyAPIImpl) GetEventGatewayStaticKey(
+	ctx context.Context,
+	request kkOps.GetEventGatewayStaticKeyRequest,
+	opts ...kkOps.Option,
+) (*kkOps.GetEventGatewayStaticKeyResponse, error) {
+	return a.SDK.EventGatewayStaticKeys.GetEventGatewayStaticKey(ctx, request.GatewayID, request.StaticKeyID, opts...)
+}
+
+func (a *EventGatewayStaticKeyAPIImpl) CreateEventGatewayStaticKey(
+	ctx context.Context,
+	request kkOps.CreateEventGatewayStaticKeyRequest,
+	opts ...kkOps.Option,
+) (*kkOps.CreateEventGatewayStaticKeyResponse, error) {
+	return a.SDK.EventGatewayStaticKeys.CreateEventGatewayStaticKey(
+		ctx, request.GatewayID, request.EventGatewayStaticKeyCreate, opts...)
+}
+
+func (a *EventGatewayStaticKeyAPIImpl) DeleteEventGatewayStaticKey(
+	ctx context.Context,
+	request kkOps.DeleteEventGatewayStaticKeyRequest,
+	opts ...kkOps.Option,
+) (*kkOps.DeleteEventGatewayStaticKeyResponse, error) {
+	return a.SDK.EventGatewayStaticKeys.DeleteEventGatewayStaticKey(
+		ctx, request.GatewayID, request.StaticKeyID, opts...)
+}

--- a/internal/konnect/helpers/sdk.go
+++ b/internal/konnect/helpers/sdk.go
@@ -55,6 +55,7 @@ type SDKAPI interface {
 	GetEventGatewayConsumePolicyAPI() EventGatewayConsumePolicyAPI
 	GetEventGatewayDataPlaneCertificateAPI() EventGatewayDataPlaneCertificateAPI
 	GetEventGatewaySchemaRegistryAPI() EventGatewaySchemaRegistryAPI
+	GetEventGatewayStaticKeyAPI() EventGatewayStaticKeyAPI
 }
 
 // This is the real implementation of the SDKAPI
@@ -391,6 +392,15 @@ func (k *KonnectSDK) GetEventGatewaySchemaRegistryAPI() EventGatewaySchemaRegist
 	}
 
 	return &EventGatewaySchemaRegistryAPIImpl{SDK: k.SDK}
+}
+
+// GetEventGatewayStaticKeyAPI returns the implementation of the EventGatewayStaticKeyAPI interface.
+func (k *KonnectSDK) GetEventGatewayStaticKeyAPI() EventGatewayStaticKeyAPI {
+	if k.SDK == nil {
+		return nil
+	}
+
+	return &EventGatewayStaticKeyAPIImpl{SDK: k.SDK}
 }
 
 func (k *KonnectSDK) GetOrganizationTeamAPI() OrganizationTeamAPI {

--- a/internal/konnect/helpers/sdk_mock.go
+++ b/internal/konnect/helpers/sdk_mock.go
@@ -46,6 +46,7 @@ type MockKonnectSDK struct {
 	EventGatewayConsumePolicyFactory        func() EventGatewayConsumePolicyAPI
 	EventGatewayDataPlaneCertificateFactory func() EventGatewayDataPlaneCertificateAPI
 	EventGatewaySchemaRegistryFactory       func() EventGatewaySchemaRegistryAPI
+	EventGatewayStaticKeyFactory            func() EventGatewayStaticKeyAPI
 }
 
 // Returns a mock instance of the ControlPlaneAPI
@@ -337,6 +338,14 @@ func (m *MockKonnectSDK) GetEventGatewayDataPlaneCertificateAPI() EventGatewayDa
 func (m *MockKonnectSDK) GetEventGatewaySchemaRegistryAPI() EventGatewaySchemaRegistryAPI {
 	if m.EventGatewaySchemaRegistryFactory != nil {
 		return m.EventGatewaySchemaRegistryFactory()
+	}
+	return nil
+}
+
+// Returns a mock instance of the EventGatewayStaticKeyAPI
+func (m *MockKonnectSDK) GetEventGatewayStaticKeyAPI() EventGatewayStaticKeyAPI {
+	if m.EventGatewayStaticKeyFactory != nil {
+		return m.EventGatewayStaticKeyFactory()
 	}
 	return nil
 }

--- a/test/e2e/scenarios/event-gateway/dump/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/dump/scenario.yaml
@@ -19,6 +19,8 @@ vars:
   consumePolicyName: default-consume-policy-name-for-dump-test
   schemaRegistryRef: default-schema-registry
   schemaRegistryName: default-schema-registry-name-for-dump-test
+  staticKeyRef: default-static-key
+  staticKeyName: default-static-key-name-for-dump-test
 
 defaults:
   mask:
@@ -46,7 +48,7 @@ steps:
           - select: summary
             expect:
               fields:
-                applied: 6
+                applied: 7
                 failed: 0
 
   # Dump event_gateways with child resources and validate the output structure.
@@ -104,6 +106,12 @@ steps:
             expect:
               fields:
                 name: "{{ .vars.schemaRegistryName }}"
+          - name: static-key-present
+            select: >-
+              event_gateways[?name=='{{ .vars.egwName }}'] | [0].static_keys[?name=='{{ .vars.staticKeyName }}'] | [0]
+            expect:
+              fields:
+                name: "{{ .vars.staticKeyName }}"
           - name: namespace-label-preserved
             select: "_defaults.kongctl"
             expect:
@@ -116,7 +124,7 @@ steps:
           - -f
           - "{{ .workdir }}/dump.yaml"
           - --mode
-          - apply
+          - sync
         assertions:
           - select: summary
             expect:

--- a/test/e2e/scenarios/event-gateway/dump/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/dump/testdata/config.yaml
@@ -73,5 +73,3 @@ event_gateways:
         name: default-static-key-name-for-dump-test
         description: "Default Static Key description for Dump Test"
         value: "${env[\"STATIC_KEY_VALUE\"]}"
-    
-    

--- a/test/e2e/scenarios/event-gateway/dump/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/dump/testdata/config.yaml
@@ -68,3 +68,10 @@ event_gateways:
             type: basic
             username: testuser
             password: "${env[\"KAFKA_PASSWORD\"]}"
+    static_keys:
+      - ref: default-static-key
+        name: default-static-key-name-for-dump-test
+        description: "Default Static Key description for Dump Test"
+        value: "${env[\"STATIC_KEY_VALUE\"]}"
+    
+    

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/011-static-key/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/011-static-key/config.yaml
@@ -1,0 +1,128 @@
+_defaults:
+  kongctl:
+    namespace: egw-plan-apply
+
+event_gateways:
+  - ref: plan-apply-egw
+    name: plan-apply-egw
+    description: "Updated description for plan apply workflow"
+    backend_clusters:
+      - ref: plan-apply-backend-cluster
+        name: plan-apply-backend-cluster
+        description: "Updated description for plan apply backend cluster"
+        bootstrap_servers:
+          - "egw-backend-1-updated.example.com:9092"
+        authentication:
+          type: anonymous
+        tls:
+          enabled: true
+          skip_verify: false
+          tls_versions:
+            - tls12
+            - tls13
+    virtual_clusters:
+      - ref: plan-apply-virtual-cluster
+        name: plan-apply-virtual-cluster
+        description: "Virtual cluster for plan apply workflow"
+        destination:
+          name: plan-apply-backend-cluster
+        authentication:
+          - type: sasl_scram
+            algorithm: sha512
+        acl_mode: enforce_on_gateway
+        dns_label: vc-default
+        cluster_policies:
+          - ref: plan-apply-cluster-policy
+            name: plan-apply-cluster-policy-name-for-test
+            description: Plan Apply Cluster Policy description
+            type: acls
+            enabled: true
+            config:
+              rules:
+                - action: "deny"
+                  operations:
+                  - name: "describe_configs"
+                  resource_names:
+                  - match: "*"
+                  resource_type: "transactional_id"
+        produce_policies:
+          - ref: plan-apply-produce-policy
+            name: plan-apply-produce-policy-name-for-test
+            description: Plan Apply Produce Policy description
+            type: modify_headers
+            enabled: true
+            labels:
+              env: staging
+              team: streaming
+            config:
+              actions:
+                - op: set
+                  key: x-producer-id
+                  value: "${client_id}"
+                - op: remove
+                  key: x-original-header
+        consume_policies:
+          - condition: ""
+            description: description
+            enabled: true
+            name: skip-record-policy
+            ref: plan-apply-consume-policy
+            type: skip_record
+    schema_registries:
+      - ref: plan-apply-schema-registry
+        name: plan-apply-schema-registry-name
+        description: "Plan Apply Schema Registry description"
+        type: confluent
+        config:
+          schema_type: json
+          endpoint: https://schema-registry.example.com
+          timeout_seconds: 30
+          authentication:
+            type: basic
+            username: testuser
+            password: testpassword
+    static_keys:
+      - ref: plan-apply-static-key
+        name: plan-apply-static-key-name
+        description: "Plan Apply Static Key description"
+        value: "${env[\"STATIC_KEY_VALUE\"]}"
+    listeners:
+      - ref: plan-apply-listener
+        name: plan-apply-listener
+        description: "Listener for plan apply workflow"
+        ports:
+          - "9093-9095"
+        addresses:
+          - localhost
+        policies:
+          - ref: plan-apply-listener-1-policy-1-ref
+            name: plan-apply-listener-1-policy-1-name
+            type: forward_to_virtual_cluster
+            description: "Plan Apply Listener 1 Policy 1"
+            enabled: true
+            condition: "${ssl_sni} == \"example.com\""
+            labels:
+              env: staging
+              team: payments
+            config:
+              type: sni
+              advertised_port: 9092
+              sni_suffix: ".example.com"
+    data_plane_certificates:
+      - ref: plan-apply-dataplane-certificate-ref
+        name: plan-apply-dataplane-certificate-name
+        description: "Plan Apply Dataplane Certificate description"
+        certificate: |-
+          -----BEGIN CERTIFICATE-----
+          MIIB4TCCAYugAwIBAgIUAenxUyPjkSLCe2BQXoBMBacqgLowDQYJKoZIhvcNAQEL
+          BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+          GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yNDEwMjgyMDA3NDlaFw0zNDEw
+          MjYyMDA3NDlaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+          HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwXDANBgkqhkiG9w0BAQEF
+          AANLADBIAkEAyzipjrbAaLO/yPg7lL1dLWzhqNdc3S4YNR7f1RG9whWhbsPE2z42
+          e6WGFf9hggP6xjG4qbU8jFVczpd1UPwGbQIDAQABo1MwUTAdBgNVHQ4EFgQUkPPB
+          ghj+iHOHAKJlC1gLbKT/ZHQwHwYDVR0jBBgwFoAUkPPBghj+iHOHAKJlC1gLbKT/
+          ZHQwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAANBALfy49GvA2ld+u+G
+          Koxa8kCt7uywoqu0hfbBfUT4HqmXPvsuhz8RinE5ltxId108vtDNlD/+bKl+N5Ub
+          qKjBs0k=
+          -----END CERTIFICATE-----

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/scenario.yaml
@@ -37,6 +37,9 @@ vars:
   schemaRegistryRef: plan-apply-schema-registry
   schemaRegistryName: plan-apply-schema-registry-name
   schemaRegistryDesc: "Plan Apply Schema Registry description"
+  staticKeyRef: plan-apply-static-key
+  staticKeyName: plan-apply-static-key-name
+  staticKeyDesc: "Plan Apply Static Key description"
 
 defaults:
   mask:
@@ -873,3 +876,77 @@ steps:
                 name: "{{ .vars.schemaRegistryName }}"
                 description: "{{ .vars.schemaRegistryDesc }}"
                 type: confluent
+  - name: 012-plan-apply-static-key
+    inputOverlayDirs:
+      - overlays/011-static-key
+    commands:
+      - name: 000-plan-create-static-key
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-static-key.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_static_key' && resource_ref=='{{ .vars.staticKeyRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.staticKeyRef }}"
+      - name: 001-diff-plan-text
+        outputFormat: text
+        parseAs: raw
+        run:
+          - diff
+          - --plan
+          - "{{ .workdir }}/plan-static-key.json"
+        assertions:
+          - select: stdout
+            expect:
+              fields:
+                "contains(@, 'Plan: 1 to add')": true
+                "contains(@, 'event_gateway_static_key \"plan-apply-static-key\" will be created')": true
+      - name: 002-apply-plan
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-static-key.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 003-verify-static-key
+        run:
+          - get
+          - event-gateway
+          - static-keys
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 1
+          - select: "[0]"
+            expect:
+              fields:
+                name: "{{ .vars.staticKeyName }}"
+                description: "{{ .vars.staticKeyDesc }}"

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/011-static-key/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/011-static-key/config.yaml
@@ -1,0 +1,132 @@
+_defaults:
+  kongctl:
+    namespace: egw-plan-sync
+
+event_gateways:
+  - ref: plan-sync-egw
+    name: plan-sync-egw
+    description: "Updated description for plan sync workflow"
+    backend_clusters:
+      - ref: plan-sync-backend-cluster
+        name: plan-sync-backend-cluster
+        description: "Updated description for plan apply backend cluster"
+        bootstrap_servers:
+          - "egw-backend-1-updated.example.com:9092"
+        authentication:
+          type: anonymous
+        tls:
+          enabled: true
+          skip_verify: false
+          tls_versions:
+            - tls12
+            - tls13
+    virtual_clusters:
+      - ref: plan-sync-virtual-cluster
+        name: plan-sync-virtual-cluster
+        description: "Virtual cluster for plan sync workflow"
+        destination:
+          id: !ref plan-sync-backend-cluster#id
+        authentication:
+          - type: anonymous
+        acl_mode: enforce_on_gateway
+        dns_label: vc-default
+        cluster_policies:
+          - ref: plan-sync-cluster-policy
+            name: plan-sync-cluster-policy-name-for-test
+            description: Plan Sync Cluster Policy description
+            type: acls
+            enabled: true
+            config:
+              rules:
+                - action: "deny"
+                  operations:
+                  - name: "describe_configs"
+                  resource_names:
+                  - match: "*"
+                  resource_type: "transactional_id"
+        produce_policies:
+          - ref: plan-sync-produce-policy
+            name: plan-sync-produce-policy-name-for-test
+            description: Plan Sync Produce Policy description
+            type: modify_headers
+            enabled: true
+            labels:
+              env: staging
+              team: streaming
+            config:
+              actions:
+                - op: set
+                  key: x-producer-id
+                  value: "${client_id}"
+                - op: remove
+                  key: x-original-header
+        consume_policies:
+          - condition: ""
+            config:
+              key_validation_action: mark
+              type: json
+              value_validation_action: skip
+            description: ""
+            enabled: true
+            name: plan-sync-consume-policy-name-for-test
+            ref: plan-sync-consume-policy
+            type: schema_validation
+    schema_registries:
+      - ref: plan-sync-schema-registry
+        name: plan-sync-schema-registry-name
+        description: "Plan Sync Schema Registry description"
+        type: confluent
+        config:
+          schema_type: json
+          endpoint: https://schema-registry.example.com
+          timeout_seconds: 30
+          authentication:
+            type: basic
+            username: testuser
+            password: testpassword
+    static_keys:
+      - ref: plan-sync-static-key
+        name: plan-sync-static-key-name
+        description: "Plan Sync Static Key description"
+        value: "${env[\"STATIC_KEY_VALUE\"]}"
+    listeners:
+      - ref: plan-sync-listener
+        name: plan-sync-listener
+        description: "Listener for plan sync workflow"
+        ports:
+          - 9092
+        addresses:
+          - localhost
+        policies:
+          - ref: plan-sync-listener-1-policy-1-ref
+            name: plan-sync-listener-1-policy-1-name
+            type: forward_to_virtual_cluster
+            description: "Plan Sync Listener 1 Policy 1"
+            enabled: true
+            condition: "${ssl_sni} == \"example.com\""
+            labels:
+              env: staging
+              team: payments
+            config:
+              type: port_mapping
+              destination:
+                id: !ref plan-sync-virtual-cluster#id
+              advertised_host: "example.com"
+    data_plane_certificates:
+      - ref: plan-sync-dataplane-certificate-ref
+        name: plan-sync-dataplane-certificate-name
+        description: "Plan Sync Dataplane Certificate description"
+        certificate: |-
+          -----BEGIN CERTIFICATE-----
+          MIIB4TCCAYugAwIBAgIUAenxUyPjkSLCe2BQXoBMBacqgLowDQYJKoZIhvcNAQEL
+          BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+          GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yNDEwMjgyMDA3NDlaFw0zNDEw
+          MjYyMDA3NDlaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+          HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwXDANBgkqhkiG9w0BAQEF
+          AANLADBIAkEAyzipjrbAaLO/yPg7lL1dLWzhqNdc3S4YNR7f1RG9whWhbsPE2z42
+          e6WGFf9hggP6xjG4qbU8jFVczpd1UPwGbQIDAQABo1MwUTAdBgNVHQ4EFgQUkPPB
+          ghj+iHOHAKJlC1gLbKT/ZHQwHwYDVR0jBBgwFoAUkPPBghj+iHOHAKJlC1gLbKT/
+          ZHQwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAANBALfy49GvA2ld+u+G
+          Koxa8kCt7uywoqu0hfbBfUT4HqmXPvsuhz8RinE5ltxId108vtDNlD/+bKl+N5Ub
+          qKjBs0k=
+          -----END CERTIFICATE-----

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/scenario.yaml
@@ -37,6 +37,9 @@ vars:
   schemaRegistryRef: plan-sync-schema-registry
   schemaRegistryName: plan-sync-schema-registry-name
   schemaRegistryDesc: "Plan Sync Schema Registry description"
+  staticKeyRef: plan-sync-static-key
+  staticKeyName: plan-sync-static-key-name
+  staticKeyDesc: "Plan Sync Static Key description"
 
 defaults:
   mask:
@@ -981,4 +984,89 @@ steps:
             expect:
               fields:
                 "contains(@, 'No changes detected. Konnect is up to date.')": true
-
+  - name: 012-plan-sync-static-key
+    inputOverlayDirs:
+      - overlays/011-static-key
+    commands:
+      - name: 000-plan-create-static-key
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-static-key.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: sync
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_static_key' && resource_ref=='{{ .vars.staticKeyRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.staticKeyRef }}"
+      - name: 001-diff-plan-text
+        outputFormat: text
+        parseAs: raw
+        run:
+          - diff
+          - --plan
+          - "{{ .workdir }}/plan-static-key.json"
+        assertions:
+          - select: stdout
+            expect:
+              fields:
+                "contains(@, 'Plan: 1 to add')": true
+                "contains(@, 'event_gateway_static_key \"plan-sync-static-key\" will be created')": true
+      - name: 002-sync-plan
+        outputFormat: json
+        run:
+          - sync
+          - --plan
+          - "{{ .workdir }}/plan-static-key.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 003-verify-static-key
+        run:
+          - get
+          - event-gateway
+          - static-keys
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 1
+          - select: "[0]"
+            expect:
+              fields:
+                name: "{{ .vars.staticKeyName }}"
+                description: "{{ .vars.staticKeyDesc }}"
+      - name: 004-diff-no-changes
+        outputFormat: text
+        parseAs: raw
+        run:
+          - diff
+          - -f
+          - "{{ .workdir }}/config.yaml"
+        assertions:
+          - select: stdout
+            expect:
+              fields:
+                "contains(@, 'No changes detected. Konnect is up to date.')": true

--- a/test/e2e/scenarios/event-gateway/static-key/overlays/001-update-fields/config.yaml
+++ b/test/e2e/scenarios/event-gateway/static-key/overlays/001-update-fields/config.yaml
@@ -10,4 +10,4 @@ event_gateways:
       - ref: default-static-key-ref
         name: default-static-key-name
         description: "Updated Static Key description"
-        value: "my-super-secret-static-key-value"
+        value: "YXNkZmdoamthc2RmZ2hqa2FzZGZnaGprYXNkZmdoams="

--- a/test/e2e/scenarios/event-gateway/static-key/overlays/001-update-fields/config.yaml
+++ b/test/e2e/scenarios/event-gateway/static-key/overlays/001-update-fields/config.yaml
@@ -1,0 +1,13 @@
+_defaults:
+  kongctl:
+    namespace: event-gateways-static-key-test
+
+event_gateways:
+  - ref: egw-cp-for-static-key-test-ref
+    name: egw-cp-for-static-key-test-name
+    description: "EGW CP for Static Key Test"
+    static_keys:
+      - ref: default-static-key-ref
+        name: default-static-key-name
+        description: "Updated Static Key description"
+        value: "my-super-secret-static-key-value"

--- a/test/e2e/scenarios/event-gateway/static-key/overlays/002-sync-delete/config.yaml
+++ b/test/e2e/scenarios/event-gateway/static-key/overlays/002-sync-delete/config.yaml
@@ -1,0 +1,9 @@
+_defaults:
+  kongctl:
+    namespace: event-gateways-static-key-test
+
+event_gateways:
+  - ref: egw-cp-for-static-key-test-ref
+    name: egw-cp-for-static-key-test-name
+    description: "EGW CP for Static Key Test"
+    static_keys: []

--- a/test/e2e/scenarios/event-gateway/static-key/overlays/003-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/static-key/overlays/003-root-level-declaration/config.yaml
@@ -1,0 +1,15 @@
+_defaults:
+  kongctl:
+    namespace: event-gateways-static-key-test
+
+event_gateways:
+  - ref: egw-cp-for-static-key-test-ref
+    name: egw-cp-for-static-key-test-name
+    description: "EGW CP for Static Key Test"
+
+event_gateway_static_keys:
+  - ref: default-static-key-ref
+    event_gateway: egw-cp-for-static-key-test-ref
+    name: default-static-key-name
+    description: "Default root level Static Key description"
+    value: "my-super-secret-static-key-value"

--- a/test/e2e/scenarios/event-gateway/static-key/overlays/003-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/static-key/overlays/003-root-level-declaration/config.yaml
@@ -12,4 +12,4 @@ event_gateway_static_keys:
     event_gateway: egw-cp-for-static-key-test-ref
     name: default-static-key-name
     description: "Default root level Static Key description"
-    value: "YXNkZmdoamthc2RmZ2hqa2FzZGZnaGprYXNkZmdoams="
+    value: !env "STATIC_KEY_VALUE"

--- a/test/e2e/scenarios/event-gateway/static-key/overlays/003-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/static-key/overlays/003-root-level-declaration/config.yaml
@@ -12,4 +12,4 @@ event_gateway_static_keys:
     event_gateway: egw-cp-for-static-key-test-ref
     name: default-static-key-name
     description: "Default root level Static Key description"
-    value: "my-super-secret-static-key-value"
+    value: "YXNkZmdoamthc2RmZ2hqa2FzZGZnaGprYXNkZmdoams="

--- a/test/e2e/scenarios/event-gateway/static-key/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/static-key/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -1,0 +1,10 @@
+_defaults:
+  kongctl:
+    namespace: event-gateways-static-key-test
+
+event_gateways:
+  - ref: egw-cp-for-static-key-test-ref
+    name: egw-cp-for-static-key-test-name
+    description: "EGW CP for Static Key Test"
+
+event_gateway_static_keys: []

--- a/test/e2e/scenarios/event-gateway/static-key/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/static-key/scenario.yaml
@@ -2,6 +2,7 @@ baseInputsPath: testdata
 
 env:
   KONGCTL_LOG_LEVEL: info
+  STATIC_KEY_VALUE: "YXNkZmdoamthc2RmZ2hqa2FzZGZnaGprYXNkZmdoams="
 
 test:
   enabledByEnvVar: KONGCTL_ENABLE_EVENT_GATEWAY
@@ -56,6 +57,7 @@ steps:
               fields:
                 action: CREATE
                 resource_ref: "{{ .vars.staticKeyRef }}"
+
       - name: 002-apply-create
         outputFormat: json
         run:
@@ -245,6 +247,7 @@ steps:
               fields:
                 action: CREATE
                 resource_ref: "{{ .vars.staticKeyRef }}"
+                "fields.value": __ENV__:STATIC_KEY_VALUE
       - name: 002-apply-create
         outputFormat: json
         run:

--- a/test/e2e/scenarios/event-gateway/static-key/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/static-key/scenario.yaml
@@ -69,7 +69,27 @@ steps:
               fields:
                 applied: 2
                 failed: 0
-  - name: 002-plan-apply-replace
+
+      - name: 003-verify-create
+        run:
+          - get
+          - event-gateway
+          - static-keys
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 1
+          - select: "[0]"
+            expect:
+              fields:
+                name: "{{ .vars.staticKeyName }}"
+                description: "Default Static Key description"
+  - name: 002-plan-sync-replace
     # Static keys do not support update – changing description triggers DELETE+CREATE.
     inputOverlayDirs:
       - overlays/001-update-fields
@@ -82,12 +102,12 @@ steps:
           - -f
           - "{{ .workdir }}/config.yaml"
           - --mode
-          - apply
+          - sync
         assertions:
           - select: metadata
             expect:
               fields:
-                mode: apply
+                mode: sync
           - select: summary
             expect:
               fields:
@@ -109,7 +129,7 @@ steps:
       - name: 002-apply-replace
         outputFormat: json
         run:
-          - apply
+          - sync
           - --plan
           - "{{ .workdir }}/plan-replace.json"
           - --auto-approve
@@ -119,6 +139,26 @@ steps:
               fields:
                 applied: 2
                 failed: 0
+
+      - name: 003-verify-replace
+        run:
+          - get
+          - event-gateway
+          - static-keys
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 1
+          - select: "[0]"
+            expect:
+              fields:
+                name: "{{ .vars.staticKeyName }}"
+                description: "Updated Static Key description"
   - name: 003-sync-delete
     inputOverlayDirs:
       - overlays/002-sync-delete
@@ -161,6 +201,21 @@ steps:
               fields:
                 applied: 1
                 failed: 0
+
+      - name: 003-verify-delete
+        run:
+          - get
+          - event-gateway
+          - static-keys
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 0
   - name: 004-root-level-declaration
     inputOverlayDirs:
       - overlays/003-root-level-declaration
@@ -203,6 +258,26 @@ steps:
               fields:
                 applied: 1
                 failed: 0
+
+      - name: 003-verify-create
+        run:
+          - get
+          - event-gateway
+          - static-keys
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 1
+          - select: "[0]"
+            expect:
+              fields:
+                name: default-static-key-name
+                description: "Default root level Static Key description"
   - name: 005-sync-delete-root-level
     inputOverlayDirs:
       - overlays/004-sync-delete-root-level-declaration
@@ -245,3 +320,18 @@ steps:
               fields:
                 applied: 1
                 failed: 0
+
+      - name: 003-verify-delete-root-level
+        run:
+          - get
+          - event-gateway
+          - static-keys
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 0

--- a/test/e2e/scenarios/event-gateway/static-key/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/static-key/scenario.yaml
@@ -1,0 +1,247 @@
+baseInputsPath: testdata
+
+env:
+  KONGCTL_LOG_LEVEL: info
+
+test:
+  enabledByEnvVar: KONGCTL_ENABLE_EVENT_GATEWAY
+
+vars:
+  egwName: egw-cp-for-static-key-test-name
+  staticKeyRef: default-static-key-ref
+  staticKeyName: default-static-key-name
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - created_at
+      - updated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+  - name: 001-plan-apply-create
+    commands:
+      - name: 001-plan-create
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-create.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 2
+                by_action.CREATE: 2
+          - select: >-
+              changes[?resource_type=='event_gateway' && resource_ref=='egw-cp-for-static-key-test-ref'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "egw-cp-for-static-key-test-ref"
+          - select: >-
+              changes[?resource_type=='event_gateway_static_key' && resource_ref=='{{ .vars.staticKeyRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.staticKeyRef }}"
+      - name: 002-apply-create
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-create.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 2
+                failed: 0
+  - name: 002-plan-apply-replace
+    # Static keys do not support update – changing description triggers DELETE+CREATE.
+    inputOverlayDirs:
+      - overlays/001-update-fields
+    commands:
+      - name: 001-plan-replace
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-replace.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 2
+                by_action.DELETE: 1
+                by_action.CREATE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_static_key' && action=='DELETE'] | [0]
+            expect:
+              fields:
+                action: DELETE
+                resource_type: "event_gateway_static_key"
+          - select: >-
+              changes[?resource_type=='event_gateway_static_key' && action=='CREATE'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.staticKeyRef }}"
+      - name: 002-apply-replace
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-replace.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 2
+                failed: 0
+  - name: 003-sync-delete
+    inputOverlayDirs:
+      - overlays/002-sync-delete
+    commands:
+      - name: 001-plan-sync-delete
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-sync-delete.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: sync
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_static_key'] | [0]
+            expect:
+              fields:
+                action: DELETE
+                resource_type: "event_gateway_static_key"
+      - name: 002-sync-delete
+        outputFormat: json
+        run:
+          - sync
+          - --plan
+          - "{{ .workdir }}/plan-sync-delete.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+  - name: 004-root-level-declaration
+    inputOverlayDirs:
+      - overlays/003-root-level-declaration
+    commands:
+      - name: 001-plan-root-level
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-root-level.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_static_key' && resource_ref=='{{ .vars.staticKeyRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.staticKeyRef }}"
+      - name: 002-apply-create
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-root-level.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+  - name: 005-sync-delete-root-level
+    inputOverlayDirs:
+      - overlays/004-sync-delete-root-level-declaration
+    commands:
+      - name: 001-plan-sync-delete-root-level
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-sync-delete-root-level.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: sync
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_static_key'] | [0]
+            expect:
+              fields:
+                action: DELETE
+                resource_type: "event_gateway_static_key"
+      - name: 002-sync-delete-root-level
+        outputFormat: json
+        run:
+          - sync
+          - --plan
+          - "{{ .workdir }}/plan-sync-delete-root-level.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0

--- a/test/e2e/scenarios/event-gateway/static-key/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/static-key/testdata/config.yaml
@@ -1,0 +1,13 @@
+_defaults:
+  kongctl:
+    namespace: event-gateways-static-key-test
+
+event_gateways:
+  - ref: egw-cp-for-static-key-test-ref
+    name: egw-cp-for-static-key-test-name
+    description: "EGW CP for Static Key Test"
+    static_keys:
+      - ref: default-static-key-ref
+        name: default-static-key-name
+        description: "Default Static Key description"
+        value: "my-super-secret-static-key-value"

--- a/test/e2e/scenarios/event-gateway/static-key/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/static-key/testdata/config.yaml
@@ -10,4 +10,4 @@ event_gateways:
       - ref: default-static-key-ref
         name: default-static-key-name
         description: "Default Static Key description"
-        value: "my-super-secret-static-key-value"
+        value: "YXNkZmdoamthc2RmZ2hqa2FzZGZnaGprYXNkZmdoams="


### PR DESCRIPTION
## Summary
In this PR, we are adding support for
1. Declarative management of Event Gateway Static Keys
2. Imperative GET for Static Keys
3. Dump for Static Keys
4. View for Static Keys

Example for GET
```
./kongctl get egw static-keys --gateway-id $EGW_ID
./kongctl get egw sk --gateway-id $EGW_ID --static-key-id $SKID
./kongctl get konnect egw sk --gateway-name $EGW_NAME --static-key-name $SKNAME
```

