### PR TITLE
Task: allow maintainer-triggered triage of public issues

### DIFF
--- a/.github/workflows/slash-cmd-issue-triage.lock.yml
+++ b/.github/workflows/slash-cmd-issue-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"56b8a79e700c26222580bb93576bc08b3c44e43d99e3b124c9bda0c5fd46c9fc","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"2fcc36c914829cad484ae49ff8d13fe04d5ae24a79ac52e46e6104e2d4dba3eb","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"239aec45b78c8799417efdd5bc6d8cc036629ec1","version":"v0.71.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.0","digest":"sha256:9c2228324fb1f26f39dc9471612e530ae3efc3156dac05efb2e8d212878d454d","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.0@sha256:9c2228324fb1f26f39dc9471612e530ae3efc3156dac05efb2e8d212878d454d"},{"image":"ghcr.io/github/github-mcp-server:v1.0.2","digest":"sha256:26db03408086a99cf1916348dcc4f9614206658f9082a8060dc7c81ad787f4ba","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.2@sha256:26db03408086a99cf1916348dcc4f9614206658f9082a8060dc7c81ad787f4ba"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -64,6 +64,10 @@ name: "Requested Issue Triage"
     - edited
     - reopened
     - labeled
+  # roles: # Roles processed as role check in pre-activation job
+  # - admin # Roles processed as role check in pre-activation job
+  # - maintainer # Roles processed as role check in pre-activation job
+  # - write # Roles processed as role check in pre-activation job
 
 permissions: {}
 
@@ -75,7 +79,7 @@ run-name: "Requested Issue Triage"
 jobs:
   activation:
     needs: pre_activation
-    if: "needs.pre_activation.outputs.activated == 'true' && (github.event_name == 'issues' && (startsWith(github.event.issue.body, '/triage ') || startsWith(github.event.issue.body, '/triage\n') || github.event.issue.body == '/triage') || github.event_name == 'issue_comment' && (startsWith(github.event.comment.body, '/triage ') || startsWith(github.event.comment.body, '/triage\n') || github.event.comment.body == '/triage') && github.event.issue.pull_request == null || github.event_name == 'issues' && github.event.label.name == 'triage-approved')"
+    if: "needs.pre_activation.outputs.activated == 'true' && ((github.event_name == 'issues' || github.event_name == 'issue_comment') && (github.event_name == 'issues' && (startsWith(github.event.issue.body, '/triage ') || startsWith(github.event.issue.body, '/triage\n') || github.event.issue.body == '/triage') || github.event_name == 'issue_comment' && (startsWith(github.event.comment.body, '/triage ') || startsWith(github.event.comment.body, '/triage\n') || github.event.comment.body == '/triage') && github.event.issue.pull_request == null) || (!(github.event_name == 'issues')) && (!(github.event_name == 'issue_comment')) || github.event_name == 'issues' && github.event.label.name == 'triage-approved')"
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -242,14 +246,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_e11ab2b993033642_EOF'
+          cat << 'GH_AW_PROMPT_88866d4b02d61824_EOF'
           <system>
-          GH_AW_PROMPT_e11ab2b993033642_EOF
+          GH_AW_PROMPT_88866d4b02d61824_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_e11ab2b993033642_EOF'
+          cat << 'GH_AW_PROMPT_88866d4b02d61824_EOF'
           <safe-output-tools>
           Tools: add_comment, add_labels(max:5), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -281,15 +285,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_e11ab2b993033642_EOF
+          GH_AW_PROMPT_88866d4b02d61824_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
           if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
             cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
           fi
-          cat << 'GH_AW_PROMPT_e11ab2b993033642_EOF'
+          cat << 'GH_AW_PROMPT_88866d4b02d61824_EOF'
           </system>
           {{#runtime-import .github/workflows/slash-cmd-issue-triage.md}}
-          GH_AW_PROMPT_e11ab2b993033642_EOF
+          GH_AW_PROMPT_88866d4b02d61824_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -454,7 +458,6 @@ jobs:
         env:
           GH_AW_BLOCKED_USERS_VAR: ${{ vars.GH_AW_GITHUB_BLOCKED_USERS || '' }}
           GH_AW_TRUSTED_USERS_VAR: ${{ vars.GH_AW_GITHUB_TRUSTED_USERS || '' }}
-          GH_AW_APPROVAL_LABELS_EXTRA: triage-approved
           GH_AW_APPROVAL_LABELS_VAR: ${{ vars.GH_AW_GITHUB_APPROVAL_LABELS || '' }}
         run: bash "${RUNNER_TEMP}/gh-aw/actions/parse_guard_list.sh"
       - name: Download activation artifact
@@ -475,9 +478,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_3368ccbfcbf72a63_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_062f189e1f3487a1_EOF'
           {"add_comment":{"max":1},"add_labels":{"max":5},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_3368ccbfcbf72a63_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_062f189e1f3487a1_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -683,7 +686,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_e5c2df0a0f349305_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_1fd4329ff1834a24_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -699,7 +702,7 @@ jobs:
                   "allow-only": {
                     "approval-labels": ${{ steps.parse-guard-vars.outputs.approval_labels }},
                     "blocked-users": ${{ steps.parse-guard-vars.outputs.blocked_users }},
-                    "min-integrity": "approved",
+                    "min-integrity": "none",
                     "repos": "all",
                     "trusted-users": ${{ steps.parse-guard-vars.outputs.trusted_users }}
                   }
@@ -727,7 +730,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_e5c2df0a0f349305_EOF
+          GH_AW_MCP_CONFIG_1fd4329ff1834a24_EOF
       - name: Clean git credentials
         continue-on-error: true
         run: bash "${RUNNER_TEMP}/gh-aw/actions/clean_git_credentials.sh"
@@ -1250,7 +1253,7 @@ jobs:
             await main();
 
   pre_activation:
-    if: "github.event_name == 'issues' && (startsWith(github.event.issue.body, '/triage ') || startsWith(github.event.issue.body, '/triage\n') || github.event.issue.body == '/triage') || github.event_name == 'issue_comment' && (startsWith(github.event.comment.body, '/triage ') || startsWith(github.event.comment.body, '/triage\n') || github.event.comment.body == '/triage') && github.event.issue.pull_request == null || github.event_name == 'issues' && github.event.label.name == 'triage-approved'"
+    if: "(github.event_name == 'issues' || github.event_name == 'issue_comment') && (github.event_name == 'issues' && (startsWith(github.event.issue.body, '/triage ') || startsWith(github.event.issue.body, '/triage\n') || github.event.issue.body == '/triage') || github.event_name == 'issue_comment' && (startsWith(github.event.comment.body, '/triage ') || startsWith(github.event.comment.body, '/triage\n') || github.event.comment.body == '/triage') && github.event.issue.pull_request == null) || (!(github.event_name == 'issues')) && (!(github.event_name == 'issue_comment')) || github.event_name == 'issues' && github.event.label.name == 'triage-approved'"
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' && steps.check_command_position.outputs.command_position_ok == 'true' }}

--- a/.github/workflows/slash-cmd-issue-triage.md
+++ b/.github/workflows/slash-cmd-issue-triage.md
@@ -8,6 +8,7 @@ on:
     events: [issues]
     remove_label: false
   reaction: eyes
+  roles: [admin, maintainer, write]
 
 timeout-minutes: 10
 source: githubnext/agentics/workflows/issue-triage.md@69b5e3ae5fa7f35fa555b0a22aee14c36ab57ebb
@@ -35,9 +36,7 @@ tools:
   web-fetch:
   github:
     toolsets: [default]
-    min-integrity: approved
-    approval-labels:
-      - triage-approved
+    min-integrity: none
 ---
 
 # Requested Issue Triage


### PR DESCRIPTION
## Summary

- Make the issue triage workflow role gate explicit with `roles: [admin, maintainer, write]`
- Lower the GitHub MCP integrity threshold for this workflow to `min-integrity: none`
- Remove the workflow-specific `triage-approved` approval-label promotion path and recompile the lock file

## Rationale

The previous approach kept `min-integrity: approved` and tried to promote externally-authored issues through the `triage-approved` label. The rerun still failed because the GitHub MCP integrity guard labeled issue #983 as below `approved` even though the raw issue payload contained `triage-approved`.

This workflow is manually triggered by `/triage` or the `triage-approved` label, and the compiled pre-activation gate requires the triggering actor to have `admin`, `maintainer`, or `write` repository permission before the agent job can run. Lowering `min-integrity` lets the maintainer-triggered agent read public issue content from non-members while keeping arbitrary users from initiating the agent workflow.

The workflow remains constrained by safe outputs: it can add up to five existing labels and one comment.

## Validation

- `gh aw compile slash-cmd-issue-triage --strict`
- `git diff --check`