### PR TITLE
Test: Adds e2e delete cleanup coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ CLAUDE.local.md
 .serena/
 .latest-e2e
 .e2e-artifacts/
+.e2e_artifacts/
 .cache/
 
 # Python cache folders

--- a/test/e2e/scenarios/adopt/auth-strategy-adopt/cleanup.yaml
+++ b/test/e2e/scenarios/adopt/auth-strategy-adopt/cleanup.yaml
@@ -1,0 +1,25 @@
+application_auth_strategies:
+  - ref: adopt-e2e-auth-strategy
+    name: adopt-e2e-auth-strategy
+    display_name: "Adopt E2E Auth Strategy"
+    strategy_type: key_auth
+    configs:
+      key-auth:
+        key_names:
+          - X-API-Key
+          - apikey
+    kongctl:
+      namespace: team-auth-test
+      protected: false
+
+  - ref: adopt-e2e-auth-strategy-uuid
+    name: adopt-e2e-auth-strategy-uuid
+    display_name: "Adopt E2E Auth Strategy UUID"
+    strategy_type: key_auth
+    configs:
+      key-auth:
+        key_names:
+          - X-API-Key
+    kongctl:
+      namespace: team-auth-test
+      protected: false

--- a/test/e2e/scenarios/adopt/auth-strategy-adopt/scenario.yaml
+++ b/test/e2e/scenarios/adopt/auth-strategy-adopt/scenario.yaml
@@ -117,3 +117,28 @@ steps:
                 namespace: "{{ .vars.namespace }}"
                 id: "{{ .vars.auth_strategy_id_2 }}"
                 resource_type: auth_strategy
+
+  - name: 006-delete-cleanup
+    skipInputs: true
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .scenario_dir }}/cleanup.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 2
+                by_action.DELETE: 2
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/adopt/create-portal-adopt-dump-plan/cleanup.yaml
+++ b/test/e2e/scenarios/adopt/create-portal-adopt-dump-plan/cleanup.yaml
@@ -1,0 +1,9 @@
+portals:
+  - ref: adopt-e2e-portal
+    name: adopt-e2e-portal
+    display_name: "Adopt Scenario Portal"
+    authentication_enabled: false
+    rbac_enabled: false
+    kongctl:
+      namespace: team-e2e
+      protected: false

--- a/test/e2e/scenarios/adopt/create-portal-adopt-dump-plan/scenario.yaml
+++ b/test/e2e/scenarios/adopt/create-portal-adopt-dump-plan/scenario.yaml
@@ -70,3 +70,28 @@ steps:
             expect:
               fields:
                 total_changes: 0
+
+  - name: 002-delete-cleanup
+    skipInputs: true
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .scenario_dir }}/cleanup.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/adopt/full/cleanup.yaml
+++ b/test/e2e/scenarios/adopt/full/cleanup.yaml
@@ -1,0 +1,24 @@
+control_planes:
+  - ref: adopt-e2e-cp
+    name: adopt-e2e-cp
+    description: "Adopt Scenario Control Plane"
+    cluster_type: "CLUSTER_TYPE_CONTROL_PLANE"
+    kongctl:
+      namespace: team-e2e
+      protected: false
+
+portals:
+  - ref: adopt-e2e-portal
+    name: adopt-e2e-portal
+    display_name: "Adopt Scenario Portal"
+    kongctl:
+      namespace: team-e2e
+      protected: false
+
+apis:
+  - ref: adopt-e2e-api
+    name: adopt-e2e-api
+    description: "Adopt Scenario API"
+    kongctl:
+      namespace: team-e2e
+      protected: false

--- a/test/e2e/scenarios/adopt/full/scenario.yaml
+++ b/test/e2e/scenarios/adopt/full/scenario.yaml
@@ -130,3 +130,28 @@ steps:
             expect:
               fields:
                 total_changes: 0
