### PR TITLE
Test: Add `all` resources e2e scenario

### DIFF
--- a/internal/declarative/planner/event_gateway_static_key_planner.go
+++ b/internal/declarative/planner/event_gateway_static_key_planner.go
@@ -3,6 +3,7 @@ package planner
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/kong/kongctl/internal/declarative/resources"
 	"github.com/kong/kongctl/internal/declarative/state"
@@ -243,8 +244,9 @@ func (p *Planner) planStaticKeyDelete(
 }
 
 // doesStaticKeyNeedChange checks whether a static key needs to be replaced.
-// The API returns the stored value when it is a vault reference, but omits plaintext values. Compare values only
-// when Konnect returned one; an omitted current value is treated as an unchanged write-only secret.
+// The API returns the stored value when it is a secret reference, but omits plaintext values. Compare values only
+// when Konnect returned one; an omitted current value is treated as unchanged plaintext unless the desired value
+// is a reference that Konnect would return after replacement.
 //
 // Any change triggers a replace (static keys do not support update).
 func (p *Planner) doesStaticKeyNeedChange(
@@ -252,11 +254,11 @@ func (p *Planner) doesStaticKeyNeedChange(
 	desired resources.EventGatewayStaticKeyResource,
 ) bool {
 	// Compare value
-	currentVal := ""
-	if current.Value != nil {
-		currentVal = *current.Value
-	}
-	if currentVal != "" && currentVal != desired.Value {
+	if current.Value == nil {
+		if isStaticKeySecretReference(desired.Value) {
+			return true
+		}
+	} else if *current.Value != desired.Value {
 		return true
 	}
 
@@ -279,4 +281,9 @@ func (p *Planner) doesStaticKeyNeedChange(
 	}
 
 	return false
+}
+
+func isStaticKeySecretReference(value string) bool {
+	value = strings.TrimSpace(value)
+	return (strings.HasPrefix(value, "${") || strings.HasPrefix(value, "{vault://")) && strings.HasSuffix(value, "}")
 }

--- a/internal/declarative/planner/event_gateway_static_key_planner.go
+++ b/internal/declarative/planner/event_gateway_static_key_planner.go
@@ -243,8 +243,8 @@ func (p *Planner) planStaticKeyDelete(
 }
 
 // doesStaticKeyNeedChange checks whether a static key needs to be replaced.
-// The API returns the stored value when it is a vault reference, but does not return plaintext. We compare
-// it directly against the desired value anyway.
+// The API returns the stored value when it is a vault reference, but omits plaintext values. Compare values only
+// when Konnect returned one; an omitted current value is treated as an unchanged write-only secret.
 //
 // Any change triggers a replace (static keys do not support update).
 func (p *Planner) doesStaticKeyNeedChange(
@@ -256,7 +256,7 @@ func (p *Planner) doesStaticKeyNeedChange(
 	if current.Value != nil {
 		currentVal = *current.Value
 	}
-	if currentVal != desired.Value {
+	if currentVal != "" && currentVal != desired.Value {
 		return true
 	}
 

--- a/internal/declarative/planner/event_gateway_static_key_planner_test.go
+++ b/internal/declarative/planner/event_gateway_static_key_planner_test.go
@@ -152,6 +152,72 @@ func TestDoesStaticKeyNeedChange_PlaintextValueOmittedByAPI(t *testing.T) {
 	assert.False(t, p.doesStaticKeyNeedChange(current, desired))
 }
 
+func TestDoesStaticKeyNeedChange_OmittedPlaintextToSecretReference(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		value string
+	}{
+		{
+			name:  "env reference",
+			value: `${env["NEW_KEY"]}`,
+		},
+		{
+			name:  "vault reference",
+			value: "{vault://env/new-key}",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := newTestStaticKeyPlanner()
+
+			current := state.EventGatewayStaticKey{
+				EventGatewayStaticKey: kkComps.EventGatewayStaticKey{
+					ID:   "key-123",
+					Name: "my-key",
+				},
+			}
+			desired := resources.EventGatewayStaticKeyResource{
+				EventGatewayStaticKeyCreate: kkComps.EventGatewayStaticKeyCreate{
+					Name:  "my-key",
+					Value: tc.value,
+				},
+				Ref: "my-key-ref",
+			}
+
+			assert.True(t, p.doesStaticKeyNeedChange(current, desired))
+		})
+	}
+}
+
+func TestDoesStaticKeyNeedChange_PresentEmptyValueChanged(t *testing.T) {
+	t.Parallel()
+
+	p := newTestStaticKeyPlanner()
+
+	currentVal := ""
+	current := state.EventGatewayStaticKey{
+		EventGatewayStaticKey: kkComps.EventGatewayStaticKey{
+			ID:    "key-123",
+			Name:  "my-key",
+			Value: &currentVal,
+		},
+	}
+	desired := resources.EventGatewayStaticKeyResource{
+		EventGatewayStaticKeyCreate: kkComps.EventGatewayStaticKeyCreate{
+			Name:  "my-key",
+			Value: "secret",
+		},
+		Ref: "my-key-ref",
+	}
+
+	assert.True(t, p.doesStaticKeyNeedChange(current, desired))
+}
+
 func TestDoesStaticKeyNeedChange_VaultRefChanged(t *testing.T) {
 	t.Parallel()
 

--- a/internal/declarative/planner/event_gateway_static_key_planner_test.go
+++ b/internal/declarative/planner/event_gateway_static_key_planner_test.go
@@ -125,6 +125,33 @@ func TestDoesStaticKeyNeedChange_ValueChanged(t *testing.T) {
 	assert.True(t, p.doesStaticKeyNeedChange(current, desired))
 }
 
+func TestDoesStaticKeyNeedChange_PlaintextValueOmittedByAPI(t *testing.T) {
+	t.Parallel()
+
+	p := newTestStaticKeyPlanner()
+
+	desc := "a description"
+	current := state.EventGatewayStaticKey{
+		EventGatewayStaticKey: kkComps.EventGatewayStaticKey{
+			ID:          "key-123",
+			Name:        "my-key",
+			Description: &desc,
+			Labels:      map[string]string{"env": "prod"},
+		},
+	}
+	desired := resources.EventGatewayStaticKeyResource{
+		EventGatewayStaticKeyCreate: kkComps.EventGatewayStaticKeyCreate{
+			Name:        "my-key",
+			Value:       "secret",
+			Description: &desc,
+			Labels:      map[string]string{"env": "prod"},
+		},
+		Ref: "my-key-ref",
+	}
+
+	assert.False(t, p.doesStaticKeyNeedChange(current, desired))
+}
+
 func TestDoesStaticKeyNeedChange_VaultRefChanged(t *testing.T) {
 	t.Parallel()
 

--- a/test/e2e/scenarios/all/overlays/randomize-custom-domain/ops.yaml
+++ b/test/e2e/scenarios/all/overlays/randomize-custom-domain/ops.yaml
@@ -1,0 +1,5 @@
+ops:
+  - file: config.yaml
+    match: "portals[?ref=='all-portal'].custom_domain | [0]"
+    set:
+      hostname: "{{ .vars.customDomainHostname }}"

--- a/test/e2e/scenarios/all/scenario.yaml
+++ b/test/e2e/scenarios/all/scenario.yaml
@@ -1,0 +1,499 @@
+baseInputsPath: testdata
+
+env:
+  KONGCTL_LOG_LEVEL: info
+
+test:
+  enabledByEnvVar: KONGCTL_E2E_RUN_PORTAL_IDENTITY_PROVIDERS
+  requiredEnvVars:
+    - KONGCTL_E2E_PORTAL_IDP_ISSUER_URL
+    - KONGCTL_E2E_PORTAL_IDP_CLIENT_ID
+    - KONGCTL_E2E_PORTAL_IDP_CLIENT_SECRET
+  info: >-
+    Requires real Dev Portal IdP values; set KONGCTL_E2E_RUN_PORTAL_IDENTITY_PROVIDERS=1
+    and provide the KONGCTL_E2E_PORTAL_IDP_* env vars to enable.
+
+vars:
+  namespace: all-resources
+  portalName: all-portal
+  apiName: all-api
+  controlPlaneName: all-cp-runtime
+  certificateControlPlaneName: all-cp-certs
+  controlPlaneGroupName: all-cp-group
+  gatewayServiceName: all-gateway-service
+  organizationTeamName: all-org-team
+  authStrategyName: all-key-auth
+  oidcAuthStrategyName: all-oidc-auth
+  dcrProviderName: all-dcr-http
+  catalogServiceName: all-catalog-service
+  eventGatewayName: all-event-gateway
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - resource_id
+      - change_id
+      - generated_at
+      - created_at
+      - updated_at
+      - api_spec_ids
+
+steps:
+  - name: 000-init
+    skipInputs: true
+    commands:
+      - name: 000-generate-custom-domain-hostname
+        parseAs: raw
+        exec:
+          - bash
+          - -c
+          - |
+            set -euo pipefail
+            printf 'all-%s.kongctl-e2e.io' "$(date +%s%N | sha256sum | cut -c1-10)"
+        recordVar:
+          name: customDomainHostname
+          responsePath: stdout
+
+  - name: 001-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 002-sync-all
+    inputOverlayOpsFiles:
+      - overlays/randomize-custom-domain/ops.yaml
+    commands:
+      - name: 000-sync-all
+        outputFormat: json
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: sync
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success
+          - select: "plan.changes[?resource_type=='portal' && resource_ref=='all-portal'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='application_auth_strategy' && resource_ref=='all-key-auth'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='application_auth_strategy' && resource_ref=='all-oidc-auth'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='dcr_provider' && resource_ref=='all-dcr-http'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='control_plane' && resource_ref=='all-cp-runtime'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='control_plane' && resource_ref=='all-cp-certs'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='control_plane' && resource_ref=='all-cp-group'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: >-
+              plan.changes[?resource_type=='control_plane_data_plane_certificate' &&
+              resource_ref=='all-cp-data-plane-cert'] | [0]
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='api' && resource_ref=='all-api'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='api_version' && resource_ref=='all-api-v1'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='api_publication' && resource_ref=='all-api-publication'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='api_implementation' && resource_ref=='all-api-implementation'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='api_document' && resource_ref=='all-api-doc-overview'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='api_document' && resource_ref=='all-api-doc-child'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='_deck' && resource_ref=='all-cp-runtime'] | [0]"
+            expect:
+              fields:
+                action: EXTERNAL_TOOL
+                "length(post_resolution_targets[?resource_type=='gateway_service' && resource_ref=='all-gateway-service'])": 1
+          - select: "plan.changes[?resource_type=='portal_customization' && resource_ref=='all-portal-customization'] | [0]"
+            expect:
+              fields:
+                action: UPDATE
+          - select: "plan.changes[?resource_type=='portal_auth_settings' && resource_ref=='all-portal-auth-settings'] | [0]"
+            expect:
+              fields:
+                action: UPDATE
+          - select: "plan.changes[?resource_type=='portal_identity_provider' && resource_ref=='all-portal-oidc-idp'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='portal_custom_domain' && resource_ref=='all-portal-custom-domain'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='portal_page' && resource_ref=='all-portal-page'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='portal_page' && resource_ref=='all-portal-child-page'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='portal_snippet' && resource_ref=='all-portal-snippet'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='portal_team' && resource_ref=='all-portal-team'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='portal_team_role' && resource_ref=='all-portal-team-role'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='portal_asset_logo' && resource_ref=='all-portal-logo'] | [0]"
+            expect:
+              fields:
+                action: UPDATE
+          - select: "plan.changes[?resource_type=='portal_asset_favicon' && resource_ref=='all-portal-favicon'] | [0]"
+            expect:
+              fields:
+                action: UPDATE
+          - select: "plan.changes[?resource_type=='portal_email_config' && resource_ref=='all-portal-email-config'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='portal_email_template' && resource_ref=='all-reset-password-template'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='catalog_service' && resource_ref=='all-catalog-service'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='organization_team' && resource_ref=='all-org-team'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='event_gateway' && resource_ref=='all-event-gateway'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: >-
+              plan.changes[?resource_type=='event_gateway_backend_cluster' &&
+              resource_ref=='all-event-backend-cluster'] | [0]
+            expect:
+              fields:
+                action: CREATE
+          - select: >-
+              plan.changes[?resource_type=='event_gateway_virtual_cluster' &&
+              resource_ref=='all-event-virtual-cluster'] | [0]
+            expect:
+              fields:
+                action: CREATE
+          - select: >-
+              plan.changes[?resource_type=='event_gateway_virtual_cluster_cluster_policy' &&
+              resource_ref=='all-event-cluster-policy'] | [0]
+            expect:
+              fields:
+                action: CREATE
+          - select: >-
+              plan.changes[?resource_type=='event_gateway_virtual_cluster_produce_policy' &&
+              resource_ref=='all-event-produce-policy'] | [0]
+            expect:
+              fields:
+                action: CREATE
+          - select: >-
+              plan.changes[?resource_type=='event_gateway_virtual_cluster_consume_policy' &&
+              resource_ref=='all-event-consume-policy'] | [0]
+            expect:
+              fields:
+                action: CREATE
+          - select: >-
+              plan.changes[?resource_type=='event_gateway_schema_registry' &&
+              resource_ref=='all-event-schema-registry'] | [0]
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='event_gateway_static_key' && resource_ref=='all-event-static-key'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: "plan.changes[?resource_type=='event_gateway_listener' && resource_ref=='all-event-listener'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+          - select: >-
+              plan.changes[?resource_type=='event_gateway_listener_policy' &&
+              resource_ref=='all-event-listener-policy'] | [0]
+            expect:
+              fields:
+                action: CREATE
+          - select: >-
+              plan.changes[?resource_type=='event_gateway_data_plane_certificate' &&
+              resource_ref=='all-event-data-plane-cert'] | [0]
+            expect:
+              fields:
+                action: CREATE
+          - select: >-
+              plan.changes[?resource_type=='event_gateway_tls_trust_bundle' &&
+              resource_ref=='all-event-tls-trust-bundle'] | [0]
+            expect:
+              fields:
+                action: CREATE
+
+      - name: 001-get-portals
+        run: ["get", "portals", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.portalName }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.portalName }}"
+                display_name: "All Resources Portal"
+
+      - name: 002-get-apis
+        run: ["get", "apis", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.apiName }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.apiName }}"
+                version: "1.0.0"
+
+      - name: 003-get-control-planes
+        run: ["get", "gateway", "control-planes", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.controlPlaneName }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.controlPlaneName }}"
+          - select: "[?name=='{{ .vars.certificateControlPlaneName }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.certificateControlPlaneName }}"
+          - select: "[?name=='{{ .vars.controlPlaneGroupName }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.controlPlaneGroupName }}"
+
+      - name: 004-get-gateway-services
+        run:
+          - get
+          - gw
+          - cp
+          - services
+          - --control-plane-name
+          - "{{ .vars.controlPlaneName }}"
+          - -o
+          - json
+        assertions:
+          - select: "[?name=='{{ .vars.gatewayServiceName }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.gatewayServiceName }}"
+
+      - name: 005-get-auth-strategies
+        run: ["get", "auth-strategies", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.authStrategyName }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.authStrategyName }}"
+          - select: "[?name=='{{ .vars.oidcAuthStrategyName }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.oidcAuthStrategyName }}"
+
+      - name: 006-get-dcr-providers
+        run: ["get", "dcr-providers", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.dcrProviderName }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.dcrProviderName }}"
+
+      - name: 007-get-organization-teams
+        run: ["get", "org", "teams", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.organizationTeamName }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.organizationTeamName }}"
+
+      - name: 008-get-catalog-services
+        run: ["get", "catalog", "services", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.catalogServiceName }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.catalogServiceName }}"
+                display_name: "All Resources Catalog Service"
+
+      - name: 009-get-event-gateways
+        run: ["get", "event-gateways", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.eventGatewayName }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.eventGatewayName }}"
+
+  - name: 003-sync-no-op
+    inputOverlayOpsFiles:
+      - overlays/randomize-custom-domain/ops.yaml
+    commands:
+      - name: 000-sync-no-op
+        outputFormat: json
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: sync
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 0
+          - select: plan.changes
+            expect:
+              fields:
+                "length(@)": 0
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+                failed: 0
+                status: success
+
+  - name: 004-delete-all
+    inputOverlayOpsFiles:
+      - overlays/randomize-custom-domain/ops.yaml
+    commands:
+      - name: 000-delete-all
+        outputFormat: json
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success
+
+  - name: 005-verify-deleted
+    skipInputs: true
+    commands:
+      - name: 000-get-portals
+        run: ["get", "portals", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.portalName }}']"
+            expect:
+              fields:
+                "length(@)": 0
+
+      - name: 001-get-apis
+        run: ["get", "apis", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.apiName }}']"
+            expect:
+              fields:
+                "length(@)": 0
+
+      - name: 002-get-control-planes
+        run: ["get", "gateway", "control-planes", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.controlPlaneName }}']"
+            expect:
+              fields:
+                "length(@)": 0
+          - select: "[?name=='{{ .vars.certificateControlPlaneName }}']"
+            expect:
+              fields:
+                "length(@)": 0
+          - select: "[?name=='{{ .vars.controlPlaneGroupName }}']"
+            expect:
+              fields:
+                "length(@)": 0
+
+      - name: 003-get-auth-strategies
+        run: ["get", "auth-strategies", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.authStrategyName }}']"
+            expect:
+              fields:
+                "length(@)": 0
+          - select: "[?name=='{{ .vars.oidcAuthStrategyName }}']"
+            expect:
+              fields:
+                "length(@)": 0
+
+      - name: 004-get-dcr-providers
+        run: ["get", "dcr-providers", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.dcrProviderName }}']"
+            expect:
+              fields:
+                "length(@)": 0
+
+      - name: 005-get-organization-teams
+        run: ["get", "org", "teams", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.organizationTeamName }}']"
+            expect:
+              fields:
+                "length(@)": 0
+
+      - name: 006-get-catalog-services
+        run: ["get", "catalog", "services", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.catalogServiceName }}']"
+            expect:
+              fields:
+                "length(@)": 0
+
+      - name: 007-get-event-gateways
+        run: ["get", "event-gateways", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.eventGatewayName }}']"
+            expect:
+              fields:
+                "length(@)": 0

