### PR TITLE
Feat: Portal IdP resource support

### DIFF
--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -379,6 +379,22 @@ portals:
            groups: string
          idp_metadata_url: string # SAML
          idp_metadata_xml: string # SAML
+portal_identity_providers:
+ - ref: string
+   portal: string required # prefer: !ref <portal-ref>
+   type: One of (oidc | saml) required
+   enabled: boolean
+   config: object required
+     issuer_url: string # OIDC
+     client_id: string # OIDC
+     client_secret: string # OIDC
+     scopes: array[string] # OIDC
+     claim_mappings: # OIDC
+       name: string
+       email: string
+       groups: string
+     idp_metadata_url: string # SAML
+     idp_metadata_xml: string # SAML
    custom_domain: # https://developer.konghq.com/api/konnect/portal-management/v3/#/operations/create-portal-custom-domain
      ref: string
      hostname: string required

--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -357,14 +357,17 @@ portals:
      robots: string (nullable)
    auth_settings: # https://developer.konghq.com/api/konnect/portal-management/v3/#/operations/update-portal-authentication-settings
      ref: string
+     # OIDC and SAML provider-specific fields are no longer supported here.
+     # Move provider config to identity_providers or portal_identity_providers.
      basic_auth_enabled: boolean
      konnect_mapping_enabled: boolean
      idp_mapping_enabled: boolean
    identity_providers: # https://developer.konghq.com/api/konnect/portal-management/v3/#/operations/create-portal-identity-provider
      - ref: string
+       # Use this child for portal OIDC and SAML provider configuration.
+       # At the root of a config, use portal_identity_providers.
        type: One of (oidc | saml) required
        enabled: boolean
-       login_path: string
        config: object required
          issuer_url: string # OIDC
          client_id: string # OIDC

--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -358,19 +358,24 @@ portals:
    auth_settings: # https://developer.konghq.com/api/konnect/portal-management/v3/#/operations/update-portal-authentication-settings
      ref: string
      basic_auth_enabled: boolean
-     oidc_auth_enabled: boolean (deprecated)
-     saml_auth_enabled: boolean (deprecated)
-     oidc_team_mapping_enabled: boolean
      konnect_mapping_enabled: boolean
      idp_mapping_enabled: boolean
-     oidc_issuer: string (deprecated)
-     oidc_client_id: string (deprecated)
-     oidc_client_secret: string (deprecated)
-     oidc_scopes: array[string] (deprecated)
-     oidc_claim_mappings:
-       name: string (deprecated)
-       email: string (deprecated)
-       groups: string (deprecated)
+   identity_providers: # https://developer.konghq.com/api/konnect/portal-management/v3/#/operations/create-portal-identity-provider
+     - ref: string
+       type: One of (oidc | saml) required
+       enabled: boolean
+       login_path: string
+       config: object required
+         issuer_url: string # OIDC
+         client_id: string # OIDC
+         client_secret: string # OIDC
+         scopes: array[string] # OIDC
+         claim_mappings: # OIDC
+           name: string
+           email: string
+           groups: string
+         idp_metadata_url: string # SAML
+         idp_metadata_xml: string # SAML
    custom_domain: # https://developer.konghq.com/api/konnect/portal-management/v3/#/operations/create-portal-custom-domain
      ref: string
      hostname: string required

--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -557,6 +557,33 @@ A runnable example is available in
   while planning.
 - Human-readable plan and diff output redact `!env` values.
 
+### Write-only Secret Fields
+
+Some Konnect APIs accept secret values on create or update but do not return
+them from `get` or `list` responses. Common examples include:
+
+- Portal identity provider `config.client_secret`
+- DCR provider secrets such as `dcr_token`, `api_key`, and
+  `initial_client_secret`
+- Event Gateway schema registry authentication `password`
+
+For these fields, `kongctl` prefers idempotent planning over perpetual
+updates. When the API does not expose the current value, the planner skips
+that field during diff calculation instead of assuming drift on every run.
+
+This means:
+
+- The initial create or update still sends the configured secret value.
+- Re-applying the same declarative configuration will usually be a no-op
+  instead of planning an update forever.
+- Changing only a write-only secret may not be detectable from live state, so
+  `plan` may show no changes even though the configured secret value differs
+  from what is currently stored in Konnect.
+
+When you need to rotate a write-only secret declaratively, make the change
+alongside another observable field, or recreate the resource if the API does
+not provide a safe observable signal for that update.
+
 ### Path Resolution
 
 All file paths are resolved relative to the directory containing the

--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -265,6 +265,67 @@ api_publications:
     portal: main-portal
 ```
 
+### Portal Identity Provider Migration
+
+> Breaking change: portal OIDC and SAML configuration is no longer accepted
+> under `auth_settings` or `portal_auth_settings`.
+>
+> Move provider-specific fields to `identity_providers` when they are nested
+> under a portal, or to `portal_identity_providers` when they are declared at
+> the root of a configuration.
+>
+> `auth_settings` now only supports:
+> `basic_auth_enabled`, `konnect_mapping_enabled`, and
+> `idp_mapping_enabled`.
+
+Previous configuration:
+
+```yaml
+portals:
+  - ref: developer-portal
+    name: "developer-portal"
+    auth_settings:
+      ref: portal-auth
+      basic_auth_enabled: true
+      konnect_mapping_enabled: false
+      idp_mapping_enabled: true
+      oidc_auth_enabled: true
+      oidc_issuer: !env PORTAL_IDP_ISSUER_URL
+      oidc_client_id: !env PORTAL_IDP_CLIENT_ID
+      oidc_client_secret: !env PORTAL_IDP_CLIENT_SECRET
+      oidc_scopes:
+        - openid
+        - profile
+```
+
+Updated configuration:
+
+```yaml
+portals:
+  - ref: developer-portal
+    name: "developer-portal"
+    auth_settings:
+      ref: portal-auth
+      basic_auth_enabled: true
+      konnect_mapping_enabled: false
+      idp_mapping_enabled: true
+    identity_providers:
+      - ref: portal-oidc
+        type: oidc
+        enabled: true
+        config:
+          issuer_url: !env PORTAL_IDP_ISSUER_URL
+          client_id: !env PORTAL_IDP_CLIENT_ID
+          client_secret: !env PORTAL_IDP_CLIENT_SECRET
+          scopes:
+            - openid
+            - profile
+```
+
+If you keep the deprecated OIDC or SAML fields under `auth_settings`,
+`kongctl` will fail validation and tell you to move that configuration to
+`identity_providers`.
+
 ### Control Plane Groups
 
 Control planes can represent Konnect control plane groups by setting their cluster type to `"CLUSTER_TYPE_CONTROL_PLANE_GROUP"`. Group entries manage membership through the `members` array. Each member must resolve to the Konnect ID of a non-group control plane, so you can provide literal UUIDs or reference other declarative control planes with `!ref`.

--- a/docs/examples/declarative/portal-idp/README.md
+++ b/docs/examples/declarative/portal-idp/README.md
@@ -1,0 +1,58 @@
+# Portal Identity Provider Example
+
+This example shows how to configure a Developer Portal OIDC identity provider
+in declarative mode.
+
+The OIDC issuer URL, client ID, and client secret are loaded from environment
+variables with `!env` so they do not need to be stored in plaintext in the
+declarative configuration.
+
+Konnect validates the issuer URL against the IdP metadata endpoint. You must
+provide a real issuer URL for an OIDC provider you control or have access to.
+
+The configuration uses the `portal-idp-example` namespace so it stays isolated
+from other declarative resources in the same Konnect organization.
+
+## Files
+
+- `portal-idp.yaml` - creates a portal and configures a nested OIDC identity
+  provider. The `config.issuer_url`, `config.client_id`, and
+  `config.client_secret` fields use `!env`.
+
+## Usage
+
+Preview the change:
+
+```bash
+PORTAL_IDP_ISSUER_URL='https://your-idp.example.com/oauth2/default' \
+PORTAL_IDP_CLIENT_ID='your-client-id' \
+PORTAL_IDP_CLIENT_SECRET='your-client-secret' \
+kongctl diff -f portal-idp.yaml
+```
+
+Apply the configuration:
+
+```bash
+PORTAL_IDP_ISSUER_URL='https://your-idp.example.com/oauth2/default' \
+PORTAL_IDP_CLIENT_ID='your-client-id' \
+PORTAL_IDP_CLIENT_SECRET='your-client-secret' \
+kongctl apply -f portal-idp.yaml --auto-approve
+```
+
+Check the portal identity provider after apply:
+
+```bash
+kongctl get portal identity-providers --portal-name portal-idp-example -o yaml
+```
+
+Human-readable diff output redacts `!env` values by design. Use `get` after
+apply to confirm the resolved values.
+
+Delete the example when you are done:
+
+```bash
+PORTAL_IDP_ISSUER_URL='https://your-idp.example.com/oauth2/default' \
+PORTAL_IDP_CLIENT_ID='your-client-id' \
+PORTAL_IDP_CLIENT_SECRET='your-client-secret' \
+kongctl delete -f portal-idp.yaml --auto-approve
+```

--- a/docs/examples/declarative/portal-idp/README.md
+++ b/docs/examples/declarative/portal-idp/README.md
@@ -13,6 +13,25 @@ provide a real issuer URL for an OIDC provider you control or have access to.
 The configuration uses the `portal-idp-example` namespace so it stays isolated
 from other declarative resources in the same Konnect organization.
 
+## Migrating from `auth_settings`
+
+Older portal declarative configs could place OIDC or SAML fields under
+`portals[].auth_settings` or `portal_auth_settings`. That shape is no longer
+accepted.
+
+Use `auth_settings` only for the portal-level flags:
+
+- `basic_auth_enabled`
+- `konnect_mapping_enabled`
+- `idp_mapping_enabled`
+
+Move provider-specific values such as `oidc_issuer`, `oidc_client_id`,
+`oidc_client_secret`, `oidc_scopes`, `oidc_claim_mappings`, and the SAML
+equivalents to `identity_providers` or `portal_identity_providers`.
+
+If you apply an old configuration, `kongctl` now fails validation and tells
+you to move that configuration to `identity_providers`.
+
 ## Files
 
 - `portal-idp.yaml` - creates a portal and configures a nested OIDC identity

--- a/docs/examples/declarative/portal-idp/portal-idp.yaml
+++ b/docs/examples/declarative/portal-idp/portal-idp.yaml
@@ -1,0 +1,24 @@
+_defaults:
+  kongctl:
+    namespace: portal-idp-example
+
+portals:
+  - ref: portal-idp-example
+    name: portal-idp-example
+    display_name: Portal Identity Provider Example
+    description: Portal OIDC identity provider values loaded from !env
+    identity_providers:
+      - ref: portal-oidc
+        type: oidc
+        enabled: true
+        config:
+          issuer_url: !env PORTAL_IDP_ISSUER_URL
+          client_id: !env PORTAL_IDP_CLIENT_ID
+          client_secret: !env PORTAL_IDP_CLIENT_SECRET
+          scopes:
+            - openid
+            - profile
+          claim_mappings:
+            name: name
+            email: email
+            groups: groups

--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -2265,15 +2265,16 @@ func createStateClient(kkClient helpers.SDKAPI) *state.Client {
 		CatalogServiceAPI:     kkClient.GetCatalogServicesAPI(),
 
 		// Portal child resource APIs
-		PortalPageAPI:          kkClient.GetPortalPageAPI(),
-		PortalAuthSettingsAPI:  kkClient.GetPortalAuthSettingsAPI(),
-		PortalCustomizationAPI: kkClient.GetPortalCustomizationAPI(),
-		PortalCustomDomainAPI:  kkClient.GetPortalCustomDomainAPI(),
-		PortalSnippetAPI:       kkClient.GetPortalSnippetAPI(),
-		PortalTeamAPI:          kkClient.GetPortalTeamAPI(),
-		PortalTeamRolesAPI:     kkClient.GetPortalTeamRolesAPI(),
-		PortalEmailsAPI:        kkClient.GetPortalEmailsAPI(),
-		AssetsAPI:              kkClient.GetAssetsAPI(),
+		PortalPageAPI:             kkClient.GetPortalPageAPI(),
+		PortalAuthSettingsAPI:     kkClient.GetPortalAuthSettingsAPI(),
+		PortalIdentityProviderAPI: kkClient.GetPortalIdentityProviderAPI(),
+		PortalCustomizationAPI:    kkClient.GetPortalCustomizationAPI(),
+		PortalCustomDomainAPI:     kkClient.GetPortalCustomDomainAPI(),
+		PortalSnippetAPI:          kkClient.GetPortalSnippetAPI(),
+		PortalTeamAPI:             kkClient.GetPortalTeamAPI(),
+		PortalTeamRolesAPI:        kkClient.GetPortalTeamRolesAPI(),
+		PortalEmailsAPI:           kkClient.GetPortalEmailsAPI(),
+		AssetsAPI:                 kkClient.GetAssetsAPI(),
 
 		// API child resource APIs
 		APIVersionAPI:        kkClient.GetAPIVersionAPI(),

--- a/internal/cmd/root/products/konnect/portal/auth_settings.go
+++ b/internal/cmd/root/products/konnect/portal/auth_settings.go
@@ -165,9 +165,9 @@ func portalAuthSettingsDetailView(settings *kkComps.PortalAuthenticationSettings
 	}
 
 	var b strings.Builder
-	fmt.Fprintf(&b, "Basic Auth Enabled: %t\n", settings.BasicAuthEnabled)
-	fmt.Fprintf(&b, "IdP Mapping Enabled: %v\n", valueOrNA(settings.IdpMappingEnabled))
-	fmt.Fprintf(&b, "Konnect Mapping Enabled: %t\n", settings.KonnectMappingEnabled)
+	fmt.Fprintf(&b, "basic_auth_enabled: %t\n", settings.BasicAuthEnabled)
+	fmt.Fprintf(&b, "idp_mapping_enabled: %v\n", valueOrNA(settings.IdpMappingEnabled))
+	fmt.Fprintf(&b, "konnect_mapping_enabled: %t\n", settings.KonnectMappingEnabled)
 
 	return strings.TrimRight(b.String(), "\n")
 }

--- a/internal/cmd/root/products/konnect/portal/auth_settings.go
+++ b/internal/cmd/root/products/konnect/portal/auth_settings.go
@@ -8,7 +8,6 @@ import (
 	"github.com/kong/kongctl/internal/cmd"
 	"github.com/kong/kongctl/internal/cmd/output/tableview"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
-	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/meta"
 	"github.com/kong/kongctl/internal/util/i18n"
 	"github.com/kong/kongctl/internal/util/normalizers"
@@ -135,9 +134,6 @@ func runGetPortalAuthSettings(c *cobra.Command, args []string) error {
 	}
 
 	settings := res.PortalAuthenticationSettingsResponse
-	if err := helpers.HydratePortalAuthSettingsOIDCConfig(settings, res.RawResponse); err != nil && logger != nil {
-		logger.Debug("failed to hydrate portal auth settings OIDC config from raw response", "error", err)
-	}
 
 	return tableview.RenderForFormat(helper,
 		false,
@@ -152,30 +148,14 @@ func runGetPortalAuthSettings(c *cobra.Command, args []string) error {
 }
 
 func portalAuthSettingsToRecord(settings *kkComps.PortalAuthenticationSettingsResponse) any {
-	oidcConfig := settings.GetOidcConfig()
-
 	return struct {
-		BasicAuthEnabled       string `json:"basic_auth_enabled"`
-		OidcAuthEnabled        string `json:"oidc_auth_enabled"`
-		SamlAuthEnabled        string `json:"saml_auth_enabled"`
-		OidcTeamMappingEnabled string `json:"oidc_team_mapping_enabled"`
-		IdpMappingEnabled      string `json:"idp_mapping_enabled"`
-		KonnectMappingEnabled  string `json:"konnect_mapping_enabled"`
-		OidcIssuer             string `json:"oidc_config.issuer"`
-		OidcClientID           string `json:"oidc_config.client_id"`
-		OidcScopes             string `json:"oidc_config.scopes"`
-		OidcClaimMappings      string `json:"oidc_config.claim_mappings"`
+		BasicAuthEnabled      string `json:"basic_auth_enabled"`
+		IdpMappingEnabled     string `json:"idp_mapping_enabled"`
+		KonnectMappingEnabled string `json:"konnect_mapping_enabled"`
 	}{
-		BasicAuthEnabled:       fmt.Sprintf("%v", settings.BasicAuthEnabled),
-		OidcAuthEnabled:        fmt.Sprintf("%v", settings.OidcAuthEnabled),
-		SamlAuthEnabled:        fmt.Sprintf("%v", valueOrNA(settings.SamlAuthEnabled)),
-		OidcTeamMappingEnabled: fmt.Sprintf("%v", settings.OidcTeamMappingEnabled),
-		IdpMappingEnabled:      fmt.Sprintf("%v", valueOrNA(settings.IdpMappingEnabled)),
-		KonnectMappingEnabled:  fmt.Sprintf("%v", settings.KonnectMappingEnabled),
-		OidcIssuer:             fmt.Sprintf("%v", valueOrNAString(oidcConfig.GetIssuer())),
-		OidcClientID:           fmt.Sprintf("%v", valueOrNAString(oidcConfig.GetClientID())),
-		OidcScopes:             fmt.Sprintf("%v", sliceOrNA(oidcConfig.GetScopes())),
-		OidcClaimMappings:      fmt.Sprintf("%v", valueOrNA(oidcConfig.GetClaimMappings())),
+		BasicAuthEnabled:      fmt.Sprintf("%v", settings.BasicAuthEnabled),
+		IdpMappingEnabled:     fmt.Sprintf("%v", valueOrNA(settings.IdpMappingEnabled)),
+		KonnectMappingEnabled: fmt.Sprintf("%v", settings.KonnectMappingEnabled),
 	}
 }
 
@@ -191,18 +171,4 @@ func valueOrNA(value any) any {
 	default:
 		return v
 	}
-}
-
-func valueOrNAString(value string) any {
-	if strings.TrimSpace(value) == "" {
-		return valueNA
-	}
-	return value
-}
-
-func sliceOrNA(values []string) any {
-	if len(values) == 0 {
-		return valueNA
-	}
-	return strings.Join(values, ",")
 }

--- a/internal/cmd/root/products/konnect/portal/auth_settings.go
+++ b/internal/cmd/root/products/konnect/portal/auth_settings.go
@@ -159,6 +159,27 @@ func portalAuthSettingsToRecord(settings *kkComps.PortalAuthenticationSettingsRe
 	}
 }
 
+func portalAuthSettingsDetailView(settings *kkComps.PortalAuthenticationSettingsResponse) string {
+	if settings == nil {
+		return ""
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Basic Auth Enabled: %t\n", settings.BasicAuthEnabled)
+	fmt.Fprintf(&b, "IdP Mapping Enabled: %v\n", valueOrNA(settings.IdpMappingEnabled))
+	fmt.Fprintf(&b, "Konnect Mapping Enabled: %t\n", settings.KonnectMappingEnabled)
+
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func buildPortalAuthSettingsChildView(settings *kkComps.PortalAuthenticationSettingsResponse) tableview.ChildView {
+	return tableview.ChildView{
+		Title:          "Authentication Settings",
+		Mode:           tableview.ChildViewModeDetail,
+		DetailRenderer: func(int) string { return portalAuthSettingsDetailView(settings) },
+	}
+}
+
 func valueOrNA(value any) any {
 	switch v := value.(type) {
 	case *bool:

--- a/internal/cmd/root/products/konnect/portal/auth_settings_test.go
+++ b/internal/cmd/root/products/konnect/portal/auth_settings_test.go
@@ -25,9 +25,9 @@ func TestPortalAuthSettingsDetailView_ExcludesDeprecatedFields(t *testing.T) {
 
 	detail := portalAuthSettingsDetailView(settings)
 
-	require.Contains(t, detail, "Basic Auth Enabled: true")
-	require.Contains(t, detail, "IdP Mapping Enabled: true")
-	require.Contains(t, detail, "Konnect Mapping Enabled: false")
+	require.Contains(t, detail, "basic_auth_enabled: true")
+	require.Contains(t, detail, "idp_mapping_enabled: true")
+	require.Contains(t, detail, "konnect_mapping_enabled: false")
 	require.NotContains(t, strings.ToLower(detail), "oidc")
 	require.NotContains(t, strings.ToLower(detail), "saml")
 }
@@ -43,5 +43,5 @@ func TestBuildPortalAuthSettingsChildView_UsesDetailMode(t *testing.T) {
 	require.Equal(t, tableview.ChildViewModeDetail, view.Mode)
 	require.Equal(t, "Authentication Settings", view.Title)
 	require.NotNil(t, view.DetailRenderer)
-	require.Contains(t, view.DetailRenderer(0), "Basic Auth Enabled: true")
+	require.Contains(t, view.DetailRenderer(0), "basic_auth_enabled: true")
 }

--- a/internal/cmd/root/products/konnect/portal/auth_settings_test.go
+++ b/internal/cmd/root/products/konnect/portal/auth_settings_test.go
@@ -1,0 +1,47 @@
+package portal
+
+import (
+	"strings"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kongctl/internal/cmd/output/tableview"
+)
+
+func TestPortalAuthSettingsDetailView_ExcludesDeprecatedFields(t *testing.T) {
+	idpMappingEnabled := true
+	samlAuthEnabled := true
+
+	settings := &kkComps.PortalAuthenticationSettingsResponse{
+		BasicAuthEnabled:       true,
+		IdpMappingEnabled:      &idpMappingEnabled,
+		KonnectMappingEnabled:  false,
+		OidcAuthEnabled:        true,
+		SamlAuthEnabled:        &samlAuthEnabled,
+		OidcTeamMappingEnabled: true,
+	}
+
+	detail := portalAuthSettingsDetailView(settings)
+
+	require.Contains(t, detail, "Basic Auth Enabled: true")
+	require.Contains(t, detail, "IdP Mapping Enabled: true")
+	require.Contains(t, detail, "Konnect Mapping Enabled: false")
+	require.NotContains(t, strings.ToLower(detail), "oidc")
+	require.NotContains(t, strings.ToLower(detail), "saml")
+}
+
+func TestBuildPortalAuthSettingsChildView_UsesDetailMode(t *testing.T) {
+	settings := &kkComps.PortalAuthenticationSettingsResponse{
+		BasicAuthEnabled:      true,
+		KonnectMappingEnabled: true,
+	}
+
+	view := buildPortalAuthSettingsChildView(settings)
+
+	require.Equal(t, tableview.ChildViewModeDetail, view.Mode)
+	require.Equal(t, "Authentication Settings", view.Title)
+	require.NotNil(t, view.DetailRenderer)
+	require.Contains(t, view.DetailRenderer(0), "Basic Auth Enabled: true")
+}

--- a/internal/cmd/root/products/konnect/portal/getPortal.go
+++ b/internal/cmd/root/products/konnect/portal/getPortal.go
@@ -584,6 +584,14 @@ func newGetPortalCmd(verb verbs.VerbValue,
 		rv.AddCommand(authSettingsCmd)
 	}
 
+	if identityProvidersCmd := newGetPortalIdentityProvidersCmd(
+		verb,
+		addParentFlags,
+		parentPreRun,
+	); identityProvidersCmd != nil {
+		rv.AddCommand(identityProvidersCmd)
+	}
+
 	if assetsCmd := newGetPortalAssetsCmd(verb, addParentFlags, parentPreRun); assetsCmd != nil {
 		rv.AddCommand(assetsCmd)
 	}

--- a/internal/cmd/root/products/konnect/portal/identity_providers.go
+++ b/internal/cmd/root/products/konnect/portal/identity_providers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"charm.land/bubbles/v2/table"
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
 	"github.com/kong/kongctl/internal/cmd"
@@ -25,7 +26,6 @@ type portalIdentityProviderRecord struct {
 	ID        string `json:"id"`
 	Type      string `json:"type"`
 	Enabled   string `json:"enabled"`
-	LoginPath string `json:"login_path"`
 	CreatedAt string `json:"created_at"`
 	UpdatedAt string `json:"updated_at"`
 }
@@ -168,22 +168,64 @@ func runGetPortalIdentityProviders(c *cobra.Command, args []string) error {
 }
 
 func portalIdentityProviderToRecord(provider kkComps.IdentityProvider) portalIdentityProviderRecord {
-	enabled := valueNA
-	if provider.Enabled != nil {
-		enabled = fmt.Sprintf("%v", *provider.Enabled)
-	}
-
-	providerType := valueNA
-	if provider.Type != nil {
-		providerType = string(*provider.Type)
-	}
-
 	return portalIdentityProviderRecord{
 		ID:        optionalPtr(provider.GetID()),
-		Type:      providerType,
-		Enabled:   enabled,
-		LoginPath: optionalPtr(provider.GetLoginPath()),
+		Type:      portalIdentityProviderType(provider),
+		Enabled:   portalIdentityProviderEnabled(provider),
 		CreatedAt: formatTimePtr(provider.GetCreatedAt()),
 		UpdatedAt: formatTimePtr(provider.GetUpdatedAt()),
+	}
+}
+
+func portalIdentityProviderType(provider kkComps.IdentityProvider) string {
+	if provider.Type == nil {
+		return valueNA
+	}
+	return string(*provider.Type)
+}
+
+func portalIdentityProviderEnabled(provider kkComps.IdentityProvider) string {
+	if provider.Enabled == nil {
+		return valueNA
+	}
+	return fmt.Sprintf("%v", *provider.Enabled)
+}
+
+func portalIdentityProviderDetailView(provider kkComps.IdentityProvider) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "ID: %s\n", optionalPtr(provider.GetID()))
+	fmt.Fprintf(&b, "Type: %s\n", portalIdentityProviderType(provider))
+	fmt.Fprintf(&b, "Enabled: %s\n", portalIdentityProviderEnabled(provider))
+	fmt.Fprintf(&b, "Created At: %s\n", formatTimePtr(provider.GetCreatedAt()))
+	fmt.Fprintf(&b, "Updated At: %s\n", formatTimePtr(provider.GetUpdatedAt()))
+	fmt.Fprintf(&b, "Config:\n")
+
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func buildPortalIdentityProvidersChildView(providers []kkComps.IdentityProvider) tableview.ChildView {
+	rows := make([]table.Row, 0, len(providers))
+	for _, provider := range providers {
+		record := portalIdentityProviderToRecord(provider)
+		rows = append(rows, table.Row{record.ID, record.Type, record.Enabled})
+	}
+
+	return tableview.ChildView{
+		Headers: []string{"ID", "TYPE", "ENABLED"},
+		Rows:    rows,
+		Title:   "Identity Providers",
+		DetailRenderer: func(index int) string {
+			if index < 0 || index >= len(providers) {
+				return ""
+			}
+			return portalIdentityProviderDetailView(providers[index])
+		},
+		ParentType: "portal-identity-provider",
+		DetailContext: func(index int) any {
+			if index < 0 || index >= len(providers) {
+				return nil
+			}
+			return providers[index]
+		},
 	}
 }

--- a/internal/cmd/root/products/konnect/portal/identity_providers.go
+++ b/internal/cmd/root/products/konnect/portal/identity_providers.go
@@ -198,9 +198,60 @@ func portalIdentityProviderDetailView(provider kkComps.IdentityProvider) string 
 	fmt.Fprintf(&b, "enabled: %s\n", portalIdentityProviderEnabled(provider))
 	fmt.Fprintf(&b, "created_at: %s\n", formatTimePtr(provider.GetCreatedAt()))
 	fmt.Fprintf(&b, "updated_at: %s\n", formatTimePtr(provider.GetUpdatedAt()))
-	fmt.Fprintf(&b, "config:\n")
+	appendPortalIdentityProviderConfigDetail(&b, provider.GetConfig())
 
 	return strings.TrimRight(b.String(), "\n")
+}
+
+func appendPortalIdentityProviderConfigDetail(b *strings.Builder, config *kkComps.IdentityProviderConfig) {
+	if b == nil || config == nil {
+		return
+	}
+
+	switch config.Type {
+	case kkComps.IdentityProviderConfigTypeOIDCIdentityProviderConfigOutput:
+		if config.OIDCIdentityProviderConfigOutput == nil {
+			return
+		}
+		fmt.Fprintf(b, "config.type: oidc\n")
+		fmt.Fprintf(b, "config.issuer_url: %s\n", config.OIDCIdentityProviderConfigOutput.IssuerURL)
+		fmt.Fprintf(b, "config.client_id: %s\n", config.OIDCIdentityProviderConfigOutput.ClientID)
+		if len(config.OIDCIdentityProviderConfigOutput.Scopes) > 0 {
+			fmt.Fprintf(b, "config.scopes: %s\n", strings.Join(config.OIDCIdentityProviderConfigOutput.Scopes, ", "))
+		}
+		if config.OIDCIdentityProviderConfigOutput.ClaimMappings != nil {
+			fmt.Fprintf(
+				b,
+				"config.claim_mappings.name: %s\n",
+				optionalPtr(config.OIDCIdentityProviderConfigOutput.ClaimMappings.Name),
+			)
+			fmt.Fprintf(
+				b,
+				"config.claim_mappings.email: %s\n",
+				optionalPtr(config.OIDCIdentityProviderConfigOutput.ClaimMappings.Email),
+			)
+			fmt.Fprintf(
+				b,
+				"config.claim_mappings.groups: %s\n",
+				optionalPtr(config.OIDCIdentityProviderConfigOutput.ClaimMappings.Groups),
+			)
+		}
+	case kkComps.IdentityProviderConfigTypeSAMLIdentityProviderConfig:
+		if config.SAMLIdentityProviderConfig == nil {
+			return
+		}
+		fmt.Fprintf(b, "config.type: saml\n")
+		fmt.Fprintf(
+			b,
+			"config.idp_metadata_url: %s\n",
+			optionalPtr(config.SAMLIdentityProviderConfig.IdpMetadataURL),
+		)
+		fmt.Fprintf(
+			b,
+			"config.idp_metadata_xml: %s\n",
+			optionalPtr(config.SAMLIdentityProviderConfig.IdpMetadataXML),
+		)
+	}
 }
 
 func buildPortalIdentityProvidersChildView(providers []kkComps.IdentityProvider) tableview.ChildView {

--- a/internal/cmd/root/products/konnect/portal/identity_providers.go
+++ b/internal/cmd/root/products/konnect/portal/identity_providers.go
@@ -1,0 +1,189 @@
+package portal
+
+import (
+	"fmt"
+	"strings"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/cmd"
+	"github.com/kong/kongctl/internal/cmd/output/tableview"
+	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/kong/kongctl/internal/meta"
+	"github.com/kong/kongctl/internal/util/i18n"
+	"github.com/kong/kongctl/internal/util/normalizers"
+	"github.com/segmentio/cli"
+	"github.com/spf13/cobra"
+)
+
+const (
+	identityProvidersCommandName = "identity-providers"
+	identityProviderTypeFlagName = "type"
+)
+
+type portalIdentityProviderRecord struct {
+	ID        string `json:"id"`
+	Type      string `json:"type"`
+	Enabled   string `json:"enabled"`
+	LoginPath string `json:"login_path"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+var (
+	identityProvidersShort = i18n.T("root.products.konnect.portal.identityProvidersShort",
+		"List portal identity providers")
+	identityProvidersLong = normalizers.LongDesc(i18n.T("root.products.konnect.portal.identityProvidersLong",
+		`Use the identity-providers command to list identity providers for a Konnect portal.`))
+	identityProvidersExample = normalizers.Examples(
+		i18n.T("root.products.konnect.portal.identityProvidersExamples",
+			fmt.Sprintf(`
+# List identity providers for a portal by ID
+%[1]s get portal identity-providers --portal-id <portal-id>
+# Filter identity providers by type
+%[1]s get portal identity-providers --portal-name my-portal --type oidc
+`, meta.CLIName)))
+)
+
+func newGetPortalIdentityProvidersCmd(
+	verb verbs.VerbValue,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     identityProvidersCommandName,
+		Short:   identityProvidersShort,
+		Long:    identityProvidersLong,
+		Example: identityProvidersExample,
+		Aliases: []string{"identity-provider", "idps", "idp"},
+		PreRunE: func(c *cobra.Command, args []string) error {
+			if parentPreRun != nil {
+				if err := parentPreRun(c, args); err != nil {
+					return err
+				}
+			}
+			return bindPortalChildFlags(c, args)
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			return runGetPortalIdentityProviders(c, args)
+		},
+	}
+
+	addPortalChildFlags(cmd)
+	cmd.Flags().String(identityProviderTypeFlagName, "", "Filter identity providers by type")
+
+	if addParentFlags != nil {
+		addParentFlags(verb, cmd)
+	}
+
+	return cmd
+}
+
+func runGetPortalIdentityProviders(c *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("unexpected arguments: %s", strings.Join(args, ", "))
+	}
+
+	helper := cmd.BuildHelper(c, args)
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+	outType, err := helper.GetOutputFormat()
+	if err != nil {
+		return err
+	}
+
+	printer, err := cli.Format(outType.String(), helper.GetStreams().Out)
+	if err != nil {
+		return err
+	}
+	defer printer.Flush()
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return err
+	}
+
+	portalID, portalName := getPortalIdentifiers(cfg)
+	if portalID == "" && portalName == "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf("either --%s or --%s is required", portalIDFlagName, portalNameFlagName),
+		}
+	}
+	if portalID == "" {
+		portalID, err = resolvePortalIDByName(portalName, sdk.GetPortalAPI(), helper, cfg)
+		if err != nil {
+			return err
+		}
+	}
+
+	identityProviderAPI := sdk.GetPortalIdentityProviderAPI()
+	if identityProviderAPI == nil {
+		return &cmd.ExecutionError{
+			Msg: "Portal identity providers client is not available",
+			Err: fmt.Errorf("portal identity providers client not configured"),
+		}
+	}
+
+	var filter *kkOps.GetPortalIdentityProvidersQueryParamFilter
+	providerType, _ := c.Flags().GetString(identityProviderTypeFlagName)
+	providerType = strings.TrimSpace(providerType)
+	if providerType != "" {
+		filter = &kkOps.GetPortalIdentityProvidersQueryParamFilter{
+			Type: &kkComps.StringFieldEqualsFilter{Eq: &providerType},
+		}
+	}
+
+	resp, err := identityProviderAPI.ListPortalIdentityProviders(
+		helper.GetContext(),
+		kkOps.GetPortalIdentityProvidersRequest{PortalID: portalID, Filter: filter},
+	)
+	if err != nil {
+		attrs := cmd.TryConvertErrorToAttrs(err)
+		return cmd.PrepareExecutionError("Failed to get portal identity providers", err, helper.GetCmd(), attrs...)
+	}
+
+	providers := resp.IdentityProviders
+	records := make([]portalIdentityProviderRecord, 0, len(providers))
+	for _, provider := range providers {
+		records = append(records, portalIdentityProviderToRecord(provider))
+	}
+
+	return tableview.RenderForFormat(helper,
+		false,
+		outType,
+		printer,
+		helper.GetStreams(),
+		records,
+		providers,
+		"",
+		tableview.WithRootLabel(helper.GetCmd().Name()),
+	)
+}
+
+func portalIdentityProviderToRecord(provider kkComps.IdentityProvider) portalIdentityProviderRecord {
+	enabled := valueNA
+	if provider.Enabled != nil {
+		enabled = fmt.Sprintf("%v", *provider.Enabled)
+	}
+
+	providerType := valueNA
+	if provider.Type != nil {
+		providerType = string(*provider.Type)
+	}
+
+	return portalIdentityProviderRecord{
+		ID:        optionalPtr(provider.GetID()),
+		Type:      providerType,
+		Enabled:   enabled,
+		LoginPath: optionalPtr(provider.GetLoginPath()),
+		CreatedAt: formatTimePtr(provider.GetCreatedAt()),
+		UpdatedAt: formatTimePtr(provider.GetUpdatedAt()),
+	}
+}

