### PR TITLE
e2e: cover single API document lookup

### DIFF
--- a/internal/konnect/auth/auth_test.go
+++ b/internal/konnect/auth/auth_test.go
@@ -157,26 +157,42 @@ func TestValidateKonnectURL(t *testing.T) {
 		{name: "trailing dot normalized", url: "https://us.api.konghq.com."},
 
 		// scheme errors
-		{name: "http not allowed", url: "http://us.api.konghq.com",
-			wantErr: "must use HTTPS"},
-		{name: "empty scheme", url: "//us.api.konghq.com",
-			wantErr: "must use HTTPS"},
+		{
+			name: "http not allowed", url: "http://us.api.konghq.com",
+			wantErr: "must use HTTPS",
+		},
+		{
+			name: "empty scheme", url: "//us.api.konghq.com",
+			wantErr: "must use HTTPS",
+		},
 
 		// untrusted hosts
-		{name: "arbitrary host", url: "https://evil.com",
-			wantErr: "not a trusted konghq.com domain"},
-		{name: "subdomain typosquat", url: "https://us.api.konghq.com.evil.com",
-			wantErr: "not a trusted konghq.com domain"},
-		{name: "konghq.com prefix only", url: "https://konghq.com.evil.com",
-			wantErr: "not a trusted konghq.com domain"},
-		{name: "localhost", url: "https://localhost",
-			wantErr: "not a trusted konghq.com domain"},
-		{name: "link-local", url: "https://169.254.169.254",
-			wantErr: "not a trusted konghq.com domain"},
+		{
+			name: "arbitrary host", url: "https://evil.com",
+			wantErr: "not a trusted konghq.com domain",
+		},
+		{
+			name: "subdomain typosquat", url: "https://us.api.konghq.com.evil.com",
+			wantErr: "not a trusted konghq.com domain",
+		},
+		{
+			name: "konghq.com prefix only", url: "https://konghq.com.evil.com",
+			wantErr: "not a trusted konghq.com domain",
+		},
+		{
+			name: "localhost", url: "https://localhost",
+			wantErr: "not a trusted konghq.com domain",
+		},
+		{
+			name: "link-local", url: "https://169.254.169.254",
+			wantErr: "not a trusted konghq.com domain",
+		},
 
 		// parse errors
-		{name: "invalid URL", url: "://bad-url",
-			wantErr: "invalid Konnect URL"},
+		{
+			name: "invalid URL", url: "://bad-url",
+			wantErr: "invalid Konnect URL",
+		},
 	}
 
 	for _, tt := range tests {
@@ -191,6 +207,7 @@ func TestValidateKonnectURL(t *testing.T) {
 		})
 	}
 }
+
 func TestRequestDeviceCode_NonOKStatus(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/test/e2e/scenarios/apis/nested-child-lifecycle/scenario.yaml
+++ b/test/e2e/scenarios/apis/nested-child-lifecycle/scenario.yaml
@@ -10,7 +10,6 @@ vars:
 defaults:
   mask:
     dropKeys:
-      - id
       - resource_id
       - change_id
       - created_at
@@ -153,12 +152,57 @@ steps:
           contains: "not found"
       - name: 006-get-documents
         run: ["get", "api", "documents", "--api-name", "API Nested", "-o", "json"]
+        recordVar:
+          name: rootDocID
+          responsePath: "[?title=='Root Document'] | [0].id"
         assertions:
+          - select: "[?title=='Root Document'] | [0]"
+            expect:
+              fields:
+                title: "Root Document"
+                slug: "root-document"
+                status: "published"
+                "length(id) > `0`": true
           - select: "[?title=='Child Document'] | [0]"
             expect:
               fields:
                 title: "Child Document"
                 status: "unpublished"
+      - name: 007-get-document-by-title
+        run: ["get", "api", "documents", "--api-name", "API Nested", "Root Document", "-o", "json"]
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                id: "{{ .vars.rootDocID }}"
+                title: "Root Document"
+                slug: "root-document"
+                status: "published"
+      - name: 008-get-document-by-slug
+        run: ["get", "api", "documents", "--api-name", "API Nested", "root-document", "-o", "json"]
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                id: "{{ .vars.rootDocID }}"
+                title: "Root Document"
+                slug: "root-document"
+                status: "published"
+      - name: 009-get-document-by-uuid
+        run: ["get", "api", "documents", "--api-name", "API Nested", "{{ .vars.rootDocID }}", "-o", "json"]
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                id: "{{ .vars.rootDocID }}"
+                title: "Root Document"
+                slug: "root-document"
+                status: "published"
+      - name: 010-get-document-not-found
+        run: ["get", "api", "documents", "--api-name", "API Nested", "nonexistent-document", "-o", "json"]
+        expectFailure:
+          exitCode: 1
+          contains: "not found"
 
   - name: 003-apply-update
     inputOverlayDirs:


### PR DESCRIPTION
## Summary

- expand `apis/nested-child-lifecycle` E2E coverage for `get api documents <identifier>`
- record the root document ID from list output and assert single lookup by title, slug, and UUID
- add a not-found assertion for missing document identifiers
- keep `id` visible in this scenario so the UUID lookup can assert the returned ID
- include mechanical `make format` normalization in `internal/konnect/auth/auth_test.go`

Closes #923.

## Validation

- `make format`
- `make build`
- `make lint`
- `make test`
- `KONGCTL_E2E_ARTIFACTS_DIR=.e2e_artifacts SCENARIO=apis/nested-child-lifecycle make test-e2e-scenarios`

E2E artifacts: `.e2e_artifacts/20260429-125223`