--- a/test/e2e/scenarios/all/testdata/config.yaml
+++ b/test/e2e/scenarios/all/testdata/config.yaml
@@ -1,0 +1,458 @@
+_defaults:
+  kongctl:
+    namespace: all-resources
+
+dcr_providers:
+  - ref: all-dcr-http
+    name: all-dcr-http
+    provider_type: http
+    issuer: https://all-dcr-issuer.example.com
+    dcr_config:
+      dcr_base_url: https://all-dcr.example.com/v1/dcr
+      api_key: all_dcr_api_key
+    labels:
+      suite: all
+      resource: dcr-provider
+
+application_auth_strategies:
+  - ref: all-key-auth
+    name: all-key-auth
+    display_name: All Resources Key Auth
+    strategy_type: key_auth
+    configs:
+      key_auth:
+        key_names:
+          - X-API-Key
+          - Api-Key
+    labels:
+      suite: all
+      resource: key-auth-strategy
+
+  - ref: all-oidc-auth
+    name: all-oidc-auth
+    display_name: All Resources OIDC Auth
+    strategy_type: openid_connect
+    dcr_provider_id: !ref all-dcr-http
+    configs:
+      openid_connect:
+        issuer: https://all-dcr-issuer.example.com
+        credential_claim:
+          - sub
+        auth_methods:
+          - bearer
+        scopes:
+          - openid
+          - profile
+          - email
+    labels:
+      suite: all
+      resource: oidc-auth-strategy
+
+control_planes:
+  - ref: all-cp-runtime
+    name: all-cp-runtime
+    description: Control plane with deck-managed gateway entities
+    cluster_type: CLUSTER_TYPE_CONTROL_PLANE
+    _deck:
+      files:
+        - kong.yaml
+      flags:
+        - --analytics=false
+    gateway_services:
+      - ref: all-gateway-service
+        _external:
+          selector:
+            matchFields:
+              name: all-gateway-service
+
+  - ref: all-cp-certs
+    name: all-cp-certs
+    description: Control plane with a data plane certificate
+    cluster_type: CLUSTER_TYPE_CONTROL_PLANE
+    auth_type: pinned_client_certs
+    proxy_urls:
+      - host: all-cp-certs.example.com
+        port: 443
+        protocol: https
+    data_plane_certificates:
+      - ref: all-cp-data-plane-cert
+        cert: |-
+          -----BEGIN CERTIFICATE-----
+          MIIB4TCCAYugAwIBAgIUAenxUyPjkSLCe2BQXoBMBacqgLowDQYJKoZIhvcNAQEL
+          BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+          GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yNDEwMjgyMDA3NDlaFw0zNDEw
+          MjYyMDA3NDlaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+          HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwXDANBgkqhkiG9w0BAQEF
+          AANLADBIAkEAyzipjrbAaLO/yPg7lL1dLWzhqNdc3S4YNR7f1RG9whWhbsPE2z42
+          e6WGFf9hggP6xjG4qbU8jFVczpd1UPwGbQIDAQABo1MwUTAdBgNVHQ4EFgQUkPPB
+          ghj+iHOHAKJlC1gLbKT/ZHQwHwYDVR0jBBgwFoAUkPPBghj+iHOHAKJlC1gLbKT/
+          ZHQwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAANBALfy49GvA2ld+u+G
+          Koxa8kCt7uywoqu0hfbBfUT4HqmXPvsuhz8RinE5ltxId108vtDNlD/+bKl+N5Ub
+          qKjBs0k=
+          -----END CERTIFICATE-----
+
+  - ref: all-cp-group
+    name: all-cp-group
+    description: Control plane group covering group membership configuration
+    cluster_type: CLUSTER_TYPE_CONTROL_PLANE_GROUP
+    members:
+      - id: !ref all-cp-runtime#id
+      - id: !ref all-cp-certs#id
+
+portals:
+  - ref: all-portal
+    name: all-portal
+    display_name: All Resources Portal
+    description: Portal covering declarative child resources
+    authentication_enabled: false
+    rbac_enabled: true
+    auto_approve_developers: false
+    auto_approve_applications: false
+    default_page_visibility: public
+    default_application_auth_strategy_id: !ref all-key-auth#id
+    labels:
+      suite: all
+      resource: portal
+    customization:
+      ref: all-portal-customization
+      theme:
+        mode: light
+        colors:
+          primary: "#8250FF"
+      layout: topnav
+      menu:
+        main:
+          - path: /guides
+            title: Guides
+            external: false
+            visibility: public
+          - path: /apis
+            title: APIs
+            external: false
+            visibility: public
+        footer_sections:
+          - title: Resources
+            items:
+              - path: "#"
+                title: Documentation
+                external: false
+                visibility: public
+    auth_settings:
+      ref: all-portal-auth-settings
+      basic_auth_enabled: true
+      konnect_mapping_enabled: true
+      idp_mapping_enabled: false
+    identity_providers:
+      - ref: all-portal-oidc-idp
+        type: oidc
+        enabled: true
+        config:
+          issuer_url: !env KONGCTL_E2E_PORTAL_IDP_ISSUER_URL
+          client_id: !env KONGCTL_E2E_PORTAL_IDP_CLIENT_ID
+          client_secret: !env KONGCTL_E2E_PORTAL_IDP_CLIENT_SECRET
+          scopes:
+            - openid
+            - profile
+          claim_mappings:
+            name: name
+            email: email
+            groups: groups
+    custom_domain:
+      ref: all-portal-custom-domain
+      hostname: all-placeholder.kongctl-e2e.io
+      enabled: true
+      ssl:
+        domain_verification_method: http
+    pages:
+      - ref: all-portal-page
+        slug: guides
+        title: Guides
+        description: Guides page
+        visibility: public
+        status: published
+        content: |-
+          # Guides
+
+          Start here for the all resources e2e scenario.
+        children:
+          - ref: all-portal-child-page
+            slug: getting-started
+            title: Getting Started
+            description: Getting started child page
+            visibility: public
+            status: published
+            content: |-
+              ## Getting Started
+
+              This child page validates nested portal pages.
+    snippets:
+      - ref: all-portal-snippet
+        name: all-portal-snippet
+        title: All Resources Snippet
+        description: Reusable content for the all resources scenario
+        visibility: public
+        status: published
+        content: |-
+          <section>All resources snippet</section>
+    teams:
+      - ref: all-portal-team
+        name: all-portal-team
+        description: Portal team for all resources
+        roles:
+          - ref: all-portal-team-role
+            role_name: API Viewer
+            entity_id: !ref all-api#id
+            entity_type_name: Services
+            entity_region: us
+    email_config:
+      ref: all-portal-email-config
+      domain_name: all.mail.kongctl-e2e.io
+      from_name: Kong Developer Portal
+      from_email: noreply@all.mail.kongctl-e2e.io
+      reply_to_email: support@all.mail.kongctl-e2e.io
+    email_templates:
+      reset-password:
+        ref: all-reset-password-template
+        enabled: true
+        content:
+          subject: Reset your password
+          title: Reset Password
+          body: Click the button to reset your password.
+          button_label: Reset
+    assets:
+      logo: data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==
+      favicon: data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==
+
+apis:
+  - ref: all-api
+    name: all-api
+    description: API covering versions, publications, implementations, and docs
+    version: 1.0.0
+    labels:
+      suite: all
+      resource: api
+    attributes:
+      domains:
+        - platform
+      environments:
+        - dev
+    versions:
+      - ref: all-api-v1
+        version: 1.0.0
+        publish_status: published
+        deprecated: false
+        spec:
+          content: |-
+            openapi: 3.0.0
+            info:
+              title: All API
+              version: 1.0.0
+            paths: {}
+    publications:
+      - ref: all-api-publication
+        portal_id: !ref all-portal#id
+        visibility: private
+        auth_strategy_ids:
+          - !ref all-key-auth#id
+        auto_approve_registrations: false
+    implementations:
+      - ref: all-api-implementation
+        service:
+          control_plane_id: !ref all-cp-runtime#id
+          id: !ref all-gateway-service#id
+    documents:
+      - ref: all-api-doc-overview
+        title: Overview
+        slug: overview
+        status: published
+        content: |-
+          # Overview
+
+          Overview documentation for the all API.
+        children:
+          - ref: all-api-doc-child
+            title: Child Guide
+            slug: child-guide
+            status: published
+            content: |-
+              ## Child Guide
+
+              Child documentation validates nested API documents.
+
+catalog_services:
+  - ref: all-catalog-service
+    name: all-catalog-service
+    display_name: All Resources Catalog Service
+    description: Catalog service for the all resources scenario
+    labels:
+      suite: all
+      resource: catalog-service
+    custom_fields:
+      owner: platform-team
+      cost_center: "R&D"
+      product_manager: "All Resources PM"
+      jira_project:
+        name: All Resources Project
+        link: https://jira.example.com/projects/ALL
+      dashboard:
+        name: All Resources Dashboard
+        link: https://dashboards.example.com/all-resources
+      git_repo:
+        name: all-resources
+        link: https://github.com/example/all-resources
+      slack_channel:
+        name: "#all-resources"
+        link: https://slack.example.com/archives/all-resources
+
+organization:
+  teams:
+    - ref: all-org-team
+      name: all-org-team
+      description: Organization team for the all resources scenario
+      labels:
+        suite: all
+        resource: organization-team
+
+event_gateways:
+  - ref: all-event-gateway
+    name: all-event-gateway
+    description: Event gateway covering all nested event gateway resources
+    backend_clusters:
+      - ref: all-event-backend-cluster
+        name: all-event-backend-cluster
+        description: Backend cluster for all resources
+        bootstrap_servers:
+          - all-backend.example.com:9092
+        authentication:
+          type: anonymous
+        tls:
+          enabled: true
+          skip_verify: false
+          tls_versions:
+            - tls12
+            - tls13
+    virtual_clusters:
+      - ref: all-event-virtual-cluster
+        name: all-event-virtual-cluster
+        description: Virtual cluster for all resources
+        destination:
+          id: !ref all-event-backend-cluster#id
+        authentication:
+          - type: anonymous
+        acl_mode: enforce_on_gateway
+        dns_label: all-vc
+        cluster_policies:
+          - ref: all-event-cluster-policy
+            name: all-event-cluster-policy
+            description: Cluster policy for all resources
+            type: acls
+            enabled: true
+            config:
+              rules:
+                - action: deny
+                  operations:
+                    - name: describe_configs
+                  resource_names:
+                    - match: "*"
+                  resource_type: transactional_id
+        produce_policies:
+          - ref: all-event-produce-policy
+            name: all-event-produce-policy
+            description: Produce policy for all resources
+            type: modify_headers
+            enabled: true
+            labels:
+              suite: all
+            config:
+              actions:
+                - op: set
+                  key: x-producer-id
+                  value: "${client_id}"
+        consume_policies:
+          - ref: all-event-consume-policy
+            name: all-event-consume-policy
+            description: Consume policy for all resources
+            type: schema_validation
+            enabled: true
+            condition: ""
+            config:
+              key_validation_action: mark
+              type: json
+              value_validation_action: skip
+    schema_registries:
+      - ref: all-event-schema-registry
+        name: all-event-schema-registry
+        description: Schema registry for all resources
+        type: confluent
+        config:
+          schema_type: json
+          endpoint: https://schema-registry.example.com
+          timeout_seconds: 30
+          authentication:
+            type: basic
+            username: all-user
+            password: all-password
+    static_keys:
+      - ref: all-event-static-key
+        name: all-event-static-key
+        description: Static key for all resources
+        value: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
+    listeners:
+      - ref: all-event-listener
+        name: all-event-listener
+        description: Listener for all resources
+        ports:
+          - 9092
+        addresses:
+          - localhost
+        policies:
+          - ref: all-event-listener-policy
+            name: all-event-listener-policy
+            type: forward_to_virtual_cluster
+            description: Listener policy for all resources
+            enabled: true
+            condition: "${ssl_sni} == \"all.example.com\""
+            labels:
+              suite: all
+            config:
+              type: port_mapping
+              destination:
+                id: !ref all-event-virtual-cluster#id
+              advertised_host: all.example.com
+    data_plane_certificates:
+      - ref: all-event-data-plane-cert
+        name: all-event-data-plane-cert
+        description: Event gateway data plane certificate for all resources
+        certificate: |-
+          -----BEGIN CERTIFICATE-----
+          MIIB4TCCAYugAwIBAgIUAenxUyPjkSLCe2BQXoBMBacqgLowDQYJKoZIhvcNAQEL
+          BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+          GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yNDEwMjgyMDA3NDlaFw0zNDEw
+          MjYyMDA3NDlaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+          HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwXDANBgkqhkiG9w0BAQEF
+          AANLADBIAkEAyzipjrbAaLO/yPg7lL1dLWzhqNdc3S4YNR7f1RG9whWhbsPE2z42
+          e6WGFf9hggP6xjG4qbU8jFVczpd1UPwGbQIDAQABo1MwUTAdBgNVHQ4EFgQUkPPB
+          ghj+iHOHAKJlC1gLbKT/ZHQwHwYDVR0jBBgwFoAUkPPBghj+iHOHAKJlC1gLbKT/
+          ZHQwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAANBALfy49GvA2ld+u+G
+          Koxa8kCt7uywoqu0hfbBfUT4HqmXPvsuhz8RinE5ltxId108vtDNlD/+bKl+N5Ub
+          qKjBs0k=
+          -----END CERTIFICATE-----
+    tls_trust_bundles:
+      - ref: all-event-tls-trust-bundle
+        name: all-event-tls-trust-bundle
+        description: TLS trust bundle for all resources
+        config:
+          trusted_ca: |-
+            -----BEGIN CERTIFICATE-----
+            MIIB4TCCAYugAwIBAgIUAenxUyPjkSLCe2BQXoBMBacqgLowDQYJKoZIhvcNAQEL
+            BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+            GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yNDEwMjgyMDA3NDlaFw0zNDEw
+            MjYyMDA3NDlaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+            HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwXDANBgkqhkiG9w0BAQEF
+            AANLADBIAkEAyzipjrbAaLO/yPg7lL1dLWzhqNdc3S4YNR7f1RG9whWhbsPE2z42
+            e6WGFf9hggP6xjG4qbU8jFVczpd1UPwGbQIDAQABo1MwUTAdBgNVHQ4EFgQUkPPB
+            ghj+iHOHAKJlC1gLbKT/ZHQwHwYDVR0jBBgwFoAUkPPBghj+iHOHAKJlC1gLbKT/
+            ZHQwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAANBALfy49GvA2ld+u+G
+            Koxa8kCt7uywoqu0hfbBfUT4HqmXPvsuhz8RinE5ltxId108vtDNlD/+bKl+N5Ub
+            qKjBs0k=
+            -----END CERTIFICATE-----

