### PR TITLE
Test: root-level api_publication visibility ownership

### DIFF
--- a/test/e2e/scenarios/apis/root-level-publication-visibility/overlays/002-set-public/publications.yaml
+++ b/test/e2e/scenarios/apis/root-level-publication-visibility/overlays/002-set-public/publications.yaml
@@ -1,0 +1,5 @@
+api_publications:
+  - ref: sms-to-e2e-portal
+    api: sms
+    portal_id: !ref e2e-portal#id
+    visibility: public

--- a/test/e2e/scenarios/apis/root-level-publication-visibility/overlays/003-remove-visibility/publications.yaml
+++ b/test/e2e/scenarios/apis/root-level-publication-visibility/overlays/003-remove-visibility/publications.yaml
@@ -1,0 +1,4 @@
+api_publications:
+  - ref: sms-to-e2e-portal
+    api: sms
+    portal_id: !ref e2e-portal#id

--- a/test/e2e/scenarios/apis/root-level-publication-visibility/overlays/003-remove-visibility/publications.yaml
+++ b/test/e2e/scenarios/apis/root-level-publication-visibility/overlays/003-remove-visibility/publications.yaml
@@ -1,4 +1,0 @@
-api_publications:
-  - ref: sms-to-e2e-portal
-    api: sms
-    portal_id: !ref e2e-portal#id

--- a/test/e2e/scenarios/apis/root-level-publication-visibility/scenario.yaml
+++ b/test/e2e/scenarios/apis/root-level-publication-visibility/scenario.yaml
@@ -1,7 +1,7 @@
 baseInputsPath: testdata
 
 env:
-  KONGCTL_LOG_LEVEL: debug
+  KONGCTL_LOG_LEVEL: info
 
 vars:
   portalRef: e2e-portal
@@ -153,8 +153,6 @@ steps:
                 "length(@)": 0
 
   - name: 003-omit-visibility-after-public
-    inputOverlayDirs:
-      - overlays/003-remove-visibility
     commands:
       - name: 000-apply-no-op
         run:

--- a/test/e2e/scenarios/apis/root-level-publication-visibility/scenario.yaml
+++ b/test/e2e/scenarios/apis/root-level-publication-visibility/scenario.yaml
@@ -1,0 +1,216 @@
+baseInputsPath: testdata
+
+env:
+  KONGCTL_LOG_LEVEL: debug
+
+vars:
+  portalRef: e2e-portal
+  portalName: "E2E Root-Level Publication Portal"
+  apiRef: sms
+  apiName: "E2E SMS API"
+  publicationRef: sms-to-e2e-portal
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - created_at
+      - updated_at
+      - resource_id
+      - change_id
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-apply-omitted-visibility
+    commands:
+      - name: 000-apply
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - -f
+          - "{{ .workdir }}/apis.yaml"
+          - -f
+          - "{{ .workdir }}/publications.yaml"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 4
+                failed: 0
+                skipped: 0
+                status: "success"
+                total_changes: 4
+          - select: >-
+              plan.changes[?resource_type=='api_publication' &&
+                            resource_ref=='{{ .vars.publicationRef }}'] | [0]
+            expect:
+              fields:
+                action: "CREATE"
+      - name: 001-get-api-publications
+        run:
+          - get
+          - api
+          - publications
+          - --api-name
+          - "{{ .vars.apiName }}"
+          - -o
+          - json
+        assertions:
+          - select: "[0]"
+            expect:
+              fields:
+                visibility: "private"
+                "length(portal_id)": 36
+      - name: 002-plan-no-op
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - -f
+          - "{{ .workdir }}/apis.yaml"
+          - -f
+          - "{{ .workdir }}/publications.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+          - select: "changes[?resource_type=='api_publication']"
+            expect:
+              fields:
+                "length(@)": 0
+
+  - name: 002-set-explicit-public
+    inputOverlayDirs:
+      - overlays/002-set-public
+    commands:
+      - name: 000-apply
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - -f
+          - "{{ .workdir }}/apis.yaml"
+          - -f
+          - "{{ .workdir }}/publications.yaml"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+          - select: >-
+              plan.changes[?resource_type=='api_publication' &&
+                            resource_ref=='{{ .vars.publicationRef }}'] | [0]
+            expect:
+              fields:
+                action: "UPDATE"
+                "fields.visibility": "public"
+      - name: 001-get-api-publications
+        run:
+          - get
+          - api
+          - publications
+          - --api-name
+          - "{{ .vars.apiName }}"
+          - -o
+          - json
+        assertions:
+          - select: "[0]"
+            expect:
+              fields:
+                visibility: "public"
+      - name: 002-plan-no-op
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - -f
+          - "{{ .workdir }}/apis.yaml"
+          - -f
+          - "{{ .workdir }}/publications.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+          - select: "changes[?resource_type=='api_publication']"
+            expect:
+              fields:
+                "length(@)": 0
+
+  - name: 003-omit-visibility-after-public
+    inputOverlayDirs:
+      - overlays/003-remove-visibility
+    commands:
+      - name: 000-apply-no-op
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - -f
+          - "{{ .workdir }}/apis.yaml"
+          - -f
+          - "{{ .workdir }}/publications.yaml"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 0
+                failed: 0
+                skipped: 0
+                status: "success"
+                total_changes: 0
+          - select: "plan.changes[?resource_type=='api_publication']"
+            expect:
+              fields:
+                "length(@)": 0
+      - name: 001-get-api-publications
+        run:
+          - get
+          - api
+          - publications
+          - --api-name
+          - "{{ .vars.apiName }}"
+          - -o
+          - json
+        assertions:
+          - select: "[0]"
+            expect:
+              fields:
+                visibility: "public"
+      - name: 002-plan-no-op
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - -f
+          - "{{ .workdir }}/apis.yaml"
+          - -f
+          - "{{ .workdir }}/publications.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+          - select: "changes[?resource_type=='api_publication']"
+            expect:
+              fields:
+                "length(@)": 0

