### PR TITLE
[codex] harden agentic workflow prompt guidance

### DIFF
--- a/.github/workflows/code-simplifier.md
+++ b/.github/workflows/code-simplifier.md
@@ -46,6 +46,15 @@ preserving all functionality. Create an issue detailing the recomended simplifie
 - **Analysis Date**: $(date +%Y-%m-%d)
 - **Workspace**: ${{ github.workspace }}
 
+**Important tool usage notes:**
+- Use GitHub MCP tools (for example `search_pull_requests`,
+  `list_pull_requests`, `pull_request_read`, `get_commit`, and
+  `get_file_contents`) for all GitHub reads.
+- Use safe-output tools (`create_issue`, `noop`) for all GitHub writes and
+  completion signaling.
+- Do NOT use `gh` CLI commands for GitHub API reads or writes because the CLI
+  is not authenticated in this environment.
+
 ## Phase 1: Identify Recently Modified Code
 
 ### 1.1 Find Recent Changes
@@ -60,7 +69,7 @@ YESTERDAY=$(date -d '1 day ago' '+%Y-%m-%d' 2>/dev/null || date -v-1d '+%Y-%m-%d
 git log --since="24 hours ago" --pretty=format:"%H %s" --no-merges
 ```
 
-Use GitHub tools to:
+Use GitHub MCP tools to:
 - Search for pull requests merged in the last 24 hours: `repo:${{ github.repository }} is:pr is:merged merged:>=${YESTERDAY}`
 - Get details of merged PRs to understand what files were changed
 - Ignore changes that are purely documentation, cicd, workflows, configuration, or non-code files (non .go or non go related files).
@@ -253,7 +262,7 @@ Please verify:
 
 ### 4.3 Use Safe Outputs
 
-Create the issue request by emitting `create-issue` with the generated content in
+Create the issue request by emitting `create_issue` with the generated content in
 the required format.
 
 ## Important Guidelines

--- a/.github/workflows/e2e-coverage-scanner.md
+++ b/.github/workflows/e2e-coverage-scanner.md
@@ -50,6 +50,14 @@ The goal is steady daily improvement, not issue spam.
 Prefer deep analysis of one slice over shallow analysis of the whole
 repository.
 
+**Important tool usage notes:**
+- Use GitHub MCP tools (for example `search_issues` and `list_issues`) for all
+  GitHub reads and issue deduplication checks.
+- Use safe-output tools (`create_issue`, `noop`) for all GitHub writes and
+  completion signaling.
+- Do NOT use `gh` CLI commands for GitHub API reads or writes because the CLI
+  is not authenticated in this environment.
+
 ## Persistent State
 
 Use cache-memory exactly as lightweight workflow state.
@@ -230,6 +238,8 @@ Do not file issues for speculative ideas, stylistic preferences, or vague
    - If one focused verification pass does not resolve the candidate, drop it
 
 5. Deduplicate before creating anything.
+   - Use GitHub MCP issue search and list tools for this step; do not use
+     shell `gh` commands
    - Search open issues in this repository for similar titles and bodies
    - Pay special attention to open issues with the `e2e` label
    - If an open issue already tracks the same gap or a substantially similar
@@ -244,7 +254,7 @@ Do not file issues for speculative ideas, stylistic preferences, or vague
 
 7. Finalize before timeout.
    - Update cache-memory state for the chosen slice before finishing
-   - Emit `create-issue` for each approved finding, or `noop` if none qualify
+   - Emit `create_issue` for each approved finding, or `noop` if none qualify
    - Do not perform more exploratory reads after starting finalization
 
 ## Issue Requirements

--- a/.github/workflows/release.md
+++ b/.github/workflows/release.md
@@ -473,6 +473,15 @@ All data is pre-fetched in `/tmp/gh-aw/release-data/`:
 Generate complete release notes that replace the existing release content,
 so users can quickly understand what changed and why it matters.
 
+**Important tool usage notes:**
+- All required GitHub release, PR, issue, and compare data has already been
+  pre-fetched into `/tmp/gh-aw/release-data/`.
+- Use local shell commands only to inspect those pre-fetched files and relevant
+  repository files.
+- Do NOT use `gh` CLI commands or make additional GitHub API calls from the
+  agent. The agent should operate only on the pre-fetched local data.
+- Use the `update_release` safe-output tool exactly once for the final write.
+
 The highlights should be:
 - User-impact focused, not a raw changelog dump
 - Concise and scannable in under one minute

--- a/.github/workflows/weekly-repo-status.md
+++ b/.github/workflows/weekly-repo-status.md
@@ -39,6 +39,13 @@ source: githubnext/agentics/workflows/daily-repo-status.md@69b5e3ae5fa7f35fa555b
 
 Create an upbeat weekly status report for the repo as a GitHub Discussion.
 
+**Important tool usage notes:**
+- Use GitHub MCP tools for all GitHub reads when gathering repository activity.
+- Use safe-output tools (`create_discussion`, `noop`) for all GitHub writes and
+  completion signaling.
+- Do NOT use `gh` CLI commands for GitHub API reads or writes because the CLI
+  is not authenticated in this environment.
+
 ## What to include
 
 - Recent repository activity (issues, PRs, discussions, releases, code changes)
@@ -62,7 +69,7 @@ Create an upbeat weekly status report for the repo as a GitHub Discussion.
 
 Before finishing, emit exactly one safe output.
 
-- Prefer `create-discussion` with the weekly report.
+- Prefer `create_discussion` with the weekly report.
 - If no meaningful report can be created, emit `noop` explaining why.
 - If the discussion tool is unavailable or fails, emit `missing_tool` or `noop`
   so the workflow never finishes with no safe outputs.


### PR DESCRIPTION
## Summary

Harden the agentic workflow prompts so they consistently steer agents toward MCP/safe-output usage instead of unauthenticated `gh` CLI fallbacks.

## What changed

- added explicit tool-usage guidance to the scanner, simplifier, weekly repo status, and release workflow prompts
- clarified that GitHub reads should use MCP tools or pre-fetched local data
- clarified that GitHub writes should use safe-output tools
- fixed prompt wording to use `create_issue` / `create_discussion` where applicable
- added scanner-specific guidance to use MCP issue search/list for deduplication instead of shell `gh`

## Why

Historical failing runs in this repo showed workflows succeeding overall while producing no safe outputs, with agent logs indicating blocked MCP usage and fallback attempts through `gh`. The prompt changes make the intended tool path explicit across the remaining agentic workflows.

## Impact

These are prompt-only workflow markdown changes. No compiled lockfiles changed.

## Validation

- `gh aw compile e2e-coverage-scanner --strict`
- `gh aw compile code-simplifier --strict`
- `gh aw compile weekly-repo-status --strict`
- `gh aw compile release`