+
+  - name: 004-delete-cleanup
+    skipInputs: true
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .scenario_dir }}/cleanup.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 3
+                by_action.DELETE: 3
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/adopt/team-create-adopt-dump/cleanup.yaml
+++ b/test/e2e/scenarios/adopt/team-create-adopt-dump/cleanup.yaml
@@ -1,0 +1,8 @@
+organization:
+  teams:
+    - ref: e2e-adopt-test-team
+      name: e2e-adopt-test-team
+      description: E2E test team for adopt and dump workflow
+      kongctl:
+        namespace: team-e2e-test
+        protected: false

--- a/test/e2e/scenarios/adopt/team-create-adopt-dump/scenario.yaml
+++ b/test/e2e/scenarios/adopt/team-create-adopt-dump/scenario.yaml
@@ -77,3 +77,28 @@ steps:
             expect:
               fields:
                 total_changes: 0
+
+  - name: 002-delete-cleanup
+    skipInputs: true
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .scenario_dir }}/cleanup.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/apis/root-level-publication-visibility/scenario.yaml
+++ b/test/e2e/scenarios/apis/root-level-publication-visibility/scenario.yaml
@@ -212,3 +212,28 @@ steps:
             expect:
               fields:
                 "length(@)": 0
+
+  - name: 004-delete-cleanup
+    inputOverlayDirs:
+      - overlays/002-set-public
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - -f
+          - "{{ .workdir }}/apis.yaml"
+          - -f
+          - "{{ .workdir }}/publications.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/control-plane/apply/scenario.yaml
+++ b/test/e2e/scenarios/control-plane/apply/scenario.yaml
@@ -88,3 +88,27 @@ steps:
             expect:
               fields:
                 total_changes: 0
+
+  - name: 004-delete-cleanup
+    commands:
+      - name: 004-000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/control-plane.yaml"
+          - --auto-approve
+        assertions:
+          - select: "plan.metadata"
+            expect:
+              fields:
+                mode: delete
+          - select: "plan.summary"
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: "summary"
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/control-plane/get/scenario.yaml
+++ b/test/e2e/scenarios/control-plane/get/scenario.yaml
@@ -83,3 +83,27 @@ steps:
         expectFailure:
           exitCode: 1
           contains: "not found"
+
+  - name: 006-delete-cleanup
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/control-plane.yaml"
+          - --auto-approve
+        assertions:
+          - select: "plan.metadata"
+            expect:
+              fields:
+                mode: delete
+          - select: "plan.summary"
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: "summary"
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/control-plane/groups/scenario.yaml
+++ b/test/e2e/scenarios/control-plane/groups/scenario.yaml
@@ -41,3 +41,27 @@ steps:
             expect:
               fields:
                 total_changes: 0
+
+  - name: 003-delete-cleanup
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/control-plane.yaml"
+          - --auto-approve
+        assertions:
+          - select: "plan.metadata"
+            expect:
+              fields:
+                mode: delete
+          - select: "plan.summary"
+            expect:
+              fields:
+                total_changes: 3
+                by_action.DELETE: 3
+          - select: "summary"
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/control-plane/plan/apply-workflow/scenario.yaml
+++ b/test/e2e/scenarios/control-plane/plan/apply-workflow/scenario.yaml
@@ -200,3 +200,29 @@ steps:
             expect:
               fields:
                 total_changes: 0
+
+  - name: 004-delete-cleanup
+    inputOverlayDirs:
+      - overlays/001-update
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/control-plane.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/control-plane/sync-groups/scenario.yaml
+++ b/test/e2e/scenarios/control-plane/sync-groups/scenario.yaml
@@ -79,3 +79,29 @@ steps:
             expect:
               fields:
                 total_changes: 0
+
+  - name: 004-delete-cleanup
+    inputOverlayDirs:
+      - overlays/002-update-members
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/control-plane.yaml"
+          - --auto-approve
+        assertions:
+          - select: "plan.metadata"
+            expect:
+              fields:
+                mode: delete
+          - select: "plan.summary"
+            expect:
+              fields:
+                total_changes: 3
+                by_action.DELETE: 3
+          - select: "summary"
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/control-plane/sync/scenario.yaml
+++ b/test/e2e/scenarios/control-plane/sync/scenario.yaml
@@ -80,3 +80,29 @@ steps:
             expect:
               fields:
                 "@": "CLUSTER_TYPE_CONTROL_PLANE"