--- a/test/e2e/scenarios/all/testdata/config.yaml
+++ b/test/e2e/scenarios/all/testdata/config.yaml
@@ -206,10 +206,9 @@ portals:
             entity_region: us
     email_config:
       ref: all-portal-email-config
-      domain_name: all.mail.kongctl-e2e.io
       from_name: Kong Developer Portal
-      from_email: noreply@all.mail.kongctl-e2e.io
-      reply_to_email: support@all.mail.kongctl-e2e.io
+      from_email: noreply@example.com
+      reply_to_email: support@example.com
     email_templates:
       reset-password:
         ref: all-reset-password-template

--- a/test/e2e/scenarios/all/testdata/kong.yaml
+++ b/test/e2e/scenarios/all/testdata/kong.yaml
@@ -1,0 +1,17 @@
+_format_version: "3.0"
+
+_info:
+  select_tags:
+    - kongctl-e2e-all
+
+services:
+  - name: all-gateway-service
+    url: https://all-api.kongctl-e2e.test/
+    tags:
+      - kongctl-e2e-all
+    routes:
+      - name: all-gateway-route
+        paths:
+          - /all
+        tags:
+          - kongctl-e2e-all


### PR DESCRIPTION
## Summary

Closes #947.

Adds an `all` e2e scenario that exercises the current declarative resource surface in one config, including portals, portal child resources, APIs, control planes, gateway entities, DCR providers, application auth strategies, catalog services, organization teams, and event gateway resources.

The scenario performs an initial sync, verifies created resources through CLI reads, runs a no-op sync assertion, deletes the config, and verifies the top-level resources are gone. It reuses the existing portal identity provider e2e environment variables instead of introducing new ones.

## Notes

Konnect omits plaintext Event Gateway static key values after creation. The planner now treats an omitted current value as unchanged plaintext, but still plans replacement when adopting a secret reference value that Konnect would return after replacement. This prevents perpetual plaintext delete/create churn without blocking migration to env or vault references.

The `all` scenario covers `portal_email_config` without registering a custom email domain because Konnect enforces a small shared-org email-domain limit. The dedicated `portal/email` scenario continues to cover custom email domain behavior.

## Validation

- `make format`
- `make build`
- `make test`
- `make lint`
- `go test -tags=e2e ./test/e2e/harness/scenario -count=1`
- `make test-e2e-scenarios SCENARIO=all`

Latest E2E artifacts: `/home/rspurgeon/go/e2e-artifacts/20260502-162555`