### PR TITLE
Feat: Add declarative benchmark runner, reporting, and notifications

### DIFF
--- a/.github/workflows/declarative-benchmark.yaml
+++ b/.github/workflows/declarative-benchmark.yaml
@@ -1,0 +1,91 @@
+name: Declarative Benchmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      case:
+        description: "Case selector: all, a size, or a case name"
+        required: false
+        default: "all"
+      command_timeout:
+        description: "Timeout for each measured kongctl command"
+        required: false
+        default: "30m"
+      benchmark_flags:
+        description: "Additional flags passed to the benchmark runner"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: konnect-declarative-benchmark
+  cancel-in-progress: false
+
+jobs:
+  declarative-benchmark:
+    name: Declarative Benchmark
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    environment: benchmark
+    env:
+      KONGCTL_BENCHMARK_ARTIFACTS_DIR: ${{ github.workspace }}/.benchmark-artifacts/${{ github.run_id }}
+      KONGCTL_BENCHMARK_CASE: ${{ inputs.case }}
+      KONGCTL_BENCHMARK_COMMAND_TIMEOUT: ${{ inputs.command_timeout }}
+      KONGCTL_BENCHMARK_KONNECT_PAT: ${{ secrets.KONGCTL_BENCHMARK_KONNECT_PAT }}
+      KONGCTL_BENCHMARK_KONNECT_BASE_URL: ${{ vars.KONGCTL_BENCHMARK_KONNECT_BASE_URL || 'https://us.api.konghq.com' }}
+      KONGCTL_E2E_LOG_LEVEL: debug
+      KONGCTL_E2E_CONSOLE_LOG_LEVEL: warn
+      KONGCTL_E2E_RESET: "1"
+      KONGCTL_E2E_HTTP_TIMEOUT: ${{ vars.KONGCTL_BENCHMARK_HTTP_TIMEOUT || '0s' }}
+      KONGCTL_E2E_HTTP_TCP_USER_TIMEOUT: ${{ vars.KONGCTL_BENCHMARK_HTTP_TCP_USER_TIMEOUT || '0s' }}
+      KONGCTL_E2E_HTTP_DISABLE_KEEPALIVES: ${{ vars.KONGCTL_BENCHMARK_HTTP_DISABLE_KEEPALIVES || '' }}
+      KONGCTL_E2E_HTTP_RECYCLE_CONNECTIONS_ON_ERROR: >-
+        ${{ vars.KONGCTL_BENCHMARK_HTTP_RECYCLE_CONNECTIONS_ON_ERROR || '1' }}
+      KONGCTL_E2E_HTTP_RETRY_ATTEMPTS: ${{ vars.KONGCTL_BENCHMARK_HTTP_RETRY_ATTEMPTS || '4' }}
+      KONGCTL_E2E_HTTP_RETRY_INTERVAL: ${{ vars.KONGCTL_BENCHMARK_HTTP_RETRY_INTERVAL || '1s' }}
+      KONGCTL_E2E_HTTP_RETRY_MAX_INTERVAL: ${{ vars.KONGCTL_BENCHMARK_HTTP_RETRY_MAX_INTERVAL || '5s' }}
+      KONGCTL_E2E_HTTP_RETRY_BACKOFF_FACTOR: ${{ vars.KONGCTL_BENCHMARK_HTTP_RETRY_BACKOFF_FACTOR || '2' }}
+      KONGCTL_E2E_HTTP_RETRY_JITTER: ${{ vars.KONGCTL_BENCHMARK_HTTP_RETRY_JITTER || '250ms' }}
+      KONGCTL_E2E_RESET_HTTP_TIMEOUT: ${{ vars.KONGCTL_BENCHMARK_RESET_HTTP_TIMEOUT || '0s' }}
+      KONGCTL_E2E_RESET_TIMEOUT: ${{ vars.KONGCTL_BENCHMARK_RESET_TIMEOUT || '0s' }}
+      KONGCTL_E2E_RESET_RETRY_ATTEMPTS: ${{ vars.KONGCTL_BENCHMARK_RESET_RETRY_ATTEMPTS || '3' }}
+      KONGCTL_E2E_RESET_RETRY_INTERVAL: ${{ vars.KONGCTL_BENCHMARK_RESET_RETRY_INTERVAL || '1s' }}
+      KONGCTL_E2E_RESET_RETRY_MAX_INTERVAL: ${{ vars.KONGCTL_BENCHMARK_RESET_RETRY_MAX_INTERVAL || '5s' }}
+      KONGCTL_E2E_RESET_RETRY_BACKOFF_FACTOR: ${{ vars.KONGCTL_BENCHMARK_RESET_RETRY_BACKOFF_FACTOR || '2' }}
+      KONGCTL_E2E_RESET_RETRY_JITTER: ${{ vars.KONGCTL_BENCHMARK_RESET_RETRY_JITTER || '250ms' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - run: git config --global url.https://$GITHUB_TOKEN@github.com/.insteadOf https://github.com/
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PRIVATE_READ }}
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Run declarative benchmark
+        run: make benchmark-declarative BENCHMARK_FLAGS="${{ inputs.benchmark_flags }}"
+
+      - name: Write workflow summary
+        if: always()
+        run: |
+          summary="$(find "${KONGCTL_BENCHMARK_ARTIFACTS_DIR}" -name summary.md -print | sort | tail -n 1)"
+          if [ -n "${summary}" ] && [ -f "${summary}" ]; then
+            cat "${summary}" >> "${GITHUB_STEP_SUMMARY}"
+          else
+            echo "No benchmark summary found." >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: declarative-benchmark-${{ github.run_id }}
+          path: ${{ env.KONGCTL_BENCHMARK_ARTIFACTS_DIR }}
+          if-no-files-found: warn

--- a/.github/workflows/declarative-benchmark.yaml
+++ b/.github/workflows/declarative-benchmark.yaml
@@ -15,9 +15,20 @@ on:
         description: "Additional flags passed to the benchmark runner"
         required: false
         default: ""
+      repeat:
+        description: "Number of times to execute each selected case"
+        required: false
+        default: "1"
+  schedule:
+    # Nightly small/medium runs, Sunday through Friday at 06:00 UTC.
+    - cron: "0 6 * * 0-5"
+    # Weekly large/xl runs, Saturday at 06:00 UTC.
+    - cron: "0 6 * * 6"
 
 permissions:
-  contents: read
+  contents: write
+  discussions: write
+  issues: write
 
 concurrency:
   group: konnect-declarative-benchmark
@@ -31,8 +42,16 @@ jobs:
     environment: benchmark
     env:
       KONGCTL_BENCHMARK_ARTIFACTS_DIR: ${{ github.workspace }}/.benchmark-artifacts/${{ github.run_id }}
-      KONGCTL_BENCHMARK_CASE: ${{ inputs.case }}
-      KONGCTL_BENCHMARK_COMMAND_TIMEOUT: ${{ inputs.command_timeout }}
+      KONGCTL_BENCHMARK_CASE: >-
+        ${{ github.event_name == 'schedule' && github.event.schedule == '0 6 * * 6' && 'large,xl' ||
+            github.event_name == 'schedule' && 'small,medium' ||
+            inputs.case }}
+      KONGCTL_BENCHMARK_COMMAND_TIMEOUT: >-
+        ${{ github.event_name == 'workflow_dispatch' && inputs.command_timeout || '30m' }}
+      KONGCTL_BENCHMARK_REPEAT: ${{ github.event_name == 'workflow_dispatch' && inputs.repeat || '3' }}
+      KONGCTL_BENCHMARK_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      KONGCTL_BENCHMARK_DISCUSSION_NUMBER: ${{ vars.KONGCTL_BENCHMARK_DISCUSSION_NUMBER || '' }}
+      KONGCTL_BENCHMARK_FLAGS: ${{ github.event_name == 'workflow_dispatch' && inputs.benchmark_flags || '' }}
       KONGCTL_BENCHMARK_KONNECT_PAT: ${{ secrets.KONGCTL_BENCHMARK_KONNECT_PAT }}
       KONGCTL_BENCHMARK_KONNECT_BASE_URL: ${{ vars.KONGCTL_BENCHMARK_KONNECT_BASE_URL || 'https://us.api.konghq.com' }}
       KONGCTL_E2E_LOG_LEVEL: debug
@@ -64,13 +83,200 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PRIVATE_READ }}
 
+      - name: Prepare benchmark history
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          results_dir="${RUNNER_TEMP}/benchmark-results"
+          rm -rf "${results_dir}"
+          git fetch origin benchmark-results || true
+
+          if git show-ref --verify --quiet refs/remotes/origin/benchmark-results; then
+            git worktree add -B benchmark-results "${results_dir}" origin/benchmark-results
+          else
+            git worktree add --detach "${results_dir}" HEAD
+            git -C "${results_dir}" switch --orphan benchmark-results
+            git -C "${results_dir}" rm -rf . >/dev/null 2>&1 || true
+            mkdir -p "${results_dir}/runs"
+            {
+              echo "# Benchmark Results"
+              echo
+              echo "This branch stores generated declarative benchmark summaries."
+              echo "Raw logs and fixture details remain available as GitHub Actions artifacts."
+            } > "${results_dir}/README.md"
+          fi
+
+          git -C "${results_dir}" remote set-url origin \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          echo "KONGCTL_BENCHMARK_HISTORY_DIR=${results_dir}" >> "${GITHUB_ENV}"
+
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
       - name: Run declarative benchmark
-        run: make benchmark-declarative BENCHMARK_FLAGS="${{ inputs.benchmark_flags }}"
+        run: make benchmark-declarative BENCHMARK_FLAGS="${KONGCTL_BENCHMARK_FLAGS}"
+
+      - name: Publish benchmark summaries
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          run_dir="$(find "${KONGCTL_BENCHMARK_ARTIFACTS_DIR}" -name results.json -print | sort | tail -n 1)"
+          if [ -z "${run_dir}" ]; then
+            echo "No benchmark results found; skipping benchmark-results update."
+            exit 0
+          fi
+          run_dir="$(dirname "${run_dir}")"
+
+          case_slug="$(printf '%s' "${KONGCTL_BENCHMARK_CASE}" \
+            | tr -cs '[:alnum:]._-' '-' \
+            | sed 's/^-//; s/-$//')"
+          if [ -z "${case_slug}" ]; then
+            case_slug="all"
+          fi
+
+          results_dir="${KONGCTL_BENCHMARK_HISTORY_DIR}"
+          destination="${results_dir}/runs/$(date -u +%Y/%m/%d)/${GITHUB_RUN_ID}-${case_slug}"
+          latest="${results_dir}/latest"
+          mkdir -p "${destination}"
+          rm -rf "${latest}"
+          mkdir -p "${latest}"
+
+          for file in \
+            results.json \
+            summary.md \
+            summary.txt \
+            dashboard.md \
+            regressions.md \
+            regressions.json \
+            history-report.json
+          do
+            if [ -f "${run_dir}/${file}" ]; then
+              cp "${run_dir}/${file}" "${destination}/${file}"
+              cp "${run_dir}/${file}" "${latest}/${file}"
+            fi
+          done
+
+          jq -n \
+            --arg run_id "${GITHUB_RUN_ID}" \
+            --arg run_attempt "${GITHUB_RUN_ATTEMPT}" \
+            --arg run_url "${KONGCTL_BENCHMARK_RUN_URL}" \
+            --arg case "${KONGCTL_BENCHMARK_CASE}" \
+            --arg repeat "${KONGCTL_BENCHMARK_REPEAT}" \
+            --arg created_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{
+              run_id: $run_id,
+              run_attempt: $run_attempt,
+              run_url: $run_url,
+              case: $case,
+              repeat: $repeat,
+              created_at: $created_at
+            }' > "${destination}/metadata.json"
+          cp "${destination}/metadata.json" "${latest}/metadata.json"
+
+          git -C "${results_dir}" config user.name "github-actions[bot]"
+          git -C "${results_dir}" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C "${results_dir}" add -A
+          if git -C "${results_dir}" diff --cached --quiet; then
+            echo "No benchmark summary changes to publish."
+            exit 0
+          fi
+
+          git -C "${results_dir}" commit -m "benchmark: add run ${GITHUB_RUN_ID}"
+          git -C "${results_dir}" push origin HEAD:benchmark-results
+
+      - name: Update benchmark discussion dashboard
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          dashboard="$(find "${KONGCTL_BENCHMARK_ARTIFACTS_DIR}" -name dashboard.md -print | sort | tail -n 1)"
+          if [ -z "${dashboard}" ] || [ ! -f "${dashboard}" ]; then
+            echo "No benchmark dashboard found; skipping discussion update."
+            exit 0
+          fi
+          if [ -z "${KONGCTL_BENCHMARK_DISCUSSION_NUMBER}" ]; then
+            echo "KONGCTL_BENCHMARK_DISCUSSION_NUMBER is not configured; skipping discussion update."
+            exit 0
+          fi
+
+          owner="${GITHUB_REPOSITORY%/*}"
+          repo="${GITHUB_REPOSITORY#*/}"
+          discussion_id="$(gh api graphql \
+            -f query='
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  discussion(number: $number) { id }
+                }
+              }' \
+            -F owner="${owner}" \
+            -F repo="${repo}" \
+            -F number="${KONGCTL_BENCHMARK_DISCUSSION_NUMBER}" \
+            --jq '.data.repository.discussion.id // empty')"
+
+          if [ -z "${discussion_id}" ]; then
+            echo "Discussion ${KONGCTL_BENCHMARK_DISCUSSION_NUMBER} was not found; skipping update."
+            exit 0
+          fi
+
+          body="$(cat "${dashboard}")"
+          gh api graphql \
+            -f query='
+              mutation($id: ID!, $body: String!) {
+                updateDiscussion(input: { discussionId: $id, body: $body }) {
+                  discussion { url }
+                }
+              }' \
+            -F id="${discussion_id}" \
+            -F body="${body}"
+
+      - name: Open or update regression issue
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          regressions_json="$(find "${KONGCTL_BENCHMARK_ARTIFACTS_DIR}" -name regressions.json -print | sort | tail -n 1)"
+          regressions_md="$(find "${KONGCTL_BENCHMARK_ARTIFACTS_DIR}" -name regressions.md -print | sort | tail -n 1)"
+          if [ -z "${regressions_json}" ] || [ ! -f "${regressions_json}" ]; then
+            echo "No regression report found; skipping issue update."
+            exit 0
+          fi
+          if [ "$(jq -r '.has_regressions' "${regressions_json}")" != "true" ]; then
+            echo "No benchmark regressions detected; leaving issues unchanged."
+            exit 0
+          fi
+
+          title="[benchmark-regression] Declarative benchmark regressions"
+          gh label create benchmark-regression \
+            --description "Benchmark regression alert" \
+            --color B60205 >/dev/null 2>&1 || true
+
+          issue_number="$(gh issue list \
+            --state open \
+            --search "${title} in:title" \
+            --json number \
+            --jq '.[0].number // empty')"
+
+          if [ -n "${issue_number}" ]; then
+            gh issue edit "${issue_number}" --body-file "${regressions_md}"
+            gh issue comment "${issue_number}" \
+              --body "Benchmark regressions reproduced in run ${KONGCTL_BENCHMARK_RUN_URL}."
+          else
+            gh issue create \
+              --title "${title}" \
+              --body-file "${regressions_md}" \
+              --label benchmark-regression
+          fi
 
       - name: Write workflow summary
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -41,8 +41,11 @@ CLAUDE.local.md
 
 .serena/
 .latest-e2e
+.latest-benchmark
 .e2e-artifacts/
+.benchmark-artifacts/
 .e2e_artifacts/
+.benchmark_artifacts/
 .cache/
 
 # Python cache folders

--- a/Makefile
+++ b/Makefile
@@ -117,8 +117,10 @@ benchmark-declarative:
 	ART_DIR=$$(cd "$$ART_DIR" && pwd); \
 	( KONGCTL_BENCHMARK_ARTIFACTS_DIR="$$ART_DIR" \
 	  KONGCTL_E2E_ARTIFACTS_DIR="$$ART_DIR" \
-	  go run -tags=e2e ./test/benchmarks/declarative $(BENCHMARK_FLAGS) ; \
-	  echo $$? > "$$ART_DIR/.exit_code" ) | tee "$$ART_DIR/run.log"; \
+	  code=0; \
+	  go run -tags=e2e ./test/benchmarks/declarative $(BENCHMARK_FLAGS) || code=$$?; \
+	  echo $$code > "$$ART_DIR/.exit_code"; \
+	  exit $$code ) | tee "$$ART_DIR/run.log"; \
 	code=$$(cat "$$ART_DIR/.exit_code"); rm -f "$$ART_DIR/.exit_code"; \
 	if [ -f "$$ART_DIR/summary.txt" ]; then \
 		echo; \

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -X main.version=$(VERSION) -X main.commit=$(GIT_COMMIT) -X main.date=$(BUILD_DATE)
 LATEST_E2E_LINK ?= .latest-e2e
+LATEST_BENCHMARK_LINK ?= .latest-benchmark
 
 .PHONY: lint
 lint:
@@ -101,6 +102,44 @@ test-e2e-scenarios:
 
 .PHONY: scenario
 scenario: test-e2e-scenarios
