### PR TITLE
feat: event gateway tls trust bundles

### DIFF
--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -2293,6 +2293,7 @@ func createStateClient(kkClient helpers.SDKAPI) *state.Client {
 		EventGatewayConsumePolicyAPI:        kkClient.GetEventGatewayConsumePolicyAPI(),
 		EventGatewaySchemaRegistryAPI:       kkClient.GetEventGatewaySchemaRegistryAPI(),
 		EventGatewayStaticKeyAPI:            kkClient.GetEventGatewayStaticKeyAPI(),
+		EventGatewayTLSTrustBundleAPI:       kkClient.GetEventGatewayTLSTrustBundleAPI(),
 		// Organization APIs
 		OrganizationTeamAPI: kkClient.GetOrganizationTeamAPI(),
 	})

--- a/internal/cmd/root/products/konnect/eventgateway/child_common.go
+++ b/internal/cmd/root/products/konnect/eventgateway/child_common.go
@@ -53,6 +53,12 @@ const (
 	staticKeyIDConfigPath   = "konnect.event-gateway.static-key.id"
 	staticKeyNameConfigPath = "konnect.event-gateway.static-key.name"
 
+	tlsTrustBundleIDFlagName   = "tls-trust-bundle-id"
+	tlsTrustBundleNameFlagName = "tls-trust-bundle-name"
+
+	tlsTrustBundleIDConfigPath   = "konnect.event-gateway.tls-trust-bundle.id"
+	tlsTrustBundleNameConfigPath = "konnect.event-gateway.tls-trust-bundle.name"
+
 	valueNA = "n/a"
 )
 
@@ -317,6 +323,42 @@ func bindStaticKeyChildFlags(c *cobra.Command, args []string) error {
 
 func getStaticKeyIdentifiers(cfg config.Hook) (id string, name string) {
 	return cfg.GetString(staticKeyIDConfigPath), cfg.GetString(staticKeyNameConfigPath)
+}
+
+func addTLSTrustBundleChildFlags(cmd *cobra.Command) {
+	cmd.Flags().String(tlsTrustBundleIDFlagName, "",
+		fmt.Sprintf(`The ID of the TLS trust bundle to retrieve.
+- Config path: [ %s ]`, tlsTrustBundleIDConfigPath))
+	cmd.Flags().String(tlsTrustBundleNameFlagName, "",
+		fmt.Sprintf(`The name of the TLS trust bundle to retrieve.
+- Config path: [ %s ]`, tlsTrustBundleNameConfigPath))
+	cmd.MarkFlagsMutuallyExclusive(tlsTrustBundleIDFlagName, tlsTrustBundleNameFlagName)
+}
+
+func bindTLSTrustBundleChildFlags(c *cobra.Command, args []string) error {
+	helper := cmd.BuildHelper(c, args)
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	if flag := c.Flags().Lookup(tlsTrustBundleIDFlagName); flag != nil {
+		if err := cfg.BindFlag(tlsTrustBundleIDConfigPath, flag); err != nil {
+			return err
+		}
+	}
+
+	if flag := c.Flags().Lookup(tlsTrustBundleNameFlagName); flag != nil {
+		if err := cfg.BindFlag(tlsTrustBundleNameConfigPath, flag); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getTLSTrustBundleIdentifiers(cfg config.Hook) (id string, name string) {
+	return cfg.GetString(tlsTrustBundleIDConfigPath), cfg.GetString(tlsTrustBundleNameConfigPath)
 }
 
 func resolveEventGatewayIDByName(

--- a/internal/cmd/root/products/konnect/eventgateway/getEventGateway.go
+++ b/internal/cmd/root/products/konnect/eventgateway/getEventGateway.go
@@ -530,6 +530,11 @@ func newGetEventGatewayControlPlaneCmd(verb verbs.VerbValue,
 		rv.AddCommand(staticKeysCmd)
 	}
 
+	tlsTrustBundlesCmd := newGetEventGatewayTLSTrustBundlesCmd(verb, addParentFlags, parentPreRun)
+	if tlsTrustBundlesCmd != nil {
+		rv.AddCommand(tlsTrustBundlesCmd)
+	}
+
 	listenerPoliciesCmd := newGetEventGatewayListenerPoliciesCmd(verb, addParentFlags, parentPreRun)
 	if listenerPoliciesCmd != nil {
 		rv.AddCommand(listenerPoliciesCmd)

--- a/internal/cmd/root/products/konnect/eventgateway/interactive_children.go
+++ b/internal/cmd/root/products/konnect/eventgateway/interactive_children.go
@@ -21,6 +21,7 @@ func init() {
 	tableview.RegisterChildLoader("event-gateway", "listeners", loadEventGatewayListeners)
 	tableview.RegisterChildLoader("event-gateway", "schema-registries", loadEventGatewaySchemaRegistries)
 	tableview.RegisterChildLoader("event-gateway", "static-keys", loadEventGatewayStaticKeys)
+	tableview.RegisterChildLoader("event-gateway", "tls-trust-bundles", loadEventGatewayTLSTrustBundles)
 	tableview.RegisterChildLoader("listener", "policies", loadEventGatewayListenerPolicies)
 	tableview.RegisterChildLoader("virtual-cluster", "cluster-policies", loadEventGatewayVirtualClusterClusterPolicies)
 	tableview.RegisterChildLoader("virtual-cluster", "produce-policies", loadEventGatewayVirtualClusterProducePolicies)
@@ -486,4 +487,42 @@ func loadEventGatewayStaticKeys(
 	}
 
 	return buildStaticKeyChildView(keys), nil
+}
+
+func loadEventGatewayTLSTrustBundles(
+	_ context.Context,
+	helper cmd.Helper,
+	parent any,
+) (tableview.ChildView, error) {
+	gatewayID, err := eventGatewayIDFromParent(parent)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	bundleAPI := sdk.GetEventGatewayTLSTrustBundleAPI()
+	if bundleAPI == nil {
+		return tableview.ChildView{}, fmt.Errorf("event gateway TLS trust bundle client is not available")
+	}
+
+	bundles, err := fetchTLSTrustBundles(helper, bundleAPI, gatewayID, cfg, "")
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	return buildTLSTrustBundleChildView(bundles), nil
 }

--- a/internal/cmd/root/products/konnect/eventgateway/tls_trust_bundles.go
+++ b/internal/cmd/root/products/konnect/eventgateway/tls_trust_bundles.go
@@ -422,3 +422,71 @@ func tlsTrustBundleToRecord(tb kkComps.TLSTrustBundle) tlsTrustBundleSummaryReco
 		LocalUpdatedTime: updatedAt,
 	}
 }
+
+func tlsTrustBundleDetailView(tb *kkComps.TLSTrustBundle) string {
+	if tb == nil {
+		return ""
+	}
+
+	id := strings.TrimSpace(tb.ID)
+	if id == "" {
+		id = valueNA
+	}
+
+	name := tb.Name
+	if name == "" {
+		name = valueNA
+	}
+
+	description := valueNA
+	if tb.Description != nil && strings.TrimSpace(*tb.Description) != "" {
+		description = strings.TrimSpace(*tb.Description)
+	}
+
+	trustedCa := strings.TrimSpace(tb.Config.TrustedCa)
+	if trustedCa == "" {
+		trustedCa = valueNA
+	}
+
+	createdAt := tb.CreatedAt.In(time.Local).Format("2006-01-02 15:04:05")
+	updatedAt := tb.UpdatedAt.In(time.Local).Format("2006-01-02 15:04:05")
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "id: %s\n", id)
+	fmt.Fprintf(&b, "name: %s\n", name)
+	fmt.Fprintf(&b, "description: %s\n", description)
+	fmt.Fprintf(&b, "config.trusted_ca: %s\n", trustedCa)
+	fmt.Fprintf(&b, "created_at: %s\n", createdAt)
+	fmt.Fprintf(&b, "updated_at: %s\n", updatedAt)
+
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func buildTLSTrustBundleChildView(bundles []kkComps.TLSTrustBundle) tableview.ChildView {
+	tableRows := make([]table.Row, 0, len(bundles))
+	for i := range bundles {
+		record := tlsTrustBundleToRecord(bundles[i])
+		tableRows = append(tableRows, table.Row{record.ID, record.Name, record.Description})
+	}
+
+	detailFn := func(index int) string {
+		if index < 0 || index >= len(bundles) {
+			return ""
+		}
+		return tlsTrustBundleDetailView(&bundles[index])
+	}
+
+	return tableview.ChildView{
+		Headers:        []string{"ID", "NAME", "DESCRIPTION"},
+		Rows:           tableRows,
+		DetailRenderer: detailFn,
+		Title:          "TLS Trust Bundles",
+		ParentType:     "tls-trust-bundle",
+		DetailContext: func(index int) any {
+			if index < 0 || index >= len(bundles) {
+				return nil
+			}
+			return &bundles[index]
+		},
+	}
+}

--- a/internal/cmd/root/products/konnect/eventgateway/tls_trust_bundles.go
+++ b/internal/cmd/root/products/konnect/eventgateway/tls_trust_bundles.go
@@ -1,0 +1,424 @@
+package eventgateway
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/table"
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/cmd"
+	cmdCommon "github.com/kong/kongctl/internal/cmd/common"
+	"github.com/kong/kongctl/internal/cmd/output/tableview"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
+	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/kong/kongctl/internal/config"
+	"github.com/kong/kongctl/internal/konnect/helpers"
+	"github.com/kong/kongctl/internal/meta"
+	"github.com/kong/kongctl/internal/util"
+	"github.com/kong/kongctl/internal/util/i18n"
+	"github.com/kong/kongctl/internal/util/normalizers"
+	"github.com/segmentio/cli"
+	"github.com/spf13/cobra"
+)
+
+const (
+	tlsTrustBundlesCommandName = "tls-trust-bundles"
+)
+
+type tlsTrustBundleSummaryRecord struct {
+	ID               string
+	Name             string
+	Description      string
+	LocalCreatedTime string
+	LocalUpdatedTime string
+}
+
+var (
+	tlsTrustBundlesUse = tlsTrustBundlesCommandName
+
+	tlsTrustBundlesShort = i18n.T("root.products.konnect.eventgateway.tlsTrustBundlesShort",
+		"Manage TLS trust bundles for an Event Gateway")
+	tlsTrustBundlesLong = normalizers.LongDesc(
+		i18n.T(
+			"root.products.konnect.eventgateway.tlsTrustBundlesLong",
+			`Use the tls-trust-bundles command to list or retrieve TLS trust bundles for a specific Event Gateway.
+
+TLS trust bundles define trusted certificate authorities used for mTLS client certificate
+verification and are referenced by TLS listener policies.`,
+		),
+	)
+	tlsTrustBundlesExample = normalizers.Examples(
+		i18n.T("root.products.konnect.eventgateway.tlsTrustBundlesExamples",
+			fmt.Sprintf(`
+# List TLS trust bundles for an event gateway by name
+%[1]s get event-gateway tls-trust-bundles --gateway-name my-gateway
+# List TLS trust bundles for an event gateway by ID
+%[1]s get event-gateway tls-trust-bundles --gateway-id <gateway-id>
+# Get a specific TLS trust bundle by name (positional argument)
+%[1]s get event-gateway tls-trust-bundles --gateway-name my-gateway my-bundle
+# Get a specific TLS trust bundle by ID (positional argument)
+%[1]s get event-gateway tls-trust-bundles --gateway-id <gateway-id> <bundle-id>
+# Get a specific TLS trust bundle by name (flag)
+%[1]s get event-gateway tls-trust-bundles --gateway-name my-gateway --tls-trust-bundle-name my-bundle
+# Get a specific TLS trust bundle by ID (flag)
+%[1]s get event-gateway tls-trust-bundles --gateway-id <gateway-id> --tls-trust-bundle-id <bundle-id>
+`, meta.CLIName)))
+)
+
+func newGetEventGatewayTLSTrustBundlesCmd(
+	verb verbs.VerbValue,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) *cobra.Command {
+	c := &cobra.Command{
+		Use:     tlsTrustBundlesUse,
+		Short:   tlsTrustBundlesShort,
+		Long:    tlsTrustBundlesLong,
+		Example: tlsTrustBundlesExample,
+		Aliases: []string{"tls-trust-bundle", "ttb"},
+		PreRunE: func(c *cobra.Command, args []string) error {
+			if parentPreRun != nil {
+				if err := parentPreRun(c, args); err != nil {
+					return err
+				}
+			}
+			if err := bindEventGatewayChildFlags(c, args); err != nil {
+				return err
+			}
+			return bindTLSTrustBundleChildFlags(c, args)
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			handler := tlsTrustBundlesHandler{cmd: c}
+			return handler.run(args)
+		},
+	}
+
+	addEventGatewayChildFlags(c)
+	addTLSTrustBundleChildFlags(c)
+
+	if addParentFlags != nil {
+		addParentFlags(verb, c)
+	}
+
+	return c
+}
+
+type tlsTrustBundlesHandler struct {
+	cmd *cobra.Command
+}
+
+func (h tlsTrustBundlesHandler) run(args []string) error {
+	helper := cmd.BuildHelper(h.cmd, args)
+
+	if len(args) > 1 {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf(
+				"too many arguments. Listing TLS trust bundles requires 0 or 1 arguments (ID or name)"),
+		}
+	}
+
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	// Check if positional arg and flags are both provided
+	if len(args) == 1 {
+		tbID, tbName := getTLSTrustBundleIdentifiers(cfg)
+		if tbID != "" || tbName != "" {
+			return &cmd.ConfigurationError{
+				Err: fmt.Errorf(
+					"cannot specify both positional argument and --%s or --%s flags",
+					tlsTrustBundleIDFlagName,
+					tlsTrustBundleNameFlagName,
+				),
+			}
+		}
+	}
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+
+	outType, err := helper.GetOutputFormat()
+	if err != nil {
+		return err
+	}
+
+	printer, err := cli.Format(outType.String(), helper.GetStreams().Out)
+	if err != nil {
+		return err
+	}
+	defer printer.Flush()
+
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return err
+	}
+
+	gatewayID, gatewayName := getEventGatewayIdentifiers(cfg)
+	if gatewayID != "" && gatewayName != "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf("only one of --%s or --%s can be provided", gatewayIDFlagName, gatewayNameFlagName),
+		}
+	}
+
+	if gatewayID == "" && gatewayName == "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf(
+				"an event gateway identifier is required. Provide --%s or --%s",
+				gatewayIDFlagName,
+				gatewayNameFlagName,
+			),
+		}
+	}
+
+	if gatewayID == "" {
+		gatewayID, err = resolveEventGatewayIDByName(gatewayName, sdk.GetEventGatewayControlPlaneAPI(), helper, cfg)
+		if err != nil {
+			return err
+		}
+	}
+
+	bundleAPI := sdk.GetEventGatewayTLSTrustBundleAPI()
+	if bundleAPI == nil {
+		return &cmd.ExecutionError{
+			Msg: "TLS trust bundle client is not available",
+			Err: fmt.Errorf("TLS trust bundle client not configured"),
+		}
+	}
+
+	// Validate mutual exclusivity of bundle ID and name flags
+	tbID, tbName := getTLSTrustBundleIdentifiers(cfg)
+	if tbID != "" && tbName != "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf(
+				"only one of --%s or --%s can be provided",
+				tlsTrustBundleIDFlagName,
+				tlsTrustBundleNameFlagName,
+			),
+		}
+	}
+
+	var tbIdentifier string
+	if len(args) == 1 {
+		tbIdentifier = strings.TrimSpace(args[0])
+	} else if tbID != "" {
+		tbIdentifier = tbID
+	} else if tbName != "" {
+		tbIdentifier = tbName
+	}
+
+	if tbIdentifier != "" {
+		return h.getSingleTLSTrustBundle(helper, bundleAPI, gatewayID, tbIdentifier, outType, printer, cfg)
+	}
+
+	return h.listTLSTrustBundles(helper, bundleAPI, gatewayID, outType, printer, cfg)
+}
+
+func (h tlsTrustBundlesHandler) listTLSTrustBundles(
+	helper cmd.Helper,
+	bundleAPI helpers.EventGatewayTLSTrustBundleAPI,
+	gatewayID string,
+	outType cmdCommon.OutputFormat,
+	printer cli.PrintFlusher,
+	cfg config.Hook,
+) error {
+	bundles, err := fetchTLSTrustBundles(helper, bundleAPI, gatewayID, cfg, "")
+	if err != nil {
+		return err
+	}
+
+	records := make([]tlsTrustBundleSummaryRecord, 0, len(bundles))
+	for _, tb := range bundles {
+		records = append(records, tlsTrustBundleToRecord(tb))
+	}
+
+	tableRows := make([]table.Row, 0, len(records))
+	for _, record := range records {
+		tableRows = append(tableRows, table.Row{record.ID, record.Name, record.Description})
+	}
+
+	return tableview.RenderForFormat(
+		helper,
+		false,
+		outType,
+		printer,
+		helper.GetStreams(),
+		records,
+		bundles,
+		"",
+		tableview.WithCustomTable([]string{"ID", "NAME", "DESCRIPTION"}, tableRows),
+		tableview.WithRootLabel(helper.GetCmd().Name()),
+	)
+}
+
+func (h tlsTrustBundlesHandler) getSingleTLSTrustBundle(
+	helper cmd.Helper,
+	bundleAPI helpers.EventGatewayTLSTrustBundleAPI,
+	gatewayID string,
+	identifier string,
+	outType cmdCommon.OutputFormat,
+	printer cli.PrintFlusher,
+	cfg config.Hook,
+) error {
+	bundleID := identifier
+	if !util.IsValidUUID(identifier) {
+		// Resolve name to ID by listing and matching exactly
+		bundles, err := fetchTLSTrustBundles(helper, bundleAPI, gatewayID, cfg, identifier)
+		if err != nil {
+			return err
+		}
+		match := findTLSTrustBundleByName(bundles, identifier)
+		if match == nil {
+			return &cmd.ConfigurationError{
+				Err: fmt.Errorf("TLS trust bundle %q not found", identifier),
+			}
+		}
+		bundleID = match.ID
+	}
+
+	res, err := bundleAPI.GetEventGatewayTLSTrustBundle(helper.GetContext(),
+		kkOps.GetEventGatewayTLSTrustBundleRequest{
+			GatewayID:        gatewayID,
+			TLSTrustBundleID: bundleID,
+		})
+	if err != nil {
+		attrs := cmd.TryConvertErrorToAttrs(err)
+		return cmd.PrepareExecutionError("Failed to get TLS trust bundle", err, helper.GetCmd(), attrs...)
+	}
+
+	if res.GetTLSTrustBundle() == nil {
+		return &cmd.ExecutionError{
+			Msg: "TLS trust bundle response was empty",
+			Err: fmt.Errorf("no TLS trust bundle returned for id %s", bundleID),
+		}
+	}
+
+	tb := res.GetTLSTrustBundle()
+
+	return tableview.RenderForFormat(
+		helper,
+		false,
+		outType,
+		printer,
+		helper.GetStreams(),
+		tlsTrustBundleToRecord(*tb),
+		tb,
+		"",
+		tableview.WithRootLabel(helper.GetCmd().Name()),
+	)
+}
+
+func fetchTLSTrustBundles(
+	helper cmd.Helper,
+	bundleAPI helpers.EventGatewayTLSTrustBundleAPI,
+	gatewayID string,
+	cfg config.Hook,
+	nameFilter string,
+) ([]kkComps.TLSTrustBundle, error) {
+	requestPageSize := int64(cfg.GetInt(common.RequestPageSizeConfigPath))
+	if requestPageSize < 1 {
+		requestPageSize = int64(common.DefaultRequestPageSize)
+	}
+
+	var allBundles []kkComps.TLSTrustBundle
+	var pageAfter *string
+
+	for {
+		req := kkOps.ListEventGatewayTLSTrustBundlesRequest{
+			GatewayID: gatewayID,
+			PageSize:  new(requestPageSize),
+		}
+
+		if nameFilter != "" {
+			req.Filter = &kkComps.EventGatewayCommonFilter{
+				Name: &kkComps.StringFieldContainsFilter{
+					Contains: nameFilter,
+				},
+			}
+		}
+
+		if pageAfter != nil {
+			req.PageAfter = pageAfter
+		}
+
+		res, err := bundleAPI.ListEventGatewayTLSTrustBundles(helper.GetContext(), req)
+		if err != nil {
+			attrs := cmd.TryConvertErrorToAttrs(err)
+			return nil, cmd.PrepareExecutionError("Failed to list TLS trust bundles", err, helper.GetCmd(), attrs...)
+		}
+
+		if res.GetListTLSTrustBundlesResponse() == nil {
+			break
+		}
+
+		allBundles = append(allBundles, res.GetListTLSTrustBundlesResponse().Data...)
+
+		if res.GetListTLSTrustBundlesResponse().Meta == nil ||
+			res.GetListTLSTrustBundlesResponse().Meta.Page.Next == nil {
+			break
+		}
+
+		u, err := url.Parse(*res.GetListTLSTrustBundlesResponse().Meta.Page.Next)
+		if err != nil {
+			return nil, cmd.PrepareExecutionError(
+				"Failed to list TLS trust bundles: invalid cursor",
+				err,
+				helper.GetCmd(),
+			)
+		}
+
+		values := u.Query()
+		pageAfter = new(values.Get("page[after]"))
+	}
+
+	return allBundles, nil
+}
+
+func findTLSTrustBundleByName(
+	bundles []kkComps.TLSTrustBundle,
+	name string,
+) *kkComps.TLSTrustBundle {
+	lowered := strings.ToLower(name)
+	for i := range bundles {
+		if strings.ToLower(bundles[i].Name) == lowered {
+			return &bundles[i]
+		}
+	}
+	return nil
+}
+
+func tlsTrustBundleToRecord(tb kkComps.TLSTrustBundle) tlsTrustBundleSummaryRecord {
+	id := tb.ID
+	if id != "" {
+		id = util.AbbreviateUUID(id)
+	} else {
+		id = valueNA
+	}
+
+	name := tb.Name
+	if name == "" {
+		name = valueNA
+	}
+
+	description := valueNA
+	if tb.Description != nil && *tb.Description != "" {
+		description = *tb.Description
+	}
+
+	createdAt := tb.CreatedAt.In(time.Local).Format("2006-01-02 15:04:05")
+	updatedAt := tb.UpdatedAt.In(time.Local).Format("2006-01-02 15:04:05")
+
+	return tlsTrustBundleSummaryRecord{
+		ID:               id,
+		Name:             name,
+		Description:      description,
+		LocalCreatedTime: createdAt,
+		LocalUpdatedTime: updatedAt,
+	}
+}

