### PR TITLE
Fix: move gateway core entities get & list commands under control plane parent command

### DIFF
--- a/internal/cmd/root/products/konnect/gateway/common/common.go
+++ b/internal/cmd/root/products/konnect/gateway/common/common.go
@@ -36,11 +36,11 @@ func BindControlPlaneFlags(c *cobra.Command, args []string) error {
 func AddControlPlaneFlags(c *cobra.Command) {
 	// ---- CP Identifiers, mutually exclusive
 	c.Flags().String(ControlPlaneIDFlagName, "",
-		fmt.Sprintf(`The ID of the control plane to use for a gateway service command.
+		fmt.Sprintf(`The ID of the control plane to use for a gateway control-plane child command.
 - Config path: [ %s ]`, ControlPlaneIDConfigPath))
 
 	c.Flags().String(ControlPlaneNameFlagName, "",
-		fmt.Sprintf(`The name of the control plane to use for a gateway service command.
+		fmt.Sprintf(`The name of the control plane to use for a gateway control-plane child command.
 - Config path: [ %s ]`, ControlPlaneNameConfigPath))
 	c.MarkFlagsMutuallyExclusive(ControlPlaneIDFlagName, ControlPlaneNameFlagName)
 }

--- a/internal/cmd/root/products/konnect/gateway/consumer/consumer.go
+++ b/internal/cmd/root/products/konnect/gateway/consumer/consumer.go
@@ -20,9 +20,9 @@ var (
 	routeExamples = normalizers.Examples(i18n.T("root.products.konnect.gateway.consumer.consumerExamples",
 		fmt.Sprintf(`
 	# List the Konnect consumers
-	%[1]s get konnect gateway consumers --control-plane-id <id>
-	# Get a specific Konnect route
-	%[1]s get konnect gateway route --control-plane-id <id> <id|name>
+	%[1]s get konnect gateway control-plane consumers --control-plane-id <id>
+	# Get a specific Konnect consumer
+	%[1]s get konnect gateway control-plane consumer --control-plane-id <id> <id|name>
 	`, meta.CLIName)))
 )
 
@@ -35,7 +35,7 @@ func NewConsumerCmd(verb verbs.VerbValue,
 		Short:   routeShort,
 		Long:    routeLong,
 		Example: routeExamples,
-		Aliases: []string{"consumer", "consumers"},
+		Aliases: []string{"consumers"},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return common.BindControlPlaneFlags(cmd, args)
 		},

--- a/internal/cmd/root/products/konnect/gateway/consumer/getConsumer.go
+++ b/internal/cmd/root/products/konnect/gateway/consumer/getConsumer.go
@@ -45,12 +45,12 @@ var (
 	getConsumerExamples = normalizers.Examples(
 		i18n.T("root.products.konnect.gateway.consumer.getConsumerExamples",
 			fmt.Sprintf(`
-	# List all the Kong Gateway Consumers for the a given Control Plane (by ID)
-	%[1]s get konnect gateway consumers --control-plane-id <id>
-	# List all the Kong Gateway Consumers for the a given Control Plane (by name)
-	%[1]s get konnect gateway consumers --control-plane-name <name>
-	# Get a specific Kong Gateway Consumers located on the given Control Plane (by name)
-	%[1]s get konnect gateway consumer --control-plane-name <name> <consumer-name>
+	# List all Kong Gateway Consumers for a given control plane (by ID)
+	%[1]s get konnect gateway control-plane consumers --control-plane-id <id>
+	# List all Kong Gateway Consumers for a given control plane (by name)
+	%[1]s get konnect gateway control-plane consumers --control-plane-name <name>
+	# Get a specific Kong Gateway Consumer located on the given control plane (by name)
+	%[1]s get konnect gateway control-plane consumer --control-plane-name <name> <consumer-name>
 	`, meta.CLIName)))
 )
 
@@ -114,10 +114,10 @@ func (c *getConsumerCmd) runE(cobraCmd *cobra.Command, args []string) error {
 	// TODO!: Fix up the below casting to Konnect SDKs, as it will fail in testing once that is written.
 	//         A service API needs to be added to our internal SDK API interfaces
 
-	// 'get konnect gateway consumers ' can be run like various ways:
-	//	> get konnect gateway consumers <id>				# Get by UUID
-	//  > get konnect gateway consumers <username>	# Get by uname
-	//  > get konnect gateway consumers							# List all
+	// 'get konnect gateway control-plane consumers' can be run in various ways:
+	//	> get konnect gateway control-plane consumers <id>				# Get by UUID
+	//  > get konnect gateway control-plane consumers <username>	# Get by username
+	//  > get konnect gateway control-plane consumers							# List all
 	internalSDK := kkClient.(*helpers.KonnectSDK).SDK
 
 	if len(helper.GetArgs()) == 1 { // validate above checks that args is 0 or 1

--- a/internal/cmd/root/products/konnect/gateway/controlplane/controlplane.go
+++ b/internal/cmd/root/products/konnect/gateway/controlplane/controlplane.go
@@ -3,7 +3,10 @@ package controlplane
 import (
 	"fmt"
 
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/gateway/consumer"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/gateway/dataplanecertificate"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/gateway/route"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/gateway/service"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	"github.com/kong/kongctl/internal/meta"
 	"github.com/kong/kongctl/internal/util/i18n"
@@ -49,15 +52,11 @@ func NewControlPlaneCmd(verb verbs.VerbValue,
 
 	// Handle supported verbs
 	if verb == verbs.Get || verb == verbs.List {
-		cmd := newGetControlPlaneCmd(verb, &baseCmd, addParentFlags, parentPreRun).Command
-		dataPlaneCertificateCmd, err := dataplanecertificate.NewDataPlaneCertificateCmd(
-			verb, addParentFlags, parentPreRun,
-		)
-		if err != nil {
+		getCmd := newGetControlPlaneCmd(verb, &baseCmd, addParentFlags, parentPreRun)
+		if err := addControlPlaneChildCommands(getCmd.Command, verb, addParentFlags, parentPreRun); err != nil {
 			return nil, err
 		}
-		cmd.AddCommand(dataPlaneCertificateCmd)
-		return cmd, nil
+		return getCmd.Command, nil
 	}
 	if verb == verbs.Create {
 		return newCreateControlPlaneCmd(verb, &baseCmd, addParentFlags, parentPreRun).Command, nil
@@ -68,4 +67,32 @@ func NewControlPlaneCmd(verb verbs.VerbValue,
 
 	// Return base command for unsupported verbs
 	return &baseCmd, nil
+}
+
+func addControlPlaneChildCommands(
+	baseCmd *cobra.Command,
+	verb verbs.VerbValue,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) error {
+	childCommandConstructors := []func(
+		verbs.VerbValue,
+		func(verbs.VerbValue, *cobra.Command),
+		func(*cobra.Command, []string) error,
+	) (*cobra.Command, error){
+		dataplanecertificate.NewDataPlaneCertificateCmd,
+		service.NewServiceCmd,
+		route.NewRouteCmd,
+		consumer.NewConsumerCmd,
+	}
+
+	for _, newChildCommand := range childCommandConstructors {
+		childCmd, err := newChildCommand(verb, addParentFlags, parentPreRun)
+		if err != nil {
+			return err
+		}
+		baseCmd.AddCommand(childCmd)
+	}
+
+	return nil
 }

--- a/internal/cmd/root/products/konnect/gateway/gateway.go
+++ b/internal/cmd/root/products/konnect/gateway/gateway.go
@@ -1,12 +1,11 @@
 package gateway
 
 import (
-	"github.com/kong/kongctl/internal/cmd/root/products/konnect/gateway/consumer"
+	"fmt"
+
 	_ "github.com/kong/kongctl/internal/cmd/root/products/konnect/gateway/consumergroup" // register consumer-group child loaders
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/gateway/controlplane"
-	_ "github.com/kong/kongctl/internal/cmd/root/products/konnect/gateway/plugin" // register plugin child loaders
-	"github.com/kong/kongctl/internal/cmd/root/products/konnect/gateway/route"
-	"github.com/kong/kongctl/internal/cmd/root/products/konnect/gateway/service"
+	_ "github.com/kong/kongctl/internal/cmd/root/products/konnect/gateway/plugin"   // register plugin child loaders
 	_ "github.com/kong/kongctl/internal/cmd/root/products/konnect/gateway/upstream" // register upstream child loaders
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	"github.com/kong/kongctl/internal/util/i18n"
@@ -30,27 +29,18 @@ func NewGatewayCmd(verb verbs.VerbValue,
 		Short:   gatewayShort,
 		Long:    gatewayLong,
 		Aliases: []string{"gw", "GW"},
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
 	}
 
 	c, e := controlplane.NewControlPlaneCmd(verb, addParentFlags, parentPreRun)
-	if e != nil {
-		return nil, e
-	}
-	cmd.AddCommand(c)
-
-	c, e = service.NewServiceCmd(verb, addParentFlags, parentPreRun)
-	if e != nil {
-		return nil, e
-	}
-	cmd.AddCommand(c)
-
-	c, e = route.NewRouteCmd(verb, addParentFlags, parentPreRun)
-	if e != nil {
-		return nil, e
-	}
-	cmd.AddCommand(c)
-
-	c, e = consumer.NewConsumerCmd(verb, addParentFlags, parentPreRun)
 	if e != nil {
 		return nil, e
 	}

--- a/internal/cmd/root/products/konnect/gateway/gateway_test.go
+++ b/internal/cmd/root/products/konnect/gateway/gateway_test.go
@@ -1,0 +1,63 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGatewayCoreEntityCommandsAreNestedUnderControlPlane(t *testing.T) {
+	for _, verb := range []verbs.VerbValue{verbs.Get, verbs.List} {
+		t.Run(verb.String(), func(t *testing.T) {
+			cmd, err := NewGatewayCmd(verb, nil, nil)
+			require.NoError(t, err)
+
+			for _, name := range []string{"service", "services", "route", "routes", "consumer", "consumers"} {
+				assert.False(t, hasDirectSubcommand(cmd, name), "gateway should not expose %q directly", name)
+			}
+
+			controlPlaneCmd := directSubcommand(cmd, "control-plane")
+			require.NotNil(t, controlPlaneCmd)
+
+			for _, name := range []string{"service", "services", "route", "routes", "consumer", "consumers"} {
+				assert.True(t, hasDirectSubcommand(controlPlaneCmd, name), "control-plane should expose %q", name)
+			}
+		})
+	}
+}
+
+func TestGatewayCoreEntitySiblingPathsFail(t *testing.T) {
+	for _, name := range []string{"services", "routes", "consumers"} {
+		t.Run(name, func(t *testing.T) {
+			cmd, err := NewGatewayCmd(verbs.Get, nil, nil)
+			require.NoError(t, err)
+
+			cmd.SetArgs([]string{name})
+
+			err = cmd.Execute()
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "unknown command")
+		})
+	}
+}
+
+func directSubcommand(parent *cobra.Command, name string) *cobra.Command {
+	for _, child := range parent.Commands() {
+		if child.Name() == name {
+			return child
+		}
+		for _, alias := range child.Aliases {
+			if alias == name {
+				return child
+			}
+		}
+	}
+	return nil
+}
+
+func hasDirectSubcommand(parent *cobra.Command, name string) bool {
+	return directSubcommand(parent, name) != nil
+}

--- a/internal/cmd/root/products/konnect/gateway/route/getRoute.go
+++ b/internal/cmd/root/products/konnect/gateway/route/getRoute.go
@@ -198,12 +198,12 @@ var (
 	getRouteExamples = normalizers.Examples(
 		i18n.T("root.products.konnect.gateway.route.getRouteExamples",
 			fmt.Sprintf(`
-	# List all the Kong Gateway Routes for the a given Control Plane (by ID)
-	%[1]s get konnect gateway routes --control-plane-id <id>
-	# List all the Kong Gateway Routes for the a given Control Plane (by name)
-	%[1]s get konnect gateway routes --control-plane-name <name>
-	# Get a specific Kong Gateway Routes located on the given Control Plane (by name)
-	%[1]s get konnect gateway route --control-plane-name <name> <route-name>
+	# List all Kong Gateway Routes for a given control plane (by ID)
+	%[1]s get konnect gateway control-plane routes --control-plane-id <id>
+	# List all Kong Gateway Routes for a given control plane (by name)
+	%[1]s get konnect gateway control-plane routes --control-plane-name <name>
+	# Get a specific Kong Gateway Route located on the given control plane (by name)
+	%[1]s get konnect gateway control-plane route --control-plane-name <name> <route-name>
 	`, meta.CLIName)))
 )
 
@@ -382,10 +382,10 @@ func (c *getRouteCmd) runE(cobraCmd *cobra.Command, args []string) error {
 	// TODO!: Fix up the below casting to Konnect SDKs, as it will fail in testing once that is written.
 	//         A service API needs to be added to our internal SDK API interfaces
 
-	// 'get konnect gateway routes ' can be run like various ways:
-	//	> get konnect gateway routes <id>    # Get by UUID
-	//  > get konnect gateway routes <name>	# Get by name
-	//  > get konnect gateway routes # List all
+	// 'get konnect gateway control-plane routes' can be run in various ways:
+	//	> get konnect gateway control-plane routes <id>    # Get by UUID
+	//  > get konnect gateway control-plane routes <name>	# Get by name
+	//  > get konnect gateway control-plane routes # List all
 	if len(helper.GetArgs()) == 1 { // validate above checks that args is 0 or 1
 		id := helper.GetArgs()[0]
 

--- a/internal/cmd/root/products/konnect/gateway/route/route.go
+++ b/internal/cmd/root/products/konnect/gateway/route/route.go
@@ -20,9 +20,9 @@ var (
 	routeExamples = normalizers.Examples(i18n.T("root.products.konnect.gateway.route.routeExamples",
 		fmt.Sprintf(`
 	# List the Konnect routes 
-	%[1]s get konnect gateway routes --control-plane-id <id>
+	%[1]s get konnect gateway control-plane routes --control-plane-id <id>
 	# Get a specific Konnect route
-	%[1]s get konnect gateway route --control-plane-id <id> <id|name>
+	%[1]s get konnect gateway control-plane route --control-plane-id <id> <id|name>
 	`, meta.CLIName)))
 )
 

--- a/internal/cmd/root/products/konnect/gateway/service/getService.go
+++ b/internal/cmd/root/products/konnect/gateway/service/getService.go
@@ -168,10 +168,10 @@ var (
 	getServiceExamples = normalizers.Examples(
 		i18n.T("root.products.konnect.gateway.service.getServiceExamples",
 			fmt.Sprintf(`
-	# List all the Gateway Services for the a given control plane
-	%[1]s get konnect gateway service --control-plane-id <id>
-	# Get a specific Kong Gateway Services for the a given control plane
-	%[1]s get konnect gateway service --control-plane-id <id> <service-name>
+	# List all Gateway Services for a given control plane
+	%[1]s get konnect gateway control-plane services --control-plane-id <id>
+	# Get a specific Kong Gateway Service for a given control plane
+	%[1]s get konnect gateway control-plane service --control-plane-id <id> <service-name>
 	`, meta.CLIName)))
 )
 
@@ -358,10 +358,10 @@ func (c *getServiceCmd) runE(cobraCmd *cobra.Command, args []string) error {
 	// TODO!: Fix up the below casting to Konnect SDKs, as it will fail in testing once that is written.
 	//         A service API needs to be added to our internal SDK API interfaces
 
-	// 'get konnect gateway services' can be run like various ways:
-	//	> get konnect gateway services <id>    # Get by UUID
-	//  > get konnect gateway services <name>	# Get by name
-	//  > get konnect gateway services # List all
+	// 'get konnect gateway control-plane services' can be run in various ways:
+	//	> get konnect gateway control-plane services <id>    # Get by UUID
+	//  > get konnect gateway control-plane services <name>	# Get by name
+	//  > get konnect gateway control-plane services # List all
 	if len(helper.GetArgs()) == 1 { // validate above checks that args is 0 or 1
 		id := helper.GetArgs()[0]
 

--- a/internal/cmd/root/products/konnect/gateway/service/service.go
+++ b/internal/cmd/root/products/konnect/gateway/service/service.go
@@ -19,10 +19,10 @@ var (
 		`The gateway service command allows you to work with Konnect Kong Gateway Service resources.`))
 	serviceExamples = normalizers.Examples(i18n.T("root.products.konnect.gateway.service.serviceExamples",
 		fmt.Sprintf(`
-	# List the Konnect Kong Gateway Services for the current organization
-	%[1]s get konnect gateway services 
-	# Get a specific Konnect Kong Gateway Service 
-	%[1]s get konnect gateway service <id|name>
+	# List the Konnect Kong Gateway Services for a control plane
+	%[1]s get konnect gateway control-plane services --control-plane-name <name>
+	# Get a specific Konnect Kong Gateway Service in a control plane
+	%[1]s get konnect gateway control-plane service <id|name> --control-plane-name <name>
 	`, meta.CLIName)))
 )
 

--- a/internal/cmd/root/verbs/create/gateway.go
+++ b/internal/cmd/root/verbs/create/gateway.go
@@ -59,13 +59,7 @@ Setting this value overrides tokens obtained from the login command.
 
 	// Override the example to show direct usage without "konnect"
 	gatewayCmd.Example = `  # Create a new control plane
-  kongctl create gateway control-plane <name>
-  # Create a new service in a control plane
-  kongctl create gateway service <name> --control-plane <id|name>
-  # Create a new route in a control plane
-  kongctl create gateway route <name> --control-plane <id|name>
-  # Create a new consumer in a control plane
-  kongctl create gateway consumer <name> --control-plane <id|name>`
+  kongctl create gateway control-plane <name>`
 
 	return gatewayCmd, nil
 }

--- a/internal/cmd/root/verbs/get/gateway.go
+++ b/internal/cmd/root/verbs/get/gateway.go
@@ -72,9 +72,9 @@ Setting this value overrides tokens obtained from the login command.
   # Get a specific control plane
   kongctl get gateway control-plane <id|name>
   # List services in a control plane
-  kongctl get gateway services --control-plane <id|name>
+  kongctl get gateway control-plane services --control-plane-name <name>
   # Get a specific service
-  kongctl get gateway service <id|name> --control-plane <id|name>`
+  kongctl get gateway control-plane service <id|name> --control-plane-name <name>`
 
 	return gatewayCmd, nil
 }

--- a/internal/cmd/root/verbs/list/gateway.go
+++ b/internal/cmd/root/verbs/list/gateway.go
@@ -70,11 +70,11 @@ Setting this value overrides tokens obtained from the login command.
 	gatewayCmd.Example = `  # List all control planes
   kongctl list gateway control-planes
   # List services in a control plane
-  kongctl list gateway services --control-plane <id|name>
+  kongctl list gateway control-plane services --control-plane-name <name>
   # List routes in a control plane
-  kongctl list gateway routes --control-plane <id|name>
+  kongctl list gateway control-plane routes --control-plane-name <name>
   # List consumers in a control plane
-  kongctl list gateway consumers --control-plane <id|name>`
+  kongctl list gateway control-plane consumers --control-plane-name <name>`
 
 	return gatewayCmd, nil
 }

--- a/test/e2e/scenarios/deck/basic/scenario.yaml
+++ b/test/e2e/scenarios/deck/basic/scenario.yaml
@@ -67,6 +67,7 @@ steps:
         run:
           - get
           - gw
+          - cp
           - services
           - --control-plane-name
           - "e2e-cp"
@@ -206,6 +207,7 @@ steps:
         run:
           - get
           - gw
+          - cp
           - services
           - --control-plane-name
           - "e2e-cp"

--- a/test/e2e/scenarios/deck/multi-file/scenario.yaml
+++ b/test/e2e/scenarios/deck/multi-file/scenario.yaml
@@ -58,6 +58,7 @@ steps:
         run:
           - get
           - gw
+          - cp
           - services
           - --control-plane-name
           - "e2e-cp"

--- a/test/e2e/scenarios/deck/sync/scenario.yaml
+++ b/test/e2e/scenarios/deck/sync/scenario.yaml
@@ -37,6 +37,7 @@ steps:
         run:
           - get
           - gw
+          - cp
           - services
           - --control-plane-name
           - "code-breakers"


### PR DESCRIPTION
## Summary

Reworks the existing gateway core-entity get/list command layout so services, routes, and consumers live under the gateway control-plane command instead of as siblings of control-plane.

## Changes

- Removed direct `gateway service`, `gateway route`, and `gateway consumer` registrations for get/list.
- Registered those existing commands under `gateway control-plane`, including aliases like `gw cp services`.
- Added command-tree coverage to assert stale sibling paths are gone and child commands are available under control planes.
- Updated gateway help examples and deck e2e validation commands to use `get gw cp services --control-plane-name ...`.

## Validation

- `make format`
- `make build`
- `make test`
- `make lint`
- Manual CLI checks for old sibling paths and new nested paths

Closes #937