+
+  - name: 003-delete-cleanup
+    inputOverlayDirs:
+      - overlays/002-sync-with-delete
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/control-plane.yaml"
+          - --auto-approve
+        assertions:
+          - select: "plan.metadata"
+            expect:
+              fields:
+                mode: delete
+          - select: "plan.summary"
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: "summary"
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/dcr-providers/workflow/scenario.yaml
+++ b/test/e2e/scenarios/dcr-providers/workflow/scenario.yaml
@@ -352,14 +352,3 @@ steps:
               fields:
                 failed: 0
                 status: success
-      - name: 001-get-empty
-        run:
-          - get
-          - dcr-providers
-          - -o
-          - json
-        assertions:
-          - select: "@"
-            expect:
-              fields:
-                "length(@)": 0

--- a/test/e2e/scenarios/deck/multi-file/scenario.yaml
+++ b/test/e2e/scenarios/deck/multi-file/scenario.yaml
@@ -72,3 +72,28 @@ steps:
             expect:
               fields:
                 name: "e2e-gw-svc-two"
+
+  - name: 002-delete-cleanup
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/apis.yaml"
+          - -f
+          - "{{ .workdir }}/control-plane.yaml"
+          - -f
+          - "{{ .workdir }}/gateway-service-one.yaml"
+          - -f
+          - "{{ .workdir }}/gateway-service-two.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/deck/sync/scenario.yaml
+++ b/test/e2e/scenarios/deck/sync/scenario.yaml
@@ -68,3 +68,25 @@ steps:
             expect:
               fields:
                 "length(@)": 0
+
+  - name: 003-delete-cleanup
+    commands:
+      - name: 000-delete
+        outputFormat: json
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/konnect/"
+          - --base-dir
+          - "{{ .workdir }}"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/dump/control-planes/scenario.yaml
+++ b/test/e2e/scenarios/dump/control-planes/scenario.yaml
@@ -127,3 +127,22 @@ steps:
             expect:
               fields:
                 name: "e2e-dump-cp"
+
+  - name: 005-delete-cleanup
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/control-plane-with-gw-svc.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/dump/filtered/scenario.yaml
+++ b/test/e2e/scenarios/dump/filtered/scenario.yaml
@@ -206,3 +206,26 @@ steps:
         outputFormat: none
         expectFailure:
           contains: "mutually exclusive"
+
+  - name: 010-delete-cleanup
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - -f
+          - "{{ .workdir }}/apis.yaml"
+          - -f
+          - "{{ .workdir }}/auth-strategies.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/dump/portal-owned/scenario.yaml
+++ b/test/e2e/scenarios/dump/portal-owned/scenario.yaml
@@ -83,3 +83,26 @@ steps:
             expect:
               fields:
                 total_changes: 0
+
+  - name: 003-delete-cleanup
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - -f
+          - "{{ .workdir }}/apis.yaml"
+          - -f
+          - "{{ .workdir }}/auth-strategies.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/scenario.yaml
@@ -1025,3 +1025,28 @@ steps:
               fields:
                 name: "{{ .vars.trustBundleName }}"
                 description: "{{ .vars.trustBundleDesc }}"
+
+  - name: 014-delete-cleanup
+    inputOverlayDirs:
+      - overlays/012-trust-bundles
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: plan.summary
+            expect:
+              fields:
+                "total_changes > `0`": true
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/scenario.yaml
@@ -1157,3 +1157,28 @@ steps:
             expect:
               fields:
                 "contains(@, 'No changes detected. Konnect is up to date.')": true
