### PR TITLE
[codex] prefix User-Agent versions with v

### DIFF
--- a/internal/konnect/apiutil/client_test.go
+++ b/internal/konnect/apiutil/client_test.go
@@ -94,7 +94,7 @@ func TestRequestSetsUserAgentHeader(t *testing.T) {
 	t.Cleanup(func() {
 		meta.SetCLIVersion(original)
 	})
-	meta.SetCLIVersion("v0.5.0")
+	meta.SetCLIVersion("0.5.0")
 
 	var gotUserAgent string
 	client := roundTripFunc(func(req *http.Request) (*http.Response, error) {

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -36,5 +36,10 @@ func CLIVersion() string {
 
 // UserAgent returns the canonical User-Agent value for kongctl requests.
 func UserAgent() string {
-	return CLIName + "/" + CLIVersion()
+	version := CLIVersion()
+	if version != DefaultCLIVersion && !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+
+	return CLIName + "/" + version
 }

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -25,6 +25,23 @@ func TestUserAgentUsesConfiguredVersion(t *testing.T) {
 		SetCLIVersion(original)
 	})
 
+	SetCLIVersion(" 0.5.0 ")
+
+	if got := UserAgent(); got != "kongctl/v0.5.0" {
+		t.Fatalf("UserAgent() = %q, want %q", got, "kongctl/v0.5.0")
+	}
+
+	if got := CLIVersion(); got != "0.5.0" {
+		t.Fatalf("CLIVersion() = %q, want %q", got, "0.5.0")
+	}
+}
+
+func TestUserAgentKeepsPrefixedVersion(t *testing.T) {
+	original := CLIVersion()
+	t.Cleanup(func() {
+		SetCLIVersion(original)
+	})
+
 	SetCLIVersion(" v0.5.0 ")
 
 	if got := UserAgent(); got != "kongctl/v0.5.0" {


### PR DESCRIPTION
## Summary
- normalize `meta.UserAgent()` so release versions are emitted as `kongctl/vX.Y.Z`
- leave the build-injected CLI version unchanged so `kongctl version` continues to report bare semver
- update tests to cover both unprefixed and already-prefixed version inputs

## Why
The current release build path injects a bare version string like `0.7.0`. That value is correct for CLI version output, but it produces a `User-Agent` value that does not match the expected Kong tooling convention.

## Impact
HTTP requests sent by kongctl will now use a `User-Agent` value like `kongctl/v0.7.0` while the CLI version command remains unchanged.

## Root Cause
`meta.UserAgent()` previously concatenated `kongctl/` with the raw CLI version string, so any release build that injected `0.7.0` produced `kongctl/0.7.0` instead of `kongctl/v0.7.0`.

## Validation
- `make build`
- `make test-all`

Closes #825