### PR TITLE
Test: cover portal custom domain replanning

### DIFF
--- a/test/e2e/scenarios/portal/custom-domain/overlays/004-replace-http-domain/config.yaml
+++ b/test/e2e/scenarios/portal/custom-domain/overlays/004-replace-http-domain/config.yaml
@@ -1,0 +1,17 @@
+_defaults:
+  kongctl:
+    namespace: portal-custom-domain
+
+portals:
+  - ref: portal-1
+    name: "portal-1"
+    display_name: "Portal 1"
+    description: "Portal using HTTP verification for its custom domain"
+    kongctl:
+      namespace: portal-custom-domain
+    custom_domain:
+      ref: portal-1-custom-domain
+      hostname: "{{ .vars.portal1ReplacementHostname }}"
+      enabled: true
+      ssl:
+        domain_verification_method: http

--- a/test/e2e/scenarios/portal/custom-domain/overlays/005-disable-http-domain/config.yaml
+++ b/test/e2e/scenarios/portal/custom-domain/overlays/005-disable-http-domain/config.yaml
@@ -1,0 +1,17 @@
+_defaults:
+  kongctl:
+    namespace: portal-custom-domain
+
+portals:
+  - ref: portal-1
+    name: "portal-1"
+    display_name: "Portal 1"
+    description: "Portal using HTTP verification for its custom domain"
+    kongctl:
+      namespace: portal-custom-domain
+    custom_domain:
+      ref: portal-1-custom-domain
+      hostname: "{{ .vars.portal1ReplacementHostname }}"
+      enabled: false
+      ssl:
+        domain_verification_method: http

--- a/test/e2e/scenarios/portal/custom-domain/overlays/006-remove-http-domain-retain-portal/config.yaml
+++ b/test/e2e/scenarios/portal/custom-domain/overlays/006-remove-http-domain-retain-portal/config.yaml
@@ -1,0 +1,11 @@
+_defaults:
+  kongctl:
+    namespace: portal-custom-domain
+
+portals:
+  - ref: portal-1
+    name: "portal-1"
+    display_name: "Portal 1"
+    description: "Portal using HTTP verification for its custom domain"
+    kongctl:
+      namespace: portal-custom-domain

--- a/test/e2e/scenarios/portal/custom-domain/scenario.yaml
+++ b/test/e2e/scenarios/portal/custom-domain/scenario.yaml
@@ -8,6 +8,7 @@ vars:
   portal1Ref: portal-1
   portal1DomainRef: portal-1-custom-domain
   portal1Hostname: ""
+  portal1ReplacementHostname: ""
   portal2Ref: portal-2
   portal2DomainRef: portal-2-custom-domain
   portal2Hostname: ""
@@ -48,6 +49,18 @@ steps:
             printf 'portal2-cert-%s.kongctl-e2e.io' "$(date +%s%N | sha256sum | cut -c1-10)"
         recordVar:
           name: portal2Hostname
+          responsePath: stdout
+
+      - name: 002-generate-portal1-replacement-hostname
+        parseAs: raw
+        exec:
+          - bash
+          - -c
+          - |
+            set -euo pipefail
+            printf 'portal1-replacement-%s.kongctl-e2e.io' "$(date +%s%N | sha256sum | cut -c1-10)"
+        recordVar:
+          name: portal1ReplacementHostname
           responsePath: stdout
 
   - name: 000-reset-org
@@ -110,6 +123,24 @@ steps:
               fields:
                 name: "{{ .vars.portal1Ref }}"
                 canonical_domain: "{{ .vars.portal1Hostname }}"
+      - name: 003-plan-http-domain-no-op
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-http-domain-no-op.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+          - select: "changes[?resource_type=='portal_custom_domain']"
+            expect:
+              fields:
+                "length(@)": 0
 
   - name: 002-plan-apply-custom-certificate
     inputOverlayDirs:
@@ -233,3 +264,186 @@ steps:
             expect:
               fields:
                 canonical_domain: "{{ .vars.portal1Hostname }}"
