### PR TITLE
Security: enhancements in ci workflows

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -28,6 +28,10 @@ jobs:
     outputs:
       status: ${{ steps.up-to-date.outputs.status }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
       - name: checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -48,6 +52,10 @@ jobs:
     outputs:
       result: ${{ steps.check.outputs.result }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
       - name: Check if secrets are available
         id: check
         run: |
@@ -66,6 +74,10 @@ jobs:
       - up-to-date
     if: always()
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
       - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "Some jobs failed or were cancelled."

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -11,6 +11,10 @@ jobs:
     permissions:
       contents: read
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+      with:
+        egress-policy: audit
     - name: Checkout repository
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
     - name: Install gh-aw extension

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -11,13 +11,13 @@ jobs:
     permissions:
       contents: read
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
-      with:
-        egress-policy: audit
-    - name: Checkout repository
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-    - name: Install gh-aw extension
-      uses: github/gh-aw-actions/setup-cli@abea67e08ee83539ea33aaae67bf0cddaa0b03b5 # v0.68.3
-      with:
-        version: v0.68.1
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Install gh-aw extension
+        uses: github/gh-aw-actions/setup-cli@abea67e08ee83539ea33aaae67bf0cddaa0b03b5 # v0.68.3
+        with:
+          version: v0.68.1

--- a/.github/workflows/declarative-benchmark.yaml
+++ b/.github/workflows/declarative-benchmark.yaml
@@ -76,6 +76,10 @@ jobs:
       KONGCTL_E2E_RESET_RETRY_JITTER: ${{ vars.KONGCTL_BENCHMARK_RESET_RETRY_JITTER || '250ms' }}
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,6 +17,10 @@ jobs:
     env:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -37,6 +37,10 @@ jobs:
     outputs:
       required: ${{ steps.detect.outputs.required }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
       - name: Checkout
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -100,6 +104,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -120,6 +128,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -209,6 +221,10 @@ jobs:
       KONGCTL_E2E_PORTAL_IDP_UPDATE_CLIENT_ID: ${{ secrets.KONGCTL_E2E_PORTAL_IDP_UPDATE_CLIENT_ID }}
       KONGCTL_E2E_PORTAL_IDP_UPDATE_CLIENT_SECRET: ${{ secrets.KONGCTL_E2E_PORTAL_IDP_UPDATE_CLIENT_SECRET }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -386,6 +402,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -670,6 +690,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
       - name: Check requirement outcome
         shell: bash
         run: |

--- a/.github/workflows/release.lock.yml
+++ b/.github/workflows/release.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7050984c358b397cdb11f33fb6c373254916935b962732431ca6f0307563bdf5","compiler_version":"v0.68.1","agent_id":"copilot"}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","DOCKER_TOKEN","DOCKER_USERNAME","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_TOKEN_PRIVATE_READ","GITHUB_TOKEN","TAP_GITHUB_TOKEN"],"actions":[{"repo":"Homebrew/actions/setup-homebrew","sha":"cced187498280712e078aaba62dc13a3e9cd80bf","version":"cced187498280712e078aaba62dc13a3e9cd80bf"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/github-script","sha":"ed597411d8f924073f98dfc5c65a23a2325f34cd","version":"v8"},{"repo":"actions/setup-go","sha":"4a3601121dd01d1626a1e23e37211e3254c1c06c","version":"v6"},{"repo":"actions/upload-artifact","sha":"bbbca2ddaa5d8feaa63e36b76fdaad77386f024f","version":"v7"},{"repo":"docker/login-action","sha":"c94ce9fb468520275223c153574b00df6fe4bcc9","version":"c94ce9fb468520275223c153574b00df6fe4bcc9"},{"repo":"docker/setup-buildx-action","sha":"8d2750c68a42422c14e847fe6c8ac0403b4cbd6f","version":"8d2750c68a42422c14e847fe6c8ac0403b4cbd6f"},{"repo":"docker/setup-qemu-action","sha":"c7c53464625b32c7a7e944ae62b3e17d2b600130","version":"c7c53464625b32c7a7e944ae62b3e17d2b600130"},{"repo":"github/gh-aw-actions/setup","sha":"2fe53acc038ba01c3bbdc767d4b25df31ca5bdfc","version":"v0.68.1"},{"repo":"goreleaser/goreleaser-action","sha":"e435ccd777264be153ace6237001ef4d979d3a7a","version":"e435ccd777264be153ace6237001ef4d979d3a7a"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"9b8ef348abf452b6c57bd733b87ee3f047c318bbab5e9dbbbc2d4715a22c89ba","compiler_version":"v0.68.1","agent_id":"copilot"}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","DOCKER_TOKEN","DOCKER_USERNAME","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_TOKEN_PRIVATE_READ","GITHUB_TOKEN","TAP_GITHUB_TOKEN"],"actions":[{"repo":"Homebrew/actions/setup-homebrew","sha":"cced187498280712e078aaba62dc13a3e9cd80bf","version":"cced187498280712e078aaba62dc13a3e9cd80bf"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/github-script","sha":"ed597411d8f924073f98dfc5c65a23a2325f34cd","version":"v8"},{"repo":"actions/setup-go","sha":"4a3601121dd01d1626a1e23e37211e3254c1c06c","version":"v6"},{"repo":"actions/upload-artifact","sha":"bbbca2ddaa5d8feaa63e36b76fdaad77386f024f","version":"v7"},{"repo":"docker/login-action","sha":"c94ce9fb468520275223c153574b00df6fe4bcc9","version":"c94ce9fb468520275223c153574b00df6fe4bcc9"},{"repo":"docker/setup-buildx-action","sha":"8d2750c68a42422c14e847fe6c8ac0403b4cbd6f","version":"8d2750c68a42422c14e847fe6c8ac0403b4cbd6f"},{"repo":"docker/setup-qemu-action","sha":"c7c53464625b32c7a7e944ae62b3e17d2b600130","version":"c7c53464625b32c7a7e944ae62b3e17d2b600130"},{"repo":"github/gh-aw-actions/setup","sha":"2fe53acc038ba01c3bbdc767d4b25df31ca5bdfc","version":"v0.68.1"},{"repo":"goreleaser/goreleaser-action","sha":"e435ccd777264be153ace6237001ef4d979d3a7a","version":"e435ccd777264be153ace6237001ef4d979d3a7a"},{"repo":"step-security/harden-runner","sha":"6c3c2f2c1c457b00c10c4848d6f5491db3b629df","version":"6c3c2f2c1c457b00c10c4848d6f5491db3b629df"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -49,6 +49,7 @@
 #   - docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # c7c53464625b32c7a7e944ae62b3e17d2b600130
 #   - github/gh-aw-actions/setup@2fe53acc038ba01c3bbdc767d4b25df31ca5bdfc # v0.68.1
 #   - goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # e435ccd777264be153ace6237001ef4d979d3a7a
+#   - step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # 6c3c2f2c1c457b00c10c4848d6f5491db3b629df
 
 name: "Release"
 "on":
@@ -189,14 +190,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_41b685eada4df4e2_EOF'
+          cat << 'GH_AW_PROMPT_0aa6a46bf29aa4e2_EOF'
           <system>
-          GH_AW_PROMPT_41b685eada4df4e2_EOF
+          GH_AW_PROMPT_0aa6a46bf29aa4e2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_41b685eada4df4e2_EOF'
+          cat << 'GH_AW_PROMPT_0aa6a46bf29aa4e2_EOF'
           <safe-output-tools>
           Tools: update_release, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -228,12 +229,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_41b685eada4df4e2_EOF
+          GH_AW_PROMPT_0aa6a46bf29aa4e2_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_41b685eada4df4e2_EOF'
+          cat << 'GH_AW_PROMPT_0aa6a46bf29aa4e2_EOF'
           </system>
           {{#runtime-import .github/workflows/release.md}}
-          GH_AW_PROMPT_41b685eada4df4e2_EOF
+          GH_AW_PROMPT_0aa6a46bf29aa4e2_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -411,9 +412,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_d6b3f828fd17517f_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a144719e88a74bda_EOF'
           {"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_release":{"max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_d6b3f828fd17517f_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_a144719e88a74bda_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -600,7 +601,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.17'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_a51b2abf0bf9079c_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_14d7d815d602e5f6_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -641,7 +642,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_a51b2abf0bf9079c_EOF
+          GH_AW_MCP_CONFIG_14d7d815d602e5f6_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -974,6 +975,10 @@ jobs:
           GH_HOST="${GITHUB_SERVER_URL#https://}"
           GH_HOST="${GH_HOST#http://}"
           echo "GH_HOST=${GH_HOST}" >> "$GITHUB_ENV"
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # 6c3c2f2c1c457b00c10c4848d6f5491db3b629df
+        with:
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -1300,6 +1305,10 @@ jobs:
           GH_HOST="${GITHUB_SERVER_URL#https://}"
           GH_HOST="${GH_HOST#http://}"
           echo "GH_HOST=${GH_HOST}" >> "$GITHUB_ENV"
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # 6c3c2f2c1c457b00c10c4848d6f5491db3b629df
+        with:
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/release.md
+++ b/.github/workflows/release.md
@@ -53,6 +53,10 @@ jobs:
       release_tag: ${{ steps.compute_config.outputs.release_tag }}
       release_version: ${{ steps.compute_config.outputs.release_version }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -190,6 +194,10 @@ jobs:
       RELEASE_TAG: ${{ needs.config.outputs.release_tag }}
       RELEASE_VERSION: ${{ needs.config.outputs.release_version }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/sdk-prerelease-preview.yml
+++ b/.github/workflows/sdk-prerelease-preview.yml
@@ -22,6 +22,10 @@ jobs:
     name: Stage prerelease
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
       - name: Resolve latest prerelease
         id: release
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,19 @@
+on: push
+
+name: Security
+
+jobs:
+  ensure-pinned-actions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Ensure SHA pinned actions
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@ca46236c6ce584ae24bc6283ba8dcf4b3ec8a066 # v5.0.4
+        with:
+          allowlist: |
+            Kong/

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -2,6 +2,9 @@ on: push
 
 name: Security
 
+permissions:
+   contents: read
+
 jobs:
   ensure-pinned-actions:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: git config --global url.https://$GITHUB_TOKEN@github.com/.insteadOf https://github.com/


### PR DESCRIPTION
- added ensure-pinned action
- added egress auditing for code related workflows and releases.
- ran `gh aw compile` locally and committed the results to account for release workflow.
- excluded agentic workflows that deal with issue triaging, e2e coverage, etc. from egress auditing.

`egress-policy: audit` gives us info about what network calls are being made and by which process.
An example from deck: https://github.com/Kong/deck/actions/runs/25032749507