+
+  - name: 014-delete-cleanup
+    inputOverlayDirs:
+      - overlays/012-trust-bundles
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: plan.summary
+            expect:
+              fields:
+                "total_changes > `0`": true
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/external/portal-publication/scenario.yaml
+++ b/test/e2e/scenarios/external/portal-publication/scenario.yaml
@@ -117,3 +117,46 @@ steps:
             expect:
               fields:
                 "length(@)": 1
+
+  - name: 004-delete-cleanup
+    commands:
+      - name: 000-delete-api-publication
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/team-a/api.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: plan.summary
+            expect:
+              fields:
+                "total_changes > `0`": true
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success
+      - name: 001-delete-platform-portal
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/platform/portal.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: plan.summary
+            expect:
+              fields:
+                "total_changes > `0`": true
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/external/portal-sync/cleanup.yaml
+++ b/test/e2e/scenarios/external/portal-sync/cleanup.yaml
@@ -1,0 +1,9 @@
+portals:
+  - ref: central-portal
+    name: "central-team-portal"
+    display_name: "Central Team Portal"
+    description: "Central portal owned by the platform team"
+    authentication_enabled: false
+    kongctl:
+      namespace: default
+      protected: false

--- a/test/e2e/scenarios/external/portal-sync/scenario.yaml
+++ b/test/e2e/scenarios/external/portal-sync/scenario.yaml
@@ -64,3 +64,28 @@ steps:
             expect:
               fields:
                 "length(@)": 0
+
+  - name: 003-delete-cleanup
+    skipInputs: true
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .scenario_dir }}/cleanup.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/org/teams/apply/scenario.yaml
+++ b/test/e2e/scenarios/org/teams/apply/scenario.yaml
@@ -156,3 +156,29 @@ steps:
                 labels.tier: "core"
                 labels.platform: "web-mobile"
                 system_team: false
+
+  - name: 003-delete-cleanup
+    inputOverlayDirs:
+      - overlays/002-update-fields
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/teams.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 2
+                by_action.DELETE: 2
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/org/teams/get/cleanup.yaml
+++ b/test/e2e/scenarios/org/teams/get/cleanup.yaml
@@ -1,0 +1,14 @@
+organization:
+  teams:
+    - ref: team-alpha
+      name: e2e-get-team-alpha
+      description: "E2E Get Test Team Alpha"
+      kongctl:
+        namespace: e2e-get-team
+        protected: false
+    - ref: team-beta
+      name: e2e-get-team-beta
+      description: "E2E Get Test Team Beta"
+      kongctl:
+        namespace: e2e-get-team
+        protected: false

--- a/test/e2e/scenarios/org/teams/get/scenario.yaml
+++ b/test/e2e/scenarios/org/teams/get/scenario.yaml
@@ -17,6 +17,7 @@
 # 7. List by name              (text output; only alpha name must appear)
 
 vars:
+  namespace: e2e-get-team
   team_alpha_name: e2e-get-team-alpha
   team_beta_name: e2e-get-team-beta
   team_alpha_description: "E2E Get Test Team Alpha"
@@ -38,6 +39,8 @@ steps:
             inline:
               name: "{{ .vars.team_alpha_name }}"
               description: "{{ .vars.team_alpha_description }}"
+              labels:
+                KONGCTL-namespace: "{{ .vars.namespace }}"
           recordVar:
             name: team_alpha_id
             responsePath: id
@@ -49,6 +52,8 @@ steps:
             inline:
               name: "{{ .vars.team_beta_name }}"
               description: "{{ .vars.team_beta_description }}"
+              labels:
+                KONGCTL-namespace: "{{ .vars.namespace }}"
           recordVar:
             name: team_beta_id
             responsePath: id
@@ -177,3 +182,28 @@ steps:
             expect:
               fields:
                 "contains(stdout, 'e2e-get-team-beta')": false