+
+  - name: 004-replace-http-domain
+    inputOverlayDirs:
+      - overlays/004-replace-http-domain
+    commands:
+      - name: 000-plan-replace-http-domain
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-replace-http-domain.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 2
+                by_action.DELETE: 1
+                by_action.CREATE: 1
+          - select: >-
+              changes[?resource_type=='portal_custom_domain' && action=='DELETE' &&
+              resource_ref=='{{ .vars.portal1DomainRef }}']
+            expect:
+              fields:
+                "length(@)": 1
+          - select: >-
+              changes[?resource_type=='portal_custom_domain' && action=='CREATE' &&
+              resource_ref=='{{ .vars.portal1DomainRef }}'] | [0]
+            expect:
+              fields:
+                "fields.hostname": "{{ .vars.portal1ReplacementHostname }}"
+                "fields.enabled": true
+                "fields.ssl.domain_verification_method": http
+      - name: 001-sync-replace-http-domain
+        outputFormat: json
+        run:
+          - sync
+          - --plan
+          - "{{ .workdir }}/plan-replace-http-domain.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 2
+                failed: 0
+      - name: 002-get-portals-replacement
+        run: ["get", "portals", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.portal1Ref }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.portal1Ref }}"
+                canonical_domain: "{{ .vars.portal1ReplacementHostname }}"
+      - name: 003-plan-replacement-no-op
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-replacement-no-op.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+          - select: "changes[?resource_type=='portal_custom_domain']"
+            expect:
+              fields:
+                "length(@)": 0
+
+  - name: 005-update-http-domain-enabled
+    inputOverlayDirs:
+      - overlays/005-disable-http-domain
+    commands:
+      - name: 000-plan-disable-http-domain
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-disable-http-domain.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+          - select: >-
+              changes[?resource_type=='portal_custom_domain' && action=='UPDATE' &&
+              resource_ref=='{{ .vars.portal1DomainRef }}'] | [0]
+            expect:
+              fields:
+                "fields.enabled": false
+                "changed_fields.enabled.new": false
+      - name: 001-apply-disable-http-domain
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-disable-http-domain.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 002-plan-disable-no-op
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-disable-no-op.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+          - select: "changes[?resource_type=='portal_custom_domain']"
+            expect:
+              fields:
+                "length(@)": 0
+
+  - name: 006-sync-remove-http-domain-retain-portal
+    inputOverlayDirs:
+      - overlays/006-remove-http-domain-retain-portal
+    commands:
+      - name: 000-plan-remove-http-domain
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-remove-http-domain.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: >-
+              changes[?resource_type=='portal_custom_domain' && action=='DELETE' &&
+              resource_ref=='{{ .vars.portal1Ref }}__custom_domain']
+            expect:
+              fields:
+                "length(@)": 1
+      - name: 001-sync-remove-http-domain
+        outputFormat: json
+        run:
+          - sync
+          - --plan
+          - "{{ .workdir }}/plan-remove-http-domain.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 002-get-portals-domain-removed
+        run: ["get", "portals", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.portal1Ref }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.portal1Ref }}"
+          - select: >-
+              [?name=='{{ .vars.portal1Ref }}'] | [0].canonical_domain != '{{ .vars.portal1ReplacementHostname }}'
+            expect:
+              fields:
+                "@": true


### PR DESCRIPTION
## Summary

Adds focused e2e coverage for portal custom-domain replanning behavior related to #153.

## Changes

- Adds an apply-then-plan no-op assertion for a portal custom domain.
- Adds coverage for hostname replacement as DELETE+CREATE, followed by a no-op plan.
- Adds coverage for enabled-only UPDATE, followed by a no-op plan.
- Adds sync removal coverage where the portal is retained and only its custom domain is deleted.

## Why

Issue #153 reported that portal custom domains were repeatedly planned as CREATE after apply. The implementation now has unit coverage and appears fixed, but the existing e2e scenario only covered this indirectly. These steps make the regression explicit in the live scenario.

## Validation

- `go test ./internal/declarative/planner`
- `KONGCTL_E2E_SCENARIO=portal/custom-domain KONGCTL_E2E_SKIP_STEPS='*' go test -tags=e2e ./test/e2e -run Test_Scenarios -count=1`
- YAML parse check for the modified scenario and overlays
- `git diff --check`

Closes #153