### PR TITLE
Fix: api sub-command default json output and ignore text config

### DIFF
--- a/internal/cmd/root/verbs/api/api.go
+++ b/internal/cmd/root/verbs/api/api.go
@@ -269,10 +269,13 @@ func run(helper cmd.Helper, method string, allowBody bool) error {
 		return err
 	}
 	if outType == cmdcommon.TEXT {
-		return &cmd.ConfigurationError{
-			Err: fmt.Errorf("%s command supports only json or yaml output formats (received %q)",
-				helper.GetCmd().CommandPath(), outType.String()),
+		if helper.GetCmd().Flags().Changed(cmdcommon.OutputFlagName) {
+			return &cmd.ConfigurationError{
+				Err: fmt.Errorf("%s command supports only json or yaml output formats (received %q)",
+					helper.GetCmd().CommandPath(), outType.String()),
+			}
 		}
+		outType = cmdcommon.JSON
 	}
 
 	jqSettings, err := jqoutput.ResolveSettings(helper.GetCmd(), cfg)

--- a/internal/cmd/root/verbs/api/api_test.go
+++ b/internal/cmd/root/verbs/api/api_test.go
@@ -847,9 +847,96 @@ func TestRunRejectsJQRawOutputWithYAMLOutput(t *testing.T) {
 	require.Contains(t, err.Error(), "--output json")
 }
 
-func TestRunRejectsTextOutputFormat(t *testing.T) {
+func TestRunUsesJSONForImplicitTextOutputFormat(t *testing.T) {
 	original := requestFn
 	t.Cleanup(func() { requestFn = original })
+
+	requestFn = func(
+		_ context.Context,
+		_ apiutil.Doer,
+		_ string,
+		_ string,
+		_ string,
+		_ string,
+		_ map[string]string,
+		_ io.Reader,
+	) (*apiutil.Result, error) {
+		return &apiutil.Result{StatusCode: http.StatusOK, Body: []byte(`{"ok":true}`)}, nil
+	}
+
+	streams := iostreams.NewTestIOStreamsOnly()
+	cmdObj := &cobra.Command{Use: "test"}
+	addFlags(cmdObj)
+
+	cfg := newMockAPIConfig()
+
+	args := []string{"/v1/resources"}
+	helper := &cmdtest.MockHelper{
+		GetCmdMock:          func() *cobra.Command { return cmdObj },
+		GetArgsMock:         func() []string { return args },
+		GetStreamsMock:      func() *iostreams.IOStreams { return streams },
+		GetConfigMock:       func() (configpkg.Hook, error) { return cfg, nil },
+		GetOutputFormatMock: func() (cmdcommon.OutputFormat, error) { return cmdcommon.TEXT, nil },
+		GetLoggerMock: func() (*slog.Logger, error) {
+			return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{})), nil
+		},
+		GetContextMock: func() context.Context { return context.Background() },
+	}
+
+	err := run(helper, http.MethodGet, false)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"ok":true}`, strings.TrimSpace(streams.Out.(*bytes.Buffer).String()))
+}
+
+func TestRunRendersYAMLOutput(t *testing.T) {
+	original := requestFn
+	t.Cleanup(func() { requestFn = original })
+
+	requestFn = func(
+		_ context.Context,
+		_ apiutil.Doer,
+		_ string,
+		_ string,
+		_ string,
+		_ string,
+		_ map[string]string,
+		_ io.Reader,
+	) (*apiutil.Result, error) {
+		return &apiutil.Result{StatusCode: http.StatusOK, Body: []byte(`{"ok":true}`)}, nil
+	}
+
+	streams := iostreams.NewTestIOStreamsOnly()
+	cmdObj := &cobra.Command{Use: "test"}
+	addFlags(cmdObj)
+	cmdObj.Flags().StringP(
+		cmdcommon.OutputFlagName, cmdcommon.OutputFlagShort, cmdcommon.DefaultOutputFormat, "Output format",
+	)
+	require.NoError(t, cmdObj.Flags().Set(cmdcommon.OutputFlagName, cmdcommon.YAML.String()))
+
+	cfg := newMockAPIConfig()
+
+	args := []string{"/v1/resources"}
+	helper := &cmdtest.MockHelper{
+		GetCmdMock:          func() *cobra.Command { return cmdObj },
+		GetArgsMock:         func() []string { return args },
+		GetStreamsMock:      func() *iostreams.IOStreams { return streams },
+		GetConfigMock:       func() (configpkg.Hook, error) { return cfg, nil },
+		GetOutputFormatMock: func() (cmdcommon.OutputFormat, error) { return cmdcommon.YAML, nil },
+		GetLoggerMock: func() (*slog.Logger, error) {
+			return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{})), nil
+		},
+		GetContextMock: func() context.Context { return context.Background() },
+	}
+
+	err := run(helper, http.MethodGet, false)
+	require.NoError(t, err)
+	require.Contains(t, streams.Out.(*bytes.Buffer).String(), "ok: true")
+}
+
+func TestRunRejectsExplicitTextOutputFormat(t *testing.T) {
+	original := requestFn
+	t.Cleanup(func() { requestFn = original })
+
 	requestFn = func(
 		context.Context,
 		apiutil.Doer,
@@ -867,6 +954,10 @@ func TestRunRejectsTextOutputFormat(t *testing.T) {
 	streams := iostreams.NewTestIOStreamsOnly()
 	cmdObj := &cobra.Command{Use: "test"}
 	addFlags(cmdObj)
+	cmdObj.Flags().StringP(
+		cmdcommon.OutputFlagName, cmdcommon.OutputFlagShort, cmdcommon.DefaultOutputFormat, "Output format",
+	)
+	require.NoError(t, cmdObj.Flags().Set(cmdcommon.OutputFlagName, cmdcommon.TEXT.String()))
 
 	cfg := newMockAPIConfig()
 


### PR DESCRIPTION
## Summary

Fixes `kongctl api` so an inherited/default `output: text` configuration no longer makes the command fail out of the box.

## Root Cause

The raw `api` verb only supports structured response rendering, but it rejected the resolved `text` output format unconditionally. Since kongctl defaults to `text`, users without an explicit output override hit a configuration error before the request ran.

## Changes

- Treat implicit/default `text` output as `json` for the `api` verb.
- Preserve the existing configuration error when users explicitly pass `-o text` or `--output text`.
- Add tests for implicit text fallback, YAML output, and explicit text rejection.

Closes #910.

## Validation

- `make format`
- `go test ./internal/cmd/root/verbs/api`
- `make build`
- `make test`
- `make lint`