+
+  - name: 007-delete-cleanup
+    skipInputs: true
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .scenario_dir }}/cleanup.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 2
+                by_action.DELETE: 2
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/org/teams/plan/apply-workflow/scenario.yaml
+++ b/test/e2e/scenarios/org/teams/plan/apply-workflow/scenario.yaml
@@ -177,3 +177,30 @@ steps:
               fields:
                 description: "Frontend engineering team with expanded capabilities"
                 labels.tier: "core"
+
+  - name: 003-delete-cleanup
+    inputOverlayDirs:
+      - overlays/002-plan-update
+    commands:
+      - name: 000-delete
+        outputFormat: json
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/teams.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 3
+                by_action.DELETE: 3
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/org/teams/plan/sync-workflow/scenario.yaml
+++ b/test/e2e/scenarios/org/teams/plan/sync-workflow/scenario.yaml
@@ -179,3 +179,30 @@ steps:
             expect:
               fields:
                 total_changes: 0
+
+  - name: 003-delete-cleanup
+    inputOverlayDirs:
+      - overlays/002-plan-sync
+    commands:
+      - name: 000-delete
+        outputFormat: json
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/teams.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 3
+                by_action.DELETE: 3
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/org/teams/sync/scenario.yaml
+++ b/test/e2e/scenarios/org/teams/sync/scenario.yaml
@@ -139,3 +139,29 @@ steps:
                 applied: 0
                 failed: 0
                 status: success
+
+  - name: 003-delete-cleanup
+    inputOverlayDirs:
+      - overlays/002-sync-update
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/teams.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 3
+                by_action.DELETE: 3
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/plan/apply-workflow/scenario.yaml
+++ b/test/e2e/scenarios/plan/apply-workflow/scenario.yaml
@@ -171,3 +171,30 @@ steps:
               fields:
                 description: "Orders API with updated details"
                 labels.lifecycle: production
+
+  - name: 003-delete-cleanup
+    inputOverlayDirs:
+      - overlays/002-plan-update
+    commands:
+      - name: 000-delete
+        outputFormat: json
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 3
+                by_action.DELETE: 3
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/plan/sync-workflow/scenario.yaml
+++ b/test/e2e/scenarios/plan/sync-workflow/scenario.yaml
@@ -179,3 +179,30 @@ steps:
             expect:
               fields:
                 total_changes: 0
+
+  - name: 003-delete-cleanup
+    inputOverlayDirs:
+      - overlays/002-plan-sync
+    commands:
+      - name: 000-delete
+        outputFormat: json
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 3
+                by_action.DELETE: 3
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/portal/api_with_attributes/scenario.yaml
+++ b/test/e2e/scenarios/portal/api_with_attributes/scenario.yaml
@@ -194,3 +194,29 @@ steps:
                 applied: 0
                 failed: 0
                 total_changes: 0
+
+  - name: 005-delete-cleanup
+    inputOverlayDirs:
+      - overlays/003-sync-null-attributes
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/api.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/portal/assets/scenario.yaml
+++ b/test/e2e/scenarios/portal/assets/scenario.yaml
@@ -194,3 +194,25 @@ steps:
             expect:
               fields:
                 "length(@)": 0
+
+  - name: 004-delete-cleanup
+    inputOverlayDirs:
+      - overlays/002-update
+    commands:
+      - name: 000-delete
+        outputFormat: json
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/portal/auth-strategy-link/scenario.yaml
+++ b/test/e2e/scenarios/portal/auth-strategy-link/scenario.yaml
@@ -294,3 +294,31 @@ steps:
             expect:
               fields:
                 "length(@)": 0
+
+  - name: 007-delete-cleanup
+    inputOverlayOps:
+      - file: "apis.yaml"
+        match: "apis[?ref=='sms'].publications[?ref=='sms-to-e2e-portal'] | [0]"
+        set:
+          visibility: "private"
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - -f
+          - "{{ .workdir }}/auth-strategies.yaml"
+          - -f
+          - "{{ .workdir }}/apis.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/portal/auth_settings/scenario.yaml
+++ b/test/e2e/scenarios/portal/auth_settings/scenario.yaml
@@ -81,3 +81,23 @@ steps:
                 basic_auth_enabled: true
                 idp_mapping_enabled: false
                 konnect_mapping_enabled: true
