### PR TITLE
Fix: properly resolve portal app auth strategy refs

### DIFF
--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -822,6 +822,33 @@ func (e *Executor) syncResolvedDCRProviderID(
 	return nil
 }
 
+func (e *Executor) syncResolvedPortalDefaultAuthStrategyID(
+	ctx context.Context,
+	change *planner.PlannedChange,
+) error {
+	if change == nil {
+		return nil
+	}
+
+	authStrategyRef, ok := change.References[planner.FieldDefaultApplicationStrategyID]
+	if !ok {
+		return nil
+	}
+
+	if unresolvedReferenceID(authStrategyRef.ID) {
+		authStrategyID, err := e.resolveAuthStrategyRef(ctx, authStrategyRef)
+		if err != nil {
+			return fmt.Errorf("failed to resolve auth strategy reference: %w", err)
+		}
+		authStrategyRef.ID = authStrategyID
+		change.References[planner.FieldDefaultApplicationStrategyID] = authStrategyRef
+	}
+
+	change.Fields[planner.FieldDefaultApplicationStrategyID] = authStrategyRef.ID
+
+	return nil
+}
+
 // resolvePortalRef resolves a portal reference to its ID
 func (e *Executor) resolvePortalRef(ctx context.Context, refInfo planner.ReferenceInfo) (string, error) {
 	// First check if the reference already has an ID (resolved from dependency)
@@ -1613,19 +1640,8 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 
 	switch change.ResourceType {
 	case planner.ResourceTypePortal:
-		// Resolve auth strategy reference if present
-		if authStrategyRef, ok := change.References[planner.FieldDefaultApplicationStrategyID]; ok &&
-			authStrategyRef.ID == "" {
-			authStrategyID, err := e.resolveAuthStrategyRef(ctx, authStrategyRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve auth strategy reference: %w", err)
-			}
-			// Update the reference with the resolved ID
-			authStrategyRef.ID = authStrategyID
-			change.References[planner.FieldDefaultApplicationStrategyID] = authStrategyRef
-
-			// Also update the field value to use the resolved ID instead of the placeholder
-			change.Fields[planner.FieldDefaultApplicationStrategyID] = authStrategyID
+		if err := e.syncResolvedPortalDefaultAuthStrategyID(ctx, change); err != nil {
+			return "", err
 		}
 		return e.portalExecutor.Create(ctx, *change)
 	case planner.ResourceTypeControlPlane:
@@ -2132,6 +2148,9 @@ func (e *Executor) updateResource(ctx context.Context, change *planner.PlannedCh
 
 	switch change.ResourceType {
 	case planner.ResourceTypePortal:
+		if err := e.syncResolvedPortalDefaultAuthStrategyID(ctx, change); err != nil {
+			return "", err
+		}
 		return e.portalExecutor.Update(ctx, *change)
 	case planner.ResourceTypeControlPlane:
 		id, err := e.controlPlaneExecutor.Update(ctx, *change)

--- a/internal/declarative/executor/portal_adapter.go
+++ b/internal/declarative/executor/portal_adapter.go
@@ -2,7 +2,7 @@ package executor
 
 import (
 	"context"
-	"strings"
+	"fmt"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/kong/kongctl/internal/declarative/common"
@@ -52,12 +52,11 @@ func (p *PortalAdapter) MapCreateFields(_ context.Context, execCtx *ExecutionCon
 	}
 
 	if defaultAppAuthStrategyID, ok := fields[planner.FieldDefaultApplicationStrategyID].(string); ok {
-		// Defensive: skip if this is a reference placeholder that wasn't resolved
-		// (should have been resolved by executor, but be defensive)
-		if !strings.HasPrefix(defaultAppAuthStrategyID, tags.RefPlaceholderPrefix) {
-			create.DefaultApplicationAuthStrategyID = &defaultAppAuthStrategyID
+		if tags.IsRefPlaceholder(defaultAppAuthStrategyID) {
+			return fmt.Errorf("unresolved auth strategy reference for %s: %s",
+				planner.FieldDefaultApplicationStrategyID, defaultAppAuthStrategyID)
 		}
-		// If it's still a placeholder, skip setting it to avoid sending invalid data to API
+		create.DefaultApplicationAuthStrategyID = &defaultAppAuthStrategyID
 	}
 
 	// Handle labels using centralized helper
@@ -112,11 +111,11 @@ func (p *PortalAdapter) MapUpdateFields(_ context.Context, execCtx *ExecutionCon
 			}
 		case planner.FieldDefaultApplicationStrategyID:
 			if authID, ok := value.(string); ok {
-				// Defensive: skip if this is a reference placeholder that wasn't resolved
-				if !strings.HasPrefix(authID, tags.RefPlaceholderPrefix) {
-					update.DefaultApplicationAuthStrategyID = &authID
+				if tags.IsRefPlaceholder(authID) {
+					return fmt.Errorf("unresolved auth strategy reference for %s: %s",
+						planner.FieldDefaultApplicationStrategyID, authID)
 				}
-				// If it's still a placeholder, skip setting it to avoid sending invalid data to API
+				update.DefaultApplicationAuthStrategyID = &authID
 			}
 		case planner.FieldDefaultAPIVisibility:
 			if visibility, ok := value.(string); ok {

--- a/internal/declarative/executor/portal_operations_test.go
+++ b/internal/declarative/executor/portal_operations_test.go
@@ -237,6 +237,54 @@ func TestExecutor_createPortal(t *testing.T) {
 	}
 }
 
+func TestExecutor_createResourcePortalResolvesUnknownAuthStrategyReferenceBeforeCreate(t *testing.T) {
+	mockAPI := new(MockPortalAPI)
+	var gotPortal kkComps.CreatePortal
+
+	mockAPI.On("CreatePortal", mock.Anything, mock.MatchedBy(func(portal kkComps.CreatePortal) bool {
+		gotPortal = portal
+		return true
+	})).Return(&kkOps.CreatePortalResponse{
+		PortalResponse: &kkComps.PortalResponse{
+			ID: "portal-123",
+		},
+	}, nil).Once()
+
+	client := state.NewClient(state.ClientConfig{
+		PortalAPI: mockAPI,
+	})
+	executor := New(client, nil, false)
+	executor.refToID[planner.ResourceTypeApplicationAuthStrategy] = map[string]string{
+		"portal-default-strategy": "11111111-1111-4111-8111-111111111111",
+	}
+
+	change := planner.PlannedChange{
+		ResourceType: planner.ResourceTypePortal,
+		ResourceRef:  "simple-portal",
+		Action:       planner.ActionCreate,
+		Namespace:    "default",
+		Fields: map[string]any{
+			planner.FieldName:                         "simple-portal",
+			planner.FieldDefaultApplicationStrategyID: "__REF__:portal-default-strategy#id",
+		},
+		References: map[string]planner.ReferenceInfo{
+			planner.FieldDefaultApplicationStrategyID: {
+				Ref: "__REF__:portal-default-strategy#id",
+				ID:  "[unknown]",
+			},
+		},
+	}
+
+	id, err := executor.createResource(testContextWithLogger(), &change)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "portal-123", id)
+	if assert.NotNil(t, gotPortal.DefaultApplicationAuthStrategyID) {
+		assert.Equal(t, "11111111-1111-4111-8111-111111111111", *gotPortal.DefaultApplicationAuthStrategyID)
+	}
+	mockAPI.AssertExpectations(t)
+}
+
 func TestExecutor_updatePortal(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/test/e2e/scenarios/portal/default_application_auth_strategy/scenario.yaml
+++ b/test/e2e/scenarios/portal/default_application_auth_strategy/scenario.yaml
@@ -43,7 +43,20 @@ steps:
                 skipped: 0
                 status: "success"
                 total_changes: 2
-      - name: 001-re-apply-no-op
+        recordVar:
+          name: authStrategyV1ID
+          responsePath: >-
+            execution.applied_changes[?resource_ref=='apikey-app-auth-strategy'] | [0].resource_id
+      - name: 001-get-portals-verify-v1
+        run:
+          - get
+          - portals
+        assertions:
+          - select: "[?name=='My Simple Portal'] | [0]"
+            expect:
+              fields:
+                default_application_auth_strategy_id: "{{ .vars.authStrategyV1ID }}"
+      - name: 002-re-apply-no-op
         run:
           - apply
           - -f

--- a/test/e2e/scenarios/portal/default_application_auth_strategy_ref_selection/overlays/001-distractor/config.yaml
+++ b/test/e2e/scenarios/portal/default_application_auth_strategy_ref_selection/overlays/001-distractor/config.yaml
@@ -1,0 +1,11 @@
+application_auth_strategies:
+  - ref: aaa-distractor-app-auth-strategy
+    name: aaa-distractor-app-auth-strategy
+    display_name: Distractor API Key Authentication
+    strategy_type: key_auth
+    configs:
+      key-auth:
+        key_names:
+          - X-Distractor-Key
+
+portals: []

--- a/test/e2e/scenarios/portal/default_application_auth_strategy_ref_selection/overlays/002-target-portal/config.yaml
+++ b/test/e2e/scenarios/portal/default_application_auth_strategy_ref_selection/overlays/002-target-portal/config.yaml
@@ -1,0 +1,32 @@
+application_auth_strategies:
+  - ref: aaa-distractor-app-auth-strategy
+    name: aaa-distractor-app-auth-strategy
+    display_name: Distractor API Key Authentication
+    strategy_type: key_auth
+    configs:
+      key-auth:
+        key_names:
+          - X-Distractor-Key
+  - ref: mmm-target-app-auth-strategy
+    name: mmm-target-app-auth-strategy
+    display_name: Target API Key Authentication
+    strategy_type: key_auth
+    configs:
+      key-auth:
+        key_names:
+          - X-Target-Key
+  - ref: zzz-distractor-app-auth-strategy
+    name: zzz-distractor-app-auth-strategy
+    display_name: Later Distractor API Key Authentication
+    strategy_type: key_auth
+    configs:
+      key-auth:
+        key_names:
+          - X-Later-Distractor-Key
+
+portals:
+  - ref: ref-selection-portal
+    name: Ref Selection Portal
+    display_name: Ref Selection Portal
+    description: Verifies default_application_auth_strategy_id follows the referenced strategy.
+    default_application_auth_strategy_id: !ref mmm-target-app-auth-strategy#id

--- a/test/e2e/scenarios/portal/default_application_auth_strategy_ref_selection/scenario.yaml
+++ b/test/e2e/scenarios/portal/default_application_auth_strategy_ref_selection/scenario.yaml
@@ -1,0 +1,97 @@
+baseInputsPath: testdata
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-create-distractor-strategy
+    inputOverlayDirs:
+      - overlays/001-distractor
+    commands:
+      - name: 000-apply
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+                total_changes: 1
+          - select: >-
+              execution.applied_changes[?resource_type=='application_auth_strategy' &&
+                            resource_ref=='aaa-distractor-app-auth-strategy'] | [0]
+            expect:
+              fields:
+                action: CREATE
+
+  - name: 002-create-target-and-portal
+    inputOverlayDirs:
+      - overlays/002-target-portal
+    commands:
+      - name: 000-apply
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 3
+                failed: 0
+                total_changes: 3
+          - select: >-
+              execution.applied_changes[?resource_type=='application_auth_strategy' &&
+                            resource_ref=='mmm-target-app-auth-strategy'] | [0]
+            expect:
+              fields:
+                action: CREATE
+          - select: >-
+              execution.applied_changes[?resource_type=='application_auth_strategy' &&
+                            resource_ref=='zzz-distractor-app-auth-strategy'] | [0]
+            expect:
+              fields:
+                action: CREATE
+          - select: >-
+              execution.applied_changes[?resource_type=='portal' &&
+                            resource_ref=='ref-selection-portal'] | [0]
+            expect:
+              fields:
+                action: CREATE
+        recordVar:
+          name: targetAuthStrategyID
+          responsePath: >-
+            execution.applied_changes[?resource_ref=='mmm-target-app-auth-strategy'] | [0].resource_id
+      - name: 001-get-portals-verify-target
+        run:
+          - get
+          - portals
+        assertions:
+          - select: "[?name=='Ref Selection Portal'] | [0]"
+            expect:
+              fields:
+                default_application_auth_strategy_id: "{{ .vars.targetAuthStrategyID }}"
+
+  - name: 003-delete-cleanup
+    inputOverlayDirs:
+      - overlays/002-target-portal
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/portal/default_application_auth_strategy_ref_selection/testdata/config.yaml
+++ b/test/e2e/scenarios/portal/default_application_auth_strategy_ref_selection/testdata/config.yaml
@@ -1,0 +1,2 @@
+application_auth_strategies: []
+portals: []


### PR DESCRIPTION
## Summary

Fixes declarative portal creation/update so `default_application_auth_strategy_id` references are resolved before request mapping, including references marked with the planner's `[unknown]` sentinel for resources created earlier in the same execution.

## Root Cause

Portal default auth strategy references were planned correctly, but executor create handling only resolved references with an empty ID. Same-plan references use `[unknown]`, so the portal adapter received the original `__REF__:` placeholder and silently omitted the field from the Konnect request. In simple cases Konnect could mask this by choosing the only available auth strategy as the default; with multiple strategies the portal could be assigned the wrong default.

## Changes

- Resolve portal default auth strategy references when the planned ID is empty or `[unknown]`.
- Apply the same resolution path before portal updates.
- Return an explicit error if an unresolved auth strategy placeholder reaches portal request mapping.
- Add a unit regression test for the executor resolution path.
- Add E2E coverage that uses distractor strategies to verify the referenced strategy is selected.
- Strengthen the existing default auth strategy E2E scenario to verify the initial `!ref` relationship.

Fixes #91.

## Validation

- `go test ./internal/declarative/executor -run TestExecutor_createResourcePortalResolvesUnknownAuthStrategyReferenceBeforeCreate -count=1`
- `go test ./internal/declarative/executor ./internal/declarative/planner ./internal/declarative/loader`
- `make test-e2e-scenarios SCENARIO=portal/default_application_auth_strategy_ref_selection`
- `make test-e2e-scenarios SCENARIO=portal/default_application_auth_strategy`
- `make build`
- `make lint`