--- a/internal/cmd/root/products/konnect/portal/identity_providers.go
+++ b/internal/cmd/root/products/konnect/portal/identity_providers.go
@@ -193,12 +193,12 @@ func portalIdentityProviderEnabled(provider kkComps.IdentityProvider) string {
 
 func portalIdentityProviderDetailView(provider kkComps.IdentityProvider) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "ID: %s\n", optionalPtr(provider.GetID()))
-	fmt.Fprintf(&b, "Type: %s\n", portalIdentityProviderType(provider))
-	fmt.Fprintf(&b, "Enabled: %s\n", portalIdentityProviderEnabled(provider))
-	fmt.Fprintf(&b, "Created At: %s\n", formatTimePtr(provider.GetCreatedAt()))
-	fmt.Fprintf(&b, "Updated At: %s\n", formatTimePtr(provider.GetUpdatedAt()))
-	fmt.Fprintf(&b, "Config:\n")
+	fmt.Fprintf(&b, "id: %s\n", optionalPtr(provider.GetID()))
+	fmt.Fprintf(&b, "type: %s\n", portalIdentityProviderType(provider))
+	fmt.Fprintf(&b, "enabled: %s\n", portalIdentityProviderEnabled(provider))
+	fmt.Fprintf(&b, "created_at: %s\n", formatTimePtr(provider.GetCreatedAt()))
+	fmt.Fprintf(&b, "updated_at: %s\n", formatTimePtr(provider.GetUpdatedAt()))
+	fmt.Fprintf(&b, "config:\n")
 
 	return strings.TrimRight(b.String(), "\n")
 }

--- a/internal/cmd/root/products/konnect/portal/identity_providers_test.go
+++ b/internal/cmd/root/products/konnect/portal/identity_providers_test.go
@@ -1,0 +1,61 @@
+package portal
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPortalIdentityProviderDetailView_OmitsLoginPath(t *testing.T) {
+	providerID := "11111111-1111-1111-1111-111111111111"
+	enabled := true
+	providerType := kkComps.IdentityProviderTypeOidc
+	now := time.Date(2026, time.April, 21, 12, 30, 0, 0, time.UTC)
+
+	provider := kkComps.IdentityProvider{
+		ID:      &providerID,
+		Type:    &providerType,
+		Enabled: &enabled,
+		Config: &kkComps.IdentityProviderConfig{
+			OIDCIdentityProviderConfigOutput: &kkComps.OIDCIdentityProviderConfigOutput{
+				IssuerURL: "https://issuer.example.test",
+				ClientID:  "client-id",
+			},
+			Type: kkComps.IdentityProviderConfigTypeOIDCIdentityProviderConfigOutput,
+		},
+		CreatedAt: &now,
+		UpdatedAt: &now,
+	}
+
+	detail := portalIdentityProviderDetailView(provider)
+
+	require.Contains(t, detail, "Type: oidc")
+	require.Contains(t, detail, "Enabled: true")
+	require.Contains(t, detail, "Config:")
+	require.NotContains(t, strings.ToLower(detail), "login path")
+}
+
+func TestBuildPortalIdentityProvidersChildView_UsesCompactCollectionColumns(t *testing.T) {
+	providerID := "11111111-1111-1111-1111-111111111111"
+	enabled := true
+	providerType := kkComps.IdentityProviderTypeOidc
+
+	view := buildPortalIdentityProvidersChildView([]kkComps.IdentityProvider{
+		{
+			ID:      &providerID,
+			Type:    &providerType,
+			Enabled: &enabled,
+		},
+	})
+
+	require.Equal(t, []string{"ID", "TYPE", "ENABLED"}, view.Headers)
+	require.Equal(t, "Identity Providers", view.Title)
+	require.Len(t, view.Rows, 1)
+	require.Equal(t, "oidc", view.Rows[0][1])
+	require.Equal(t, "true", view.Rows[0][2])
+	require.NotNil(t, view.DetailRenderer)
+	require.NotNil(t, view.DetailContext)
+}

--- a/internal/cmd/root/products/konnect/portal/identity_providers_test.go
+++ b/internal/cmd/root/products/konnect/portal/identity_providers_test.go
@@ -32,9 +32,9 @@ func TestPortalIdentityProviderDetailView_OmitsLoginPath(t *testing.T) {
 
 	detail := portalIdentityProviderDetailView(provider)
 
-	require.Contains(t, detail, "Type: oidc")
-	require.Contains(t, detail, "Enabled: true")
-	require.Contains(t, detail, "Config:")
+	require.Contains(t, detail, "type: oidc")
+	require.Contains(t, detail, "enabled: true")
+	require.Contains(t, detail, "config:")
 	require.NotContains(t, strings.ToLower(detail), "login path")
 }
 

--- a/internal/cmd/root/products/konnect/portal/identity_providers_test.go
+++ b/internal/cmd/root/products/konnect/portal/identity_providers_test.go
@@ -34,7 +34,9 @@ func TestPortalIdentityProviderDetailView_OmitsLoginPath(t *testing.T) {
 
 	require.Contains(t, detail, "type: oidc")
 	require.Contains(t, detail, "enabled: true")
-	require.Contains(t, detail, "config:")
+	require.Contains(t, detail, "config.type: oidc")
+	require.Contains(t, detail, "config.issuer_url: https://issuer.example.test")
+	require.Contains(t, detail, "config.client_id: client-id")
 	require.NotContains(t, strings.ToLower(detail), "login path")
 }
 

