### PR TITLE
fix: virtual cluster destination ref resolution

### DIFF
--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -2411,6 +2411,16 @@ func (e *Executor) updateResource(ctx context.Context, change *planner.PlannedCh
 			gatewayRef.ID = gatewayID
 			change.References[planner.FieldEventGatewayID] = gatewayRef
 		}
+		// Resolve event gateway backend cluster reference if needed
+		if backendClusterRef, ok := change.References[planner.FieldEventGatewayBackendClusterID]; ok &&
+			backendClusterRef.ID == "" {
+			backendClusterID, err := e.resolveEventGatewayBackendClusterRef(ctx, change.Parent.ID, backendClusterRef)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve event gateway backend cluster reference: %w", err)
+			}
+			backendClusterRef.ID = backendClusterID
+			change.References[planner.FieldEventGatewayBackendClusterID] = backendClusterRef
+		}
 		return e.eventGatewayVirtualClusterExecutor.Update(ctx, *change)
 	case planner.ResourceTypeOrganizationTeam:
 		return e.organizationTeamExecutor.Update(ctx, *change)

--- a/internal/declarative/planner/event_gateway_virtual_cluster_planner.go
+++ b/internal/declarative/planner/event_gateway_virtual_cluster_planner.go
@@ -397,13 +397,21 @@ func (p *Planner) planVirtualClusterUpdate(
 		if backendCluster != nil {
 			backendClusterName = backendCluster.Name
 		}
+		backendClusterRef, _, ok := tags.ParseRefPlaceholder(cluster.Destination.BackendClusterReferenceByID.ID)
+		if ok {
+			backendCluster := p.resources.GetBackendClusterByRef(backendClusterRef)
+			if backendCluster != nil {
+				backendClusterName = backendCluster.Name
+			}
+		}
 
-		change.References = map[string]ReferenceInfo{
-			FieldEventGatewayBackendClusterID: {
-				Ref: cluster.Destination.BackendClusterReferenceByID.ID,
-				LookupFields: map[string]string{
-					FieldName: backendClusterName,
-				},
+		if change.References == nil {
+			change.References = make(map[string]ReferenceInfo)
+		}
+		change.References[FieldEventGatewayBackendClusterID] = ReferenceInfo{
+			Ref: cluster.Destination.BackendClusterReferenceByID.ID,
+			LookupFields: map[string]string{
+				FieldName: backendClusterName,
 			},
 		}
 	}

--- a/internal/declarative/planner/event_gateway_virtual_cluster_planner.go
+++ b/internal/declarative/planner/event_gateway_virtual_cluster_planner.go
@@ -389,6 +389,25 @@ func (p *Planner) planVirtualClusterUpdate(
 		},
 	}
 
+	// Set backend cluster reference if destination uses a ref placeholder
+	if cluster.Destination.BackendClusterReferenceByID != nil &&
+		tags.IsRefPlaceholder(cluster.Destination.BackendClusterReferenceByID.ID) {
+		var backendClusterName string
+		backendCluster := p.resources.GetBackendClusterByRef(cluster.Destination.BackendClusterReferenceByID.ID)
+		if backendCluster != nil {
+			backendClusterName = backendCluster.Name
+		}
+
+		change.References = map[string]ReferenceInfo{
+			FieldEventGatewayBackendClusterID: {
+				Ref: cluster.Destination.BackendClusterReferenceByID.ID,
+				LookupFields: map[string]string{
+					FieldName: backendClusterName,
+				},
+			},
+		}
+	}
+
 	p.logger.Debug("Enqueuing virtual cluster UPDATE",
 		"cluster_ref", cluster.Ref,
 		"cluster_name", cluster.Name,

--- a/test/e2e/scenarios/event-gateway/cluster-policy/overlays/001-update-fields/config.yaml
+++ b/test/e2e/scenarios/event-gateway/cluster-policy/overlays/001-update-fields/config.yaml
@@ -26,7 +26,7 @@ event_gateways:
         name: default-virtual-cluster-name-for-cluster-policy-test
         description: "Virtual Cluster for Cluster Policy Test"
         destination:
-          name: default-backend-cluster
+          id: !ref default-backend-cluster#id
         authentication:
          - type: anonymous
         acl_mode: enforce_on_gateway

--- a/test/e2e/scenarios/event-gateway/cluster-policy/overlays/002-sync-delete/config.yaml
+++ b/test/e2e/scenarios/event-gateway/cluster-policy/overlays/002-sync-delete/config.yaml
@@ -26,7 +26,7 @@ event_gateways:
         name: default-virtual-cluster-name-for-cluster-policy-test
         description: "Virtual Cluster for Cluster Policy Test"
         destination:
-          name: default-backend-cluster
+          id: !ref default-backend-cluster#id
         authentication:
          - type: anonymous
         acl_mode: enforce_on_gateway

--- a/test/e2e/scenarios/event-gateway/cluster-policy/overlays/003-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/cluster-policy/overlays/003-root-level-declaration/config.yaml
@@ -26,7 +26,7 @@ event_gateways:
         name: default-virtual-cluster-name-for-cluster-policy-test
         description: "Virtual Cluster for Cluster Policy Test"
         destination:
-          name: default-backend-cluster
+          id: !ref default-backend-cluster#id
         authentication:
          - type: anonymous
         acl_mode: enforce_on_gateway

--- a/test/e2e/scenarios/event-gateway/cluster-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/cluster-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -26,7 +26,7 @@ event_gateways:
         name: default-virtual-cluster-name-for-cluster-policy-test
         description: "Virtual Cluster for Cluster Policy Test"
         destination:
-          name: default-backend-cluster
+          id: !ref default-backend-cluster#id
         authentication:
          - type: anonymous
         acl_mode: enforce_on_gateway

--- a/test/e2e/scenarios/event-gateway/cluster-policy/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/cluster-policy/testdata/config.yaml
@@ -26,7 +26,7 @@ event_gateways:
         name: default-virtual-cluster-name-for-cluster-policy-test
         description: "Virtual Cluster for Cluster Policy Test"
         destination:
-          name: default-backend-cluster
+          id: !ref default-backend-cluster#id
         authentication:
          - type: anonymous
         acl_mode: enforce_on_gateway

--- a/test/e2e/scenarios/event-gateway/consume-policy/overlays/001-update-fields/config.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/overlays/001-update-fields/config.yaml
@@ -26,7 +26,7 @@ event_gateways:
         name: default-virtual-cluster-name-for-consume-policy-test
         description: "Virtual Cluster for Consume Policy Test"
         destination:
-          name: default-backend-cluster
+          id: !ref default-backend-cluster#id
         authentication:
          - type: anonymous
         acl_mode: enforce_on_gateway

--- a/test/e2e/scenarios/event-gateway/consume-policy/overlays/002-sync-delete/config.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/overlays/002-sync-delete/config.yaml
@@ -26,7 +26,7 @@ event_gateways:
         name: default-virtual-cluster-name-for-consume-policy-test
         description: "Virtual Cluster for Consume Policy Test"
         destination:
-          name: default-backend-cluster
+          id: !ref default-backend-cluster#id
         authentication:
          - type: anonymous
         acl_mode: enforce_on_gateway

--- a/test/e2e/scenarios/event-gateway/consume-policy/overlays/003-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/overlays/003-root-level-declaration/config.yaml
@@ -26,7 +26,7 @@ event_gateways:
         name: default-virtual-cluster-name-for-consume-policy-test
         description: "Virtual Cluster for Consume Policy Test"
         destination:
-          name: default-backend-cluster
+          id: !ref default-backend-cluster#id
         authentication:
          - type: anonymous
         acl_mode: enforce_on_gateway

--- a/test/e2e/scenarios/event-gateway/consume-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -26,7 +26,7 @@ event_gateways:
         name: default-virtual-cluster-name-for-consume-policy-test
         description: "Virtual Cluster for Consume Policy Test"
         destination:
-          name: default-backend-cluster
+          id: !ref default-backend-cluster#id
         authentication:
          - type: anonymous
         acl_mode: enforce_on_gateway

--- a/test/e2e/scenarios/event-gateway/consume-policy/overlays/005-skip-record-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/overlays/005-skip-record-policy/config.yaml
@@ -26,7 +26,7 @@ event_gateways:
         name: default-virtual-cluster-name-for-consume-policy-test
         description: "Virtual Cluster for Consume Policy Test"
         destination:
-          name: default-backend-cluster
+          id: !ref default-backend-cluster#id
         authentication:
          - type: anonymous
         acl_mode: enforce_on_gateway

--- a/test/e2e/scenarios/event-gateway/consume-policy/overlays/006-schema-validation-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/overlays/006-schema-validation-policy/config.yaml
@@ -26,7 +26,7 @@ event_gateways:
         name: default-virtual-cluster-name-for-consume-policy-test
         description: "Virtual Cluster for Consume Policy Test"
         destination:
-          name: default-backend-cluster
+          id: !ref default-backend-cluster#id
         authentication:
          - type: anonymous
         acl_mode: enforce_on_gateway

--- a/test/e2e/scenarios/event-gateway/consume-policy/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/testdata/config.yaml
@@ -26,7 +26,7 @@ event_gateways:
         name: default-virtual-cluster-name-for-consume-policy-test
         description: "Virtual Cluster for Consume Policy Test"
         destination:
-          name: default-backend-cluster
+          id: !ref default-backend-cluster#id
         authentication:
          - type: anonymous
         acl_mode: enforce_on_gateway

--- a/test/e2e/scenarios/event-gateway/dump/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/dump/testdata/config.yaml
@@ -26,7 +26,7 @@ event_gateways:
         name: default-virtual-cluster
         description: "Virtual Cluster for Dump Test"
         destination:
-          name: default-backend-cluster
+          id: !ref default-backend-cluster
         authentication:
          - type: anonymous
         acl_mode: passthrough

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/003-virtual-cluster/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/003-virtual-cluster/config.yaml
@@ -25,7 +25,7 @@ event_gateways:
         name: plan-apply-virtual-cluster
         description: "Virtual cluster for plan apply workflow"
         destination:
-          name: plan-apply-backend-cluster #id: !ref plan-apply-backend-cluster#id
+          id: !ref plan-apply-backend-cluster#id
         authentication:
         - type: sasl_scram
           algorithm: sha512

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/004-listener/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/004-listener/config.yaml
@@ -25,7 +25,7 @@ event_gateways:
         name: plan-apply-virtual-cluster
         description: "Virtual cluster for plan apply workflow"
         destination:
-          name: plan-apply-backend-cluster #id: !ref plan-apply-backend-cluster#id
+          id: !ref plan-apply-backend-cluster#id
         authentication:
         - type: sasl_scram
           algorithm: sha512

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/005-listener-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/005-listener-policy/config.yaml
@@ -25,7 +25,7 @@ event_gateways:
         name: plan-apply-virtual-cluster
         description: "Virtual cluster for plan apply workflow"
         destination:
-          name: plan-apply-backend-cluster #id: !ref plan-apply-backend-cluster#id
+          id: !ref plan-apply-backend-cluster#id
         authentication:
         - type: sasl_scram
           algorithm: sha512

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/006-data-plane-certificate/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/006-data-plane-certificate/config.yaml
@@ -25,7 +25,7 @@ event_gateways:
         name: plan-apply-virtual-cluster
         description: "Virtual cluster for plan apply workflow"
         destination:
-          name: plan-apply-backend-cluster #id: !ref plan-apply-backend-cluster#id
+          id: !ref plan-apply-backend-cluster#id
         authentication:
           - type: sasl_scram
             algorithm: sha512

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/007-cluster-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/007-cluster-policy/config.yaml
@@ -25,7 +25,7 @@ event_gateways:
         name: plan-apply-virtual-cluster
         description: "Virtual cluster for plan apply workflow"
         destination:
-          name: plan-apply-backend-cluster #id: !ref plan-apply-backend-cluster#id
+          id: !ref plan-apply-backend-cluster#id
         authentication:
           - type: sasl_scram
             algorithm: sha512

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/008-produce-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/008-produce-policy/config.yaml
@@ -25,7 +25,7 @@ event_gateways:
         name: plan-apply-virtual-cluster
         description: "Virtual cluster for plan apply workflow"
         destination:
-          name: plan-apply-backend-cluster
+          id: !ref plan-apply-backend-cluster#id
         authentication:
           - type: sasl_scram
             algorithm: sha512

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/009-consume-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/009-consume-policy/config.yaml
@@ -25,7 +25,7 @@ event_gateways:
         name: plan-apply-virtual-cluster
         description: "Virtual cluster for plan apply workflow"
         destination:
-          name: plan-apply-backend-cluster #id: !ref plan-apply-backend-cluster#id
+          id: !ref plan-apply-backend-cluster#id
         authentication:
           - type: sasl_scram
             algorithm: sha512

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/010-schema-registry/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/010-schema-registry/config.yaml
@@ -25,7 +25,7 @@ event_gateways:
         name: plan-apply-virtual-cluster
         description: "Virtual cluster for plan apply workflow"
         destination:
-          name: plan-apply-backend-cluster
+          id: !ref plan-apply-backend-cluster#id
         authentication:
           - type: sasl_scram
             algorithm: sha512

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/011-static-key/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/011-static-key/config.yaml
@@ -25,7 +25,7 @@ event_gateways:
         name: plan-apply-virtual-cluster
         description: "Virtual cluster for plan apply workflow"
         destination:
-          name: plan-apply-backend-cluster
+          id: !ref plan-apply-backend-cluster#id
         authentication:
           - type: sasl_scram
             algorithm: sha512

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/012-trust-bundles/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/012-trust-bundles/config.yaml
@@ -25,7 +25,7 @@ event_gateways:
         name: plan-apply-virtual-cluster
         description: "Virtual cluster for plan apply workflow"
         destination:
-          name: plan-apply-backend-cluster
+          id: !ref plan-apply-backend-cluster#id
         authentication:
           - type: sasl_scram
             algorithm: sha512

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/001-update-fields/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/001-update-fields/config.yaml
@@ -26,7 +26,7 @@ event_gateways:
         name: default-virtual-cluster-name-for-produce-policy-test
         description: "Virtual Cluster for Produce Policy Test"
         destination:
-          name: default-backend-cluster
+          id: !ref default-backend-cluster#id
         authentication:
          - type: anonymous
         acl_mode: enforce_on_gateway

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/002-sync-delete/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/002-sync-delete/config.yaml
@@ -26,7 +26,7 @@ event_gateways:
         name: default-virtual-cluster-name-for-produce-policy-test
         description: "Virtual Cluster for Produce Policy Test"
         destination:
-          name: default-backend-cluster
+          id: !ref default-backend-cluster#id
         authentication:
          - type: anonymous
         acl_mode: enforce_on_gateway

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/003-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/003-root-level-declaration/config.yaml
@@ -26,7 +26,7 @@ event_gateways:
         name: default-virtual-cluster-name-for-produce-policy-test
         description: "Virtual Cluster for Produce Policy Test"
         destination:
-          name: default-backend-cluster
+          id: !ref default-backend-cluster#id
         authentication:
          - type: anonymous
         acl_mode: enforce_on_gateway

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -26,7 +26,7 @@ event_gateways:
         name: default-virtual-cluster-name-for-produce-policy-test
         description: "Virtual Cluster for Produce Policy Test"
         destination:
-          name: default-backend-cluster
+          id: !ref default-backend-cluster#id
         authentication:
          - type: anonymous
         acl_mode: enforce_on_gateway

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/005-schema-validation-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/005-schema-validation-policy/config.yaml
@@ -26,7 +26,7 @@ event_gateways:
         name: default-virtual-cluster-name-for-produce-policy-test
         description: "Virtual Cluster for Produce Policy Test"
         destination:
-          name: default-backend-cluster
+          id: !ref default-backend-cluster#id
         authentication:
          - type: anonymous
         acl_mode: enforce_on_gateway

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/006-update-schema-validation/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/006-update-schema-validation/config.yaml
@@ -26,7 +26,7 @@ event_gateways:
         name: default-virtual-cluster-name-for-produce-policy-test
         description: "Virtual Cluster for Produce Policy Test"
         destination:
-          name: default-backend-cluster
+          id: !ref default-backend-cluster#id
         authentication:
          - type: anonymous
         acl_mode: enforce_on_gateway

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/007-sync-delete-schema-validation/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/007-sync-delete-schema-validation/config.yaml
@@ -26,7 +26,7 @@ event_gateways:
         name: default-virtual-cluster-name-for-produce-policy-test
         description: "Virtual Cluster for Produce Policy Test"
         destination:
-          name: default-backend-cluster
+          id: !ref default-backend-cluster#id
         authentication:
          - type: anonymous
         acl_mode: enforce_on_gateway

--- a/test/e2e/scenarios/event-gateway/produce-policy/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/testdata/config.yaml
@@ -26,7 +26,7 @@ event_gateways:
         name: default-virtual-cluster-name-for-produce-policy-test
         description: "Virtual Cluster for Produce Policy Test"
         destination:
-          name: default-backend-cluster
+          id: !ref default-backend-cluster#id
         authentication:
          - type: anonymous
         acl_mode: enforce_on_gateway

--- a/test/e2e/scenarios/event-gateway/virtual-cluster/overlays/001-update-fields/config.yaml
+++ b/test/e2e/scenarios/event-gateway/virtual-cluster/overlays/001-update-fields/config.yaml
@@ -26,7 +26,7 @@ event_gateways:
         name: default-virtual-cluster
         description: "Virtual Cluster for Test Updated"
         destination:
-          name: default-backend-cluster
+          id: !ref default-backend-cluster#id
         authentication:
           - type: sasl_plain
             mediation: passthrough

--- a/test/e2e/scenarios/event-gateway/virtual-cluster/overlays/003-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/virtual-cluster/overlays/003-root-level-declaration/config.yaml
@@ -27,7 +27,7 @@ event_gateway_virtual_clusters:
     event_gateway: egw-cp-for-bc-vc-test
     description: "Virtual Cluster for Test"
     destination:
-      name: default-backend-cluster
+      id: !ref default-backend-cluster#id
     authentication:
       - type: anonymous
     acl_mode: passthrough

--- a/test/e2e/scenarios/event-gateway/virtual-cluster/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/virtual-cluster/testdata/config.yaml
@@ -26,7 +26,7 @@ event_gateways:
         name: default-virtual-cluster
         description: "Virtual Cluster for Test"
         destination:
-          name: default-backend-cluster
+          id: !ref default-backend-cluster#id
         authentication:
          - type: anonymous
         acl_mode: passthrough


### PR DESCRIPTION
## Summary
We are fixing a bug in planner and executor for event gateway virtual clusters where update fails when !ref tag is used for destination ID.

## Why is modifying tests required?
1. Virtual cluster is not a child of backend cluster, yet references it - using !ref is the recommended way in config
2. Because updates are broken with !ref tag
3. Right now, the execution of plan is sequential, and virtual clusters are always queued after backend clusters. Once the execution is parallelized, executor needs to be aware of the dependency using the references in the planned change. (will come up in future PR)