### PR TITLE
Task: Trigger issue triage from approval label

### DIFF
--- a/.github/workflows/slash-cmd-issue-triage.lock.yml
+++ b/.github/workflows/slash-cmd-issue-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"02d5eac40205bfc17db10f33704899a323eef022435515f0692bcdc64e2e2e62","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3bd6bdc0278d444a0c052d2642069ff09cd401f1a83512ce3a8ec54ffa7f24f7","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"239aec45b78c8799417efdd5bc6d8cc036629ec1","version":"v0.71.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.0","digest":"sha256:9c2228324fb1f26f39dc9471612e530ae3efc3156dac05efb2e8d212878d454d","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.0@sha256:9c2228324fb1f26f39dc9471612e530ae3efc3156dac05efb2e8d212878d454d"},{"image":"ghcr.io/github/github-mcp-server:v1.0.2","digest":"sha256:26db03408086a99cf1916348dcc4f9614206658f9082a8060dc7c81ad787f4ba","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.2@sha256:26db03408086a99cf1916348dcc4f9614206658f9082a8060dc7c81ad787f4ba"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -63,6 +63,7 @@ name: "Requested Issue Triage"
     - opened
     - edited
     - reopened
+    - labeled
 
 permissions: {}
 
@@ -74,7 +75,7 @@ run-name: "Requested Issue Triage"
 jobs:
   activation:
     needs: pre_activation
-    if: "needs.pre_activation.outputs.activated == 'true' && (github.event_name == 'issues' && (startsWith(github.event.issue.body, '/triage ') || startsWith(github.event.issue.body, '/triage\n') || github.event.issue.body == '/triage') || github.event_name == 'issue_comment' && (startsWith(github.event.comment.body, '/triage ') || startsWith(github.event.comment.body, '/triage\n') || github.event.comment.body == '/triage') && github.event.issue.pull_request == null)"
+    if: "needs.pre_activation.outputs.activated == 'true' && (github.event_name == 'issues' && (startsWith(github.event.issue.body, '/triage ') || startsWith(github.event.issue.body, '/triage\n') || github.event.issue.body == '/triage') || github.event_name == 'issue_comment' && (startsWith(github.event.comment.body, '/triage ') || startsWith(github.event.comment.body, '/triage\n') || github.event.comment.body == '/triage') && github.event.issue.pull_request == null || github.event_name == 'issues' && github.event.label.name == 'triage-approved')"
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -82,10 +83,12 @@ jobs:
       issues: write
     outputs:
       body: ${{ steps.sanitized.outputs.body }}
+      command_name: ${{ steps.get_trigger_label.outputs.command_name }}
       comment_id: ${{ steps.add-comment.outputs.comment-id }}
       comment_repo: ${{ steps.add-comment.outputs.comment-repo }}
       comment_url: ${{ steps.add-comment.outputs.comment-url }}
       engine_id: ${{ steps.generate_aw_info.outputs.engine_id }}
+      label_command: ${{ steps.get_trigger_label.outputs.label_name }}
       lockdown_check_failed: ${{ steps.generate_aw_info.outputs.lockdown_check_failed == 'true' }}
       model: ${{ steps.generate_aw_info.outputs.model }}
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
@@ -211,6 +214,17 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/add_workflow_run_comment.cjs');
             await main();
+      - name: Get trigger label name
+        id: get_trigger_label
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          GH_AW_MATCHED_COMMAND: ${{ needs.pre_activation.outputs.matched_command }}
+        with:
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io, getOctokit);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/get_trigger_label.cjs');
+            await main();
       - name: Create prompt with built-in context
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -228,14 +242,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_f2e8ae0ed95fe9a0_EOF'
+          cat << 'GH_AW_PROMPT_2a36745a988baca5_EOF'
           <system>
-          GH_AW_PROMPT_f2e8ae0ed95fe9a0_EOF
+          GH_AW_PROMPT_2a36745a988baca5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_f2e8ae0ed95fe9a0_EOF'
+          cat << 'GH_AW_PROMPT_2a36745a988baca5_EOF'
           <safe-output-tools>
           Tools: add_comment, add_labels(max:5), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -267,15 +281,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_f2e8ae0ed95fe9a0_EOF
+          GH_AW_PROMPT_2a36745a988baca5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_f2e8ae0ed95fe9a0_EOF'
+          cat << 'GH_AW_PROMPT_2a36745a988baca5_EOF'
           </system>
           {{#runtime-import .github/workflows/slash-cmd-issue-triage.md}}
-          GH_AW_PROMPT_f2e8ae0ed95fe9a0_EOF
+          GH_AW_PROMPT_2a36745a988baca5_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -460,9 +474,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_f990f13c7f2251e5_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_197660da6b8f4e51_EOF'
           {"add_comment":{"max":1},"add_labels":{"max":5},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_f990f13c7f2251e5_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_197660da6b8f4e51_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -668,7 +682,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_51ecf2643d9a7fcf_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_1cfed567fd0a1bdf_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -712,7 +726,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_51ecf2643d9a7fcf_EOF
+          GH_AW_MCP_CONFIG_1cfed567fd0a1bdf_EOF
       - name: Clean git credentials
         continue-on-error: true
         run: bash "${RUNNER_TEMP}/gh-aw/actions/clean_git_credentials.sh"
@@ -1235,7 +1249,7 @@ jobs:
             await main();
 
   pre_activation:
-    if: "github.event_name == 'issues' && (startsWith(github.event.issue.body, '/triage ') || startsWith(github.event.issue.body, '/triage\n') || github.event.issue.body == '/triage') || github.event_name == 'issue_comment' && (startsWith(github.event.comment.body, '/triage ') || startsWith(github.event.comment.body, '/triage\n') || github.event.comment.body == '/triage') && github.event.issue.pull_request == null"
+    if: "github.event_name == 'issues' && (startsWith(github.event.issue.body, '/triage ') || startsWith(github.event.issue.body, '/triage\n') || github.event.issue.body == '/triage') || github.event_name == 'issue_comment' && (startsWith(github.event.comment.body, '/triage ') || startsWith(github.event.comment.body, '/triage\n') || github.event.comment.body == '/triage') && github.event.issue.pull_request == null || github.event_name == 'issues' && github.event.label.name == 'triage-approved'"
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' && steps.check_command_position.outputs.command_position_ok == 'true' }}

--- a/.github/workflows/slash-cmd-issue-triage.md
+++ b/.github/workflows/slash-cmd-issue-triage.md
@@ -3,6 +3,10 @@ on:
   slash_command:
     name: triage
     events: [issues, issue_comment]  # Only in issue bodies and issue comments
+  label_command:
+    name: triage-approved
+    events: [issues]
+    remove_label: false
   reaction: eyes
 
 timeout-minutes: 10


### PR DESCRIPTION
## Summary

- Add `triage-approved` as a label command trigger for the requested issue triage workflow.
- Keep the label on the issue after activation so it continues to act as the MCP approval signal.
- Recompile the generated lock workflow so `issues.labeled` activates triage when the applied label is `triage-approved`.

## Rationale

PR 978 made `triage-approved` authorize reading otherwise filtered external issue content, but maintainers still had to add the label and then invoke `/triage`. This makes the label application itself the requested triage trigger while preserving the existing `/triage` path.

## Validation

- `gh aw compile slash-cmd-issue-triage --no-check-update`
- `gh aw compile slash-cmd-issue-triage --no-check-update --no-emit --validate`
- `git diff --check`
