### PR TITLE
Security: added url validation for login and auth flows

### DIFF
--- a/internal/cmd/root/products/konnect/loginKonnect.go
+++ b/internal/cmd/root/products/konnect/loginKonnect.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kong/kongctl/internal/cmd"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/kong/kongctl/internal/config"
 	"github.com/kong/kongctl/internal/konnect/auth"
 	"github.com/kong/kongctl/internal/konnect/httpclient"
 	"github.com/kong/kongctl/internal/meta"
@@ -35,23 +36,26 @@ type loginKonnectCmd struct {
 	*cobra.Command
 }
 
+// resolveAuthURLs returns the fully constructed auth and token poll URLs from cfg.
+func resolveAuthURLs(cfg config.Hook) (authURL, pollURL string) {
+	authBaseURL := cfg.GetString(common.AuthBaseURLConfigPath)
+	if authBaseURL == "" {
+		authBaseURL = common.AuthBaseURLDefault
+	}
+	return authBaseURL + cfg.GetString(common.AuthPathConfigPath),
+		authBaseURL + cfg.GetString(common.TokenURLPathConfigPath)
+}
+
 func (c *loginKonnectCmd) validate(helper cmd.Helper) error {
 	cfg, err := helper.GetConfig()
 	if err != nil {
 		return err
 	}
 
-	authBaseURL := cfg.GetString(common.AuthBaseURLConfigPath)
-	if authBaseURL == "" {
-		authBaseURL = common.AuthBaseURLDefault
-	}
-
-	authURL := authBaseURL + cfg.GetString(common.AuthPathConfigPath)
+	authURL, pollURL := resolveAuthURLs(cfg)
 	if err := auth.ValidateKonnectURL(authURL); err != nil {
 		return cmd.PrepareExecutionErrorWithHelper(helper, "invalid auth URL", err)
 	}
-
-	pollURL := authBaseURL + cfg.GetString(common.TokenURLPathConfigPath)
 	if err := auth.ValidateKonnectURL(pollURL); err != nil {
 		return cmd.PrepareExecutionErrorWithHelper(helper, "invalid token poll URL", err)
 	}
@@ -85,16 +89,8 @@ func (c *loginKonnectCmd) run(helper cmd.Helper) error {
 		return err
 	}
 
-	authBaseURL := cfg.GetString(common.AuthBaseURLConfigPath)
-	if authBaseURL == "" {
-		authBaseURL = common.AuthBaseURLDefault
-	}
-	authPath := cfg.GetString(common.AuthPathConfigPath)
 	// Device authorization endpoints default to the global Konnect API host but can be overridden.
-	authURL := authBaseURL + authPath
-
-	pollPath := cfg.GetString(common.TokenURLPathConfigPath)
-	pollURL := authBaseURL + pollPath
+	authURL, pollURL := resolveAuthURLs(cfg)
 
 	clientID := cfg.GetString(common.MachineClientIDConfigPath)
 

--- a/internal/cmd/root/products/konnect/loginKonnect.go
+++ b/internal/cmd/root/products/konnect/loginKonnect.go
@@ -35,7 +35,27 @@ type loginKonnectCmd struct {
 	*cobra.Command
 }
 
-func (c *loginKonnectCmd) validate(_ cmd.Helper) error {
+func (c *loginKonnectCmd) validate(helper cmd.Helper) error {
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	authBaseURL := cfg.GetString(common.AuthBaseURLConfigPath)
+	if authBaseURL == "" {
+		authBaseURL = common.AuthBaseURLDefault
+	}
+
+	authURL := authBaseURL + cfg.GetString(common.AuthPathConfigPath)
+	if err := auth.ValidateKonnectURL(authURL); err != nil {
+		return cmd.PrepareExecutionErrorWithHelper(helper, "invalid auth URL", err)
+	}
+
+	pollURL := authBaseURL + cfg.GetString(common.TokenURLPathConfigPath)
+	if err := auth.ValidateKonnectURL(pollURL); err != nil {
+		return cmd.PrepareExecutionErrorWithHelper(helper, "invalid token poll URL", err)
+	}
+
 	return nil
 }
 

--- a/internal/konnect/auth/auth.go
+++ b/internal/konnect/auth/auth.go
@@ -161,6 +161,14 @@ func RequestDeviceCode(httpClient *http.Client,
 		logger.Error("Device code request failed", "error", err)
 		return DeviceCodeResponse{}, err
 	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return DeviceCodeResponse{}, fmt.Errorf(
+			"device code request to %s failed with HTTP %d",
+			url, resp.StatusCode,
+		)
+	}
 
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/konnect/auth/auth.go
+++ b/internal/konnect/auth/auth.go
@@ -105,9 +105,29 @@ func (t *AccessToken) IsExpired() bool {
 	return time.Now().After(t.ReceivedAt.Add(time.Duration(t.Token.ExpiresAfter) * time.Second))
 }
 
+// ValidateKonnectURL parses rawURL and ensures it uses HTTPS and targets a
+// trusted *.konghq.com domain
+func ValidateKonnectURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid Konnect URL: %w", err)
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("Konnect URL must use HTTPS, got %q", u.Scheme)
+	}
+	host := u.Hostname()
+	if host != "konghq.com" && !strings.HasSuffix(host, ".konghq.com") {
+		return fmt.Errorf("Konnect URL host %q is not a trusted konghq.com domain", host)
+	}
+	return nil
+}
+
 func RequestDeviceCode(httpClient *http.Client,
 	url string, clientID string, logger *slog.Logger,
 ) (DeviceCodeResponse, error) {
+	if err := ValidateKonnectURL(url); err != nil {
+		return DeviceCodeResponse{}, err
+	}
 	logger.Info("Requesting device code", "url", url, "client_id", clientID)
 	requestBody := struct {
 		ClientID uuid.UUID `form:"client_id"`
@@ -160,6 +180,10 @@ func RefreshAccessToken(
 ) (*AccessToken, error) {
 	jar, err := cookiejar.New(nil)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := ValidateKonnectURL(refreshURL); err != nil {
 		return nil, err
 	}
 
@@ -230,6 +254,9 @@ func RefreshAccessToken(
 func PollForToken(ctx context.Context, httpClient *http.Client,
 	url string, clientID string, deviceCode string, logger *slog.Logger,
 ) (*AccessToken, error) {
+	if err := ValidateKonnectURL(url); err != nil {
+		return nil, err
+	}
 	logger.Info("Polling for token", "url", url, "client_id", clientID, "device_code", deviceCode)
 	requestBody := struct {
 		GrantType  string    `form:"grant_type"`
@@ -401,6 +428,9 @@ func GetAuthenticatedClient(
 	transportOptions httpclient.TransportOptions,
 	logger *slog.Logger,
 ) (*kk.SDK, kk.HTTPClient, error) {
+	if err := ValidateKonnectURL(baseURL); err != nil {
+		return nil, nil, err
+	}
 	kkMetadata.SetUserAgent(meta.UserAgent())
 
 	opts := []kk.SDKOption{

--- a/internal/konnect/auth/auth.go
+++ b/internal/konnect/auth/auth.go
@@ -105,21 +105,27 @@ func (t *AccessToken) IsExpired() bool {
 	return time.Now().After(t.ReceivedAt.Add(time.Duration(t.Token.ExpiresAfter) * time.Second))
 }
 
+// trustedKonnectDomains is the allow list of Kong-owned domains accepted as
+// Konnect API endpoints. konghq.tech is used for staging/test environments.
+var trustedKonnectDomains = []string{"konghq.com", "konghq.tech"}
+
 // ValidateKonnectURL parses rawURL and ensures it uses HTTPS and targets a
-// trusted *.konghq.com domain
+// trusted Kong-owned domains.
 func ValidateKonnectURL(rawURL string) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return fmt.Errorf("invalid Konnect URL: %w", err)
 	}
 	if u.Scheme != "https" {
-		return fmt.Errorf("Konnect URL must use HTTPS, got %q", u.Scheme)
+		return fmt.Errorf("konnect URL must use HTTPS, got %q", u.Scheme)
 	}
-	host := u.Hostname()
-	if host != "konghq.com" && !strings.HasSuffix(host, ".konghq.com") {
-		return fmt.Errorf("Konnect URL host %q is not a trusted konghq.com domain", host)
+	host := strings.TrimSuffix(strings.ToLower(u.Hostname()), ".")
+	for _, domain := range trustedKonnectDomains {
+		if host == domain || strings.HasSuffix(host, "."+domain) {
+			return nil
+		}
 	}
-	return nil
+	return fmt.Errorf("konnect URL host %q is not a trusted konghq.com domain", host)
 }
 
 func RequestDeviceCode(httpClient *http.Client,

--- a/internal/konnect/auth/auth_test.go
+++ b/internal/konnect/auth/auth_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -188,3 +191,57 @@ func TestValidateKonnectURL(t *testing.T) {
 		})
 	}
 }
+func TestRequestDeviceCode_NonOKStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+	}{
+		{
+			name:       "404 HTML page",
+			statusCode: http.StatusNotFound,
+			body:       "<html><body>Not Found</body></html>",
+		},
+		{
+			name:       "500 server error",
+			statusCode: http.StatusInternalServerError,
+			body:       "Internal Server Error",
+		},
+		{
+			name:       "403 forbidden",
+			statusCode: http.StatusForbidden,
+			body:       `{"error":"forbidden"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &http.Client{
+				Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: tt.statusCode,
+						Body:       io.NopCloser(strings.NewReader(tt.body)),
+					}, nil
+				}),
+			}
+
+			_, err := RequestDeviceCode(
+				client,
+				"https://us.konghq.com/some/endpoint",
+				"344f59db-f401-4ce7-9407-00a0823fbacf",
+				slog.New(slog.NewTextHandler(io.Discard, nil)),
+			)
+
+			require.Error(t, err)
+			require.NotContains(t, err.Error(), "invalid character",
+				"error should not be a JSON parse failure")
+			require.Contains(t, err.Error(), fmt.Sprintf("HTTP %d", tt.statusCode))
+		})
+	}
+}
+
+// roundTripFunc allows an inline function to be used as an http.RoundTripper,
+// intercepting HTTP requests without making real network calls.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/internal/konnect/auth/auth_test.go
+++ b/internal/konnect/auth/auth_test.go
@@ -136,3 +136,55 @@ func TestJWTExpiresIn_APIResponseMismatch(t *testing.T) {
 	require.NotEqual(t, apiExpiresIn, secs, "jwtExpiresIn should return JWT exp, not API expires_in")
 	require.InDelta(t, int(jwtLifetime.Seconds()), secs, 5)
 }
+
+func TestValidateKonnectURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr string
+	}{
+		// valid URLs
+		{name: "production base URL", url: "https://us.api.konghq.com"},
+		{name: "global API URL", url: "https://global.api.konghq.com"},
+		{name: "refresh endpoint", url: "https://global.api.konghq.com/kauth/api/v1/refresh"},
+		{name: "apex domain", url: "https://konghq.com"},
+		{name: "staging base URL", url: "https://api.konghq.tech"},
+		{name: "staging subdomain", url: "https://us.api.konghq.tech"},
+		{name: "uppercase host normalized", url: "https://US.API.KONGHQ.COM"},
+		{name: "trailing dot normalized", url: "https://us.api.konghq.com."},
+
+		// scheme errors
+		{name: "http not allowed", url: "http://us.api.konghq.com",
+			wantErr: "must use HTTPS"},
+		{name: "empty scheme", url: "//us.api.konghq.com",
+			wantErr: "must use HTTPS"},
+
+		// untrusted hosts
+		{name: "arbitrary host", url: "https://evil.com",
+			wantErr: "not a trusted konghq.com domain"},
+		{name: "subdomain typosquat", url: "https://us.api.konghq.com.evil.com",
+			wantErr: "not a trusted konghq.com domain"},
+		{name: "konghq.com prefix only", url: "https://konghq.com.evil.com",
+			wantErr: "not a trusted konghq.com domain"},
+		{name: "localhost", url: "https://localhost",
+			wantErr: "not a trusted konghq.com domain"},
+		{name: "link-local", url: "https://169.254.169.254",
+			wantErr: "not a trusted konghq.com domain"},
+
+		// parse errors
+		{name: "invalid URL", url: "://bad-url",
+			wantErr: "invalid Konnect URL"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateKonnectURL(tt.url)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
For: https://konghq.atlassian.net/browse/APIOP-7

This was marked by Aikido as a critical vulnerability in a sub-issue.
On inspection, it doesn't look like a critical issue. 
Chances of a SSRF attack seem to be low
as the input is client controlled.
Erring on the side of caution, this change adds a validation layer
on top for the URLs. This enables an early exit in case of invalid
URL values.