+
+  - name: 002-delete-cleanup
+    commands:
+      - name: 000-delete
+        outputFormat: json
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/portal/customization/scenario.yaml
+++ b/test/e2e/scenarios/portal/customization/scenario.yaml
@@ -148,3 +148,25 @@ steps:
             expect:
               fields:
                 total_changes: 0
+
+  - name: 005-delete-cleanup
+    inputOverlayDirs:
+      - overlays/003-update
+    commands:
+      - name: 000-delete
+        outputFormat: json
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/portal/default_application_auth_strategy/scenario.yaml
+++ b/test/e2e/scenarios/portal/default_application_auth_strategy/scenario.yaml
@@ -210,3 +210,31 @@ steps:
             expect:
               fields:
                 total_changes: 0
+
+  - name: 006-delete-cleanup
+    inputOverlayDirs:
+      - overlays/003-update-portal-to-v2
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/app-auth-strategy.yaml"
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 3
+                by_action.DELETE: 3
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/portal/edit/scenario.yaml
+++ b/test/e2e/scenarios/portal/edit/scenario.yaml
@@ -95,3 +95,24 @@ steps:
               fields:
                 failed: 0
                 total_changes: 0
+
+  - name: 003-delete-cleanup
+    inputOverlayDirs:
+      - overlays/002-modify
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete

--- a/test/e2e/scenarios/portal/email-templates/scenario.yaml
+++ b/test/e2e/scenarios/portal/email-templates/scenario.yaml
@@ -156,3 +156,25 @@ steps:
               fields:
                 applied: 2
                 failed: 0
+
+  - name: 004-delete-cleanup
+    inputOverlayDirs:
+      - overlays/003-remove
+    commands:
+      - name: 000-delete
+        outputFormat: json
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/portal/email/scenario.yaml
+++ b/test/e2e/scenarios/portal/email/scenario.yaml
@@ -151,3 +151,25 @@ steps:
               fields:
                 applied: 1
                 failed: 0
+
+  - name: 004-delete-cleanup
+    inputOverlayDirs:
+      - overlays/003-remove
+    commands:
+      - name: 000-delete
+        outputFormat: json
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/portal/publication-auth-omitted-noop/scenario.yaml
+++ b/test/e2e/scenarios/portal/publication-auth-omitted-noop/scenario.yaml
@@ -127,3 +127,26 @@ steps:
             expect:
               fields:
                 "length(@)": 0
+
+  - name: 003-delete-cleanup
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - -f
+          - "{{ .workdir }}/auth-strategies.yaml"
+          - -f
+          - "{{ .workdir }}/apis.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/portal/sync/scenario.yaml
+++ b/test/e2e/scenarios/portal/sync/scenario.yaml
@@ -175,3 +175,26 @@ steps:
             expect:
               fields:
                 "length(@)": 0
+
+  - name: 005-delete-cleanup
+    inputOverlayDirs:
+      - overlays/002-delete-api
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - -f
+          - "{{ .workdir }}/apis.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/portal/visibility/scenario.yaml
+++ b/test/e2e/scenarios/portal/visibility/scenario.yaml
@@ -211,3 +211,24 @@ steps:
             expect:
               fields:
                 "length(@)": 0
+
+  - name: 005-delete-cleanup
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - -f
+          - "{{ .workdir }}/apis.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success


### PR DESCRIPTION
## Summary

This expands end-of-scenario cleanup coverage across the e2e scenario suite by adding terminal `delete -f ... --auto-approve` cleanup steps to scenarios that create persistent Konnect resources.

The cleanup steps assert on delete command success and plan mode, but avoid the extra post-delete `get` verification reads that were inflating Konnect API traffic. For adopt and direct-create cases that do not have a suitable final declarative input, this adds small scenario-local cleanup fixtures under `test/e2e/scenarios/.../cleanup.yaml`.