+
+.PHONY: benchmark-declarative
+benchmark-declarative:
+	@set -eu; \
+	ART_DIR="$${KONGCTL_BENCHMARK_ARTIFACTS_DIR:-}"; \
+	if [ -z "$$ART_DIR" ]; then \
+		ART_DIR=".benchmark-artifacts"; \
+	fi; \
+	mkdir -p "$$ART_DIR"; \
+	run_id=$$(date +%Y%m%d-%H%M%S); \
+	ART_DIR="$$ART_DIR/$$run_id"; \
+	mkdir -p "$$ART_DIR"; \
+	ART_DIR=$$(cd "$$ART_DIR" && pwd); \
+	( KONGCTL_BENCHMARK_ARTIFACTS_DIR="$$ART_DIR" \
+	  KONGCTL_E2E_ARTIFACTS_DIR="$$ART_DIR" \
+	  go run -tags=e2e ./test/benchmarks/declarative $(BENCHMARK_FLAGS) ; \
+	  echo $$? > "$$ART_DIR/.exit_code" ) | tee "$$ART_DIR/run.log"; \
+	code=$$(cat "$$ART_DIR/.exit_code"); rm -f "$$ART_DIR/.exit_code"; \
+	if [ -f "$$ART_DIR/summary.txt" ]; then \
+		echo; \
+		cat "$$ART_DIR/summary.txt"; \
+		echo; \
+	elif [ -f "$$ART_DIR/summary.md" ]; then \
+		echo; \
+		cat "$$ART_DIR/summary.md"; \
+		echo; \
+	fi; \
+	echo "Declarative benchmark artifacts: $$ART_DIR"; \
+	ln -sfn "$$ART_DIR" "$(LATEST_BENCHMARK_LINK)" || true; \
+	exit $$code
+
+.PHONY: benchmark-declarative-case
+benchmark-declarative-case:
+	@if [ -z "$(CASE)" ]; then \
+		echo "CASE is required, for example: make benchmark-declarative-case CASE=medium-single" >&2; \
+		exit 1; \
+	fi
+	@$(MAKE) benchmark-declarative BENCHMARK_FLAGS="--case $(CASE) $(BENCHMARK_FLAGS)"
 
 .PHONY: open-latest-e2e
 open-latest-e2e:

--- a/docs/declarative-benchmarks.md
+++ b/docs/declarative-benchmarks.md
@@ -1,0 +1,154 @@
+# Declarative Benchmarks
+
+The declarative benchmark runner measures live Konnect API behavior for larger
+declarative configuration sets. It is local-first: GitHub Actions runs the same
+`make` targets that developers can run on their machines.
+
+The initial benchmark suite focuses on API resources and API documents. The
+runner generates deterministic fixtures for these case sizes:
+
+- `small`
+- `medium`
+- `large`
+- `xl`
+
+Each size is rendered in both layouts:
+
+- `single-file`
+- `multi-file`
+
+Each case resets the target Konnect org, applies the generated configuration,
+then immediately reapplies the same configuration to measure no-op behavior.
+
+## Credentials
+
+Use a dedicated Konnect org for benchmark runs. Configure the benchmark PAT with
+one of these environment variables:
+
+```sh
+export KONGCTL_BENCHMARK_KONNECT_PAT="$(cat ~/.konnect/benchmark-pat)"
+```
+
+or, for compatibility with existing E2E setup:
+
+```sh
+export KONGCTL_E2E_KONNECT_PAT="$(cat ~/.konnect/benchmark-pat)"
+```
+
+The benchmark base URL defaults to `https://us.api.konghq.com`. Override it
+with:
+
+```sh
+export KONGCTL_BENCHMARK_KONNECT_BASE_URL="https://us.api.konghq.com"
+```
+
+## Local Execution
+
+Run the full declarative benchmark suite:
+
+```sh
+make benchmark-declarative
+```
+
+Run one case:
+
+```sh
+make benchmark-declarative-case CASE=medium-single
+```
+
+Accepted case selectors include:
+
+- `all`
+- a size, such as `small` or `xl`
+- a layout, such as `multi-file`
+- a case name, such as `large-multi-file`
+- the shortened layout alias, such as `large-multi`
+
+Pass additional runner flags with `BENCHMARK_FLAGS`:
+
+```sh
+make benchmark-declarative-case CASE=small-single \
+  BENCHMARK_FLAGS="--command-timeout 10m"
+```
+
+Artifacts are written under `.benchmark-artifacts/<timestamp>` by default. The
+latest run is linked from `.latest-benchmark`.
+
+The benchmark runner forces measured `kongctl apply` commands to use debug
+logging by default so HTTP request and response log lines are available for
+metrics. Override this only for troubleshooting:
+
+```sh
+export KONGCTL_BENCHMARK_LOG_LEVEL=trace
+```
+
+## Results
+
+Every run writes:
+
+- `results.json`: structured suite, case, phase, duration, and HTTP metrics
+- `summary.md`: Markdown summary suitable for workflow summaries or issues
+- per-command artifacts under `benchmarks/<case>/commands/`
+- generated fixture files under `benchmarks/<case>/inputs/`
+- `http-metrics.json` next to each measured command
+
+The primary regression signal is HTTP request count. Wall-clock duration is also
+tracked, but it is noisier because the benchmark runs against SaaS APIs.
+The suite duration includes fixture generation and destructive org reset. The
+per-phase durations measure only `kongctl apply` commands.
+
+## Baseline Comparison
+
+Compare a run against a previous `results.json`:
+
+```sh
+make benchmark-declarative-case CASE=medium-single \
+  BENCHMARK_FLAGS="--baseline path/to/results.json"
+```
+
+Request-count regressions can fail the run:
+
+```sh
+make benchmark-declarative-case CASE=medium-single \
+  BENCHMARK_FLAGS="--baseline path/to/results.json --fail-on-regression"
+```
+
+The default allowed request-count increase is five percent. Duration increases
+greater than fifty percent are reported in the comparison summary but do not
+fail the run.
+
+## GitHub Actions
+
+The `Declarative Benchmark` workflow is manual-only. It accepts:
+
+- `case`: case selector passed to the local runner
+- `command_timeout`: timeout for each measured `kongctl` command
+- `benchmark_flags`: extra runner flags
+
+Configure these in the `benchmark` environment:
+
+- `KONGCTL_BENCHMARK_KONNECT_PAT`
+- optional `KONGCTL_BENCHMARK_KONNECT_BASE_URL`
+
+The workflow uploads benchmark artifacts and writes `summary.md` to the GitHub
+Actions job summary.
+
+## Result Storage Options
+
+For now, artifacts are the source of truth. They preserve raw command output,
+logs, generated fixtures, structured metrics, and the human summary.
+
+Clean follow-up storage options are:
+
+- **Issue ledger**: keep one tracking issue for benchmark history. Each run
+  appends `summary.md`, links the artifact, and labels request-count
+  regressions.
+- **Discussion ledger**: keep one discussion for benchmark history. This is
+  better for long-running performance records and less noisy than issue
+  comments.
+- **Checked-in baseline**: commit an approved `results.json` snapshot for the
+  current suite. This gives the strictest review path for baseline updates.
+
+The issue or discussion ledger should store summaries and links. The raw
+artifact bundle should remain attached to the workflow run so investigations can
+inspect command logs and generated inputs.

--- a/docs/declarative-benchmarks.md
+++ b/docs/declarative-benchmarks.md
@@ -71,6 +71,13 @@ make benchmark-declarative-case CASE=small-single \
   BENCHMARK_FLAGS="--command-timeout 10m"
 ```
 
+Repeat each selected case to collect local samples:
+
+```sh
+make benchmark-declarative-case CASE=medium \
+  BENCHMARK_FLAGS="--repeat 3"
+```
+
 Artifacts are written under `.benchmark-artifacts/<timestamp>` by default. The
 latest run is linked from `.latest-benchmark`.
 
@@ -88,6 +95,11 @@ Every run writes:
 
 - `results.json`: structured suite, case, phase, duration, and HTTP metrics
 - `summary.md`: Markdown summary suitable for workflow summaries or issues
+- `summary.txt`: terminal-oriented summary printed by the `make` target
+- `dashboard.md`: generated discussion dashboard body
+- `regressions.md`: generated regression issue body
+- `regressions.json`: machine-readable regression status
+- `history-report.json`: detailed current-vs-history report
 - per-command artifacts under `benchmarks/<case>/commands/`
 - generated fixture files under `benchmarks/<case>/inputs/`
 - `http-metrics.json` next to each measured command
@@ -96,6 +108,21 @@ The primary regression signal is HTTP request count. Wall-clock duration is also
 tracked, but it is noisier because the benchmark runs against SaaS APIs.
 The suite duration includes fixture generation and destructive org reset. The
 per-phase durations measure only `kongctl apply` commands.
+
+When `--history-dir` or `KONGCTL_BENCHMARK_HISTORY_DIR` is set, the runner scans
+prior `results.json` files under that directory. If the directory has a `runs/`
+subdirectory, only `runs/` is scanned so `latest/` copies are not counted twice.
+
+Request-count regressions compare the current median request count to recent
+history. Duration regressions compare the current median wall-clock duration to
+recent history using the larger of:
+
+- the configured duration threshold percentage
+- three median absolute deviations from historical samples
+- a 500 ms absolute floor
+
+The default minimum history is three historical samples per case phase. Override
+it with `--min-history-samples` or `KONGCTL_BENCHMARK_MIN_HISTORY_SAMPLES`.
 
 ## Baseline Comparison
 
@@ -119,36 +146,57 @@ fail the run.
 
 ## GitHub Actions
 
-The `Declarative Benchmark` workflow is manual-only. It accepts:
+The `Declarative Benchmark` workflow can be run manually and also runs on a
+schedule:
+
+- Sunday through Friday at 06:00 UTC: `small,medium`
+- Saturday at 06:00 UTC: `large,xl`
+
+Size selectors include both layouts, so `small,medium` runs single-file and
+multi-file cases for each size.
+
+Manual runs accept:
 
 - `case`: case selector passed to the local runner
 - `command_timeout`: timeout for each measured `kongctl` command
 - `benchmark_flags`: extra runner flags
+- `repeat`: number of times to execute each selected case
 
 Configure these in the `benchmark` environment:
 
-- `KONGCTL_BENCHMARK_KONNECT_PAT`
+- `KONGCTL_BENCHMARK_KONNECT_PAT`: PAT for the dedicated benchmark org
 - optional `KONGCTL_BENCHMARK_KONNECT_BASE_URL`
+- optional `KONGCTL_BENCHMARK_DISCUSSION_NUMBER`: discussion number to update
+  with the generated dashboard
+
+Scheduled runs use `--repeat 3` by default. Manual runs default to one
+repetition unless the `repeat` input or `benchmark_flags` overrides it.
 
 The workflow uploads benchmark artifacts and writes `summary.md` to the GitHub
-Actions job summary.
+Actions job summary. It also stores generated summaries on the
+`benchmark-results` branch:
 
-## Result Storage Options
+- `runs/YYYY/MM/DD/<run-id>-<case>/`
+- `latest/`
 
-For now, artifacts are the source of truth. They preserve raw command output,
-logs, generated fixtures, structured metrics, and the human summary.
+Raw command output, logs, and generated fixtures remain workflow artifacts.
+The branch intentionally stores summaries and structured result JSON only.
 
-Clean follow-up storage options are:
+## Dashboard and Alerts
 
-- **Issue ledger**: keep one tracking issue for benchmark history. Each run
-  appends `summary.md`, links the artifact, and labels request-count
-  regressions.
-- **Discussion ledger**: keep one discussion for benchmark history. This is
-  better for long-running performance records and less noisy than issue
-  comments.
-- **Checked-in baseline**: commit an approved `results.json` snapshot for the
-  current suite. This gives the strictest review path for baseline updates.
+The workflow updates a GitHub Discussion when
+`KONGCTL_BENCHMARK_DISCUSSION_NUMBER` is configured. The discussion body is
+replaced with `dashboard.md` from the latest run, which includes current
+medians, recent-history medians, and regression status.
 
-The issue or discussion ledger should store summaries and links. The raw
-artifact bundle should remain attached to the workflow run so investigations can
-inspect command logs and generated inputs.
+When `regressions.json` reports `has_regressions: true`, the workflow opens or
+updates one rolling issue titled:
+
+```text
+[benchmark-regression] Declarative benchmark regressions
+```
+
+The issue body is replaced with `regressions.md`, and repeated regressions add a
+comment that links to the latest workflow run. Passing runs do not automatically
+close the issue; that remains a human decision while the benchmark signal is
+being tuned.

--- a/planning/gh-730-benchmarking.md
+++ b/planning/gh-730-benchmarking.md
@@ -1,0 +1,385 @@
+# GH-730 Declarative Benchmarking Plan
+
+## Goal
+
+Issue `#730` requests a repeatable performance benchmarking capability for the
+declarative engine, focused on larger declarative configuration sets against the
+real Konnect SaaS API. The benchmark system should establish baselines, support
+tracking over time, and help detect regressions as the GA release approaches.
+
+The benchmark capability needs to work in two environments:
+
+- GitHub Actions CI, where it will run most often
+- local developer machines, where contributors need a supported way to run the
+  same benchmark flows manually
+
+## Issue Summary
+
+The issue body asks for a benchmarking process that:
+
+- creates test case configuration inputs for `small`, `medium`, `large`, and
+  `XL`
+- exercises both single-file and multiple-file declarative inputs
+- reuses `scripts/command-analyzer.sh` for wall-clock timing and API request and
+  response log auditing
+- adds a GitHub workflow to run the benchmarks
+- tracks benchmark results over time
+- tracks regressions in an issue
+
+The automated issue triage comment is useful as implementation guidance, but it
+should be treated as advisory rather than canonical requirements.
+
+## Interpreted Acceptance Criteria
+
+The feature is likely complete when all of the following are true:
+
+- benchmark fixtures exist for multiple declarative workload sizes
+- the benchmark process supports both single-file and multi-file inputs
+- benchmark execution captures runtime and API behavior in a structured way
+- a GitHub Actions workflow can run the benchmark suite
+- results can be compared over time against a known baseline
+- regressions can be surfaced automatically or semi-automatically
+
+## Repository Assessment
+
+### Existing E2E harness is the strongest foundation
+
+The repository already includes a real-Konnect E2E harness with strong support
+for repeatable execution and artifact capture:
+
+- builds `kongctl` once per run and reuses the binary
+- creates isolated config state per run
+- runs against live Konnect instead of mocks
+- supports destructive org reset
+- captures per-command artifacts, including:
+  - `stdout.txt`
+  - `stderr.txt`
+  - `meta.json`
+  - `kongctl.log`
+  - optional HTTP dumps
+
+Key references:
+
+- `test/e2e/harness/builder.go`
+- `test/e2e/harness/cli.go`
+- `test/e2e/harness/reset.go`
+- `test/e2e/harness/step.go`
+- `docs/e2e.md`
+
+This is already much closer to a benchmark runner than the integration suite.
+
+### Scenario DSL already models useful benchmark flows
+
+The scenario system under `test/e2e/scenarios` can already express:
+
+- reset org
+- apply declarative config
+- re-apply declarative config
+- mutate inputs between steps
+- assert no-op behavior
+- run arbitrary external commands
+
+This is valuable because benchmark cases will likely need to cover both:
+
+- initial apply cost
+- idempotent re-apply cost
+
+There are currently many scenario fixtures and patterns to borrow from, notably
+portal and declarative lifecycle scenarios.
+
+Key references:
+
+- `test/e2e/scenarios_test.go`
+- `test/e2e/harness/scenario/types.go`
+- `test/e2e/harness/scenario/run.go`
+- `docs/e2e-scenarios.md`
+- `docs/e2e-scenarios-getting-started.md`
+
+### Existing shell analyzer is useful but not sufficient by itself
+
+The repo already has:
+
+- `scripts/command-analyzer.sh`
+- `scripts/http-log-summary.sh`
+
+Current strengths:
+
+- wall-clock timing for a `kongctl` invocation
+- request and response log parsing
+- method and route summaries
+- timing summaries from log duration fields
+
+Current limitations:
+
+- output is human-readable rather than machine-readable
+- it is a standalone shell entrypoint rather than part of the E2E artifact model
+- it is not yet organized as a benchmark suite runner
+
+The current scripts are good operator tools, but they are not yet a durable
+benchmarking system.
+
+### CI workflow patterns already exist and should be reused
+
+The repository already has a mature E2E workflow that handles:
+
+- build-once binary packaging
+- matrix execution
+- environment-scoped PAT usage
+- org-scoped concurrency
+- artifact upload
+- final aggregation and verification
+
+Key reference:
+
+- `.github/workflows/e2e.yaml`
+
+This matters because benchmarking should follow the same operational model
+rather than introducing a completely separate CI pattern.
+
+### Integration tests are not the correct substrate
+
+The integration suite is largely mock-based. The real SDK path is not a mature,
+ready-to-use basis for live performance measurement.
+
+Key reference:
+
+- `test/integration/declarative/sdk_helper_test.go`
+
+Conclusion: the benchmark feature should live beside E2E infrastructure, not
+inside the current integration-test framework.
+
+## Proposed Direction
+
+### Build a dedicated benchmark runner
+
+Rather than forcing benchmarks into regular tests or only shell scripts, add a
+dedicated benchmark runner under the repository test tooling that reuses E2E
+harness internals.
+
+Recommended shape:
+
+- a small Go command or package under `test/benchmarks/`
+- reuse:
+  - binary preparation
+  - Konnect PAT and base URL handling
+  - org reset behavior
+  - artifact directory structure
+  - command execution and log capture
+
+Why this is preferable:
+
+- benchmark runs are destructive and external, which is a poor fit for normal
+  `go test -bench`
+- the repository already has reusable harness code for exactly this style of
+  execution
+- structured result generation is easier in Go than in large shell scripts
+
+### Generate benchmark fixtures deterministically
+
+The benchmark system needs workload sizes such as:
+
+- `small`
+- `medium`
+- `large`
+- `xl`
+
+Those should be generated from committed templates or logical fixture
+descriptions rather than committing very large static YAML payloads.
+
+Recommended approach:
+
+- commit seed fixture definitions and generator inputs
+- generate runtime fixture material into the benchmark artifacts directory
+- emit both:
+  - single-file layout
+  - multi-file layout
+
+This keeps repo size manageable while making workloads reproducible.
+
+### Start with two benchmark phases per case
+
+For each benchmark case, the first useful flow is:
+
+1. reset org
+2. measured apply against empty state
+3. measured re-apply against matching state
+
+That gives two high-value signals:
+
+- create/apply cost
+- idempotency/no-op cost
+
+Possible later extensions:
+
+- `plan` benchmark runs
+- `sync` benchmark runs
+- delete-heavy scenarios
+- specialized resource family suites
+
+### Prefer request-count baselines over raw time baselines
+
+Since the benchmarks run against real Konnect SaaS, raw wall-clock duration will
+contain more noise than local-only benchmarks.
+
+The most stable performance signals are likely:
+
+- total API request count
+- per-route request breakdown
+- write vs read behavior
+
+Wall-clock time is still important, but it should be treated as a noisier,
+secondary signal and likely compared using medians or repeated runs rather than
+single hard thresholds.
+
+### Keep results structured
+
+The benchmark runner should emit structured outputs such as:
+
+- `results.json`
+- `summary.md`
+- per-case API route breakdown JSON
+- raw command artifacts and logs
+
+This likely implies either:
+
+- extending `scripts/http-log-summary.sh` with a machine-readable JSON mode, or
+- moving the log parsing into Go while keeping the shell script as a thin
+  convenience wrapper
+
+## Recommended Initial Scope
+
+For v1, keep the benchmark suite narrow and stable.
+
+Suggested resource focus:
+
+- portal
+- api
+- api version
+- api publication
+- application auth strategy
+- optionally control plane
+
+Reasoning:
+
+- these are representative declarative resources
+- they exercise planner and executor behavior
+- they avoid turning the benchmark into a content-blob upload benchmark
+
+Areas to defer until later unless specifically required:
+
+- huge binary assets
+- Gmail-backed portal application scenarios
+- event gateway coverage
+- every supported resource type in one initial suite
+
+## CI Strategy
+
+Recommended workflow design:
+
+- new dedicated workflow, separate from the standard E2E workflow
+- triggers:
+  - `workflow_dispatch`
+  - scheduled weekly run
+- reuse the same environment and matrix patterns already established in E2E
+- use dedicated benchmark orgs if available
+- upload artifacts for every run
+
+Recommended initial posture:
+
+- informational and non-blocking at first
+- compare results to an approved baseline
+- open or update an issue when thresholds are exceeded
+
+Possible later evolution:
+
+- smaller targeted benchmark smoke checks for PRs
+- benchmark summaries posted to GitHub Discussions or workflow summaries
+
+## Local Developer Workflow
+
+The local benchmark command should mirror CI as closely as possible.
+
+Recommended developer entrypoints:
+
+- `make benchmark-declarative`
+- `make benchmark-declarative-case CASE=medium-single`
+
+Expected env vars should match the E2E conventions where possible, for example:
+
+- `KONGCTL_E2E_KONNECT_PAT`
+- `KONGCTL_E2E_KONNECT_BASE_URL`
+
+This keeps the operational model familiar and avoids introducing another set of
+credentials and environment conventions.
+
+## Suggested Benchmark Dimensions
+
+Initial matrix:
+
+- size:
+  - `small`
+  - `medium`
+  - `large`
+  - `xl`
+- layout:
+  - `single-file`
+  - `multi-file`
+- phase:
+  - `apply_create`
+  - `apply_noop`
+
+Potential additional dimensions later:
+
+- repetitions per case
+- region/base URL
+- `plan` vs `apply` vs `sync`
+- resource family subsets
+
+## Baseline and Regression Tracking
+
+Recommended model:
+
+- keep raw artifacts for each run
+- emit a normalized structured result for the suite
+- compare the latest run against a checked-in approved baseline JSON
+
+Recommended regression policy:
+
+- request-count regressions are primary
+- wall-clock regressions are secondary
+- use tighter thresholds for request count changes
+- use looser thresholds for duration changes because SaaS timing is noisier
+
+Potential long-term history options:
+
+- checked-in baseline JSON snapshots
+- workflow summary markdown
+- pinned GitHub Discussion with historical result summaries
+- issue creation or issue comment updates on regression
+
+## Open Questions
+
+These are still unresolved and should be answered before implementation is
+locked in:
+
+1. Should v1 cover only core declarative resources, or also event gateways and
+   org or team resources?
+2. Are dedicated benchmark Konnect orgs available, separate from the normal E2E
+   org pool?
+3. Should the first version remain informational only, or should some portion
+   run as a PR-time quality gate?
+4. How should approved baselines be stored and reviewed over time?
+5. Is GitHub Discussion posting required in v1, or can it follow after the
+   runner and workflow exist?
+
+## Recommended Next Step
+
+Before implementation starts, convert this note into a more concrete execution
+plan with:
+
+- target file and package layout
+- benchmark fixture generation strategy
+- result schema
+- CI workflow shape
+- baseline comparison rules
+- phased delivery plan for v1 and later enhancements