--- a/internal/cmd/root/verbs/dump/declarative.go
+++ b/internal/cmd/root/verbs/dump/declarative.go
@@ -199,6 +199,7 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 			EventGatewayConsumePolicyAPI:        sdk.GetEventGatewayConsumePolicyAPI(),
 			EventGatewaySchemaRegistryAPI:       sdk.GetEventGatewaySchemaRegistryAPI(),
 			EventGatewayStaticKeyAPI:            sdk.GetEventGatewayStaticKeyAPI(),
+			EventGatewayTLSTrustBundleAPI:       sdk.GetEventGatewayTLSTrustBundleAPI(),
 			OrganizationTeamAPI:                 sdk.GetOrganizationTeamAPI(),
 		})
 	}

--- a/internal/cmd/root/verbs/dump/declarative_children.go
+++ b/internal/cmd/root/verbs/dump/declarative_children.go
@@ -210,6 +210,12 @@ func populateEventGatewayChildren(
 		} else if len(keys) > 0 {
 			gateway.StaticKeys = keys
 		}
+
+		if bundles, err := buildEventGatewayTLSTrustBundles(ctx, logger, client, gatewayID, gateway.Name); err != nil {
+			logWarn(logger, "failed to load event gateway TLS trust bundles", gatewayID, gateway.Name, err)
+		} else if len(bundles) > 0 {
+			gateway.TrustBundles = bundles
+		}
 	}
 }
 
@@ -307,6 +313,44 @@ func buildEventGatewaySchemaRegistries(
 		res := declresources.EventGatewaySchemaRegistryResource{
 			SchemaRegistryCreate: createReq,
 			Ref:                  sr.ID,
+		}
+
+		results = append(results, res)
+	}
+
+	return results, nil
+}
+
+func buildEventGatewayTLSTrustBundles(
+	ctx context.Context,
+	logger *slog.Logger,
+	client *declstate.Client,
+	gatewayID string,
+	gatewayName string,
+) ([]declresources.EventGatewayTLSTrustBundleResource, error) {
+	bundles, err := client.ListEventGatewayTLSTrustBundles(ctx, gatewayID)
+	if err != nil {
+		return nil, err
+	}
+	if len(bundles) == 0 {
+		return nil, nil
+	}
+
+	results := make([]declresources.EventGatewayTLSTrustBundleResource, 0, len(bundles))
+	for _, tb := range bundles {
+		if strings.TrimSpace(tb.ID) == "" {
+			logWarn(logger, "TLS trust bundle missing ID", gatewayID, gatewayName, nil)
+			continue
+		}
+
+		res := declresources.EventGatewayTLSTrustBundleResource{
+			CreateTLSTrustBundleRequest: kkComps.CreateTLSTrustBundleRequest{
+				Name:        tb.Name,
+				Description: tb.Description,
+				Config:      kkComps.TLSTrustBundleConfig{TrustedCa: tb.Config.TrustedCa},
+				Labels:      tb.Labels,
+			},
+			Ref: tb.ID,
 		}
 
 		results = append(results, res)

--- a/internal/declarative/executor/event_gateway_tls_trust_bundle_adapter.go
+++ b/internal/declarative/executor/event_gateway_tls_trust_bundle_adapter.go
@@ -1,0 +1,257 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/kong/kongctl/internal/declarative/state"
+)
+
+// EventGatewayTLSTrustBundleAdapter implements ResourceOperations for Event Gateway TLS Trust Bundle resources.
+// TLS trust bundles support update operations.
+type EventGatewayTLSTrustBundleAdapter struct {
+	client *state.Client
+}
+
+// NewEventGatewayTLSTrustBundleAdapter creates a new EventGatewayTLSTrustBundleAdapter.
+func NewEventGatewayTLSTrustBundleAdapter(client *state.Client) *EventGatewayTLSTrustBundleAdapter {
+	return &EventGatewayTLSTrustBundleAdapter{client: client}
+}
+
+// MapCreateFields maps fields to CreateTLSTrustBundleRequest.
+func (a *EventGatewayTLSTrustBundleAdapter) MapCreateFields(
+	_ context.Context,
+	_ *ExecutionContext,
+	fields map[string]any,
+	create *kkComps.CreateTLSTrustBundleRequest,
+) error {
+	name, ok := fields["name"].(string)
+	if !ok || name == "" {
+		return fmt.Errorf("name is required")
+	}
+	create.Name = name
+
+	if desc, ok := fields["description"].(string); ok {
+		create.Description = &desc
+	}
+
+	cfg, err := extractTrustBundleConfig(fields)
+	if err != nil {
+		return err
+	}
+	create.Config = cfg
+
+	if labelsRaw, ok := fields["labels"].(map[string]any); ok {
+		lbls := make(map[string]string, len(labelsRaw))
+		for k, v := range labelsRaw {
+			if sv, ok := v.(string); ok {
+				lbls[k] = sv
+			}
+		}
+		create.Labels = lbls
+	} else if lbls, ok := fields["labels"].(map[string]string); ok {
+		create.Labels = lbls
+	}
+
+	return nil
+}
+
+// MapUpdateFields maps fields to UpdateTLSTrustBundleRequest.
+func (a *EventGatewayTLSTrustBundleAdapter) MapUpdateFields(
+	_ context.Context,
+	_ *ExecutionContext,
+	fields map[string]any,
+	update *kkComps.UpdateTLSTrustBundleRequest,
+	_ map[string]string,
+) error {
+	if name, ok := fields["name"].(string); ok && name != "" {
+		update.Name = &name
+	}
+
+	if desc, ok := fields["description"].(string); ok {
+		update.Description = &desc
+	}
+
+	if _, hasConfig := fields["config"]; hasConfig {
+		cfg, err := extractTrustBundleConfig(fields)
+		if err != nil {
+			return err
+		}
+		update.Config = &cfg
+	}
+
+	if labelsRaw, ok := fields["labels"].(map[string]any); ok {
+		lbls := make(map[string]string, len(labelsRaw))
+		for k, v := range labelsRaw {
+			if sv, ok := v.(string); ok {
+				lbls[k] = sv
+			}
+		}
+		update.Labels = lbls
+	} else if lbls, ok := fields["labels"].(map[string]string); ok {
+		update.Labels = lbls
+	}
+
+	return nil
+}
+
+// Create creates a new TLS trust bundle.
+func (a *EventGatewayTLSTrustBundleAdapter) Create(
+	ctx context.Context,
+	req kkComps.CreateTLSTrustBundleRequest,
+	namespace string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	gatewayID, err := a.getEventGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return "", err
+	}
+
+	return a.client.CreateEventGatewayTLSTrustBundle(ctx, gatewayID, req, namespace)
+}
+
+// Update updates an existing TLS trust bundle.
+func (a *EventGatewayTLSTrustBundleAdapter) Update(
+	ctx context.Context,
+	id string,
+	req kkComps.UpdateTLSTrustBundleRequest,
+	namespace string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	gatewayID, err := a.getEventGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return "", err
+	}
+
+	return a.client.UpdateEventGatewayTLSTrustBundle(ctx, gatewayID, id, req, namespace)
+}
+
+// Delete deletes a TLS trust bundle.
+func (a *EventGatewayTLSTrustBundleAdapter) Delete(
+	ctx context.Context,
+	id string,
+	execCtx *ExecutionContext,
+) error {
+	gatewayID, err := a.getEventGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return err
+	}
+
+	return a.client.DeleteEventGatewayTLSTrustBundle(ctx, gatewayID, id)
+}
+
+// GetByID retrieves a TLS trust bundle by ID.
+func (a *EventGatewayTLSTrustBundleAdapter) GetByID(
+	ctx context.Context,
+	id string,
+	execCtx *ExecutionContext,
+) (ResourceInfo, error) {
+	gatewayID, err := a.getEventGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	tb, err := a.client.GetEventGatewayTLSTrustBundle(ctx, gatewayID, id)
+	if err != nil {
+		return nil, err
+	}
+	if tb == nil {
+		return nil, nil
+	}
+
+	return &EventGatewayTLSTrustBundleResourceInfo{bundle: tb}, nil
+}
+
+// GetByName is not supported for TLS trust bundles (no direct name-based lookup).
+func (a *EventGatewayTLSTrustBundleAdapter) GetByName(
+	_ context.Context,
+	_ string,
+) (ResourceInfo, error) {
+	return nil, fmt.Errorf("GetByName not supported for event gateway TLS trust bundles")
+}
+
+// ResourceType returns the resource type string.
+func (a *EventGatewayTLSTrustBundleAdapter) ResourceType() string {
+	return planner.ResourceTypeEventGatewayTLSTrustBundle
+}
+
+// RequiredFields returns the list of required fields for this resource.
+func (a *EventGatewayTLSTrustBundleAdapter) RequiredFields() []string {
+	return []string{"name", "config"}
+}
+
+// SupportsUpdate returns true – TLS trust bundles support update operations.
+func (a *EventGatewayTLSTrustBundleAdapter) SupportsUpdate() bool {
+	return true
+}
+
+// getEventGatewayIDFromExecutionContext extracts the event gateway ID from the execution context.
+func (a *EventGatewayTLSTrustBundleAdapter) getEventGatewayIDFromExecutionContext(
+	execCtx *ExecutionContext,
+) (string, error) {
+	if execCtx == nil || execCtx.PlannedChange == nil {
+		return "", fmt.Errorf("execution context required")
+	}
+
+	change := *execCtx.PlannedChange
+
+	// Priority 1: Check References (for new parent)
+	if gatewayRef, ok := change.References["event_gateway_id"]; ok && gatewayRef.ID != "" {
+		return gatewayRef.ID, nil
+	}
+
+	// Priority 2: Check Parent field (for existing parent)
+	if change.Parent != nil && change.Parent.ID != "" {
+		return change.Parent.ID, nil
+	}
+
+	return "", fmt.Errorf("event gateway ID required for TLS trust bundle operations")
+}
+
+// EventGatewayTLSTrustBundleResourceInfo wraps an Event Gateway TLS Trust Bundle to implement ResourceInfo.
+type EventGatewayTLSTrustBundleResourceInfo struct {
+	bundle *state.EventGatewayTLSTrustBundle
+}
+
+func (e *EventGatewayTLSTrustBundleResourceInfo) GetID() string {
+	return e.bundle.ID
+}
+
+func (e *EventGatewayTLSTrustBundleResourceInfo) GetName() string {
+	return e.bundle.Name
+}
+
+func (e *EventGatewayTLSTrustBundleResourceInfo) GetLabels() map[string]string {
+	return e.bundle.Labels
+}
+
+func (e *EventGatewayTLSTrustBundleResourceInfo) GetNormalizedLabels() map[string]string {
+	return e.bundle.NormalizedLabels
+}
+
+// extractTrustBundleConfig extracts TLSTrustBundleConfig from a fields map.
+func extractTrustBundleConfig(fields map[string]any) (kkComps.TLSTrustBundleConfig, error) {
+	var cfg kkComps.TLSTrustBundleConfig
+
+	switch v := fields["config"].(type) {
+	case kkComps.TLSTrustBundleConfig:
+		cfg = v
+	case map[string]any:
+		if trustedCA, ok := v["trusted_ca"].(string); ok {
+			cfg.TrustedCa = trustedCA
+		} else {
+			return cfg, fmt.Errorf("config.trusted_ca is required")
+		}
+	default:
+		return cfg, fmt.Errorf("config is required for TLS trust bundle")
+	}
+
+	if cfg.TrustedCa == "" {
+		return cfg, fmt.Errorf("config.trusted_ca is required")
+	}
+
+	return cfg, nil
+}

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -66,6 +66,8 @@ type Executor struct {
 		kkComps.SchemaRegistryCreate, kkComps.SchemaRegistryUpdate]
 	eventGatewayStaticKeyExecutor *BaseExecutor[
 		kkComps.EventGatewayStaticKeyCreate, kkComps.EventGatewayStaticKeyCreate]
+	eventGatewayTLSTrustBundleExecutor *BaseExecutor[
+		kkComps.CreateTLSTrustBundleRequest, kkComps.UpdateTLSTrustBundleRequest]
 
 	// Portal child resource executors
 	portalCustomizationExecutor *BaseSingletonExecutor[kkComps.PortalCustomization]
@@ -239,6 +241,13 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 	e.eventGatewayStaticKeyExecutor = NewBaseExecutor[
 		kkComps.EventGatewayStaticKeyCreate, kkComps.EventGatewayStaticKeyCreate](
 		NewEventGatewayStaticKeyAdapter(client),
+		client,
+		dryRun,
+	)
+
+	e.eventGatewayTLSTrustBundleExecutor = NewBaseExecutor[
+		kkComps.CreateTLSTrustBundleRequest, kkComps.UpdateTLSTrustBundleRequest](
+		NewEventGatewayTLSTrustBundleAdapter(client),
 		client,
 		dryRun,
 	)
@@ -2000,6 +2009,17 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 			change.References["event_gateway_id"] = gatewayRef
 		}
 		return e.eventGatewayStaticKeyExecutor.Create(ctx, *change)
