### PR TITLE
test: cover api_publication re-apply idempotency

### DIFF
--- a/test/e2e/scenarios/portal/visibility/scenario.yaml
+++ b/test/e2e/scenarios/portal/visibility/scenario.yaml
@@ -60,6 +60,27 @@ steps:
             mask:
               dropKeys:
                 - api_spec_ids
+      - name: 003-apply-no-op-after-create
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - -f
+          - "{{ .workdir }}/apis.yaml"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 0
+                failed: 0
+                skipped: 0
+                status: "success"
+                total_changes: 0
+          - select: "plan.changes[?resource_type=='api_publication']"
+            expect:
+              fields:
+                "length(@)": 0
 
   - name: 002-mutate-publication-visibility
     inputOverlayOps:


### PR DESCRIPTION
## Summary

This expands E2E coverage for `api_publication` idempotency by adding an unchanged second `apply` assertion to the existing portal visibility scenario.

## Why

Issue #86 reported that `api_publication` resources continued to plan updates on a second apply even when the input files were unchanged. Current publication scenarios already covered no-op `plan` behavior and some no-op `apply` cases, but they did not directly assert the exact repro shape from the issue: an unchanged second `apply` immediately after creation using the portal/API declarative files.

This PR adds that direct assertion so we keep coverage on the behavior even if the original bug is no longer reproducible.

## Impact

- Increases confidence that `api_publication` creation is followed by a stable no-op re-apply
- Gives issue #86 a concrete regression test path in the E2E suite
- Does not change planner or executor behavior

## Validation

- `make test-e2e-scenarios SCENARIO=portal/auth-strategy-link`
- `make test-e2e-scenarios SCENARIO=portal/visibility`

Closes #86