### PR TITLE
Task: allow repo metadata in issue triage workflow

### DIFF
--- a/.github/workflows/slash-cmd-issue-triage.lock.yml
+++ b/.github/workflows/slash-cmd-issue-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3bd6bdc0278d444a0c052d2642069ff09cd401f1a83512ce3a8ec54ffa7f24f7","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"56b8a79e700c26222580bb93576bc08b3c44e43d99e3b124c9bda0c5fd46c9fc","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"239aec45b78c8799417efdd5bc6d8cc036629ec1","version":"v0.71.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.0","digest":"sha256:9c2228324fb1f26f39dc9471612e530ae3efc3156dac05efb2e8d212878d454d","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.0@sha256:9c2228324fb1f26f39dc9471612e530ae3efc3156dac05efb2e8d212878d454d"},{"image":"ghcr.io/github/github-mcp-server:v1.0.2","digest":"sha256:26db03408086a99cf1916348dcc4f9614206658f9082a8060dc7c81ad787f4ba","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.2@sha256:26db03408086a99cf1916348dcc4f9614206658f9082a8060dc7c81ad787f4ba"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -242,14 +242,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_2a36745a988baca5_EOF'
+          cat << 'GH_AW_PROMPT_e11ab2b993033642_EOF'
           <system>
-          GH_AW_PROMPT_2a36745a988baca5_EOF
+          GH_AW_PROMPT_e11ab2b993033642_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_2a36745a988baca5_EOF'
+          cat << 'GH_AW_PROMPT_e11ab2b993033642_EOF'
           <safe-output-tools>
           Tools: add_comment, add_labels(max:5), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -281,15 +281,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_2a36745a988baca5_EOF
+          GH_AW_PROMPT_e11ab2b993033642_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_2a36745a988baca5_EOF'
+          cat << 'GH_AW_PROMPT_e11ab2b993033642_EOF'
           </system>
           {{#runtime-import .github/workflows/slash-cmd-issue-triage.md}}
-          GH_AW_PROMPT_2a36745a988baca5_EOF
+          GH_AW_PROMPT_e11ab2b993033642_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -370,6 +370,7 @@ jobs:
     permissions:
       contents: read
       issues: read
+      pull-requests: read
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""
@@ -474,9 +475,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_197660da6b8f4e51_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_3368ccbfcbf72a63_EOF'
           {"add_comment":{"max":1},"add_labels":{"max":5},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_197660da6b8f4e51_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_3368ccbfcbf72a63_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -682,7 +683,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_1cfed567fd0a1bdf_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_e5c2df0a0f349305_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -692,7 +693,7 @@ jobs:
                   "GITHUB_HOST": "\${GITHUB_SERVER_URL}",
                   "GITHUB_PERSONAL_ACCESS_TOKEN": "\${GITHUB_MCP_SERVER_TOKEN}",
                   "GITHUB_READ_ONLY": "1",
-                  "GITHUB_TOOLSETS": "issues"
+                  "GITHUB_TOOLSETS": "context,repos,issues,pull_requests"
                 },
                 "guard-policies": {
                   "allow-only": {
@@ -726,7 +727,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_1cfed567fd0a1bdf_EOF
+          GH_AW_MCP_CONFIG_e5c2df0a0f349305_EOF
       - name: Clean git credentials
         continue-on-error: true
         run: bash "${RUNNER_TEMP}/gh-aw/actions/clean_git_credentials.sh"

--- a/.github/workflows/slash-cmd-issue-triage.md
+++ b/.github/workflows/slash-cmd-issue-triage.md
@@ -22,6 +22,7 @@ description: |
 permissions:
   contents: read
   issues: read
+  pull-requests: read
 
 network: defaults
 
@@ -33,7 +34,7 @@ safe-outputs:
 tools:
   web-fetch:
   github:
-    toolsets: [issues]
+    toolsets: [default]
     min-integrity: approved
     approval-labels:
       - triage-approved


### PR DESCRIPTION
## Summary

- Expand the issue triage workflow GitHub MCP toolsets from `issues` to `default`
- Add the `pull-requests: read` permission required by the `default` toolset expansion
- Recompile the generated lock file so the agent job starts GitHub MCP with the default toolsets

## Rationale

The failed agentic workflow run for issue #983 activated correctly after the `triage-approved` label was applied, but the agent could not read the issue. The MCP gateway integrity guard filtered the issue as below `approved` integrity even though the raw issue payload contained `labels:["triage-approved"]`.

The run logs showed the guard repeatedly attempting to call `search_repositories` for repository metadata, while the workflow had configured only the `issues` toolset. That made the metadata lookup fail with `unknown tool "search_repositories"`. Using the documented `default` toolset gives the guard the repository metadata path it was missing.

## Validation

- `gh aw compile slash-cmd-issue-triage --strict`
- `git diff --check`

Note: `gh aw mcp inspect slash-cmd-issue-triage --server github --verbose` could not complete locally because no GitHub token is available in the command environment for that inspector.