+	case planner.ResourceTypeEventGatewayTLSTrustBundle:
+		// Resolve event gateway reference if needed
+		if gatewayRef, ok := change.References["event_gateway_id"]; ok && gatewayRef.ID == "" {
+			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
+			}
+			gatewayRef.ID = gatewayID
+			change.References["event_gateway_id"] = gatewayRef
+		}
+		return e.eventGatewayTLSTrustBundleExecutor.Create(ctx, *change)
 	case planner.ResourceTypeEventGatewayClusterPolicy:
 		// Resolve event gateway reference if needed
 		if gatewayRef, ok := change.References["event_gateway_id"]; ok && gatewayRef.ID == "" {
@@ -2369,6 +2389,17 @@ func (e *Executor) updateResource(ctx context.Context, change *planner.PlannedCh
 			change.References["event_gateway_id"] = gatewayRef
 		}
 		return e.eventGatewaySchemaRegistryExecutor.Update(ctx, *change)
+	case planner.ResourceTypeEventGatewayTLSTrustBundle:
+		// Resolve event gateway reference if needed (typically should already be in Parent)
+		if gatewayRef, ok := change.References["event_gateway_id"]; ok && gatewayRef.ID == "" {
+			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
+			}
+			gatewayRef.ID = gatewayID
+			change.References["event_gateway_id"] = gatewayRef
+		}
+		return e.eventGatewayTLSTrustBundleExecutor.Update(ctx, *change)
 	case planner.ResourceTypeEventGatewayClusterPolicy:
 		// Resolve event gateway reference if needed
 		if gatewayRef, ok := change.References["event_gateway_id"]; ok && gatewayRef.ID == "" {
@@ -2584,6 +2615,9 @@ func (e *Executor) deleteResource(ctx context.Context, change *planner.PlannedCh
 	case planner.ResourceTypeEventGatewayStaticKey:
 		// No need to resolve event gateway reference for delete - parent ID should be in Parent field
 		return e.eventGatewayStaticKeyExecutor.Delete(ctx, *change)
+	case planner.ResourceTypeEventGatewayTLSTrustBundle:
+		// No need to resolve event gateway reference for delete - parent ID should be in Parent field
+		return e.eventGatewayTLSTrustBundleExecutor.Delete(ctx, *change)
 	case planner.ResourceTypeEventGatewayClusterPolicy:
 		// Both gateway ID and virtual cluster ID should be in References for delete
 		return e.eventGatewayClusterPolicyExecutor.Delete(ctx, *change)

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -916,6 +916,12 @@ func (l *Loader) extractNestedResources(rs *resources.ResourceSet) {
 		}
 		egw.StaticKeys = nil
 
+		for _, tb := range egw.TrustBundles {
+			tb.EventGateway = egw.Ref
+			rs.EventGatewayTLSTrustBundles = append(rs.EventGatewayTLSTrustBundles, tb)
+		}
+		egw.TrustBundles = nil
+
 		for _, sr := range egw.SchemaRegistries {
 			sr.EventGateway = egw.Ref
 			rs.EventGatewaySchemaRegistries = append(rs.EventGatewaySchemaRegistries, sr)

--- a/internal/declarative/planner/constants.go
+++ b/internal/declarative/planner/constants.go
@@ -111,6 +111,9 @@ const (
 	// Static keys do not support update – changes are applied as delete + create.
 	ResourceTypeEventGatewayStaticKey = "event_gateway_static_key"
 
+	// ResourceTypeEventGatewayTLSTrustBundle is the resource type for event gateway TLS trust bundles.
+	ResourceTypeEventGatewayTLSTrustBundle = "event_gateway_tls_trust_bundle"
+
 	// ResourceTypeDeck represents an internal deck execution step.
 	ResourceTypeDeck = "_deck"
 )

--- a/internal/declarative/planner/egw_control_plane_planner.go
+++ b/internal/declarative/planner/egw_control_plane_planner.go
@@ -257,6 +257,18 @@ func (p *Planner) planEGWControlPlaneChanges(
 				return err
 			}
 		}
+
+		// Plan TLS trust bundles for this gateway (whether it exists or is being created)
+		trustBundles := p.resources.GetTrustBundlesForGateway(desiredEGWCP.Ref)
+
+		if len(trustBundles) > 0 || plan.Metadata.Mode == PlanModeSync {
+			if err := p.planEventGatewayTLSTrustBundleChanges(
+				ctx, plannerCtx, namespace, desiredEGWCP.Name, gatewayID, desiredEGWCP.Ref,
+				gatewayChangeID, trustBundles, plan,
+			); err != nil {
+				return err
+			}
+		}
 	}
 
 	// Check for managed resources to delete (sync mode only)

--- a/internal/declarative/planner/event_gateway_tls_trust_bundle_planner.go
+++ b/internal/declarative/planner/event_gateway_tls_trust_bundle_planner.go
@@ -1,0 +1,313 @@
+package planner
+
+import (
+	"context"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+)
+
+// planEventGatewayTLSTrustBundleChanges plans changes for Event Gateway TLS Trust Bundles
+// for a specific gateway.
+func (p *Planner) planEventGatewayTLSTrustBundleChanges(
+	ctx context.Context,
+	_ *Config,
+	namespace string,
+	gatewayName string,
+	gatewayID string,
+	gatewayRef string,
+	gatewayChangeID string,
+	desired []resources.EventGatewayTLSTrustBundleResource,
+	plan *Plan,
+) error {
+	p.logger.Debug("Planning Event Gateway TLS Trust Bundle changes",
+		"gateway_name", gatewayName,
+		"gateway_id", gatewayID,
+		"gateway_ref", gatewayRef,
+		"gateway_change_id", gatewayChangeID,
+		"desired_count", len(desired),
+		"namespace", namespace,
+	)
+
+	if gatewayID != "" {
+		return p.planTrustBundleChangesForExistingGateway(
+			ctx, namespace, gatewayID, gatewayRef, gatewayName, desired, plan,
+		)
+	}
+
+	// Gateway doesn't exist yet: plan creates only with dependency on gateway creation
+	p.planTrustBundleCreatesForNewGateway(
+		namespace, gatewayRef, gatewayName, gatewayChangeID, desired, plan)
+	return nil
+}
+
+// planTrustBundleChangesForExistingGateway handles full diff for trust bundles of an existing gateway.
+func (p *Planner) planTrustBundleChangesForExistingGateway(
+	ctx context.Context,
+	namespace string,
+	gatewayID string,
+	gatewayRef string,
+	gatewayName string,
+	desired []resources.EventGatewayTLSTrustBundleResource,
+	plan *Plan,
+) error {
+	p.logger.Debug("Planning changes for existing gateway TLS trust bundles",
+		"gateway_id", gatewayID,
+		"gateway_ref", gatewayRef,
+		"desired_count", len(desired),
+	)
+
+	currentBundles, err := p.client.ListEventGatewayTLSTrustBundles(ctx, gatewayID)
+	if err != nil {
+		return fmt.Errorf("failed to list TLS trust bundles for gateway %s: %w", gatewayID, err)
+	}
+
+	p.logger.Debug("Fetched current TLS trust bundles",
+		"gateway_id", gatewayID,
+		"current_count", len(currentBundles),
+	)
+
+	currentByName := make(map[string]state.EventGatewayTLSTrustBundle)
+	for _, tb := range currentBundles {
+		currentByName[tb.Name] = tb
+	}
+
+	desiredNames := make(map[string]bool)
+
+	for _, desiredTB := range desired {
+		name := desiredTB.GetMoniker()
+		desiredNames[name] = true
+
+		current, exists := currentByName[name]
+
+		if !exists {
+			p.logger.Debug("Planning TLS trust bundle CREATE",
+				"bundle_name", name,
+				"gateway_ref", gatewayRef,
+			)
+			p.planTrustBundleCreate(namespace, gatewayRef, gatewayName, gatewayID, desiredTB, []string{}, plan)
+		} else {
+			p.logger.Debug("Checking if TLS trust bundle needs update",
+				"bundle_name", name,
+				"bundle_id", current.ID,
+			)
+
+			needsUpdate, updateFields, changedFields := p.shouldUpdateTrustBundle(current, desiredTB)
+			if needsUpdate {
+				p.logger.Debug("Planning TLS trust bundle UPDATE",
+					"bundle_name", name,
+					"bundle_id", current.ID,
+					"update_fields", updateFields,
+				)
+				p.planTrustBundleUpdate(
+					namespace, gatewayRef, gatewayID,
+					current.ID, desiredTB, updateFields, changedFields, plan)
+			}
+		}
+	}
+
+	// SYNC MODE: Delete unmanaged trust bundles
+	if plan.Metadata.Mode == PlanModeSync {
+		for name, current := range currentByName {
+			if !desiredNames[name] {
+				p.logger.Debug("Planning TLS trust bundle DELETE (sync mode)",
+					"bundle_name", name,
+					"bundle_id", current.ID,
+				)
+				p.planTrustBundleDelete(gatewayRef, gatewayID, current.ID, name, plan)
+			}
+		}
+	}
+
+	return nil
+}
+
+// planTrustBundleCreatesForNewGateway plans creates for trust bundles when the gateway doesn't exist yet.
+func (p *Planner) planTrustBundleCreatesForNewGateway(
+	namespace string,
+	gatewayRef string,
+	gatewayName string,
+	gatewayChangeID string,
+	bundles []resources.EventGatewayTLSTrustBundleResource,
+	plan *Plan,
+) {
+	p.logger.Debug("Planning TLS trust bundle creates for new gateway",
+		"gateway_ref", gatewayRef,
+		"gateway_change_id", gatewayChangeID,
+		"bundle_count", len(bundles),
+	)
+
+	var dependsOn []string
+	if gatewayChangeID != "" {
+		dependsOn = []string{gatewayChangeID}
+	}
+
+	for _, tb := range bundles {
+		p.planTrustBundleCreate(namespace, gatewayRef, gatewayName, "", tb, dependsOn, plan)
+	}
+}
+
+// planTrustBundleCreate plans a CREATE change for a TLS trust bundle.
+func (p *Planner) planTrustBundleCreate(
+	namespace string,
+	gatewayRef string,
+	gatewayName string,
+	gatewayID string,
+	tb resources.EventGatewayTLSTrustBundleResource,
+	dependsOn []string,
+	plan *Plan,
+) {
+	fields := buildTrustBundleFields(tb)
+
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionCreate, ResourceTypeEventGatewayTLSTrustBundle, tb.Ref),
+		ResourceType: ResourceTypeEventGatewayTLSTrustBundle,
+		ResourceRef:  tb.Ref,
+		Action:       ActionCreate,
+		Fields:       fields,
+		Namespace:    namespace,
+		DependsOn:    dependsOn,
+	}
+
+	if gatewayID != "" {
+		change.Parent = &ParentInfo{
+			Ref: gatewayRef,
+			ID:  gatewayID,
+		}
+	} else {
+		change.References = map[string]ReferenceInfo{
+			"event_gateway_id": {
+				Ref: gatewayRef,
+				ID:  "", // to be resolved at runtime
+				LookupFields: map[string]string{
+					"name": gatewayName,
+				},
+			},
+		}
+	}
+
+	plan.AddChange(change)
+}
+
+// planTrustBundleUpdate plans an UPDATE change for a TLS trust bundle.
+func (p *Planner) planTrustBundleUpdate(
+	namespace string,
+	gatewayRef string,
+	gatewayID string,
+	bundleID string,
+	tb resources.EventGatewayTLSTrustBundleResource,
+	updateFields map[string]any,
+	changedFields map[string]FieldChange,
+	plan *Plan,
+) {
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionUpdate, ResourceTypeEventGatewayTLSTrustBundle, tb.Ref),
+		ResourceType: ResourceTypeEventGatewayTLSTrustBundle,
+		ResourceRef:  tb.Ref,
+		ResourceID:   bundleID,
+		Action:       ActionUpdate,
+		Fields:       updateFields,
+		Namespace:    namespace,
+		Parent: &ParentInfo{
+			Ref: gatewayRef,
+			ID:  gatewayID,
+		},
+	}
+	if len(changedFields) > 0 {
+		change.ChangedFields = changedFields
+	}
+
+	plan.AddChange(change)
+}
+
+// planTrustBundleDelete plans a DELETE change for a TLS trust bundle.
+func (p *Planner) planTrustBundleDelete(
+	gatewayRef string,
+	gatewayID string,
+	bundleID string,
+	bundleName string,
+	plan *Plan,
+) {
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionDelete, ResourceTypeEventGatewayTLSTrustBundle, bundleName),
+		ResourceType: ResourceTypeEventGatewayTLSTrustBundle,
+		ResourceRef:  bundleName,
+		ResourceID:   bundleID,
+		Action:       ActionDelete,
+		Namespace:    "",
+		Parent: &ParentInfo{
+			Ref: gatewayRef,
+			ID:  gatewayID,
+		},
+	}
+
+	plan.AddChange(change)
+}
+
+// shouldUpdateTrustBundle compares current and desired TLS trust bundle state.
+// It returns whether an update is needed, the fields to send in the PUT request,
+// and a map of which specific fields changed.
+func (p *Planner) shouldUpdateTrustBundle(
+	current state.EventGatewayTLSTrustBundle,
+	desired resources.EventGatewayTLSTrustBundleResource,
+) (bool, map[string]any, map[string]FieldChange) {
+	updates := make(map[string]any)
+	changes := make(map[string]FieldChange)
+
+	// Compare name
+	if current.Name != desired.Name {
+		changes["name"] = FieldChange{Old: current.Name, New: desired.Name}
+	}
+
+	// Compare description
+	currentDesc := ""
+	if current.Description != nil {
+		currentDesc = *current.Description
+	}
+	desiredDesc := ""
+	if desired.Description != nil {
+		desiredDesc = *desired.Description
+	}
+	if currentDesc != desiredDesc {
+		changes["description"] = FieldChange{Old: currentDesc, New: desiredDesc}
+	}
+
+	// Compare config.trusted_ca (nested object comparison)
+	if current.Config.TrustedCa != desired.Config.TrustedCa {
+		changes["config.trusted_ca"] = FieldChange{Old: current.Config.TrustedCa, New: desired.Config.TrustedCa}
+	}
+
+	// Compare labels
+	if !labelsEqual(current.NormalizedLabels, desired.Labels) {
+		changes["labels"] = FieldChange{Old: current.NormalizedLabels, New: desired.Labels}
+	}
+
+	if len(changes) > 0 {
+		updates = buildTrustBundleFields(desired)
+	}
+
+	return len(changes) > 0, updates, changes
+}
+
+// buildTrustBundleFields builds the field map used in PlannedChange.Fields.
+func buildTrustBundleFields(tb resources.EventGatewayTLSTrustBundleResource) map[string]any {
+	fields := make(map[string]any)
+
+	fields["name"] = tb.Name
+
+	if tb.Description != nil {
+		fields["description"] = *tb.Description
+	}
+
+	fields["config"] = kkComps.TLSTrustBundleConfig{
+		TrustedCa: tb.Config.TrustedCa,
+	}
+
+	if len(tb.Labels) > 0 {
+		fields["labels"] = tb.Labels
+	}
+
+	return fields
+}

