### PR TITLE
Fix: Allow env tags in dynamic declarative maps

### DIFF
--- a/internal/declarative/loader/env_validation.go
+++ b/internal/declarative/loader/env_validation.go
@@ -26,6 +26,9 @@ func validateEnvNode(node *yaml.Node, targetType reflect.Type, path []string) er
 	if targetType == nil {
 		return nil
 	}
+	if isEnvDynamicFieldType(targetType) {
+		return validateDynamicEnvNode(node, path)
+	}
 
 	switch node.Kind {
 	case yaml.DocumentNode:
@@ -48,7 +51,7 @@ func validateEnvNode(node *yaml.Node, targetType reflect.Type, path []string) er
 
 				nextPath := append(path, keyNode.Value)
 				if valueNode.Tag == "!env" {
-					if !isEnvStringFieldType(fieldType) {
+					if !isEnvStringCompatibleType(fieldType) {
 						return fmt.Errorf(
 							"!env currently supports string-typed fields only (field: %s)",
 							strings.Join(nextPath, "."),
@@ -64,17 +67,19 @@ func validateEnvNode(node *yaml.Node, targetType reflect.Type, path []string) er
 		case reflect.Map:
 			elemType := derefType(targetType.Elem())
 			for i := 0; i+1 < len(node.Content); i += 2 {
+				keyNode := node.Content[i]
 				valueNode := node.Content[i+1]
+				nextPath := append(path, keyNode.Value)
 				if valueNode.Tag == "!env" {
-					if !isEnvStringFieldType(elemType) {
+					if !isEnvStringCompatibleType(elemType) {
 						return fmt.Errorf(
 							"!env currently supports string-typed fields only (field: %s)",
-							strings.Join(path, "."),
+							strings.Join(nextPath, "."),
 						)
 					}
 					continue
 				}
-				if err := validateEnvNode(valueNode, elemType, path); err != nil {
+				if err := validateEnvNode(valueNode, elemType, nextPath); err != nil {
 					return err
 				}
 			}
@@ -89,7 +94,7 @@ func validateEnvNode(node *yaml.Node, targetType reflect.Type, path []string) er
 		elemType := derefType(targetType.Elem())
 		for _, child := range node.Content {
 			if child.Tag == "!env" {
-				if !isEnvStringFieldType(elemType) {
+				if !isEnvStringCompatibleType(elemType) {
 					return fmt.Errorf(
 						"!env currently supports string-typed fields only (field: %s)",
 						strings.Join(path, "."),
@@ -98,6 +103,46 @@ func validateEnvNode(node *yaml.Node, targetType reflect.Type, path []string) er
 				continue
 			}
 			if err := validateEnvNode(child, elemType, path); err != nil {
+				return err
+			}
+		}
+	case yaml.ScalarNode, yaml.AliasNode:
+		return nil
+	default:
+		return nil
+	}
+
+	return nil
+}
+
+func validateDynamicEnvNode(node *yaml.Node, path []string) error {
+	if node == nil {
+		return nil
+	}
+
+	switch node.Kind {
+	case yaml.DocumentNode:
+		if len(node.Content) == 0 {
+			return nil
+		}
+		return validateDynamicEnvNode(node.Content[0], path)
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			keyNode := node.Content[i]
+			valueNode := node.Content[i+1]
+			if valueNode.Tag == "!env" {
+				continue
+			}
+			if err := validateDynamicEnvNode(valueNode, append(path, keyNode.Value)); err != nil {
+				return err
+			}
+		}
+	case yaml.SequenceNode:
+		for _, child := range node.Content {
+			if child.Tag == "!env" {
+				continue
+			}
+			if err := validateDynamicEnvNode(child, path); err != nil {
 				return err
 			}
 		}
@@ -175,9 +220,18 @@ func structuredFieldInline(field reflect.StructField) bool {
 	return !jsonSkip && jsonInline
 }
 
-func isEnvStringFieldType(fieldType reflect.Type) bool {
+func isEnvStringCompatibleType(fieldType reflect.Type) bool {
 	fieldType = derefType(fieldType)
-	return fieldType != nil && fieldType.Kind() == reflect.String
+	if fieldType == nil {
+		return false
+	}
+
+	return fieldType.Kind() == reflect.String || isEnvDynamicFieldType(fieldType)
+}
+
+func isEnvDynamicFieldType(fieldType reflect.Type) bool {
+	fieldType = derefType(fieldType)
+	return fieldType != nil && fieldType.Kind() == reflect.Interface && fieldType.NumMethod() == 0
 }
 
 func derefType(t reflect.Type) reflect.Type {

--- a/internal/declarative/loader/env_validation_test.go
+++ b/internal/declarative/loader/env_validation_test.go
@@ -1,0 +1,48 @@
+package loader
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3" //nolint:gomodguard // yaml.v3 required for custom tag inspection
+)
+
+func TestValidateEnvNodeAllowsDynamicMapEnvTags(t *testing.T) {
+	type dynamicConfig struct {
+		Values map[string]any `yaml:"values"`
+	}
+
+	content := []byte(`
+values:
+  direct: !env DIRECT_VALUE
+  nested:
+    leaf: !env NESTED_VALUE
+  list:
+    - !env LIST_VALUE
+    - child: !env LIST_CHILD_VALUE
+`)
+
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal(content, &node))
+
+	err := validateEnvNode(&node, reflect.TypeFor[dynamicConfig](), nil)
+	require.NoError(t, err)
+}
+
+func TestValidateEnvNodeRejectsBoolEnvTag(t *testing.T) {
+	type staticConfig struct {
+		Enabled bool `yaml:"enabled"`
+	}
+
+	content := []byte(`enabled: !env ENABLED`)
+
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal(content, &node))
+
+	err := validateEnvNode(&node, reflect.TypeFor[staticConfig](), nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "!env currently supports string-typed fields only")
+	assert.Contains(t, err.Error(), "enabled")
+}

--- a/internal/declarative/loader/tag_integration_test.go
+++ b/internal/declarative/loader/tag_integration_test.go
@@ -312,6 +312,30 @@ dcr_providers:
 	assert.Contains(t, err.Error(), "dcr_config.disable_event_hooks must be a boolean")
 }
 
+func TestLoader_EnvTagIntegration_DCRProviderDynamicConfigRejectsNonStringEnvValue(t *testing.T) {
+	t.Setenv("DCR_SETTINGS", "api_key_enabled: true")
+
+	tmpDir := t.TempDir()
+	mainContent := `
+dcr_providers:
+  - ref: env-dcr
+    name: env-dcr
+    provider_type: http
+    issuer: https://issuer.example.test
+    dcr_config:
+      dcr_base_url: https://dcr.example.test/register
+      api_key: !env DCR_SETTINGS#api_key_enabled
+`
+
+	mainFile := filepath.Join(tmpDir, "main.yaml")
+	require.NoError(t, os.WriteFile(mainFile, []byte(mainContent), 0o600))
+
+	loader := NewWithBaseDir(tmpDir)
+	_, err := loader.LoadFile(mainFile)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "!env value must resolve to a string")
+}
+
 func TestLoader_EnvTagStringOnlyFields(t *testing.T) {
 	t.Setenv("PORTAL_AUTH_ENABLED", "true")
 

--- a/internal/declarative/loader/tag_integration_test.go
+++ b/internal/declarative/loader/tag_integration_test.go
@@ -288,6 +288,30 @@ dcr_providers:
 	assert.Equal(t, "__ENV__:DCR_API_KEY", envSources["/dcr_config/api_key"])
 }
 
+func TestLoader_EnvTagIntegration_DCRProviderBoolConfigRejectsString(t *testing.T) {
+	t.Setenv("DCR_DISABLE_EVENT_HOOKS", "true")
+
+	tmpDir := t.TempDir()
+	mainContent := `
+dcr_providers:
+  - ref: env-dcr
+    name: env-dcr
+    provider_type: http
+    issuer: https://issuer.example.test
+    dcr_config:
+      dcr_base_url: https://dcr.example.test/register
+      disable_event_hooks: !env DCR_DISABLE_EVENT_HOOKS
+`
+
+	mainFile := filepath.Join(tmpDir, "main.yaml")
+	require.NoError(t, os.WriteFile(mainFile, []byte(mainContent), 0o600))
+
+	loader := NewWithBaseDir(tmpDir)
+	_, err := loader.LoadFile(mainFile)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dcr_config.disable_event_hooks must be a boolean")
+}
+
 func TestLoader_EnvTagStringOnlyFields(t *testing.T) {
 	t.Setenv("PORTAL_AUTH_ENABLED", "true")
 

--- a/internal/declarative/loader/tag_integration_test.go
+++ b/internal/declarative/loader/tag_integration_test.go
@@ -254,6 +254,40 @@ portals:
 	assert.Equal(t, "__ENV__:PORTAL_DESCRIPTION", rs.GetEnvSources("env-portal")["/description"])
 }
 
+func TestLoader_EnvTagIntegration_DCRProviderDynamicConfig(t *testing.T) {
+	t.Setenv("DCR_BASE_URL", "https://dcr.example.test/register")
+	t.Setenv("DCR_API_KEY", "api-key-from-env")
+
+	tmpDir := t.TempDir()
+	mainContent := `
+dcr_providers:
+  - ref: env-dcr
+    name: env-dcr
+    provider_type: http
+    issuer: https://issuer.example.test
+    dcr_config:
+      dcr_base_url: !env DCR_BASE_URL
+      api_key: !env DCR_API_KEY
+`
+
+	mainFile := filepath.Join(tmpDir, "main.yaml")
+	require.NoError(t, os.WriteFile(mainFile, []byte(mainContent), 0o600))
+
+	loader := NewWithBaseDir(tmpDir)
+	rs, err := loader.LoadFile(mainFile)
+	require.NoError(t, err)
+	require.NotNil(t, rs)
+	require.Len(t, rs.DCRProviders, 1)
+
+	dcrConfig := rs.DCRProviders[0].DCRConfig
+	assert.Equal(t, "https://dcr.example.test/register", dcrConfig["dcr_base_url"])
+	assert.Equal(t, "api-key-from-env", dcrConfig["api_key"])
+
+	envSources := rs.GetEnvSources("env-dcr")
+	assert.Equal(t, "__ENV__:DCR_BASE_URL", envSources["/dcr_config/dcr_base_url"])
+	assert.Equal(t, "__ENV__:DCR_API_KEY", envSources["/dcr_config/api_key"])
+}
+
 func TestLoader_EnvTagStringOnlyFields(t *testing.T) {
 	t.Setenv("PORTAL_AUTH_ENABLED", "true")
 

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -24,6 +24,11 @@ func (l *Loader) validateResourceSet(rs *resources.ResourceSet) error {
 		return err
 	}
 
+	// Validate DCR providers
+	if err := l.validateDCRProviders(rs.DCRProviders, rs); err != nil {
+		return err
+	}
+
 	// Validate control planes
 	if err := l.validateControlPlanes(rs.ControlPlanes, rs); err != nil {
 		return err
@@ -286,6 +291,42 @@ func (l *Loader) validateAuthStrategies(
 		}
 
 		names[stratName] = strategy.GetRef()
+	}
+
+	return nil
+}
+
+// validateDCRProviders validates DCR provider resources
+func (l *Loader) validateDCRProviders(
+	providers []resources.DCRProviderResource,
+	rs *resources.ResourceSet,
+) error {
+	names := make(map[string]string) // name -> ref mapping (names unique per type)
+
+	for i := range providers {
+		provider := &providers[i]
+
+		// Validate resource
+		if err := provider.Validate(); err != nil {
+			return fmt.Errorf("invalid dcr_provider %q: %w", provider.GetRef(), err)
+		}
+
+		// Check global ref uniqueness across different resource types
+		// Don't check within same type - that's handled by the loader during append
+		if existing, found := rs.GetResourceByRef(provider.GetRef()); found {
+			if existing.GetType() != resources.ResourceTypeDCRProvider {
+				return fmt.Errorf("duplicate ref '%s' (already defined as %s)",
+					provider.GetRef(), existing.GetType())
+			}
+		}
+
+		providerName := provider.GetMoniker()
+		if existingRef, exists := names[providerName]; exists {
+			return fmt.Errorf("duplicate dcr_provider name '%s' (ref: %s conflicts with ref: %s)",
+				providerName, provider.GetRef(), existingRef)
+		}
+
+		names[providerName] = provider.GetRef()
 	}
 
 	return nil

--- a/internal/declarative/resources/dcr_provider.go
+++ b/internal/declarative/resources/dcr_provider.go
@@ -66,11 +66,10 @@ func (d DCRProviderResource) Validate() error {
 	if NormalizeDCRProviderIssuer(d.Issuer) == "" {
 		return fmt.Errorf("issuer is required")
 	}
-	if d.DCRConfig == nil {
-		return fmt.Errorf("dcr_config is required")
-	}
-	if err := validateDCRProviderConfig(d.ProviderType, d.DCRConfig); err != nil {
-		return err
+	if d.DCRConfig != nil {
+		if err := validateDCRProviderConfig(d.ProviderType, d.DCRConfig); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/declarative/resources/dcr_provider.go
+++ b/internal/declarative/resources/dcr_provider.go
@@ -69,7 +69,39 @@ func (d DCRProviderResource) Validate() error {
 	if d.DCRConfig == nil {
 		return fmt.Errorf("dcr_config is required")
 	}
+	if err := validateDCRProviderConfig(d.ProviderType, d.DCRConfig); err != nil {
+		return err
+	}
 	return nil
+}
+
+func validateDCRProviderConfig(providerType string, config map[string]any) error {
+	for _, field := range dcrProviderBoolConfigFields(providerType) {
+		value, ok := config[field]
+		if !ok || value == nil {
+			continue
+		}
+		if _, ok := value.(bool); !ok {
+			return fmt.Errorf("dcr_config.%s must be a boolean", field)
+		}
+	}
+
+	return nil
+}
+
+func dcrProviderBoolConfigFields(providerType string) []string {
+	switch providerType {
+	case "auth0":
+		return []string{"use_developer_managed_scopes"}
+	case "http":
+		return []string{
+			"disable_event_hooks",
+			"disable_refresh_secret",
+			"allow_multiple_credentials",
+		}
+	default:
+		return nil
+	}
 }
 
 func (d *DCRProviderResource) SetDefaults() {

--- a/internal/declarative/resources/dcr_provider.go
+++ b/internal/declarative/resources/dcr_provider.go
@@ -66,10 +66,11 @@ func (d DCRProviderResource) Validate() error {
 	if NormalizeDCRProviderIssuer(d.Issuer) == "" {
 		return fmt.Errorf("issuer is required")
 	}
-	if d.DCRConfig != nil {
-		if err := validateDCRProviderConfig(d.ProviderType, d.DCRConfig); err != nil {
-			return err
-		}
+	if d.DCRConfig == nil {
+		return fmt.Errorf("dcr_config is required")
+	}
+	if err := validateDCRProviderConfig(d.ProviderType, d.DCRConfig); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/declarative/resources/dcr_provider_test.go
+++ b/internal/declarative/resources/dcr_provider_test.go
@@ -102,15 +102,6 @@ func TestDCRProviderResourceValidateRequiresCoreFields(t *testing.T) {
 			},
 			wantErr: "issuer is required",
 		},
-		{
-			name: "dcr_config",
-			provider: DCRProviderResource{
-				BaseResource: BaseResource{Ref: "dcr"},
-				ProviderType: "okta",
-				Issuer:       "https://issuer.example.com",
-			},
-			wantErr: "dcr_config is required",
-		},
 	}
 
 	for _, tt := range tests {
@@ -120,6 +111,16 @@ func TestDCRProviderResourceValidateRequiresCoreFields(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.wantErr)
 		})
 	}
+}
+
+func TestDCRProviderResourceValidateAllowsOmittedConfig(t *testing.T) {
+	provider := DCRProviderResource{
+		BaseResource: BaseResource{Ref: "dcr"},
+		ProviderType: "okta",
+		Issuer:       "https://issuer.example.com",
+	}
+
+	require.NoError(t, provider.Validate())
 }
 
 func TestDCRProviderResourceValidateRejectsStringBooleanConfigFields(t *testing.T) {

--- a/internal/declarative/resources/dcr_provider_test.go
+++ b/internal/declarative/resources/dcr_provider_test.go
@@ -102,6 +102,15 @@ func TestDCRProviderResourceValidateRequiresCoreFields(t *testing.T) {
 			},
 			wantErr: "issuer is required",
 		},
+		{
+			name: "dcr_config",
+			provider: DCRProviderResource{
+				BaseResource: BaseResource{Ref: "dcr"},
+				ProviderType: "okta",
+				Issuer:       "https://issuer.example.com",
+			},
+			wantErr: "dcr_config is required",
+		},
 	}
 
 	for _, tt := range tests {
@@ -111,16 +120,6 @@ func TestDCRProviderResourceValidateRequiresCoreFields(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.wantErr)
 		})
 	}
-}
-
-func TestDCRProviderResourceValidateAllowsOmittedConfig(t *testing.T) {
-	provider := DCRProviderResource{
-		BaseResource: BaseResource{Ref: "dcr"},
-		ProviderType: "okta",
-		Issuer:       "https://issuer.example.com",
-	}
-
-	require.NoError(t, provider.Validate())
 }
 
 func TestDCRProviderResourceValidateRejectsStringBooleanConfigFields(t *testing.T) {

--- a/internal/declarative/resources/dcr_provider_test.go
+++ b/internal/declarative/resources/dcr_provider_test.go
@@ -121,3 +121,49 @@ func TestDCRProviderResourceValidateRequiresCoreFields(t *testing.T) {
 		})
 	}
 }
+
+func TestDCRProviderResourceValidateRejectsStringBooleanConfigFields(t *testing.T) {
+	tests := []struct {
+		name         string
+		providerType string
+		field        string
+	}{
+		{
+			name:         "http disable_event_hooks",
+			providerType: "http",
+			field:        "disable_event_hooks",
+		},
+		{
+			name:         "http disable_refresh_secret",
+			providerType: "http",
+			field:        "disable_refresh_secret",
+		},
+		{
+			name:         "http allow_multiple_credentials",
+			providerType: "http",
+			field:        "allow_multiple_credentials",
+		},
+		{
+			name:         "auth0 use_developer_managed_scopes",
+			providerType: "auth0",
+			field:        "use_developer_managed_scopes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := DCRProviderResource{
+				BaseResource: BaseResource{Ref: "dcr"},
+				ProviderType: tt.providerType,
+				Issuer:       "https://issuer.example.com",
+				DCRConfig: map[string]any{
+					tt.field: "true",
+				},
+			}
+
+			err := provider.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "dcr_config."+tt.field+" must be a boolean")
+		})
+	}
+}

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -66,7 +66,7 @@ type ResourceRef struct {
 type ResourceSet struct {
 	Portals []PortalResource `yaml:"portals,omitempty"                               json:"portals,omitempty"`
 	// AuditLogs contains organization-scoped audit-log resources.
-	AuditLogs AuditLogsResource `yaml:"audit-logs,omitempty" json:"audit-logs,omitempty"`
+	AuditLogs AuditLogsResource `yaml:"audit-logs,omitempty" json:"audit-logs"`
 	// ApplicationAuthStrategies contains auth strategy configurations
 	ApplicationAuthStrategies []ApplicationAuthStrategyResource `yaml:"application_auth_strategies,omitempty"           json:"application_auth_strategies,omitempty"` //nolint:lll
 	DCRProviders              []DCRProviderResource             `yaml:"dcr_providers,omitempty"                        json:"dcr_providers,omitempty"`                //nolint:lll

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -66,7 +66,7 @@ type ResourceRef struct {
 type ResourceSet struct {
 	Portals []PortalResource `yaml:"portals,omitempty"                               json:"portals,omitempty"`
 	// AuditLogs contains organization-scoped audit-log resources.
-	AuditLogs AuditLogsResource `yaml:"audit-logs,omitempty" json:"audit-logs"`
+	AuditLogs AuditLogsResource `yaml:"audit-logs,omitempty" json:"audit-logs,omitempty"`
 	// ApplicationAuthStrategies contains auth strategy configurations
 	ApplicationAuthStrategies []ApplicationAuthStrategyResource `yaml:"application_auth_strategies,omitempty"           json:"application_auth_strategies,omitempty"` //nolint:lll
 	DCRProviders              []DCRProviderResource             `yaml:"dcr_providers,omitempty"                        json:"dcr_providers,omitempty"`                //nolint:lll

--- a/internal/declarative/tags/env.go
+++ b/internal/declarative/tags/env.go
@@ -48,7 +48,7 @@ func (r *EnvTagResolver) Resolve(node *yaml.Node) (any, error) {
 		return BuildEnvPlaceholder(varRef, extractPath), nil
 	}
 
-	return resolveEnvValue(varRef, extractPath)
+	return resolveEnvStringValue(varRef, extractPath)
 }
 
 func parseEnvNode(node *yaml.Node) (string, string, error) {
@@ -103,6 +103,20 @@ func resolveEnvValue(varRef, extractPath string) (any, error) {
 	return result, nil
 }
 
+func resolveEnvStringValue(varRef, extractPath string) (string, error) {
+	value, err := resolveEnvValue(varRef, extractPath)
+	if err != nil {
+		return "", err
+	}
+
+	strValue, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("!env value must resolve to a string")
+	}
+
+	return strValue, nil
+}
+
 // BuildEnvPlaceholder serializes an env reference into a deferred placeholder string.
 func BuildEnvPlaceholder(varRef, extractPath string) string {
 	if extractPath == "" {
@@ -139,15 +153,5 @@ func ResolveEnvPlaceholder(placeholder string) (string, error) {
 		return "", fmt.Errorf("invalid env placeholder: %s", placeholder)
 	}
 
-	value, err := resolveEnvValue(varRef, extractPath)
-	if err != nil {
-		return "", err
-	}
-
-	strValue, ok := value.(string)
-	if !ok {
-		return "", fmt.Errorf("!env value must resolve to a string for deferred execution")
-	}
-
-	return strValue, nil
+	return resolveEnvStringValue(varRef, extractPath)
 }

--- a/internal/declarative/tags/env_test.go
+++ b/internal/declarative/tags/env_test.go
@@ -16,6 +16,7 @@ func TestEnvTagResolver_Tag(t *testing.T) {
 func TestEnvTagResolver_Resolve(t *testing.T) {
 	t.Setenv("TEST_ENV_SIMPLE", "secret-value")
 	t.Setenv("TEST_ENV_CONFIG", "credentials:\n  username: admin\n")
+	t.Setenv("TEST_ENV_BOOL_CONFIG", "settings:\n  enabled: true\n")
 
 	tests := []struct {
 		name     string
@@ -50,6 +51,15 @@ func TestEnvTagResolver_Resolve(t *testing.T) {
 				Value: " TEST_ENV_CONFIG # credentials.username ",
 			},
 			expected: "admin",
+		},
+		{
+			name: "reject extracted non-string value",
+			mode: EnvTagModeResolve,
+			node: &yaml.Node{
+				Kind:  yaml.ScalarNode,
+				Value: "TEST_ENV_BOOL_CONFIG#settings.enabled",
+			},
+			wantErr: "!env value must resolve to a string",
 		},
 		{
 			name: "preserve placeholder",

--- a/test/e2e/scenarios/yaml-tags/env/scenario.yaml
+++ b/test/e2e/scenarios/yaml-tags/env/scenario.yaml
@@ -5,6 +5,8 @@ env:
 
 vars:
   namespace: yaml-env-tags
+  dcrProviderRef: env-dcr-http
+  dcrProviderName: env-dcr-http
   portalRef: env-portal
   portalName: env-portal
   ordersAPIRef: env-orders
@@ -36,6 +38,8 @@ steps:
       KONGCTL_E2E_ENV_PORTAL_META: '{"display_name":"Portal Display Planned"}'
       KONGCTL_E2E_ENV_API_DESC: Orders API description planned
       KONGCTL_E2E_ENV_API_META: '{"owner":"planned-owner"}'
+      KONGCTL_E2E_ENV_DCR_BASE_URL: https://env-dcr.example.com/planned/dcr
+      KONGCTL_E2E_ENV_DCR_API_KEY: planned_api_key
     commands:
       - name: 000-plan-create
         outputFormat: disable
@@ -54,12 +58,18 @@ steps:
           - select: summary
             expect:
               fields:
-                total_changes: 2
-                by_action.CREATE: 2
+                total_changes: 3
+                by_action.CREATE: 3
           - select: warnings[?contains(message, 'deferred !env values')]
             expect:
               fields:
-                "length(@)": 2
+                "length(@)": 3
+          - select: >-
+              changes[?resource_type=='dcr_provider' && resource_ref=='{{ .vars.dcrProviderRef }}'] | [0]
+            expect:
+              fields:
+                "fields.dcr_config.dcr_base_url": __ENV__:KONGCTL_E2E_ENV_DCR_BASE_URL
+                "fields.dcr_config.api_key": __ENV__:KONGCTL_E2E_ENV_DCR_API_KEY
           - select: >-
               changes[?resource_type=='portal' && resource_ref=='{{ .vars.portalRef }}'] | [0]
             expect:
@@ -83,10 +93,12 @@ steps:
           - select: stdout
             expect:
               fields:
-                "contains(@, 'Plan: 2 to add')": true
+                "contains(@, 'Plan: 3 to add')": true
                 "contains(@, '[redacted from !env]')": true
                 "contains(@, 'Portal description planned')": false
                 "contains(@, '__ENV__:KONGCTL_E2E_ENV_PORTAL_DESC')": false
+                "contains(@, 'planned_api_key')": false
+                "contains(@, '__ENV__:KONGCTL_E2E_ENV_DCR_API_KEY')": false
       - name: 002-apply-plan
         outputFormat: json
         env:
@@ -94,6 +106,8 @@ steps:
           KONGCTL_E2E_ENV_PORTAL_META: '{"display_name":"Portal Display Applied"}'
           KONGCTL_E2E_ENV_API_DESC: Orders API description applied
           KONGCTL_E2E_ENV_API_META: '{"owner":"applied-owner"}'
+          KONGCTL_E2E_ENV_DCR_BASE_URL: https://env-dcr.example.com/applied/dcr
+          KONGCTL_E2E_ENV_DCR_API_KEY: applied_api_key
         run:
           - apply
           - --plan
@@ -103,9 +117,18 @@ steps:
           - select: summary
             expect:
               fields:
-                applied: 2
+                applied: 3
                 failed: 0
-      - name: 003-get-portal
+      - name: 003-get-dcr-providers
+        run: ["get", "dcr-providers", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.dcrProviderName }}'] | [0]"
+            expect:
+              fields:
+                provider_type: http
+                issuer: https://env-dcr-issuer.example.com
+                dcr_config.dcr_base_url: https://env-dcr.example.com/applied/dcr
+      - name: 004-get-portal
         run: ["get", "portals", "-o", "json"]
         assertions:
           - select: "[?name=='{{ .vars.portalName }}'] | [0]"
@@ -113,7 +136,7 @@ steps:
               fields:
                 display_name: Portal Display Applied
                 description: Portal description applied
-      - name: 004-get-apis
+      - name: 005-get-apis
         run: ["get", "apis", "-o", "json"]
         assertions:
           - select: "[?name=='{{ .vars.ordersAPIName }}'] | [0]"
@@ -128,6 +151,8 @@ steps:
       KONGCTL_E2E_ENV_PORTAL_META: '{"display_name":"Portal Display Direct Apply"}'
       KONGCTL_E2E_ENV_API_DESC: Orders API description direct apply
       KONGCTL_E2E_ENV_API_META: '{"owner":"direct-apply-owner"}'
+      KONGCTL_E2E_ENV_DCR_BASE_URL: https://env-dcr.example.com/direct-apply/dcr
+      KONGCTL_E2E_ENV_DCR_API_KEY: direct_apply_api_key
     commands:
       - name: 000-apply-inline
         outputFormat: json
@@ -144,8 +169,13 @@ steps:
           - select: plan.summary
             expect:
               fields:
-                total_changes: 2
-                by_action.UPDATE: 2
+                total_changes: 3
+                by_action.UPDATE: 3
+          - select: >-
+              plan.changes[?resource_type=='dcr_provider' && resource_ref=='{{ .vars.dcrProviderRef }}'] | [0]
+            expect:
+              fields:
+                "changed_fields.dcr_config.new.dcr_base_url": __ENV__:KONGCTL_E2E_ENV_DCR_BASE_URL
           - select: >-
               plan.changes[?resource_type=='portal' && resource_ref=='{{ .vars.portalRef }}'] | [0]
             expect:
@@ -160,9 +190,16 @@ steps:
           - select: summary
             expect:
               fields:
-                applied: 2
+                applied: 3
                 failed: 0
-      - name: 001-get-portal
+      - name: 001-get-dcr-providers
+        run: ["get", "dcr-providers", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.dcrProviderName }}'] | [0]"
+            expect:
+              fields:
+                dcr_config.dcr_base_url: https://env-dcr.example.com/direct-apply/dcr
+      - name: 002-get-portal
         run: ["get", "portals", "-o", "json"]
         assertions:
           - select: "[?name=='{{ .vars.portalName }}'] | [0]"
@@ -170,7 +207,7 @@ steps:
               fields:
                 display_name: Portal Display Direct Apply
                 description: Portal description direct apply
-      - name: 002-get-apis
+      - name: 003-get-apis
         run: ["get", "apis", "-o", "json"]
         assertions:
           - select: "[?name=='{{ .vars.ordersAPIName }}'] | [0]"
@@ -205,10 +242,10 @@ steps:
           - select: summary
             expect:
               fields:
-                total_changes: 3
+                total_changes: 4
                 by_action.CREATE: 1
                 by_action.UPDATE: 1
-                by_action.DELETE: 1
+                by_action.DELETE: 2
           - select: warnings[?contains(message, 'deferred !env values')]
             expect:
               fields:
@@ -231,6 +268,11 @@ steps:
             expect:
               fields:
                 action: DELETE
+          - select: >-
+              changes[?resource_type=='dcr_provider' && resource_ref=='{{ .vars.dcrProviderRef }}'] | [0]
+            expect:
+              fields:
+                action: DELETE
       - name: 001-diff-plan-text
         outputFormat: text
         parseAs: raw
@@ -242,7 +284,7 @@ steps:
           - select: stdout
             expect:
               fields:
-                "contains(@, 'Plan: 1 to add, 1 to change, 1 to destroy')": true
+                "contains(@, 'Plan: 1 to add, 1 to change, 2 to destroy')": true
                 "contains(@, '[redacted from !env]')": true
                 "contains(@, 'Inventory API description sync planned')": false
                 "contains(@, '__ENV__:KONGCTL_E2E_ENV_INVENTORY_API_DESC')": false
@@ -262,7 +304,7 @@ steps:
           - select: summary
             expect:
               fields:
-                applied: 3
+                applied: 4
                 failed: 0
       - name: 003-get-portal
         run: ["get", "portals", "-o", "json"]

--- a/test/e2e/scenarios/yaml-tags/env/testdata/config.yaml
+++ b/test/e2e/scenarios/yaml-tags/env/testdata/config.yaml
@@ -2,6 +2,18 @@ _defaults:
   kongctl:
     namespace: yaml-env-tags
 
+dcr_providers:
+  - ref: env-dcr-http
+    name: env-dcr-http
+    provider_type: http
+    issuer: https://env-dcr-issuer.example.com
+    dcr_config:
+      dcr_base_url: !env KONGCTL_E2E_ENV_DCR_BASE_URL
+      api_key: !env KONGCTL_E2E_ENV_DCR_API_KEY
+    labels:
+      suite: yaml-env-tags
+      provider: http
+
 portals:
   - ref: env-portal
     name: env-portal


### PR DESCRIPTION
## Summary

Fixes #983 by making deferred `!env` validation handle dynamic declarative fields generically instead of special-casing DCR provider config.

## Details

- Added an e2e regression fixture for `dcr_providers[].dcr_config` values loaded from `!env`.
- Preserved rejection of `!env` on statically non-string fields such as bools.
- Treated empty-interface targets and `map[string]any` values as dynamic string-compatible targets for `!env` placeholders.
- Recurse through nested dynamic maps and sequences before unmarshalling so nested dynamic fields work outside DCR as well.
- Added loader unit coverage for resolved DCR config values and deferred source paths at `/dcr_config/dcr_base_url` and `/dcr_config/api_key`.

The red e2e reproduction failed before the fix with:

```text
!env currently supports string-typed fields only (field: dcr_providers.dcr_config)
```

## Validation

- `make test-e2e-scenarios SCENARIO=yaml-tags/env` failed before the fix with the expected loader error.
- `go test ./internal/declarative/loader`
- `make test-e2e-scenarios SCENARIO=yaml-tags/env`
- `go fix ./...`
- `make format`
- `make build`
- `make lint`
- `make test`