--- a/test/e2e/scenarios/apis/root-level-publication-visibility/testdata/apis.yaml
+++ b/test/e2e/scenarios/apis/root-level-publication-visibility/testdata/apis.yaml
@@ -1,0 +1,8 @@
+apis:
+  - ref: sms
+    name: "E2E SMS API"
+    description: "Demo API used to verify root-level publication visibility ownership"
+    versions:
+      - ref: sms-v1
+        version: "1.0.0"
+        spec: !file ./apis/e2e-api.yaml

--- a/test/e2e/scenarios/apis/root-level-publication-visibility/testdata/apis/e2e-api.yaml
+++ b/test/e2e/scenarios/apis/root-level-publication-visibility/testdata/apis/e2e-api.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.0
+info:
+  title: E2E SMS API
+  version: "1.0.0"
+paths:
+  /messages:
+    get:
+      summary: List messages
+      responses:
+        "200":
+          description: OK

--- a/test/e2e/scenarios/apis/root-level-publication-visibility/testdata/portal.yaml
+++ b/test/e2e/scenarios/apis/root-level-publication-visibility/testdata/portal.yaml
@@ -1,0 +1,10 @@
+portals:
+  - ref: e2e-portal
+    name: "E2E Root-Level Publication Portal"
+    display_name: "E2E Root-Level Publication Portal"
+    description: "Portal used to verify omitted root-level publication visibility remains unmanaged"
+    authentication_enabled: false
+    rbac_enabled: false
+    auto_approve_developers: false
+    auto_approve_applications: false
+    default_api_visibility: "private"

--- a/test/e2e/scenarios/apis/root-level-publication-visibility/testdata/publications.yaml
+++ b/test/e2e/scenarios/apis/root-level-publication-visibility/testdata/publications.yaml
@@ -1,0 +1,4 @@
+api_publications:
+  - ref: sms-to-e2e-portal
+    api: sms
+    portal_id: !ref e2e-portal#id


### PR DESCRIPTION
## Summary
Adds a focused e2e scenario for root-level `api_publications` that covers publication visibility ownership semantics.

## What Changed
- Added `test/e2e/scenarios/apis/root-level-publication-visibility/`.
- Covered create with publication `visibility` omitted.
- Covered transition to explicit `visibility: public`.
- Covered removing `visibility` again and asserting the publication remains unmanaged with no drift.
- Set the portal fixture's `default_api_visibility` to `private` so the initial live publication state is deterministic.

## Why
Issue #112 is old enough that the first step was to re-evaluate whether the bug still matters and what the current test coverage looks like. Existing scenarios already covered explicit publication visibility values, but there was still a gap around:
- root-level `api_publications`
- omitted publication `visibility`
- declarative ownership behavior after a field is removed from input

This PR closes that gap without changing runtime behavior.

## Behavior Being Protected
When `visibility` is omitted from the declarative input:
- `kongctl` does not manage that field in planning or execution
- no update should be planned just because the live publication has a value
- after setting `visibility: public` explicitly once, removing it from input should leave the live publication unchanged and produce no drift

## Validation
- `make test-e2e-scenarios SCENARIO=apis/root-level-publication-visibility`

## Impact
This improves regression coverage for API publication visibility handling and documents the intended declarative ownership semantics around omitted fields.


Closes #112 