--- a/internal/declarative/planner/event_gateway_tls_trust_bundle_planner_test.go
+++ b/internal/declarative/planner/event_gateway_tls_trust_bundle_planner_test.go
@@ -1,0 +1,193 @@
+package planner
+
+import (
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func sampleTrustedCA() string {
+	return "-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----"
+}
+
+func newTrustBundlePlanner() *Planner {
+	return &Planner{}
+}
+
+func makeTrustBundleCurrent(name string,
+	desc *string, ca string, labels map[string]string) state.EventGatewayTLSTrustBundle {
+	normalized := labels
+	if normalized == nil {
+		normalized = map[string]string{}
+	}
+	return state.EventGatewayTLSTrustBundle{
+		TLSTrustBundle: kkComps.TLSTrustBundle{
+			ID:          "bundle-id-123",
+			Name:        name,
+			Description: desc,
+			Config:      kkComps.TLSTrustBundleConfig{TrustedCa: ca},
+			Labels:      labels,
+		},
+		NormalizedLabels: normalized,
+	}
+}
+
+func makeTrustBundleDesired(name string,
+	desc *string, ca string, labels map[string]string) resources.EventGatewayTLSTrustBundleResource {
+	return resources.EventGatewayTLSTrustBundleResource{
+		CreateTLSTrustBundleRequest: kkComps.CreateTLSTrustBundleRequest{
+			Name:        name,
+			Description: desc,
+			Config:      kkComps.TLSTrustBundleConfig{TrustedCa: ca},
+			Labels:      labels,
+		},
+		Ref: name + "-ref",
+	}
+}
+
+// ---------------------------------------------------------------------------
+// shouldUpdateTrustBundle – no change
+// ---------------------------------------------------------------------------
+
+func TestShouldUpdateTrustBundle_NoChanges(t *testing.T) {
+	t.Parallel()
+
+	p := newTrustBundlePlanner()
+	desc := "a description"
+	ca := sampleTrustedCA()
+	labels := map[string]string{"env": "prod"}
+
+	current := makeTrustBundleCurrent("my-bundle", &desc, ca, labels)
+	desired := makeTrustBundleDesired("my-bundle", &desc, ca, labels)
+
+	needsUpdate, fields, changed := p.shouldUpdateTrustBundle(current, desired)
+
+	assert.False(t, needsUpdate)
+	assert.Empty(t, fields)
+	assert.Empty(t, changed)
+}
+
+func TestShouldUpdateTrustBundle_NoChanges_NilDescription(t *testing.T) {
+	t.Parallel()
+
+	p := newTrustBundlePlanner()
+	ca := sampleTrustedCA()
+
+	current := makeTrustBundleCurrent("my-bundle", nil, ca, nil)
+	desired := makeTrustBundleDesired("my-bundle", nil, ca, nil)
+
+	needsUpdate, _, _ := p.shouldUpdateTrustBundle(current, desired)
+	assert.False(t, needsUpdate)
+}
+
+// ---------------------------------------------------------------------------
+// shouldUpdateTrustBundle – name changed
+// ---------------------------------------------------------------------------
+
+func TestShouldUpdateTrustBundle_NameChanged(t *testing.T) {
+	t.Parallel()
+
+	p := newTrustBundlePlanner()
+	ca := sampleTrustedCA()
+
+	current := makeTrustBundleCurrent("old-name", nil, ca, nil)
+	desired := makeTrustBundleDesired("new-name", nil, ca, nil)
+
+	needsUpdate, updateFields, changed := p.shouldUpdateTrustBundle(current, desired)
+
+	assert.True(t, needsUpdate)
+	require.Contains(t, changed, "name")
+	assert.Equal(t, "old-name", changed["name"].Old)
+	assert.Equal(t, "new-name", changed["name"].New)
+	assert.NotEmpty(t, updateFields)
+}
+
+// ---------------------------------------------------------------------------
+// shouldUpdateTrustBundle – description changed
+// ---------------------------------------------------------------------------
+
+func TestShouldUpdateTrustBundle_DescriptionChanged(t *testing.T) {
+	t.Parallel()
+
+	p := newTrustBundlePlanner()
+	ca := sampleTrustedCA()
+	oldDesc := "old description"
+	newDesc := "new description"
+
+	current := makeTrustBundleCurrent("my-bundle", &oldDesc, ca, nil)
+	desired := makeTrustBundleDesired("my-bundle", &newDesc, ca, nil)
+
+	needsUpdate, updateFields, changed := p.shouldUpdateTrustBundle(current, desired)
+
+	assert.True(t, needsUpdate)
+	require.Contains(t, changed, "description")
+	assert.Equal(t, oldDesc, changed["description"].Old)
+	assert.Equal(t, newDesc, changed["description"].New)
+	assert.NotEmpty(t, updateFields)
+}
+
+func TestShouldUpdateTrustBundle_DescriptionAddedToNil(t *testing.T) {
+	t.Parallel()
+
+	p := newTrustBundlePlanner()
+	ca := sampleTrustedCA()
+	newDesc := "now has a description"
+
+	current := makeTrustBundleCurrent("my-bundle", nil, ca, nil)
+	desired := makeTrustBundleDesired("my-bundle", &newDesc, ca, nil)
+
+	needsUpdate, _, changed := p.shouldUpdateTrustBundle(current, desired)
+
+	assert.True(t, needsUpdate)
+	assert.Contains(t, changed, "description")
+}
+
+// ---------------------------------------------------------------------------
+// shouldUpdateTrustBundle – trusted_ca changed
+// ---------------------------------------------------------------------------
+
+func TestShouldUpdateTrustBundle_TrustedCaChanged(t *testing.T) {
+	t.Parallel()
+
+	p := newTrustBundlePlanner()
+	oldCA := "-----BEGIN CERTIFICATE-----\nOLD\n-----END CERTIFICATE-----"
+	newCA := "-----BEGIN CERTIFICATE-----\nNEW\n-----END CERTIFICATE-----"
+
+	current := makeTrustBundleCurrent("my-bundle", nil, oldCA, nil)
+	desired := makeTrustBundleDesired("my-bundle", nil, newCA, nil)
+
+	needsUpdate, updateFields, changed := p.shouldUpdateTrustBundle(current, desired)
+
+	assert.True(t, needsUpdate)
+	require.Contains(t, changed, "config.trusted_ca")
+	assert.Equal(t, oldCA, changed["config.trusted_ca"].Old)
+	assert.Equal(t, newCA, changed["config.trusted_ca"].New)
+	assert.NotEmpty(t, updateFields)
+}
+
+// ---------------------------------------------------------------------------
+// shouldUpdateTrustBundle – labels changed
+// ---------------------------------------------------------------------------
+
+func TestShouldUpdateTrustBundle_LabelsChanged(t *testing.T) {
+	t.Parallel()
+
+	p := newTrustBundlePlanner()
+	ca := sampleTrustedCA()
+
+	current := makeTrustBundleCurrent("my-bundle", nil, ca, map[string]string{"env": "staging"})
+	desired := makeTrustBundleDesired("my-bundle", nil, ca, map[string]string{"env": "prod"})
+
+	needsUpdate, _, changed := p.shouldUpdateTrustBundle(current, desired)
+
+	assert.True(t, needsUpdate)
+	assert.Contains(t, changed, "labels")
+}

--- a/internal/declarative/protection/lookup.go
+++ b/internal/declarative/protection/lookup.go
@@ -127,7 +127,8 @@ func IsManagedResourceProtected(
 		resources.ResourceTypeEventGatewayDataPlaneCertificate,
 		resources.ResourceTypeEventGatewayProducePolicy,
 		resources.ResourceTypeEventGatewaySchemaRegistry,
-		resources.ResourceTypeEventGatewayStaticKey:
+		resources.ResourceTypeEventGatewayStaticKey,
+		resources.ResourceTypeEventGatewayTLSTrustBundle:
 		return false, nil
 	}
 

--- a/internal/declarative/resources/event_gateway_control_plane.go
+++ b/internal/declarative/resources/event_gateway_control_plane.go
@@ -25,6 +25,7 @@ type EventGatewayControlPlaneResource struct {
 	DataPlaneCertificates []EventGatewayDataPlaneCertificateResource `yaml:"data_plane_certificates,omitempty" json:"data_plane_certificates,omitempty"` //nolint:lll
 	SchemaRegistries      []EventGatewaySchemaRegistryResource       `yaml:"schema_registries,omitempty"       json:"schema_registries,omitempty"`       //nolint:lll
 	StaticKeys            []EventGatewayStaticKeyResource            `yaml:"static_keys,omitempty"             json:"static_keys,omitempty"`             //nolint:lll
+	TrustBundles          []EventGatewayTLSTrustBundleResource       `yaml:"trust_bundles,omitempty"           json:"trust_bundles,omitempty"`           //nolint:lll
 }
 
 func (e EventGatewayControlPlaneResource) GetType() ResourceType {
@@ -125,6 +126,18 @@ func (e EventGatewayControlPlaneResource) Validate() error {
 		staticKeyRefs[sk.GetRef()] = true
 	}
 
+	// Validate TLS trust bundles
+	trustBundleRefs := make(map[string]bool)
+	for i, tb := range e.TrustBundles {
+		if err := tb.Validate(); err != nil {
+			return fmt.Errorf("invalid TLS trust bundle %d: %w", i, err)
+		}
+		if trustBundleRefs[tb.GetRef()] {
+			return fmt.Errorf("duplicate TLS trust bundle ref: %s", tb.GetRef())
+		}
+		trustBundleRefs[tb.GetRef()] = true
+	}
+
 	return nil
 }
 
@@ -155,6 +168,10 @@ func (e *EventGatewayControlPlaneResource) SetDefaults() {
 
 	for i := range e.StaticKeys {
 		e.StaticKeys[i].SetDefaults()
+	}
+
+	for i := range e.TrustBundles {
+		e.TrustBundles[i].SetDefaults()
 	}
 }
 

--- a/internal/declarative/resources/event_gateway_control_plane.go
+++ b/internal/declarative/resources/event_gateway_control_plane.go
@@ -25,7 +25,7 @@ type EventGatewayControlPlaneResource struct {
 	DataPlaneCertificates []EventGatewayDataPlaneCertificateResource `yaml:"data_plane_certificates,omitempty" json:"data_plane_certificates,omitempty"` //nolint:lll
 	SchemaRegistries      []EventGatewaySchemaRegistryResource       `yaml:"schema_registries,omitempty"       json:"schema_registries,omitempty"`       //nolint:lll
 	StaticKeys            []EventGatewayStaticKeyResource            `yaml:"static_keys,omitempty"             json:"static_keys,omitempty"`             //nolint:lll
-	TrustBundles          []EventGatewayTLSTrustBundleResource       `yaml:"trust_bundles,omitempty"           json:"trust_bundles,omitempty"`           //nolint:lll
+	TrustBundles          []EventGatewayTLSTrustBundleResource       `yaml:"tls_trust_bundles,omitempty"       json:"tls_trust_bundles,omitempty"`       //nolint:lll
 }
 
 func (e EventGatewayControlPlaneResource) GetType() ResourceType {

--- a/internal/declarative/resources/event_gateway_tls_trust_bundle.go
+++ b/internal/declarative/resources/event_gateway_tls_trust_bundle.go
@@ -1,0 +1,150 @@
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+)
+
+func init() {
+	registerResourceType(
+		ResourceTypeEventGatewayTLSTrustBundle,
+		func(rs *ResourceSet) *[]EventGatewayTLSTrustBundleResource {
+			return &rs.EventGatewayTLSTrustBundles
+		},
+		AutoExplain[EventGatewayTLSTrustBundleResource](),
+	)
+}
+
+// EventGatewayTLSTrustBundleResource represents an Event Gateway TLS Trust Bundle resource.
+// Trust bundles define trusted certificate authorities used for mTLS client certificate
+// verification. They are referenced by TLS listener policies.
+// This resource supports update operations.
+type EventGatewayTLSTrustBundleResource struct {
+	kkComps.CreateTLSTrustBundleRequest `yaml:",inline" json:",inline"`
+	Ref                                 string `yaml:"ref"                     json:"ref"`
+	// Parent Event Gateway reference (for root-level definitions)
+	EventGateway string `yaml:"event_gateway,omitempty" json:"event_gateway,omitempty"`
+
+	// Resolved Konnect ID (not serialized)
+	konnectID string `yaml:"-" json:"-"`
+}
+
+func (e EventGatewayTLSTrustBundleResource) GetType() ResourceType {
+	return ResourceTypeEventGatewayTLSTrustBundle
+}
+
+func (e EventGatewayTLSTrustBundleResource) GetRef() string {
+	return e.Ref
+}
+
+func (e EventGatewayTLSTrustBundleResource) GetMoniker() string {
+	return e.Name
+}
+
+func (e EventGatewayTLSTrustBundleResource) GetDependencies() []ResourceRef {
+	var deps []ResourceRef
+	if e.EventGateway != "" {
+		deps = append(deps, ResourceRef{Kind: "event_gateway", Ref: e.EventGateway})
+	}
+	return deps
+}
+
+func (e EventGatewayTLSTrustBundleResource) GetKonnectID() string {
+	return e.konnectID
+}
+
+func (e EventGatewayTLSTrustBundleResource) Validate() error {
+	if err := ValidateRef(e.Ref); err != nil {
+		return fmt.Errorf("invalid TLS trust bundle ref: %w", err)
+	}
+	if e.Name == "" {
+		return fmt.Errorf("TLS trust bundle %q is missing required field: name", e.Ref)
+	}
+	if e.Config.TrustedCa == "" {
+		return fmt.Errorf("TLS trust bundle %q is missing required field: config.trusted_ca", e.Ref)
+	}
+	return nil
+}
+
+func (e *EventGatewayTLSTrustBundleResource) SetDefaults() {
+	if e.Name == "" {
+		e.Name = e.Ref
+	}
+}
+
+func (e EventGatewayTLSTrustBundleResource) GetKonnectMonikerFilter() string {
+	return fmt.Sprintf("name[eq]=%s", e.Name)
+}
+
+func (e *EventGatewayTLSTrustBundleResource) TryMatchKonnectResource(konnectResource any) bool {
+	if id := tryMatchByField(konnectResource, "Name", e.Name); id != "" {
+		e.konnectID = id
+		return true
+	}
+	return false
+}
+
+// GetParentRef REQUIRED: marks resource as a child of Event Gateway.
+func (e EventGatewayTLSTrustBundleResource) GetParentRef() *ResourceRef {
+	if e.EventGateway != "" {
+		return &ResourceRef{Kind: "event_gateway", Ref: e.EventGateway}
+	}
+	return nil
+}
+
+// MarshalJSON ensures trust bundle metadata (ref, event_gateway) are included.
+// Without this, the embedded CreateTLSTrustBundleRequest's MarshalJSON is promoted and
+// drops metadata fields.
+func (e EventGatewayTLSTrustBundleResource) MarshalJSON() ([]byte, error) {
+	type alias struct {
+		Ref          string                       `json:"ref"`
+		EventGateway string                       `json:"event_gateway,omitempty"`
+		Name         string                       `json:"name"`
+		Description  *string                      `json:"description,omitempty"`
+		Config       kkComps.TLSTrustBundleConfig `json:"config"`
+		Labels       map[string]string            `json:"labels,omitempty"`
+	}
+
+	payload := alias{
+		Ref:          e.Ref,
+		EventGateway: e.EventGateway,
+		Name:         e.Name,
+		Description:  e.Description,
+		Config:       e.Config,
+		Labels:       e.Labels,
+	}
+
+	return json.Marshal(payload)
+}
+
+// UnmarshalJSON rejects kongctl metadata (not supported on child resources).
+func (e *EventGatewayTLSTrustBundleResource) UnmarshalJSON(data []byte) error {
+	var temp struct {
+		Ref          string                       `json:"ref"`
+		EventGateway string                       `json:"event_gateway,omitempty"`
+		Kongctl      any                          `json:"kongctl,omitempty"`
+		Name         string                       `json:"name"`
+		Description  *string                      `json:"description,omitempty"`
+		Config       kkComps.TLSTrustBundleConfig `json:"config"`
+		Labels       map[string]string            `json:"labels,omitempty"`
+	}
+
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return err
+	}
+
+	if temp.Kongctl != nil {
+		return fmt.Errorf("kongctl metadata not supported on child resources")
+	}
+
+	e.Ref = temp.Ref
+	e.EventGateway = temp.EventGateway
+	e.Name = temp.Name
+	e.Description = temp.Description
+	e.Config = temp.Config
+	e.Labels = temp.Labels
+
+	return nil
+}

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -41,6 +41,7 @@ const (
 	ResourceTypeEventGatewayConsumePolicy        ResourceType = "event_gateway_virtual_cluster_consume_policy"
 	ResourceTypeEventGatewaySchemaRegistry       ResourceType = "event_gateway_schema_registry"
 	ResourceTypeEventGatewayStaticKey            ResourceType = "event_gateway_static_key"
+	ResourceTypeEventGatewayTLSTrustBundle       ResourceType = "event_gateway_tls_trust_bundle"
 )
 
 const (
@@ -98,6 +99,7 @@ type ResourceSet struct {
 	EventGatewayDataPlaneCertificates []EventGatewayDataPlaneCertificateResource `yaml:"event_gateway_data_plane_certificates,omitempty" json:"event_gateway_data_plane_certificates,omitempty"`                   //nolint:lll
 	EventGatewaySchemaRegistries      []EventGatewaySchemaRegistryResource       `yaml:"event_gateway_schema_registries,omitempty"       json:"event_gateway_schema_registries,omitempty"`                         //nolint:lll
 	EventGatewayStaticKeys            []EventGatewayStaticKeyResource            `yaml:"event_gateway_static_keys,omitempty"              json:"event_gateway_static_keys,omitempty"`                              //nolint:lll
+	EventGatewayTLSTrustBundles       []EventGatewayTLSTrustBundleResource       `yaml:"event_gateway_tls_trust_bundles,omitempty"        json:"event_gateway_tls_trust_bundles,omitempty"`                        //nolint:lll
 	// DefaultNamespace tracks namespace from _defaults when no resources are present
 	// This is used by the planner to determine which namespace to check for deletions
 	DefaultNamespace  string   `yaml:"-"                                               json:"-"`
@@ -969,4 +971,33 @@ func (rs *ResourceSet) GetStaticKeysForGateway(
 	}
 
 	return keys
+}
+
+// GetTrustBundlesForGateway returns all TLS trust bundles (nested + root-level)
+// for a specific event gateway
+func (rs *ResourceSet) GetTrustBundlesForGateway(
+	gatewayRef string,
+) []EventGatewayTLSTrustBundleResource {
+	var bundles []EventGatewayTLSTrustBundleResource
+
+	// Add nested trust bundles from the event gateway
+	for _, gateway := range rs.EventGatewayControlPlanes {
+		if gateway.Ref == gatewayRef {
+			for _, tb := range gateway.TrustBundles {
+				tbCopy := tb
+				tbCopy.EventGateway = gatewayRef
+				bundles = append(bundles, tbCopy)
+			}
+			break
+		}
+	}
+
+	// Add root-level trust bundles for this gateway
+	for _, tb := range rs.EventGatewayTLSTrustBundles {
+		if tb.EventGateway == gatewayRef {
+			bundles = append(bundles, tb)
+		}
+	}
+
+	return bundles
 }

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -63,6 +63,7 @@ type ClientConfig struct {
 	EventGatewayDataPlaneCertificateAPI helpers.EventGatewayDataPlaneCertificateAPI
 	EventGatewaySchemaRegistryAPI       helpers.EventGatewaySchemaRegistryAPI
 	EventGatewayStaticKeyAPI            helpers.EventGatewayStaticKeyAPI
+	EventGatewayTLSTrustBundleAPI       helpers.EventGatewayTLSTrustBundleAPI
 
 	// Identity resources
 	OrganizationTeamAPI helpers.OrganizationTeamAPI
@@ -109,6 +110,7 @@ type Client struct {
 	eventGatewayDataPlaneCertificateAPI helpers.EventGatewayDataPlaneCertificateAPI
 	eventGatewaySchemaRegistryAPI       helpers.EventGatewaySchemaRegistryAPI
 	eventGatewayStaticKeyAPI            helpers.EventGatewayStaticKeyAPI
+	eventGatewayTLSTrustBundleAPI       helpers.EventGatewayTLSTrustBundleAPI
 
 	// Organization resource APIs
 	organizationTeamAPI helpers.OrganizationTeamAPI
@@ -156,6 +158,7 @@ func NewClient(config ClientConfig) *Client {
 		eventGatewayDataPlaneCertificateAPI: config.EventGatewayDataPlaneCertificateAPI,
 		eventGatewaySchemaRegistryAPI:       config.EventGatewaySchemaRegistryAPI,
 		eventGatewayStaticKeyAPI:            config.EventGatewayStaticKeyAPI,
+		eventGatewayTLSTrustBundleAPI:       config.EventGatewayTLSTrustBundleAPI,
 
 		// Identity resource APIs
 		organizationTeamAPI: config.OrganizationTeamAPI,
@@ -5680,6 +5683,191 @@ func (c *Client) DeleteEventGatewayStaticKey(
 	_, err := c.eventGatewayStaticKeyAPI.DeleteEventGatewayStaticKey(ctx, deleteReq)
 	if err != nil {
 		return WrapAPIError(err, "delete event gateway static key", nil)
+	}
+
+	return nil
+}
+
+// EventGatewayTLSTrustBundle represents an event gateway TLS trust bundle for internal use.
+type EventGatewayTLSTrustBundle struct {
+	kkComps.TLSTrustBundle
+	NormalizedLabels map[string]string
+}
+
+// ListEventGatewayTLSTrustBundles lists all TLS trust bundles for a gateway using cursor-based pagination.
+func (c *Client) ListEventGatewayTLSTrustBundles(
+	ctx context.Context,
+	gatewayID string,
+) ([]EventGatewayTLSTrustBundle, error) {
+	if err := ValidateAPIClient(c.eventGatewayTLSTrustBundleAPI, "event gateway TLS trust bundle API"); err != nil {
+		return nil, err
+	}
+
+	var allData []kkComps.TLSTrustBundle
+	var pageAfter *string
+
+	for {
+		req := kkOps.ListEventGatewayTLSTrustBundlesRequest{
+			GatewayID: gatewayID,
+		}
+
+		if pageAfter != nil {
+			req.PageAfter = pageAfter
+		}
+
+		res, err := c.eventGatewayTLSTrustBundleAPI.ListEventGatewayTLSTrustBundles(ctx, req)
+		if err != nil {
+			return nil, WrapAPIError(err, "list event gateway TLS trust bundles", nil)
+		}
+
+		if res.ListTLSTrustBundlesResponse == nil {
+			return []EventGatewayTLSTrustBundle{}, nil
+		}
+
+		allData = append(allData, res.ListTLSTrustBundlesResponse.Data...)
+
+		if res.ListTLSTrustBundlesResponse.Meta == nil ||
+			res.ListTLSTrustBundlesResponse.Meta.Page.Next == nil {
+			break
+		}
+
+		u, err := url.Parse(*res.ListTLSTrustBundlesResponse.Meta.Page.Next)
+		if err != nil {
+			return nil, WrapAPIError(err, "list event gateway TLS trust bundles: invalid cursor", nil)
+		}
+
+		values := u.Query()
+		after := values.Get("page[after]")
+		pageAfter = &after
+	}
+
+	result := make([]EventGatewayTLSTrustBundle, 0, len(allData))
+	for _, tb := range allData {
+		result = append(result, EventGatewayTLSTrustBundle{
+			TLSTrustBundle:   tb,
+			NormalizedLabels: tb.Labels,
+		})
+	}
+
+	return result, nil
+}
+
+// CreateEventGatewayTLSTrustBundle creates a new TLS trust bundle for an event gateway.
+func (c *Client) CreateEventGatewayTLSTrustBundle(
+	ctx context.Context,
+	gatewayID string,
+	req kkComps.CreateTLSTrustBundleRequest,
+	_ string, // namespace
+) (string, error) {
+	if err := ValidateAPIClient(c.eventGatewayTLSTrustBundleAPI, "event gateway TLS trust bundle API"); err != nil {
+		return "", err
+	}
+
+	createReq := kkOps.CreateEventGatewayTLSTrustBundleRequest{
+		GatewayID:                   gatewayID,
+		CreateTLSTrustBundleRequest: req,
+	}
+
+	resp, err := c.eventGatewayTLSTrustBundleAPI.CreateEventGatewayTLSTrustBundle(ctx, createReq)
+	if err != nil {
+		return "", WrapAPIError(err, "create event gateway TLS trust bundle", &ErrorWrapperOptions{
+			ResourceType: "event_gateway_tls_trust_bundle",
+			ResourceName: req.Name,
+			UseEnhanced:  true,
+		})
+	}
+
+	if err := ValidateResponse(resp.TLSTrustBundle, "create event gateway TLS trust bundle"); err != nil {
+		return "", err
+	}
+
+	return resp.TLSTrustBundle.ID, nil
+}
+
+// GetEventGatewayTLSTrustBundle retrieves a TLS trust bundle by ID.
+func (c *Client) GetEventGatewayTLSTrustBundle(
+	ctx context.Context,
+	gatewayID string,
+	bundleID string,
+) (*EventGatewayTLSTrustBundle, error) {
+	if err := ValidateAPIClient(c.eventGatewayTLSTrustBundleAPI, "event gateway TLS trust bundle API"); err != nil {
+		return nil, err
+	}
+
+	req := kkOps.GetEventGatewayTLSTrustBundleRequest{
+		GatewayID:        gatewayID,
+		TLSTrustBundleID: bundleID,
+	}
+
+	resp, err := c.eventGatewayTLSTrustBundleAPI.GetEventGatewayTLSTrustBundle(ctx, req)
+	if err != nil {
+		return nil, WrapAPIError(err, "get event gateway TLS trust bundle", &ErrorWrapperOptions{
+			ResourceType: "event_gateway_tls_trust_bundle",
+			UseEnhanced:  true,
+		})
+	}
+
+	if resp.TLSTrustBundle == nil {
+		return nil, nil
+	}
+
+	return &EventGatewayTLSTrustBundle{
+		TLSTrustBundle:   *resp.TLSTrustBundle,
+		NormalizedLabels: resp.TLSTrustBundle.Labels,
+	}, nil
+}
+
+// UpdateEventGatewayTLSTrustBundle updates a TLS trust bundle.
+func (c *Client) UpdateEventGatewayTLSTrustBundle(
+	ctx context.Context,
+	gatewayID string,
+	bundleID string,
+	req kkComps.UpdateTLSTrustBundleRequest,
+	_ string, // namespace
+) (string, error) {
+	if err := ValidateAPIClient(c.eventGatewayTLSTrustBundleAPI, "event gateway TLS trust bundle API"); err != nil {
+		return "", err
+	}
+
+	updateReq := kkOps.UpdateEventGatewayTLSTrustBundleRequest{
+		GatewayID:                   gatewayID,
+		TLSTrustBundleID:            bundleID,
+		UpdateTLSTrustBundleRequest: req,
+	}
+
+	resp, err := c.eventGatewayTLSTrustBundleAPI.UpdateEventGatewayTLSTrustBundle(ctx, updateReq)
+	if err != nil {
+		return "", WrapAPIError(err, "update event gateway TLS trust bundle", &ErrorWrapperOptions{
+			ResourceType: "event_gateway_tls_trust_bundle",
+			UseEnhanced:  true,
+		})
+	}
+
+	if err := ValidateResponse(resp.TLSTrustBundle, "update event gateway TLS trust bundle"); err != nil {
+		return "", err
+	}
+
+	return resp.TLSTrustBundle.ID, nil
+}
+
+// DeleteEventGatewayTLSTrustBundle deletes a TLS trust bundle by ID.
+func (c *Client) DeleteEventGatewayTLSTrustBundle(
+	ctx context.Context,
+	gatewayID string,
+	bundleID string,
+) error {
+	if err := ValidateAPIClient(c.eventGatewayTLSTrustBundleAPI, "event gateway TLS trust bundle API"); err != nil {
+		return err
+	}
+
+	deleteReq := kkOps.DeleteEventGatewayTLSTrustBundleRequest{
+		GatewayID:        gatewayID,
+		TLSTrustBundleID: bundleID,
+	}
+
+	_, err := c.eventGatewayTLSTrustBundleAPI.DeleteEventGatewayTLSTrustBundle(ctx, deleteReq)
+	if err != nil {
+		return WrapAPIError(err, "delete event gateway TLS trust bundle", nil)
 	}
 
 	return nil

--- a/internal/konnect/helpers/event_gateway_tls_trust_bundles.go
+++ b/internal/konnect/helpers/event_gateway_tls_trust_bundles.go
@@ -1,0 +1,76 @@
+package helpers
+
+import (
+	"context"
+
+	kkSDK "github.com/Kong/sdk-konnect-go"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+)
+
+// EventGatewayTLSTrustBundleAPI defines the interface for Event Gateway TLS Trust Bundle operations.
+type EventGatewayTLSTrustBundleAPI interface {
+	ListEventGatewayTLSTrustBundles(ctx context.Context,
+		request kkOps.ListEventGatewayTLSTrustBundlesRequest,
+		opts ...kkOps.Option) (*kkOps.ListEventGatewayTLSTrustBundlesResponse, error)
+	GetEventGatewayTLSTrustBundle(ctx context.Context,
+		request kkOps.GetEventGatewayTLSTrustBundleRequest,
+		opts ...kkOps.Option) (*kkOps.GetEventGatewayTLSTrustBundleResponse, error)
+	CreateEventGatewayTLSTrustBundle(ctx context.Context,
+		request kkOps.CreateEventGatewayTLSTrustBundleRequest,
+		opts ...kkOps.Option) (*kkOps.CreateEventGatewayTLSTrustBundleResponse, error)
+	UpdateEventGatewayTLSTrustBundle(ctx context.Context,
+		request kkOps.UpdateEventGatewayTLSTrustBundleRequest,
+		opts ...kkOps.Option) (*kkOps.UpdateEventGatewayTLSTrustBundleResponse, error)
+	DeleteEventGatewayTLSTrustBundle(ctx context.Context,
+		request kkOps.DeleteEventGatewayTLSTrustBundleRequest,
+		opts ...kkOps.Option) (*kkOps.DeleteEventGatewayTLSTrustBundleResponse, error)
+}
+
+// EventGatewayTLSTrustBundleAPIImpl provides an implementation of the EventGatewayTLSTrustBundleAPI interface.
+type EventGatewayTLSTrustBundleAPIImpl struct {
+	SDK *kkSDK.SDK
+}
+
+func (a *EventGatewayTLSTrustBundleAPIImpl) ListEventGatewayTLSTrustBundles(
+	ctx context.Context,
+	request kkOps.ListEventGatewayTLSTrustBundlesRequest,
+	opts ...kkOps.Option,
+) (*kkOps.ListEventGatewayTLSTrustBundlesResponse, error) {
+	return a.SDK.EventGatewayTLSTrustBundles.ListEventGatewayTLSTrustBundles(ctx, request, opts...)
+}
+
+func (a *EventGatewayTLSTrustBundleAPIImpl) GetEventGatewayTLSTrustBundle(
+	ctx context.Context,
+	request kkOps.GetEventGatewayTLSTrustBundleRequest,
+	opts ...kkOps.Option,
+) (*kkOps.GetEventGatewayTLSTrustBundleResponse, error) {
+	return a.SDK.EventGatewayTLSTrustBundles.GetEventGatewayTLSTrustBundle(
+		ctx, request.GatewayID, request.TLSTrustBundleID, opts...)
+}
+
+func (a *EventGatewayTLSTrustBundleAPIImpl) CreateEventGatewayTLSTrustBundle(
+	ctx context.Context,
+	request kkOps.CreateEventGatewayTLSTrustBundleRequest,
+	opts ...kkOps.Option,
+) (*kkOps.CreateEventGatewayTLSTrustBundleResponse, error) {
+	return a.SDK.EventGatewayTLSTrustBundles.CreateEventGatewayTLSTrustBundle(
+		ctx, request.GatewayID, request.CreateTLSTrustBundleRequest, opts...)
+}
+
+func (a *EventGatewayTLSTrustBundleAPIImpl) UpdateEventGatewayTLSTrustBundle(
+	ctx context.Context,
+	request kkOps.UpdateEventGatewayTLSTrustBundleRequest,
+	opts ...kkOps.Option,
+) (*kkOps.UpdateEventGatewayTLSTrustBundleResponse, error) {
+	return a.SDK.EventGatewayTLSTrustBundles.UpdateEventGatewayTLSTrustBundle(ctx, request, opts...)
+}
+
+func (a *EventGatewayTLSTrustBundleAPIImpl) DeleteEventGatewayTLSTrustBundle(
+	ctx context.Context,
+	request kkOps.DeleteEventGatewayTLSTrustBundleRequest,
+	opts ...kkOps.Option,
+) (*kkOps.DeleteEventGatewayTLSTrustBundleResponse, error) {
+	return a.SDK.EventGatewayTLSTrustBundles.DeleteEventGatewayTLSTrustBundle(
+		ctx, request.GatewayID, request.TLSTrustBundleID, opts...,
+	)
+}

--- a/internal/konnect/helpers/sdk.go
+++ b/internal/konnect/helpers/sdk.go
@@ -57,6 +57,7 @@ type SDKAPI interface {
 	GetEventGatewayDataPlaneCertificateAPI() EventGatewayDataPlaneCertificateAPI
 	GetEventGatewaySchemaRegistryAPI() EventGatewaySchemaRegistryAPI
 	GetEventGatewayStaticKeyAPI() EventGatewayStaticKeyAPI
+	GetEventGatewayTLSTrustBundleAPI() EventGatewayTLSTrustBundleAPI
 }
 
 // This is the real implementation of the SDKAPI
@@ -416,6 +417,15 @@ func (k *KonnectSDK) GetEventGatewayStaticKeyAPI() EventGatewayStaticKeyAPI {
 	}
 
 	return &EventGatewayStaticKeyAPIImpl{SDK: k.SDK}
+}
+
+// GetEventGatewayTLSTrustBundleAPI returns the implementation of the EventGatewayTLSTrustBundleAPI interface.
+func (k *KonnectSDK) GetEventGatewayTLSTrustBundleAPI() EventGatewayTLSTrustBundleAPI {
+	if k.SDK == nil {
+		return nil
+	}
+
+	return &EventGatewayTLSTrustBundleAPIImpl{SDK: k.SDK}
 }
 
 func (k *KonnectSDK) GetOrganizationTeamAPI() OrganizationTeamAPI {

--- a/internal/konnect/helpers/sdk_mock.go
+++ b/internal/konnect/helpers/sdk_mock.go
@@ -48,6 +48,7 @@ type MockKonnectSDK struct {
 	EventGatewayDataPlaneCertificateFactory func() EventGatewayDataPlaneCertificateAPI
 	EventGatewaySchemaRegistryFactory       func() EventGatewaySchemaRegistryAPI
 	EventGatewayStaticKeyFactory            func() EventGatewayStaticKeyAPI
+	EventGatewayTLSTrustBundleFactory       func() EventGatewayTLSTrustBundleAPI
 }
 
 // Returns a mock instance of the ControlPlaneAPI
@@ -355,6 +356,14 @@ func (m *MockKonnectSDK) GetEventGatewaySchemaRegistryAPI() EventGatewaySchemaRe
 func (m *MockKonnectSDK) GetEventGatewayStaticKeyAPI() EventGatewayStaticKeyAPI {
 	if m.EventGatewayStaticKeyFactory != nil {
 		return m.EventGatewayStaticKeyFactory()
+	}
+	return nil
+}
+
+// Returns a mock instance of the EventGatewayTLSTrustBundleAPI
+func (m *MockKonnectSDK) GetEventGatewayTLSTrustBundleAPI() EventGatewayTLSTrustBundleAPI {
+	if m.EventGatewayTLSTrustBundleFactory != nil {
+		return m.EventGatewayTLSTrustBundleFactory()
 	}
 	return nil
 }

--- a/test/e2e/scenarios/event-gateway/dump/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/dump/scenario.yaml
@@ -21,6 +21,8 @@ vars:
   schemaRegistryName: default-schema-registry-name-for-dump-test
   staticKeyRef: default-static-key
   staticKeyName: default-static-key-name-for-dump-test
+  trustBundleRef: default-tls-trust-bundle-ref-dump
+  trustBundleName: default-tls-trust-bundle-name-dump
 
 defaults:
   mask:
@@ -48,7 +50,7 @@ steps:
           - select: summary
             expect:
               fields:
-                applied: 7
+                applied: 8
                 failed: 0
 
   # Dump event_gateways with child resources and validate the output structure.
@@ -112,6 +114,12 @@ steps:
             expect:
               fields:
                 name: "{{ .vars.staticKeyName }}"
+          - name: trust-bundle-present
+            select: >-
+              event_gateways[?name=='{{ .vars.egwName }}'] | [0].trust_bundles[?name=='{{ .vars.trustBundleName }}'] | [0]
+            expect:
+              fields:
+                name: "{{ .vars.trustBundleName }}"
           - name: namespace-label-preserved
             select: "_defaults.kongctl"
             expect:

--- a/test/e2e/scenarios/event-gateway/dump/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/dump/scenario.yaml
@@ -116,7 +116,7 @@ steps:
                 name: "{{ .vars.staticKeyName }}"
           - name: trust-bundle-present
             select: >-
-              event_gateways[?name=='{{ .vars.egwName }}'] | [0].trust_bundles[?name=='{{ .vars.trustBundleName }}'] | [0]
+              event_gateways[?name=='{{ .vars.egwName }}'] | [0].tls_trust_bundles[?name=='{{ .vars.trustBundleName }}'] | [0]
             expect:
               fields:
                 name: "{{ .vars.trustBundleName }}"

--- a/test/e2e/scenarios/event-gateway/dump/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/dump/testdata/config.yaml
@@ -73,3 +73,43 @@ event_gateways:
         name: default-static-key-name-for-dump-test
         description: "Default Static Key description for Dump Test"
         value: "${env[\"STATIC_KEY_VALUE\"]}"
+    trust_bundles:
+      - ref: default-tls-trust-bundle-ref-dump
+        name: default-tls-trust-bundle-name-dump
+        description: "Default TLS Trust Bundle description for Dump Test"
+        config:
+          trusted_ca: |-
+            -----BEGIN CERTIFICATE-----
+            MIIFPjCCAyYCCQD2y9kVBp5f1jANBgkqhkiG9w0BAQsFADBhMQswCQYDVQQGEwJJ
+            TjELMAkGA1UECAwCS0ExDDAKBgNVBAcMA0JMUjEPMA0GA1UECgwGQVBJT1BzMRAw
+            DgYDVQQLDAdLT05HQ1RMMRQwEgYDVQQDDAtFMkVTQ0VOQVJJTzAeFw0yNjA0MTcw
+            NzQ0MTJaFw0zNjA0MTQwNzQ0MTJaMGExCzAJBgNVBAYTAklOMQswCQYDVQQIDAJL
+            QTEMMAoGA1UEBwwDQkxSMQ8wDQYDVQQKDAZBUElPUHMxEDAOBgNVBAsMB0tPTkdD
+            VEwxFDASBgNVBAMMC0UyRVNDRU5BUklPMIICIjANBgkqhkiG9w0BAQEFAAOCAg8A
+            MIICCgKCAgEA8Ej5Tqj4ulz9WH4CalU9fJQsnSpSf3CbZfL9uAHGc2zZCErYH18m
+            91XpWP0YNe/Htz8JM22K6HKqrW5z+93VwUrAiI88w9jECXVkw7r5QB3yxZ/QYJiD
+            290AVTzjLIcgM6hywXyiTOE6rZlvoqRGObk5Kv31gpV2UvJuY21YMvlnSTQ0VmQs
+            bBBvmdpebE7AMF/YFsx6/05L47wv3cmIJ+X3RO3YpZmlntl3vgxdM/RgXtIttBsC
+            U+ugm9OlcEwT1tb6H5mY02cy7hSyvibpUg+7PWz/kwVBLz5WUVBYurKbWq5wHTcf
+            cWfxFS7gyyBFPMVAZMnXLlq7HyicdGLBU1+WsJF1WwdS6e+cNSpWEt4STF78so+u
+            i5+CM5gz2HOKD3XuQmnYmu0GMIeSqP1Pu50OprBNhOI6Wsw0r6jo9dvGK+A/TqIf
+            Cf8ACulhRib+3qyTlSK9U5QfmRzw9stt2EjkqEuG9afJC3fqTNGgiY5J5/CPWU0n
+            MQU9SHsNMoOL8OAQ3u6xVrEAYruMfwJykxZLKm9Lhi+7FxPRk0B99Y4MNml215ou
+            cEMI27XCKGfq1RwtKyIYNnMjADNoN5sAMlTxaZra1mcnyZeMKE1nDwtpIP9DJmjH
+            I0eqA7kFB4Ndc276aovOe/5lEfqQYi+nGIcCaazwOhIqWekIHRE6n3sCAwEAATAN
+            BgkqhkiG9w0BAQsFAAOCAgEAhs2XcLqy78r4tGkGqEIWpjmjnkw7OQTn14uLVIjH
+            RjAhMyowefzHU35Icck3k60zOljNA96ChFiWj8H5w+DP4QKW23HZZ5c8htUPehNA
+            lkt6WH/s13jHW+08I5rRxCNHpnoB9Te5kg33Y059ZHgz4HliatOdmKJ3PbyBbkCg
+            X93aLDQ1Hpv0k9XsU7uczKwSLmd3VSFAxOT+mvGU6G4XwdCvqJHqn2pn7N0+ZmGA
+            /kbVOkAq5e4bYyC87yTLQiaTZLdb0jamL6sCPJnW5aEmPKgl7kILrVAKOIdihDxW
+            r/9vDrw2gUmnpW8DO+QxmNBIZ7soua/b5AOBeG9vpaVqH6sisoILLGPDL6Vh6Xg4
+            DONgc/2T1EDpeutwzxnUC85g28Vh9J6/o+inungVEfUFOAYwTuJYYmme3BuuIVSx
+            3K7LNims8ZHUbq3s0JOH4Pwef38WCozTa6Cufoh8BlUURbr0OBp7u4Wy7Pg3zCdu
+            AVbLk0nbLMRdm6bE5k+YGnuYIQwZ3UWJ3m44zYE2cgtsqm08NAjqQeAHh8hngtaM
+            pE/YOhO3S9xO1IbFbsqdPw8ajZmXOlhGBCX6LnDFsikTj+kG5lPTNr9ueLpcQ5eu
+            Jeo7mJ0RN29/eYI7ob59j8IIkTVSd8lJEpLoakPV4uyZPNgDx14MUB1Bz7qGU7gj
+            oxQ=
+            -----END CERTIFICATE-----
+
+    
+    

--- a/test/e2e/scenarios/event-gateway/dump/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/dump/testdata/config.yaml
@@ -73,7 +73,7 @@ event_gateways:
         name: default-static-key-name-for-dump-test
         description: "Default Static Key description for Dump Test"
         value: "${env[\"STATIC_KEY_VALUE\"]}"
-    trust_bundles:
+    tls_trust_bundles:
       - ref: default-tls-trust-bundle-ref-dump
         name: default-tls-trust-bundle-name-dump
         description: "Default TLS Trust Bundle description for Dump Test"

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/012-trust-bundles/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/012-trust-bundles/config.yaml
@@ -1,0 +1,165 @@
+_defaults:
+  kongctl:
+    namespace: egw-plan-apply
+
+event_gateways:
+  - ref: plan-apply-egw
+    name: plan-apply-egw
+    description: "Updated description for plan apply workflow"
+    backend_clusters:
+      - ref: plan-apply-backend-cluster
+        name: plan-apply-backend-cluster
+        description: "Updated description for plan apply backend cluster"
+        bootstrap_servers:
+          - "egw-backend-1-updated.example.com:9092"
+        authentication:
+          type: anonymous
+        tls:
+          enabled: true
+          skip_verify: false
+          tls_versions:
+            - tls12
+            - tls13
+    virtual_clusters:
+      - ref: plan-apply-virtual-cluster
+        name: plan-apply-virtual-cluster
+        description: "Virtual cluster for plan apply workflow"
+        destination:
+          name: plan-apply-backend-cluster
+        authentication:
+          - type: sasl_scram
+            algorithm: sha512
+        acl_mode: enforce_on_gateway
+        dns_label: vc-default
+        cluster_policies:
+          - ref: plan-apply-cluster-policy
+            name: plan-apply-cluster-policy-name-for-test
+            description: Plan Apply Cluster Policy description
+            type: acls
+            enabled: true
+            config:
+              rules:
+                - action: "deny"
+                  operations:
+                  - name: "describe_configs"
+                  resource_names:
+                  - match: "*"
+                  resource_type: "transactional_id"
+        produce_policies:
+          - ref: plan-apply-produce-policy
+            name: plan-apply-produce-policy-name-for-test
+            description: Plan Apply Produce Policy description
+            type: modify_headers
+            enabled: true
+            labels:
+              env: staging
+              team: streaming
+            config:
+              actions:
+                - op: set
+                  key: x-producer-id
+                  value: "${client_id}"
+                - op: remove
+                  key: x-original-header
+        consume_policies:
+          - condition: ""
+            description: description
+            enabled: true
+            name: skip-record-policy
+            ref: plan-apply-consume-policy
+            type: skip_record
+    schema_registries:
+      - ref: plan-apply-schema-registry
+        name: plan-apply-schema-registry-name
+        description: "Plan Apply Schema Registry description"
+        type: confluent
+        config:
+          schema_type: json
+          endpoint: https://schema-registry.example.com
+          timeout_seconds: 30
+          authentication:
+            type: basic
+            username: testuser
+            password: testpassword
+    static_keys:
+      - ref: plan-apply-static-key
+        name: plan-apply-static-key-name
+        description: "Plan Apply Static Key description"
+        value: "${env[\"STATIC_KEY_VALUE\"]}"
+    listeners:
+      - ref: plan-apply-listener
+        name: plan-apply-listener
+        description: "Listener for plan apply workflow"
+        ports:
+          - "9093-9095"
+        addresses:
+          - localhost
+        policies:
+          - ref: plan-apply-listener-1-policy-1-ref
+            name: plan-apply-listener-1-policy-1-name
+            type: forward_to_virtual_cluster
+            description: "Plan Apply Listener 1 Policy 1"
+            enabled: true
+            condition: "${ssl_sni} == \"example.com\""
+            labels:
+              env: staging
+              team: payments
+            config:
+              type: sni
+              advertised_port: 9092
+              sni_suffix: ".example.com"
+    data_plane_certificates:
+      - ref: plan-apply-dataplane-certificate-ref
+        name: plan-apply-dataplane-certificate-name
+        description: "Plan Apply Dataplane Certificate description"
+        certificate: |-
+          -----BEGIN CERTIFICATE-----
+          MIIB4TCCAYugAwIBAgIUAenxUyPjkSLCe2BQXoBMBacqgLowDQYJKoZIhvcNAQEL
+          BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+          GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yNDEwMjgyMDA3NDlaFw0zNDEw
+          MjYyMDA3NDlaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+          HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwXDANBgkqhkiG9w0BAQEF
+          AANLADBIAkEAyzipjrbAaLO/yPg7lL1dLWzhqNdc3S4YNR7f1RG9whWhbsPE2z42
+          e6WGFf9hggP6xjG4qbU8jFVczpd1UPwGbQIDAQABo1MwUTAdBgNVHQ4EFgQUkPPB
+          ghj+iHOHAKJlC1gLbKT/ZHQwHwYDVR0jBBgwFoAUkPPBghj+iHOHAKJlC1gLbKT/
+          ZHQwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAANBALfy49GvA2ld+u+G
+          Koxa8kCt7uywoqu0hfbBfUT4HqmXPvsuhz8RinE5ltxId108vtDNlD/+bKl+N5Ub
+          qKjBs0k=
+          -----END CERTIFICATE-----
+    trust_bundles:
+      - ref: default-tls-trust-bundle-ref
+        name: default-tls-trust-bundle-name
+        description: "Default TLS Trust Bundle description"
+        config:
+          trusted_ca: |-
+            -----BEGIN CERTIFICATE-----
+            MIIFPjCCAyYCCQD2y9kVBp5f1jANBgkqhkiG9w0BAQsFADBhMQswCQYDVQQGEwJJ
+            TjELMAkGA1UECAwCS0ExDDAKBgNVBAcMA0JMUjEPMA0GA1UECgwGQVBJT1BzMRAw
+            DgYDVQQLDAdLT05HQ1RMMRQwEgYDVQQDDAtFMkVTQ0VOQVJJTzAeFw0yNjA0MTcw
+            NzQ0MTJaFw0zNjA0MTQwNzQ0MTJaMGExCzAJBgNVBAYTAklOMQswCQYDVQQIDAJL
+            QTEMMAoGA1UEBwwDQkxSMQ8wDQYDVQQKDAZBUElPUHMxEDAOBgNVBAsMB0tPTkdD
+            VEwxFDASBgNVBAMMC0UyRVNDRU5BUklPMIICIjANBgkqhkiG9w0BAQEFAAOCAg8A
+            MIICCgKCAgEA8Ej5Tqj4ulz9WH4CalU9fJQsnSpSf3CbZfL9uAHGc2zZCErYH18m
+            91XpWP0YNe/Htz8JM22K6HKqrW5z+93VwUrAiI88w9jECXVkw7r5QB3yxZ/QYJiD
+            290AVTzjLIcgM6hywXyiTOE6rZlvoqRGObk5Kv31gpV2UvJuY21YMvlnSTQ0VmQs
+            bBBvmdpebE7AMF/YFsx6/05L47wv3cmIJ+X3RO3YpZmlntl3vgxdM/RgXtIttBsC
+            U+ugm9OlcEwT1tb6H5mY02cy7hSyvibpUg+7PWz/kwVBLz5WUVBYurKbWq5wHTcf
+            cWfxFS7gyyBFPMVAZMnXLlq7HyicdGLBU1+WsJF1WwdS6e+cNSpWEt4STF78so+u
+            i5+CM5gz2HOKD3XuQmnYmu0GMIeSqP1Pu50OprBNhOI6Wsw0r6jo9dvGK+A/TqIf
+            Cf8ACulhRib+3qyTlSK9U5QfmRzw9stt2EjkqEuG9afJC3fqTNGgiY5J5/CPWU0n
+            MQU9SHsNMoOL8OAQ3u6xVrEAYruMfwJykxZLKm9Lhi+7FxPRk0B99Y4MNml215ou
+            cEMI27XCKGfq1RwtKyIYNnMjADNoN5sAMlTxaZra1mcnyZeMKE1nDwtpIP9DJmjH
+            I0eqA7kFB4Ndc276aovOe/5lEfqQYi+nGIcCaazwOhIqWekIHRE6n3sCAwEAATAN
+            BgkqhkiG9w0BAQsFAAOCAgEAhs2XcLqy78r4tGkGqEIWpjmjnkw7OQTn14uLVIjH
+            RjAhMyowefzHU35Icck3k60zOljNA96ChFiWj8H5w+DP4QKW23HZZ5c8htUPehNA
+            lkt6WH/s13jHW+08I5rRxCNHpnoB9Te5kg33Y059ZHgz4HliatOdmKJ3PbyBbkCg
+            X93aLDQ1Hpv0k9XsU7uczKwSLmd3VSFAxOT+mvGU6G4XwdCvqJHqn2pn7N0+ZmGA
+            /kbVOkAq5e4bYyC87yTLQiaTZLdb0jamL6sCPJnW5aEmPKgl7kILrVAKOIdihDxW
+            r/9vDrw2gUmnpW8DO+QxmNBIZ7soua/b5AOBeG9vpaVqH6sisoILLGPDL6Vh6Xg4
+            DONgc/2T1EDpeutwzxnUC85g28Vh9J6/o+inungVEfUFOAYwTuJYYmme3BuuIVSx
+            3K7LNims8ZHUbq3s0JOH4Pwef38WCozTa6Cufoh8BlUURbr0OBp7u4Wy7Pg3zCdu
+            AVbLk0nbLMRdm6bE5k+YGnuYIQwZ3UWJ3m44zYE2cgtsqm08NAjqQeAHh8hngtaM
+            pE/YOhO3S9xO1IbFbsqdPw8ajZmXOlhGBCX6LnDFsikTj+kG5lPTNr9ueLpcQ5eu
+            Jeo7mJ0RN29/eYI7ob59j8IIkTVSd8lJEpLoakPV4uyZPNgDx14MUB1Bz7qGU7gj
+            oxQ=
+            -----END CERTIFICATE-----

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/012-trust-bundles/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/012-trust-bundles/config.yaml
@@ -126,7 +126,7 @@ event_gateways:
           Koxa8kCt7uywoqu0hfbBfUT4HqmXPvsuhz8RinE5ltxId108vtDNlD/+bKl+N5Ub
           qKjBs0k=
           -----END CERTIFICATE-----
-    trust_bundles:
+    tls_trust_bundles:
       - ref: default-tls-trust-bundle-ref
         name: default-tls-trust-bundle-name
         description: "Default TLS Trust Bundle description"

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/scenario.yaml
@@ -40,6 +40,9 @@ vars:
   staticKeyRef: plan-apply-static-key
   staticKeyName: plan-apply-static-key-name
   staticKeyDesc: "Plan Apply Static Key description"
+  trustBundleRef: default-tls-trust-bundle-ref
+  trustBundleName: default-tls-trust-bundle-name
+  trustBundleDesc: "Default TLS Trust Bundle description"
 
 defaults:
   mask:
@@ -950,3 +953,77 @@ steps:
               fields:
                 name: "{{ .vars.staticKeyName }}"
                 description: "{{ .vars.staticKeyDesc }}"
+  - name: 013-plan-apply-trust-bundle
+    inputOverlayDirs:
+      - overlays/012-trust-bundles
+    commands:
+      - name: 000-plan-create-trust-bundle
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-trust-bundle.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_tls_trust_bundle' && resource_ref=='{{ .vars.trustBundleRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.trustBundleRef }}"
+      - name: 001-diff-plan-text
+        outputFormat: text
+        parseAs: raw
+        run:
+          - diff
+          - --plan
+          - "{{ .workdir }}/plan-trust-bundle.json"
+        assertions:
+          - select: stdout
+            expect:
+              fields:
+                "contains(@, 'Plan: 1 to add')": true
+                "contains(@, 'event_gateway_tls_trust_bundle \"default-tls-trust-bundle-ref\" will be created')": true
+      - name: 002-apply-plan
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-trust-bundle.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 003-verify-trust-bundle
+        run:
+          - get
+          - event-gateway
+          - tls-trust-bundles
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 1
+          - select: "[0]"
+            expect:
+              fields:
+                name: "{{ .vars.trustBundleName }}"
+                description: "{{ .vars.trustBundleDesc }}"

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/012-trust-bundles/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/012-trust-bundles/config.yaml
@@ -1,0 +1,169 @@
+_defaults:
+  kongctl:
+    namespace: egw-plan-sync
+
+event_gateways:
+  - ref: plan-sync-egw
+    name: plan-sync-egw
+    description: "Updated description for plan sync workflow"
+    backend_clusters:
+      - ref: plan-sync-backend-cluster
+        name: plan-sync-backend-cluster
+        description: "Updated description for plan apply backend cluster"
+        bootstrap_servers:
+          - "egw-backend-1-updated.example.com:9092"
+        authentication:
+          type: anonymous
+        tls:
+          enabled: true
+          skip_verify: false
+          tls_versions:
+            - tls12
+            - tls13
+    virtual_clusters:
+      - ref: plan-sync-virtual-cluster
+        name: plan-sync-virtual-cluster
+        description: "Virtual cluster for plan sync workflow"
+        destination:
+          id: !ref plan-sync-backend-cluster#id
+        authentication:
+          - type: anonymous
+        acl_mode: enforce_on_gateway
+        dns_label: vc-default
+        cluster_policies:
+          - ref: plan-sync-cluster-policy
+            name: plan-sync-cluster-policy-name-for-test
+            description: Plan Sync Cluster Policy description
+            type: acls
+            enabled: true
+            config:
+              rules:
+                - action: "deny"
+                  operations:
+                  - name: "describe_configs"
+                  resource_names:
+                  - match: "*"
+                  resource_type: "transactional_id"
+        produce_policies:
+          - ref: plan-sync-produce-policy
+            name: plan-sync-produce-policy-name-for-test
+            description: Plan Sync Produce Policy description
+            type: modify_headers
+            enabled: true
+            labels:
+              env: staging
+              team: streaming
+            config:
+              actions:
+                - op: set
+                  key: x-producer-id
+                  value: "${client_id}"
+                - op: remove
+                  key: x-original-header
+        consume_policies:
+          - condition: ""
+            config:
+              key_validation_action: mark
+              type: json
+              value_validation_action: skip
+            description: ""
+            enabled: true
+            name: plan-sync-consume-policy-name-for-test
+            ref: plan-sync-consume-policy
+            type: schema_validation
+    schema_registries:
+      - ref: plan-sync-schema-registry
+        name: plan-sync-schema-registry-name
+        description: "Plan Sync Schema Registry description"
+        type: confluent
+        config:
+          schema_type: json
+          endpoint: https://schema-registry.example.com
+          timeout_seconds: 30
+          authentication:
+            type: basic
+            username: testuser
+            password: testpassword
+    static_keys:
+      - ref: plan-sync-static-key
+        name: plan-sync-static-key-name
+        description: "Plan Sync Static Key description"
+        value: "${env[\"STATIC_KEY_VALUE\"]}"
+    listeners:
+      - ref: plan-sync-listener
+        name: plan-sync-listener
+        description: "Listener for plan sync workflow"
+        ports:
+          - 9092
+        addresses:
+          - localhost
+        policies:
+          - ref: plan-sync-listener-1-policy-1-ref
+            name: plan-sync-listener-1-policy-1-name
+            type: forward_to_virtual_cluster
+            description: "Plan Sync Listener 1 Policy 1"
+            enabled: true
+            condition: "${ssl_sni} == \"example.com\""
+            labels:
+              env: staging
+              team: payments
+            config:
+              type: port_mapping
+              destination:
+                id: !ref plan-sync-virtual-cluster#id
+              advertised_host: "example.com"
+    data_plane_certificates:
+      - ref: plan-sync-dataplane-certificate-ref
+        name: plan-sync-dataplane-certificate-name
+        description: "Plan Sync Dataplane Certificate description"
+        certificate: |-
+          -----BEGIN CERTIFICATE-----
+          MIIB4TCCAYugAwIBAgIUAenxUyPjkSLCe2BQXoBMBacqgLowDQYJKoZIhvcNAQEL
+          BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+          GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yNDEwMjgyMDA3NDlaFw0zNDEw
+          MjYyMDA3NDlaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+          HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwXDANBgkqhkiG9w0BAQEF
+          AANLADBIAkEAyzipjrbAaLO/yPg7lL1dLWzhqNdc3S4YNR7f1RG9whWhbsPE2z42
+          e6WGFf9hggP6xjG4qbU8jFVczpd1UPwGbQIDAQABo1MwUTAdBgNVHQ4EFgQUkPPB
+          ghj+iHOHAKJlC1gLbKT/ZHQwHwYDVR0jBBgwFoAUkPPBghj+iHOHAKJlC1gLbKT/
+          ZHQwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAANBALfy49GvA2ld+u+G
+          Koxa8kCt7uywoqu0hfbBfUT4HqmXPvsuhz8RinE5ltxId108vtDNlD/+bKl+N5Ub
+          qKjBs0k=
+          -----END CERTIFICATE-----
+    trust_bundles:
+      - ref: default-tls-trust-bundle-ref
+        name: default-tls-trust-bundle-name
+        description: "Default TLS Trust Bundle description"
+        config:
+          trusted_ca: |-
+            -----BEGIN CERTIFICATE-----
+            MIIFPjCCAyYCCQD2y9kVBp5f1jANBgkqhkiG9w0BAQsFADBhMQswCQYDVQQGEwJJ
+            TjELMAkGA1UECAwCS0ExDDAKBgNVBAcMA0JMUjEPMA0GA1UECgwGQVBJT1BzMRAw
+            DgYDVQQLDAdLT05HQ1RMMRQwEgYDVQQDDAtFMkVTQ0VOQVJJTzAeFw0yNjA0MTcw
+            NzQ0MTJaFw0zNjA0MTQwNzQ0MTJaMGExCzAJBgNVBAYTAklOMQswCQYDVQQIDAJL
+            QTEMMAoGA1UEBwwDQkxSMQ8wDQYDVQQKDAZBUElPUHMxEDAOBgNVBAsMB0tPTkdD
+            VEwxFDASBgNVBAMMC0UyRVNDRU5BUklPMIICIjANBgkqhkiG9w0BAQEFAAOCAg8A
+            MIICCgKCAgEA8Ej5Tqj4ulz9WH4CalU9fJQsnSpSf3CbZfL9uAHGc2zZCErYH18m
+            91XpWP0YNe/Htz8JM22K6HKqrW5z+93VwUrAiI88w9jECXVkw7r5QB3yxZ/QYJiD
+            290AVTzjLIcgM6hywXyiTOE6rZlvoqRGObk5Kv31gpV2UvJuY21YMvlnSTQ0VmQs
+            bBBvmdpebE7AMF/YFsx6/05L47wv3cmIJ+X3RO3YpZmlntl3vgxdM/RgXtIttBsC
+            U+ugm9OlcEwT1tb6H5mY02cy7hSyvibpUg+7PWz/kwVBLz5WUVBYurKbWq5wHTcf
+            cWfxFS7gyyBFPMVAZMnXLlq7HyicdGLBU1+WsJF1WwdS6e+cNSpWEt4STF78so+u
+            i5+CM5gz2HOKD3XuQmnYmu0GMIeSqP1Pu50OprBNhOI6Wsw0r6jo9dvGK+A/TqIf
+            Cf8ACulhRib+3qyTlSK9U5QfmRzw9stt2EjkqEuG9afJC3fqTNGgiY5J5/CPWU0n
+            MQU9SHsNMoOL8OAQ3u6xVrEAYruMfwJykxZLKm9Lhi+7FxPRk0B99Y4MNml215ou
+            cEMI27XCKGfq1RwtKyIYNnMjADNoN5sAMlTxaZra1mcnyZeMKE1nDwtpIP9DJmjH
+            I0eqA7kFB4Ndc276aovOe/5lEfqQYi+nGIcCaazwOhIqWekIHRE6n3sCAwEAATAN
+            BgkqhkiG9w0BAQsFAAOCAgEAhs2XcLqy78r4tGkGqEIWpjmjnkw7OQTn14uLVIjH
+            RjAhMyowefzHU35Icck3k60zOljNA96ChFiWj8H5w+DP4QKW23HZZ5c8htUPehNA
+            lkt6WH/s13jHW+08I5rRxCNHpnoB9Te5kg33Y059ZHgz4HliatOdmKJ3PbyBbkCg
+            X93aLDQ1Hpv0k9XsU7uczKwSLmd3VSFAxOT+mvGU6G4XwdCvqJHqn2pn7N0+ZmGA
+            /kbVOkAq5e4bYyC87yTLQiaTZLdb0jamL6sCPJnW5aEmPKgl7kILrVAKOIdihDxW
+            r/9vDrw2gUmnpW8DO+QxmNBIZ7soua/b5AOBeG9vpaVqH6sisoILLGPDL6Vh6Xg4
+            DONgc/2T1EDpeutwzxnUC85g28Vh9J6/o+inungVEfUFOAYwTuJYYmme3BuuIVSx
+            3K7LNims8ZHUbq3s0JOH4Pwef38WCozTa6Cufoh8BlUURbr0OBp7u4Wy7Pg3zCdu
+            AVbLk0nbLMRdm6bE5k+YGnuYIQwZ3UWJ3m44zYE2cgtsqm08NAjqQeAHh8hngtaM
+            pE/YOhO3S9xO1IbFbsqdPw8ajZmXOlhGBCX6LnDFsikTj+kG5lPTNr9ueLpcQ5eu
+            Jeo7mJ0RN29/eYI7ob59j8IIkTVSd8lJEpLoakPV4uyZPNgDx14MUB1Bz7qGU7gj
+            oxQ=
+            -----END CERTIFICATE-----

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/012-trust-bundles/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/012-trust-bundles/config.yaml
@@ -130,7 +130,7 @@ event_gateways:
           Koxa8kCt7uywoqu0hfbBfUT4HqmXPvsuhz8RinE5ltxId108vtDNlD/+bKl+N5Ub
           qKjBs0k=
           -----END CERTIFICATE-----
-    trust_bundles:
+    tls_trust_bundles:
       - ref: default-tls-trust-bundle-ref
         name: default-tls-trust-bundle-name
         description: "Default TLS Trust Bundle description"

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/scenario.yaml
@@ -40,6 +40,9 @@ vars:
   staticKeyRef: plan-sync-static-key
   staticKeyName: plan-sync-static-key-name
   staticKeyDesc: "Plan Sync Static Key description"
+  trustBundleRef: default-tls-trust-bundle-ref
+  trustBundleName: default-tls-trust-bundle-name
+  trustBundleDesc: "Default TLS Trust Bundle description"
 
 defaults:
   mask:
@@ -1058,6 +1061,92 @@ steps:
               fields:
                 name: "{{ .vars.staticKeyName }}"
                 description: "{{ .vars.staticKeyDesc }}"
+      - name: 004-diff-no-changes
+        outputFormat: text
+        parseAs: raw
+        run:
+          - diff
+          - -f
+          - "{{ .workdir }}/config.yaml"
+        assertions:
+          - select: stdout
+            expect:
+              fields:
+                "contains(@, 'No changes detected. Konnect is up to date.')": true
+  - name: 013-plan-sync-trust-bundle
+    inputOverlayDirs:
+      - overlays/012-trust-bundles
+    commands:
+      - name: 000-plan-create-trust-bundle
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-trust-bundle.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: sync
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_tls_trust_bundle' && resource_ref=='{{ .vars.trustBundleRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.trustBundleRef }}"
+      - name: 001-diff-plan-text
+        outputFormat: text
+        parseAs: raw
+        run:
+          - diff
+          - --plan
+          - "{{ .workdir }}/plan-trust-bundle.json"
+        assertions:
+          - select: stdout
+            expect:
+              fields:
+                "contains(@, 'Plan: 1 to add')": true
+                "contains(@, 'event_gateway_tls_trust_bundle \"default-tls-trust-bundle-ref\" will be created')": true
+      - name: 002-sync-plan
+        outputFormat: json
+        run:
+          - sync
+          - --plan
+          - "{{ .workdir }}/plan-trust-bundle.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 003-verify-trust-bundle
+        run:
+          - get
+          - event-gateway
+          - tls-trust-bundles
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 1
+          - select: "[0]"
+            expect:
+              fields:
+                name: "{{ .vars.trustBundleName }}"
+                description: "{{ .vars.trustBundleDesc }}"
       - name: 004-diff-no-changes
         outputFormat: text
         parseAs: raw

--- a/test/e2e/scenarios/event-gateway/static-key/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/static-key/scenario.yaml
@@ -57,7 +57,6 @@ steps:
               fields:
                 action: CREATE
                 resource_ref: "{{ .vars.staticKeyRef }}"
-
       - name: 002-apply-create
         outputFormat: json
         run:

--- a/test/e2e/scenarios/event-gateway/static-key/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/static-key/scenario.yaml
@@ -57,6 +57,7 @@ steps:
               fields:
                 action: CREATE
                 resource_ref: "{{ .vars.staticKeyRef }}"
+
       - name: 002-apply-create
         outputFormat: json
         run:

--- a/test/e2e/scenarios/event-gateway/tls-trust-bundle/overlays/001-update-fields/config.yaml
+++ b/test/e2e/scenarios/event-gateway/tls-trust-bundle/overlays/001-update-fields/config.yaml
@@ -1,0 +1,45 @@
+_defaults:
+  kongctl:
+    namespace: event-gateways-tls-trust-bundle-test
+
+event_gateways:
+  - ref: egw-cp-for-tls-trust-bundle-test-ref
+    name: egw-cp-for-tls-trust-bundle-test-name
+    description: "EGW CP for TLS Trust Bundle Test"
+    trust_bundles:
+      - ref: default-tls-trust-bundle-ref
+        name: default-tls-trust-bundle-name
+        description: "Updated TLS Trust Bundle description"
+        config:
+          trusted_ca: |-
+            -----BEGIN CERTIFICATE-----
+            MIIFPjCCAyYCCQD2y9kVBp5f1jANBgkqhkiG9w0BAQsFADBhMQswCQYDVQQGEwJJ
+            TjELMAkGA1UECAwCS0ExDDAKBgNVBAcMA0JMUjEPMA0GA1UECgwGQVBJT1BzMRAw
+            DgYDVQQLDAdLT05HQ1RMMRQwEgYDVQQDDAtFMkVTQ0VOQVJJTzAeFw0yNjA0MTcw
+            NzQ0MTJaFw0zNjA0MTQwNzQ0MTJaMGExCzAJBgNVBAYTAklOMQswCQYDVQQIDAJL
+            QTEMMAoGA1UEBwwDQkxSMQ8wDQYDVQQKDAZBUElPUHMxEDAOBgNVBAsMB0tPTkdD
+            VEwxFDASBgNVBAMMC0UyRVNDRU5BUklPMIICIjANBgkqhkiG9w0BAQEFAAOCAg8A
+            MIICCgKCAgEA8Ej5Tqj4ulz9WH4CalU9fJQsnSpSf3CbZfL9uAHGc2zZCErYH18m
+            91XpWP0YNe/Htz8JM22K6HKqrW5z+93VwUrAiI88w9jECXVkw7r5QB3yxZ/QYJiD
+            290AVTzjLIcgM6hywXyiTOE6rZlvoqRGObk5Kv31gpV2UvJuY21YMvlnSTQ0VmQs
+            bBBvmdpebE7AMF/YFsx6/05L47wv3cmIJ+X3RO3YpZmlntl3vgxdM/RgXtIttBsC
+            U+ugm9OlcEwT1tb6H5mY02cy7hSyvibpUg+7PWz/kwVBLz5WUVBYurKbWq5wHTcf
+            cWfxFS7gyyBFPMVAZMnXLlq7HyicdGLBU1+WsJF1WwdS6e+cNSpWEt4STF78so+u
+            i5+CM5gz2HOKD3XuQmnYmu0GMIeSqP1Pu50OprBNhOI6Wsw0r6jo9dvGK+A/TqIf
+            Cf8ACulhRib+3qyTlSK9U5QfmRzw9stt2EjkqEuG9afJC3fqTNGgiY5J5/CPWU0n
+            MQU9SHsNMoOL8OAQ3u6xVrEAYruMfwJykxZLKm9Lhi+7FxPRk0B99Y4MNml215ou
+            cEMI27XCKGfq1RwtKyIYNnMjADNoN5sAMlTxaZra1mcnyZeMKE1nDwtpIP9DJmjH
+            I0eqA7kFB4Ndc276aovOe/5lEfqQYi+nGIcCaazwOhIqWekIHRE6n3sCAwEAATAN
+            BgkqhkiG9w0BAQsFAAOCAgEAhs2XcLqy78r4tGkGqEIWpjmjnkw7OQTn14uLVIjH
+            RjAhMyowefzHU35Icck3k60zOljNA96ChFiWj8H5w+DP4QKW23HZZ5c8htUPehNA
+            lkt6WH/s13jHW+08I5rRxCNHpnoB9Te5kg33Y059ZHgz4HliatOdmKJ3PbyBbkCg
+            X93aLDQ1Hpv0k9XsU7uczKwSLmd3VSFAxOT+mvGU6G4XwdCvqJHqn2pn7N0+ZmGA
+            /kbVOkAq5e4bYyC87yTLQiaTZLdb0jamL6sCPJnW5aEmPKgl7kILrVAKOIdihDxW
+            r/9vDrw2gUmnpW8DO+QxmNBIZ7soua/b5AOBeG9vpaVqH6sisoILLGPDL6Vh6Xg4
+            DONgc/2T1EDpeutwzxnUC85g28Vh9J6/o+inungVEfUFOAYwTuJYYmme3BuuIVSx
+            3K7LNims8ZHUbq3s0JOH4Pwef38WCozTa6Cufoh8BlUURbr0OBp7u4Wy7Pg3zCdu
+            AVbLk0nbLMRdm6bE5k+YGnuYIQwZ3UWJ3m44zYE2cgtsqm08NAjqQeAHh8hngtaM
+            pE/YOhO3S9xO1IbFbsqdPw8ajZmXOlhGBCX6LnDFsikTj+kG5lPTNr9ueLpcQ5eu
+            Jeo7mJ0RN29/eYI7ob59j8IIkTVSd8lJEpLoakPV4uyZPNgDx14MUB1Bz7qGU7gj
+            oxQ=
+            -----END CERTIFICATE-----

--- a/test/e2e/scenarios/event-gateway/tls-trust-bundle/overlays/001-update-fields/config.yaml
+++ b/test/e2e/scenarios/event-gateway/tls-trust-bundle/overlays/001-update-fields/config.yaml
@@ -6,7 +6,7 @@ event_gateways:
   - ref: egw-cp-for-tls-trust-bundle-test-ref
     name: egw-cp-for-tls-trust-bundle-test-name
     description: "EGW CP for TLS Trust Bundle Test"
-    trust_bundles:
+    tls_trust_bundles:
       - ref: default-tls-trust-bundle-ref
         name: default-tls-trust-bundle-name
         description: "Updated TLS Trust Bundle description"

--- a/test/e2e/scenarios/event-gateway/tls-trust-bundle/overlays/002-sync-delete/config.yaml
+++ b/test/e2e/scenarios/event-gateway/tls-trust-bundle/overlays/002-sync-delete/config.yaml
@@ -1,0 +1,9 @@
+_defaults:
+  kongctl:
+    namespace: event-gateways-tls-trust-bundle-test
+
+event_gateways:
+  - ref: egw-cp-for-tls-trust-bundle-test-ref
+    name: egw-cp-for-tls-trust-bundle-test-name
+    description: "EGW CP for TLS Trust Bundle Test"
+    trust_bundles: []

--- a/test/e2e/scenarios/event-gateway/tls-trust-bundle/overlays/002-sync-delete/config.yaml
+++ b/test/e2e/scenarios/event-gateway/tls-trust-bundle/overlays/002-sync-delete/config.yaml
@@ -6,4 +6,4 @@ event_gateways:
   - ref: egw-cp-for-tls-trust-bundle-test-ref
     name: egw-cp-for-tls-trust-bundle-test-name
     description: "EGW CP for TLS Trust Bundle Test"
-    trust_bundles: []
+    tls_trust_bundles: []

--- a/test/e2e/scenarios/event-gateway/tls-trust-bundle/overlays/003-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/tls-trust-bundle/overlays/003-root-level-declaration/config.yaml
@@ -1,0 +1,47 @@
+_defaults:
+  kongctl:
+    namespace: event-gateways-tls-trust-bundle-test
+
+event_gateways:
+  - ref: egw-cp-for-tls-trust-bundle-test-ref
+    name: egw-cp-for-tls-trust-bundle-test-name
+    description: "EGW CP for TLS Trust Bundle Test"
+
+event_gateway_tls_trust_bundles:
+  - ref: default-tls-trust-bundle-ref
+    event_gateway: egw-cp-for-tls-trust-bundle-test-ref
+    name: default-tls-trust-bundle-name
+    description: "Default root level TLS Trust Bundle description"
+    config:
+      trusted_ca: |-
+        -----BEGIN CERTIFICATE-----
+        MIIFPjCCAyYCCQD2y9kVBp5f1jANBgkqhkiG9w0BAQsFADBhMQswCQYDVQQGEwJJ
+        TjELMAkGA1UECAwCS0ExDDAKBgNVBAcMA0JMUjEPMA0GA1UECgwGQVBJT1BzMRAw
+        DgYDVQQLDAdLT05HQ1RMMRQwEgYDVQQDDAtFMkVTQ0VOQVJJTzAeFw0yNjA0MTcw
+        NzQ0MTJaFw0zNjA0MTQwNzQ0MTJaMGExCzAJBgNVBAYTAklOMQswCQYDVQQIDAJL
+        QTEMMAoGA1UEBwwDQkxSMQ8wDQYDVQQKDAZBUElPUHMxEDAOBgNVBAsMB0tPTkdD
+        VEwxFDASBgNVBAMMC0UyRVNDRU5BUklPMIICIjANBgkqhkiG9w0BAQEFAAOCAg8A
+        MIICCgKCAgEA8Ej5Tqj4ulz9WH4CalU9fJQsnSpSf3CbZfL9uAHGc2zZCErYH18m
+        91XpWP0YNe/Htz8JM22K6HKqrW5z+93VwUrAiI88w9jECXVkw7r5QB3yxZ/QYJiD
+        290AVTzjLIcgM6hywXyiTOE6rZlvoqRGObk5Kv31gpV2UvJuY21YMvlnSTQ0VmQs
+        bBBvmdpebE7AMF/YFsx6/05L47wv3cmIJ+X3RO3YpZmlntl3vgxdM/RgXtIttBsC
+        U+ugm9OlcEwT1tb6H5mY02cy7hSyvibpUg+7PWz/kwVBLz5WUVBYurKbWq5wHTcf
+        cWfxFS7gyyBFPMVAZMnXLlq7HyicdGLBU1+WsJF1WwdS6e+cNSpWEt4STF78so+u
+        i5+CM5gz2HOKD3XuQmnYmu0GMIeSqP1Pu50OprBNhOI6Wsw0r6jo9dvGK+A/TqIf
+        Cf8ACulhRib+3qyTlSK9U5QfmRzw9stt2EjkqEuG9afJC3fqTNGgiY5J5/CPWU0n
+        MQU9SHsNMoOL8OAQ3u6xVrEAYruMfwJykxZLKm9Lhi+7FxPRk0B99Y4MNml215ou
+        cEMI27XCKGfq1RwtKyIYNnMjADNoN5sAMlTxaZra1mcnyZeMKE1nDwtpIP9DJmjH
+        I0eqA7kFB4Ndc276aovOe/5lEfqQYi+nGIcCaazwOhIqWekIHRE6n3sCAwEAATAN
+        BgkqhkiG9w0BAQsFAAOCAgEAhs2XcLqy78r4tGkGqEIWpjmjnkw7OQTn14uLVIjH
+        RjAhMyowefzHU35Icck3k60zOljNA96ChFiWj8H5w+DP4QKW23HZZ5c8htUPehNA
+        lkt6WH/s13jHW+08I5rRxCNHpnoB9Te5kg33Y059ZHgz4HliatOdmKJ3PbyBbkCg
+        X93aLDQ1Hpv0k9XsU7uczKwSLmd3VSFAxOT+mvGU6G4XwdCvqJHqn2pn7N0+ZmGA
+        /kbVOkAq5e4bYyC87yTLQiaTZLdb0jamL6sCPJnW5aEmPKgl7kILrVAKOIdihDxW
+        r/9vDrw2gUmnpW8DO+QxmNBIZ7soua/b5AOBeG9vpaVqH6sisoILLGPDL6Vh6Xg4
+        DONgc/2T1EDpeutwzxnUC85g28Vh9J6/o+inungVEfUFOAYwTuJYYmme3BuuIVSx
+        3K7LNims8ZHUbq3s0JOH4Pwef38WCozTa6Cufoh8BlUURbr0OBp7u4Wy7Pg3zCdu
+        AVbLk0nbLMRdm6bE5k+YGnuYIQwZ3UWJ3m44zYE2cgtsqm08NAjqQeAHh8hngtaM
+        pE/YOhO3S9xO1IbFbsqdPw8ajZmXOlhGBCX6LnDFsikTj+kG5lPTNr9ueLpcQ5eu
+        Jeo7mJ0RN29/eYI7ob59j8IIkTVSd8lJEpLoakPV4uyZPNgDx14MUB1Bz7qGU7gj
+        oxQ=
+        -----END CERTIFICATE-----

--- a/test/e2e/scenarios/event-gateway/tls-trust-bundle/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/tls-trust-bundle/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -1,0 +1,10 @@
+_defaults:
+  kongctl:
+    namespace: event-gateways-tls-trust-bundle-test
+
+event_gateways:
+  - ref: egw-cp-for-tls-trust-bundle-test-ref
+    name: egw-cp-for-tls-trust-bundle-test-name
+    description: "EGW CP for TLS Trust Bundle Test"
+
+event_gateway_tls_trust_bundles: []

--- a/test/e2e/scenarios/event-gateway/tls-trust-bundle/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/tls-trust-bundle/scenario.yaml
@@ -1,0 +1,331 @@
+baseInputsPath: testdata
+
+env:
+  KONGCTL_LOG_LEVEL: info
+
+test:
+  enabledByEnvVar: KONGCTL_ENABLE_EVENT_GATEWAY
+
+vars:
+  egwName: egw-cp-for-tls-trust-bundle-test-name
+  trustBundleRef: default-tls-trust-bundle-ref
+  trustBundleName: default-tls-trust-bundle-name
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - created_at
+      - updated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+  - name: 001-plan-apply-create
+    commands:
+      - name: 001-plan-create
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-create.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 2
+                by_action.CREATE: 2
+          - select: >-
+              changes[?resource_type=='event_gateway' && resource_ref=='egw-cp-for-tls-trust-bundle-test-ref'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "egw-cp-for-tls-trust-bundle-test-ref"
+          - select: >-
+              changes[?resource_type=='event_gateway_tls_trust_bundle' && resource_ref=='{{ .vars.trustBundleRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.trustBundleRef }}"
+
+      - name: 002-apply-create
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-create.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 2
+                failed: 0
+
+      - name: 003-verify-create
+        run:
+          - get
+          - event-gateway
+          - tls-trust-bundles
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 1
+          - select: "[0]"
+            expect:
+              fields:
+                name: "{{ .vars.trustBundleName }}"
+                description: "Default TLS Trust Bundle description"
+  - name: 002-plan-apply-update
+    # TLS trust bundles support UPDATE – changing description triggers UPDATE.
+    inputOverlayDirs:
+      - overlays/001-update-fields
+    commands:
+      - name: 001-plan-update
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-update.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_tls_trust_bundle' && action=='UPDATE'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                resource_ref: "{{ .vars.trustBundleRef }}"
+      - name: 002-apply-update
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-update.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+
+      - name: 003-verify-update
+        run:
+          - get
+          - event-gateway
+          - tls-trust-bundles
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 1
+          - select: "[0]"
+            expect:
+              fields:
+                name: "{{ .vars.trustBundleName }}"
+                description: "Updated TLS Trust Bundle description"
+  - name: 003-sync-delete
+    inputOverlayDirs:
+      - overlays/002-sync-delete
+    commands:
+      - name: 001-plan-sync-delete
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-sync-delete.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: sync
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_tls_trust_bundle'] | [0]
+            expect:
+              fields:
+                action: DELETE
+                resource_type: "event_gateway_tls_trust_bundle"
+      - name: 002-sync-delete
+        outputFormat: json
+        run:
+          - sync
+          - --plan
+          - "{{ .workdir }}/plan-sync-delete.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+
+      - name: 003-verify-delete
+        run:
+          - get
+          - event-gateway
+          - tls-trust-bundles
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 0
+  - name: 004-root-level-declaration
+    inputOverlayDirs:
+      - overlays/003-root-level-declaration
+    commands:
+      - name: 001-plan-root-level
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-root-level.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_tls_trust_bundle' && resource_ref=='{{ .vars.trustBundleRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.trustBundleRef }}"
+      - name: 002-apply-create
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-root-level.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+
+      - name: 003-verify-create
+        run:
+          - get
+          - event-gateway
+          - tls-trust-bundles
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 1
+          - select: "[0]"
+            expect:
+              fields:
+                name: default-tls-trust-bundle-name
+                description: "Default root level TLS Trust Bundle description"
+  - name: 005-sync-delete-root-level
+    inputOverlayDirs:
+      - overlays/004-sync-delete-root-level-declaration
+    commands:
+      - name: 001-plan-sync-delete-root-level
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-sync-delete-root-level.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: sync
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_tls_trust_bundle'] | [0]
+            expect:
+              fields:
+                action: DELETE
+                resource_type: "event_gateway_tls_trust_bundle"
+      - name: 002-sync-delete-root-level
+        outputFormat: json
+        run:
+          - sync
+          - --plan
+          - "{{ .workdir }}/plan-sync-delete-root-level.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+
+      - name: 003-verify-delete-root-level
+        run:
+          - get
+          - event-gateway
+          - tls-trust-bundles
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 0

--- a/test/e2e/scenarios/event-gateway/tls-trust-bundle/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/tls-trust-bundle/testdata/config.yaml
@@ -1,0 +1,45 @@
+_defaults:
+  kongctl:
+    namespace: event-gateways-tls-trust-bundle-test
+
+event_gateways:
+  - ref: egw-cp-for-tls-trust-bundle-test-ref
+    name: egw-cp-for-tls-trust-bundle-test-name
+    description: "EGW CP for TLS Trust Bundle Test"
+    trust_bundles:
+      - ref: default-tls-trust-bundle-ref
+        name: default-tls-trust-bundle-name
+        description: "Default TLS Trust Bundle description"
+        config:
+          trusted_ca: |-
+            -----BEGIN CERTIFICATE-----
+            MIIFPjCCAyYCCQD2y9kVBp5f1jANBgkqhkiG9w0BAQsFADBhMQswCQYDVQQGEwJJ
+            TjELMAkGA1UECAwCS0ExDDAKBgNVBAcMA0JMUjEPMA0GA1UECgwGQVBJT1BzMRAw
+            DgYDVQQLDAdLT05HQ1RMMRQwEgYDVQQDDAtFMkVTQ0VOQVJJTzAeFw0yNjA0MTcw
+            NzQ0MTJaFw0zNjA0MTQwNzQ0MTJaMGExCzAJBgNVBAYTAklOMQswCQYDVQQIDAJL
+            QTEMMAoGA1UEBwwDQkxSMQ8wDQYDVQQKDAZBUElPUHMxEDAOBgNVBAsMB0tPTkdD
+            VEwxFDASBgNVBAMMC0UyRVNDRU5BUklPMIICIjANBgkqhkiG9w0BAQEFAAOCAg8A
+            MIICCgKCAgEA8Ej5Tqj4ulz9WH4CalU9fJQsnSpSf3CbZfL9uAHGc2zZCErYH18m
+            91XpWP0YNe/Htz8JM22K6HKqrW5z+93VwUrAiI88w9jECXVkw7r5QB3yxZ/QYJiD
+            290AVTzjLIcgM6hywXyiTOE6rZlvoqRGObk5Kv31gpV2UvJuY21YMvlnSTQ0VmQs
+            bBBvmdpebE7AMF/YFsx6/05L47wv3cmIJ+X3RO3YpZmlntl3vgxdM/RgXtIttBsC
+            U+ugm9OlcEwT1tb6H5mY02cy7hSyvibpUg+7PWz/kwVBLz5WUVBYurKbWq5wHTcf
+            cWfxFS7gyyBFPMVAZMnXLlq7HyicdGLBU1+WsJF1WwdS6e+cNSpWEt4STF78so+u
+            i5+CM5gz2HOKD3XuQmnYmu0GMIeSqP1Pu50OprBNhOI6Wsw0r6jo9dvGK+A/TqIf
+            Cf8ACulhRib+3qyTlSK9U5QfmRzw9stt2EjkqEuG9afJC3fqTNGgiY5J5/CPWU0n
+            MQU9SHsNMoOL8OAQ3u6xVrEAYruMfwJykxZLKm9Lhi+7FxPRk0B99Y4MNml215ou
+            cEMI27XCKGfq1RwtKyIYNnMjADNoN5sAMlTxaZra1mcnyZeMKE1nDwtpIP9DJmjH
+            I0eqA7kFB4Ndc276aovOe/5lEfqQYi+nGIcCaazwOhIqWekIHRE6n3sCAwEAATAN
+            BgkqhkiG9w0BAQsFAAOCAgEAhs2XcLqy78r4tGkGqEIWpjmjnkw7OQTn14uLVIjH
+            RjAhMyowefzHU35Icck3k60zOljNA96ChFiWj8H5w+DP4QKW23HZZ5c8htUPehNA
+            lkt6WH/s13jHW+08I5rRxCNHpnoB9Te5kg33Y059ZHgz4HliatOdmKJ3PbyBbkCg
+            X93aLDQ1Hpv0k9XsU7uczKwSLmd3VSFAxOT+mvGU6G4XwdCvqJHqn2pn7N0+ZmGA
+            /kbVOkAq5e4bYyC87yTLQiaTZLdb0jamL6sCPJnW5aEmPKgl7kILrVAKOIdihDxW
+            r/9vDrw2gUmnpW8DO+QxmNBIZ7soua/b5AOBeG9vpaVqH6sisoILLGPDL6Vh6Xg4
+            DONgc/2T1EDpeutwzxnUC85g28Vh9J6/o+inungVEfUFOAYwTuJYYmme3BuuIVSx
+            3K7LNims8ZHUbq3s0JOH4Pwef38WCozTa6Cufoh8BlUURbr0OBp7u4Wy7Pg3zCdu
+            AVbLk0nbLMRdm6bE5k+YGnuYIQwZ3UWJ3m44zYE2cgtsqm08NAjqQeAHh8hngtaM
+            pE/YOhO3S9xO1IbFbsqdPw8ajZmXOlhGBCX6LnDFsikTj+kG5lPTNr9ueLpcQ5eu
+            Jeo7mJ0RN29/eYI7ob59j8IIkTVSd8lJEpLoakPV4uyZPNgDx14MUB1Bz7qGU7gj
+            oxQ=
+            -----END CERTIFICATE-----

--- a/test/e2e/scenarios/event-gateway/tls-trust-bundle/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/tls-trust-bundle/testdata/config.yaml
@@ -6,7 +6,7 @@ event_gateways:
   - ref: egw-cp-for-tls-trust-bundle-test-ref
     name: egw-cp-for-tls-trust-bundle-test-name
     description: "EGW CP for TLS Trust Bundle Test"
-    trust_bundles:
+    tls_trust_bundles:
       - ref: default-tls-trust-bundle-ref
         name: default-tls-trust-bundle-name
         description: "Default TLS Trust Bundle description"


### PR DESCRIPTION
API reference: https://developer.konghq.com/api/konnect/event-gateway/v1/#/operations/list-event-gateway-tls-trust-bundles

## Summary
In this PR, we are adding support for
1. Declarative management of Event Gateway TLS Trust Bundles
2. Imperative GET for TLS Trust Bundles
3. Dump for TLS Trust Bundles
4. View for TLS Trust Bundles
Example for GET
```
./kongctl get egw tls-trust-bundles --gateway-id $EGW_ID
./kongctl get egw ttb --gateway-id $EGW_ID --tls-trust-bundle-id $TTBID
./kongctl get konnect egw ttb --gateway-name $EGW_NAME --tls-trust-bundle-name $TTBNAME
```