--- a/internal/cmd/root/products/konnect/portal/interactive_children.go
+++ b/internal/cmd/root/products/konnect/portal/interactive_children.go
@@ -7,12 +7,15 @@ import (
 
 	"charm.land/bubbles/v2/table"
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
 
 	"github.com/kong/kongctl/internal/cmd"
 	"github.com/kong/kongctl/internal/cmd/output/tableview"
 )
 
 func init() {
+	tableview.RegisterChildLoader("portal", "auth-settings", loadPortalAuthSettings)
+	tableview.RegisterChildLoader("portal", "identity-providers", loadPortalIdentityProviders)
 	tableview.RegisterChildLoader("portal", "pages", loadPortalPages)
 	tableview.RegisterChildLoader("portal", "snippets", loadPortalSnippets)
 	tableview.RegisterChildLoader("portal", "applications", loadPortalApplications)
@@ -24,6 +27,80 @@ func init() {
 	tableview.RegisterChildLoader("portal-team", "team-roles", loadPortalTeamRolesForTeam)
 	tableview.RegisterChildLoader("portal-page", "content", loadPortalPageContent)
 	tableview.RegisterChildLoader("portal-snippet", "content", loadPortalSnippetContent)
+}
+
+func loadPortalAuthSettings(_ context.Context, helper cmd.Helper, parent any) (tableview.ChildView, error) {
+	portalID, err := portalIDFromParent(parent)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	authAPI := sdk.GetPortalAuthSettingsAPI()
+	if authAPI == nil {
+		return tableview.ChildView{}, fmt.Errorf("portal auth settings client is not available")
+	}
+
+	res, err := authAPI.GetPortalAuthenticationSettings(helper.GetContext(), portalID)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+	if res == nil || res.PortalAuthenticationSettingsResponse == nil {
+		return tableview.ChildView{}, fmt.Errorf("empty portal auth settings response")
+	}
+
+	return buildPortalAuthSettingsChildView(res.PortalAuthenticationSettingsResponse), nil
+}
+
+func loadPortalIdentityProviders(_ context.Context, helper cmd.Helper, parent any) (tableview.ChildView, error) {
+	portalID, err := portalIDFromParent(parent)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	identityProviderAPI := sdk.GetPortalIdentityProviderAPI()
+	if identityProviderAPI == nil {
+		return tableview.ChildView{}, fmt.Errorf("portal identity providers client is not available")
+	}
+
+	resp, err := identityProviderAPI.ListPortalIdentityProviders(
+		helper.GetContext(),
+		kkOps.GetPortalIdentityProvidersRequest{PortalID: portalID},
+	)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	return buildPortalIdentityProvidersChildView(resp.IdentityProviders), nil
 }
 
 func loadPortalPages(_ context.Context, helper cmd.Helper, parent any) (tableview.ChildView, error) {

--- a/internal/cmd/root/verbs/dump/declarative.go
+++ b/internal/cmd/root/verbs/dump/declarative.go
@@ -177,6 +177,7 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 			CatalogServiceAPI:                   sdk.GetCatalogServicesAPI(),
 			PortalPageAPI:                       sdk.GetPortalPageAPI(),
 			PortalAuthSettingsAPI:               sdk.GetPortalAuthSettingsAPI(),
+			PortalIdentityProviderAPI:           sdk.GetPortalIdentityProviderAPI(),
 			PortalCustomizationAPI:              sdk.GetPortalCustomizationAPI(),
 			PortalCustomDomainAPI:               sdk.GetPortalCustomDomainAPI(),
 			PortalSnippetAPI:                    sdk.GetPortalSnippetAPI(),

--- a/internal/cmd/root/verbs/dump/declarative_children.go
+++ b/internal/cmd/root/verbs/dump/declarative_children.go
@@ -52,6 +52,12 @@ func populatePortalChildren(
 			portal.Teams = teams
 		}
 
+		if identityProviders, err := buildPortalIdentityProviders(ctx, client, portalID); err != nil {
+			logWarn(logger, "failed to load portal identity providers", portalID, portal.Name, err)
+		} else if len(identityProviders) > 0 {
+			portal.IdentityProviders = identityProviders
+		}
+
 		if authSettings, err := buildPortalAuthSettings(ctx, client, portalID); err != nil {
 			logWarn(logger, "failed to load portal auth settings", portalID, portal.Name, err)
 		} else if authSettings != nil {
@@ -671,35 +677,70 @@ func buildPortalAuthSettings(
 	resource := declresources.PortalAuthSettingsResource{
 		Ref: ref,
 		PortalAuthenticationSettingsUpdateRequest: kkComps.PortalAuthenticationSettingsUpdateRequest{
-			BasicAuthEnabled:       new(settings.BasicAuthEnabled),
-			OidcAuthEnabled:        new(settings.OidcAuthEnabled),
-			SamlAuthEnabled:        settings.SamlAuthEnabled,
-			OidcTeamMappingEnabled: new(settings.OidcTeamMappingEnabled),
-			KonnectMappingEnabled:  new(settings.KonnectMappingEnabled),
-			IdpMappingEnabled:      settings.IdpMappingEnabled,
+			BasicAuthEnabled:      new(settings.BasicAuthEnabled),
+			KonnectMappingEnabled: new(settings.KonnectMappingEnabled),
+			IdpMappingEnabled:     settings.IdpMappingEnabled,
 		},
 	}
 
-	if settings.OidcConfig != nil {
-		if strings.TrimSpace(settings.OidcConfig.Issuer) != "" {
-			resource.OidcIssuer = stringPointer(settings.OidcConfig.Issuer)
+	return &resource, nil
+}
+
+func buildPortalIdentityProviders(
+	ctx context.Context,
+	client *declstate.Client,
+	portalID string,
+) ([]declresources.PortalIdentityProviderResource, error) {
+	providers, err := client.ListPortalIdentityProviders(ctx, portalID)
+	if err != nil {
+		if isNotFound(err) {
+			return nil, nil
 		}
-		if strings.TrimSpace(settings.OidcConfig.ClientID) != "" {
-			resource.OidcClientID = stringPointer(settings.OidcConfig.ClientID)
-		}
-		if len(settings.OidcConfig.Scopes) > 0 {
-			resource.OidcScopes = settings.OidcConfig.Scopes
-		}
-		if settings.OidcConfig.ClaimMappings != nil {
-			resource.OidcClaimMappings = &kkComps.PortalAuthenticationSettingsUpdateRequestPortalClaimMappings{
-				Name:   settings.OidcConfig.ClaimMappings.Name,
-				Email:  settings.OidcConfig.ClaimMappings.Email,
-				Groups: settings.OidcConfig.ClaimMappings.Groups,
-			}
-		}
+		return nil, err
 	}
 
-	return &resource, nil
+	results := make([]declresources.PortalIdentityProviderResource, 0, len(providers))
+	for _, provider := range providers {
+		providerRes := declresources.PortalIdentityProviderResource{
+			Ref: buildChildRef("portal-identity-provider", provider.ID),
+			CreateIdentityProvider: kkComps.CreateIdentityProvider{
+				Type:      provider.Type.ToPointer(),
+				Enabled:   provider.Enabled,
+				LoginPath: provider.LoginPath,
+			},
+		}
+
+		if provider.Config != nil {
+			switch provider.Config.Type {
+			case kkComps.IdentityProviderConfigTypeOIDCIdentityProviderConfigOutput:
+				if provider.Config.OIDCIdentityProviderConfigOutput != nil {
+					config := kkComps.CreateCreateIdentityProviderConfigOIDCIdentityProviderConfig(
+						kkComps.OIDCIdentityProviderConfig{
+							IssuerURL:     provider.Config.OIDCIdentityProviderConfigOutput.IssuerURL,
+							ClientID:      provider.Config.OIDCIdentityProviderConfigOutput.ClientID,
+							Scopes:        provider.Config.OIDCIdentityProviderConfigOutput.Scopes,
+							ClaimMappings: provider.Config.OIDCIdentityProviderConfigOutput.ClaimMappings,
+						},
+					)
+					providerRes.Config = &config
+				}
+			case kkComps.IdentityProviderConfigTypeSAMLIdentityProviderConfig:
+				if provider.Config.SAMLIdentityProviderConfig != nil {
+					config := kkComps.CreateCreateIdentityProviderConfigSAMLIdentityProviderConfigInput(
+						kkComps.SAMLIdentityProviderConfigInput{
+							IdpMetadataURL: provider.Config.SAMLIdentityProviderConfig.IdpMetadataURL,
+							IdpMetadataXML: provider.Config.SAMLIdentityProviderConfig.IdpMetadataXML,
+						},
+					)
+					providerRes.Config = &config
+				}
+			}
+		}
+
+		results = append(results, providerRes)
+	}
+
+	return results, nil
 }
 
 func buildPortalCustomization(
@@ -1612,7 +1653,10 @@ func convertConsumePolicyToResource(
 
 	data, err := json.Marshal(policyMap)
 	if err != nil {
-		return declresources.EventGatewayConsumePolicyResource{}, fmt.Errorf("failed to marshal consume policy: %w", err)
+		return declresources.EventGatewayConsumePolicyResource{}, fmt.Errorf(
+			"failed to marshal consume policy: %w",
+			err,
+		)
 	}
 
 	var createPolicy kkComps.EventGatewayConsumePolicyCreate

--- a/internal/cmd/root/verbs/dump/declarative_children_test.go
+++ b/internal/cmd/root/verbs/dump/declarative_children_test.go
@@ -1,6 +1,14 @@
 package dump
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	declstate "github.com/kong/kongctl/internal/declarative/state"
+	"github.com/stretchr/testify/require"
+)
 
 func TestNormalizePortalPageSlug(t *testing.T) {
 	tests := []struct {
@@ -108,4 +116,199 @@ func TestResolveAPIPublicationRef(t *testing.T) {
 			t.Fatalf("expected error, got nil")
 		}
 	})
+}
+
+type stubDumpPortalAuthSettingsAPI struct {
+	getResponse *kkOps.GetPortalAuthenticationSettingsResponse
+	getErr      error
+}
+
+func (s *stubDumpPortalAuthSettingsAPI) UpdatePortalAuthenticationSettings(
+	context.Context,
+	string,
+	*kkComps.PortalAuthenticationSettingsUpdateRequest,
+	...kkOps.Option,
+) (*kkOps.UpdatePortalAuthenticationSettingsResponse, error) {
+	return nil, nil
+}
+
+func (s *stubDumpPortalAuthSettingsAPI) GetPortalAuthenticationSettings(
+	_ context.Context,
+	_ string,
+	_ ...kkOps.Option,
+) (*kkOps.GetPortalAuthenticationSettingsResponse, error) {
+	if s.getResponse != nil || s.getErr != nil {
+		return s.getResponse, s.getErr
+	}
+	return &kkOps.GetPortalAuthenticationSettingsResponse{
+		PortalAuthenticationSettingsResponse: &kkComps.PortalAuthenticationSettingsResponse{},
+	}, nil
+}
+
+type stubDumpPortalIdentityProviderAPI struct {
+	listResponse *kkOps.GetPortalIdentityProvidersResponse
+	listErr      error
+}
+
+func (s *stubDumpPortalIdentityProviderAPI) ListPortalIdentityProviders(
+	_ context.Context,
+	_ kkOps.GetPortalIdentityProvidersRequest,
+	_ ...kkOps.Option,
+) (*kkOps.GetPortalIdentityProvidersResponse, error) {
+	if s.listResponse != nil || s.listErr != nil {
+		return s.listResponse, s.listErr
+	}
+	return &kkOps.GetPortalIdentityProvidersResponse{}, nil
+}
+
+func (s *stubDumpPortalIdentityProviderAPI) GetPortalIdentityProvider(
+	context.Context,
+	string,
+	string,
+	...kkOps.Option,
+) (*kkOps.GetPortalIdentityProviderResponse, error) {
+	return nil, nil
+}
+
+func (s *stubDumpPortalIdentityProviderAPI) CreatePortalIdentityProvider(
+	context.Context,
+	string,
+	kkComps.CreateIdentityProvider,
+	...kkOps.Option,
+) (*kkOps.CreatePortalIdentityProviderResponse, error) {
+	return nil, nil
+}
+
+func (s *stubDumpPortalIdentityProviderAPI) UpdatePortalIdentityProvider(
+	context.Context,
+	kkOps.UpdatePortalIdentityProviderRequest,
+	...kkOps.Option,
+) (*kkOps.UpdatePortalIdentityProviderResponse, error) {
+	return nil, nil
+}
+
+func (s *stubDumpPortalIdentityProviderAPI) DeletePortalIdentityProvider(
+	context.Context,
+	string,
+	string,
+	...kkOps.Option,
+) (*kkOps.DeletePortalIdentityProviderResponse, error) {
+	return nil, nil
+}
+
+func TestBuildPortalAuthSettings_IncludesOnlySupportedFields(t *testing.T) {
+	t.Parallel()
+
+	client := declstate.NewClient(declstate.ClientConfig{
+		PortalAuthSettingsAPI: &stubDumpPortalAuthSettingsAPI{
+			getResponse: &kkOps.GetPortalAuthenticationSettingsResponse{
+				PortalAuthenticationSettingsResponse: &kkComps.PortalAuthenticationSettingsResponse{
+					BasicAuthEnabled:       true,
+					KonnectMappingEnabled:  true,
+					IdpMappingEnabled:      boolPtr(false),
+					OidcAuthEnabled:        true,
+					SamlAuthEnabled:        boolPtr(true),
+					OidcTeamMappingEnabled: true,
+				},
+			},
+		},
+	})
+
+	resource, err := buildPortalAuthSettings(context.Background(), client, "portal-1")
+	require.NoError(t, err)
+	require.NotNil(t, resource)
+	require.NotEmpty(t, resource.Ref)
+	require.NotNil(t, resource.BasicAuthEnabled)
+	require.True(t, *resource.BasicAuthEnabled)
+	require.NotNil(t, resource.KonnectMappingEnabled)
+	require.True(t, *resource.KonnectMappingEnabled)
+	require.NotNil(t, resource.IdpMappingEnabled)
+	require.False(t, *resource.IdpMappingEnabled)
+	require.Nil(t, resource.OidcAuthEnabled)
+	require.Nil(t, resource.SamlAuthEnabled)
+	require.Nil(t, resource.OidcTeamMappingEnabled)
+	require.Nil(t, resource.OidcIssuer)
+	require.Nil(t, resource.OidcClientID)
+	require.Nil(t, resource.OidcClientSecret)
+	require.Nil(t, resource.OidcClaimMappings)
+	require.Nil(t, resource.OidcScopes)
+}
+
+func TestBuildPortalIdentityProviders_MapsOIDCAndSAMLChildren(t *testing.T) {
+	t.Parallel()
+
+	oidcID := "portal-idp-oidc"
+	samlID := "portal-idp-saml"
+	oidcEnabled := true
+	samlEnabled := false
+	oidcType := kkComps.IdentityProviderTypeOidc
+	samlType := kkComps.IdentityProviderTypeSaml
+
+	client := declstate.NewClient(declstate.ClientConfig{
+		PortalIdentityProviderAPI: &stubDumpPortalIdentityProviderAPI{
+			listResponse: &kkOps.GetPortalIdentityProvidersResponse{
+				IdentityProviders: []kkComps.IdentityProvider{
+					{
+						ID:      &oidcID,
+						Type:    &oidcType,
+						Enabled: &oidcEnabled,
+						Config: &kkComps.IdentityProviderConfig{
+							Type: kkComps.IdentityProviderConfigTypeOIDCIdentityProviderConfigOutput,
+							OIDCIdentityProviderConfigOutput: &kkComps.OIDCIdentityProviderConfigOutput{
+								IssuerURL: "https://issuer.example.test",
+								ClientID:  "client-id",
+								Scopes:    []string{"openid", "email"},
+								ClaimMappings: &kkComps.OIDCIdentityProviderClaimMappings{
+									Email: stringPtr("email"),
+								},
+							},
+						},
+					},
+					{
+						ID:      &samlID,
+						Type:    &samlType,
+						Enabled: &samlEnabled,
+						Config: &kkComps.IdentityProviderConfig{
+							Type: kkComps.IdentityProviderConfigTypeSAMLIdentityProviderConfig,
+							SAMLIdentityProviderConfig: &kkComps.SAMLIdentityProviderConfig{
+								IdpMetadataURL: stringPtr("https://issuer.example.test/saml.xml"),
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	resources, err := buildPortalIdentityProviders(context.Background(), client, "portal-1")
+	require.NoError(t, err)
+	require.Len(t, resources, 2)
+
+	require.Equal(t, kkComps.IdentityProviderTypeOidc, *resources[0].Type)
+	require.Equal(t, oidcEnabled, *resources[0].Enabled)
+	require.NotNil(t, resources[0].Config)
+	require.Equal(t, kkComps.CreateIdentityProviderConfigTypeOIDCIdentityProviderConfig, resources[0].Config.Type)
+	require.NotNil(t, resources[0].Config.OIDCIdentityProviderConfig)
+	require.Equal(t, "https://issuer.example.test", resources[0].Config.OIDCIdentityProviderConfig.IssuerURL)
+	require.Equal(t, "client-id", resources[0].Config.OIDCIdentityProviderConfig.ClientID)
+	require.Nil(t, resources[0].Config.OIDCIdentityProviderConfig.ClientSecret)
+
+	require.Equal(t, kkComps.IdentityProviderTypeSaml, *resources[1].Type)
+	require.Equal(t, samlEnabled, *resources[1].Enabled)
+	require.NotNil(t, resources[1].Config)
+	require.Equal(t, kkComps.CreateIdentityProviderConfigTypeSAMLIdentityProviderConfigInput, resources[1].Config.Type)
+	require.NotNil(t, resources[1].Config.SAMLIdentityProviderConfigInput)
+	require.Equal(
+		t,
+		"https://issuer.example.test/saml.xml",
+		*resources[1].Config.SAMLIdentityProviderConfigInput.IdpMetadataURL,
+	)
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+func stringPtr(value string) *string {
+	return &value
 }

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -2536,6 +2536,16 @@ func (e *Executor) deleteResource(ctx context.Context, change *planner.PlannedCh
 	case "portal_custom_domain":
 		// No references to resolve for portal_custom_domain
 		return e.portalDomainExecutor.Delete(ctx, *change)
+	case "portal_identity_provider":
+		if portalRef, ok := change.References["portal_id"]; ok && portalRef.ID == "" {
+			portalID, err := e.resolvePortalRef(ctx, portalRef)
+			if err != nil {
+				return fmt.Errorf("failed to resolve portal reference: %w", err)
+			}
+			portalRef.ID = portalID
+			change.References["portal_id"] = portalRef
+		}
+		return e.portalIdentityProviderExecutor.Delete(ctx, *change)
 	case "portal_page":
 		// First resolve portal reference if needed
 		if portalRef, ok := change.References["portal_id"]; ok && portalRef.ID == "" {

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -70,11 +70,12 @@ type Executor struct {
 		kkComps.CreateTLSTrustBundleRequest, kkComps.UpdateTLSTrustBundleRequest]
 
 	// Portal child resource executors
-	portalCustomizationExecutor *BaseSingletonExecutor[kkComps.PortalCustomization]
-	portalAuthSettingsExecutor  *BaseSingletonExecutor[kkComps.PortalAuthenticationSettingsUpdateRequest]
-	portalAssetLogoExecutor     *BaseSingletonExecutor[kkComps.ReplacePortalImageAsset]
-	portalAssetFaviconExecutor  *BaseSingletonExecutor[kkComps.ReplacePortalImageAsset]
-	portalDomainExecutor        *BaseExecutor[kkComps.CreatePortalCustomDomainRequest,
+	portalCustomizationExecutor    *BaseSingletonExecutor[kkComps.PortalCustomization]
+	portalAuthSettingsExecutor     *BaseSingletonExecutor[kkComps.PortalAuthenticationSettingsUpdateRequest]
+	portalIdentityProviderExecutor *BaseExecutor[kkComps.CreateIdentityProvider, kkComps.UpdateIdentityProvider]
+	portalAssetLogoExecutor        *BaseSingletonExecutor[kkComps.ReplacePortalImageAsset]
+	portalAssetFaviconExecutor     *BaseSingletonExecutor[kkComps.ReplacePortalImageAsset]
+	portalDomainExecutor           *BaseExecutor[kkComps.CreatePortalCustomDomainRequest,
 		kkComps.UpdatePortalCustomDomainRequest]
 	portalPageExecutor          *BaseExecutor[kkComps.CreatePortalPageRequest, kkComps.UpdatePortalPageRequest]
 	portalSnippetExecutor       *BaseExecutor[kkComps.CreatePortalSnippetRequest, kkComps.UpdatePortalSnippetRequest]
@@ -259,6 +260,11 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 	)
 	e.portalAuthSettingsExecutor = NewBaseSingletonExecutor[kkComps.PortalAuthenticationSettingsUpdateRequest](
 		NewPortalAuthSettingsAdapter(client),
+		dryRun,
+	)
+	e.portalIdentityProviderExecutor = NewBaseExecutor[kkComps.CreateIdentityProvider, kkComps.UpdateIdentityProvider](
+		NewPortalIdentityProviderAdapter(client),
+		client,
 		dryRun,
 	)
 	e.portalAssetLogoExecutor = NewBaseSingletonExecutor[kkComps.ReplacePortalImageAsset](
@@ -1762,6 +1768,16 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 			return "", err
 		}
 		return e.portalAuthSettingsExecutor.Update(ctx, *change, portalID)
+	case "portal_identity_provider":
+		if portalRef, ok := change.References["portal_id"]; ok && portalRef.ID == "" {
+			portalID, err := e.resolvePortalRef(ctx, portalRef)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve portal reference: %w", err)
+			}
+			portalRef.ID = portalID
+			change.References["portal_id"] = portalRef
+		}
+		return e.portalIdentityProviderExecutor.Create(ctx, *change)
 	case "portal_asset_logo":
 		// Portal asset logo is a singleton resource - always exists, so we update instead
 		portalID, err := e.resolvePortalRef(ctx, change.References["portal_id"])
@@ -2205,6 +2221,16 @@ func (e *Executor) updateResource(ctx context.Context, change *planner.PlannedCh
 			return "", err
 		}
 		return e.portalAuthSettingsExecutor.Update(ctx, *change, portalID)
+	case "portal_identity_provider":
+		if portalRef, ok := change.References["portal_id"]; ok && portalRef.ID == "" {
+			portalID, err := e.resolvePortalRef(ctx, portalRef)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve portal reference: %w", err)
+			}
+			portalRef.ID = portalID
+			change.References["portal_id"] = portalRef
+		}
+		return e.portalIdentityProviderExecutor.Update(ctx, *change)
 	case "portal_email_config":
 		if portalRef, ok := change.References["portal_id"]; ok && portalRef.ID == "" {
 			portalID, err := e.resolvePortalRef(ctx, portalRef)

--- a/internal/declarative/executor/portal_auth_settings_adapter.go
+++ b/internal/declarative/executor/portal_auth_settings_adapter.go
@@ -35,61 +35,11 @@ func (p *PortalAuthSettingsAdapter) MapUpdateFields(
 	if v, ok := fields["basic_auth_enabled"].(bool); ok {
 		update.BasicAuthEnabled = &v
 	}
-	if v, ok := fields["oidc_auth_enabled"].(bool); ok {
-		update.OidcAuthEnabled = &v
-	}
-	if v, ok := fields["saml_auth_enabled"].(bool); ok {
-		update.SamlAuthEnabled = &v
-	}
-	if v, ok := fields["oidc_team_mapping_enabled"].(bool); ok {
-		update.OidcTeamMappingEnabled = &v
-	}
 	if v, ok := fields["konnect_mapping_enabled"].(bool); ok {
 		update.KonnectMappingEnabled = &v
 	}
 	if v, ok := fields["idp_mapping_enabled"].(bool); ok {
 		update.IdpMappingEnabled = &v
-	}
-	if v, ok := fields["oidc_issuer"].(string); ok {
-		update.OidcIssuer = &v
-	}
-	if v, ok := fields["oidc_client_id"].(string); ok {
-		update.OidcClientID = &v
-	}
-	if v, ok := fields["oidc_client_secret"].(string); ok {
-		update.OidcClientSecret = &v
-	}
-	if v, ok := fields["oidc_scopes"].([]string); ok {
-		update.OidcScopes = v
-	}
-	if v, ok := fields["oidc_claim_mappings"].(*kkComps.PortalClaimMappings); ok {
-		// Convert PortalClaimMappings to PortalAuthenticationSettingsUpdateRequestPortalClaimMappings
-		converted := &kkComps.PortalAuthenticationSettingsUpdateRequestPortalClaimMappings{
-			Name:   v.Name,
-			Email:  v.Email,
-			Groups: v.Groups,
-		}
-		update.OidcClaimMappings = converted
-	} else if v, ok := fields["oidc_claim_mappings"].(kkComps.PortalClaimMappings); ok {
-		// Convert PortalClaimMappings to PortalAuthenticationSettingsUpdateRequestPortalClaimMappings
-		converted := &kkComps.PortalAuthenticationSettingsUpdateRequestPortalClaimMappings{
-			Name:   v.Name,
-			Email:  v.Email,
-			Groups: v.Groups,
-		}
-		update.OidcClaimMappings = converted
-	} else if m, ok := fields["oidc_claim_mappings"].(map[string]any); ok {
-		claim := &kkComps.PortalAuthenticationSettingsUpdateRequestPortalClaimMappings{}
-		if name, ok := m["name"].(string); ok {
-			claim.Name = &name
-		}
-		if email, ok := m["email"].(string); ok {
-			claim.Email = &email
-		}
-		if groups, ok := m["groups"].(string); ok {
-			claim.Groups = &groups
-		}
-		update.OidcClaimMappings = claim
 	}
 
 	if logger, ok := ctx.Value(log.LoggerKey).(*slog.Logger); ok && logger != nil {

--- a/internal/declarative/executor/portal_identity_provider_adapter.go
+++ b/internal/declarative/executor/portal_identity_provider_adapter.go
@@ -1,0 +1,268 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/state"
+)
+
+// PortalIdentityProviderAdapter implements ResourceOperations for portal identity providers.
+type PortalIdentityProviderAdapter struct {
+	client *state.Client
+}
+
+// NewPortalIdentityProviderAdapter creates a new portal identity provider adapter.
+func NewPortalIdentityProviderAdapter(client *state.Client) *PortalIdentityProviderAdapter {
+	return &PortalIdentityProviderAdapter{client: client}
+}
+
+// MapCreateFields maps planner fields to CreateIdentityProvider.
+func (p *PortalIdentityProviderAdapter) MapCreateFields(
+	_ context.Context, _ *ExecutionContext, fields map[string]any, create *kkComps.CreateIdentityProvider,
+) error {
+	typeName, ok := fields["type"].(string)
+	if !ok || typeName == "" {
+		return fmt.Errorf("type is required")
+	}
+	providerType := kkComps.IdentityProviderType(typeName)
+	create.Type = providerType.ToPointer()
+
+	if enabled, ok := fields["enabled"].(bool); ok {
+		create.Enabled = &enabled
+	}
+	if loginPath, ok := fields["login_path"].(string); ok {
+		create.LoginPath = &loginPath
+	}
+
+	config, err := createIdentityProviderConfigFromField(fields["config"])
+	if err != nil {
+		return err
+	}
+	create.Config = config
+	return nil
+}
+
+// MapUpdateFields maps planner fields to UpdateIdentityProvider.
+func (p *PortalIdentityProviderAdapter) MapUpdateFields(
+	_ context.Context,
+	_ *ExecutionContext,
+	fields map[string]any,
+	update *kkComps.UpdateIdentityProvider,
+	_ map[string]string,
+) error {
+	if enabled, ok := fields["enabled"].(bool); ok {
+		update.Enabled = &enabled
+	}
+	if loginPath, ok := fields["login_path"].(string); ok {
+		update.LoginPath = &loginPath
+	}
+	if rawConfig, ok := fields["config"]; ok {
+		config, err := createIdentityProviderConfigFromField(rawConfig)
+		if err != nil {
+			return err
+		}
+		updateConfig, err := updateIdentityProviderConfigFromCreate(config)
+		if err != nil {
+			return err
+		}
+		update.Config = updateConfig
+	}
+	return nil
+}
+
+// Create creates a new portal identity provider.
+func (p *PortalIdentityProviderAdapter) Create(
+	ctx context.Context, req kkComps.CreateIdentityProvider, namespace string, execCtx *ExecutionContext,
+) (string, error) {
+	portalID, err := p.getPortalID(execCtx)
+	if err != nil {
+		return "", err
+	}
+
+	enabled := req.Enabled
+
+	id, err := p.client.CreatePortalIdentityProvider(ctx, portalID, req, namespace)
+	if err != nil {
+		return "", err
+	}
+
+	if enabled != nil && *enabled {
+		update := kkComps.UpdateIdentityProvider{Enabled: enabled}
+		if err := p.client.UpdatePortalIdentityProvider(
+			ctx,
+			portalID,
+			id,
+			update,
+			namespace,
+		); err != nil {
+			return "", err
+		}
+	}
+
+	return id, nil
+}
+
+// Update updates an existing portal identity provider.
+func (p *PortalIdentityProviderAdapter) Update(
+	ctx context.Context, id string, req kkComps.UpdateIdentityProvider, namespace string, execCtx *ExecutionContext,
+) (string, error) {
+	portalID, err := p.getPortalID(execCtx)
+	if err != nil {
+		return "", err
+	}
+
+	if err := p.client.UpdatePortalIdentityProvider(ctx, portalID, id, req, namespace); err != nil {
+		return "", err
+	}
+
+	return id, nil
+}
+
+// Delete deletes a portal identity provider.
+func (p *PortalIdentityProviderAdapter) Delete(ctx context.Context, id string, execCtx *ExecutionContext) error {
+	portalID, err := p.getPortalID(execCtx)
+	if err != nil {
+		return err
+	}
+	return p.client.DeletePortalIdentityProvider(ctx, portalID, id)
+}
+
+// GetByName returns nil because portal identity providers are looked up by ID.
+func (p *PortalIdentityProviderAdapter) GetByName(_ context.Context, _ string) (ResourceInfo, error) {
+	return nil, nil
+}
+
+// GetByID gets a portal identity provider by ID.
+func (p *PortalIdentityProviderAdapter) GetByID(
+	ctx context.Context, id string, execCtx *ExecutionContext,
+) (ResourceInfo, error) {
+	portalID, err := p.getPortalID(execCtx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get portal ID for identity provider lookup: %w", err)
+	}
+
+	provider, err := p.client.GetPortalIdentityProvider(ctx, portalID, id)
+	if err != nil {
+		return nil, err
+	}
+	if provider == nil {
+		return nil, nil
+	}
+
+	return &PortalIdentityProviderResourceInfo{provider: provider}, nil
+}
+
+// ResourceType returns the resource type name.
+func (p *PortalIdentityProviderAdapter) ResourceType() string {
+	return "portal_identity_provider"
+}
+
+// RequiredFields returns the required fields for creation.
+func (p *PortalIdentityProviderAdapter) RequiredFields() []string {
+	return []string{"type", "config"}
+}
+
+// SupportsUpdate returns true.
+func (p *PortalIdentityProviderAdapter) SupportsUpdate() bool {
+	return true
+}
+
+func (p *PortalIdentityProviderAdapter) getPortalID(execCtx *ExecutionContext) (string, error) {
+	if execCtx == nil || execCtx.PlannedChange == nil {
+		return "", fmt.Errorf("execution context is required for portal identity provider operations")
+	}
+
+	change := *execCtx.PlannedChange
+	if portalRef, ok := change.References["portal_id"]; ok && portalRef.ID != "" {
+		return portalRef.ID, nil
+	}
+	if change.Parent != nil && change.Parent.ID != "" {
+		return change.Parent.ID, nil
+	}
+	return "", fmt.Errorf("portal ID is required for portal identity provider operations")
+}
+
+func createIdentityProviderConfigFromField(raw any) (*kkComps.CreateIdentityProviderConfig, error) {
+	switch config := raw.(type) {
+	case kkComps.CreateIdentityProviderConfig:
+		return &config, nil
+	case *kkComps.CreateIdentityProviderConfig:
+		return config, nil
+	case map[string]any:
+		encoded, err := json.Marshal(config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode identity provider config: %w", err)
+		}
+
+		var decoded kkComps.CreateIdentityProviderConfig
+		if err := json.Unmarshal(encoded, &decoded); err != nil {
+			return nil, fmt.Errorf("failed to decode identity provider config: %w", err)
+		}
+		return &decoded, nil
+	default:
+		return nil, fmt.Errorf("config is required")
+	}
+}
+
+func updateIdentityProviderConfigFromCreate(
+	config *kkComps.CreateIdentityProviderConfig,
+) (*kkComps.UpdateIdentityProviderConfig, error) {
+	if config == nil {
+		return nil, nil
+	}
+
+	switch config.Type {
+	case kkComps.CreateIdentityProviderConfigTypeOIDCIdentityProviderConfig:
+		if config.OIDCIdentityProviderConfig == nil {
+			return nil, fmt.Errorf("oidc identity provider config is required")
+		}
+		converted := kkComps.CreateUpdateIdentityProviderConfigOIDCIdentityProviderConfig(
+			*config.OIDCIdentityProviderConfig,
+		)
+		return &converted, nil
+	case kkComps.CreateIdentityProviderConfigTypeSAMLIdentityProviderConfigInput:
+		if config.SAMLIdentityProviderConfigInput == nil {
+			return nil, fmt.Errorf("saml identity provider config is required")
+		}
+		converted := kkComps.CreateUpdateIdentityProviderConfigSAMLIdentityProviderConfigInput(
+			*config.SAMLIdentityProviderConfigInput,
+		)
+		return &converted, nil
+	default:
+		return nil, fmt.Errorf("identity provider config type is required")
+	}
+}
+
+// PortalIdentityProviderResourceInfo implements ResourceInfo for portal identity providers.
+type PortalIdentityProviderResourceInfo struct {
+	provider *state.PortalIdentityProvider
+}
+
+// GetID returns the resource ID.
+func (p *PortalIdentityProviderResourceInfo) GetID() string {
+	if p.provider == nil {
+		return ""
+	}
+	return p.provider.ID
+}
+
+// GetName returns the resource name.
+func (p *PortalIdentityProviderResourceInfo) GetName() string {
+	if p.provider == nil {
+		return ""
+	}
+	return string(p.provider.Type)
+}
+
+// GetLabels returns the resource labels.
+func (p *PortalIdentityProviderResourceInfo) GetLabels() map[string]string {
+	return nil
+}
+
+// GetNormalizedLabels returns the normalized labels.
+func (p *PortalIdentityProviderResourceInfo) GetNormalizedLabels() map[string]string {
+	return map[string]string{}
+}

--- a/internal/declarative/executor/portal_identity_provider_adapter.go
+++ b/internal/declarative/executor/portal_identity_provider_adapter.go
@@ -89,7 +89,7 @@ func (p *PortalIdentityProviderAdapter) Create(
 		return "", err
 	}
 
-	if enabled != nil && *enabled {
+	if enabled != nil {
 		update := kkComps.UpdateIdentityProvider{Enabled: enabled}
 		if err := p.client.UpdatePortalIdentityProvider(
 			ctx,

--- a/internal/declarative/executor/portal_identity_provider_adapter_test.go
+++ b/internal/declarative/executor/portal_identity_provider_adapter_test.go
@@ -16,6 +16,11 @@ import (
 type stubPortalIdentityProviderAPI struct {
 	createReq kkComps.CreateIdentityProvider
 	updateReq kkOps.UpdatePortalIdentityProviderRequest
+	getResp   *kkOps.GetPortalIdentityProviderResponse
+	deleteReq struct {
+		portalID string
+		id       string
+	}
 }
 
 func (s *stubPortalIdentityProviderAPI) ListPortalIdentityProviders(
@@ -27,11 +32,14 @@ func (s *stubPortalIdentityProviderAPI) ListPortalIdentityProviders(
 }
 
 func (s *stubPortalIdentityProviderAPI) GetPortalIdentityProvider(
-	context.Context,
-	string,
-	string,
-	...kkOps.Option,
+	_ context.Context,
+	_ string,
+	_ string,
+	_ ...kkOps.Option,
 ) (*kkOps.GetPortalIdentityProviderResponse, error) {
+	if s.getResp != nil {
+		return s.getResp, nil
+	}
 	return nil, nil
 }
 
@@ -58,11 +66,13 @@ func (s *stubPortalIdentityProviderAPI) UpdatePortalIdentityProvider(
 }
 
 func (s *stubPortalIdentityProviderAPI) DeletePortalIdentityProvider(
-	context.Context,
-	string,
-	string,
-	...kkOps.Option,
+	_ context.Context,
+	portalID string,
+	id string,
+	_ ...kkOps.Option,
 ) (*kkOps.DeletePortalIdentityProviderResponse, error) {
+	s.deleteReq.portalID = portalID
+	s.deleteReq.id = id
 	return nil, nil
 }
 
@@ -92,4 +102,56 @@ func TestPortalIdentityProviderAdapterCreateUpdatesExplicitFalseEnabled(t *testi
 	assert.False(t, *api.updateReq.UpdateIdentityProvider.Enabled)
 	assert.Equal(t, "portal-1", api.updateReq.PortalID)
 	assert.Equal(t, "provider-1", api.updateReq.ID)
+}
+
+func TestPortalIdentityProviderAdapterDeleteUsesResolvedPortalID(t *testing.T) {
+	t.Parallel()
+
+	api := &stubPortalIdentityProviderAPI{}
+	client := state.NewClient(state.ClientConfig{PortalIdentityProviderAPI: api})
+	adapter := NewPortalIdentityProviderAdapter(client)
+
+	execCtx := NewExecutionContext(&planner.PlannedChange{
+		Parent: &planner.ParentInfo{ID: "portal-1"},
+	})
+
+	err := adapter.Delete(testContextWithLogger(), "provider-1", execCtx)
+	require.NoError(t, err)
+	assert.Equal(t, "portal-1", api.deleteReq.portalID)
+	assert.Equal(t, "provider-1", api.deleteReq.id)
+}
+
+func TestExecutorDeleteResourceHandlesPortalIdentityProvider(t *testing.T) {
+	t.Parallel()
+
+	providerID := "provider-1"
+	providerType := kkComps.IdentityProviderTypeOidc
+	api := &stubPortalIdentityProviderAPI{
+		getResp: &kkOps.GetPortalIdentityProviderResponse{
+			IdentityProvider: &kkComps.IdentityProvider{
+				ID:   &providerID,
+				Type: &providerType,
+			},
+		},
+	}
+	client := state.NewClient(state.ClientConfig{PortalIdentityProviderAPI: api})
+	executor := New(client, nil, false)
+
+	change := &planner.PlannedChange{
+		ResourceType: "portal_identity_provider",
+		ResourceID:   providerID,
+		Namespace:    "default",
+		Parent:       &planner.ParentInfo{ID: "portal-1", Ref: "portal-1"},
+		References: map[string]planner.ReferenceInfo{
+			"portal_id": {ID: "portal-1", Ref: "portal-1"},
+		},
+		Fields: map[string]any{
+			"type": "oidc",
+		},
+	}
+
+	err := executor.deleteResource(testContextWithLogger(), change)
+	require.NoError(t, err)
+	assert.Equal(t, "portal-1", api.deleteReq.portalID)
+	assert.Equal(t, providerID, api.deleteReq.id)
 }

--- a/internal/declarative/executor/portal_identity_provider_adapter_test.go
+++ b/internal/declarative/executor/portal_identity_provider_adapter_test.go
@@ -37,7 +37,7 @@ func (s *stubPortalIdentityProviderAPI) GetPortalIdentityProvider(
 
 func (s *stubPortalIdentityProviderAPI) CreatePortalIdentityProvider(
 	_ context.Context,
-	portalID string,
+	_ string,
 	request kkComps.CreateIdentityProvider,
 	_ ...kkOps.Option,
 ) (*kkOps.CreatePortalIdentityProviderResponse, error) {

--- a/internal/declarative/executor/portal_identity_provider_adapter_test.go
+++ b/internal/declarative/executor/portal_identity_provider_adapter_test.go
@@ -1,0 +1,95 @@
+package executor
+
+import (
+	"context"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/konnect/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubPortalIdentityProviderAPI struct {
+	createReq kkComps.CreateIdentityProvider
+	updateReq kkOps.UpdatePortalIdentityProviderRequest
+}
+
+func (s *stubPortalIdentityProviderAPI) ListPortalIdentityProviders(
+	context.Context,
+	kkOps.GetPortalIdentityProvidersRequest,
+	...kkOps.Option,
+) (*kkOps.GetPortalIdentityProvidersResponse, error) {
+	return nil, nil
+}
+
+func (s *stubPortalIdentityProviderAPI) GetPortalIdentityProvider(
+	context.Context,
+	string,
+	string,
+	...kkOps.Option,
+) (*kkOps.GetPortalIdentityProviderResponse, error) {
+	return nil, nil
+}
+
+func (s *stubPortalIdentityProviderAPI) CreatePortalIdentityProvider(
+	_ context.Context,
+	portalID string,
+	request kkComps.CreateIdentityProvider,
+	_ ...kkOps.Option,
+) (*kkOps.CreatePortalIdentityProviderResponse, error) {
+	s.createReq = request
+	id := "provider-1"
+	return &kkOps.CreatePortalIdentityProviderResponse{
+		IdentityProvider: &kkComps.IdentityProvider{ID: &id},
+	}, nil
+}
+
+func (s *stubPortalIdentityProviderAPI) UpdatePortalIdentityProvider(
+	_ context.Context,
+	request kkOps.UpdatePortalIdentityProviderRequest,
+	_ ...kkOps.Option,
+) (*kkOps.UpdatePortalIdentityProviderResponse, error) {
+	s.updateReq = request
+	return &kkOps.UpdatePortalIdentityProviderResponse{}, nil
+}
+
+func (s *stubPortalIdentityProviderAPI) DeletePortalIdentityProvider(
+	context.Context,
+	string,
+	string,
+	...kkOps.Option,
+) (*kkOps.DeletePortalIdentityProviderResponse, error) {
+	return nil, nil
+}
+
+var _ helpers.PortalIdentityProviderAPI = (*stubPortalIdentityProviderAPI)(nil)
+
+func TestPortalIdentityProviderAdapterCreateUpdatesExplicitFalseEnabled(t *testing.T) {
+	t.Parallel()
+
+	api := &stubPortalIdentityProviderAPI{}
+	client := state.NewClient(state.ClientConfig{PortalIdentityProviderAPI: api})
+	adapter := NewPortalIdentityProviderAdapter(client)
+
+	enabled := false
+	req := kkComps.CreateIdentityProvider{
+		Type:    kkComps.IdentityProviderTypeOidc.ToPointer(),
+		Enabled: &enabled,
+	}
+	execCtx := NewExecutionContext(&planner.PlannedChange{
+		Parent: &planner.ParentInfo{ID: "portal-1"},
+	})
+
+	id, err := adapter.Create(testContextWithLogger(), req, "default", execCtx)
+	require.NoError(t, err)
+	assert.Equal(t, "provider-1", id)
+
+	require.NotNil(t, api.updateReq.UpdateIdentityProvider.Enabled)
+	assert.False(t, *api.updateReq.UpdateIdentityProvider.Enabled)
+	assert.Equal(t, "portal-1", api.updateReq.PortalID)
+	assert.Equal(t, "provider-1", api.updateReq.ID)
+}

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -833,6 +833,13 @@ func (l *Loader) extractNestedResources(rs *resources.ResourceSet) {
 			rs.PortalAuthSettings = append(rs.PortalAuthSettings, authSettings)
 		}
 
+		// Extract identity providers
+		for j := range portal.IdentityProviders {
+			provider := portal.IdentityProviders[j]
+			provider.Portal = portal.Ref
+			rs.PortalIdentityProviders = append(rs.PortalIdentityProviders, provider)
+		}
+
 		// Extract custom domain (single resource)
 		if portal.CustomDomain != nil {
 			customDomain := *portal.CustomDomain
@@ -891,6 +898,7 @@ func (l *Loader) extractNestedResources(rs *resources.ResourceSet) {
 		// Clear nested resources from Portal
 		portal.Customization = nil
 		portal.AuthSettings = nil
+		portal.IdentityProviders = nil
 		portal.CustomDomain = nil
 		portal.Pages = nil
 		portal.Snippets = nil

--- a/internal/declarative/loader/ref_resolver.go
+++ b/internal/declarative/loader/ref_resolver.go
@@ -209,6 +209,24 @@ func ResolveReferences(ctx context.Context, rs *resources.ResourceSet) error {
 		processCount++
 	}
 
+	for i := range rs.PortalIdentityProviders {
+		if err := resolveResourceFields(
+			ctx,
+			&rs.PortalIdentityProviders[i],
+			rs,
+			resolver,
+			resolutionPath,
+			logger,
+		); err != nil {
+			return fmt.Errorf(
+				"resolving portal identity provider %s: %w",
+				rs.PortalIdentityProviders[i].GetRef(),
+				err,
+			)
+		}
+		processCount++
+	}
+
 	for i := range rs.PortalCustomDomains {
 		if err := resolveResourceFields(ctx, &rs.PortalCustomDomains[i], rs, resolver, resolutionPath, logger); err != nil {
 			return fmt.Errorf("resolving portal custom domain %s: %w", rs.PortalCustomDomains[i].GetRef(), err)

--- a/internal/declarative/loader/tag_integration_test.go
+++ b/internal/declarative/loader/tag_integration_test.go
@@ -335,3 +335,48 @@ portals:
 	assert.Equal(t, "__ENV__:CUSTOM_CERT", envSources["/ssl/custom_certificate"])
 	assert.Equal(t, "__ENV__:CUSTOM_KEY", envSources["/ssl/custom_private_key"])
 }
+
+func TestLoader_EnvTagIntegration_PortalIdentityProviderConfig(t *testing.T) {
+	t.Setenv("IDP_ISSUER_URL", "https://example.okta.test/oauth2/default")
+	t.Setenv("IDP_CLIENT_ID", "client-id-from-env")
+	t.Setenv("IDP_CLIENT_SECRET", "client-secret-from-env")
+
+	tmpDir, err := os.MkdirTemp("", "loader-env-portal-idp-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	mainContent := `
+portals:
+  - ref: env-portal
+    name: env-portal
+    identity_providers:
+      - ref: env-portal-idp
+        type: oidc
+        config:
+          issuer_url: !env IDP_ISSUER_URL
+          client_id: !env IDP_CLIENT_ID
+          client_secret: !env IDP_CLIENT_SECRET
+`
+
+	mainFile := filepath.Join(tmpDir, "main.yaml")
+	require.NoError(t, os.WriteFile(mainFile, []byte(mainContent), 0o600))
+
+	loader := NewWithBaseDir(tmpDir)
+	rs, err := loader.LoadFile(mainFile)
+	require.NoError(t, err)
+	require.NotNil(t, rs)
+	require.Len(t, rs.PortalIdentityProviders, 1)
+
+	config := rs.PortalIdentityProviders[0].Config
+	require.NotNil(t, config)
+	require.NotNil(t, config.OIDCIdentityProviderConfig)
+	assert.Equal(t, "https://example.okta.test/oauth2/default", config.OIDCIdentityProviderConfig.IssuerURL)
+	assert.Equal(t, "client-id-from-env", config.OIDCIdentityProviderConfig.ClientID)
+	require.NotNil(t, config.OIDCIdentityProviderConfig.ClientSecret)
+	assert.Equal(t, "client-secret-from-env", *config.OIDCIdentityProviderConfig.ClientSecret)
+
+	envSources := rs.GetEnvSources("env-portal-idp")
+	assert.Equal(t, "__ENV__:IDP_ISSUER_URL", envSources["/config/issuer_url"])
+	assert.Equal(t, "__ENV__:IDP_CLIENT_ID", envSources["/config/client_id"])
+	assert.Equal(t, "__ENV__:IDP_CLIENT_SECRET", envSources["/config/client_secret"])
+}

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/kong/kongctl/internal/declarative/resources"
 	"github.com/kong/kongctl/internal/declarative/tags"
 	"github.com/kong/kongctl/internal/declarative/validator"
@@ -510,19 +511,62 @@ func (l *Loader) validateSeparateAPIChildResources(rs *resources.ResourceSet) er
 	}
 
 	// Validate portal auth settings
+	// Validate portal auth settings
 	for i := range rs.PortalAuthSettings {
 		settings := &rs.PortalAuthSettings[i]
 		if err := settings.Validate(); err != nil {
 			return fmt.Errorf("invalid portal_auth_settings %q: %w", settings.GetRef(), err)
 		}
+		if settings.Portal == "" {
+			return fmt.Errorf("portal_auth_settings %q must specify portal", settings.GetRef())
+		}
+		if deprecatedField := deprecatedPortalAuthSettingsField(settings); deprecatedField != "" {
+			return fmt.Errorf(
+				"portal_auth_settings %q uses deprecated field %q; move identity provider configuration to identity_providers",
+				settings.GetRef(),
+				deprecatedField,
+			)
+		}
 		for j := i + 1; j < len(rs.PortalAuthSettings); j++ {
 			if rs.PortalAuthSettings[j].GetRef() == settings.GetRef() {
 				return fmt.Errorf(
-					"duplicate ref '%s' (already defined as portal_auth_settings)",
+					"duplicate ref %s (already defined as portal_auth_settings)",
 					settings.GetRef(),
 				)
 			}
 		}
+	}
+
+	// Validate portal identity providers
+	portalProviderRefs := make(map[string]bool)
+	portalProviderTypes := make(map[string]map[kkComps.IdentityProviderType]string)
+	for i := range rs.PortalIdentityProviders {
+		provider := &rs.PortalIdentityProviders[i]
+		if err := provider.Validate(); err != nil {
+			return fmt.Errorf("invalid portal_identity_provider %q: %w", provider.GetRef(), err)
+		}
+		if provider.Portal == "" {
+			return fmt.Errorf("portal_identity_provider %q must specify portal", provider.GetRef())
+		}
+		if portalProviderRefs[provider.GetRef()] {
+			return fmt.Errorf("duplicate ref %s (already defined as portal_identity_provider)", provider.GetRef())
+		}
+		portalProviderRefs[provider.GetRef()] = true
+
+		if _, ok := portalProviderTypes[provider.Portal]; !ok {
+			portalProviderTypes[provider.Portal] = make(map[kkComps.IdentityProviderType]string)
+		}
+		providerType := *provider.Type
+		if existingRef, ok := portalProviderTypes[provider.Portal][providerType]; ok {
+			return fmt.Errorf(
+				"multiple portal_identity_provider entries target portal %q and type %q (%s and %s)",
+				provider.Portal,
+				string(providerType),
+				existingRef,
+				provider.GetRef(),
+			)
+		}
+		portalProviderTypes[provider.Portal][providerType] = provider.GetRef()
 	}
 
 	// Validate portal custom domains
@@ -829,4 +873,27 @@ func (l *Loader) validateNamespaces(rs *resources.ResourceSet) error {
 	}
 
 	return nil
+}
+
+func deprecatedPortalAuthSettingsField(settings *resources.PortalAuthSettingsResource) string {
+	switch {
+	case settings.OidcAuthEnabled != nil:
+		return "oidc_auth_enabled"
+	case settings.SamlAuthEnabled != nil:
+		return "saml_auth_enabled"
+	case settings.OidcTeamMappingEnabled != nil:
+		return "oidc_team_mapping_enabled"
+	case settings.OidcIssuer != nil:
+		return "oidc_issuer"
+	case settings.OidcClientID != nil:
+		return "oidc_client_id"
+	case settings.OidcClientSecret != nil:
+		return "oidc_client_secret"
+	case settings.OidcScopes != nil:
+		return "oidc_scopes"
+	case settings.OidcClaimMappings != nil:
+		return "oidc_claim_mappings"
+	default:
+		return ""
+	}
 }

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -511,7 +511,6 @@ func (l *Loader) validateSeparateAPIChildResources(rs *resources.ResourceSet) er
 	}
 
 	// Validate portal auth settings
-	// Validate portal auth settings
 	for i := range rs.PortalAuthSettings {
 		settings := &rs.PortalAuthSettings[i]
 		if err := settings.Validate(); err != nil {

--- a/internal/declarative/loader/validator_test.go
+++ b/internal/declarative/loader/validator_test.go
@@ -727,3 +727,69 @@ func extractNestedResourcesForTest(rs *resources.ResourceSet) {
 		api.Implementations = nil
 	}
 }
+
+func TestLoader_validateResourceSet_RejectsDeprecatedPortalAuthSettingsFields(t *testing.T) {
+	loader := New()
+	rs := &resources.ResourceSet{
+		Portals: []resources.PortalResource{{
+			BaseResource: resources.BaseResource{Ref: "portal-1"},
+			CreatePortal: kkComps.CreatePortal{Name: "portal-one"},
+		}},
+		PortalAuthSettings: []resources.PortalAuthSettingsResource{{
+			Ref:    "portal-auth-settings",
+			Portal: "portal-1",
+			PortalAuthenticationSettingsUpdateRequest: kkComps.PortalAuthenticationSettingsUpdateRequest{
+				OidcAuthEnabled: new(true),
+			},
+		}},
+	}
+
+	err := loader.validateResourceSet(rs)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "uses deprecated field \"oidc_auth_enabled\"")
+	assert.Contains(t, err.Error(), "move identity provider configuration to identity_providers")
+}
+
+func TestLoader_validateResourceSet_RejectsDuplicatePortalIdentityProviderTypesPerPortal(t *testing.T) {
+	loader := New()
+	configA := kkComps.CreateCreateIdentityProviderConfigOIDCIdentityProviderConfig(kkComps.OIDCIdentityProviderConfig{
+		IssuerURL: "https://accounts.google.com",
+		ClientID:  "client-id-a",
+	})
+	configB := kkComps.CreateCreateIdentityProviderConfigOIDCIdentityProviderConfig(kkComps.OIDCIdentityProviderConfig{
+		IssuerURL: "https://login.microsoftonline.com/common/v2.0",
+		ClientID:  "client-id-b",
+	})
+	rs := &resources.ResourceSet{
+		Portals: []resources.PortalResource{{
+			BaseResource: resources.BaseResource{Ref: "portal-1"},
+			CreatePortal: kkComps.CreatePortal{Name: "portal-one"},
+		}},
+		PortalIdentityProviders: []resources.PortalIdentityProviderResource{
+			{
+				Ref:    "portal-oidc-a",
+				Portal: "portal-1",
+				CreateIdentityProvider: kkComps.CreateIdentityProvider{
+					Type:   kkComps.IdentityProviderTypeOidc.ToPointer(),
+					Config: &configA,
+				},
+			},
+			{
+				Ref:    "portal-oidc-b",
+				Portal: "portal-1",
+				CreateIdentityProvider: kkComps.CreateIdentityProvider{
+					Type:   kkComps.IdentityProviderTypeOidc.ToPointer(),
+					Config: &configB,
+				},
+			},
+		},
+	}
+
+	err := loader.validateResourceSet(rs)
+	assert.Error(t, err)
+	assert.Contains(
+		t,
+		err.Error(),
+		"multiple portal_identity_provider entries target portal \"portal-1\" and type \"oidc\"",
+	)
+}

--- a/internal/declarative/loader/validator_test.go
+++ b/internal/declarative/loader/validator_test.go
@@ -793,3 +793,93 @@ func TestLoader_validateResourceSet_RejectsDuplicatePortalIdentityProviderTypesP
 		"multiple portal_identity_provider entries target portal \"portal-1\" and type \"oidc\"",
 	)
 }
+
+func TestLoader_validateResourceSet_RejectsDuplicatePortalIdentityProviderSAMLTypesPerPortal(t *testing.T) {
+	loader := New()
+	configA := kkComps.CreateCreateIdentityProviderConfigSAMLIdentityProviderConfigInput(
+		kkComps.SAMLIdentityProviderConfigInput{
+			IdpMetadataURL: stringPtr("https://example-a.test/saml.xml"),
+		},
+	)
+	configB := kkComps.CreateCreateIdentityProviderConfigSAMLIdentityProviderConfigInput(
+		kkComps.SAMLIdentityProviderConfigInput{
+			IdpMetadataURL: stringPtr("https://example-b.test/saml.xml"),
+		},
+	)
+	rs := &resources.ResourceSet{
+		Portals: []resources.PortalResource{{
+			BaseResource: resources.BaseResource{Ref: "portal-1"},
+			CreatePortal: kkComps.CreatePortal{Name: "portal-one"},
+		}},
+		PortalIdentityProviders: []resources.PortalIdentityProviderResource{
+			{
+				Ref:    "portal-saml-a",
+				Portal: "portal-1",
+				CreateIdentityProvider: kkComps.CreateIdentityProvider{
+					Type:   kkComps.IdentityProviderTypeSaml.ToPointer(),
+					Config: &configA,
+				},
+			},
+			{
+				Ref:    "portal-saml-b",
+				Portal: "portal-1",
+				CreateIdentityProvider: kkComps.CreateIdentityProvider{
+					Type:   kkComps.IdentityProviderTypeSaml.ToPointer(),
+					Config: &configB,
+				},
+			},
+		},
+	}
+
+	err := loader.validateResourceSet(rs)
+	assert.Error(t, err)
+	assert.Contains(
+		t,
+		err.Error(),
+		"multiple portal_identity_provider entries target portal \"portal-1\" and type \"saml\"",
+	)
+}
+
+func TestLoader_validateResourceSet_AllowsMixedPortalIdentityProviderTypesPerPortal(t *testing.T) {
+	loader := New()
+	oidcConfig := kkComps.CreateCreateIdentityProviderConfigOIDCIdentityProviderConfig(kkComps.OIDCIdentityProviderConfig{
+		IssuerURL: "https://accounts.google.com",
+		ClientID:  "client-id-a",
+	})
+	samlConfig := kkComps.CreateCreateIdentityProviderConfigSAMLIdentityProviderConfigInput(
+		kkComps.SAMLIdentityProviderConfigInput{
+			IdpMetadataURL: stringPtr("https://example.test/saml.xml"),
+		},
+	)
+	rs := &resources.ResourceSet{
+		Portals: []resources.PortalResource{{
+			BaseResource: resources.BaseResource{Ref: "portal-1"},
+			CreatePortal: kkComps.CreatePortal{Name: "portal-one"},
+		}},
+		PortalIdentityProviders: []resources.PortalIdentityProviderResource{
+			{
+				Ref:    "portal-oidc",
+				Portal: "portal-1",
+				CreateIdentityProvider: kkComps.CreateIdentityProvider{
+					Type:   kkComps.IdentityProviderTypeOidc.ToPointer(),
+					Config: &oidcConfig,
+				},
+			},
+			{
+				Ref:    "portal-saml",
+				Portal: "portal-1",
+				CreateIdentityProvider: kkComps.CreateIdentityProvider{
+					Type:   kkComps.IdentityProviderTypeSaml.ToPointer(),
+					Config: &samlConfig,
+				},
+			},
+		},
+	}
+
+	err := loader.validateResourceSet(rs)
+	assert.NoError(t, err)
+}
+
+func stringPtr(value string) *string {
+	return &value
+}

--- a/internal/declarative/planner/base_planner.go
+++ b/internal/declarative/planner/base_planner.go
@@ -115,6 +115,11 @@ func (b *BasePlanner) GetDesiredPortalAuthSettings(namespace string) []resources
 	return b.planner.resources.GetPortalAuthSettingsByNamespace(namespace)
 }
 
+// GetDesiredPortalIdentityProviders returns desired portal identity provider resources from the specified namespace
+func (b *BasePlanner) GetDesiredPortalIdentityProviders(namespace string) []resources.PortalIdentityProviderResource {
+	return b.planner.resources.GetPortalIdentityProvidersByNamespace(namespace)
+}
+
 // GetDesiredPortalCustomDomains returns desired portal custom domain resources from the specified namespace
 func (b *BasePlanner) GetDesiredPortalCustomDomains(namespace string) []resources.PortalCustomDomainResource {
 	return b.planner.resources.GetPortalCustomDomainsByNamespace(namespace)

--- a/internal/declarative/planner/constants.go
+++ b/internal/declarative/planner/constants.go
@@ -64,6 +64,9 @@ const (
 	// ResourceTypePortalAuthSettings is the resource type for portal auth settings
 	ResourceTypePortalAuthSettings = "portal_auth_settings"
 
+	// ResourceTypePortalIdentityProvider is the resource type for portal identity providers
+	ResourceTypePortalIdentityProvider = "portal_identity_provider"
+
 	// ResourceTypePortalCustomDomain is the resource type for portal custom domains
 	ResourceTypePortalCustomDomain = "portal_custom_domain"
 

--- a/internal/declarative/planner/env_placeholders_test.go
+++ b/internal/declarative/planner/env_placeholders_test.go
@@ -158,3 +158,50 @@ func TestApplyDeferredEnvPlaceholders_UnionFields(t *testing.T) {
 	require.Len(t, plan.Warnings, 1)
 	assert.Contains(t, plan.Warnings[0].Message, "Contains deferred !env values")
 }
+
+func TestPlanPortalIdentityProviderCreate_PreservesDeferredEnvPlaceholders(t *testing.T) {
+	planner := &Planner{}
+	plan := NewPlan("1.0", "test", PlanModeApply)
+
+	enabled := true
+	clientSecret := "resolved-client-secret"
+	config := kkComps.CreateCreateIdentityProviderConfigOIDCIdentityProviderConfig(kkComps.OIDCIdentityProviderConfig{
+		IssuerURL:    "https://resolved.example.test/oauth2/default",
+		ClientID:     "resolved-client-id",
+		ClientSecret: &clientSecret,
+		Scopes:       []string{"openid", "profile"},
+	})
+	provider := resources.PortalIdentityProviderResource{
+		Ref:    "env-portal-idp",
+		Portal: "env-portal",
+		CreateIdentityProvider: kkComps.CreateIdentityProvider{
+			Type:    kkComps.IdentityProviderTypeOidc.ToPointer(),
+			Enabled: &enabled,
+			Config:  &config,
+		},
+	}
+
+	planner.planPortalIdentityProviderCreate("test-ns", provider, "", plan)
+
+	rs := &resources.ResourceSet{
+		EnvSources: map[string]map[string]string{
+			"env-portal-idp": { // #nosec G101 -- deferred !env placeholder names are not credentials.
+				"/config/issuer_url":    "__ENV__:PORTAL_IDP_ISSUER_URL",
+				"/config/client_id":     "__ENV__:PORTAL_IDP_CLIENT_ID",
+				// #nosec G101
+				"/config/client_secret": "__ENV__:PORTAL_IDP_CLIENT_SECRET",
+			},
+		},
+	}
+
+	planner.applyDeferredEnvPlaceholders(plan, rs)
+
+	require.Len(t, plan.Changes, 1)
+	configFields, ok := plan.Changes[0].Fields["config"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "__ENV__:PORTAL_IDP_ISSUER_URL", configFields["issuer_url"])
+	assert.Equal(t, "__ENV__:PORTAL_IDP_CLIENT_ID", configFields["client_id"])
+	assert.Equal(t, "__ENV__:PORTAL_IDP_CLIENT_SECRET", configFields["client_secret"])
+	require.Len(t, plan.Warnings, 1)
+	assert.Contains(t, plan.Warnings[0].Message, "Contains deferred !env values")
+}

--- a/internal/declarative/planner/planner.go
+++ b/internal/declarative/planner/planner.go
@@ -79,18 +79,19 @@ type Planner struct {
 	resources *resources.ResourceSet
 
 	// Legacy field access for backward compatibility (provides global access)
-	desiredPortals              []resources.PortalResource
-	desiredPortalPages          []resources.PortalPageResource
-	desiredPortalSnippets       []resources.PortalSnippetResource
-	desiredPortalTeams          []resources.PortalTeamResource
-	desiredPortalTeamRoles      []resources.PortalTeamRoleResource
-	desiredPortalCustomizations []resources.PortalCustomizationResource
-	desiredPortalAuthSettings   []resources.PortalAuthSettingsResource
-	desiredPortalCustomDomains  []resources.PortalCustomDomainResource
-	desiredPortalAssetLogos     []resources.PortalAssetLogoResource
-	desiredPortalAssetFavicons  []resources.PortalAssetFaviconResource
-	desiredPortalEmailConfigs   []resources.PortalEmailConfigResource
-	desiredPortalEmailTemplates []resources.PortalEmailTemplateResource
+	desiredPortals                 []resources.PortalResource
+	desiredPortalPages             []resources.PortalPageResource
+	desiredPortalSnippets          []resources.PortalSnippetResource
+	desiredPortalTeams             []resources.PortalTeamResource
+	desiredPortalTeamRoles         []resources.PortalTeamRoleResource
+	desiredPortalCustomizations    []resources.PortalCustomizationResource
+	desiredPortalAuthSettings      []resources.PortalAuthSettingsResource
+	desiredPortalIdentityProviders []resources.PortalIdentityProviderResource
+	desiredPortalCustomDomains     []resources.PortalCustomDomainResource
+	desiredPortalAssetLogos        []resources.PortalAssetLogoResource
+	desiredPortalAssetFavicons     []resources.PortalAssetFaviconResource
+	desiredPortalEmailConfigs      []resources.PortalEmailConfigResource
+	desiredPortalEmailTemplates    []resources.PortalEmailTemplateResource
 }
 
 // NewPlanner creates a new planner
@@ -227,6 +228,7 @@ func (p *Planner) GeneratePlan(ctx context.Context, rs *resources.ResourceSet, o
 		namespacePlanner.desiredPortalTeamRoles = rs.PortalTeamRoles
 		namespacePlanner.desiredPortalCustomizations = rs.PortalCustomizations
 		namespacePlanner.desiredPortalAuthSettings = rs.PortalAuthSettings
+		namespacePlanner.desiredPortalIdentityProviders = rs.PortalIdentityProviders
 		namespacePlanner.desiredPortalCustomDomains = rs.PortalCustomDomains
 		namespacePlanner.desiredPortalAssetLogos = rs.PortalAssetLogos
 		namespacePlanner.desiredPortalAssetFavicons = rs.PortalAssetFavicons

--- a/internal/declarative/planner/portal_child_planner.go
+++ b/internal/declarative/planner/portal_child_planner.go
@@ -544,18 +544,17 @@ func portalIdentityProviderConfigDiffValueFromCreate(config *kkComps.CreateIdent
 		return nil
 	}
 	if config.OIDCIdentityProviderConfig != nil {
-		var clientSecret any
-		if config.OIDCIdentityProviderConfig.ClientSecret != nil {
-			clientSecret = *config.OIDCIdentityProviderConfig.ClientSecret
-		}
-		return map[string]any{
+		diffValue := map[string]any{
 			"type":           "oidc",
 			"issuer_url":     config.OIDCIdentityProviderConfig.IssuerURL,
 			"client_id":      config.OIDCIdentityProviderConfig.ClientID,
-			"client_secret":  clientSecret,
 			"scopes":         config.OIDCIdentityProviderConfig.Scopes,
 			"claim_mappings": config.OIDCIdentityProviderConfig.ClaimMappings,
 		}
+		if config.OIDCIdentityProviderConfig.ClientSecret != nil {
+			diffValue["client_secret"] = *config.OIDCIdentityProviderConfig.ClientSecret
+		}
+		return diffValue
 	}
 	if config.SAMLIdentityProviderConfigInput != nil {
 		return map[string]any{

--- a/internal/declarative/planner/portal_child_planner.go
+++ b/internal/declarative/planner/portal_child_planner.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"slices"
 	"strings"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
@@ -178,16 +179,11 @@ func (p *Planner) planPortalAuthSettingsUpdateWithFields(
 		if lookupName == "" {
 			lookupName = settings.Portal
 		}
-		change.Parent = &ParentInfo{
-			Ref: settings.Portal,
-			ID:  portalID,
-		}
+		change.Parent = &ParentInfo{Ref: settings.Portal, ID: portalID}
 		change.References = map[string]ReferenceInfo{
 			"portal_id": {
-				Ref: settings.Portal,
-				LookupFields: map[string]string{
-					"name": lookupName,
-				},
+				Ref:          settings.Portal,
+				LookupFields: map[string]string{"name": lookupName},
 			},
 		}
 	}
@@ -209,35 +205,7 @@ func (p *Planner) shouldUpdatePortalAuthSettings(
 
 	if desired.BasicAuthEnabled != nil && !p.compareBoolToPtr(current.BasicAuthEnabled, desired.BasicAuthEnabled) {
 		updates["basic_auth_enabled"] = *desired.BasicAuthEnabled
-		changedFields["basic_auth_enabled"] = FieldChange{
-			Old: current.BasicAuthEnabled,
-			New: *desired.BasicAuthEnabled,
-		}
-	}
-
-	if desired.OidcAuthEnabled != nil && !p.compareBoolToPtr(current.OidcAuthEnabled, desired.OidcAuthEnabled) {
-		updates["oidc_auth_enabled"] = *desired.OidcAuthEnabled
-		changedFields["oidc_auth_enabled"] = FieldChange{
-			Old: current.OidcAuthEnabled,
-			New: *desired.OidcAuthEnabled,
-		}
-	}
-
-	if desired.SamlAuthEnabled != nil && !p.comparePtrBools(current.SamlAuthEnabled, desired.SamlAuthEnabled) {
-		updates["saml_auth_enabled"] = *desired.SamlAuthEnabled
-		changedFields["saml_auth_enabled"] = FieldChange{
-			Old: current.SamlAuthEnabled,
-			New: *desired.SamlAuthEnabled,
-		}
-	}
-
-	if desired.OidcTeamMappingEnabled != nil &&
-		!p.compareBoolToPtr(current.OidcTeamMappingEnabled, desired.OidcTeamMappingEnabled) {
-		updates["oidc_team_mapping_enabled"] = *desired.OidcTeamMappingEnabled
-		changedFields["oidc_team_mapping_enabled"] = FieldChange{
-			Old: current.OidcTeamMappingEnabled,
-			New: *desired.OidcTeamMappingEnabled,
-		}
+		changedFields["basic_auth_enabled"] = FieldChange{Old: current.BasicAuthEnabled, New: *desired.BasicAuthEnabled}
 	}
 
 	if desired.KonnectMappingEnabled != nil &&
@@ -257,71 +225,6 @@ func (p *Planner) shouldUpdatePortalAuthSettings(
 		}
 	}
 
-	if desired.OidcIssuer != nil {
-		if current.OidcConfig == nil || current.OidcConfig.Issuer != *desired.OidcIssuer {
-			updates["oidc_issuer"] = *desired.OidcIssuer
-			var oldValue any
-			if current.OidcConfig != nil {
-				oldValue = current.OidcConfig.Issuer
-			}
-			changedFields["oidc_issuer"] = FieldChange{
-				Old: oldValue,
-				New: *desired.OidcIssuer,
-			}
-		}
-	}
-
-	if desired.OidcClientID != nil {
-		if current.OidcConfig == nil || current.OidcConfig.ClientID != *desired.OidcClientID {
-			updates["oidc_client_id"] = *desired.OidcClientID
-			var oldValue any
-			if current.OidcConfig != nil {
-				oldValue = current.OidcConfig.ClientID
-			}
-			changedFields["oidc_client_id"] = FieldChange{
-				Old: oldValue,
-				New: *desired.OidcClientID,
-			}
-		}
-	}
-
-	if desired.OidcClientSecret != nil {
-		updates["oidc_client_secret"] = *desired.OidcClientSecret
-		changedFields["oidc_client_secret"] = FieldChange{
-			Old: nil,
-			New: *desired.OidcClientSecret,
-		}
-	}
-
-	if desired.OidcScopes != nil {
-		if current.OidcConfig == nil || !p.compareStringSlices(current.OidcConfig.Scopes, desired.OidcScopes) {
-			updates["oidc_scopes"] = desired.OidcScopes
-			var oldValue any
-			if current.OidcConfig != nil {
-				oldValue = current.OidcConfig.Scopes
-			}
-			changedFields["oidc_scopes"] = FieldChange{
-				Old: oldValue,
-				New: desired.OidcScopes,
-			}
-		}
-	}
-
-	if desired.OidcClaimMappings != nil {
-		if current.OidcConfig == nil ||
-			!reflect.DeepEqual(current.OidcConfig.ClaimMappings, desired.OidcClaimMappings) {
-			updates["oidc_claim_mappings"] = desired.OidcClaimMappings
-			var oldValue any
-			if current.OidcConfig != nil {
-				oldValue = current.OidcConfig.ClaimMappings
-			}
-			changedFields["oidc_claim_mappings"] = FieldChange{
-				Old: oldValue,
-				New: desired.OidcClaimMappings,
-			}
-		}
-	}
-
 	return len(updates) > 0, updates, changedFields
 }
 
@@ -331,49 +234,336 @@ func (p *Planner) buildAllPortalAuthSettingsFields(settings resources.PortalAuth
 	if settings.BasicAuthEnabled != nil {
 		fields["basic_auth_enabled"] = *settings.BasicAuthEnabled
 	}
-	if settings.OidcAuthEnabled != nil {
-		fields["oidc_auth_enabled"] = *settings.OidcAuthEnabled
-	}
-	if settings.SamlAuthEnabled != nil {
-		fields["saml_auth_enabled"] = *settings.SamlAuthEnabled
-	}
-	if settings.OidcTeamMappingEnabled != nil {
-		fields["oidc_team_mapping_enabled"] = *settings.OidcTeamMappingEnabled
-	}
 	if settings.KonnectMappingEnabled != nil {
 		fields["konnect_mapping_enabled"] = *settings.KonnectMappingEnabled
 	}
 	if settings.IdpMappingEnabled != nil {
 		fields["idp_mapping_enabled"] = *settings.IdpMappingEnabled
 	}
-	if settings.OidcIssuer != nil {
-		fields["oidc_issuer"] = *settings.OidcIssuer
-	}
-	if settings.OidcClientID != nil {
-		fields["oidc_client_id"] = *settings.OidcClientID
-	}
-	if settings.OidcClientSecret != nil {
-		fields["oidc_client_secret"] = *settings.OidcClientSecret
-	}
-	if settings.OidcScopes != nil {
-		fields["oidc_scopes"] = settings.OidcScopes
-	}
-	if settings.OidcClaimMappings != nil {
-		fields["oidc_claim_mappings"] = map[string]any{
-			"name":   safeString(settings.OidcClaimMappings.Name),
-			"email":  safeString(settings.OidcClaimMappings.Email),
-			"groups": safeString(settings.OidcClaimMappings.Groups),
-		}
-	}
 
 	return fields
 }
 
-func safeString(val *string) string {
-	if val != nil {
-		return *val
+// Portal Identity Providers planning (collection)
+
+func (p *Planner) planPortalIdentityProvidersChanges(
+	ctx context.Context, parentNamespace string, portalID string, portalRef string,
+	desired []resources.PortalIdentityProviderResource, plan *Plan,
+) error {
+	existingProviders := make(map[kkComps.IdentityProviderType]state.PortalIdentityProvider)
+	if portalID != "" {
+		providers, err := p.listPortalIdentityProviders(ctx, portalID)
+		if err != nil {
+			if strings.Contains(err.Error(), "portal identity provider API") {
+				return nil
+			}
+			return fmt.Errorf("failed to list existing portal identity providers for portal %s: %w", portalID, err)
+		}
+		for _, provider := range providers {
+			if existing, ok := existingProviders[provider.Type]; ok {
+				return fmt.Errorf(
+					"multiple existing portal identity providers found with type %q in portal %q (%s and %s)",
+					string(provider.Type),
+					portalRef,
+					existing.ID,
+					provider.ID,
+				)
+			}
+			existingProviders[provider.Type] = provider
+		}
 	}
-	return ""
+
+	desiredTypes := make(map[kkComps.IdentityProviderType]bool)
+	for _, provider := range desired {
+		if provider.Type == nil {
+			continue
+		}
+		providerType := *provider.Type
+		if desiredTypes[providerType] {
+			return fmt.Errorf(
+				"duplicate portal identity provider type %q found in portal %q: types must be unique within a portal",
+				string(providerType),
+				portalRef,
+			)
+		}
+		desiredTypes[providerType] = true
+
+		if plan.HasChange(ResourceTypePortalIdentityProvider, provider.GetRef()) {
+			continue
+		}
+
+		if current, ok := existingProviders[providerType]; ok {
+			shouldUpdate, updateFields, changedFields := p.shouldUpdatePortalIdentityProvider(current, provider)
+			if shouldUpdate {
+				p.planPortalIdentityProviderUpdate(
+					parentNamespace,
+					current,
+					provider,
+					portalRef,
+					portalID,
+					updateFields,
+					changedFields,
+					plan,
+				)
+			}
+			continue
+		}
+
+		p.planPortalIdentityProviderCreate(parentNamespace, provider, portalID, plan)
+	}
+
+	if plan.Metadata.Mode == PlanModeSync && !p.isPortalExternal(portalRef) {
+		for providerType, current := range existingProviders {
+			if !desiredTypes[providerType] {
+				p.planPortalIdentityProviderDelete(parentNamespace, portalRef, portalID, current, plan)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (p *Planner) planPortalIdentityProviderCreate(
+	parentNamespace string, provider resources.PortalIdentityProviderResource, portalID string, plan *Plan,
+) {
+	fields := p.buildAllPortalIdentityProviderFields(provider)
+	dependencies := p.portalChildDependencies(plan, provider.Portal)
+
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionCreate, ResourceTypePortalIdentityProvider, provider.GetRef()),
+		ResourceType: ResourceTypePortalIdentityProvider,
+		ResourceRef:  provider.GetRef(),
+		Action:       ActionCreate,
+		Fields:       fields,
+		DependsOn:    dependencies,
+		Namespace:    parentNamespace,
+	}
+
+	if provider.Portal != "" {
+		portalName := p.findPortalName(provider.Portal)
+		if portalID != "" {
+			change.Parent = &ParentInfo{Ref: provider.Portal, ID: portalID}
+		} else {
+			change.References = map[string]ReferenceInfo{
+				"portal_id": {Ref: provider.Portal, LookupFields: map[string]string{"name": portalName}},
+			}
+		}
+	}
+
+	plan.AddChange(change)
+}
+
+func (p *Planner) shouldUpdatePortalIdentityProvider(
+	current state.PortalIdentityProvider,
+	desired resources.PortalIdentityProviderResource,
+) (bool, map[string]any, map[string]FieldChange) {
+	updates := make(map[string]any)
+	changedFields := make(map[string]FieldChange)
+
+	if desired.Enabled != nil && !p.comparePtrBools(current.Enabled, desired.Enabled) {
+		updates["enabled"] = *desired.Enabled
+		changedFields["enabled"] = FieldChange{Old: current.Enabled, New: *desired.Enabled}
+	}
+
+	if desired.LoginPath != nil {
+		currentLoginPath := ""
+		if current.LoginPath != nil {
+			currentLoginPath = *current.LoginPath
+		}
+		if current.LoginPath == nil || currentLoginPath != *desired.LoginPath {
+			updates["login_path"] = *desired.LoginPath
+			changedFields["login_path"] = FieldChange{Old: current.LoginPath, New: *desired.LoginPath}
+		}
+	}
+
+	if desired.Config != nil {
+		if portalIdentityProviderConfigNeedsUpdate(current.Config, desired.Config) {
+			updates["config"] = portalIdentityProviderConfigDiffValueFromCreate(desired.Config)
+			changedFields["config"] = FieldChange{
+				Old: portalIdentityProviderConfigDiffValue(current.Config),
+				New: portalIdentityProviderConfigDiffValueFromCreate(desired.Config),
+			}
+		}
+	}
+
+	return len(updates) > 0, updates, changedFields
+}
+
+func (p *Planner) planPortalIdentityProviderUpdate(
+	parentNamespace string,
+	current state.PortalIdentityProvider,
+	desired resources.PortalIdentityProviderResource,
+	portalRef string,
+	portalID string,
+	updateFields map[string]any,
+	changedFields map[string]FieldChange,
+	plan *Plan,
+) {
+	change := PlannedChange{
+		ID:            p.nextChangeID(ActionUpdate, ResourceTypePortalIdentityProvider, desired.GetRef()),
+		ResourceType:  ResourceTypePortalIdentityProvider,
+		ResourceRef:   desired.GetRef(),
+		ResourceID:    current.ID,
+		Action:        ActionUpdate,
+		Fields:        updateFields,
+		ChangedFields: changedFields,
+		DependsOn:     p.portalChildDependencies(plan, portalRef),
+		Namespace:     parentNamespace,
+	}
+
+	if portalRef != "" {
+		change.References = map[string]ReferenceInfo{
+			"portal_id": {Ref: portalRef, LookupFields: map[string]string{"name": p.findPortalName(portalRef)}},
+		}
+		change.Parent = &ParentInfo{Ref: portalRef, ID: portalID}
+	}
+
+	plan.AddChange(change)
+}
+
+func (p *Planner) planPortalIdentityProviderDelete(
+	parentNamespace string, portalRef string, portalID string, provider state.PortalIdentityProvider, plan *Plan,
+) {
+	fields := map[string]any{"type": string(provider.Type)}
+	if provider.LoginPath != nil {
+		fields["login_path"] = *provider.LoginPath
+	}
+
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionDelete, ResourceTypePortalIdentityProvider, provider.ID),
+		ResourceType: ResourceTypePortalIdentityProvider,
+		ResourceRef:  provider.ID,
+		ResourceID:   provider.ID,
+		Action:       ActionDelete,
+		Fields:       fields,
+		Namespace:    parentNamespace,
+	}
+
+	if portalRef != "" {
+		change.Parent = &ParentInfo{Ref: portalRef, ID: portalID}
+		change.References = map[string]ReferenceInfo{
+			"portal_id": {Ref: portalRef, LookupFields: map[string]string{"name": p.findPortalName(portalRef)}},
+		}
+	}
+
+	plan.AddChange(change)
+}
+
+func (p *Planner) buildAllPortalIdentityProviderFields(
+	provider resources.PortalIdentityProviderResource,
+) map[string]any {
+	fields := make(map[string]any)
+	if provider.Type != nil {
+		fields["type"] = string(*provider.Type)
+	}
+	if provider.Enabled != nil {
+		fields["enabled"] = *provider.Enabled
+	}
+	if provider.LoginPath != nil {
+		fields["login_path"] = *provider.LoginPath
+	}
+	if provider.Config != nil {
+		fields["config"] = portalIdentityProviderConfigDiffValueFromCreate(provider.Config)
+	}
+	return fields
+}
+
+func portalIdentityProviderConfigNeedsUpdate(
+	current *kkComps.IdentityProviderConfig,
+	desired *kkComps.CreateIdentityProviderConfig,
+) bool {
+	if desired == nil {
+		return false
+	}
+	if current == nil || current.Type == "" {
+		return true
+	}
+
+	switch desired.Type {
+	case kkComps.CreateIdentityProviderConfigTypeOIDCIdentityProviderConfig:
+		if current.Type != kkComps.IdentityProviderConfigTypeOIDCIdentityProviderConfigOutput {
+			return true
+		}
+		desiredOIDC := desired.OIDCIdentityProviderConfig
+		currentOIDC := current.OIDCIdentityProviderConfigOutput
+		if desiredOIDC == nil || currentOIDC == nil {
+			return true
+		}
+		if currentOIDC.IssuerURL != desiredOIDC.IssuerURL || currentOIDC.ClientID != desiredOIDC.ClientID {
+			return true
+		}
+		if !slices.Equal(currentOIDC.Scopes, desiredOIDC.Scopes) {
+			return true
+		}
+		if !reflect.DeepEqual(currentOIDC.ClaimMappings, desiredOIDC.ClaimMappings) {
+			return true
+		}
+		return desiredOIDC.ClientSecret != nil
+	case kkComps.CreateIdentityProviderConfigTypeSAMLIdentityProviderConfigInput:
+		if current.Type != kkComps.IdentityProviderConfigTypeSAMLIdentityProviderConfig {
+			return true
+		}
+		desiredSAML := desired.SAMLIdentityProviderConfigInput
+		currentSAML := current.SAMLIdentityProviderConfig
+		if desiredSAML == nil || currentSAML == nil {
+			return true
+		}
+		return !reflect.DeepEqual(desiredSAML.IdpMetadataURL, currentSAML.IdpMetadataURL) ||
+			!reflect.DeepEqual(desiredSAML.IdpMetadataXML, currentSAML.IdpMetadataXML)
+	default:
+		return true
+	}
+}
+
+func portalIdentityProviderConfigDiffValue(config *kkComps.IdentityProviderConfig) any {
+	if config == nil {
+		return nil
+	}
+	if config.OIDCIdentityProviderConfigOutput != nil {
+		return map[string]any{
+			"type":           "oidc",
+			"issuer_url":     config.OIDCIdentityProviderConfigOutput.IssuerURL,
+			"client_id":      config.OIDCIdentityProviderConfigOutput.ClientID,
+			"scopes":         config.OIDCIdentityProviderConfigOutput.Scopes,
+			"claim_mappings": config.OIDCIdentityProviderConfigOutput.ClaimMappings,
+		}
+	}
+	if config.SAMLIdentityProviderConfig != nil {
+		return map[string]any{
+			"type":             "saml",
+			"idp_metadata_url": config.SAMLIdentityProviderConfig.IdpMetadataURL,
+			"idp_metadata_xml": config.SAMLIdentityProviderConfig.IdpMetadataXML,
+		}
+	}
+	return nil
+}
+
+func portalIdentityProviderConfigDiffValueFromCreate(config *kkComps.CreateIdentityProviderConfig) any {
+	if config == nil {
+		return nil
+	}
+	if config.OIDCIdentityProviderConfig != nil {
+		var clientSecret any
+		if config.OIDCIdentityProviderConfig.ClientSecret != nil {
+			clientSecret = *config.OIDCIdentityProviderConfig.ClientSecret
+		}
+		return map[string]any{
+			"type":           "oidc",
+			"issuer_url":     config.OIDCIdentityProviderConfig.IssuerURL,
+			"client_id":      config.OIDCIdentityProviderConfig.ClientID,
+			"client_secret":  clientSecret,
+			"scopes":         config.OIDCIdentityProviderConfig.Scopes,
+			"claim_mappings": config.OIDCIdentityProviderConfig.ClaimMappings,
+		}
+	}
+	if config.SAMLIdentityProviderConfigInput != nil {
+		return map[string]any{
+			"type":             "saml",
+			"idp_metadata_url": config.SAMLIdentityProviderConfigInput.IdpMetadataURL,
+			"idp_metadata_xml": config.SAMLIdentityProviderConfigInput.IdpMetadataXML,
+		}
+	}
+	return nil
 }
 
 func (p *Planner) planPortalCustomizationUpdate(

--- a/internal/declarative/planner/portal_child_planner.go
+++ b/internal/declarative/planner/portal_child_planner.go
@@ -498,7 +498,8 @@ func portalIdentityProviderConfigNeedsUpdate(
 		if !reflect.DeepEqual(currentOIDC.ClaimMappings, desiredOIDC.ClaimMappings) {
 			return true
 		}
-		return desiredOIDC.ClientSecret != nil
+		// client_secret is write-only and is never returned by the API, so it is skipped.
+		return false
 	case kkComps.CreateIdentityProviderConfigTypeSAMLIdentityProviderConfigInput:
 		if current.Type != kkComps.IdentityProviderConfigTypeSAMLIdentityProviderConfig {
 			return true

--- a/internal/declarative/planner/portal_child_planner.go
+++ b/internal/declarative/planner/portal_child_planner.go
@@ -492,7 +492,11 @@ func portalIdentityProviderConfigNeedsUpdate(
 		if currentOIDC.IssuerURL != desiredOIDC.IssuerURL || currentOIDC.ClientID != desiredOIDC.ClientID {
 			return true
 		}
-		if !slices.Equal(currentOIDC.Scopes, desiredOIDC.Scopes) {
+		currentScopes := slices.Clone(currentOIDC.Scopes)
+		desiredScopes := slices.Clone(desiredOIDC.Scopes)
+		slices.Sort(currentScopes)
+		slices.Sort(desiredScopes)
+		if !slices.Equal(currentScopes, desiredScopes) {
 			return true
 		}
 		if !reflect.DeepEqual(currentOIDC.ClaimMappings, desiredOIDC.ClaimMappings) {

--- a/internal/declarative/planner/portal_child_test.go
+++ b/internal/declarative/planner/portal_child_test.go
@@ -471,3 +471,184 @@ func TestPlanPortalCustomDomain_CreateWhenAbsent(t *testing.T) {
 	assert.Equal(t, ActionCreate, plan.Changes[0].Action)
 	assert.Equal(t, "developer.example.com", plan.Changes[0].Fields["hostname"])
 }
+
+type stubPortalIdentityProviderAPI struct {
+	listFn func(
+		ctx context.Context,
+		request kkOps.GetPortalIdentityProvidersRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.GetPortalIdentityProvidersResponse, error)
+}
+
+func (s *stubPortalIdentityProviderAPI) ListPortalIdentityProviders(
+	ctx context.Context,
+	request kkOps.GetPortalIdentityProvidersRequest,
+	opts ...kkOps.Option,
+) (*kkOps.GetPortalIdentityProvidersResponse, error) {
+	if s.listFn != nil {
+		return s.listFn(ctx, request, opts...)
+	}
+	return &kkOps.GetPortalIdentityProvidersResponse{IdentityProviders: []kkComps.IdentityProvider{}}, nil
+}
+
+func (s *stubPortalIdentityProviderAPI) GetPortalIdentityProvider(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ ...kkOps.Option,
+) (*kkOps.GetPortalIdentityProviderResponse, error) {
+	return nil, nil
+}
+
+func (s *stubPortalIdentityProviderAPI) CreatePortalIdentityProvider(
+	_ context.Context,
+	_ string,
+	_ kkComps.CreateIdentityProvider,
+	_ ...kkOps.Option,
+) (*kkOps.CreatePortalIdentityProviderResponse, error) {
+	return nil, nil
+}
+
+func (s *stubPortalIdentityProviderAPI) UpdatePortalIdentityProvider(
+	_ context.Context,
+	_ kkOps.UpdatePortalIdentityProviderRequest,
+	_ ...kkOps.Option,
+) (*kkOps.UpdatePortalIdentityProviderResponse, error) {
+	return nil, nil
+}
+
+func (s *stubPortalIdentityProviderAPI) DeletePortalIdentityProvider(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ ...kkOps.Option,
+) (*kkOps.DeletePortalIdentityProviderResponse, error) {
+	return nil, nil
+}
+
+func TestPlanPortalIdentityProviders_CreateWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubPortalIdentityProviderAPI{}
+	planner := &Planner{
+		client: state.NewClient(state.ClientConfig{PortalIdentityProviderAPI: stub}),
+		logger: slog.Default(),
+		desiredPortals: []resources.PortalResource{{
+			CreatePortal: kkComps.CreatePortal{Name: "portal"},
+			BaseResource: resources.BaseResource{Ref: "portal-1"},
+		}},
+	}
+
+	config := kkComps.CreateCreateIdentityProviderConfigOIDCIdentityProviderConfig(kkComps.OIDCIdentityProviderConfig{
+		IssuerURL: "https://accounts.google.com",
+		ClientID:  "client-id-1",
+		Scopes:    []string{"openid"},
+	})
+	desired := []resources.PortalIdentityProviderResource{{
+		Ref:    "portal-oidc",
+		Portal: "portal-1",
+		CreateIdentityProvider: kkComps.CreateIdentityProvider{
+			Type:      kkComps.IdentityProviderTypeOidc.ToPointer(),
+			LoginPath: new("oidc-login"),
+			Config:    &config,
+		},
+	}}
+
+	plan := NewPlan("1.0", "test", PlanModeApply)
+	err := planner.planPortalIdentityProvidersChanges(
+		context.Background(),
+		DefaultNamespace,
+		"portal-id",
+		"portal-1",
+		desired,
+		plan,
+	)
+	assert.NoError(t, err)
+	if assert.Len(t, plan.Changes, 1) {
+		change := plan.Changes[0]
+		assert.Equal(t, ActionCreate, change.Action)
+		assert.Equal(t, ResourceTypePortalIdentityProvider, change.ResourceType)
+		assert.Equal(t, "portal-oidc", change.ResourceRef)
+		assert.Equal(t, "oidc", change.Fields["type"])
+		assert.Equal(t, "oidc-login", change.Fields["login_path"])
+		if assert.NotNil(t, change.Parent) {
+			assert.Equal(t, "portal-1", change.Parent.Ref)
+			assert.Equal(t, "portal-id", change.Parent.ID)
+		}
+	}
+}
+
+func TestPlanPortalIdentityProviders_UpdateWhenStateDiffers(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubPortalIdentityProviderAPI{
+		listFn: func(
+			_ context.Context,
+			_ kkOps.GetPortalIdentityProvidersRequest,
+			_ ...kkOps.Option,
+		) (*kkOps.GetPortalIdentityProvidersResponse, error) {
+			currentConfig := kkComps.CreateIdentityProviderConfigOIDCIdentityProviderConfigOutput(
+				kkComps.OIDCIdentityProviderConfigOutput{
+					IssuerURL: "https://accounts.google.com",
+					ClientID:  "client-id-old",
+					Scopes:    []string{"openid"},
+				},
+			)
+			return &kkOps.GetPortalIdentityProvidersResponse{
+				IdentityProviders: []kkComps.IdentityProvider{{
+					ID:        new("provider-id"),
+					Type:      kkComps.IdentityProviderTypeOidc.ToPointer(),
+					Enabled:   new(false),
+					LoginPath: new("oidc-login"),
+					Config:    &currentConfig,
+				}},
+			}, nil
+		},
+	}
+	planner := &Planner{
+		client: state.NewClient(state.ClientConfig{PortalIdentityProviderAPI: stub}),
+		logger: slog.Default(),
+		desiredPortals: []resources.PortalResource{{
+			CreatePortal: kkComps.CreatePortal{Name: "portal"},
+			BaseResource: resources.BaseResource{Ref: "portal-1"},
+		}},
+	}
+
+	desiredConfig := kkComps.CreateCreateIdentityProviderConfigOIDCIdentityProviderConfig(
+		kkComps.OIDCIdentityProviderConfig{
+			IssuerURL: "https://accounts.google.com",
+			ClientID:  "client-id-new",
+			Scopes:    []string{"openid", "profile"},
+		},
+	)
+	desired := []resources.PortalIdentityProviderResource{{
+		Ref:    "portal-oidc",
+		Portal: "portal-1",
+		CreateIdentityProvider: kkComps.CreateIdentityProvider{
+			Type:      kkComps.IdentityProviderTypeOidc.ToPointer(),
+			Enabled:   new(true),
+			LoginPath: new("oidc-login-updated"),
+			Config:    &desiredConfig,
+		},
+	}}
+
+	plan := NewPlan("1.0", "test", PlanModeApply)
+	err := planner.planPortalIdentityProvidersChanges(
+		context.Background(),
+		DefaultNamespace,
+		"portal-id",
+		"portal-1",
+		desired,
+		plan,
+	)
+	assert.NoError(t, err)
+	if assert.Len(t, plan.Changes, 1) {
+		change := plan.Changes[0]
+		assert.Equal(t, ActionUpdate, change.Action)
+		assert.Equal(t, ResourceTypePortalIdentityProvider, change.ResourceType)
+		assert.Equal(t, "provider-id", change.ResourceID)
+		assert.Equal(t, true, change.Fields["enabled"])
+		assert.Equal(t, "oidc-login-updated", change.Fields["login_path"])
+		assert.Contains(t, change.ChangedFields, "config")
+	}
+}

--- a/internal/declarative/planner/portal_child_test.go
+++ b/internal/declarative/planner/portal_child_test.go
@@ -656,7 +656,6 @@ func TestPlanPortalIdentityProviders_UpdateWhenStateDiffers(t *testing.T) {
 func TestPlanPortalIdentityProviders_IgnoresWriteOnlyClientSecret(t *testing.T) {
 	t.Parallel()
 
-	clientSecret := "write-only-secret"
 	stub := &stubPortalIdentityProviderAPI{
 		listFn: func(
 			_ context.Context,
@@ -698,7 +697,7 @@ func TestPlanPortalIdentityProviders_IgnoresWriteOnlyClientSecret(t *testing.T) 
 		kkComps.OIDCIdentityProviderConfig{
 			IssuerURL:    "https://accounts.google.com",
 			ClientID:     "client-id-1",
-			ClientSecret: &clientSecret,
+			ClientSecret: new("placeholder"),
 			Scopes:       []string{"openid", "profile"},
 			ClaimMappings: &kkComps.OIDCIdentityProviderClaimMappings{
 				Name:   new("name"),

--- a/internal/declarative/planner/portal_child_test.go
+++ b/internal/declarative/planner/portal_child_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kong/kongctl/internal/declarative/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type stubPortalCustomDomainAPI struct {
@@ -727,4 +728,20 @@ func TestPlanPortalIdentityProviders_IgnoresWriteOnlyClientSecret(t *testing.T) 
 	)
 	assert.NoError(t, err)
 	assert.Empty(t, plan.Changes)
+}
+
+func TestPortalIdentityProviderConfigDiffValueFromCreate_OmitsAbsentClientSecret(t *testing.T) {
+	t.Parallel()
+
+	config := kkComps.CreateCreateIdentityProviderConfigOIDCIdentityProviderConfig(
+		kkComps.OIDCIdentityProviderConfig{
+			IssuerURL: "https://accounts.google.com",
+			ClientID:  "client-id-1",
+			Scopes:    []string{"openid", "profile"},
+		},
+	)
+
+	diffValue, ok := portalIdentityProviderConfigDiffValueFromCreate(&config).(map[string]any)
+	require.True(t, ok)
+	assert.NotContains(t, diffValue, "client_secret")
 }

--- a/internal/declarative/planner/portal_child_test.go
+++ b/internal/declarative/planner/portal_child_test.go
@@ -550,7 +550,7 @@ func TestPlanPortalIdentityProviders_CreateWhenAbsent(t *testing.T) {
 		Portal: "portal-1",
 		CreateIdentityProvider: kkComps.CreateIdentityProvider{
 			Type:      kkComps.IdentityProviderTypeOidc.ToPointer(),
-			LoginPath: new("oidc-login"),
+			LoginPath: ptr("oidc-login"),
 			Config:    &config,
 		},
 	}}
@@ -597,10 +597,10 @@ func TestPlanPortalIdentityProviders_UpdateWhenStateDiffers(t *testing.T) {
 			)
 			return &kkOps.GetPortalIdentityProvidersResponse{
 				IdentityProviders: []kkComps.IdentityProvider{{
-					ID:        new("provider-id"),
+					ID:        ptr("provider-id"),
 					Type:      kkComps.IdentityProviderTypeOidc.ToPointer(),
-					Enabled:   new(false),
-					LoginPath: new("oidc-login"),
+					Enabled:   ptr(false),
+					LoginPath: ptr("oidc-login"),
 					Config:    &currentConfig,
 				}},
 			}, nil
@@ -627,8 +627,8 @@ func TestPlanPortalIdentityProviders_UpdateWhenStateDiffers(t *testing.T) {
 		Portal: "portal-1",
 		CreateIdentityProvider: kkComps.CreateIdentityProvider{
 			Type:      kkComps.IdentityProviderTypeOidc.ToPointer(),
-			Enabled:   new(true),
-			LoginPath: new("oidc-login-updated"),
+			Enabled:   ptr(true),
+			LoginPath: ptr("oidc-login-updated"),
 			Config:    &desiredConfig,
 		},
 	}}
@@ -669,17 +669,17 @@ func TestPlanPortalIdentityProviders_IgnoresWriteOnlyClientSecret(t *testing.T) 
 					ClientID:  "client-id-1",
 					Scopes:    []string{"openid", "profile"},
 					ClaimMappings: &kkComps.OIDCIdentityProviderClaimMappings{
-						Name:   new("name"),
-						Email:  new("email"),
-						Groups: new("groups"),
+						Name:   ptr("name"),
+						Email:  ptr("email"),
+						Groups: ptr("groups"),
 					},
 				},
 			)
 			return &kkOps.GetPortalIdentityProvidersResponse{
 				IdentityProviders: []kkComps.IdentityProvider{{
-					ID:      new("provider-id"),
+					ID:      ptr("provider-id"),
 					Type:    kkComps.IdentityProviderTypeOidc.ToPointer(),
-					Enabled: new(true),
+					Enabled: ptr(true),
 					Config:  &currentConfig,
 				}},
 			}, nil
@@ -698,12 +698,12 @@ func TestPlanPortalIdentityProviders_IgnoresWriteOnlyClientSecret(t *testing.T) 
 		kkComps.OIDCIdentityProviderConfig{
 			IssuerURL:    "https://accounts.google.com",
 			ClientID:     "client-id-1",
-			ClientSecret: new("placeholder"),
+			ClientSecret: ptr("placeholder"),
 			Scopes:       []string{"openid", "profile"},
 			ClaimMappings: &kkComps.OIDCIdentityProviderClaimMappings{
-				Name:   new("name"),
-				Email:  new("email"),
-				Groups: new("groups"),
+				Name:   ptr("name"),
+				Email:  ptr("email"),
+				Groups: ptr("groups"),
 			},
 		},
 	)
@@ -712,7 +712,72 @@ func TestPlanPortalIdentityProviders_IgnoresWriteOnlyClientSecret(t *testing.T) 
 		Portal: "portal-1",
 		CreateIdentityProvider: kkComps.CreateIdentityProvider{
 			Type:    kkComps.IdentityProviderTypeOidc.ToPointer(),
-			Enabled: new(true),
+			Enabled: ptr(true),
+			Config:  &desiredConfig,
+		},
+	}}
+
+	plan := NewPlan("1.0", "test", PlanModeApply)
+	err := planner.planPortalIdentityProvidersChanges(
+		context.Background(),
+		DefaultNamespace,
+		"portal-id",
+		"portal-1",
+		desired,
+		plan,
+	)
+	assert.NoError(t, err)
+	assert.Empty(t, plan.Changes)
+}
+
+func TestPlanPortalIdentityProviders_IgnoresOIDCScopeOrderChanges(t *testing.T) {
+	t.Parallel()
+
+	stub := &stubPortalIdentityProviderAPI{
+		listFn: func(
+			_ context.Context,
+			_ kkOps.GetPortalIdentityProvidersRequest,
+			_ ...kkOps.Option,
+		) (*kkOps.GetPortalIdentityProvidersResponse, error) {
+			currentConfig := kkComps.CreateIdentityProviderConfigOIDCIdentityProviderConfigOutput(
+				kkComps.OIDCIdentityProviderConfigOutput{
+					IssuerURL: "https://accounts.google.com",
+					ClientID:  "client-id-1",
+					Scopes:    []string{"profile", "openid"},
+				},
+			)
+			return &kkOps.GetPortalIdentityProvidersResponse{
+				IdentityProviders: []kkComps.IdentityProvider{{
+					ID:      ptr("provider-id"),
+					Type:    kkComps.IdentityProviderTypeOidc.ToPointer(),
+					Enabled: ptr(true),
+					Config:  &currentConfig,
+				}},
+			}, nil
+		},
+	}
+	planner := &Planner{
+		client: state.NewClient(state.ClientConfig{PortalIdentityProviderAPI: stub}),
+		logger: slog.Default(),
+		desiredPortals: []resources.PortalResource{{
+			CreatePortal: kkComps.CreatePortal{Name: "portal"},
+			BaseResource: resources.BaseResource{Ref: "portal-1"},
+		}},
+	}
+
+	desiredConfig := kkComps.CreateCreateIdentityProviderConfigOIDCIdentityProviderConfig(
+		kkComps.OIDCIdentityProviderConfig{
+			IssuerURL: "https://accounts.google.com",
+			ClientID:  "client-id-1",
+			Scopes:    []string{"openid", "profile"},
+		},
+	)
+	desired := []resources.PortalIdentityProviderResource{{
+		Ref:    "portal-oidc",
+		Portal: "portal-1",
+		CreateIdentityProvider: kkComps.CreateIdentityProvider{
+			Type:    kkComps.IdentityProviderTypeOidc.ToPointer(),
+			Enabled: ptr(true),
 			Config:  &desiredConfig,
 		},
 	}}
@@ -744,4 +809,8 @@ func TestPortalIdentityProviderConfigDiffValueFromCreate_OmitsAbsentClientSecret
 	diffValue, ok := portalIdentityProviderConfigDiffValueFromCreate(&config).(map[string]any)
 	require.True(t, ok)
 	assert.NotContains(t, diffValue, "client_secret")
+}
+
+func ptr[T any](value T) *T {
+	return &value
 }

--- a/internal/declarative/planner/portal_child_test.go
+++ b/internal/declarative/planner/portal_child_test.go
@@ -652,3 +652,80 @@ func TestPlanPortalIdentityProviders_UpdateWhenStateDiffers(t *testing.T) {
 		assert.Contains(t, change.ChangedFields, "config")
 	}
 }
+
+func TestPlanPortalIdentityProviders_IgnoresWriteOnlyClientSecret(t *testing.T) {
+	t.Parallel()
+
+	clientSecret := "write-only-secret"
+	stub := &stubPortalIdentityProviderAPI{
+		listFn: func(
+			_ context.Context,
+			_ kkOps.GetPortalIdentityProvidersRequest,
+			_ ...kkOps.Option,
+		) (*kkOps.GetPortalIdentityProvidersResponse, error) {
+			currentConfig := kkComps.CreateIdentityProviderConfigOIDCIdentityProviderConfigOutput(
+				kkComps.OIDCIdentityProviderConfigOutput{
+					IssuerURL: "https://accounts.google.com",
+					ClientID:  "client-id-1",
+					Scopes:    []string{"openid", "profile"},
+					ClaimMappings: &kkComps.OIDCIdentityProviderClaimMappings{
+						Name:   new("name"),
+						Email:  new("email"),
+						Groups: new("groups"),
+					},
+				},
+			)
+			return &kkOps.GetPortalIdentityProvidersResponse{
+				IdentityProviders: []kkComps.IdentityProvider{{
+					ID:      new("provider-id"),
+					Type:    kkComps.IdentityProviderTypeOidc.ToPointer(),
+					Enabled: new(true),
+					Config:  &currentConfig,
+				}},
+			}, nil
+		},
+	}
+	planner := &Planner{
+		client: state.NewClient(state.ClientConfig{PortalIdentityProviderAPI: stub}),
+		logger: slog.Default(),
+		desiredPortals: []resources.PortalResource{{
+			CreatePortal: kkComps.CreatePortal{Name: "portal"},
+			BaseResource: resources.BaseResource{Ref: "portal-1"},
+		}},
+	}
+
+	desiredConfig := kkComps.CreateCreateIdentityProviderConfigOIDCIdentityProviderConfig(
+		kkComps.OIDCIdentityProviderConfig{
+			IssuerURL:    "https://accounts.google.com",
+			ClientID:     "client-id-1",
+			ClientSecret: &clientSecret,
+			Scopes:       []string{"openid", "profile"},
+			ClaimMappings: &kkComps.OIDCIdentityProviderClaimMappings{
+				Name:   new("name"),
+				Email:  new("email"),
+				Groups: new("groups"),
+			},
+		},
+	)
+	desired := []resources.PortalIdentityProviderResource{{
+		Ref:    "portal-oidc",
+		Portal: "portal-1",
+		CreateIdentityProvider: kkComps.CreateIdentityProvider{
+			Type:    kkComps.IdentityProviderTypeOidc.ToPointer(),
+			Enabled: new(true),
+			Config:  &desiredConfig,
+		},
+	}}
+
+	plan := NewPlan("1.0", "test", PlanModeApply)
+	err := planner.planPortalIdentityProvidersChanges(
+		context.Background(),
+		DefaultNamespace,
+		"portal-id",
+		"portal-1",
+		desired,
+		plan,
+	)
+	assert.NoError(t, err)
+	assert.Empty(t, plan.Changes)
+}

--- a/internal/declarative/planner/portal_planner.go
+++ b/internal/declarative/planner/portal_planner.go
@@ -826,6 +826,26 @@ func (p *portalPlannerImpl) planPortalChildResourcesCreate(
 			"error", err.Error())
 	}
 
+	// Plan identity providers
+	identityProviders := make([]resources.PortalIdentityProviderResource, 0)
+	for _, provider := range planner.desiredPortalIdentityProviders {
+		if provider.Portal == desired.Ref {
+			identityProviders = append(identityProviders, provider)
+		}
+	}
+	if err := planner.planPortalIdentityProvidersChanges(
+		ctx,
+		parentNamespace,
+		"",
+		desired.Ref,
+		identityProviders,
+		plan,
+	); err != nil {
+		planner.logger.Debug("Failed to plan portal identity providers for new portal",
+			"portal", desired.Ref,
+			"error", err.Error())
+	}
+
 	// Plan email config
 	emailConfigs := make([]resources.PortalEmailConfigResource, 0)
 	for _, cfg := range planner.desiredPortalEmailConfigs {
@@ -1010,6 +1030,24 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 	}
 	if err := planner.planPortalAuthSettingsChanges(ctx, plannerCtx, parentNamespace, authSettings, plan); err != nil {
 		return fmt.Errorf("failed to plan portal auth settings changes: %w", err)
+	}
+
+	// Plan identity providers
+	identityProviders := make([]resources.PortalIdentityProviderResource, 0)
+	for _, provider := range planner.desiredPortalIdentityProviders {
+		if provider.Portal == desired.Ref {
+			identityProviders = append(identityProviders, provider)
+		}
+	}
+	if err := planner.planPortalIdentityProvidersChanges(
+		ctx,
+		parentNamespace,
+		current.ID,
+		desired.Ref,
+		identityProviders,
+		plan,
+	); err != nil {
+		return fmt.Errorf("failed to plan portal identity provider changes: %w", err)
 	}
 
 	// Plan email config (singleton resource)

--- a/internal/declarative/planner/resource_cache.go
+++ b/internal/declarative/planner/resource_cache.go
@@ -41,7 +41,8 @@ type planningResourceCache struct {
 	managedOrganizationTeamsAll    []state.OrganizationTeam
 	managedOrganizationTeamsLoaded bool
 
-	portalTeamsByPortalID map[string][]state.PortalTeam
+	portalTeamsByPortalID             map[string][]state.PortalTeam
+	portalIdentityProvidersByPortalID map[string][]state.PortalIdentityProvider
 }
 
 func newPlanningResourceCache() *planningResourceCache {
@@ -55,6 +56,7 @@ func newPlanningResourceCache() *planningResourceCache {
 		managedCatalogServicesByKey:           make(map[string][]state.CatalogService),
 		managedOrganizationTeamsByKey:         make(map[string][]state.OrganizationTeam),
 		portalTeamsByPortalID:                 make(map[string][]state.PortalTeam),
+		portalIdentityProvidersByPortalID:     make(map[string][]state.PortalIdentityProvider),
 	}
 }
 
@@ -498,6 +500,33 @@ func (p *Planner) listPortalTeams(ctx context.Context, portalID string) ([]state
 	}
 
 	return teams, nil
+}
+
+func (p *Planner) listPortalIdentityProviders(
+	ctx context.Context,
+	portalID string,
+) ([]state.PortalIdentityProvider, error) {
+	if portalID == "" {
+		return []state.PortalIdentityProvider{}, nil
+	}
+
+	cache := p.resourceCache
+	if cache != nil {
+		if cached, ok := cache.portalIdentityProvidersByPortalID[portalID]; ok {
+			return cached, nil
+		}
+	}
+
+	providers, err := p.client.ListPortalIdentityProviders(ctx, portalID)
+	if err != nil {
+		return nil, err
+	}
+
+	if cache != nil {
+		cache.portalIdentityProvidersByPortalID[portalID] = providers
+	}
+
+	return providers, nil
 }
 
 func normalizeNamespaces(namespaces []string) []string {

--- a/internal/declarative/protection/lookup.go
+++ b/internal/declarative/protection/lookup.go
@@ -110,6 +110,7 @@ func IsManagedResourceProtected(
 		resources.ResourceTypePortalCustomization,
 		resources.ResourceTypePortalCustomDomain,
 		resources.ResourceTypePortalAuthSettings,
+		resources.ResourceTypePortalIdentityProvider,
 		resources.ResourceTypePortalPage,
 		resources.ResourceTypePortalSnippet,
 		resources.ResourceTypePortalTeam,

--- a/internal/declarative/resources/explain_test.go
+++ b/internal/declarative/resources/explain_test.go
@@ -96,8 +96,11 @@ func TestRenderExplainText_ResourceSubject(t *testing.T) {
 	assert.Contains(t, text, "SUPPORTS ROOT: true")
 	assert.Contains(t, text, "SUPPORTS NESTED DECLARATION: false")
 	assert.Contains(t, text, "ACCEPTS kongctl metadata: yes")
-	assert.Contains(t, text,
-		"CHILD RESOURCES: auth_settings, custom_domain, customization, email_config, pages, snippets, teams")
+	assert.Contains(
+		t,
+		text,
+		"CHILD RESOURCES: auth_settings, custom_domain, customization, email_config, identity_providers, pages, snippets, teams", //nolint:lll
+	)
 	assert.Contains(t, text, "\nFIELD DETAILS: use --extended")
 	assert.NotContains(t, text, "RESOURCE: portal")
 	assert.NotContains(t, text, "PATH: portal")
@@ -129,8 +132,11 @@ func TestRenderExplainText_FieldSubject(t *testing.T) {
 	assert.Contains(t, text, "\nRESOURCE\nRESOURCE CLASS: top-level")
 	assert.Contains(t, text, "ROOT KEY: portals[]")
 	assert.Contains(t, text, "SUPPORTS NESTED DECLARATION: false")
-	assert.Contains(t, text,
-		"CHILD RESOURCES: auth_settings, custom_domain, customization, email_config, pages, snippets, teams")
+	assert.Contains(
+		t,
+		text,
+		"CHILD RESOURCES: auth_settings, custom_domain, customization, email_config, identity_providers, pages, snippets, teams", //nolint:lll
+	)
 	assert.NotContains(t, text, "PLACEMENT")
 	assert.NotContains(t, text, "YAML PATH:")
 }

--- a/internal/declarative/resources/portal.go
+++ b/internal/declarative/resources/portal.go
@@ -23,14 +23,15 @@ type PortalResource struct {
 	kkComps.CreatePortal `yaml:",inline" json:",inline"`
 
 	// Child resources that match API endpoints
-	Customization  *PortalCustomizationResource           `yaml:"customization,omitempty"   json:"customization,omitempty"`
-	AuthSettings   *PortalAuthSettingsResource            `yaml:"auth_settings,omitempty"   json:"auth_settings,omitempty"`
-	CustomDomain   *PortalCustomDomainResource            `yaml:"custom_domain,omitempty"   json:"custom_domain,omitempty"`
-	Pages          []PortalPageResource                   `yaml:"pages,omitempty"           json:"pages,omitempty"`
-	Snippets       []PortalSnippetResource                `yaml:"snippets,omitempty"        json:"snippets,omitempty"`
-	Teams          []PortalTeamResource                   `yaml:"teams,omitempty"           json:"teams,omitempty"`
-	EmailConfig    *PortalEmailConfigResource             `yaml:"email_config,omitempty"    json:"email_config,omitempty"`
-	EmailTemplates map[string]PortalEmailTemplateResource `yaml:"email_templates,omitempty" json:"email_templates,omitempty"` //nolint:lll
+	Customization     *PortalCustomizationResource           `yaml:"customization,omitempty"      json:"customization,omitempty"`      //nolint:lll
+	AuthSettings      *PortalAuthSettingsResource            `yaml:"auth_settings,omitempty"      json:"auth_settings,omitempty"`      //nolint:lll
+	IdentityProviders []PortalIdentityProviderResource       `yaml:"identity_providers,omitempty" json:"identity_providers,omitempty"` //nolint:lll
+	CustomDomain      *PortalCustomDomainResource            `yaml:"custom_domain,omitempty"      json:"custom_domain,omitempty"`      //nolint:lll
+	Pages             []PortalPageResource                   `yaml:"pages,omitempty"              json:"pages,omitempty"`
+	Snippets          []PortalSnippetResource                `yaml:"snippets,omitempty"           json:"snippets,omitempty"` //nolint:lll
+	Teams             []PortalTeamResource                   `yaml:"teams,omitempty"              json:"teams,omitempty"`
+	EmailConfig       *PortalEmailConfigResource             `yaml:"email_config,omitempty"       json:"email_config,omitempty"`    //nolint:lll
+	EmailTemplates    map[string]PortalEmailTemplateResource `yaml:"email_templates,omitempty"    json:"email_templates,omitempty"` //nolint:lll
 
 	// Assets object containing logo and favicon (data URLs from !file tag)
 	Assets *PortalAssetsResource `yaml:"assets,omitempty" json:"assets,omitempty"`
@@ -120,6 +121,17 @@ func (p PortalResource) Validate() error {
 		}
 	}
 
+	providerRefs := make(map[string]bool)
+	for i, provider := range p.IdentityProviders {
+		if err := provider.Validate(); err != nil {
+			return fmt.Errorf("invalid identity provider %d: %w", i, err)
+		}
+		if providerRefs[provider.GetRef()] {
+			return fmt.Errorf("duplicate identity provider ref: %s", provider.GetRef())
+		}
+		providerRefs[provider.GetRef()] = true
+	}
+
 	if p.CustomDomain != nil {
 		if err := p.CustomDomain.Validate(); err != nil {
 			return fmt.Errorf("invalid custom domain: %w", err)
@@ -207,6 +219,10 @@ func (p *PortalResource) SetDefaults() {
 		p.AuthSettings.SetDefaults()
 	}
 
+	for i := range p.IdentityProviders {
+		p.IdentityProviders[i].SetDefaults()
+	}
+
 	if p.CustomDomain != nil {
 		p.CustomDomain.SetDefaults()
 	}
@@ -288,6 +304,7 @@ func (p *PortalResource) UnmarshalJSON(data []byte) error {
 		"kongctl",
 		"customization",
 		"auth_settings",
+		"identity_providers",
 		"custom_domain",
 		"pages",
 		"snippets",
@@ -335,6 +352,13 @@ func (p *PortalResource) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		delete(raw, "auth_settings")
+	}
+
+	if v, ok := raw["identity_providers"]; ok {
+		if err := json.Unmarshal(v, &p.IdentityProviders); err != nil {
+			return err
+		}
+		delete(raw, "identity_providers")
 	}
 
 	if v, ok := raw["custom_domain"]; ok {
@@ -439,19 +463,20 @@ func (p PortalResource) MarshalYAML() (any, error) {
 }
 
 type portalAlias struct {
-	portalCreateAlias `                                       json:",inline"                   yaml:",inline"`
-	Ref               string                                 `json:"ref"                       yaml:"ref"`
-	Kongctl           *KongctlMeta                           `json:"kongctl,omitempty"         yaml:"kongctl,omitempty"`
-	Customization     *PortalCustomizationResource           `json:"customization,omitempty"   yaml:"customization,omitempty"` //nolint:lll
-	AuthSettings      *PortalAuthSettingsResource            `json:"auth_settings,omitempty"   yaml:"auth_settings,omitempty"` //nolint:lll
-	CustomDomain      *PortalCustomDomainResource            `json:"custom_domain,omitempty"   yaml:"custom_domain,omitempty"` //nolint:lll
-	Pages             []PortalPageResource                   `json:"pages,omitempty"           yaml:"pages,omitempty"`
-	Snippets          []PortalSnippetResource                `json:"snippets,omitempty"        yaml:"snippets,omitempty"`
-	Teams             []PortalTeamResource                   `json:"teams,omitempty"           yaml:"teams,omitempty"`
-	EmailConfig       *PortalEmailConfigResource             `json:"email_config,omitempty"    yaml:"email_config,omitempty"`    //nolint:lll
-	EmailTemplates    map[string]PortalEmailTemplateResource `json:"email_templates,omitempty" yaml:"email_templates,omitempty"` //nolint:lll
-	Assets            *PortalAssetsResource                  `json:"assets,omitempty"          yaml:"assets,omitempty"`
-	External          *ExternalBlock                         `json:"_external,omitempty"       yaml:"_external,omitempty"`
+	portalCreateAlias `                                       json:",inline"                      yaml:",inline"`
+	Ref               string                                 `json:"ref"                          yaml:"ref"`
+	Kongctl           *KongctlMeta                           `json:"kongctl,omitempty"            yaml:"kongctl,omitempty"`
+	Customization     *PortalCustomizationResource           `json:"customization,omitempty"      yaml:"customization,omitempty"`      //nolint:lll
+	AuthSettings      *PortalAuthSettingsResource            `json:"auth_settings,omitempty"      yaml:"auth_settings,omitempty"`      //nolint:lll
+	IdentityProviders []PortalIdentityProviderResource       `json:"identity_providers,omitempty" yaml:"identity_providers,omitempty"` //nolint:lll
+	CustomDomain      *PortalCustomDomainResource            `json:"custom_domain,omitempty"      yaml:"custom_domain,omitempty"`      //nolint:lll
+	Pages             []PortalPageResource                   `json:"pages,omitempty"              yaml:"pages,omitempty"`
+	Snippets          []PortalSnippetResource                `json:"snippets,omitempty"           yaml:"snippets,omitempty"` //nolint:lll
+	Teams             []PortalTeamResource                   `json:"teams,omitempty"              yaml:"teams,omitempty"`
+	EmailConfig       *PortalEmailConfigResource             `json:"email_config,omitempty"       yaml:"email_config,omitempty"`    //nolint:lll
+	EmailTemplates    map[string]PortalEmailTemplateResource `json:"email_templates,omitempty"    yaml:"email_templates,omitempty"` //nolint:lll
+	Assets            *PortalAssetsResource                  `json:"assets,omitempty"             yaml:"assets,omitempty"`
+	External          *ExternalBlock                         `json:"_external,omitempty"          yaml:"_external,omitempty"` //nolint:lll
 }
 
 type portalCreateAlias kkComps.CreatePortal
@@ -463,6 +488,7 @@ func (p PortalResource) portalAlias() portalAlias {
 		Kongctl:           p.Kongctl,
 		Customization:     p.Customization,
 		AuthSettings:      p.AuthSettings,
+		IdentityProviders: p.IdentityProviders,
 		CustomDomain:      p.CustomDomain,
 		Pages:             p.Pages,
 		Snippets:          p.Snippets,

--- a/internal/declarative/resources/portal_identity_provider.go
+++ b/internal/declarative/resources/portal_identity_provider.go
@@ -1,0 +1,196 @@
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+)
+
+func init() {
+	registerResourceType(
+		ResourceTypePortalIdentityProvider,
+		func(rs *ResourceSet) *[]PortalIdentityProviderResource { return &rs.PortalIdentityProviders },
+		AutoExplain[PortalIdentityProviderResource](),
+	)
+}
+
+// PortalIdentityProviderResource represents a portal identity provider child resource.
+type PortalIdentityProviderResource struct {
+	kkComps.CreateIdentityProvider `       yaml:",inline"          json:",inline"`
+	Ref                            string `yaml:"ref"              json:"ref"`
+	Portal                         string `yaml:"portal,omitempty" json:"portal,omitempty"`
+
+	konnectID string `yaml:"-" json:"-"`
+}
+
+// GetType returns the resource type.
+func (p PortalIdentityProviderResource) GetType() ResourceType {
+	return ResourceTypePortalIdentityProvider
+}
+
+// GetRef returns the reference identifier.
+func (p PortalIdentityProviderResource) GetRef() string {
+	return p.Ref
+}
+
+// GetMoniker returns the resource moniker.
+func (p PortalIdentityProviderResource) GetMoniker() string {
+	if p.Type == nil {
+		return p.Ref
+	}
+	return string(*p.Type)
+}
+
+// GetDependencies returns references to other resources this provider depends on.
+func (p PortalIdentityProviderResource) GetDependencies() []ResourceRef {
+	deps := []ResourceRef{}
+	if p.Portal != "" {
+		deps = append(deps, ResourceRef{Kind: "portal", Ref: p.Portal})
+	}
+	return deps
+}
+
+// Validate ensures the portal identity provider resource is valid.
+func (p PortalIdentityProviderResource) Validate() error {
+	if err := ValidateRef(p.Ref); err != nil {
+		return fmt.Errorf("invalid portal identity provider ref: %w", err)
+	}
+
+	if p.Type == nil || !p.Type.IsExact() {
+		return fmt.Errorf("identity provider type is required")
+	}
+
+	if p.Config == nil {
+		return fmt.Errorf("identity provider config is required")
+	}
+
+	switch p.Config.Type {
+	case kkComps.CreateIdentityProviderConfigTypeOIDCIdentityProviderConfig:
+		if p.Config.OIDCIdentityProviderConfig == nil {
+			return fmt.Errorf("oidc identity provider config is required")
+		}
+	case kkComps.CreateIdentityProviderConfigTypeSAMLIdentityProviderConfigInput:
+		if p.Config.SAMLIdentityProviderConfigInput == nil {
+			return fmt.Errorf("saml identity provider config is required")
+		}
+	default:
+		return fmt.Errorf("identity provider config type is required")
+	}
+
+	return nil
+}
+
+// SetDefaults applies default values to the resource.
+func (p *PortalIdentityProviderResource) SetDefaults() {}
+
+// GetKonnectID returns the resolved Konnect ID if available.
+func (p PortalIdentityProviderResource) GetKonnectID() string {
+	return p.konnectID
+}
+
+// GetKonnectMonikerFilter returns the filter string for Konnect API lookup.
+func (p PortalIdentityProviderResource) GetKonnectMonikerFilter() string {
+	return ""
+}
+
+// TryMatchKonnectResource attempts to match this resource with a Konnect resource.
+func (p *PortalIdentityProviderResource) TryMatchKonnectResource(_ any) bool {
+	return false
+}
+
+// GetParentRef implements ResourceWithParent for inheritance of namespace and protection.
+func (p PortalIdentityProviderResource) GetParentRef() *ResourceRef {
+	if p.Portal == "" {
+		return nil
+	}
+	return &ResourceRef{Kind: string(ResourceTypePortal), Ref: p.Portal}
+}
+
+// UnmarshalJSON rejects kongctl metadata on child resources.
+func (p *PortalIdentityProviderResource) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	allowedKeys := map[string]struct{}{
+		"ref":        {},
+		"portal":     {},
+		"kongctl":    {},
+		"type":       {},
+		"enabled":    {},
+		"login_path": {},
+		"config":     {},
+	}
+	for key := range raw {
+		if _, ok := allowedKeys[key]; !ok {
+			return fmt.Errorf("json: unknown field %q", key)
+		}
+	}
+
+	p.CreateIdentityProvider = kkComps.CreateIdentityProvider{}
+
+	if v, ok := raw["ref"]; ok {
+		if err := json.Unmarshal(v, &p.Ref); err != nil {
+			return err
+		}
+		delete(raw, "ref")
+	}
+
+	if v, ok := raw["portal"]; ok {
+		if err := json.Unmarshal(v, &p.Portal); err != nil {
+			return err
+		}
+		delete(raw, "portal")
+	}
+
+	if v, ok := raw["kongctl"]; ok {
+		var kongctl any
+		if err := json.Unmarshal(v, &kongctl); err != nil {
+			return err
+		}
+		if kongctl != nil {
+			return fmt.Errorf("kongctl metadata not supported on portal identity providers")
+		}
+		delete(raw, "kongctl")
+	}
+
+	if v, ok := raw["type"]; ok {
+		var providerType kkComps.IdentityProviderType
+		if err := json.Unmarshal(v, &providerType); err != nil {
+			return err
+		}
+		p.Type = &providerType
+		delete(raw, "type")
+	}
+
+	if v, ok := raw["enabled"]; ok {
+		var enabled bool
+		if err := json.Unmarshal(v, &enabled); err != nil {
+			return err
+		}
+		p.Enabled = &enabled
+		delete(raw, "enabled")
+	}
+
+	if v, ok := raw["login_path"]; ok {
+		var loginPath string
+		if err := json.Unmarshal(v, &loginPath); err != nil {
+			return err
+		}
+		p.LoginPath = &loginPath
+		delete(raw, "login_path")
+	}
+
+	if v, ok := raw["config"]; ok {
+		var config kkComps.CreateIdentityProviderConfig
+		if err := json.Unmarshal(v, &config); err != nil {
+			return err
+		}
+		p.Config = &config
+		delete(raw, "config")
+	}
+
+	return nil
+}

--- a/internal/declarative/resources/portal_identity_provider.go
+++ b/internal/declarative/resources/portal_identity_provider.go
@@ -67,10 +67,16 @@ func (p PortalIdentityProviderResource) Validate() error {
 
 	switch p.Config.Type {
 	case kkComps.CreateIdentityProviderConfigTypeOIDCIdentityProviderConfig:
+		if *p.Type != kkComps.IdentityProviderTypeOidc {
+			return fmt.Errorf("identity provider type %q does not match oidc config", *p.Type)
+		}
 		if p.Config.OIDCIdentityProviderConfig == nil {
 			return fmt.Errorf("oidc identity provider config is required")
 		}
 	case kkComps.CreateIdentityProviderConfigTypeSAMLIdentityProviderConfigInput:
+		if *p.Type != kkComps.IdentityProviderTypeSaml {
+			return fmt.Errorf("identity provider type %q does not match saml config", *p.Type)
+		}
 		if p.Config.SAMLIdentityProviderConfigInput == nil {
 			return fmt.Errorf("saml identity provider config is required")
 		}

--- a/internal/declarative/resources/portal_identity_provider_test.go
+++ b/internal/declarative/resources/portal_identity_provider_test.go
@@ -1,0 +1,60 @@
+package resources
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPortalIdentityProviderResourceUnmarshalJSON_OmittedEnabledStaysNil(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{
+		"ref": "portal-oidc",
+		"portal": "portal-1",
+		"type": "oidc",
+		"config": {
+			"issuer_url": "https://accounts.google.com",
+			"client_id": "client-id-1",
+			"client_secret": "client-secret-1",
+			"scopes": ["openid"]
+		}
+	}`)
+
+	var resource PortalIdentityProviderResource
+	if err := json.Unmarshal(input, &resource); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resource.Enabled != nil {
+		t.Fatalf("expected enabled to remain nil when omitted, got %v", *resource.Enabled)
+	}
+}
+
+func TestPortalIdentityProviderResourceUnmarshalJSON_PreservesExplicitEnabled(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`{
+		"ref": "portal-oidc",
+		"portal": "portal-1",
+		"type": "oidc",
+		"enabled": true,
+		"config": {
+			"issuer_url": "https://accounts.google.com",
+			"client_id": "client-id-1",
+			"client_secret": "client-secret-1",
+			"scopes": ["openid"]
+		}
+	}`)
+
+	var resource PortalIdentityProviderResource
+	if err := json.Unmarshal(input, &resource); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resource.Enabled == nil {
+		t.Fatal("expected enabled to be set")
+	}
+	if !*resource.Enabled {
+		t.Fatal("expected enabled to be true")
+	}
+}

--- a/internal/declarative/resources/portal_identity_provider_test.go
+++ b/internal/declarative/resources/portal_identity_provider_test.go
@@ -3,6 +3,9 @@ package resources
 import (
 	"encoding/json"
 	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPortalIdentityProviderResourceUnmarshalJSON_OmittedEnabledStaysNil(t *testing.T) {
@@ -57,4 +60,49 @@ func TestPortalIdentityProviderResourceUnmarshalJSON_PreservesExplicitEnabled(t 
 	if !*resource.Enabled {
 		t.Fatal("expected enabled to be true")
 	}
+}
+
+func TestPortalIdentityProviderResourceValidate_RejectsMismatchedOIDCType(t *testing.T) {
+	t.Parallel()
+
+	config := kkComps.CreateCreateIdentityProviderConfigOIDCIdentityProviderConfig(
+		kkComps.OIDCIdentityProviderConfig{
+			IssuerURL: "https://accounts.google.com",
+			ClientID:  "client-id-1",
+		},
+	)
+	resource := PortalIdentityProviderResource{
+		Ref: "portal-idp",
+		CreateIdentityProvider: kkComps.CreateIdentityProvider{
+			Type:   kkComps.IdentityProviderTypeSaml.ToPointer(),
+			Config: &config,
+		},
+	}
+
+	err := resource.Validate()
+	require.EqualError(t, err, `identity provider type "saml" does not match oidc config`)
+}
+
+func TestPortalIdentityProviderResourceValidate_RejectsMismatchedSAMLType(t *testing.T) {
+	t.Parallel()
+
+	config := kkComps.CreateCreateIdentityProviderConfigSAMLIdentityProviderConfigInput(
+		kkComps.SAMLIdentityProviderConfigInput{
+			IdpMetadataURL: stringPtr("https://example.test/saml.xml"),
+		},
+	)
+	resource := PortalIdentityProviderResource{
+		Ref: "portal-idp",
+		CreateIdentityProvider: kkComps.CreateIdentityProvider{
+			Type:   kkComps.IdentityProviderTypeOidc.ToPointer(),
+			Config: &config,
+		},
+	}
+
+	err := resource.Validate()
+	require.EqualError(t, err, `identity provider type "oidc" does not match saml config`)
+}
+
+func stringPtr(value string) *string {
+	return &value
 }

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -20,6 +20,7 @@ const (
 	ResourceTypePortalCustomization              ResourceType = "portal_customization"
 	ResourceTypePortalCustomDomain               ResourceType = "portal_custom_domain"
 	ResourceTypePortalAuthSettings               ResourceType = "portal_auth_settings"
+	ResourceTypePortalIdentityProvider           ResourceType = "portal_identity_provider"
 	ResourceTypePortalPage                       ResourceType = "portal_page"
 	ResourceTypePortalSnippet                    ResourceType = "portal_snippet"
 	ResourceTypePortalTeam                       ResourceType = "portal_team"
@@ -60,7 +61,7 @@ type ResourceSet struct {
 	Portals []PortalResource `yaml:"portals,omitempty"                               json:"portals,omitempty"`
 	// ApplicationAuthStrategies contains auth strategy configurations
 	ApplicationAuthStrategies []ApplicationAuthStrategyResource `yaml:"application_auth_strategies,omitempty"           json:"application_auth_strategies,omitempty"` //nolint:lll
-	DCRProviders              []DCRProviderResource             `yaml:"dcr_providers,omitempty"                        json:"dcr_providers,omitempty"`               //nolint:lll
+	DCRProviders              []DCRProviderResource             `yaml:"dcr_providers,omitempty"                        json:"dcr_providers,omitempty"`                //nolint:lll
 	// ControlPlanes contains control plane configurations
 	ControlPlanes   []ControlPlaneResource   `yaml:"control_planes,omitempty"                        json:"control_planes,omitempty"`   //nolint:lll
 	CatalogServices []CatalogServiceResource `yaml:"catalog_services,omitempty"                      json:"catalog_services,omitempty"` //nolint:lll
@@ -74,6 +75,7 @@ type ResourceSet struct {
 	// Portal child resources can be defined at root level (with parent reference) or nested under Portals
 	PortalCustomizations        []PortalCustomizationResource        `yaml:"portal_customizations,omitempty"                 json:"portal_customizations,omitempty"`          //nolint:lll
 	PortalAuthSettings          []PortalAuthSettingsResource         `yaml:"portal_auth_settings,omitempty"                  json:"portal_auth_settings,omitempty"`           //nolint:lll
+	PortalIdentityProviders     []PortalIdentityProviderResource     `yaml:"portal_identity_providers,omitempty"             json:"portal_identity_providers,omitempty"`      //nolint:lll
 	PortalCustomDomains         []PortalCustomDomainResource         `yaml:"portal_custom_domains,omitempty"                 json:"portal_custom_domains,omitempty"`          //nolint:lll
 	PortalPages                 []PortalPageResource                 `yaml:"portal_pages,omitempty"                          json:"portal_pages,omitempty"`                   //nolint:lll
 	PortalSnippets              []PortalSnippetResource              `yaml:"portal_snippets,omitempty"                       json:"portal_snippets,omitempty"`                //nolint:lll
@@ -427,6 +429,25 @@ func (rs *ResourceSet) GetPortalAuthSettingsByNamespace(namespace string) []Port
 			}
 			if GetNamespace(portal.Kongctl) == namespace {
 				filtered = append(filtered, settings)
+			}
+		}
+	}
+	return filtered
+}
+
+// GetPortalIdentityProvidersByNamespace returns all portal identity provider resources from the specified namespace
+func (rs *ResourceSet) GetPortalIdentityProvidersByNamespace(namespace string) []PortalIdentityProviderResource {
+	var filtered []PortalIdentityProviderResource
+	for _, provider := range rs.PortalIdentityProviders {
+		if portal := rs.GetPortalByRef(provider.Portal); portal != nil {
+			if portal.IsExternal() {
+				if namespace == NamespaceExternal {
+					filtered = append(filtered, provider)
+				}
+				continue
+			}
+			if GetNamespace(portal.Kongctl) == namespace {
+				filtered = append(filtered, provider)
 			}
 		}
 	}

--- a/internal/declarative/state/cache.go
+++ b/internal/declarative/state/cache.go
@@ -3,6 +3,8 @@ package state
 import (
 	"strings"
 	"time"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 )
 
 // Cache represents cached Konnect state with hierarchical structure
@@ -167,6 +169,15 @@ type PortalSnippet struct {
 	Visibility       string
 	Status           string
 	NormalizedLabels map[string]string
+}
+
+// PortalIdentityProvider represents a portal identity provider.
+type PortalIdentityProvider struct {
+	ID        string
+	Type      kkComps.IdentityProviderType
+	Enabled   *bool
+	LoginPath *string
+	Config    *kkComps.IdentityProviderConfig
 }
 
 // PortalTeam represents a portal team (developer team)

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -35,15 +35,16 @@ type ClientConfig struct {
 	CatalogServiceAPI     helpers.CatalogServicesAPI
 
 	// Portal child resource APIs
-	PortalPageAPI          helpers.PortalPageAPI
-	PortalAuthSettingsAPI  helpers.PortalAuthSettingsAPI
-	PortalCustomizationAPI helpers.PortalCustomizationAPI
-	PortalCustomDomainAPI  helpers.PortalCustomDomainAPI
-	PortalSnippetAPI       helpers.PortalSnippetAPI
-	PortalTeamAPI          helpers.PortalTeamAPI
-	PortalTeamRolesAPI     helpers.PortalTeamRolesAPI
-	PortalEmailsAPI        helpers.PortalEmailsAPI
-	AssetsAPI              helpers.AssetsAPI
+	PortalPageAPI             helpers.PortalPageAPI
+	PortalAuthSettingsAPI     helpers.PortalAuthSettingsAPI
+	PortalIdentityProviderAPI helpers.PortalIdentityProviderAPI
+	PortalCustomizationAPI    helpers.PortalCustomizationAPI
+	PortalCustomDomainAPI     helpers.PortalCustomDomainAPI
+	PortalSnippetAPI          helpers.PortalSnippetAPI
+	PortalTeamAPI             helpers.PortalTeamAPI
+	PortalTeamRolesAPI        helpers.PortalTeamRolesAPI
+	PortalEmailsAPI           helpers.PortalEmailsAPI
+	AssetsAPI                 helpers.AssetsAPI
 
 	// API child resource APIs
 	APIVersionAPI        helpers.APIVersionAPI
@@ -82,15 +83,16 @@ type Client struct {
 	catalogServiceAPI     helpers.CatalogServicesAPI
 
 	// Portal child resource APIs
-	portalPageAPI          helpers.PortalPageAPI
-	portalAuthSettingsAPI  helpers.PortalAuthSettingsAPI
-	portalCustomizationAPI helpers.PortalCustomizationAPI
-	portalCustomDomainAPI  helpers.PortalCustomDomainAPI
-	portalSnippetAPI       helpers.PortalSnippetAPI
-	portalTeamAPI          helpers.PortalTeamAPI
-	portalTeamRolesAPI     helpers.PortalTeamRolesAPI
-	portalEmailsAPI        helpers.PortalEmailsAPI
-	assetsAPI              helpers.AssetsAPI
+	portalPageAPI             helpers.PortalPageAPI
+	portalAuthSettingsAPI     helpers.PortalAuthSettingsAPI
+	portalIdentityProviderAPI helpers.PortalIdentityProviderAPI
+	portalCustomizationAPI    helpers.PortalCustomizationAPI
+	portalCustomDomainAPI     helpers.PortalCustomDomainAPI
+	portalSnippetAPI          helpers.PortalSnippetAPI
+	portalTeamAPI             helpers.PortalTeamAPI
+	portalTeamRolesAPI        helpers.PortalTeamRolesAPI
+	portalEmailsAPI           helpers.PortalEmailsAPI
+	assetsAPI                 helpers.AssetsAPI
 
 	// API child resource APIs
 	apiVersionAPI        helpers.APIVersionAPI
@@ -130,15 +132,16 @@ func NewClient(config ClientConfig) *Client {
 		catalogServiceAPI:     config.CatalogServiceAPI,
 
 		// Portal child resource APIs
-		portalPageAPI:          config.PortalPageAPI,
-		portalAuthSettingsAPI:  config.PortalAuthSettingsAPI,
-		portalCustomizationAPI: config.PortalCustomizationAPI,
-		portalCustomDomainAPI:  config.PortalCustomDomainAPI,
-		portalSnippetAPI:       config.PortalSnippetAPI,
-		portalTeamAPI:          config.PortalTeamAPI,
-		portalTeamRolesAPI:     config.PortalTeamRolesAPI,
-		portalEmailsAPI:        config.PortalEmailsAPI,
-		assetsAPI:              config.AssetsAPI,
+		portalPageAPI:             config.PortalPageAPI,
+		portalAuthSettingsAPI:     config.PortalAuthSettingsAPI,
+		portalIdentityProviderAPI: config.PortalIdentityProviderAPI,
+		portalCustomizationAPI:    config.PortalCustomizationAPI,
+		portalCustomDomainAPI:     config.PortalCustomDomainAPI,
+		portalSnippetAPI:          config.PortalSnippetAPI,
+		portalTeamAPI:             config.PortalTeamAPI,
+		portalTeamRolesAPI:        config.PortalTeamRolesAPI,
+		portalEmailsAPI:           config.PortalEmailsAPI,
+		assetsAPI:                 config.AssetsAPI,
 
 		// API child resource APIs
 		apiVersionAPI:        config.APIVersionAPI,
@@ -2548,15 +2551,6 @@ func (c *Client) GetPortalAuthSettings(
 		return nil, fmt.Errorf("no portal auth settings data in response")
 	}
 
-	if err := helpers.HydratePortalAuthSettingsOIDCConfig(
-		resp.PortalAuthenticationSettingsResponse,
-		resp.RawResponse,
-	); err != nil {
-		if logger, ok := ctx.Value(log.LoggerKey).(*slog.Logger); ok && logger != nil {
-			logger.Debug("failed to hydrate portal auth settings OIDC config from raw response", "error", err)
-		}
-	}
-
 	return resp.PortalAuthenticationSettingsResponse, nil
 }
 
@@ -2574,15 +2568,8 @@ func (c *Client) UpdatePortalAuthSettings(
 		logger.Debug("updating portal auth settings",
 			"portal_id", portalID,
 			"basic_auth_enabled", settings.BasicAuthEnabled,
-			"oidc_auth_enabled", settings.OidcAuthEnabled,
-			"saml_auth_enabled", settings.SamlAuthEnabled,
-			"oidc_team_mapping_enabled", settings.OidcTeamMappingEnabled,
 			"idp_mapping_enabled", settings.IdpMappingEnabled,
 			"konnect_mapping_enabled", settings.KonnectMappingEnabled,
-			"oidc_issuer", settings.OidcIssuer,
-			"oidc_client_id", settings.OidcClientID,
-			"oidc_scopes", settings.OidcScopes,
-			"oidc_claim_mappings", settings.OidcClaimMappings,
 		)
 	}
 
@@ -2591,6 +2578,162 @@ func (c *Client) UpdatePortalAuthSettings(
 		return WrapAPIError(err, "update portal auth settings", nil)
 	}
 	return nil
+}
+
+// ListPortalIdentityProviders returns all identity providers for a portal.
+func (c *Client) ListPortalIdentityProviders(ctx context.Context, portalID string) ([]PortalIdentityProvider, error) {
+	if err := ValidateAPIClient(c.portalIdentityProviderAPI, "portal identity provider API"); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.portalIdentityProviderAPI.ListPortalIdentityProviders(
+		ctx,
+		kkOps.GetPortalIdentityProvidersRequest{PortalID: portalID},
+	)
+	if err != nil {
+		return nil, WrapAPIError(
+			err,
+			"list portal identity providers",
+			&ErrorWrapperOptions{ResourceType: "portal_identity_provider", ResourceName: portalID, UseEnhanced: true},
+		)
+	}
+
+	providers := make([]PortalIdentityProvider, 0, len(resp.IdentityProviders))
+	for _, provider := range resp.IdentityProviders {
+		providers = append(providers, normalizePortalIdentityProvider(provider))
+	}
+
+	return providers, nil
+}
+
+// GetPortalIdentityProvider fetches a single identity provider for a portal.
+func (c *Client) GetPortalIdentityProvider(
+	ctx context.Context,
+	portalID string,
+	id string,
+) (*PortalIdentityProvider, error) {
+	if err := ValidateAPIClient(c.portalIdentityProviderAPI, "portal identity provider API"); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.portalIdentityProviderAPI.GetPortalIdentityProvider(ctx, portalID, id)
+	if err != nil {
+		var notFound *kkErrors.NotFoundError
+		if errors.As(err, &notFound) {
+			return nil, nil
+		}
+		return nil, WrapAPIError(
+			err,
+			"get portal identity provider",
+			&ErrorWrapperOptions{ResourceType: "portal_identity_provider", ResourceName: id, UseEnhanced: true},
+		)
+	}
+	if resp == nil || resp.IdentityProvider == nil {
+		return nil, nil
+	}
+
+	provider := normalizePortalIdentityProvider(*resp.IdentityProvider)
+	return &provider, nil
+}
+
+// CreatePortalIdentityProvider creates a new identity provider for a portal.
+func (c *Client) CreatePortalIdentityProvider(
+	ctx context.Context,
+	portalID string,
+	body kkComps.CreateIdentityProvider,
+	namespace string,
+) (string, error) {
+	if err := ValidateAPIClient(c.portalIdentityProviderAPI, "portal identity provider API"); err != nil {
+		return "", err
+	}
+
+	resp, err := c.portalIdentityProviderAPI.CreatePortalIdentityProvider(ctx, portalID, body)
+	if err != nil {
+		resourceName := portalIdentityProviderName(body)
+		return "", WrapAPIError(
+			err,
+			"create portal identity provider",
+			&ErrorWrapperOptions{
+				ResourceType: "portal_identity_provider",
+				ResourceName: resourceName,
+				Namespace:    namespace,
+				UseEnhanced:  true,
+			},
+		)
+	}
+	if resp == nil || resp.IdentityProvider == nil || resp.IdentityProvider.ID == nil {
+		return "", NewResponseValidationError("create portal identity provider", "IdentityProvider")
+	}
+
+	return *resp.IdentityProvider.ID, nil
+}
+
+// UpdatePortalIdentityProvider updates an identity provider for a portal.
+func (c *Client) UpdatePortalIdentityProvider(
+	ctx context.Context,
+	portalID string,
+	id string,
+	body kkComps.UpdateIdentityProvider,
+	namespace string,
+) error {
+	if err := ValidateAPIClient(c.portalIdentityProviderAPI, "portal identity provider API"); err != nil {
+		return err
+	}
+
+	_, err := c.portalIdentityProviderAPI.UpdatePortalIdentityProvider(
+		ctx,
+		kkOps.UpdatePortalIdentityProviderRequest{PortalID: portalID, ID: id, UpdateIdentityProvider: body},
+	)
+	if err != nil {
+		return WrapAPIError(
+			err,
+			"update portal identity provider",
+			&ErrorWrapperOptions{
+				ResourceType: "portal_identity_provider",
+				ResourceName: id,
+				Namespace:    namespace,
+				UseEnhanced:  true,
+			},
+		)
+	}
+	return nil
+}
+
+// DeletePortalIdentityProvider deletes an identity provider from a portal.
+func (c *Client) DeletePortalIdentityProvider(ctx context.Context, portalID string, id string) error {
+	if err := ValidateAPIClient(c.portalIdentityProviderAPI, "portal identity provider API"); err != nil {
+		return err
+	}
+
+	_, err := c.portalIdentityProviderAPI.DeletePortalIdentityProvider(ctx, portalID, id)
+	if err != nil {
+		return WrapAPIError(
+			err,
+			"delete portal identity provider",
+			&ErrorWrapperOptions{ResourceType: "portal_identity_provider", ResourceName: id, UseEnhanced: true},
+		)
+	}
+	return nil
+}
+
+func normalizePortalIdentityProvider(provider kkComps.IdentityProvider) PortalIdentityProvider {
+	normalized := PortalIdentityProvider{Config: provider.Config}
+	if provider.ID != nil {
+		normalized.ID = *provider.ID
+	}
+	if provider.Type != nil {
+		normalized.Type = *provider.Type
+	}
+	normalized.Enabled = provider.Enabled
+	normalized.LoginPath = provider.LoginPath
+	return normalized
+}
+
+func portalIdentityProviderName(body kkComps.CreateIdentityProvider) string {
+	if body.Type == nil {
+		return ""
+	}
+	return string(*body.Type)
 }
 
 // GetPortalEmailConfig fetches the current email configuration for a portal.
@@ -4966,7 +5109,8 @@ func extractProducePolicyCreateName(req kkComps.EventGatewayProducePolicyCreate)
 	if req.EventGatewayModifyHeadersPolicyCreate != nil && req.EventGatewayModifyHeadersPolicyCreate.Name != nil {
 		return *req.EventGatewayModifyHeadersPolicyCreate.Name
 	}
-	if req.EventGatewayProduceSchemaValidationPolicy != nil && req.EventGatewayProduceSchemaValidationPolicy.Name != nil {
+	if req.EventGatewayProduceSchemaValidationPolicy != nil &&
+		req.EventGatewayProduceSchemaValidationPolicy.Name != nil {
 		return *req.EventGatewayProduceSchemaValidationPolicy.Name
 	}
 	if req.EventGatewayEncryptPolicy != nil && req.EventGatewayEncryptPolicy.Name != nil {
@@ -4980,7 +5124,8 @@ func extractProducePolicyUpdateName(req kkComps.EventGatewayProducePolicyUpdate)
 	if req.EventGatewayModifyHeadersPolicy != nil && req.EventGatewayModifyHeadersPolicy.Name != nil {
 		return *req.EventGatewayModifyHeadersPolicy.Name
 	}
-	if req.EventGatewayProduceSchemaValidationPolicy != nil && req.EventGatewayProduceSchemaValidationPolicy.Name != nil {
+	if req.EventGatewayProduceSchemaValidationPolicy != nil &&
+		req.EventGatewayProduceSchemaValidationPolicy.Name != nil {
 		return *req.EventGatewayProduceSchemaValidationPolicy.Name
 	}
 	if req.EventGatewayEncryptPolicy != nil && req.EventGatewayEncryptPolicy.Name != nil {

--- a/internal/konnect/helpers/portal_identity_providers.go
+++ b/internal/konnect/helpers/portal_identity_providers.go
@@ -1,0 +1,232 @@
+package helpers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	kkSDK "github.com/Kong/sdk-konnect-go"
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+)
+
+// PortalIdentityProviderAPI defines the interface for portal identity provider operations.
+type PortalIdentityProviderAPI interface {
+	ListPortalIdentityProviders(
+		ctx context.Context,
+		request kkOps.GetPortalIdentityProvidersRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.GetPortalIdentityProvidersResponse, error)
+	GetPortalIdentityProvider(
+		ctx context.Context,
+		portalID string,
+		id string,
+		opts ...kkOps.Option,
+	) (*kkOps.GetPortalIdentityProviderResponse, error)
+	CreatePortalIdentityProvider(
+		ctx context.Context,
+		portalID string,
+		request kkComps.CreateIdentityProvider,
+		opts ...kkOps.Option,
+	) (*kkOps.CreatePortalIdentityProviderResponse, error)
+	UpdatePortalIdentityProvider(
+		ctx context.Context,
+		request kkOps.UpdatePortalIdentityProviderRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.UpdatePortalIdentityProviderResponse, error)
+	DeletePortalIdentityProvider(
+		ctx context.Context,
+		portalID string,
+		id string,
+		opts ...kkOps.Option,
+	) (*kkOps.DeletePortalIdentityProviderResponse, error)
+}
+
+// PortalIdentityProviderAPIImpl provides an implementation backed by the SDK.
+type PortalIdentityProviderAPIImpl struct {
+	SDK        *kkSDK.SDK
+	BaseURL    string
+	Token      string
+	HTTPClient kkSDK.HTTPClient
+}
+
+// ListPortalIdentityProviders lists identity providers for a portal.
+func (p *PortalIdentityProviderAPIImpl) ListPortalIdentityProviders(
+	ctx context.Context,
+	request kkOps.GetPortalIdentityProvidersRequest,
+	opts ...kkOps.Option,
+) (*kkOps.GetPortalIdentityProvidersResponse, error) {
+	if p.SDK == nil {
+		return nil, fmt.Errorf("SDK is nil")
+	}
+	return p.SDK.PortalAuthSettings.GetPortalIdentityProviders(ctx, request.PortalID, request.Filter, opts...)
+}
+
+// GetPortalIdentityProvider fetches a single identity provider for a portal.
+func (p *PortalIdentityProviderAPIImpl) GetPortalIdentityProvider(
+	ctx context.Context,
+	portalID string,
+	id string,
+	opts ...kkOps.Option,
+) (*kkOps.GetPortalIdentityProviderResponse, error) {
+	if p.SDK == nil {
+		return nil, fmt.Errorf("SDK is nil")
+	}
+	return p.SDK.PortalAuthSettings.GetPortalIdentityProvider(ctx, portalID, id, opts...)
+}
+
+// CreatePortalIdentityProvider creates a new identity provider for a portal.
+func (p *PortalIdentityProviderAPIImpl) CreatePortalIdentityProvider(
+	ctx context.Context,
+	portalID string,
+	request kkComps.CreateIdentityProvider,
+	opts ...kkOps.Option,
+) (*kkOps.CreatePortalIdentityProviderResponse, error) {
+	if p.SDK == nil {
+		return nil, fmt.Errorf("SDK is nil")
+	}
+	if p.BaseURL == "" || p.HTTPClient == nil {
+		return p.SDK.PortalAuthSettings.CreatePortalIdentityProvider(ctx, portalID, request, opts...)
+	}
+
+	sdk := kkSDK.New(
+		kkSDK.WithServerURL(p.BaseURL),
+		kkSDK.WithSecurity(kkComps.Security{
+			PersonalAccessToken: &p.Token,
+		}),
+		kkSDK.WithClient(&portalIdentityProviderCreateHTTPClient{base: p.HTTPClient}),
+	)
+	if sdk == nil || sdk.PortalAuthSettings == nil {
+		return nil, fmt.Errorf("failed to initialize SDK for portal identity provider create")
+	}
+	return sdk.PortalAuthSettings.CreatePortalIdentityProvider(ctx, portalID, request, opts...)
+}
+
+// UpdatePortalIdentityProvider updates an identity provider for a portal.
+func (p *PortalIdentityProviderAPIImpl) UpdatePortalIdentityProvider(
+	ctx context.Context,
+	request kkOps.UpdatePortalIdentityProviderRequest,
+	opts ...kkOps.Option,
+) (*kkOps.UpdatePortalIdentityProviderResponse, error) {
+	if p.SDK == nil {
+		return nil, fmt.Errorf("SDK is nil")
+	}
+	return p.SDK.PortalAuthSettings.UpdatePortalIdentityProvider(ctx, request, opts...)
+}
+
+// DeletePortalIdentityProvider deletes an identity provider from a portal.
+func (p *PortalIdentityProviderAPIImpl) DeletePortalIdentityProvider(
+	ctx context.Context,
+	portalID string,
+	id string,
+	opts ...kkOps.Option,
+) (*kkOps.DeletePortalIdentityProviderResponse, error) {
+	if p.SDK == nil {
+		return nil, fmt.Errorf("SDK is nil")
+	}
+	return p.SDK.PortalAuthSettings.DeletePortalIdentityProvider(ctx, portalID, id, opts...)
+}
+
+type portalIdentityProviderCreateHTTPClient struct {
+	base kkSDK.HTTPClient
+}
+
+func (c *portalIdentityProviderCreateHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	if c == nil || c.base == nil {
+		return nil, fmt.Errorf("http client is not configured")
+	}
+
+	if err := stripEnabledFromPortalIdentityProviderCreateRequest(req); err != nil {
+		return nil, err
+	}
+
+	return c.base.Do(req)
+}
+
+func stripEnabledFromPortalIdentityProviderCreateRequest(req *http.Request) error {
+	if !isPortalIdentityProviderCreateRequest(req) {
+		return nil
+	}
+
+	body, err := readAndRestoreRequestBody(req)
+	if err != nil {
+		return err
+	}
+	if len(bytes.TrimSpace(body)) == 0 {
+		return nil
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return fmt.Errorf("failed to decode portal identity provider create request: %w", err)
+	}
+	if _, ok := payload["enabled"]; !ok {
+		return nil
+	}
+
+	delete(payload, "enabled")
+
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to encode portal identity provider create request: %w", err)
+	}
+	restoreRequestBody(req, encoded)
+	return nil
+}
+
+func isPortalIdentityProviderCreateRequest(req *http.Request) bool {
+	if req == nil || req.URL == nil {
+		return false
+	}
+	if req.Method != http.MethodPost {
+		return false
+	}
+
+	path := strings.Trim(req.URL.Path, "/")
+	segments := strings.Split(path, "/")
+	if len(segments) != 4 {
+		return false
+	}
+
+	return segments[0] == "v3" &&
+		segments[1] == "portals" &&
+		segments[2] != "" &&
+		segments[3] == "identity-providers"
+}
+
+func readAndRestoreRequestBody(req *http.Request) ([]byte, error) {
+	if req == nil || req.Body == nil {
+		return nil, nil
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read request body: %w", err)
+	}
+	restoreRequestBody(req, body)
+	return body, nil
+}
+
+func restoreRequestBody(req *http.Request, body []byte) {
+	if req == nil {
+		return
+	}
+
+	reader := func() io.ReadCloser {
+		return io.NopCloser(bytes.NewReader(body))
+	}
+
+	req.Body = reader()
+	req.ContentLength = int64(len(body))
+	req.GetBody = func() (io.ReadCloser, error) {
+		return reader(), nil
+	}
+	req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+}
+
+var _ PortalIdentityProviderAPI = (*PortalIdentityProviderAPIImpl)(nil)

--- a/internal/konnect/helpers/portal_identity_providers.go
+++ b/internal/konnect/helpers/portal_identity_providers.go
@@ -204,7 +204,10 @@ func readAndRestoreRequestBody(req *http.Request) ([]byte, error) {
 		return nil, nil
 	}
 
-	body, err := io.ReadAll(req.Body)
+	originalBody := req.Body
+	defer originalBody.Close()
+
+	body, err := io.ReadAll(originalBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read request body: %w", err)
 	}

--- a/internal/konnect/helpers/portal_identity_providers_test.go
+++ b/internal/konnect/helpers/portal_identity_providers_test.go
@@ -1,0 +1,111 @@
+package helpers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	kkSDK "github.com/Kong/sdk-konnect-go"
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+)
+
+type portalIdentityProviderCapturingClient struct {
+	t           *testing.T
+	request     *http.Request
+	requestBody []byte
+}
+
+func (c *portalIdentityProviderCapturingClient) Do(req *http.Request) (*http.Response, error) {
+	c.t.Helper()
+
+	c.request = req.Clone(req.Context())
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	c.requestBody = body
+
+	return &http.Response{
+		StatusCode: http.StatusCreated,
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+		Body: io.NopCloser(bytes.NewReader([]byte(`{
+			"id": "provider-1",
+			"type": "oidc",
+			"enabled": false,
+			"created_at": "2026-04-17T00:00:00Z",
+			"updated_at": "2026-04-17T00:00:00Z",
+			"config": {
+				"issuer_url": "https://accounts.google.com",
+				"client_id": "client-id-1",
+				"scopes": ["openid"]
+			}
+		}`))),
+	}, nil
+}
+
+func TestPortalIdentityProviderAPIImplCreatePortalIdentityProviderStripsEnabledFromCreateBody(t *testing.T) {
+	t.Parallel()
+
+	client := &portalIdentityProviderCapturingClient{t: t}
+	api := &PortalIdentityProviderAPIImpl{
+		SDK:        kkSDK.New(),
+		BaseURL:    "https://example.test",
+		Token:      "test-token",
+		HTTPClient: client,
+	}
+
+	config := kkComps.CreateCreateIdentityProviderConfigOIDCIdentityProviderConfig(kkComps.OIDCIdentityProviderConfig{
+		IssuerURL: "https://accounts.google.com",
+		ClientID:  "client-id-1",
+		Scopes:    []string{"openid"},
+	})
+	enabled := true
+
+	resp, err := api.CreatePortalIdentityProvider(context.Background(), "portal-123", kkComps.CreateIdentityProvider{
+		Type:    kkComps.IdentityProviderTypeOidc.ToPointer(),
+		Enabled: &enabled,
+		Config:  &config,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if client.request == nil {
+		t.Fatal("expected request to be captured")
+	}
+	if client.request.Method != http.MethodPost {
+		t.Fatalf("unexpected method: %s", client.request.Method)
+	}
+	if got := client.request.URL.String(); got != "https://example.test/v3/portals/portal-123/identity-providers" {
+		t.Fatalf("unexpected URL: %s", got)
+	}
+
+	var requestBody map[string]any
+	if err := json.Unmarshal(client.requestBody, &requestBody); err != nil {
+		t.Fatalf("failed to decode request body: %v", err)
+	}
+
+	if _, ok := requestBody["enabled"]; ok {
+		t.Fatalf("expected enabled to be removed from create body, got %v", requestBody["enabled"])
+	}
+	if got := requestBody["type"]; got != "oidc" {
+		t.Fatalf("unexpected type: %v", got)
+	}
+
+	configBody, ok := requestBody["config"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected config object, got %#v", requestBody["config"])
+	}
+	if got := configBody["client_id"]; got != "client-id-1" {
+		t.Fatalf("unexpected client_id: %v", got)
+	}
+
+	if resp == nil || resp.IdentityProvider == nil || resp.IdentityProvider.ID == nil {
+		t.Fatalf("expected identity provider response, got %#v", resp)
+	}
+}

--- a/internal/konnect/helpers/portal_identity_providers_test.go
+++ b/internal/konnect/helpers/portal_identity_providers_test.go
@@ -109,3 +109,48 @@ func TestPortalIdentityProviderAPIImplCreatePortalIdentityProviderStripsEnabledF
 		t.Fatalf("expected identity provider response, got %#v", resp)
 	}
 }
+
+type trackingReadCloser struct {
+	reader io.Reader
+	closed bool
+}
+
+func (t *trackingReadCloser) Read(p []byte) (int, error) {
+	return t.reader.Read(p)
+}
+
+func (t *trackingReadCloser) Close() error {
+	t.closed = true
+	return nil
+}
+
+func TestReadAndRestoreRequestBodyClosesOriginalBody(t *testing.T) {
+	t.Parallel()
+
+	originalBody := &trackingReadCloser{reader: bytes.NewBufferString(`{"type":"oidc"}`)}
+	req, err := http.NewRequest(http.MethodPost, "https://example.test/v3/portals/p/identity-providers", originalBody)
+	if err != nil {
+		t.Fatalf("unexpected error creating request: %v", err)
+	}
+	req.Body = originalBody
+
+	body, err := readAndRestoreRequestBody(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if string(body) != `{"type":"oidc"}` {
+		t.Fatalf("unexpected body: %s", body)
+	}
+	if !originalBody.closed {
+		t.Fatal("expected original request body to be closed")
+	}
+
+	restoredBody, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("unexpected error reading restored body: %v", err)
+	}
+	if string(restoredBody) != `{"type":"oidc"}` {
+		t.Fatalf("unexpected restored body: %s", restoredBody)
+	}
+}

--- a/internal/konnect/helpers/sdk.go
+++ b/internal/konnect/helpers/sdk.go
@@ -35,6 +35,7 @@ type SDKAPI interface {
 	// Portal child resource APIs
 	GetPortalPageAPI() PortalPageAPI
 	GetPortalAuthSettingsAPI() PortalAuthSettingsAPI
+	GetPortalIdentityProviderAPI() PortalIdentityProviderAPI
 	GetPortalCustomizationAPI() PortalCustomizationAPI
 	GetPortalCustomDomainAPI() PortalCustomDomainAPI
 	GetPortalSnippetAPI() PortalSnippetAPI
@@ -202,6 +203,20 @@ func (k *KonnectSDK) GetPortalAuthSettingsAPI() PortalAuthSettingsAPI {
 	}
 
 	return &PortalAuthSettingsAPIImpl{SDK: k.SDK}
+}
+
+// Returns the implementation of the PortalIdentityProviderAPI interface
+func (k *KonnectSDK) GetPortalIdentityProviderAPI() PortalIdentityProviderAPI {
+	if k.SDK == nil {
+		return nil
+	}
+
+	return &PortalIdentityProviderAPIImpl{
+		SDK:        k.SDK,
+		BaseURL:    k.BaseURL,
+		Token:      k.Token,
+		HTTPClient: k.HTTPClient,
+	}
 }
 
 // Returns the implementation of the PortalCustomizationAPI interface

--- a/internal/konnect/helpers/sdk_mock.go
+++ b/internal/konnect/helpers/sdk_mock.go
@@ -24,6 +24,7 @@ type MockKonnectSDK struct {
 	// Portal child resource factories
 	PortalPageFactory                    func() PortalPageAPI
 	PortalAuthSettingsFactory            func() PortalAuthSettingsAPI
+	PortalIdentityProviderFactory        func() PortalIdentityProviderAPI
 	PortalCustomizationFactory           func() PortalCustomizationAPI
 	PortalCustomDomainFactory            func() PortalCustomDomainAPI
 	PortalSnippetFactory                 func() PortalSnippetAPI
@@ -156,6 +157,14 @@ func (m *MockKonnectSDK) GetPortalPageAPI() PortalPageAPI {
 func (m *MockKonnectSDK) GetPortalAuthSettingsAPI() PortalAuthSettingsAPI {
 	if m.PortalAuthSettingsFactory != nil {
 		return m.PortalAuthSettingsFactory()
+	}
+	return nil
+}
+
+// Returns a mock instance of the PortalIdentityProviderAPI
+func (m *MockKonnectSDK) GetPortalIdentityProviderAPI() PortalIdentityProviderAPI {
+	if m.PortalIdentityProviderFactory != nil {
+		return m.PortalIdentityProviderFactory()
 	}
 	return nil
 }

--- a/test/e2e/scenarios/explain/command-coverage/scenario.yaml
+++ b/test/e2e/scenarios/explain/command-coverage/scenario.yaml
@@ -78,7 +78,7 @@ steps:
                 "contains(stdout, 'RESOURCE CLASS: top-level')": true
                 "contains(stdout, 'ROOT KEY: portals[]')": true
                 "contains(stdout, 'SUPPORTS NESTED DECLARATION: false')": true
-                "contains(stdout, 'CHILD RESOURCES: auth_settings, custom_domain, customization, email_config, pages, snippets, teams')": true
+                "contains(stdout, 'CHILD RESOURCES: auth_settings, custom_domain, customization, email_config, identity_providers, pages, snippets, teams')": true
                 "contains(stdout, 'FIELD DETAILS: use --extended')": true
                 "contains(stdout, 'FIELDS')": false
 

--- a/test/e2e/scenarios/portal/auth_settings/scenario.yaml
+++ b/test/e2e/scenarios/portal/auth_settings/scenario.yaml
@@ -51,11 +51,8 @@ steps:
             expect:
               fields:
                 basic_auth_enabled: true
-                oidc_auth_enabled: true
-                oidc_issuer: https://accounts.google.com
-                "oidc_claim_mappings.email": email
-                "oidc_claim_mappings.name": name
-                "oidc_claim_mappings.groups": groups
+                idp_mapping_enabled: false
+                konnect_mapping_enabled: true
       - name: 001-apply-auth-settings
         outputFormat: json
         run:
@@ -82,82 +79,5 @@ steps:
           - expect:
               fields:
                 basic_auth_enabled: true
-                oidc_auth_enabled: true
-                oidc_config.issuer: https://accounts.google.com
-                oidc_config.client_id: client-id-1
-                oidc_config.claim_mappings.email: email
-
-  - name: 002-plan-apply-auth-settings-update
-    inputOverlayDirs:
-      - overlays/002-update
-    commands:
-      - name: 000-plan-auth-settings-update
-        outputFormat: disable
-        stdoutFile: "{{ .workdir }}/plan-auth-settings-update.json"
-        run:
-          - plan
-          - -f
-          - "{{ .workdir }}/config.yaml"
-          - --mode
-          - apply
-        assertions:
-          - select: summary
-            expect:
-              fields:
-                total_changes: 1
-                by_action.UPDATE: 1
-          - select: >-
-              changes[?resource_type=='portal_auth_settings' && resource_ref=='{{ .vars.authSettingsRef }}'] | [0].fields
-            expect:
-              fields:
-                basic_auth_enabled: false
-                oidc_issuer: https://login.microsoftonline.com/common/v2.0
-                oidc_claim_mappings.name: full_name
-                oidc_claim_mappings.email: email_address
-                oidc_claim_mappings.groups: teams
-      - name: 001-apply-auth-settings-update
-        env:
-          KONNECT_SDK_HTTP_DUMP_REQUEST: "true"
-          KONNECT_SDK_HTTP_DUMP_RESPONSE: "true"
-        outputFormat: json
-        run:
-          - apply
-          - --plan
-          - "{{ .workdir }}/plan-auth-settings-update.json"
-          - --auto-approve
-        assertions:
-          - select: summary
-            expect:
-              fields:
-                applied: 1
-                failed: 0
-      - name: 002-get-auth-settings-updated
-        run:
-          - get
-          - portal
-          - auth-settings
-          - --portal-name
-          - "{{ .vars.portalRef }}"
-          - -o
-          - json
-        assertions:
-          - expect:
-              fields:
-                basic_auth_enabled: false
-                oidc_auth_enabled: true
-                saml_auth_enabled: false
-                idp_mapping_enabled: true
-                konnect_mapping_enabled: false
-                oidc_team_mapping_enabled: true
-                "contains(oidc_config.issuer, 'login.microsoftonline.com')": true
-                oidc_config.client_id: client-id-2
-                oidc_config.claim_mappings.name: full_name
-                oidc_config.claim_mappings.email: email_address
-                oidc_config.claim_mappings.groups: teams
-          - select: oidc_config.scopes
-            expect:
-              fields:
-                "length(@)": 3
-                "contains(@, 'openid')": true
-                "contains(@, 'email')": true
-                "contains(@, 'profile')": true
+                idp_mapping_enabled: false
+                konnect_mapping_enabled: true

--- a/test/e2e/scenarios/portal/auth_settings/testdata/config.yaml
+++ b/test/e2e/scenarios/portal/auth_settings/testdata/config.yaml
@@ -12,18 +12,5 @@ portals:
     auth_settings:
       ref: portal-auth-settings
       basic_auth_enabled: true
-      oidc_auth_enabled: true
-      saml_auth_enabled: false
-      oidc_team_mapping_enabled: true
-      konnect_mapping_enabled: false
-      idp_mapping_enabled: true
-      oidc_issuer: "https://accounts.google.com"
-      oidc_client_id: "client-id-1"
-      oidc_client_secret: "client-secret-1"
-      oidc_scopes:
-        - openid
-        - profile
-      oidc_claim_mappings:
-        name: name
-        email: email
-        groups: groups
+      konnect_mapping_enabled: true
+      idp_mapping_enabled: false

--- a/test/e2e/scenarios/portal/auth_settings_deprecated_fields/scenario.yaml
+++ b/test/e2e/scenarios/portal/auth_settings_deprecated_fields/scenario.yaml
@@ -1,0 +1,19 @@
+baseInputsPath: testdata
+
+env:
+  KONGCTL_LOG_LEVEL: debug
+
+steps:
+  - name: 000-plan-fails-on-deprecated-auth-settings-fields
+    commands:
+      - name: 000-plan
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        expectFailure:
+          exitCode: 1
+          contains: "move identity provider configuration to identity_providers"

--- a/test/e2e/scenarios/portal/auth_settings_deprecated_fields/testdata/config.yaml
+++ b/test/e2e/scenarios/portal/auth_settings_deprecated_fields/testdata/config.yaml
@@ -6,11 +6,10 @@ portals:
   - ref: portal-auth
     name: portal-auth
     display_name: Portal Auth Settings
-    description: Portal with auth settings managed declaratively
+    description: Portal with deprecated auth settings fields
     kongctl:
       namespace: portal-auth-settings
     auth_settings:
       ref: portal-auth-settings
-      basic_auth_enabled: false
-      konnect_mapping_enabled: true
-      idp_mapping_enabled: false
+      basic_auth_enabled: true
+      oidc_auth_enabled: true

--- a/test/e2e/scenarios/portal/identity_providers/overlays/002-root-update/config.yaml
+++ b/test/e2e/scenarios/portal/identity_providers/overlays/002-root-update/config.yaml
@@ -1,0 +1,28 @@
+_defaults:
+  kongctl:
+    namespace: portal-identity-providers
+
+portals:
+  - ref: portal-idp
+    name: portal-idp
+    display_name: Portal Identity Providers
+    description: Portal with root-level identity providers
+    kongctl:
+      namespace: portal-identity-providers
+
+portal_identity_providers:
+  - ref: portal-oidc
+    portal: portal-idp
+    type: oidc
+    enabled: false
+    config:
+      issuer_url: !env KONGCTL_E2E_PORTAL_IDP_UPDATE_ISSUER_URL
+      client_id: !env KONGCTL_E2E_PORTAL_IDP_UPDATE_CLIENT_ID
+      client_secret: !env KONGCTL_E2E_PORTAL_IDP_UPDATE_CLIENT_SECRET
+      scopes:
+        - openid
+        - email
+      claim_mappings:
+        name: full_name
+        email: email_address
+        groups: teams

--- a/test/e2e/scenarios/portal/identity_providers/scenario.yaml
+++ b/test/e2e/scenarios/portal/identity_providers/scenario.yaml
@@ -171,3 +171,44 @@ steps:
                 enabled: false
                 config.client_id: "{{ .vars.updateClientID }}"
                 config.claim_mappings.name: full_name
+
+  - name: 003-dump-and-plan-round-trip
+    skipInputs: true
+    commands:
+      - name: 000-dump-portals-with-idps
+        run:
+          - dump
+          - declarative
+          - "--resources=portals"
+          - --include-child-resources
+          - "--default-namespace={{ .vars.namespace }}"
+          - "--filter-name={{ .vars.portalRef }}"
+        outputFormat: none
+        parseAs: yaml
+        stdoutFile: "{{ .workdir }}/dump.yaml"
+        assertions:
+          - select: "_defaults.kongctl"
+            expect:
+              fields:
+                namespace: "{{ .vars.namespace }}"
+          - select: >-
+              portals[?name=='{{ .vars.portalRef }}'] | [0].identity_providers[?type=='oidc'] | [0]
+            expect:
+              fields:
+                type: oidc
+                enabled: false
+                config.client_id: "{{ .vars.updateClientID }}"
+                config.claim_mappings.name: full_name
+      - name: 001-plan-from-dump
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/dump.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0

--- a/test/e2e/scenarios/portal/identity_providers/scenario.yaml
+++ b/test/e2e/scenarios/portal/identity_providers/scenario.yaml
@@ -1,0 +1,173 @@
+baseInputsPath: testdata
+
+env:
+  KONGCTL_LOG_LEVEL: debug
+
+test:
+  enabledByEnvVar: KONGCTL_E2E_RUN_PORTAL_IDENTITY_PROVIDERS
+  requiredEnvVars:
+    - KONGCTL_E2E_PORTAL_IDP_ISSUER_URL
+    - KONGCTL_E2E_PORTAL_IDP_CLIENT_ID
+    - KONGCTL_E2E_PORTAL_IDP_CLIENT_SECRET
+    - KONGCTL_E2E_PORTAL_IDP_UPDATE_ISSUER_URL
+    - KONGCTL_E2E_PORTAL_IDP_UPDATE_CLIENT_ID
+    - KONGCTL_E2E_PORTAL_IDP_UPDATE_CLIENT_SECRET
+  info: >-
+    Requires real Dev Portal IdP values; set KONGCTL_E2E_RUN_PORTAL_IDENTITY_PROVIDERS=1
+    and provide the KONGCTL_E2E_PORTAL_IDP_* env vars to enable.
+
+vars:
+  namespace: portal-identity-providers
+  portalRef: portal-idp
+  providerRef: portal-oidc
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - change_id
+      - resource_id
+      - generated_at
+      - created_at
+      - updated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 000-record-idp-env
+    skipInputs: true
+    commands:
+      - name: 000-record-create-client-id
+        parseAs: raw
+        exec:
+          - bash
+          - -c
+          - printf '%s' "${KONGCTL_E2E_PORTAL_IDP_CLIENT_ID:-}"
+        recordVar:
+          name: createClientID
+          responsePath: stdout
+      - name: 001-record-update-client-id
+        parseAs: raw
+        exec:
+          - bash
+          - -c
+          - printf '%s' "${KONGCTL_E2E_PORTAL_IDP_UPDATE_CLIENT_ID:-}"
+        recordVar:
+          name: updateClientID
+          responsePath: stdout
+
+  - name: 001-plan-apply-identity-providers
+    commands:
+      - name: 000-plan-identity-providers
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-identity-providers.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 2
+                by_action.CREATE: 2
+          - select: >-
+              changes[?resource_type=='portal_identity_provider' && resource_ref=='{{ .vars.providerRef }}'] | [0].fields
+            expect:
+              fields:
+                type: oidc
+                enabled: true
+                config.client_id: __ENV__:KONGCTL_E2E_PORTAL_IDP_CLIENT_ID
+                config.issuer_url: __ENV__:KONGCTL_E2E_PORTAL_IDP_ISSUER_URL
+      - name: 001-apply-identity-providers
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-identity-providers.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 2
+                failed: 0
+      - name: 002-get-identity-providers
+        run:
+          - get
+          - portal
+          - identity-providers
+          - --portal-name
+          - "{{ .vars.portalRef }}"
+          - -o
+          - json
+        assertions:
+          - select: '[0]'
+            expect:
+              fields:
+                type: oidc
+                enabled: true
+                config.client_id: "{{ .vars.createClientID }}"
+                config.claim_mappings.email: email
+
+  - name: 002-plan-apply-root-level-update
+    inputOverlayDirs:
+      - overlays/002-root-update
+    commands:
+      - name: 000-plan-root-level-update
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-root-level-update.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 2
+                by_action.UPDATE: 2
+          - select: >-
+              changes[?resource_type=='portal_identity_provider' && resource_ref=='{{ .vars.providerRef }}'] | [0].fields
+            expect:
+              fields:
+                enabled: false
+                config.client_id: __ENV__:KONGCTL_E2E_PORTAL_IDP_UPDATE_CLIENT_ID
+                config.issuer_url: __ENV__:KONGCTL_E2E_PORTAL_IDP_UPDATE_ISSUER_URL
+      - name: 001-apply-root-level-update
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-root-level-update.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 2
+                failed: 0
+      - name: 002-get-identity-providers-updated
+        run:
+          - get
+          - portal
+          - identity-providers
+          - --portal-name
+          - "{{ .vars.portalRef }}"
+          - -o
+          - json
+        assertions:
+          - select: '[0]'
+            expect:
+              fields:
+                type: oidc
+                enabled: false
+                config.client_id: "{{ .vars.updateClientID }}"
+                config.claim_mappings.name: full_name

--- a/test/e2e/scenarios/portal/identity_providers/testdata/config.yaml
+++ b/test/e2e/scenarios/portal/identity_providers/testdata/config.yaml
@@ -1,0 +1,26 @@
+_defaults:
+  kongctl:
+    namespace: portal-identity-providers
+
+portals:
+  - ref: portal-idp
+    name: portal-idp
+    display_name: Portal Identity Providers
+    description: Portal with nested identity providers
+    kongctl:
+      namespace: portal-identity-providers
+    identity_providers:
+      - ref: portal-oidc
+        type: oidc
+        enabled: true
+        config:
+          issuer_url: !env KONGCTL_E2E_PORTAL_IDP_ISSUER_URL
+          client_id: !env KONGCTL_E2E_PORTAL_IDP_CLIENT_ID
+          client_secret: !env KONGCTL_E2E_PORTAL_IDP_CLIENT_SECRET
+          scopes:
+            - openid
+            - profile
+          claim_mappings:
+            name: name
+            email: email
+            groups: groups

--- a/test/e2e/scenarios/portal/identity_providers_duplicate_type/scenario.yaml
+++ b/test/e2e/scenarios/portal/identity_providers_duplicate_type/scenario.yaml
@@ -1,0 +1,19 @@
+baseInputsPath: testdata
+
+env:
+  KONGCTL_LOG_LEVEL: debug
+
+steps:
+  - name: 000-plan-fails-on-duplicate-provider-type
+    commands:
+      - name: 000-plan
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        expectFailure:
+          exitCode: 1
+          contains: "multiple portal_identity_provider entries target portal"

--- a/test/e2e/scenarios/portal/identity_providers_duplicate_type/testdata/config.yaml
+++ b/test/e2e/scenarios/portal/identity_providers_duplicate_type/testdata/config.yaml
@@ -1,0 +1,22 @@
+_defaults:
+  kongctl:
+    namespace: portal-identity-providers
+
+portals:
+  - ref: portal-idp
+    name: portal-idp
+    display_name: Portal Identity Providers
+    description: Portal with duplicate identity provider types
+    kongctl:
+      namespace: portal-identity-providers
+    identity_providers:
+      - ref: portal-oidc-a
+        type: oidc
+        config:
+          issuer_url: https://issuer-a.example.test
+          client_id: client-id-a
+      - ref: portal-oidc-b
+        type: oidc
+        config:
+          issuer_url: https://issuer-b.example.test
+          client_id: client-id-b

--- a/test/e2e/testdata/declarative/portal/auth-settings/config.yaml
+++ b/test/e2e/testdata/declarative/portal/auth-settings/config.yaml
@@ -12,18 +12,5 @@ portals:
     auth_settings:
       ref: portal-auth-settings
       basic_auth_enabled: true
-      oidc_auth_enabled: true
-      saml_auth_enabled: false
-      oidc_team_mapping_enabled: true
-      konnect_mapping_enabled: false
-      idp_mapping_enabled: true
-      oidc_issuer: "https://accounts.google.com"
-      oidc_client_id: "client-id-1"
-      oidc_client_secret: "client-secret-1"
-      oidc_scopes:
-        - openid
-        - profile
-      oidc_claim_mappings:
-        name: name
-        email: email
-        groups: groups
+      konnect_mapping_enabled: true
+      idp_mapping_enabled: false


### PR DESCRIPTION
## Summary

Implements first-class support for Konnect Dev Portal identity providers and completes the transition away from the deprecated IdP-specific fields previously carried under `portal auth_settings`.

This keeps `portal auth_settings` for the remaining portal-level booleans, adds a proper portal IdP collection resource to the declarative engine, updates CLI and TUI browsing, and refreshes docs and test coverage around the new model.

Closes #423.

## What Changed

### Declarative resource support

- Adds `portal_identity_provider` as a new declarative resource type.
- Supports both declaration forms:
  - nested: `portals[].identity_providers`
  - root-level: `portal_identity_providers`
- Wires portal IdPs through loader extraction, ref resolution, planning, execution, state caching, dump, explain output, and protection lookup.

### Portal auth settings cleanup

- Keeps `portal_auth_settings`, but narrows it to the surviving portal-level fields:
  - `basic_auth_enabled`
  - `konnect_mapping_enabled`
  - `idp_mapping_enabled`
- Removes deprecated IdP/OIDC/SAML fields from auth-settings planning, execution, dump, and rendered output.
- Adds fast-fail validation when deprecated provider-specific fields are still supplied under `auth_settings`.

### Validation and planning behavior

- Validates portal IdP type/config consistency (`oidc` must use OIDC config, `saml` must use SAML config).
- Rejects duplicate portal IdP types per portal during validation.
- Treats OIDC `client_secret` as a write-only secret for planning so repeated applies remain idempotent.
- Preserves deferred `!env` placeholders in portal IdP plan output.

### CLI and TUI

- Adds `kongctl get portal identity-providers`.
- Updates `kongctl get portal auth-settings` to render only the supported auth-settings fields.
- Adds portal child browsing in `kongctl view` for:
  - `auth-settings`
  - `identity-providers`
- Keeps the auth-settings detail view free of deprecated OIDC/SAML fields.

### Docs and examples

- Adds a new declarative example at `docs/examples/declarative/portal-idp/`.
- Uses `!env` for IdP config values in the example and in the live E2E scenario inputs.
- Documents write-only secret behavior in `docs/declarative.md`.
- Updates the declarative resource reference for the new portal IdP schema and the reduced auth-settings schema.

## Konnect/API Notes

- Portal IdPs are modeled as a collection in `kongctl`.
- Current live Konnect behavior only allows one portal identity provider per portal; validation currently rejects duplicate IdP types per portal on the client side.
- Konnect currently rejects `enabled` on portal IdP create even though the generated SDK model includes it.
  - This PR keeps the SDK-backed path and strips `enabled` from the outbound create request body via the SDK HTTP client wrapper.
  - If `enabled` is explicitly configured, a follow-up SDK update applies the desired value after create.

## Testing

Added or updated coverage across:

- unit tests for loader, planner, executor, helper, and portal/TUI render paths
- E2E scenarios for:
  - `portal/auth_settings`
  - `portal/auth_settings_deprecated_fields`
  - `portal/identity_providers`
  - `portal/identity_providers_duplicate_type`
- explain command coverage for the new portal child resource

The portal IdP live E2E scenario is gated behind environment variables because Konnect requires a real IdP issuer URL for provider validation.