--- a/test/benchmarks/declarative/main.go
+++ b/test/benchmarks/declarative/main.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -857,12 +858,8 @@ func compareBaseline(cfg config, current suiteResult) (*comparisonResult, error)
 		return nil, fmt.Errorf("read baseline: %w", err)
 	}
 
-	baselinePhases := map[string]phaseResult{}
-	for _, benchmarkCase := range baseline.Cases {
-		for _, phase := range benchmarkCase.Phases {
-			baselinePhases[benchmarkCase.Name+"\x00"+phase.Name] = phase
-		}
-	}
+	baselinePhases := aggregateSuitePhases(baseline)
+	currentPhases := aggregateSuitePhases(current)
 
 	comparison := &comparisonResult{
 		BaselinePath:      cfg.BaselinePath,
@@ -870,40 +867,117 @@ func compareBaseline(cfg config, current suiteResult) (*comparisonResult, error)
 		DurationThreshold: cfg.DurationThreshold,
 		Rows:              []comparisonRow{},
 	}
-	for _, benchmarkCase := range current.Cases {
-		for _, phase := range benchmarkCase.Phases {
-			key := benchmarkCase.Name + "\x00" + phase.Name
-			baselinePhase, ok := baselinePhases[key]
-			if !ok {
-				comparison.MissingBaselineData = append(comparison.MissingBaselineData, benchmarkCase.Name+"/"+phase.Name)
-				continue
-			}
-			row := comparisonRow{
-				CaseName:           benchmarkCase.Name,
-				PhaseName:          phase.Name,
-				BaselineRequests:   baselinePhase.HTTPMetrics.Requests,
-				CurrentRequests:    phase.HTTPMetrics.Requests,
-				RequestDelta:       phase.HTTPMetrics.Requests - baselinePhase.HTTPMetrics.Requests,
-				BaselineDurationMS: baselinePhase.DurationMS,
-				CurrentDurationMS:  phase.DurationMS,
-				DurationDeltaMS:    phase.DurationMS - baselinePhase.DurationMS,
-			}
-			row.RequestDeltaPercent = percentDelta(row.BaselineRequests, row.CurrentRequests)
-			row.DurationDeltaPercent = percentDelta64(row.BaselineDurationMS, row.CurrentDurationMS)
-			row.RequestRegression = row.RequestDelta > 0 && row.RequestDeltaPercent > cfg.RequestCountThreshold
-			row.DurationRegression = row.DurationDeltaMS > 0 && row.DurationDeltaPercent > cfg.DurationThreshold
-			if row.RequestRegression {
-				comparison.RequestRegressions++
-			}
-			if row.DurationRegression {
-				comparison.DurationRegressions++
-			}
-			comparison.ComparedPhases++
-			comparison.Rows = append(comparison.Rows, row)
+	keys := slices.Sorted(maps.Keys(currentPhases))
+	for _, key := range keys {
+		currentPhase := currentPhases[key]
+		baselinePhase, ok := baselinePhases[key]
+		if !ok {
+			comparison.MissingBaselineData = append(comparison.MissingBaselineData, comparisonKeyLabel(key))
+			continue
 		}
+		row := comparisonRow{
+			CaseName:           currentPhase.CaseName,
+			PhaseName:          currentPhase.PhaseName,
+			BaselineRequests:   baselinePhase.Phase.HTTPMetrics.Requests,
+			CurrentRequests:    currentPhase.Phase.HTTPMetrics.Requests,
+			RequestDelta:       currentPhase.Phase.HTTPMetrics.Requests - baselinePhase.Phase.HTTPMetrics.Requests,
+			BaselineDurationMS: baselinePhase.Phase.DurationMS,
+			CurrentDurationMS:  currentPhase.Phase.DurationMS,
+			DurationDeltaMS:    currentPhase.Phase.DurationMS - baselinePhase.Phase.DurationMS,
+		}
+		row.RequestDeltaPercent = percentDelta(row.BaselineRequests, row.CurrentRequests)
+		row.DurationDeltaPercent = percentDelta64(row.BaselineDurationMS, row.CurrentDurationMS)
+		row.RequestRegression = row.RequestDelta > 0 && row.RequestDeltaPercent > cfg.RequestCountThreshold
+		row.DurationRegression = row.DurationDeltaMS > 0 && row.DurationDeltaPercent > cfg.DurationThreshold
+		if row.RequestRegression {
+			comparison.RequestRegressions++
+		}
+		if row.DurationRegression {
+			comparison.DurationRegressions++
+		}
+		comparison.ComparedPhases++
+		comparison.Rows = append(comparison.Rows, row)
 	}
 
 	return comparison, nil
+}
+
+type phaseAggregate struct {
+	CaseName  string
+	PhaseName string
+	Phase     phaseResult
+}
+
+func aggregateSuitePhases(suite suiteResult) map[string]phaseAggregate {
+	phaseSamples := map[string][]phaseAggregate{}
+	for _, benchmarkCase := range suite.Cases {
+		for _, phase := range benchmarkCase.Phases {
+			key := phaseComparisonKey(benchmarkCase.Name, phase.Name)
+			phaseSamples[key] = append(phaseSamples[key], phaseAggregate{
+				CaseName:  benchmarkCase.Name,
+				PhaseName: phase.Name,
+				Phase:     phase,
+			})
+		}
+	}
+
+	aggregated := make(map[string]phaseAggregate, len(phaseSamples))
+	for key, phases := range phaseSamples {
+		aggregated[key] = aggregatePhaseResults(phases)
+	}
+	return aggregated
+}
+
+func aggregatePhaseResults(phases []phaseAggregate) phaseAggregate {
+	if len(phases) == 0 {
+		return phaseAggregate{}
+	}
+	requests := make([]int, 0, len(phases))
+	durations := make([]int64, 0, len(phases))
+	for _, phase := range phases {
+		requests = append(requests, phase.Phase.HTTPMetrics.Requests)
+		durations = append(durations, phase.Phase.DurationMS)
+	}
+
+	aggregated := phases[0]
+	aggregated.Phase.HTTPMetrics.Requests = medianInt(requests)
+	aggregated.Phase.DurationMS = medianInt64(durations)
+	return aggregated
+}
+
+func medianInt(values []int) int {
+	if len(values) == 0 {
+		return 0
+	}
+	values = slices.Clone(values)
+	slices.Sort(values)
+	midpoint := len(values) / 2
+	if len(values)%2 == 1 {
+		return values[midpoint]
+	}
+	return (values[midpoint-1] + values[midpoint]) / 2
+}
+
+func medianInt64(values []int64) int64 {
+	if len(values) == 0 {
+		return 0
+	}
+	values = slices.Clone(values)
+	slices.Sort(values)
+	midpoint := len(values) / 2
+	if len(values)%2 == 1 {
+		return values[midpoint]
+	}
+	return (values[midpoint-1] + values[midpoint]) / 2
+}
+
+func phaseComparisonKey(caseName, phaseName string) string {
+	return caseName + "\x00" + phaseName
+}
+
+func comparisonKeyLabel(key string) string {
+	caseName, phaseName, _ := strings.Cut(key, "\x00")
+	return caseName + "/" + phaseName
 }
 
 func percentDelta(baseline, current int) float64 {

--- a/test/benchmarks/declarative/main.go
+++ b/test/benchmarks/declarative/main.go
@@ -1,0 +1,1204 @@
+//go:build e2e
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/kong/kongctl/test/e2e/harness"
+)
+
+const (
+	schemaVersion  = "kongctl.declarative-benchmark.v1"
+	defaultBaseURL = "https://us.api.konghq.com"
+)
+
+type config struct {
+	CaseFilter            string
+	BaselinePath          string
+	FailOnRegression      bool
+	RequestCountThreshold float64
+	DurationThreshold     float64
+	CommandTimeout        time.Duration
+}
+
+type workloadSpec struct {
+	Size            string `json:"size"`
+	APICount        int    `json:"api_count"`
+	DocumentsPerAPI int    `json:"documents_per_api"`
+	DocumentBytes   int    `json:"document_bytes"`
+}
+
+type benchmarkCase struct {
+	Name     string       `json:"name"`
+	Layout   string       `json:"layout"`
+	Workload workloadSpec `json:"workload"`
+}
+
+type suiteResult struct {
+	SchemaVersion string            `json:"schema_version"`
+	RunID         string            `json:"run_id"`
+	GitCommit     string            `json:"git_commit,omitempty"`
+	BaseURL       string            `json:"base_url"`
+	StartedAt     time.Time         `json:"started_at"`
+	FinishedAt    time.Time         `json:"finished_at"`
+	DurationMS    int64             `json:"duration_ms"`
+	Cases         []caseResult      `json:"cases"`
+	Summary       suiteSummary      `json:"summary"`
+	Comparison    *comparisonResult `json:"comparison,omitempty"`
+}
+
+type suiteSummary struct {
+	CaseCount           int   `json:"case_count"`
+	PhaseCount          int   `json:"phase_count"`
+	FailedPhases        int   `json:"failed_phases"`
+	TotalAPIs           int   `json:"total_apis"`
+	TotalDocuments      int   `json:"total_api_documents"`
+	TotalRequests       int   `json:"total_http_requests"`
+	TotalResponses      int   `json:"total_http_responses"`
+	TotalHTTPErrors     int   `json:"total_http_errors"`
+	TotalDurationMS     int64 `json:"total_duration_ms"`
+	ComparedPhases      int   `json:"compared_phases,omitempty"`
+	RequestRegressions  int   `json:"request_regressions,omitempty"`
+	DurationRegressions int   `json:"duration_regressions,omitempty"`
+}
+
+type caseResult struct {
+	Name      string         `json:"name"`
+	Size      string         `json:"size"`
+	Layout    string         `json:"layout"`
+	Fixture   fixtureResult  `json:"fixture"`
+	Resources resourceCounts `json:"resources"`
+	Phases    []phaseResult  `json:"phases"`
+}
+
+type resourceCounts struct {
+	APIs          int `json:"apis"`
+	APIDocuments  int `json:"api_documents"`
+	DocumentBytes int `json:"api_document_bytes"`
+}
+
+type fixtureResult struct {
+	RootDir string   `json:"root_dir"`
+	Files   []string `json:"files"`
+	Args    []string `json:"args"`
+}
+
+type phaseResult struct {
+	Name        string      `json:"name"`
+	CommandDir  string      `json:"command_dir,omitempty"`
+	ExitCode    int         `json:"exit_code"`
+	TimedOut    bool        `json:"timed_out"`
+	DurationMS  int64       `json:"duration_ms"`
+	Error       string      `json:"error,omitempty"`
+	HTTPMetrics httpMetrics `json:"http_metrics"`
+}
+
+type httpMetrics struct {
+	Requests             int              `json:"requests"`
+	Responses            int              `json:"responses"`
+	Errors               int              `json:"errors"`
+	RequestCountsByRoute []methodRouteRow `json:"request_counts_by_route"`
+	ResponseStatusCounts []statusRow      `json:"response_status_counts"`
+	Timing               httpTiming       `json:"timing"`
+}
+
+type methodRouteRow struct {
+	Method string `json:"method"`
+	Route  string `json:"route"`
+	Count  int    `json:"count"`
+}
+
+type statusRow struct {
+	Status string `json:"status"`
+	Count  int    `json:"count"`
+}
+
+type httpTiming struct {
+	Responses durationStats `json:"responses"`
+	Errors    durationStats `json:"errors"`
+	Combined  durationStats `json:"combined"`
+}
+
+type durationStats struct {
+	Count int     `json:"count"`
+	SumMS float64 `json:"sum_ms"`
+	MinMS float64 `json:"min_ms"`
+	MaxMS float64 `json:"max_ms"`
+	AvgMS float64 `json:"avg_ms"`
+}
+
+type comparisonResult struct {
+	BaselinePath        string          `json:"baseline_path"`
+	RequestThreshold    float64         `json:"request_threshold"`
+	DurationThreshold   float64         `json:"duration_threshold"`
+	ComparedPhases      int             `json:"compared_phases"`
+	MissingBaselineData []string        `json:"missing_baseline_data,omitempty"`
+	Rows                []comparisonRow `json:"rows"`
+	RequestRegressions  int             `json:"request_regressions"`
+	DurationRegressions int             `json:"duration_regressions"`
+}
+
+type comparisonRow struct {
+	CaseName             string  `json:"case_name"`
+	PhaseName            string  `json:"phase_name"`
+	BaselineRequests     int     `json:"baseline_requests"`
+	CurrentRequests      int     `json:"current_requests"`
+	RequestDelta         int     `json:"request_delta"`
+	RequestDeltaPercent  float64 `json:"request_delta_percent"`
+	RequestRegression    bool    `json:"request_regression"`
+	BaselineDurationMS   int64   `json:"baseline_duration_ms"`
+	CurrentDurationMS    int64   `json:"current_duration_ms"`
+	DurationDeltaMS      int64   `json:"duration_delta_ms"`
+	DurationDeltaPercent float64 `json:"duration_delta_percent"`
+	DurationRegression   bool    `json:"duration_regression"`
+}
+
+var workloads = []workloadSpec{
+	{Size: "small", APICount: 1, DocumentsPerAPI: 2, DocumentBytes: 1024},
+	{Size: "medium", APICount: 5, DocumentsPerAPI: 5, DocumentBytes: 2048},
+	{Size: "large", APICount: 20, DocumentsPerAPI: 8, DocumentBytes: 4096},
+	{Size: "xl", APICount: 50, DocumentsPerAPI: 10, DocumentBytes: 8192},
+}
+
+var layouts = []string{"single-file", "multi-file"}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "benchmark failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	cfg := parseConfig()
+	runDir, err := normalizeEnvironment()
+	if err != nil {
+		return err
+	}
+
+	cases, err := selectCases(cfg.CaseFilter)
+	if err != nil {
+		return err
+	}
+
+	started := time.Now().UTC()
+	suite := suiteResult{
+		SchemaVersion: schemaVersion,
+		RunID:         benchmarkRunID(started),
+		GitCommit:     gitCommit(),
+		BaseURL:       os.Getenv("KONGCTL_E2E_KONNECT_BASE_URL"),
+		StartedAt:     started,
+		Cases:         []caseResult{},
+	}
+
+	runErr := executeSuite(context.Background(), cfg, cases, &suite)
+	suite.FinishedAt = time.Now().UTC()
+	suite.DurationMS = suite.FinishedAt.Sub(suite.StartedAt).Milliseconds()
+	suite.Summary = summarizeSuite(suite.Cases)
+
+	if strings.TrimSpace(cfg.BaselinePath) != "" {
+		comparison, err := compareBaseline(cfg, suite)
+		if err != nil {
+			runErr = errors.Join(runErr, err)
+		} else {
+			suite.Comparison = comparison
+			suite.Summary.ComparedPhases = comparison.ComparedPhases
+			suite.Summary.RequestRegressions = comparison.RequestRegressions
+			suite.Summary.DurationRegressions = comparison.DurationRegressions
+			if cfg.FailOnRegression && comparison.RequestRegressions > 0 {
+				runErr = errors.Join(runErr, fmt.Errorf("%d request-count regressions detected", comparison.RequestRegressions))
+			}
+		}
+	}
+
+	if err := writeSuiteOutputs(runDir, suite); err != nil {
+		runErr = errors.Join(runErr, err)
+	}
+
+	fmt.Printf("Declarative benchmark artifacts: %s\n", runDir)
+	fmt.Printf("Declarative benchmark results: %s\n", filepath.Join(runDir, "results.json"))
+	fmt.Printf("Declarative benchmark summary: %s\n", filepath.Join(runDir, "summary.md"))
+	fmt.Printf("Declarative benchmark terminal summary: %s\n", filepath.Join(runDir, "summary.txt"))
+
+	return runErr
+}
+
+func parseConfig() config {
+	defaultCase := envOrDefault("KONGCTL_BENCHMARK_CASE", "all")
+	defaultTimeout := durationEnv("KONGCTL_BENCHMARK_COMMAND_TIMEOUT", 30*time.Minute)
+
+	cfg := config{}
+	flag.StringVar(&cfg.CaseFilter, "case", defaultCase, "benchmark case selector: all, a size, or a case name")
+	flag.StringVar(
+		&cfg.BaselinePath,
+		"baseline",
+		os.Getenv("KONGCTL_BENCHMARK_BASELINE"),
+		"optional baseline results.json",
+	)
+	flag.BoolVar(
+		&cfg.FailOnRegression,
+		"fail-on-regression",
+		boolEnv("KONGCTL_BENCHMARK_FAIL_ON_REGRESSION", false),
+		"exit non-zero when request-count regressions exceed thresholds",
+	)
+	flag.Float64Var(
+		&cfg.RequestCountThreshold,
+		"request-count-threshold",
+		floatEnv("KONGCTL_BENCHMARK_REQUEST_COUNT_THRESHOLD", 0.05),
+		"allowed request-count increase ratio when comparing to a baseline",
+	)
+	flag.Float64Var(
+		&cfg.DurationThreshold,
+		"duration-threshold",
+		floatEnv("KONGCTL_BENCHMARK_DURATION_THRESHOLD", 0.50),
+		"tracked wall-clock duration increase ratio when comparing to a baseline",
+	)
+	flag.DurationVar(&cfg.CommandTimeout, "command-timeout", defaultTimeout, "timeout for each measured kongctl command")
+	flag.Parse()
+	return cfg
+}
+
+func normalizeEnvironment() (string, error) {
+	setEnvFromBenchmarkOverride("KONGCTL_E2E_KONNECT_PAT", "KONGCTL_BENCHMARK_KONNECT_PAT")
+	setEnvFromBenchmarkOverride("KONGCTL_E2E_KONNECT_BASE_URL", "KONGCTL_BENCHMARK_KONNECT_BASE_URL")
+	setEnvFromBenchmark("KONGCTL_E2E_ARTIFACTS_DIR", "KONGCTL_BENCHMARK_ARTIFACTS_DIR")
+	setEnvFromBenchmark("KONGCTL_E2E_LOG_LEVEL", "KONGCTL_BENCHMARK_LOG_LEVEL")
+	setEnvFromBenchmark("KONGCTL_E2E_CONSOLE_LOG_LEVEL", "KONGCTL_BENCHMARK_CONSOLE_LOG_LEVEL")
+
+	setDefaultEnv("KONGCTL_E2E_KONNECT_BASE_URL", defaultBaseURL)
+	setDefaultEnv("KONGCTL_E2E_LOG_LEVEL", "debug")
+	setDefaultEnv("KONGCTL_E2E_CONSOLE_LOG_LEVEL", "warn")
+	setDefaultEnv("KONGCTL_E2E_RESET", "1")
+
+	if strings.TrimSpace(os.Getenv("KONGCTL_E2E_ARTIFACTS_DIR")) == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		runDir := filepath.Join(cwd, ".benchmark-artifacts", time.Now().UTC().Format("20060102-150405"))
+		if err := os.Setenv("KONGCTL_E2E_ARTIFACTS_DIR", runDir); err != nil {
+			return "", err
+		}
+	}
+
+	runDir := os.Getenv("KONGCTL_E2E_ARTIFACTS_DIR")
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		return "", err
+	}
+	runDir, err := filepath.Abs(runDir)
+	if err != nil {
+		return "", err
+	}
+	if err := os.Setenv("KONGCTL_E2E_ARTIFACTS_DIR", runDir); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(os.Getenv("KONGCTL_E2E_KONNECT_PAT")) == "" {
+		return "", fmt.Errorf("KONGCTL_BENCHMARK_KONNECT_PAT or KONGCTL_E2E_KONNECT_PAT is required")
+	}
+	return runDir, nil
+}
+
+func executeSuite(ctx context.Context, cfg config, cases []benchmarkCase, suite *suiteResult) error {
+	for _, benchmarkCase := range cases {
+		caseResult, err := executeCase(ctx, cfg, benchmarkCase)
+		suite.Cases = append(suite.Cases, caseResult)
+		if err != nil {
+			return fmt.Errorf("case %s failed: %w", benchmarkCase.Name, err)
+		}
+	}
+	return nil
+}
+
+func executeCase(ctx context.Context, cfg config, benchmarkCase benchmarkCase) (caseResult, error) {
+	cli, err := harness.NewCLIForArtifacts("declarative-"+benchmarkCase.Name, "benchmarks")
+	if err != nil {
+		return caseResult{}, err
+	}
+	cli.SetLogLevel(benchmarkCommandLogLevel())
+	cli.Timeout = cfg.CommandTimeout
+
+	fixture, counts, err := generateFixture(cli.TestDir, benchmarkCase)
+	result := caseResult{
+		Name:      benchmarkCase.Name,
+		Size:      benchmarkCase.Workload.Size,
+		Layout:    benchmarkCase.Layout,
+		Fixture:   fixture,
+		Resources: counts,
+		Phases:    []phaseResult{},
+	}
+	if err != nil {
+		return result, err
+	}
+
+	if err := harness.ResetOrgWithCapture("before-" + benchmarkCase.Name); err != nil {
+		return result, err
+	}
+
+	create, err := executePhase(ctx, cli, fixture.Args, "apply_create")
+	result.Phases = append(result.Phases, create)
+	if err != nil {
+		return result, err
+	}
+
+	noop, err := executePhase(ctx, cli, fixture.Args, "apply_noop")
+	result.Phases = append(result.Phases, noop)
+	if err != nil {
+		return result, err
+	}
+
+	return result, nil
+}
+
+func executePhase(ctx context.Context, cli *harness.CLI, fixtureArgs []string, phase string) (phaseResult, error) {
+	args := append([]string{"apply"}, fixtureArgs...)
+	args = append(args, "--auto-approve")
+	cli.OverrideNextCommandSlug(phase)
+	res, err := cli.Run(ctx, args...)
+
+	phaseResult := phaseResult{
+		Name:       phase,
+		CommandDir: cli.LastCommandDir,
+		ExitCode:   res.ExitCode,
+		TimedOut:   res.TimedOut,
+		DurationMS: res.Duration.Milliseconds(),
+	}
+	if err != nil {
+		phaseResult.Error = err.Error()
+	}
+	if cli.LastCommandDir != "" {
+		logPath := filepath.Join(cli.LastCommandDir, "kongctl.log")
+		metrics, metricsErr := parseHTTPLog(logPath)
+		if metricsErr == nil {
+			phaseResult.HTTPMetrics = metrics
+			_ = writeJSON(filepath.Join(cli.LastCommandDir, "http-metrics.json"), metrics)
+		} else if !errors.Is(metricsErr, os.ErrNotExist) {
+			phaseResult.Error = appendErrorMessage(phaseResult.Error, metricsErr.Error())
+		}
+	}
+	return phaseResult, err
+}
+
+func selectCases(filter string) ([]benchmarkCase, error) {
+	allCases := allBenchmarkCases()
+	clean := strings.ToLower(strings.TrimSpace(filter))
+	if clean == "" || clean == "all" {
+		return allCases, nil
+	}
+
+	selected := []benchmarkCase{}
+	seen := map[string]bool{}
+	for _, token := range strings.Split(clean, ",") {
+		token = normalizeCaseToken(token)
+		if token == "" {
+			continue
+		}
+		matched := false
+		for _, candidate := range allCases {
+			if caseTokenMatches(token, candidate) {
+				if !seen[candidate.Name] {
+					selected = append(selected, candidate)
+					seen[candidate.Name] = true
+				}
+				matched = true
+			}
+		}
+		if !matched {
+			return nil, fmt.Errorf("unknown benchmark case selector %q", token)
+		}
+	}
+	if len(selected) == 0 {
+		return nil, fmt.Errorf("no benchmark cases selected")
+	}
+	return selected, nil
+}
+
+func allBenchmarkCases() []benchmarkCase {
+	cases := []benchmarkCase{}
+	for _, workload := range workloads {
+		for _, layout := range layouts {
+			cases = append(cases, benchmarkCase{
+				Name:     workload.Size + "-" + layout,
+				Layout:   layout,
+				Workload: workload,
+			})
+		}
+	}
+	return cases
+}
+
+func caseTokenMatches(token string, candidate benchmarkCase) bool {
+	if token == candidate.Name ||
+		token == candidate.Workload.Size ||
+		token == candidate.Layout ||
+		token == strings.TrimSuffix(candidate.Name, "-file") {
+		return true
+	}
+	return false
+}
+
+func normalizeCaseToken(token string) string {
+	token = strings.ToLower(strings.TrimSpace(token))
+	token = strings.ReplaceAll(token, "_", "-")
+	token = strings.ReplaceAll(token, " ", "-")
+	return token
+}
+
+func generateFixture(testDir string, benchmarkCase benchmarkCase) (fixtureResult, resourceCounts, error) {
+	inputDir := filepath.Join(testDir, "inputs", benchmarkCase.Name)
+	if err := os.MkdirAll(inputDir, 0o755); err != nil {
+		return fixtureResult{}, resourceCounts{}, err
+	}
+
+	switch benchmarkCase.Layout {
+	case "single-file":
+		return generateSingleFileFixture(inputDir, benchmarkCase)
+	case "multi-file":
+		return generateMultiFileFixture(inputDir, benchmarkCase)
+	default:
+		return fixtureResult{}, resourceCounts{}, fmt.Errorf("unsupported fixture layout %q", benchmarkCase.Layout)
+	}
+}
+
+func generateSingleFileFixture(inputDir string, benchmarkCase benchmarkCase) (fixtureResult, resourceCounts, error) {
+	path := filepath.Join(inputDir, "config.yaml")
+	counts := benchmarkCaseCounts(benchmarkCase)
+	var yaml strings.Builder
+	writeAPIs(&yaml, benchmarkCase, true)
+	if err := os.WriteFile(path, []byte(yaml.String()), 0o644); err != nil {
+		return fixtureResult{}, resourceCounts{}, err
+	}
+	return fixtureResult{
+		RootDir: inputDir,
+		Files:   []string{path},
+		Args:    []string{"-f", path},
+	}, counts, nil
+}
+
+func generateMultiFileFixture(inputDir string, benchmarkCase benchmarkCase) (fixtureResult, resourceCounts, error) {
+	files := []string{}
+	counts := benchmarkCaseCounts(benchmarkCase)
+
+	apisPath := filepath.Join(inputDir, "apis.yaml")
+	var apis strings.Builder
+	writeAPIs(&apis, benchmarkCase, false)
+	if err := os.WriteFile(apisPath, []byte(apis.String()), 0o644); err != nil {
+		return fixtureResult{}, resourceCounts{}, err
+	}
+	files = append(files, apisPath)
+
+	for apiIndex := range benchmarkCase.Workload.APICount {
+		path := filepath.Join(inputDir, fmt.Sprintf("api-%03d-documents.yaml", apiIndex+1))
+		var docs strings.Builder
+		writeAPIDocuments(&docs, benchmarkCase, apiIndex)
+		if err := os.WriteFile(path, []byte(docs.String()), 0o644); err != nil {
+			return fixtureResult{}, resourceCounts{}, err
+		}
+		files = append(files, path)
+	}
+
+	args := []string{}
+	for _, path := range files {
+		args = append(args, "-f", path)
+	}
+	return fixtureResult{RootDir: inputDir, Files: files, Args: args}, counts, nil
+}
+
+func benchmarkCaseCounts(benchmarkCase benchmarkCase) resourceCounts {
+	return resourceCounts{
+		APIs:         benchmarkCase.Workload.APICount,
+		APIDocuments: benchmarkCase.Workload.APICount * benchmarkCase.Workload.DocumentsPerAPI,
+		DocumentBytes: benchmarkCase.Workload.APICount *
+			benchmarkCase.Workload.DocumentsPerAPI *
+			benchmarkCase.Workload.DocumentBytes,
+	}
+}
+
+func writeAPIs(yaml *strings.Builder, benchmarkCase benchmarkCase, includeDocuments bool) {
+	yaml.WriteString("apis:\n")
+	for apiIndex := range benchmarkCase.Workload.APICount {
+		apiRef := apiRef(benchmarkCase, apiIndex)
+		fmt.Fprintf(yaml, "  - ref: %s\n", apiRef)
+		fmt.Fprintf(yaml, "    name: %q\n", apiName(benchmarkCase, apiIndex))
+		fmt.Fprintf(yaml, "    description: %q\n", "Declarative benchmark API resource")
+		fmt.Fprintf(yaml, "    version: %q\n", "1.0.0")
+		fmt.Fprintf(yaml, "    slug: %q\n", apiRef)
+		yaml.WriteString("    labels:\n")
+		yaml.WriteString("      benchmark: gh-730\n")
+		fmt.Fprintf(yaml, "      benchmark_size: %s\n", benchmarkCase.Workload.Size)
+		fmt.Fprintf(yaml, "      benchmark_layout: %s\n", benchmarkCase.Layout)
+		yaml.WriteString("    kongctl:\n")
+		yaml.WriteString("      namespace: gh-730-benchmark\n")
+		if includeDocuments {
+			yaml.WriteString("    documents:\n")
+			for docIndex := range benchmarkCase.Workload.DocumentsPerAPI {
+				writeNestedDocument(yaml, benchmarkCase, apiIndex, docIndex)
+			}
+		}
+	}
+}
+
+func writeAPIDocuments(yaml *strings.Builder, benchmarkCase benchmarkCase, apiIndex int) {
+	yaml.WriteString("api_documents:\n")
+	for docIndex := range benchmarkCase.Workload.DocumentsPerAPI {
+		writeRootDocument(yaml, benchmarkCase, apiIndex, docIndex)
+	}
+}
+
+func writeNestedDocument(yaml *strings.Builder, benchmarkCase benchmarkCase, apiIndex, docIndex int) {
+	docRef := documentRef(benchmarkCase, apiIndex, docIndex)
+	fmt.Fprintf(yaml, "      - ref: %s\n", docRef)
+	fmt.Fprintf(yaml, "        title: %q\n", documentTitle(benchmarkCase, apiIndex, docIndex))
+	fmt.Fprintf(yaml, "        slug: %q\n", docRef)
+	yaml.WriteString("        status: published\n")
+	writeLiteral(yaml, "        ", "content", documentContent(benchmarkCase, apiIndex, docIndex))
+}
+
+func writeRootDocument(yaml *strings.Builder, benchmarkCase benchmarkCase, apiIndex, docIndex int) {
+	docRef := documentRef(benchmarkCase, apiIndex, docIndex)
+	fmt.Fprintf(yaml, "  - ref: %s\n", docRef)
+	fmt.Fprintf(yaml, "    api: %s\n", apiRef(benchmarkCase, apiIndex))
+	fmt.Fprintf(yaml, "    title: %q\n", documentTitle(benchmarkCase, apiIndex, docIndex))
+	fmt.Fprintf(yaml, "    slug: %q\n", docRef)
+	yaml.WriteString("    status: published\n")
+	writeLiteral(yaml, "    ", "content", documentContent(benchmarkCase, apiIndex, docIndex))
+}
+
+func writeLiteral(yaml *strings.Builder, indent, key, value string) {
+	fmt.Fprintf(yaml, "%s%s: |\n", indent, key)
+	for _, line := range strings.Split(strings.TrimRight(value, "\n"), "\n") {
+		fmt.Fprintf(yaml, "%s  %s\n", indent, line)
+	}
+}
+
+func apiRef(benchmarkCase benchmarkCase, apiIndex int) string {
+	return fmt.Sprintf("gh-730-%s-api-%03d", benchmarkCase.Workload.Size, apiIndex+1)
+}
+
+func apiName(benchmarkCase benchmarkCase, apiIndex int) string {
+	return apiRef(benchmarkCase, apiIndex)
+}
+
+func documentRef(benchmarkCase benchmarkCase, apiIndex, docIndex int) string {
+	return fmt.Sprintf("gh-730-%s-api-%03d-doc-%03d", benchmarkCase.Workload.Size, apiIndex+1, docIndex+1)
+}
+
+func documentTitle(benchmarkCase benchmarkCase, apiIndex, docIndex int) string {
+	return documentRef(benchmarkCase, apiIndex, docIndex)
+}
+
+func documentContent(benchmarkCase benchmarkCase, apiIndex, docIndex int) string {
+	header := fmt.Sprintf(
+		"# %s\n\nAPI index: %03d\nDocument index: %03d\nBenchmark layout: %s\n\n",
+		documentTitle(benchmarkCase, apiIndex, docIndex),
+		apiIndex+1,
+		docIndex+1,
+		benchmarkCase.Layout,
+	)
+	paragraph := "This deterministic API document body is generated for declarative performance benchmarking. " +
+		"It intentionally repeats realistic Markdown prose so api_documents exercise larger request payloads.\n\n"
+
+	var b strings.Builder
+	b.WriteString(header)
+	for b.Len() < benchmarkCase.Workload.DocumentBytes {
+		b.WriteString(paragraph)
+	}
+	return b.String()
+}
+
+var logFieldRe = regexp.MustCompile(`([A-Za-z0-9_]+)=("[^"]*"|[^ ]+)`)
+
+func parseHTTPLog(path string) (httpMetrics, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return httpMetrics{}, err
+	}
+	defer file.Close()
+
+	routeCounts := map[string]int{}
+	statusCounts := map[string]int{}
+	metrics := httpMetrics{}
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		fields := parseLogFields(scanner.Text())
+		switch fields["log_type"] {
+		case "http_request":
+			metrics.Requests++
+			method := strings.ToUpper(fields["method"])
+			route := fields["route"]
+			if method != "" && route != "" {
+				routeCounts[method+"\x00"+route]++
+			}
+		case "http_response":
+			metrics.Responses++
+			if status := fields["status_code"]; status != "" {
+				statusCounts[status]++
+			}
+			addDuration(&metrics.Timing.Responses, fields["duration"])
+		case "http_error":
+			metrics.Errors++
+			addDuration(&metrics.Timing.Errors, fields["duration"])
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return httpMetrics{}, err
+	}
+	finalizeDurationStats(&metrics.Timing.Responses)
+	finalizeDurationStats(&metrics.Timing.Errors)
+	metrics.Timing.Combined = combineDurationStats(metrics.Timing.Responses, metrics.Timing.Errors)
+	metrics.RequestCountsByRoute = sortedMethodRouteRows(routeCounts)
+	metrics.ResponseStatusCounts = sortedStatusRows(statusCounts)
+	return metrics, nil
+}
+
+func parseLogFields(line string) map[string]string {
+	fields := map[string]string{}
+	matches := logFieldRe.FindAllStringSubmatch(line, -1)
+	for _, match := range matches {
+		value := match[2]
+		if strings.HasPrefix(value, `"`) {
+			if unquoted, err := strconv.Unquote(value); err == nil {
+				value = unquoted
+			} else {
+				value = strings.Trim(value, `"`)
+			}
+		}
+		fields[match[1]] = value
+	}
+	return fields
+}
+
+func addDuration(stats *durationStats, raw string) {
+	ms, ok := parseDurationMS(raw)
+	if !ok {
+		return
+	}
+	stats.Count++
+	stats.SumMS += ms
+	if stats.Count == 1 || ms < stats.MinMS {
+		stats.MinMS = ms
+	}
+	if stats.Count == 1 || ms > stats.MaxMS {
+		stats.MaxMS = ms
+	}
+}
+
+func finalizeDurationStats(stats *durationStats) {
+	if stats.Count > 0 {
+		stats.AvgMS = stats.SumMS / float64(stats.Count)
+	}
+}
+
+func combineDurationStats(left, right durationStats) durationStats {
+	combined := durationStats{
+		Count: left.Count + right.Count,
+		SumMS: left.SumMS + right.SumMS,
+	}
+	switch {
+	case left.Count > 0 && right.Count > 0:
+		combined.MinMS = min(left.MinMS, right.MinMS)
+		combined.MaxMS = max(left.MaxMS, right.MaxMS)
+	case left.Count > 0:
+		combined.MinMS = left.MinMS
+		combined.MaxMS = left.MaxMS
+	case right.Count > 0:
+		combined.MinMS = right.MinMS
+		combined.MaxMS = right.MaxMS
+	}
+	finalizeDurationStats(&combined)
+	return combined
+}
+
+func parseDurationMS(raw string) (float64, bool) {
+	raw = strings.TrimSpace(raw)
+	raw = strings.ReplaceAll(raw, "µs", "us")
+	raw = strings.ReplaceAll(raw, "μs", "us")
+	if raw == "" {
+		return 0, false
+	}
+
+	units := []struct {
+		Suffix     string
+		Multiplier float64
+	}{
+		{Suffix: "ns", Multiplier: 1.0 / 1_000_000},
+		{Suffix: "us", Multiplier: 1.0 / 1_000},
+		{Suffix: "ms", Multiplier: 1},
+		{Suffix: "s", Multiplier: 1000},
+		{Suffix: "m", Multiplier: 60_000},
+		{Suffix: "h", Multiplier: 3_600_000},
+	}
+	for _, unit := range units {
+		if strings.HasSuffix(raw, unit.Suffix) {
+			value, err := strconv.ParseFloat(strings.TrimSuffix(raw, unit.Suffix), 64)
+			if err != nil {
+				return 0, false
+			}
+			return value * unit.Multiplier, true
+		}
+	}
+	return 0, false
+}
+
+func sortedMethodRouteRows(counts map[string]int) []methodRouteRow {
+	rows := make([]methodRouteRow, 0, len(counts))
+	for key, count := range counts {
+		method, route, _ := strings.Cut(key, "\x00")
+		rows = append(rows, methodRouteRow{Method: method, Route: route, Count: count})
+	}
+	slices.SortFunc(rows, func(left, right methodRouteRow) int {
+		if left.Count != right.Count {
+			return right.Count - left.Count
+		}
+		if left.Method != right.Method {
+			return strings.Compare(left.Method, right.Method)
+		}
+		return strings.Compare(left.Route, right.Route)
+	})
+	return rows
+}
+
+func sortedStatusRows(counts map[string]int) []statusRow {
+	rows := make([]statusRow, 0, len(counts))
+	for status, count := range counts {
+		rows = append(rows, statusRow{Status: status, Count: count})
+	}
+	slices.SortFunc(rows, func(left, right statusRow) int {
+		if left.Count != right.Count {
+			return right.Count - left.Count
+		}
+		return strings.Compare(left.Status, right.Status)
+	})
+	return rows
+}
+
+func summarizeSuite(cases []caseResult) suiteSummary {
+	summary := suiteSummary{CaseCount: len(cases)}
+	for _, benchmarkCase := range cases {
+		summary.TotalAPIs += benchmarkCase.Resources.APIs
+		summary.TotalDocuments += benchmarkCase.Resources.APIDocuments
+		for _, phase := range benchmarkCase.Phases {
+			summary.PhaseCount++
+			if phase.ExitCode != 0 || phase.Error != "" {
+				summary.FailedPhases++
+			}
+			summary.TotalRequests += phase.HTTPMetrics.Requests
+			summary.TotalResponses += phase.HTTPMetrics.Responses
+			summary.TotalHTTPErrors += phase.HTTPMetrics.Errors
+			summary.TotalDurationMS += phase.DurationMS
+		}
+	}
+	return summary
+}
+
+func compareBaseline(cfg config, current suiteResult) (*comparisonResult, error) {
+	var baseline suiteResult
+	if err := readJSON(cfg.BaselinePath, &baseline); err != nil {
+		return nil, fmt.Errorf("read baseline: %w", err)
+	}
+
+	baselinePhases := map[string]phaseResult{}
+	for _, benchmarkCase := range baseline.Cases {
+		for _, phase := range benchmarkCase.Phases {
+			baselinePhases[benchmarkCase.Name+"\x00"+phase.Name] = phase
+		}
+	}
+
+	comparison := &comparisonResult{
+		BaselinePath:      cfg.BaselinePath,
+		RequestThreshold:  cfg.RequestCountThreshold,
+		DurationThreshold: cfg.DurationThreshold,
+		Rows:              []comparisonRow{},
+	}
+	for _, benchmarkCase := range current.Cases {
+		for _, phase := range benchmarkCase.Phases {
+			key := benchmarkCase.Name + "\x00" + phase.Name
+			baselinePhase, ok := baselinePhases[key]
+			if !ok {
+				comparison.MissingBaselineData = append(comparison.MissingBaselineData, benchmarkCase.Name+"/"+phase.Name)
+				continue
+			}
+			row := comparisonRow{
+				CaseName:           benchmarkCase.Name,
+				PhaseName:          phase.Name,
+				BaselineRequests:   baselinePhase.HTTPMetrics.Requests,
+				CurrentRequests:    phase.HTTPMetrics.Requests,
+				RequestDelta:       phase.HTTPMetrics.Requests - baselinePhase.HTTPMetrics.Requests,
+				BaselineDurationMS: baselinePhase.DurationMS,
+				CurrentDurationMS:  phase.DurationMS,
+				DurationDeltaMS:    phase.DurationMS - baselinePhase.DurationMS,
+			}
+			row.RequestDeltaPercent = percentDelta(row.BaselineRequests, row.CurrentRequests)
+			row.DurationDeltaPercent = percentDelta64(row.BaselineDurationMS, row.CurrentDurationMS)
+			row.RequestRegression = row.RequestDelta > 0 && row.RequestDeltaPercent > cfg.RequestCountThreshold
+			row.DurationRegression = row.DurationDeltaMS > 0 && row.DurationDeltaPercent > cfg.DurationThreshold
+			if row.RequestRegression {
+				comparison.RequestRegressions++
+			}
+			if row.DurationRegression {
+				comparison.DurationRegressions++
+			}
+			comparison.ComparedPhases++
+			comparison.Rows = append(comparison.Rows, row)
+		}
+	}
+
+	return comparison, nil
+}
+
+func percentDelta(baseline, current int) float64 {
+	if baseline == 0 {
+		if current == 0 {
+			return 0
+		}
+		return 1
+	}
+	return float64(current-baseline) / float64(baseline)
+}
+
+func percentDelta64(baseline, current int64) float64 {
+	if baseline == 0 {
+		if current == 0 {
+			return 0
+		}
+		return 1
+	}
+	return float64(current-baseline) / float64(baseline)
+}
+
+func writeSuiteOutputs(runDir string, suite suiteResult) error {
+	if err := writeJSON(filepath.Join(runDir, "results.json"), suite); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "summary.md"), []byte(renderSummary(suite)), 0o644); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "summary.txt"), []byte(renderTerminalSummary(suite)), 0o644); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(runDir, ".benchmark_artifacts_dir"), []byte(runDir+"\n"), 0o644)
+}
+
+func renderSummary(suite suiteResult) string {
+	var b strings.Builder
+	b.WriteString("# Declarative Benchmark Results\n\n")
+	fmt.Fprintf(&b, "- Run ID: `%s`\n", suite.RunID)
+	if suite.GitCommit != "" {
+		fmt.Fprintf(&b, "- Git commit: `%s`\n", suite.GitCommit)
+	}
+	fmt.Fprintf(&b, "- Base URL: `%s`\n", suite.BaseURL)
+	fmt.Fprintf(&b, "- Duration: `%s`\n", suite.FinishedAt.Sub(suite.StartedAt).Round(time.Millisecond))
+	fmt.Fprintf(&b, "- Cases: `%d`\n", suite.Summary.CaseCount)
+	fmt.Fprintf(&b, "- Phases: `%d`\n", suite.Summary.PhaseCount)
+	fmt.Fprintf(&b, "- HTTP requests: `%d`\n", suite.Summary.TotalRequests)
+	fmt.Fprintf(&b, "- HTTP errors: `%d`\n\n", suite.Summary.TotalHTTPErrors)
+	b.WriteString(
+		"Suite duration includes fixture generation and destructive org reset. " +
+			"Phase rows measure only `kongctl apply` commands.\n\n",
+	)
+
+	b.WriteString("| Case | Phase | APIs | API documents | Duration | Requests | Responses | Errors |\n")
+	b.WriteString("| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |\n")
+	for _, benchmarkCase := range suite.Cases {
+		for _, phase := range benchmarkCase.Phases {
+			fmt.Fprintf(
+				&b,
+				"| `%s` | `%s` | %d | %d | %s | %d | %d | %d |\n",
+				benchmarkCase.Name,
+				phase.Name,
+				benchmarkCase.Resources.APIs,
+				benchmarkCase.Resources.APIDocuments,
+				time.Duration(phase.DurationMS)*time.Millisecond,
+				phase.HTTPMetrics.Requests,
+				phase.HTTPMetrics.Responses,
+				phase.HTTPMetrics.Errors,
+			)
+		}
+	}
+
+	if suite.Comparison != nil {
+		b.WriteString("\n## Baseline Comparison\n\n")
+		fmt.Fprintf(&b, "- Baseline: `%s`\n", suite.Comparison.BaselinePath)
+		fmt.Fprintf(&b, "- Compared phases: `%d`\n", suite.Comparison.ComparedPhases)
+		fmt.Fprintf(&b, "- Request regressions: `%d`\n", suite.Comparison.RequestRegressions)
+		fmt.Fprintf(&b, "- Duration regressions: `%d`\n\n", suite.Comparison.DurationRegressions)
+		b.WriteString("| Case | Phase | Request Δ | Duration Δ |\n")
+		b.WriteString("| --- | --- | ---: | ---: |\n")
+		for _, row := range suite.Comparison.Rows {
+			fmt.Fprintf(
+				&b,
+				"| `%s` | `%s` | %+d (%.1f%%) | %+s (%.1f%%) |\n",
+				row.CaseName,
+				row.PhaseName,
+				row.RequestDelta,
+				row.RequestDeltaPercent*100,
+				time.Duration(row.DurationDeltaMS)*time.Millisecond,
+				row.DurationDeltaPercent*100,
+			)
+		}
+	}
+
+	return b.String()
+}
+
+func renderTerminalSummary(suite suiteResult) string {
+	var b strings.Builder
+	b.WriteString("Declarative benchmark summary\n")
+	fmt.Fprintf(&b, "Run: %s", suite.RunID)
+	if suite.GitCommit != "" {
+		fmt.Fprintf(&b, "  Commit: %s", suite.GitCommit)
+	}
+	fmt.Fprintf(&b, "\nBase URL: %s\n", suite.BaseURL)
+	fmt.Fprintf(
+		&b,
+		"Suite: %s  Cases: %d  Phases: %d  Requests: %d  Responses: %d  Errors: %d\n",
+		suite.FinishedAt.Sub(suite.StartedAt).Round(time.Millisecond),
+		suite.Summary.CaseCount,
+		suite.Summary.PhaseCount,
+		suite.Summary.TotalRequests,
+		suite.Summary.TotalResponses,
+		suite.Summary.TotalHTTPErrors,
+	)
+	if suite.Summary.FailedPhases > 0 {
+		fmt.Fprintf(&b, "Failed phases: %d\n", suite.Summary.FailedPhases)
+	}
+	b.WriteString("Note: suite duration includes fixture generation and destructive org reset.\n")
+	b.WriteString("      phase duration measures only the kongctl apply command.\n\n")
+
+	writeTerminalPhaseRow(&b, "CASE", "PHASE", "APIS", "DOCS", "DURATION", "REQ", "RESP", "ERR")
+	writeTerminalPhaseRow(
+		&b,
+		strings.Repeat("-", 24),
+		strings.Repeat("-", 13),
+		strings.Repeat("-", 5),
+		strings.Repeat("-", 5),
+		strings.Repeat("-", 10),
+		strings.Repeat("-", 6),
+		strings.Repeat("-", 6),
+		strings.Repeat("-", 6),
+	)
+	for _, benchmarkCase := range suite.Cases {
+		for _, phase := range benchmarkCase.Phases {
+			writeTerminalPhaseRow(
+				&b,
+				benchmarkCase.Name,
+				phase.Name,
+				strconv.Itoa(benchmarkCase.Resources.APIs),
+				strconv.Itoa(benchmarkCase.Resources.APIDocuments),
+				formatMilliseconds(phase.DurationMS),
+				strconv.Itoa(phase.HTTPMetrics.Requests),
+				strconv.Itoa(phase.HTTPMetrics.Responses),
+				strconv.Itoa(phase.HTTPMetrics.Errors),
+			)
+		}
+	}
+
+	if suite.Comparison != nil {
+		b.WriteString("\nBaseline comparison\n")
+		fmt.Fprintf(&b, "Baseline: %s\n", suite.Comparison.BaselinePath)
+		fmt.Fprintf(
+			&b,
+			"Compared phases: %d  Request regressions: %d  Duration regressions: %d\n\n",
+			suite.Comparison.ComparedPhases,
+			suite.Comparison.RequestRegressions,
+			suite.Comparison.DurationRegressions,
+		)
+		writeTerminalComparisonRow(&b, "CASE", "PHASE", "REQ_DELTA", "REQ_DELTA_%", "DUR_DELTA", "DUR_DELTA_%")
+		writeTerminalComparisonRow(
+			&b,
+			strings.Repeat("-", 24),
+			strings.Repeat("-", 13),
+			strings.Repeat("-", 10),
+			strings.Repeat("-", 12),
+			strings.Repeat("-", 8),
+			strings.Repeat("-", 10),
+		)
+		for _, row := range suite.Comparison.Rows {
+			writeTerminalComparisonRow(
+				&b,
+				row.CaseName,
+				row.PhaseName,
+				fmt.Sprintf("%+d", row.RequestDelta),
+				fmt.Sprintf("%+.1f%%", row.RequestDeltaPercent*100),
+				formatMilliseconds(row.DurationDeltaMS),
+				fmt.Sprintf("%+.1f%%", row.DurationDeltaPercent*100),
+			)
+		}
+	}
+
+	return b.String()
+}
+
+func writeTerminalPhaseRow(
+	b *strings.Builder,
+	caseName, phase, apis, docs, duration, requests, responses, errors string,
+) {
+	fmt.Fprintf(
+		b,
+		"%-24s %-13s %5s %5s %10s %6s %6s %6s\n",
+		caseName,
+		phase,
+		apis,
+		docs,
+		duration,
+		requests,
+		responses,
+		errors,
+	)
+}
+
+func writeTerminalComparisonRow(
+	b *strings.Builder,
+	caseName, phase, requestDelta, requestDeltaPercent, durationDelta, durationDeltaPercent string,
+) {
+	fmt.Fprintf(
+		b,
+		"%-24s %-13s %10s %12s %10s %12s\n",
+		caseName,
+		phase,
+		requestDelta,
+		requestDeltaPercent,
+		durationDelta,
+		durationDeltaPercent,
+	)
+}
+
+func formatMilliseconds(ms int64) string {
+	return (time.Duration(ms) * time.Millisecond).String()
+}
+
+func writeJSON(path string, value any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o644)
+}
+
+func readJSON(path string, target any) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, target)
+}
+
+func appendErrorMessage(existing, next string) string {
+	existing = strings.TrimSpace(existing)
+	next = strings.TrimSpace(next)
+	if existing == "" {
+		return next
+	}
+	if next == "" {
+		return existing
+	}
+	return existing + "; " + next
+}
+
+func benchmarkRunID(started time.Time) string {
+	if v := strings.TrimSpace(os.Getenv("KONGCTL_BENCHMARK_RUN_ID")); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(os.Getenv("GITHUB_RUN_ID")); v != "" {
+		return v
+	}
+	return started.Format("20060102-150405")
+}
+
+func gitCommit() string {
+	cmd := exec.Command("git", "rev-parse", "--short", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func setEnvFromBenchmark(target, source string) {
+	if strings.TrimSpace(os.Getenv(target)) != "" {
+		return
+	}
+	setEnvFromBenchmarkOverride(target, source)
+}
+
+func setEnvFromBenchmarkOverride(target, source string) {
+	if value := strings.TrimSpace(os.Getenv(source)); value != "" {
+		_ = os.Setenv(target, value)
+	}
+}
+
+func setDefaultEnv(key, value string) {
+	if strings.TrimSpace(os.Getenv(key)) == "" {
+		_ = os.Setenv(key, value)
+	}
+}
+
+func envOrDefault(key, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func durationEnv(key string, fallback time.Duration) time.Duration {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback
+	}
+	parsed, err := time.ParseDuration(value)
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}
+
+func boolEnv(key string, fallback bool) bool {
+	value := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+	switch value {
+	case "1", "true", "yes", "on", "y":
+		return true
+	case "0", "false", "no", "off", "n":
+		return false
+	case "":
+		return fallback
+	default:
+		return fallback
+	}
+}
+
+func floatEnv(key string, fallback float64) float64 {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback
+	}
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}
+
+func benchmarkCommandLogLevel() string {
+	if value := strings.TrimSpace(os.Getenv("KONGCTL_BENCHMARK_LOG_LEVEL")); value != "" {
+		return value
+	}
+	return "debug"
+}

--- a/test/benchmarks/declarative/main.go
+++ b/test/benchmarks/declarative/main.go
@@ -33,6 +33,10 @@ type config struct {
 	RequestCountThreshold float64
 	DurationThreshold     float64
 	CommandTimeout        time.Duration
+	Repeat                int
+	HistoryDir            string
+	RunURL                string
+	MinHistorySamples     int
 }
 
 type workloadSpec struct {
@@ -51,6 +55,7 @@ type benchmarkCase struct {
 type suiteResult struct {
 	SchemaVersion string            `json:"schema_version"`
 	RunID         string            `json:"run_id"`
+	RunURL        string            `json:"run_url,omitempty"`
 	GitCommit     string            `json:"git_commit,omitempty"`
 	BaseURL       string            `json:"base_url"`
 	StartedAt     time.Time         `json:"started_at"`
@@ -77,12 +82,13 @@ type suiteSummary struct {
 }
 
 type caseResult struct {
-	Name      string         `json:"name"`
-	Size      string         `json:"size"`
-	Layout    string         `json:"layout"`
-	Fixture   fixtureResult  `json:"fixture"`
-	Resources resourceCounts `json:"resources"`
-	Phases    []phaseResult  `json:"phases"`
+	Name       string         `json:"name"`
+	Size       string         `json:"size"`
+	Layout     string         `json:"layout"`
+	Repetition int            `json:"repetition,omitempty"`
+	Fixture    fixtureResult  `json:"fixture"`
+	Resources  resourceCounts `json:"resources"`
+	Phases     []phaseResult  `json:"phases"`
 }
 
 type resourceCounts struct {
@@ -199,6 +205,7 @@ func run() error {
 	suite := suiteResult{
 		SchemaVersion: schemaVersion,
 		RunID:         benchmarkRunID(started),
+		RunURL:        cfg.RunURL,
 		GitCommit:     gitCommit(),
 		BaseURL:       os.Getenv("KONGCTL_E2E_KONNECT_BASE_URL"),
 		StartedAt:     started,
@@ -225,7 +232,7 @@ func run() error {
 		}
 	}
 
-	if err := writeSuiteOutputs(runDir, suite); err != nil {
+	if err := writeSuiteOutputs(runDir, suite, cfg); err != nil {
 		runErr = errors.Join(runErr, err)
 	}
 
@@ -243,11 +250,35 @@ func parseConfig() config {
 
 	cfg := config{}
 	flag.StringVar(&cfg.CaseFilter, "case", defaultCase, "benchmark case selector: all, a size, or a case name")
+	flag.IntVar(
+		&cfg.Repeat,
+		"repeat",
+		intEnv("KONGCTL_BENCHMARK_REPEAT", 1),
+		"number of times to execute each selected case",
+	)
 	flag.StringVar(
 		&cfg.BaselinePath,
 		"baseline",
 		os.Getenv("KONGCTL_BENCHMARK_BASELINE"),
 		"optional baseline results.json",
+	)
+	flag.StringVar(
+		&cfg.HistoryDir,
+		"history-dir",
+		os.Getenv("KONGCTL_BENCHMARK_HISTORY_DIR"),
+		"optional benchmark-results history directory used for dashboard and regression reports",
+	)
+	flag.StringVar(
+		&cfg.RunURL,
+		"run-url",
+		os.Getenv("KONGCTL_BENCHMARK_RUN_URL"),
+		"optional URL for the benchmark run included in generated reports",
+	)
+	flag.IntVar(
+		&cfg.MinHistorySamples,
+		"min-history-samples",
+		intEnv("KONGCTL_BENCHMARK_MIN_HISTORY_SAMPLES", 3),
+		"minimum historical samples required before statistical regressions are reported",
 	)
 	flag.BoolVar(
 		&cfg.FailOnRegression,
@@ -269,6 +300,12 @@ func parseConfig() config {
 	)
 	flag.DurationVar(&cfg.CommandTimeout, "command-timeout", defaultTimeout, "timeout for each measured kongctl command")
 	flag.Parse()
+	if cfg.Repeat < 1 {
+		cfg.Repeat = 1
+	}
+	if cfg.MinHistorySamples < 1 {
+		cfg.MinHistorySamples = 1
+	}
 	return cfg
 }
 
@@ -314,17 +351,25 @@ func normalizeEnvironment() (string, error) {
 
 func executeSuite(ctx context.Context, cfg config, cases []benchmarkCase, suite *suiteResult) error {
 	for _, benchmarkCase := range cases {
-		caseResult, err := executeCase(ctx, cfg, benchmarkCase)
-		suite.Cases = append(suite.Cases, caseResult)
-		if err != nil {
-			return fmt.Errorf("case %s failed: %w", benchmarkCase.Name, err)
+		for repetition := 1; repetition <= cfg.Repeat; repetition++ {
+			caseResult, err := executeCase(ctx, cfg, benchmarkCase, repetition)
+			suite.Cases = append(suite.Cases, caseResult)
+			if err != nil {
+				return fmt.Errorf("case %s repetition %d failed: %w", benchmarkCase.Name, repetition, err)
+			}
 		}
 	}
 	return nil
 }
 
-func executeCase(ctx context.Context, cfg config, benchmarkCase benchmarkCase) (caseResult, error) {
-	cli, err := harness.NewCLIForArtifacts("declarative-"+benchmarkCase.Name, "benchmarks")
+func executeCase(ctx context.Context, cfg config, benchmarkCase benchmarkCase, repetition int) (caseResult, error) {
+	artifactName := "declarative-" + benchmarkCase.Name
+	resetStage := "before-" + benchmarkCase.Name
+	if cfg.Repeat > 1 {
+		artifactName = fmt.Sprintf("%s-r%03d", artifactName, repetition)
+		resetStage = fmt.Sprintf("%s-r%03d", resetStage, repetition)
+	}
+	cli, err := harness.NewCLIForArtifacts(artifactName, "benchmarks")
 	if err != nil {
 		return caseResult{}, err
 	}
@@ -333,18 +378,19 @@ func executeCase(ctx context.Context, cfg config, benchmarkCase benchmarkCase) (
 
 	fixture, counts, err := generateFixture(cli.TestDir, benchmarkCase)
 	result := caseResult{
-		Name:      benchmarkCase.Name,
-		Size:      benchmarkCase.Workload.Size,
-		Layout:    benchmarkCase.Layout,
-		Fixture:   fixture,
-		Resources: counts,
-		Phases:    []phaseResult{},
+		Name:       benchmarkCase.Name,
+		Size:       benchmarkCase.Workload.Size,
+		Layout:     benchmarkCase.Layout,
+		Repetition: repetition,
+		Fixture:    fixture,
+		Resources:  counts,
+		Phases:     []phaseResult{},
 	}
 	if err != nil {
 		return result, err
 	}
 
-	if err := harness.ResetOrgWithCapture("before-" + benchmarkCase.Name); err != nil {
+	if err := harness.ResetOrgWithCapture(resetStage); err != nil {
 		return result, err
 	}
 
@@ -880,7 +926,7 @@ func percentDelta64(baseline, current int64) float64 {
 	return float64(current-baseline) / float64(baseline)
 }
 
-func writeSuiteOutputs(runDir string, suite suiteResult) error {
+func writeSuiteOutputs(runDir string, suite suiteResult, cfg config) error {
 	if err := writeJSON(filepath.Join(runDir, "results.json"), suite); err != nil {
 		return err
 	}
@@ -888,6 +934,9 @@ func writeSuiteOutputs(runDir string, suite suiteResult) error {
 		return err
 	}
 	if err := os.WriteFile(filepath.Join(runDir, "summary.txt"), []byte(renderTerminalSummary(suite)), 0o644); err != nil {
+		return err
+	}
+	if err := writeHistoryOutputs(runDir, suite, cfg); err != nil {
 		return err
 	}
 	return os.WriteFile(filepath.Join(runDir, ".benchmark_artifacts_dir"), []byte(runDir+"\n"), 0o644)
@@ -911,15 +960,16 @@ func renderSummary(suite suiteResult) string {
 			"Phase rows measure only `kongctl apply` commands.\n\n",
 	)
 
-	b.WriteString("| Case | Phase | APIs | API documents | Duration | Requests | Responses | Errors |\n")
-	b.WriteString("| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |\n")
+	b.WriteString("| Case | Phase | Rep | APIs | API documents | Duration | Requests | Responses | Errors |\n")
+	b.WriteString("| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n")
 	for _, benchmarkCase := range suite.Cases {
 		for _, phase := range benchmarkCase.Phases {
 			fmt.Fprintf(
 				&b,
-				"| `%s` | `%s` | %d | %d | %s | %d | %d | %d |\n",
+				"| `%s` | `%s` | %d | %d | %d | %s | %d | %d | %d |\n",
 				benchmarkCase.Name,
 				phase.Name,
+				caseRepetition(benchmarkCase),
 				benchmarkCase.Resources.APIs,
 				benchmarkCase.Resources.APIDocuments,
 				time.Duration(phase.DurationMS)*time.Millisecond,
@@ -979,11 +1029,12 @@ func renderTerminalSummary(suite suiteResult) string {
 	b.WriteString("Note: suite duration includes fixture generation and destructive org reset.\n")
 	b.WriteString("      phase duration measures only the kongctl apply command.\n\n")
 
-	writeTerminalPhaseRow(&b, "CASE", "PHASE", "APIS", "DOCS", "DURATION", "REQ", "RESP", "ERR")
+	writeTerminalPhaseRow(&b, "CASE", "PHASE", "REP", "APIS", "DOCS", "DURATION", "REQ", "RESP", "ERR")
 	writeTerminalPhaseRow(
 		&b,
 		strings.Repeat("-", 24),
 		strings.Repeat("-", 13),
+		strings.Repeat("-", 4),
 		strings.Repeat("-", 5),
 		strings.Repeat("-", 5),
 		strings.Repeat("-", 10),
@@ -997,6 +1048,7 @@ func renderTerminalSummary(suite suiteResult) string {
 				&b,
 				benchmarkCase.Name,
 				phase.Name,
+				strconv.Itoa(caseRepetition(benchmarkCase)),
 				strconv.Itoa(benchmarkCase.Resources.APIs),
 				strconv.Itoa(benchmarkCase.Resources.APIDocuments),
 				formatMilliseconds(phase.DurationMS),
@@ -1045,13 +1097,14 @@ func renderTerminalSummary(suite suiteResult) string {
 
 func writeTerminalPhaseRow(
 	b *strings.Builder,
-	caseName, phase, apis, docs, duration, requests, responses, errors string,
+	caseName, phase, repetition, apis, docs, duration, requests, responses, errors string,
 ) {
 	fmt.Fprintf(
 		b,
-		"%-24s %-13s %5s %5s %10s %6s %6s %6s\n",
+		"%-24s %-13s %4s %5s %5s %10s %6s %6s %6s\n",
 		caseName,
 		phase,
+		repetition,
 		apis,
 		docs,
 		duration,
@@ -1079,6 +1132,13 @@ func writeTerminalComparisonRow(
 
 func formatMilliseconds(ms int64) string {
 	return (time.Duration(ms) * time.Millisecond).String()
+}
+
+func caseRepetition(benchmarkCase caseResult) int {
+	if benchmarkCase.Repetition < 1 {
+		return 1
+	}
+	return benchmarkCase.Repetition
 }
 
 func writeJSON(path string, value any) error {
@@ -1190,6 +1250,18 @@ func floatEnv(key string, fallback float64) float64 {
 		return fallback
 	}
 	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}
+
+func intEnv(key string, fallback int) int {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback
+	}
+	parsed, err := strconv.Atoi(value)
 	if err != nil {
 		return fallback
 	}

--- a/test/benchmarks/declarative/main_test.go
+++ b/test/benchmarks/declarative/main_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kong/kongctl/internal/declarative/loader"
 )
@@ -120,6 +121,63 @@ func TestRenderTerminalSummary(t *testing.T) {
 	}
 }
 
+func TestBuildHistoryReportDetectsRequestRegression(t *testing.T) {
+	t.Parallel()
+
+	historyDir := filepath.Join(t.TempDir(), "history")
+	previous := testSuiteResult("previous", 10, 1000, 0)
+	if err := writeJSON(filepath.Join(historyDir, "runs", "previous", "results.json"), previous); err != nil {
+		t.Fatal(err)
+	}
+
+	current := testSuiteResult("current", 12, 1050, 0)
+	report, err := buildHistoryReport(config{
+		HistoryDir:            historyDir,
+		MinHistorySamples:     1,
+		RequestCountThreshold: 0.05,
+		DurationThreshold:     0.50,
+	}, current)
+	if err != nil {
+		t.Fatalf("buildHistoryReport() error = %v", err)
+	}
+	if !report.HasRegressions {
+		t.Fatalf("HasRegressions = false, want true")
+	}
+	if len(report.Rows) != 1 {
+		t.Fatalf("len(Rows) = %d, want 1", len(report.Rows))
+	}
+	if !report.Rows[0].RequestRegression {
+		t.Fatalf("RequestRegression = false, want true")
+	}
+}
+
+func TestBuildHistoryReportRequiresMinimumHistory(t *testing.T) {
+	t.Parallel()
+
+	historyDir := filepath.Join(t.TempDir(), "history")
+	previous := testSuiteResult("previous", 10, 1000, 0)
+	if err := writeJSON(filepath.Join(historyDir, "runs", "previous", "results.json"), previous); err != nil {
+		t.Fatal(err)
+	}
+
+	current := testSuiteResult("current", 12, 1050, 0)
+	report, err := buildHistoryReport(config{
+		HistoryDir:            historyDir,
+		MinHistorySamples:     2,
+		RequestCountThreshold: 0.05,
+		DurationThreshold:     0.50,
+	}, current)
+	if err != nil {
+		t.Fatalf("buildHistoryReport() error = %v", err)
+	}
+	if report.HasRegressions {
+		t.Fatalf("HasRegressions = true, want false")
+	}
+	if report.InsufficientHistoryRows != 1 {
+		t.Fatalf("InsufficientHistoryRows = %d, want 1", report.InsufficientHistoryRows)
+	}
+}
+
 func TestNormalizeEnvironmentBenchmarkAuthOverridesE2E(t *testing.T) {
 	t.Setenv("KONGCTL_BENCHMARK_KONNECT_PAT", "benchmark-pat")
 	t.Setenv("KONGCTL_E2E_KONNECT_PAT", "e2e-pat")
@@ -184,4 +242,37 @@ func TestGenerateFixturesLoad(t *testing.T) {
 
 func stringsJoinLines(lines ...string) string {
 	return strings.Join(lines, "\n") + "\n"
+}
+
+func testSuiteResult(runID string, requests int, durationMS int64, errors int) suiteResult {
+	startedAt := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	return suiteResult{
+		SchemaVersion: schemaVersion,
+		RunID:         runID,
+		StartedAt:     startedAt,
+		FinishedAt:    startedAt.Add(time.Duration(durationMS) * time.Millisecond),
+		Cases: []caseResult{
+			{
+				Name:       "small-single-file",
+				Size:       "small",
+				Layout:     "single-file",
+				Repetition: 1,
+				Resources: resourceCounts{
+					APIs:         1,
+					APIDocuments: 2,
+				},
+				Phases: []phaseResult{
+					{
+						Name:       "apply_create",
+						DurationMS: durationMS,
+						HTTPMetrics: httpMetrics{
+							Requests:  requests,
+							Responses: requests,
+							Errors:    errors,
+						},
+					},
+				},
+			},
+		},
+	}
 }

--- a/test/benchmarks/declarative/main_test.go
+++ b/test/benchmarks/declarative/main_test.go
@@ -1,0 +1,187 @@
+//go:build e2e
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kong/kongctl/internal/declarative/loader"
+)
+
+func TestSelectCasesAliases(t *testing.T) {
+	t.Parallel()
+
+	cases, err := selectCases("medium-single")
+	if err != nil {
+		t.Fatalf("selectCases() error = %v", err)
+	}
+	if len(cases) != 1 {
+		t.Fatalf("len(cases) = %d, want 1", len(cases))
+	}
+	if cases[0].Name != "medium-single-file" {
+		t.Fatalf("case name = %q, want medium-single-file", cases[0].Name)
+	}
+
+	cases, err = selectCases("small")
+	if err != nil {
+		t.Fatalf("selectCases() error = %v", err)
+	}
+	if len(cases) != 2 {
+		t.Fatalf("len(cases) = %d, want 2", len(cases))
+	}
+}
+
+func TestParseHTTPLog(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "kongctl.log")
+	log := stringsJoinLines(
+		`time=now level=debug log_type=http_request method=GET route=/v2/apis`,
+		`time=now level=debug log_type=http_request method=POST route=/v2/apis`,
+		`time=now level=debug log_type=http_response method=GET route=/v2/apis status_code=200 duration=10ms`,
+		`time=now level=debug log_type=http_error method=POST route=/v2/apis duration=2s`,
+	)
+	if err := os.WriteFile(path, []byte(log), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	metrics, err := parseHTTPLog(path)
+	if err != nil {
+		t.Fatalf("parseHTTPLog() error = %v", err)
+	}
+	if metrics.Requests != 2 {
+		t.Fatalf("requests = %d, want 2", metrics.Requests)
+	}
+	if metrics.Responses != 1 {
+		t.Fatalf("responses = %d, want 1", metrics.Responses)
+	}
+	if metrics.Errors != 1 {
+		t.Fatalf("errors = %d, want 1", metrics.Errors)
+	}
+	if metrics.Timing.Combined.Count != 2 {
+		t.Fatalf("combined timing count = %d, want 2", metrics.Timing.Combined.Count)
+	}
+	if metrics.Timing.Combined.SumMS != 2010 {
+		t.Fatalf("combined timing sum = %f, want 2010", metrics.Timing.Combined.SumMS)
+	}
+}
+
+func TestRenderTerminalSummary(t *testing.T) {
+	t.Parallel()
+
+	suite := suiteResult{
+		SchemaVersion: schemaVersion,
+		RunID:         "run-1",
+		GitCommit:     "abc123",
+		BaseURL:       "https://example.test",
+		Summary: suiteSummary{
+			CaseCount:       1,
+			PhaseCount:      1,
+			TotalRequests:   6,
+			TotalResponses:  6,
+			TotalHTTPErrors: 0,
+		},
+		Cases: []caseResult{
+			{
+				Name: "small-single-file",
+				Resources: resourceCounts{
+					APIs:         1,
+					APIDocuments: 2,
+				},
+				Phases: []phaseResult{
+					{
+						Name:       "apply_create",
+						DurationMS: 702,
+						HTTPMetrics: httpMetrics{
+							Requests:  6,
+							Responses: 6,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	summary := renderTerminalSummary(suite)
+	for _, want := range []string{
+		"Declarative benchmark summary",
+		"Suite:",
+		"CASE",
+		"small-single-file",
+		"apply_create",
+		"702ms",
+	} {
+		if !strings.Contains(summary, want) {
+			t.Fatalf("terminal summary missing %q:\n%s", want, summary)
+		}
+	}
+}
+
+func TestNormalizeEnvironmentBenchmarkAuthOverridesE2E(t *testing.T) {
+	t.Setenv("KONGCTL_BENCHMARK_KONNECT_PAT", "benchmark-pat")
+	t.Setenv("KONGCTL_E2E_KONNECT_PAT", "e2e-pat")
+	t.Setenv("KONGCTL_BENCHMARK_KONNECT_BASE_URL", "https://benchmark.example.test")
+	t.Setenv("KONGCTL_E2E_KONNECT_BASE_URL", "https://e2e.example.test")
+	t.Setenv("KONGCTL_BENCHMARK_ARTIFACTS_DIR", t.TempDir())
+
+	if _, err := normalizeEnvironment(); err != nil {
+		t.Fatalf("normalizeEnvironment() error = %v", err)
+	}
+	if got := os.Getenv("KONGCTL_E2E_KONNECT_PAT"); got != "benchmark-pat" {
+		t.Fatalf("KONGCTL_E2E_KONNECT_PAT = %q, want benchmark-pat", got)
+	}
+	if got := os.Getenv("KONGCTL_E2E_KONNECT_BASE_URL"); got != "https://benchmark.example.test" {
+		t.Fatalf("KONGCTL_E2E_KONNECT_BASE_URL = %q, want benchmark URL", got)
+	}
+}
+
+func TestGenerateFixturesLoad(t *testing.T) {
+	t.Parallel()
+
+	for _, layout := range layouts {
+		t.Run(layout, func(t *testing.T) {
+			t.Parallel()
+
+			workload := workloadSpec{Size: "test", APICount: 2, DocumentsPerAPI: 3, DocumentBytes: 128}
+			benchmarkCase := benchmarkCase{
+				Name:     "test-" + layout,
+				Layout:   layout,
+				Workload: workload,
+			}
+			fixture, counts, err := generateFixture(t.TempDir(), benchmarkCase)
+			if err != nil {
+				t.Fatalf("generateFixture() error = %v", err)
+			}
+			if counts.APIs != 2 || counts.APIDocuments != 6 {
+				t.Fatalf("counts = %+v, want 2 APIs and 6 API documents", counts)
+			}
+
+			sources := make([]loader.Source, 0, len(fixture.Files))
+			for _, file := range fixture.Files {
+				sources = append(sources, loader.Source{Path: file, Type: loader.SourceTypeFile})
+			}
+			resourceSet, err := loader.New().LoadFromSources(sources, false)
+			if err != nil {
+				t.Fatalf("LoadFromSources() error = %v", err)
+			}
+			if len(resourceSet.APIs) != 2 {
+				t.Fatalf("len(APIs) = %d, want 2", len(resourceSet.APIs))
+			}
+
+			documentCount := len(resourceSet.APIDocuments)
+			for _, api := range resourceSet.APIs {
+				documentCount += len(api.Documents)
+			}
+			if documentCount != 6 {
+				t.Fatalf("document count = %d, want 6", documentCount)
+			}
+		})
+	}
+}
+
+func stringsJoinLines(lines ...string) string {
+	return strings.Join(lines, "\n") + "\n"
+}

--- a/test/benchmarks/declarative/main_test.go
+++ b/test/benchmarks/declarative/main_test.go
@@ -178,6 +178,67 @@ func TestBuildHistoryReportRequiresMinimumHistory(t *testing.T) {
 	}
 }
 
+func TestBuildHistoryReportMissingHistoryDirNotConfigured(t *testing.T) {
+	t.Parallel()
+
+	report, err := buildHistoryReport(config{
+		HistoryDir:            filepath.Join(t.TempDir(), "missing"),
+		MinHistorySamples:     1,
+		RequestCountThreshold: 0.05,
+		DurationThreshold:     0.50,
+	}, testSuiteResult("current", 10, 1000, 0))
+	if err != nil {
+		t.Fatalf("buildHistoryReport() error = %v", err)
+	}
+	if report.HistoryConfigured {
+		t.Fatalf("HistoryConfigured = true, want false")
+	}
+}
+
+func TestCompareBaselineAggregatesRepeatedSamples(t *testing.T) {
+	t.Parallel()
+
+	baseline := testSuiteResult("baseline", 10, 1000, 0)
+	baseline.Cases = append(baseline.Cases, testCaseResult(12, 1200, 0, 2))
+	current := testSuiteResult("current", 13, 1400, 0)
+	current.Cases = append(current.Cases, testCaseResult(15, 1600, 0, 2))
+
+	baselinePath := filepath.Join(t.TempDir(), "baseline.json")
+	if err := writeJSON(baselinePath, baseline); err != nil {
+		t.Fatal(err)
+	}
+
+	comparison, err := compareBaseline(config{
+		BaselinePath:          baselinePath,
+		RequestCountThreshold: 0.05,
+		DurationThreshold:     0.50,
+	}, current)
+	if err != nil {
+		t.Fatalf("compareBaseline() error = %v", err)
+	}
+	if comparison.ComparedPhases != 1 {
+		t.Fatalf("ComparedPhases = %d, want 1", comparison.ComparedPhases)
+	}
+	if len(comparison.Rows) != 1 {
+		t.Fatalf("len(Rows) = %d, want 1", len(comparison.Rows))
+	}
+	row := comparison.Rows[0]
+	if row.BaselineRequests != 11 || row.CurrentRequests != 14 {
+		t.Fatalf(
+			"requests baseline/current = %d/%d, want 11/14",
+			row.BaselineRequests,
+			row.CurrentRequests,
+		)
+	}
+	if row.BaselineDurationMS != 1100 || row.CurrentDurationMS != 1500 {
+		t.Fatalf(
+			"duration baseline/current = %d/%d, want 1100/1500",
+			row.BaselineDurationMS,
+			row.CurrentDurationMS,
+		)
+	}
+}
+
 func TestNormalizeEnvironmentBenchmarkAuthOverridesE2E(t *testing.T) {
 	t.Setenv("KONGCTL_BENCHMARK_KONNECT_PAT", "benchmark-pat")
 	t.Setenv("KONGCTL_E2E_KONNECT_PAT", "e2e-pat")
@@ -251,26 +312,28 @@ func testSuiteResult(runID string, requests int, durationMS int64, errors int) s
 		RunID:         runID,
 		StartedAt:     startedAt,
 		FinishedAt:    startedAt.Add(time.Duration(durationMS) * time.Millisecond),
-		Cases: []caseResult{
+		Cases:         []caseResult{testCaseResult(requests, durationMS, errors, 1)},
+	}
+}
+
+func testCaseResult(requests int, durationMS int64, errors, repetition int) caseResult {
+	return caseResult{
+		Name:       "small-single-file",
+		Size:       "small",
+		Layout:     "single-file",
+		Repetition: repetition,
+		Resources: resourceCounts{
+			APIs:         1,
+			APIDocuments: 2,
+		},
+		Phases: []phaseResult{
 			{
-				Name:       "small-single-file",
-				Size:       "small",
-				Layout:     "single-file",
-				Repetition: 1,
-				Resources: resourceCounts{
-					APIs:         1,
-					APIDocuments: 2,
-				},
-				Phases: []phaseResult{
-					{
-						Name:       "apply_create",
-						DurationMS: durationMS,
-						HTTPMetrics: httpMetrics{
-							Requests:  requests,
-							Responses: requests,
-							Errors:    errors,
-						},
-					},
+				Name:       "apply_create",
+				DurationMS: durationMS,
+				HTTPMetrics: httpMetrics{
+					Requests:  requests,
+					Responses: requests,
+					Errors:    errors,
 				},
 			},
 		},

--- a/test/benchmarks/declarative/report.go
+++ b/test/benchmarks/declarative/report.go
@@ -1,0 +1,550 @@
+//go:build e2e
+
+package main
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+)
+
+const (
+	historySampleLimit       = 20
+	minDurationRegressionMS  = 500
+	historyReportSchema      = "kongctl.declarative-benchmark-history.v1"
+	regressionSignalError    = "error"
+	regressionSignalRequest  = "requests"
+	regressionSignalDuration = "duration"
+)
+
+type historyReport struct {
+	SchemaVersion           string       `json:"schema_version"`
+	GeneratedAt             time.Time    `json:"generated_at"`
+	RunID                   string       `json:"run_id"`
+	RunURL                  string       `json:"run_url,omitempty"`
+	GitCommit               string       `json:"git_commit,omitempty"`
+	HistoryDir              string       `json:"history_dir,omitempty"`
+	HistoryConfigured       bool         `json:"history_configured"`
+	MinHistorySamples       int          `json:"min_history_samples"`
+	HistoricalRunCount      int          `json:"historical_run_count"`
+	HistoricalSampleCount   int          `json:"historical_sample_count"`
+	RequestThreshold        float64      `json:"request_threshold"`
+	DurationThreshold       float64      `json:"duration_threshold"`
+	ComparedRows            int          `json:"compared_rows"`
+	InsufficientHistoryRows int          `json:"insufficient_history_rows"`
+	HasRegressions          bool         `json:"has_regressions"`
+	Rows                    []historyRow `json:"rows"`
+}
+
+type historyRow struct {
+	CaseName                   string   `json:"case_name"`
+	PhaseName                  string   `json:"phase_name"`
+	CurrentSamples             int      `json:"current_samples"`
+	HistoricalSamples          int      `json:"historical_samples"`
+	CurrentRequestsMedian      float64  `json:"current_requests_median"`
+	HistoricalRequestsMedian   float64  `json:"historical_requests_median,omitempty"`
+	RequestDelta               float64  `json:"request_delta"`
+	RequestDeltaPercent        float64  `json:"request_delta_percent"`
+	RequestRegression          bool     `json:"request_regression"`
+	CurrentDurationMedianMS    float64  `json:"current_duration_median_ms"`
+	HistoricalDurationMedianMS float64  `json:"historical_duration_median_ms,omitempty"`
+	DurationDeltaMS            float64  `json:"duration_delta_ms"`
+	DurationDeltaPercent       float64  `json:"duration_delta_percent"`
+	DurationMADMS              float64  `json:"duration_mad_ms,omitempty"`
+	DurationThresholdMS        float64  `json:"duration_threshold_ms,omitempty"`
+	DurationRegression         bool     `json:"duration_regression"`
+	CurrentErrors              int      `json:"current_errors"`
+	CurrentFailedPhases        int      `json:"current_failed_phases"`
+	ErrorRegression            bool     `json:"error_regression"`
+	RegressionSignals          []string `json:"regression_signals,omitempty"`
+}
+
+type phaseSample struct {
+	RunID      string
+	StartedAt  time.Time
+	CaseName   string
+	PhaseName  string
+	Repetition int
+	DurationMS int64
+	Requests   int
+	Responses  int
+	Errors     int
+	Failed     bool
+}
+
+type phaseKey struct {
+	CaseName  string
+	PhaseName string
+}
+
+func writeHistoryOutputs(runDir string, suite suiteResult, cfg config) error {
+	report, err := buildHistoryReport(cfg, suite)
+	if err != nil {
+		return err
+	}
+	if err := writeJSON(filepath.Join(runDir, "history-report.json"), report); err != nil {
+		return err
+	}
+	if err := writeJSON(filepath.Join(runDir, "regressions.json"), report); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "dashboard.md"), []byte(renderDashboard(report, suite)), 0o644); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(runDir, "regressions.md"), []byte(renderRegressions(report, suite)), 0o644)
+}
+
+func buildHistoryReport(cfg config, current suiteResult) (historyReport, error) {
+	historyDir := strings.TrimSpace(cfg.HistoryDir)
+	historicalSamples, err := loadHistorySamples(historyDir, current.RunID)
+	if err != nil {
+		return historyReport{}, err
+	}
+
+	report := historyReport{
+		SchemaVersion:         historyReportSchema,
+		GeneratedAt:           time.Now().UTC(),
+		RunID:                 current.RunID,
+		RunURL:                current.RunURL,
+		GitCommit:             current.GitCommit,
+		HistoryDir:            historyDir,
+		HistoryConfigured:     historyDir != "",
+		MinHistorySamples:     cfg.MinHistorySamples,
+		RequestThreshold:      cfg.RequestCountThreshold,
+		DurationThreshold:     cfg.DurationThreshold,
+		HistoricalSampleCount: len(historicalSamples),
+		Rows:                  []historyRow{},
+	}
+
+	currentGroups := groupPhaseSamples(samplesFromSuite(current))
+	historyGroups := groupPhaseSamples(historicalSamples)
+	historicalRuns := map[string]bool{}
+	for _, sample := range historicalSamples {
+		historicalRuns[sample.RunID] = true
+	}
+	report.HistoricalRunCount = len(historicalRuns)
+
+	for key, currentSamples := range currentGroups {
+		history := recentSamples(historyGroups[key], historySampleLimit)
+		row := compareHistoryRow(cfg, key, currentSamples, history)
+		report.Rows = append(report.Rows, row)
+		if row.HistoricalSamples >= cfg.MinHistorySamples {
+			report.ComparedRows++
+		} else {
+			report.InsufficientHistoryRows++
+		}
+		if hasRegression(row) {
+			report.HasRegressions = true
+		}
+	}
+	sortHistoryRows(report.Rows)
+
+	return report, nil
+}
+
+func loadHistorySamples(historyDir, currentRunID string) ([]phaseSample, error) {
+	if strings.TrimSpace(historyDir) == "" {
+		return nil, nil
+	}
+	info, err := os.Stat(historyDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("history dir %s is not a directory", historyDir)
+	}
+
+	root := historyDir
+	if runsDir := filepath.Join(historyDir, "runs"); isDir(runsDir) {
+		root = runsDir
+	}
+
+	samples := []phaseSample{}
+	err = filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if entry.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.Name() != "results.json" {
+			return nil
+		}
+
+		var suite suiteResult
+		if err := readJSON(path, &suite); err != nil {
+			return fmt.Errorf("read history result %s: %w", path, err)
+		}
+		if suite.RunID == currentRunID {
+			return nil
+		}
+		samples = append(samples, samplesFromSuite(suite)...)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return samples, nil
+}
+
+func samplesFromSuite(suite suiteResult) []phaseSample {
+	samples := []phaseSample{}
+	for _, benchmarkCase := range suite.Cases {
+		for _, phase := range benchmarkCase.Phases {
+			samples = append(samples, phaseSample{
+				RunID:      suite.RunID,
+				StartedAt:  suite.StartedAt,
+				CaseName:   benchmarkCase.Name,
+				PhaseName:  phase.Name,
+				Repetition: caseRepetition(benchmarkCase),
+				DurationMS: phase.DurationMS,
+				Requests:   phase.HTTPMetrics.Requests,
+				Responses:  phase.HTTPMetrics.Responses,
+				Errors:     phase.HTTPMetrics.Errors,
+				Failed:     phase.ExitCode != 0 || phase.TimedOut || strings.TrimSpace(phase.Error) != "",
+			})
+		}
+	}
+	return samples
+}
+
+func groupPhaseSamples(samples []phaseSample) map[phaseKey][]phaseSample {
+	groups := map[phaseKey][]phaseSample{}
+	for _, sample := range samples {
+		key := phaseKey{CaseName: sample.CaseName, PhaseName: sample.PhaseName}
+		groups[key] = append(groups[key], sample)
+	}
+	return groups
+}
+
+func recentSamples(samples []phaseSample, limit int) []phaseSample {
+	if len(samples) == 0 {
+		return nil
+	}
+	samples = slices.Clone(samples)
+	slices.SortFunc(samples, func(left, right phaseSample) int {
+		if cmp := left.StartedAt.Compare(right.StartedAt); cmp != 0 {
+			return cmp
+		}
+		if left.RunID != right.RunID {
+			return strings.Compare(left.RunID, right.RunID)
+		}
+		return left.Repetition - right.Repetition
+	})
+	if limit > 0 && len(samples) > limit {
+		return samples[len(samples)-limit:]
+	}
+	return samples
+}
+
+func compareHistoryRow(cfg config, key phaseKey, currentSamples, historicalSamples []phaseSample) historyRow {
+	currentRequests := sampleRequests(currentSamples)
+	currentDurations := sampleDurations(currentSamples)
+	historicalRequests := sampleRequests(historicalSamples)
+	historicalDurations := sampleDurations(historicalSamples)
+
+	row := historyRow{
+		CaseName:                key.CaseName,
+		PhaseName:               key.PhaseName,
+		CurrentSamples:          len(currentSamples),
+		HistoricalSamples:       len(historicalSamples),
+		CurrentRequestsMedian:   medianFloat64(currentRequests),
+		CurrentDurationMedianMS: medianFloat64(currentDurations),
+		CurrentErrors:           sumSampleErrors(currentSamples),
+		CurrentFailedPhases:     sumSampleFailures(currentSamples),
+	}
+	row.ErrorRegression = row.CurrentErrors > 0 || row.CurrentFailedPhases > 0
+	if row.ErrorRegression {
+		row.RegressionSignals = append(row.RegressionSignals, regressionSignalError)
+	}
+
+	if row.HistoricalSamples < cfg.MinHistorySamples {
+		return row
+	}
+
+	row.HistoricalRequestsMedian = medianFloat64(historicalRequests)
+	row.HistoricalDurationMedianMS = medianFloat64(historicalDurations)
+	row.RequestDelta = row.CurrentRequestsMedian - row.HistoricalRequestsMedian
+	row.RequestDeltaPercent = percentDeltaFloat(row.HistoricalRequestsMedian, row.CurrentRequestsMedian)
+	row.RequestRegression = row.RequestDelta >= 1 && row.RequestDeltaPercent > cfg.RequestCountThreshold
+	if row.RequestRegression {
+		row.RegressionSignals = append(row.RegressionSignals, regressionSignalRequest)
+	}
+
+	row.DurationDeltaMS = row.CurrentDurationMedianMS - row.HistoricalDurationMedianMS
+	row.DurationDeltaPercent = percentDeltaFloat(row.HistoricalDurationMedianMS, row.CurrentDurationMedianMS)
+	row.DurationMADMS = medianAbsoluteDeviation(historicalDurations, row.HistoricalDurationMedianMS)
+	row.DurationThresholdMS = maxFloat(
+		minDurationRegressionMS,
+		row.HistoricalDurationMedianMS*cfg.DurationThreshold,
+		row.DurationMADMS*3,
+	)
+	row.DurationRegression = row.DurationDeltaMS > row.DurationThresholdMS
+	if row.DurationRegression {
+		row.RegressionSignals = append(row.RegressionSignals, regressionSignalDuration)
+	}
+
+	return row
+}
+
+func sampleRequests(samples []phaseSample) []float64 {
+	values := make([]float64, 0, len(samples))
+	for _, sample := range samples {
+		values = append(values, float64(sample.Requests))
+	}
+	return values
+}
+
+func sampleDurations(samples []phaseSample) []float64 {
+	values := make([]float64, 0, len(samples))
+	for _, sample := range samples {
+		values = append(values, float64(sample.DurationMS))
+	}
+	return values
+}
+
+func sumSampleErrors(samples []phaseSample) int {
+	total := 0
+	for _, sample := range samples {
+		total += sample.Errors
+	}
+	return total
+}
+
+func sumSampleFailures(samples []phaseSample) int {
+	total := 0
+	for _, sample := range samples {
+		if sample.Failed {
+			total++
+		}
+	}
+	return total
+}
+
+func medianFloat64(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	values = slices.Clone(values)
+	slices.Sort(values)
+	midpoint := len(values) / 2
+	if len(values)%2 == 1 {
+		return values[midpoint]
+	}
+	return (values[midpoint-1] + values[midpoint]) / 2
+}
+
+func medianAbsoluteDeviation(values []float64, center float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	deviations := make([]float64, 0, len(values))
+	for _, value := range values {
+		deviations = append(deviations, math.Abs(value-center))
+	}
+	return medianFloat64(deviations)
+}
+
+func percentDeltaFloat(baseline, current float64) float64 {
+	if baseline == 0 {
+		if current == 0 {
+			return 0
+		}
+		return 1
+	}
+	return (current - baseline) / baseline
+}
+
+func maxFloat(values ...float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	maxValue := values[0]
+	for _, value := range values[1:] {
+		maxValue = max(maxValue, value)
+	}
+	return maxValue
+}
+
+func sortHistoryRows(rows []historyRow) {
+	slices.SortFunc(rows, func(left, right historyRow) int {
+		if left.CaseName != right.CaseName {
+			return strings.Compare(left.CaseName, right.CaseName)
+		}
+		return strings.Compare(left.PhaseName, right.PhaseName)
+	})
+}
+
+func hasRegression(row historyRow) bool {
+	return row.ErrorRegression || row.RequestRegression || row.DurationRegression
+}
+
+func isDir(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func renderDashboard(report historyReport, suite suiteResult) string {
+	var b strings.Builder
+	b.WriteString("# Declarative Benchmark Dashboard\n\n")
+	b.WriteString("<!-- Generated by the Declarative Benchmark workflow. -->\n\n")
+	fmt.Fprintf(&b, "- Latest run: %s\n", markdownRunLink(report.RunID, report.RunURL))
+	if report.GitCommit != "" {
+		fmt.Fprintf(&b, "- Git commit: `%s`\n", report.GitCommit)
+	}
+	fmt.Fprintf(&b, "- Generated: `%s`\n", report.GeneratedAt.Format(time.RFC3339))
+	fmt.Fprintf(&b, "- Suite duration: `%s`\n", suite.FinishedAt.Sub(suite.StartedAt).Round(time.Millisecond))
+	fmt.Fprintf(&b, "- Case executions: `%d`\n", suite.Summary.CaseCount)
+	fmt.Fprintf(&b, "- Phases: `%d`\n", suite.Summary.PhaseCount)
+	fmt.Fprintf(&b, "- HTTP requests: `%d`\n", suite.Summary.TotalRequests)
+	fmt.Fprintf(&b, "- HTTP errors: `%d`\n", suite.Summary.TotalHTTPErrors)
+	fmt.Fprintf(&b, "- Regression status: **%s**\n\n", dashboardStatus(report))
+
+	fmt.Fprintf(
+		&b,
+		"History: `%d` runs / `%d` samples. Statistical checks require `%d` historical samples per case phase.\n\n",
+		report.HistoricalRunCount,
+		report.HistoricalSampleCount,
+		report.MinHistorySamples,
+	)
+	b.WriteString(
+		"Request regressions compare median request counts against recent history. " +
+			"Duration regressions compare median wall-clock time against recent history with a MAD-based guardrail.\n\n",
+	)
+
+	b.WriteString(
+		"| Case | Phase | Samples | Requests p50 | History requests p50 | Duration p50 | " +
+			"History duration p50 | History samples | Status |\n",
+	)
+	b.WriteString("| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |\n")
+	for _, row := range report.Rows {
+		fmt.Fprintf(
+			&b,
+			"| `%s` | `%s` | %d | %s | %s | %s | %s | %d | %s |\n",
+			row.CaseName,
+			row.PhaseName,
+			row.CurrentSamples,
+			formatCountMedian(row.CurrentRequestsMedian),
+			formatOptionalCountMedian(row.HistoricalSamples, row.HistoricalRequestsMedian),
+			formatMillisecondsFloat(row.CurrentDurationMedianMS),
+			formatOptionalMilliseconds(row.HistoricalSamples, row.HistoricalDurationMedianMS),
+			row.HistoricalSamples,
+			rowStatus(row, report.MinHistorySamples),
+		)
+	}
+
+	return b.String()
+}
+
+func renderRegressions(report historyReport, suite suiteResult) string {
+	var b strings.Builder
+	b.WriteString("# Declarative Benchmark Regression Report\n\n")
+	fmt.Fprintf(&b, "- Run: %s\n", markdownRunLink(report.RunID, report.RunURL))
+	if report.GitCommit != "" {
+		fmt.Fprintf(&b, "- Git commit: `%s`\n", report.GitCommit)
+	}
+	fmt.Fprintf(&b, "- Suite duration: `%s`\n", suite.FinishedAt.Sub(suite.StartedAt).Round(time.Millisecond))
+	fmt.Fprintf(&b, "- HTTP requests: `%d`\n", suite.Summary.TotalRequests)
+	fmt.Fprintf(&b, "- HTTP errors: `%d`\n", suite.Summary.TotalHTTPErrors)
+	fmt.Fprintf(&b, "- History samples required: `%d`\n\n", report.MinHistorySamples)
+
+	if !report.HasRegressions {
+		b.WriteString("No regressions detected in the latest benchmark run.\n")
+		return b.String()
+	}
+
+	b.WriteString("Regressions detected in the latest benchmark run.\n\n")
+	b.WriteString(
+		"| Case | Phase | Signals | Request Δ | Duration Δ | Current errors | Failed phases |\n",
+	)
+	b.WriteString("| --- | --- | --- | ---: | ---: | ---: | ---: |\n")
+	for _, row := range report.Rows {
+		if !hasRegression(row) {
+			continue
+		}
+		fmt.Fprintf(
+			&b,
+			"| `%s` | `%s` | %s | %s | %s | %d | %d |\n",
+			row.CaseName,
+			row.PhaseName,
+			strings.Join(row.RegressionSignals, ", "),
+			formatDeltaPercent(row.RequestDelta, row.RequestDeltaPercent),
+			formatDeltaPercent(row.DurationDeltaMS, row.DurationDeltaPercent),
+			row.CurrentErrors,
+			row.CurrentFailedPhases,
+		)
+	}
+	b.WriteString(
+		"\nInspect workflow artifacts for raw `kongctl` logs, generated fixtures, and per-command HTTP metrics.\n",
+	)
+	return b.String()
+}
+
+func dashboardStatus(report historyReport) string {
+	if report.HasRegressions {
+		return "regression detected"
+	}
+	if report.InsufficientHistoryRows > 0 {
+		return "collecting history"
+	}
+	return "ok"
+}
+
+func rowStatus(row historyRow, minHistorySamples int) string {
+	if hasRegression(row) {
+		return strings.Join(row.RegressionSignals, ", ")
+	}
+	if row.HistoricalSamples < minHistorySamples {
+		return "collecting history"
+	}
+	return "ok"
+}
+
+func markdownRunLink(runID, runURL string) string {
+	if strings.TrimSpace(runURL) == "" {
+		return "`" + runID + "`"
+	}
+	return fmt.Sprintf("[`%s`](%s)", runID, runURL)
+}
+
+func formatCountMedian(value float64) string {
+	if math.Trunc(value) == value {
+		return fmt.Sprintf("%.0f", value)
+	}
+	return fmt.Sprintf("%.1f", value)
+}
+
+func formatOptionalCountMedian(samples int, value float64) string {
+	if samples == 0 {
+		return "n/a"
+	}
+	return formatCountMedian(value)
+}
+
+func formatMillisecondsFloat(value float64) string {
+	return (time.Duration(math.Round(value)) * time.Millisecond).String()
+}
+
+func formatOptionalMilliseconds(samples int, value float64) string {
+	if samples == 0 {
+		return "n/a"
+	}
+	return formatMillisecondsFloat(value)
+}
+
+func formatDeltaPercent(delta, percent float64) string {
+	if delta == 0 && percent == 0 {
+		return "0"
+	}
+	return fmt.Sprintf("%+.0f (%+.1f%%)", delta, percent*100)
+}

--- a/test/benchmarks/declarative/report.go
+++ b/test/benchmarks/declarative/report.go
@@ -100,7 +100,7 @@ func writeHistoryOutputs(runDir string, suite suiteResult, cfg config) error {
 
 func buildHistoryReport(cfg config, current suiteResult) (historyReport, error) {
 	historyDir := strings.TrimSpace(cfg.HistoryDir)
-	historicalSamples, err := loadHistorySamples(historyDir, current.RunID)
+	historicalSamples, historyConfigured, err := loadHistorySamples(historyDir, current.RunID)
 	if err != nil {
 		return historyReport{}, err
 	}
@@ -112,7 +112,7 @@ func buildHistoryReport(cfg config, current suiteResult) (historyReport, error) 
 		RunURL:                current.RunURL,
 		GitCommit:             current.GitCommit,
 		HistoryDir:            historyDir,
-		HistoryConfigured:     historyDir != "",
+		HistoryConfigured:     historyConfigured,
 		MinHistorySamples:     cfg.MinHistorySamples,
 		RequestThreshold:      cfg.RequestCountThreshold,
 		DurationThreshold:     cfg.DurationThreshold,
@@ -146,19 +146,19 @@ func buildHistoryReport(cfg config, current suiteResult) (historyReport, error) 
 	return report, nil
 }
 
-func loadHistorySamples(historyDir, currentRunID string) ([]phaseSample, error) {
+func loadHistorySamples(historyDir, currentRunID string) ([]phaseSample, bool, error) {
 	if strings.TrimSpace(historyDir) == "" {
-		return nil, nil
+		return nil, false, nil
 	}
 	info, err := os.Stat(historyDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return nil, false, nil
 		}
-		return nil, err
+		return nil, false, err
 	}
 	if !info.IsDir() {
-		return nil, fmt.Errorf("history dir %s is not a directory", historyDir)
+		return nil, false, fmt.Errorf("history dir %s is not a directory", historyDir)
 	}
 
 	root := historyDir
@@ -192,9 +192,9 @@ func loadHistorySamples(historyDir, currentRunID string) ([]phaseSample, error) 
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, true, err
 	}
-	return samples, nil
+	return samples, true, nil
 }
 
 func samplesFromSuite(suite suiteResult) []phaseSample {

--- a/test/e2e/harness/cli.go
+++ b/test/e2e/harness/cli.go
@@ -117,6 +117,13 @@ func NewCLI() (*CLI, error) {
 // NewCLIT constructs a CLI instance under the per-run artifacts dir using the test's name.
 func NewCLIT(t *testing.T) (*CLI, error) {
 	t.Helper()
+	return NewCLIForArtifacts(t.Name(), "tests")
+}
+
+// NewCLIForArtifacts constructs a CLI instance under the per-run artifacts dir.
+// The group controls the subdirectory under the run root, for example "tests"
+// or "benchmarks".
+func NewCLIForArtifacts(name, group string) (*CLI, error) {
 	bin, err := BinPath()
 	if err != nil {
 		return nil, err
@@ -125,8 +132,15 @@ func NewCLIT(t *testing.T) (*CLI, error) {
 	if err != nil {
 		return nil, err
 	}
-	name := sanitizeName(t.Name())
-	testDir := filepath.Join(rd, "tests", name)
+	name = sanitizeName(name)
+	group = sanitizeName(group)
+	if strings.TrimSpace(name) == "" {
+		name = "run"
+	}
+	if strings.TrimSpace(group) == "" {
+		group = "runs"
+	}
+	testDir := filepath.Join(rd, group, name)
 	cfgDir := filepath.Join(testDir, "config")
 	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Closes #730.

Adds a local-first declarative benchmarking flow for live Konnect runs, focused initially on API resources and API documents. The benchmark runner generates deterministic small/medium/large/xl fixtures in both single-file and multi-file layouts, runs create and no-op apply phases, captures structured HTTP/request metrics, and writes both Markdown and terminal summaries.

## Details

- Adds `test/benchmarks/declarative` with fixture generation, metrics parsing, baseline comparison, and tests.
- Adds Make targets for local execution: `make benchmark-declarative` and `make benchmark-declarative-case CASE=...`.
- Adds a manual `Declarative Benchmark` workflow that invokes the same local Make target and uploads artifacts.
- Reuses E2E harness artifact capture through a reusable `NewCLIForArtifacts` constructor.
- Documents local setup, workflow configuration, result files, and storage options.

## Validation

- `git diff --check`
- `go test -tags=e2e ./test/benchmarks/declarative ./test/e2e/harness`
- `go test ./...`
- `make build-ci`