This also includes the local `.gitignore` update so the e2e artifacts directory used in this workflow is ignored consistently.

## Why

Issue #820 asks for broader delete coverage through normal scenario teardown, while also making cleanup more direct than relying only on `resetOrg: true` before the next scenario.

The main problem with the earlier pattern was that some scenarios either had no explicit cleanup at all or added extra verification reads after cleanup. That increased API traffic without adding much confidence outside the dedicated delete-focused scenarios.

## Impact

- broadens real delete-path coverage in the e2e suite
- reduces leftover scenario resources between runs
- keeps teardown assertions focused on delete command behavior instead of follow-up reads
- preserves existing special-case flows that already self-clean with `sync-delete` or are intentionally outside this tranche

## Validation

Ran these scenario validations with `KONGCTL_E2E_ARTIFACTS_DIR=/home/rspurgeon/go/e2e-artifacts`:

- `make test-e2e-scenarios SCENARIO=control-plane/apply`
- `make test-e2e-scenarios SCENARIO=control-plane/get`
- `make test-e2e-scenarios SCENARIO=control-plane/groups`
- `make test-e2e-scenarios SCENARIO=control-plane/plan/apply-workflow`
- `make test-e2e-scenarios SCENARIO=control-plane/sync-groups`
- `make test-e2e-scenarios SCENARIO=org/teams/apply`
- `make test-e2e-scenarios SCENARIO=org/teams/get`
- `make test-e2e-scenarios SCENARIO=org/teams/plan/apply-workflow`
- `make test-e2e-scenarios SCENARIO=org/teams/plan/sync-workflow`
- `make test-e2e-scenarios SCENARIO=org/teams/sync`
- `make test-e2e-scenarios SCENARIO=plan/apply-workflow`
- `make test-e2e-scenarios SCENARIO=plan/sync-workflow`
- `make test-e2e-scenarios SCENARIO=portal/edit`
- `make test-e2e-scenarios SCENARIO=portal/assets`
- `make test-e2e-scenarios SCENARIO=portal/auth_settings`
- `make test-e2e-scenarios SCENARIO=portal/customization`
- `make test-e2e-scenarios SCENARIO=portal/email`
- `make test-e2e-scenarios SCENARIO=portal/email-templates`
- `make test-e2e-scenarios SCENARIO=portal/api_with_attributes`
- `make test-e2e-scenarios SCENARIO=portal/default_application_auth_strategy`
- `make test-e2e-scenarios SCENARIO=portal/auth-strategy-link`
- `make test-e2e-scenarios SCENARIO=portal/publication-auth-omitted-noop`
- `make test-e2e-scenarios SCENARIO=portal/visibility`
- `make test-e2e-scenarios SCENARIO=portal/sync`
- `make test-e2e-scenarios SCENARIO=dump/control-planes`
- `make test-e2e-scenarios SCENARIO=dump/filtered`
- `make test-e2e-scenarios SCENARIO=dump/portal-owned`
- `make test-e2e-scenarios SCENARIO=apis/root-level-publication-visibility`
- `make test-e2e-scenarios SCENARIO=deck/multi-file`
- `make test-e2e-scenarios SCENARIO=deck/sync`
- `make test-e2e-scenarios SCENARIO=adopt/create-portal-adopt-dump-plan`
- `make test-e2e-scenarios SCENARIO=adopt/team-create-adopt-dump`
- `make test-e2e-scenarios SCENARIO=adopt/full`
- `make test-e2e-scenarios SCENARIO=adopt/auth-strategy-adopt`
- `make test-e2e-scenarios SCENARIO=external/portal-sync`
- `make test-e2e-scenarios SCENARIO=external/portal-publication`
- `make test-e2e-scenarios SCENARIO=dcr-providers/workflow`
- `make test-e2e-scenarios SCENARIO=event-gateway/plan/apply-workflow`
- `make test-e2e-scenarios SCENARIO=event-gateway/plan/sync-workflow`

Closes #820
