### PR TITLE
Fix: refresh Konnect access tokens per request

### DIFF
--- a/internal/cmd/root/products/konnect/auditlogs/create_destination.go
+++ b/internal/cmd/root/products/konnect/auditlogs/create_destination.go
@@ -131,6 +131,13 @@ func (c *createDestinationCmd) execute(helper cmd.Helper) (createDestinationOutp
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	if _, err := konnectcommon.ResolveAccessToken(ctx, cfg, tokenSource); err != nil {
+		return createDestinationOutput{}, cmd.PrepareExecutionError(
+			"failed to resolve Konnect access token",
+			err,
+			helper.GetCmd(),
+		)
+	}
 	client := httpclient.NewLoggingHTTPClient(logger)
 	regionalBaseURL := ""
 	if c.configureWebhook {
@@ -356,6 +363,9 @@ func deleteDestinationForHelper(helper cmd.Helper, destinationID string, disable
 	// so destination cleanup still runs on Ctrl+C.
 	ctx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
 	defer cancel()
+	if _, err := konnectcommon.ResolveAccessToken(ctx, cfg, tokenSource); err != nil {
+		return fmt.Errorf("resolve Konnect access token: %w", err)
+	}
 
 	baseURL, err := konnectcommon.ResolveBaseURL(cfg)
 	if err != nil {

--- a/internal/cmd/root/products/konnect/auditlogs/create_destination.go
+++ b/internal/cmd/root/products/konnect/auditlogs/create_destination.go
@@ -118,7 +118,7 @@ func (c *createDestinationCmd) execute(helper cmd.Helper) (createDestinationOutp
 		"configure_webhook", c.configureWebhook,
 	)
 
-	token, err := konnectcommon.GetAccessToken(cfg, logger)
+	tokenSource, err := konnectcommon.GetAccessTokenSource(cfg, logger)
 	if err != nil {
 		return createDestinationOutput{}, cmd.PrepareExecutionError(
 			"failed to resolve Konnect access token",
@@ -146,7 +146,7 @@ func (c *createDestinationCmd) execute(helper cmd.Helper) (createDestinationOutp
 			"resolved regional Konnect base URL for webhook operations",
 			"base_url", regionalBaseURL,
 		)
-		if err := ensureNoActiveRegionalWebhook(ctx, client, regionalBaseURL, token, logger); err != nil {
+		if err := ensureNoActiveRegionalWebhook(ctx, client, regionalBaseURL, tokenSource, logger); err != nil {
 			return createDestinationOutput{}, cmd.PrepareExecutionError(
 				"active audit-log webhook already configured for this region",
 				err,
@@ -167,7 +167,7 @@ func (c *createDestinationCmd) execute(helper cmd.Helper) (createDestinationOutp
 		logger.Debug("generated default audit-log destination name", "name", requestBody.Name)
 	}
 
-	nameTaken, err := destinationNameExists(ctx, client, token, requestBody.Name, logger)
+	nameTaken, err := destinationNameExists(ctx, client, tokenSource, requestBody.Name, logger)
 	if err != nil {
 		return createDestinationOutput{}, cmd.PrepareExecutionError(
 			"failed to verify destination name uniqueness",
@@ -193,13 +193,13 @@ func (c *createDestinationCmd) execute(helper cmd.Helper) (createDestinationOutp
 		)
 	}
 
-	destinationResult, err := apiutil.Request(
+	destinationResult, err := apiutil.RequestWithTokenSource(
 		ctx,
 		client,
 		http.MethodPost,
 		konnectcommon.GlobalBaseURL,
 		createDestinationPath,
-		token,
+		tokenSource,
 		map[string]string{
 			"Content-Type": "application/json",
 		},
@@ -271,13 +271,13 @@ func (c *createDestinationCmd) execute(helper cmd.Helper) (createDestinationOutp
 			)
 		}
 
-		webhookResult, err := apiutil.Request(
+		webhookResult, err := apiutil.RequestWithTokenSource(
 			ctx,
 			client,
 			http.MethodPatch,
 			regionalBaseURL,
 			updateWebhookPath,
-			token,
+			tokenSource,
 			map[string]string{
 				"Content-Type": "application/json",
 			},
@@ -346,7 +346,7 @@ func deleteDestinationForHelper(helper cmd.Helper, destinationID string, disable
 	if err != nil {
 		return err
 	}
-	token, err := konnectcommon.GetAccessToken(cfg, logger)
+	tokenSource, err := konnectcommon.GetAccessTokenSource(cfg, logger)
 	if err != nil {
 		return fmt.Errorf("resolve Konnect access token: %w", err)
 	}
@@ -364,7 +364,7 @@ func deleteDestinationForHelper(helper cmd.Helper, destinationID string, disable
 	client := httpclient.NewLoggingHTTPClient(logger)
 
 	if disableWebhook {
-		if err := releaseRegionalWebhook(ctx, client, baseURL, token, logger); err != nil {
+		if err := releaseRegionalWebhook(ctx, client, baseURL, tokenSource, logger); err != nil {
 			logger.Debug(
 				"regional audit-log webhook release had non-fatal errors",
 				"error", err,
@@ -373,14 +373,14 @@ func deleteDestinationForHelper(helper cmd.Helper, destinationID string, disable
 	}
 
 	path := fmt.Sprintf("%s/%s", deleteDestinationV2, url.PathEscape(destinationID))
-	return deleteDestinationWithRetry(ctx, client, baseURL, path, token, destinationID, logger)
+	return deleteDestinationWithRetry(ctx, client, baseURL, path, tokenSource, destinationID, logger)
 }
 
 func releaseRegionalWebhook(
 	ctx context.Context,
 	client apiutil.Doer,
-	baseURL,
-	token string,
+	baseURL string,
+	tokenSource apiutil.TokenSource,
 	logger *slog.Logger,
 ) error {
 	var webhookErr error
@@ -401,13 +401,13 @@ func releaseRegionalWebhook(
 		return fmt.Errorf("encode disable webhook request: %w", err)
 	}
 
-	disableResult, err := apiutil.Request(
+	disableResult, err := apiutil.RequestWithTokenSource(
 		ctx,
 		client,
 		http.MethodPatch,
 		baseURL,
 		webhookPathV2,
-		token,
+		tokenSource,
 		map[string]string{
 			"Content-Type": "application/json",
 		},
@@ -443,13 +443,13 @@ func releaseRegionalWebhook(
 			"base_url", baseURL,
 		)
 	}
-	deleteResult, err := apiutil.Request(
+	deleteResult, err := apiutil.RequestWithTokenSource(
 		ctx,
 		client,
 		http.MethodDelete,
 		baseURL,
 		deleteWebhookPathV3,
-		token,
+		tokenSource,
 		nil,
 		nil,
 	)
@@ -482,7 +482,7 @@ func releaseRegionalWebhook(
 func destinationNameExists(
 	ctx context.Context,
 	client apiutil.Doer,
-	token,
+	tokenSource apiutil.TokenSource,
 	name string,
 	logger *slog.Logger,
 ) (bool, error) {
@@ -493,13 +493,13 @@ func destinationNameExists(
 		logger.Debug("checking audit-log destination name uniqueness", "name", name)
 	}
 
-	result, err := apiutil.Request(
+	result, err := apiutil.RequestWithTokenSource(
 		ctx,
 		client,
 		http.MethodGet,
 		konnectcommon.GlobalBaseURL,
 		listDestinationPath,
-		token,
+		tokenSource,
 		nil,
 		nil,
 	)
@@ -528,17 +528,17 @@ func destinationNameExists(
 func ensureNoActiveRegionalWebhook(
 	ctx context.Context,
 	client apiutil.Doer,
-	baseURL,
-	token string,
+	baseURL string,
+	tokenSource apiutil.TokenSource,
 	logger *slog.Logger,
 ) error {
-	configResult, err := apiutil.Request(
+	configResult, err := apiutil.RequestWithTokenSource(
 		ctx,
 		client,
 		http.MethodGet,
 		baseURL,
 		webhookPathV2,
-		token,
+		tokenSource,
 		nil,
 		nil,
 	)
@@ -590,9 +590,9 @@ func isRegionalWebhookUnconfigured(enabled bool, endpoint string) bool {
 func deleteDestinationWithRetry(
 	ctx context.Context,
 	client apiutil.Doer,
-	baseURL,
-	path,
-	token,
+	baseURL string,
+	path string,
+	tokenSource apiutil.TokenSource,
 	destinationID string,
 	logger *slog.Logger,
 ) error {
@@ -603,13 +603,13 @@ func deleteDestinationWithRetry(
 
 	attempt := 1
 	for {
-		result, err := apiutil.Request(
+		result, err := apiutil.RequestWithTokenSource(
 			ctx,
 			client,
 			http.MethodDelete,
 			baseURL,
 			path,
-			token,
+			tokenSource,
 			nil,
 			nil,
 		)

--- a/internal/cmd/root/products/konnect/auditlogs/create_destination_test.go
+++ b/internal/cmd/root/products/konnect/auditlogs/create_destination_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kong/kongctl/internal/konnect/apiutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -109,7 +110,9 @@ func TestEnsureNoActiveRegionalWebhookAllowsWhenDisabled(t *testing.T) {
 		return httpResponse(http.StatusOK, `{"enabled":false,"endpoint":"unconfigured"}`), nil
 	})
 
-	err := ensureNoActiveRegionalWebhook(context.Background(), client, "https://region.example.com", "token", nil)
+	err := ensureNoActiveRegionalWebhook(
+		context.Background(), client, "https://region.example.com", testTokenSource(), nil,
+	)
 	require.NoError(t, err)
 }
 
@@ -122,7 +125,9 @@ func TestEnsureNoActiveRegionalWebhookBlocksWhenConnected(t *testing.T) {
 		return httpResponse(http.StatusOK, `{"enabled":true,"endpoint":"https://example.com/audit-logs"}`), nil
 	})
 
-	err := ensureNoActiveRegionalWebhook(context.Background(), client, "https://region.example.com", "token", nil)
+	err := ensureNoActiveRegionalWebhook(
+		context.Background(), client, "https://region.example.com", testTokenSource(), nil,
+	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "regional audit-log webhook is already configured")
 	require.Contains(t, err.Error(), "enabled=true")
@@ -137,7 +142,9 @@ func TestEnsureNoActiveRegionalWebhookBlocksWhenDisabledButConfigured(t *testing
 		return httpResponse(http.StatusOK, `{"enabled":false,"endpoint":"https://example.com/audit-logs"}`), nil
 	})
 
-	err := ensureNoActiveRegionalWebhook(context.Background(), client, "https://region.example.com", "token", nil)
+	err := ensureNoActiveRegionalWebhook(
+		context.Background(), client, "https://region.example.com", testTokenSource(), nil,
+	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "regional audit-log webhook is already configured")
 	require.Contains(t, err.Error(), "enabled=false")
@@ -152,7 +159,9 @@ func TestEnsureNoActiveRegionalWebhookBlocksWhenStateIsUnknown(t *testing.T) {
 		return httpResponse(http.StatusOK, `{"enabled":false}`), nil
 	})
 
-	err := ensureNoActiveRegionalWebhook(context.Background(), client, "https://region.example.com", "token", nil)
+	err := ensureNoActiveRegionalWebhook(
+		context.Background(), client, "https://region.example.com", testTokenSource(), nil,
+	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "regional audit-log webhook is already configured")
 }
@@ -178,7 +187,7 @@ func TestDeleteDestinationWithRetryRetriesDestinationInUseConflict(t *testing.T)
 		client,
 		"https://region.example.com",
 		"/v2/audit-log-destinations/dest-123",
-		"token",
+		testTokenSource(),
 		"dest-123",
 		nil,
 	)
@@ -203,7 +212,7 @@ func TestDeleteDestinationWithRetryDoesNotRetryOtherConflict(t *testing.T) {
 		client,
 		"https://region.example.com",
 		"/v2/audit-log-destinations/dest-123",
-		"token",
+		testTokenSource(),
 		"dest-123",
 		nil,
 	)
@@ -233,7 +242,7 @@ func TestReleaseRegionalWebhookDisablesAndDeletes(t *testing.T) {
 		}
 	})
 
-	err := releaseRegionalWebhook(context.Background(), client, "https://region.example.com", "token", nil)
+	err := releaseRegionalWebhook(context.Background(), client, "https://region.example.com", testTokenSource(), nil)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, attempts.Load())
 }
@@ -260,7 +269,7 @@ func TestReleaseRegionalWebhookTreatsNotFoundAsSuccess(t *testing.T) {
 		}
 	})
 
-	err := releaseRegionalWebhook(context.Background(), client, "https://region.example.com", "token", nil)
+	err := releaseRegionalWebhook(context.Background(), client, "https://region.example.com", testTokenSource(), nil)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, attempts.Load())
 }
@@ -287,7 +296,7 @@ func TestReleaseRegionalWebhookReturnsErrorOnUnexpectedStatus(t *testing.T) {
 		}
 	})
 
-	err := releaseRegionalWebhook(context.Background(), client, "https://region.example.com", "token", nil)
+	err := releaseRegionalWebhook(context.Background(), client, "https://region.example.com", testTokenSource(), nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "delete audit-log webhook failed")
 	require.EqualValues(t, 2, attempts.Load())
@@ -313,7 +322,7 @@ func TestDeleteDestinationWithRetryStopsOnContextTimeout(t *testing.T) {
 		client,
 		"https://region.example.com",
 		"/v2/audit-log-destinations/dest-123",
-		"token",
+		testTokenSource(),
 		"dest-123",
 		nil,
 	)
@@ -343,6 +352,10 @@ type doerFunc func(*http.Request) (*http.Response, error)
 
 func (f doerFunc) Do(r *http.Request) (*http.Response, error) {
 	return f(r)
+}
+
+func testTokenSource() apiutil.StaticTokenSource {
+	return apiutil.NewStaticTokenSource("token")
 }
 
 func httpResponse(status int, body string) *http.Response {

--- a/internal/cmd/root/products/konnect/auditlogs/get.go
+++ b/internal/cmd/root/products/konnect/auditlogs/get.go
@@ -232,7 +232,7 @@ func fetchAuditLogDestinations(helper cmd.Helper) ([]auditLogDestinationRecord, 
 		return nil, err
 	}
 
-	token, err := konnectcommon.GetAccessToken(cfg, logger)
+	tokenSource, err := konnectcommon.GetAccessTokenSource(cfg, logger)
 	if err != nil {
 		return nil, fmt.Errorf("resolve Konnect access token: %w", err)
 	}
@@ -243,13 +243,13 @@ func fetchAuditLogDestinations(helper cmd.Helper) ([]auditLogDestinationRecord, 
 	}
 
 	client := httpclient.NewLoggingHTTPClient(logger)
-	result, err := apiutil.Request(
+	result, err := apiutil.RequestWithTokenSource(
 		ctx,
 		client,
 		http.MethodGet,
 		konnectcommon.GlobalBaseURL,
 		listDestinationPath,
-		token,
+		tokenSource,
 		nil,
 		nil,
 	)
@@ -281,7 +281,7 @@ func fetchRegionalWebhookConfig(helper cmd.Helper) (auditLogWebhookConfig, error
 		return auditLogWebhookConfig{}, err
 	}
 
-	token, err := konnectcommon.GetAccessToken(cfg, logger)
+	tokenSource, err := konnectcommon.GetAccessTokenSource(cfg, logger)
 	if err != nil {
 		return auditLogWebhookConfig{}, fmt.Errorf("resolve Konnect access token: %w", err)
 	}
@@ -297,13 +297,13 @@ func fetchRegionalWebhookConfig(helper cmd.Helper) (auditLogWebhookConfig, error
 	}
 
 	client := httpclient.NewLoggingHTTPClient(logger)
-	result, err := apiutil.Request(
+	result, err := apiutil.RequestWithTokenSource(
 		ctx,
 		client,
 		http.MethodGet,
 		baseURL,
 		webhookPathV2,
-		token,
+		tokenSource,
 		nil,
 		nil,
 	)

--- a/internal/cmd/root/products/konnect/auditlogs/get.go
+++ b/internal/cmd/root/products/konnect/auditlogs/get.go
@@ -241,6 +241,9 @@ func fetchAuditLogDestinations(helper cmd.Helper) ([]auditLogDestinationRecord, 
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	if _, err := konnectcommon.ResolveAccessToken(ctx, cfg, tokenSource); err != nil {
+		return nil, fmt.Errorf("resolve Konnect access token: %w", err)
+	}
 
 	client := httpclient.NewLoggingHTTPClient(logger)
 	result, err := apiutil.RequestWithTokenSource(
@@ -294,6 +297,9 @@ func fetchRegionalWebhookConfig(helper cmd.Helper) (auditLogWebhookConfig, error
 	ctx := helper.GetContext()
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	if _, err := konnectcommon.ResolveAccessToken(ctx, cfg, tokenSource); err != nil {
+		return auditLogWebhookConfig{}, fmt.Errorf("resolve Konnect access token: %w", err)
 	}
 
 	client := httpclient.NewLoggingHTTPClient(logger)

--- a/internal/cmd/root/products/konnect/common/common.go
+++ b/internal/cmd/root/products/konnect/common/common.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -142,14 +143,30 @@ func ResolveHTTPTransportOptions(cfg config.Hook) (httpclient.TransportOptions, 
 }
 
 func GetAccessToken(cfg config.Hook, logger *slog.Logger) (string, error) {
+	source, err := GetAccessTokenSource(cfg, logger)
+	if err != nil {
+		return "", err
+	}
+
+	token, err := source.Token(context.Background())
+	if err != nil {
+		return "", accessTokenUnavailableError(cfg)
+	}
+	return token, nil
+}
+
+func GetAccessTokenSource(cfg config.Hook, logger *slog.Logger) (*auth.TokenSource, error) {
 	pat := cfg.GetString(PATConfigPath)
 	if pat != "" {
-		return pat, nil
+		return auth.NewTokenSource(cfg, auth.TokenSourceOptions{
+			PAT:    pat,
+			Logger: logger,
+		}), nil
 	}
 
 	baseURL, err := ResolveBaseURL(cfg)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	refreshPath := cfg.GetString(RefreshPathConfigPath)
@@ -160,42 +177,53 @@ func GetAccessToken(cfg config.Hook, logger *slog.Logger) (string, error) {
 
 	timeout, err := ResolveHTTPTimeout(cfg)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	transportOptions, err := ResolveHTTPTransportOptions(cfg)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	tok, err := auth.LoadAccessToken(cfg, refreshURL, timeout, transportOptions, logger)
-	if err != nil {
-		// Provide helpful guidance on authentication options instead of exposing
-		// internal implementation details like file paths
-		profile := cfg.GetProfile()
-		envVar := fmt.Sprintf("KONGCTL_%s_KONNECT_PAT", strings.ToUpper(profile))
+	return auth.NewTokenSource(cfg, auth.TokenSourceOptions{
+		PAT:              pat,
+		RefreshURL:       refreshURL,
+		Timeout:          timeout,
+		TransportOptions: transportOptions,
+		Logger:           logger,
+	}), nil
+}
 
-		return "", fmt.Errorf(
-			"authentication token not available. Use one of the following to authorize %s:\n"+
-				"  - '%s login' to authenticate via the web\n"+
-				"  - provide a token via the --%s flag\n"+
-				"  - set the %s environment variable\n"+
-				"  - configure a token value in the '%s.%s' path of your configuration file",
-			meta.CLIName,
-			meta.CLIName,
-			PATFlagName,
-			envVar,
-			profile,
-			PATConfigPath,
-		)
-	}
-	return tok.Token.AuthToken, nil
+func accessTokenUnavailableError(cfg config.Hook) error {
+	profile := cfg.GetProfile()
+	envVar := fmt.Sprintf("KONGCTL_%s_KONNECT_PAT", strings.ToUpper(profile))
+
+	return fmt.Errorf(
+		"authentication token not available. Use one of the following to authorize %s:\n"+
+			"  - '%s login' to authenticate via the web\n"+
+			"  - provide a token via the --%s flag\n"+
+			"  - set the %s environment variable\n"+
+			"  - configure a token value in the '%s.%s' path of your configuration file",
+		meta.CLIName,
+		meta.CLIName,
+		PATFlagName,
+		envVar,
+		profile,
+		PATConfigPath,
+	)
 }
 
 // This is the real implementation of the SDKAPIFactory,
 // which creates a real Konnect SDK instance
 func KonnectSDKFactory(cfg config.Hook, logger *slog.Logger) (helpers.SDKAPI, error) {
-	token, e := GetAccessToken(cfg, logger)
+	tokenSource, e := GetAccessTokenSource(cfg, logger)
+	if e != nil {
+		return nil, fmt.Errorf(
+			`no access token available. Use "%s login konnect" to authenticate or provide a Konnect PAT using the --pat flag`,
+			meta.CLIName,
+		)
+	}
+	token, e := tokenSource.Token(context.Background())
 	if e != nil {
 		return nil, fmt.Errorf(
 			`no access token available. Use "%s login konnect" to authenticate or provide a Konnect PAT using the --pat flag`,
@@ -218,16 +246,17 @@ func KonnectSDKFactory(cfg config.Hook, logger *slog.Logger) (helpers.SDKAPI, er
 		return nil, err
 	}
 
-	sdk, httpClient, err := auth.GetAuthenticatedClient(baseURL, token, timeout, transportOptions, logger)
+	sdk, httpClient, err := auth.GetAuthenticatedClient(baseURL, tokenSource, timeout, transportOptions, logger)
 	if err != nil {
 		return nil, err
 	}
 
 	return &helpers.KonnectSDK{
-		SDK:        sdk,
-		BaseURL:    baseURL,
-		Token:      token,
-		HTTPClient: httpClient,
+		SDK:         sdk,
+		BaseURL:     baseURL,
+		Token:       token,
+		TokenSource: tokenSource,
+		HTTPClient:  httpClient,
 	}, nil
 }
 

--- a/internal/cmd/root/products/konnect/common/common.go
+++ b/internal/cmd/root/products/konnect/common/common.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -148,8 +149,19 @@ func GetAccessToken(cfg config.Hook, logger *slog.Logger) (string, error) {
 		return "", err
 	}
 
-	token, err := source.Token(context.Background())
+	return ResolveAccessToken(context.Background(), cfg, source)
+}
+
+func ResolveAccessToken(ctx context.Context, cfg config.Hook, source *auth.TokenSource) (string, error) {
+	if source == nil {
+		return "", accessTokenUnavailableError(cfg)
+	}
+
+	token, err := source.Token(ctx)
 	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return "", err
+		}
 		return "", accessTokenUnavailableError(cfg)
 	}
 	return token, nil

--- a/internal/cmd/root/products/konnect/common/common.go
+++ b/internal/cmd/root/products/konnect/common/common.go
@@ -230,17 +230,11 @@ func accessTokenUnavailableError(cfg config.Hook) error {
 func KonnectSDKFactory(cfg config.Hook, logger *slog.Logger) (helpers.SDKAPI, error) {
 	tokenSource, e := GetAccessTokenSource(cfg, logger)
 	if e != nil {
-		return nil, fmt.Errorf(
-			`no access token available. Use "%s login konnect" to authenticate or provide a Konnect PAT using the --pat flag`,
-			meta.CLIName,
-		)
+		return nil, e
 	}
-	token, e := tokenSource.Token(context.Background())
+	token, e := ResolveAccessToken(context.Background(), cfg, tokenSource)
 	if e != nil {
-		return nil, fmt.Errorf(
-			`no access token available. Use "%s login konnect" to authenticate or provide a Konnect PAT using the --pat flag`,
-			meta.CLIName,
-		)
+		return nil, e
 	}
 
 	baseURL, err := ResolveBaseURL(cfg)

--- a/internal/cmd/root/products/konnect/common/common_test.go
+++ b/internal/cmd/root/products/konnect/common/common_test.go
@@ -1,13 +1,16 @@
 package common
 
 import (
+	"context"
 	"fmt"
 	"maps"
+	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
 
 	cmdcommon "github.com/kong/kongctl/internal/cmd/common"
+	"github.com/kong/kongctl/internal/konnect/auth"
 	"github.com/kong/kongctl/internal/konnect/httpclient"
 	configtest "github.com/kong/kongctl/test/config"
 	"github.com/spf13/pflag"
@@ -206,4 +209,34 @@ func TestResolveHTTPTransportOptions(t *testing.T) {
 		_, err := ResolveHTTPTransportOptions(cfg)
 		require.Error(t, err)
 	})
+}
+
+func TestResolveAccessTokenMapsMissingCredentialsToGuidance(t *testing.T) {
+	dir := t.TempDir()
+	cfg, _ := newTestConfig(map[string]string{})
+	cfg.GetPathMock = func() string { return filepath.Join(dir, "config.yaml") }
+	source := auth.NewTokenSource(cfg, auth.TokenSourceOptions{
+		RefreshURL: BaseURLDefault + RefreshPathDefault,
+	})
+
+	_, err := ResolveAccessToken(t.Context(), cfg, source)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "authentication token not available")
+	require.Contains(t, err.Error(), "kongctl login")
+	require.NotContains(t, err.Error(), dir)
+	require.NotContains(t, err.Error(), "stat ")
+}
+
+func TestResolveAccessTokenPreservesContextErrors(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	cfg, _ := newTestConfig(map[string]string{})
+	source := auth.NewTokenSource(cfg, auth.TokenSourceOptions{
+		RefreshURL: BaseURLDefault + RefreshPathDefault,
+	})
+
+	_, err := ResolveAccessToken(ctx, cfg, source)
+
+	require.ErrorIs(t, err, context.Canceled)
 }

--- a/internal/cmd/root/products/konnect/common/common_test.go
+++ b/internal/cmd/root/products/konnect/common/common_test.go
@@ -240,3 +240,16 @@ func TestResolveAccessTokenPreservesContextErrors(t *testing.T) {
 
 	require.ErrorIs(t, err, context.Canceled)
 }
+
+func TestKonnectSDKFactoryReturnsAuthConfigurationErrors(t *testing.T) {
+	cfg, _ := newTestConfig(map[string]string{
+		RegionConfigPath: "bad/region",
+	})
+
+	_, err := KonnectSDKFactory(cfg, nil)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid konnect region")
+	require.NotContains(t, err.Error(), "authentication token not available")
+	require.NotContains(t, err.Error(), "no access token available")
+}

--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -620,7 +620,7 @@ func deckPlanOptions(
 	if err != nil {
 		return planner.DeckOptions{}, err
 	}
-	token, err := tokenSource.Token(context.Background())
+	token, err := konnectcommon.ResolveAccessToken(context.Background(), cfg, tokenSource)
 	if err != nil {
 		return planner.DeckOptions{}, err
 	}
@@ -1516,7 +1516,7 @@ func runApply(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	token, err := tokenSource.Token(ctx)
+	token, err := konnectcommon.ResolveAccessToken(ctx, cfg, tokenSource)
 	if err != nil {
 		return err
 	}
@@ -1988,7 +1988,7 @@ func runDelete(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	token, err := tokenSource.Token(ctx)
+	token, err := konnectcommon.ResolveAccessToken(ctx, cfg, tokenSource)
 	if err != nil {
 		return err
 	}
@@ -2239,7 +2239,7 @@ func runSync(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	token, err := tokenSource.Token(ctx)
+	token, err := konnectcommon.ResolveAccessToken(ctx, cfg, tokenSource)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -616,7 +616,11 @@ func deckPlanOptions(
 		return planner.DeckOptions{}, nil
 	}
 
-	token, err := konnectcommon.GetAccessToken(cfg, logger)
+	tokenSource, err := konnectcommon.GetAccessTokenSource(cfg, logger)
+	if err != nil {
+		return planner.DeckOptions{}, err
+	}
+	token, err := tokenSource.Token(context.Background())
 	if err != nil {
 		return planner.DeckOptions{}, err
 	}
@@ -627,8 +631,9 @@ func deckPlanOptions(
 	}
 
 	return planner.DeckOptions{
-		KonnectToken:   token,
-		KonnectAddress: baseURL,
+		KonnectToken:       token,
+		KonnectTokenSource: tokenSource,
+		KonnectAddress:     baseURL,
 	}, nil
 }
 
@@ -1507,7 +1512,11 @@ func runApply(command *cobra.Command, args []string) error {
 		reporter = executor.NewConsoleReporterWithOptions(command.OutOrStderr(), dryRun)
 	}
 
-	token, err := konnectcommon.GetAccessToken(cfg, logger)
+	tokenSource, err := konnectcommon.GetAccessTokenSource(cfg, logger)
+	if err != nil {
+		return err
+	}
+	token, err := tokenSource.Token(ctx)
 	if err != nil {
 		return err
 	}
@@ -1517,10 +1526,11 @@ func runApply(command *cobra.Command, args []string) error {
 	}
 
 	exec := executor.NewWithOptions(stateClient, reporter, dryRun, executor.Options{
-		KonnectToken:   token,
-		KonnectBaseURL: baseURL,
-		Mode:           planner.PlanModeApply,
-		PlanBaseDir:    resolvePlanBaseDir(planFile),
+		KonnectToken:       token,
+		KonnectTokenSource: tokenSource,
+		KonnectBaseURL:     baseURL,
+		Mode:               planner.PlanModeApply,
+		PlanBaseDir:        resolvePlanBaseDir(planFile),
 	})
 
 	// Execute plan
@@ -1974,7 +1984,11 @@ func runDelete(command *cobra.Command, args []string) error {
 		reporter = executor.NewConsoleReporterWithOptions(command.OutOrStderr(), dryRun)
 	}
 
-	token, err := konnectcommon.GetAccessToken(cfg, logger)
+	tokenSource, err := konnectcommon.GetAccessTokenSource(cfg, logger)
+	if err != nil {
+		return err
+	}
+	token, err := tokenSource.Token(ctx)
 	if err != nil {
 		return err
 	}
@@ -1984,10 +1998,11 @@ func runDelete(command *cobra.Command, args []string) error {
 	}
 
 	exec := executor.NewWithOptions(stateClient, reporter, dryRun, executor.Options{
-		KonnectToken:   token,
-		KonnectBaseURL: baseURL,
-		Mode:           planner.PlanModeDelete,
-		PlanBaseDir:    resolvePlanBaseDir(planFile),
+		KonnectToken:       token,
+		KonnectTokenSource: tokenSource,
+		KonnectBaseURL:     baseURL,
+		Mode:               planner.PlanModeDelete,
+		PlanBaseDir:        resolvePlanBaseDir(planFile),
 	})
 
 	// Execute plan
@@ -2220,7 +2235,11 @@ func runSync(command *cobra.Command, args []string) error {
 		reporter = executor.NewConsoleReporterWithOptions(command.OutOrStderr(), dryRun)
 	}
 
-	token, err := konnectcommon.GetAccessToken(cfg, logger)
+	tokenSource, err := konnectcommon.GetAccessTokenSource(cfg, logger)
+	if err != nil {
+		return err
+	}
+	token, err := tokenSource.Token(ctx)
 	if err != nil {
 		return err
 	}
@@ -2230,10 +2249,11 @@ func runSync(command *cobra.Command, args []string) error {
 	}
 
 	exec := executor.NewWithOptions(stateClient, reporter, dryRun, executor.Options{
-		KonnectToken:   token,
-		KonnectBaseURL: baseURL,
-		Mode:           planner.PlanModeSync,
-		PlanBaseDir:    resolvePlanBaseDir(planFile),
+		KonnectToken:       token,
+		KonnectTokenSource: tokenSource,
+		KonnectBaseURL:     baseURL,
+		Mode:               planner.PlanModeSync,
+		PlanBaseDir:        resolvePlanBaseDir(planFile),
 	})
 
 	// Execute plan

--- a/internal/cmd/root/verbs/api/api.go
+++ b/internal/cmd/root/verbs/api/api.go
@@ -252,7 +252,7 @@ func run(helper cmd.Helper, method string, allowBody bool) error {
 		return cmd.PrepareExecutionError("failed to resolve Konnect base URL", err, helper.GetCmd())
 	}
 
-	token, err := konnectcommon.GetAccessToken(cfg, logger)
+	tokenSource, err := konnectcommon.GetAccessTokenSource(cfg, logger)
 	if err != nil {
 		return cmd.PrepareExecutionError("failed to resolve Konnect access token", err, helper.GetCmd())
 	}
@@ -339,6 +339,10 @@ func run(helper cmd.Helper, method string, allowBody bool) error {
 	}
 
 	client := httpclient.NewLoggingHTTPClient(logger)
+	token, err := tokenSource.Token(ctx)
+	if err != nil {
+		return cmd.PrepareExecutionError("failed to resolve Konnect access token", err, helper.GetCmd())
+	}
 	result, err := requestFn(ctx, client, method, baseURL, endpoint, token, headers, bodyReader)
 	if err != nil {
 		return cmd.PrepareExecutionError("failed to call Konnect API", err, helper.GetCmd())

--- a/internal/cmd/root/verbs/api/api.go
+++ b/internal/cmd/root/verbs/api/api.go
@@ -339,7 +339,7 @@ func run(helper cmd.Helper, method string, allowBody bool) error {
 	}
 
 	client := httpclient.NewLoggingHTTPClient(logger)
-	token, err := tokenSource.Token(ctx)
+	token, err := konnectcommon.ResolveAccessToken(ctx, cfg, tokenSource)
 	if err != nil {
 		return cmd.PrepareExecutionError("failed to resolve Konnect access token", err, helper.GetCmd())
 	}

--- a/internal/declarative/deck/runner.go
+++ b/internal/declarative/deck/runner.go
@@ -8,6 +8,10 @@ import (
 	"strings"
 )
 
+type KonnectTokenSource interface {
+	Token(ctx context.Context) (string, error)
+}
+
 // Runner executes deck commands.
 type Runner interface {
 	Run(ctx context.Context, opts RunOptions) (*RunResult, error)

--- a/internal/declarative/executor/deck_execution.go
+++ b/internal/declarative/executor/deck_execution.go
@@ -82,10 +82,18 @@ func (e *Executor) executeDeckStep(ctx context.Context, change *planner.PlannedC
 	args := append([]string{"gateway", mode}, flags...)
 	args = append(args, files...)
 
+	token := e.konnectToken
+	if e.konnectTokenSource != nil {
+		token, err = e.konnectTokenSource.Token(ctx)
+		if err != nil {
+			return fmt.Errorf("deck step %s: resolve Konnect token: %w", cpRef, err)
+		}
+	}
+
 	result, err := e.deckRunner.Run(ctx, deck.RunOptions{
 		Args:                    args,
 		Mode:                    mode,
-		KonnectToken:            e.konnectToken,
+		KonnectToken:            token,
 		KonnectControlPlaneName: cpName,
 		KonnectAddress:          e.konnectBaseURL,
 		WorkDir:                 workDir,

--- a/internal/declarative/executor/deck_execution_test.go
+++ b/internal/declarative/executor/deck_execution_test.go
@@ -30,6 +30,14 @@ func (s *stubDeckRunner) Run(_ context.Context, opts deck.RunOptions) (*deck.Run
 	return &deck.RunResult{}, s.err
 }
 
+type stubDeckTokenSource struct {
+	token string
+}
+
+func (s stubDeckTokenSource) Token(context.Context) (string, error) {
+	return s.token, nil
+}
+
 type stubGatewayServiceAPI struct {
 	services []kkComps.ServiceOutput
 }
@@ -69,11 +77,12 @@ func TestExecuteDeckStepUpdatesImplementation(t *testing.T) {
 	})
 
 	exec := NewWithOptions(stateClient, nil, false, Options{
-		DeckRunner:     runner,
-		KonnectToken:   "token-123",
-		KonnectBaseURL: "https://api.konghq.com",
-		Mode:           planner.PlanModeApply,
-		PlanBaseDir:    planBaseDir,
+		DeckRunner:         runner,
+		KonnectToken:       "stale-token",
+		KonnectTokenSource: stubDeckTokenSource{token: "token-123"},
+		KonnectBaseURL:     "https://api.konghq.com",
+		Mode:               planner.PlanModeApply,
+		PlanBaseDir:        planBaseDir,
 	})
 
 	plan := planner.NewPlan("1.0", "test", planner.PlanModeApply)
@@ -125,6 +134,7 @@ func TestExecuteDeckStepUpdatesImplementation(t *testing.T) {
 
 	require.Len(t, runner.calls, 1)
 	require.Equal(t, "apply", runner.calls[0].Mode)
+	require.Equal(t, "token-123", runner.calls[0].KonnectToken)
 	require.Equal(t, cpName, runner.calls[0].KonnectControlPlaneName)
 	require.Equal(t, expectedWorkDir, runner.calls[0].WorkDir)
 	expectedArgs := []string{

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -97,20 +97,22 @@ type Executor struct {
 	// API implementation is not yet supported by SDK but we include adapter for completeness
 	apiImplementationExecutor *BaseCreateDeleteExecutor[kkComps.APIImplementation]
 
-	deckRunner     deck.Runner
-	konnectToken   string
-	konnectBaseURL string
-	executionMode  planner.PlanMode
-	planBaseDir    string
+	deckRunner         deck.Runner
+	konnectToken       string
+	konnectTokenSource deck.KonnectTokenSource
+	konnectBaseURL     string
+	executionMode      planner.PlanMode
+	planBaseDir        string
 }
 
 // Options configures executor behavior.
 type Options struct {
-	DeckRunner     deck.Runner
-	KonnectToken   string
-	KonnectBaseURL string
-	Mode           planner.PlanMode
-	PlanBaseDir    string
+	DeckRunner         deck.Runner
+	KonnectToken       string
+	KonnectTokenSource deck.KonnectTokenSource
+	KonnectBaseURL     string
+	Mode               planner.PlanMode
+	PlanBaseDir        string
 }
 
 // New creates a new Executor instance with default options.
@@ -125,17 +127,18 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 		deckRunner = deck.NewRunner()
 	}
 	e := &Executor{
-		client:           client,
-		reporter:         reporter,
-		dryRun:           dryRun,
-		createdResources: make(map[string]string),
-		refToID:          make(map[string]map[string]string),
-		stateCache:       state.NewCache(),
-		deckRunner:       deckRunner,
-		konnectToken:     opts.KonnectToken,
-		konnectBaseURL:   opts.KonnectBaseURL,
-		executionMode:    opts.Mode,
-		planBaseDir:      strings.TrimSpace(opts.PlanBaseDir),
+		client:             client,
+		reporter:           reporter,
+		dryRun:             dryRun,
+		createdResources:   make(map[string]string),
+		refToID:            make(map[string]map[string]string),
+		stateCache:         state.NewCache(),
+		deckRunner:         deckRunner,
+		konnectToken:       opts.KonnectToken,
+		konnectTokenSource: opts.KonnectTokenSource,
+		konnectBaseURL:     opts.KonnectBaseURL,
+		executionMode:      opts.Mode,
+		planBaseDir:        strings.TrimSpace(opts.PlanBaseDir),
 	}
 
 	// Initialize resource executors

--- a/internal/declarative/planner/deck_requirements.go
+++ b/internal/declarative/planner/deck_requirements.go
@@ -376,10 +376,20 @@ func (p *Planner) deckDiffHasChanges(
 	args = append(args, "--json-output", "--no-color")
 	args = append(args, files...)
 
+	token := opts.Deck.KonnectToken
+	if opts.Deck.KonnectTokenSource != nil {
+		var err error
+		token, err = opts.Deck.KonnectTokenSource.Token(ctx)
+		if err != nil {
+			return false, fmt.Errorf("control_plane %s: resolve Konnect token for deck diff: %w",
+				controlPlaneRef, err)
+		}
+	}
+
 	result, err := runner.Run(ctx, deck.RunOptions{
 		Args:                    args,
 		Mode:                    string(mode),
-		KonnectToken:            opts.Deck.KonnectToken,
+		KonnectToken:            token,
 		KonnectControlPlaneName: controlPlaneName,
 		KonnectAddress:          opts.Deck.KonnectAddress,
 		WorkDir:                 deckBaseDir,

--- a/internal/declarative/planner/planner.go
+++ b/internal/declarative/planner/planner.go
@@ -42,9 +42,10 @@ var errGatewayServiceNotFound = errors.New("gateway service not found")
 
 // DeckOptions provides configuration for deck-based planning.
 type DeckOptions struct {
-	Runner         deck.Runner
-	KonnectToken   string
-	KonnectAddress string
+	Runner             deck.Runner
+	KonnectToken       string
+	KonnectTokenSource deck.KonnectTokenSource
+	KonnectAddress     string
 }
 
 // Planner generates execution plans

--- a/internal/konnect/apiutil/client.go
+++ b/internal/konnect/apiutil/client.go
@@ -16,6 +16,35 @@ type Doer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+type TokenSource interface {
+	Token(ctx context.Context) (string, error)
+	Refresh(ctx context.Context, previousToken string) (string, error)
+}
+
+type refreshableTokenSource interface {
+	Refreshable() bool
+}
+
+type StaticTokenSource struct {
+	token string
+}
+
+func NewStaticTokenSource(token string) StaticTokenSource {
+	return StaticTokenSource{token: token}
+}
+
+func (s StaticTokenSource) Token(context.Context) (string, error) {
+	return s.token, nil
+}
+
+func (s StaticTokenSource) Refresh(context.Context, string) (string, error) {
+	return "", fmt.Errorf("token refresh is not supported")
+}
+
+func (s StaticTokenSource) Refreshable() bool {
+	return false
+}
+
 // Result represents a simplified HTTP response payload.
 type Result struct {
 	StatusCode int
@@ -36,6 +65,33 @@ func Request(
 	headers map[string]string,
 	body io.Reader,
 ) (*Result, error) {
+	return request(ctx, client, method, baseURL, path, nil, token, headers, body)
+}
+
+func RequestWithTokenSource(
+	ctx context.Context,
+	client Doer,
+	method string,
+	baseURL string,
+	path string,
+	tokenSource TokenSource,
+	headers map[string]string,
+	body io.Reader,
+) (*Result, error) {
+	return request(ctx, client, method, baseURL, path, tokenSource, "", headers, body)
+}
+
+func request(
+	ctx context.Context,
+	client Doer,
+	method string,
+	baseURL string,
+	path string,
+	tokenSource TokenSource,
+	staticToken string,
+	headers map[string]string,
+	body io.Reader,
+) (*Result, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -49,6 +105,68 @@ func Request(
 		return nil, err
 	}
 
+	token := staticToken
+	if tokenSource != nil {
+		token, err = tokenSource.Token(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("resolve Konnect access token: %w", err)
+		}
+	}
+
+	req, err := newRequest(ctx, method, endpoint, token, headers, body)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+
+	if resp != nil && resp.StatusCode == http.StatusUnauthorized && shouldRefreshAndRetry(tokenSource, req) {
+		refreshedToken, refreshErr := tokenSource.Refresh(ctx, token)
+		if refreshErr != nil {
+			resp.Body.Close()
+			return nil, fmt.Errorf("refresh Konnect access token after HTTP 401: %w", refreshErr)
+		}
+
+		resp.Body.Close()
+
+		retryBody, err := retryBody(req)
+		if err != nil {
+			return nil, err
+		}
+		req, err = newRequest(ctx, method, endpoint, refreshedToken, headers, retryBody)
+		if err != nil {
+			return nil, err
+		}
+		resp, err = client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("retry request after Konnect token refresh failed: %w", err)
+		}
+	}
+	defer resp.Body.Close()
+
+	bytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	return &Result{
+		StatusCode: resp.StatusCode,
+		Body:       bytes,
+		Header:     resp.Header.Clone(),
+	}, nil
+}
+
+func newRequest(
+	ctx context.Context,
+	method string,
+	endpoint string,
+	token string,
+	headers map[string]string,
+	body io.Reader,
+) (*http.Request, error) {
 	req, err := http.NewRequestWithContext(ctx, method, endpoint, body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build request: %w", err)
@@ -64,22 +182,31 @@ func Request(
 		req.Header.Set(k, v)
 	}
 
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
-	}
-	defer resp.Body.Close()
+	return req, nil
+}
 
-	bytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
+func shouldRefreshAndRetry(tokenSource TokenSource, req *http.Request) bool {
+	if tokenSource == nil || !requestCanBeReplayed(req) {
+		return false
 	}
+	if refreshable, ok := tokenSource.(refreshableTokenSource); ok && !refreshable.Refreshable() {
+		return false
+	}
+	return true
+}
 
-	return &Result{
-		StatusCode: resp.StatusCode,
-		Body:       bytes,
-		Header:     resp.Header.Clone(),
-	}, nil
+func requestCanBeReplayed(req *http.Request) bool {
+	return req.Body == nil || req.Body == http.NoBody || req.GetBody != nil
+}
+
+func retryBody(req *http.Request) (io.Reader, error) {
+	if req.Body == nil || req.Body == http.NoBody {
+		return nil, nil
+	}
+	if req.GetBody == nil {
+		return nil, fmt.Errorf("request body cannot be replayed after Konnect token refresh")
+	}
+	return req.GetBody()
 }
 
 func resolveEndpoint(baseURL, path string) (string, error) {

--- a/internal/konnect/apiutil/client.go
+++ b/internal/konnect/apiutil/client.go
@@ -122,15 +122,18 @@ func request(
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
+	if resp == nil {
+		return nil, fmt.Errorf("request returned nil response")
+	}
 
-	if resp != nil && resp.StatusCode == http.StatusUnauthorized && shouldRefreshAndRetry(tokenSource, req) {
+	if resp.StatusCode == http.StatusUnauthorized && shouldRefreshAndRetry(tokenSource, req) {
 		refreshedToken, refreshErr := tokenSource.Refresh(ctx, token)
 		if refreshErr != nil {
-			resp.Body.Close()
+			closeResponseBody(resp)
 			return nil, fmt.Errorf("refresh Konnect access token after HTTP 401: %w", refreshErr)
 		}
 
-		resp.Body.Close()
+		closeResponseBody(resp)
 
 		retryBody, err := retryBody(req)
 		if err != nil {
@@ -144,12 +147,18 @@ func request(
 		if err != nil {
 			return nil, fmt.Errorf("retry request after Konnect token refresh failed: %w", err)
 		}
+		if resp == nil {
+			return nil, fmt.Errorf("retry request after Konnect token refresh returned nil response")
+		}
 	}
-	defer resp.Body.Close()
+	defer closeResponseBody(resp)
 
-	bytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
+	var bytes []byte
+	if resp.Body != nil {
+		bytes, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read response: %w", err)
+		}
 	}
 
 	return &Result{
@@ -207,6 +216,12 @@ func retryBody(req *http.Request) (io.Reader, error) {
 		return nil, fmt.Errorf("request body cannot be replayed after Konnect token refresh")
 	}
 	return req.GetBody()
+}
+
+func closeResponseBody(resp *http.Response) {
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
 }
 
 func resolveEndpoint(baseURL, path string) (string, error) {

--- a/internal/konnect/apiutil/client_test.go
+++ b/internal/konnect/apiutil/client_test.go
@@ -90,6 +90,37 @@ func TestRequestError(t *testing.T) {
 	}
 }
 
+func TestRequestNilResponse(t *testing.T) {
+	client := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return nil, nil
+	})
+
+	_, err := Request(context.Background(), client, http.MethodGet, "https://example.com", "/foo", "tok", nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "request returned nil response") {
+		t.Fatalf("expected nil response error, got %v", err)
+	}
+}
+
+func TestRequestNilBody(t *testing.T) {
+	client := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Header:     make(http.Header),
+		}, nil
+	})
+
+	result, err := Request(context.Background(), client, http.MethodDelete, "https://example.com", "/foo", "tok", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.StatusCode != http.StatusNoContent {
+		t.Fatalf("StatusCode = %d, want %d", result.StatusCode, http.StatusNoContent)
+	}
+	if len(result.Body) != 0 {
+		t.Fatalf("Body = %q, want empty", string(result.Body))
+	}
+}
+
 func TestRequestSetsUserAgentHeader(t *testing.T) {
 	original := meta.CLIVersion()
 	t.Cleanup(func() {
@@ -180,6 +211,40 @@ func TestRequestWithTokenSourceRefreshesAndRetries401(t *testing.T) {
 	}
 	if source.refreshCalls != 1 {
 		t.Fatalf("refreshCalls = %d, want 1", source.refreshCalls)
+	}
+}
+
+func TestRequestWithTokenSourceNilRetryResponse(t *testing.T) {
+	source := &testTokenSource{
+		token:          "old-token",
+		refreshedToken: "new-token",
+	}
+
+	attempts := 0
+	client := roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		attempts++
+		if attempts == 1 {
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"error":"expired"}`)),
+			}, nil
+		}
+		return nil, nil
+	})
+
+	_, err := RequestWithTokenSource(
+		context.Background(),
+		client,
+		http.MethodGet,
+		"https://example.com",
+		"/v1/test",
+		source,
+		nil,
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "retry request after Konnect token refresh returned nil response") {
+		t.Fatalf("expected nil retry response error, got %v", err)
 	}
 }
 

--- a/internal/konnect/apiutil/client_test.go
+++ b/internal/konnect/apiutil/client_test.go
@@ -1,6 +1,7 @@
 package apiutil
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -114,4 +115,88 @@ func TestRequestSetsUserAgentHeader(t *testing.T) {
 	if gotUserAgent != "kongctl/v0.5.0" {
 		t.Fatalf("User-Agent = %q, want %q", gotUserAgent, "kongctl/v0.5.0")
 	}
+}
+
+func TestRequestWithTokenSourceRefreshesAndRetries401(t *testing.T) {
+	source := &testTokenSource{
+		token:          "old-token",
+		refreshedToken: "new-token",
+	}
+
+	var attempts int
+	client := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		attempts++
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read request body: %v", err)
+		}
+		if string(body) != `{"ok":true}` {
+			t.Fatalf("unexpected body: %q", string(body))
+		}
+
+		switch attempts {
+		case 1:
+			if req.Header.Get("Authorization") != "Bearer old-token" {
+				t.Fatalf("first authorization = %q", req.Header.Get("Authorization"))
+			}
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"error":"expired"}`)),
+			}, nil
+		case 2:
+			if req.Header.Get("Authorization") != "Bearer new-token" {
+				t.Fatalf("retry authorization = %q", req.Header.Get("Authorization"))
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"done":true}`)),
+			}, nil
+		default:
+			t.Fatalf("unexpected attempt %d", attempts)
+			return nil, nil
+		}
+	})
+
+	result, err := RequestWithTokenSource(
+		context.Background(),
+		client,
+		http.MethodPost,
+		"https://example.com",
+		"/v1/test",
+		source,
+		map[string]string{"Content-Type": "application/json"},
+		bytes.NewReader([]byte(`{"ok":true}`)),
+	)
+	if err != nil {
+		t.Fatalf("RequestWithTokenSource() error = %v", err)
+	}
+	if result.StatusCode != http.StatusOK {
+		t.Fatalf("StatusCode = %d, want %d", result.StatusCode, http.StatusOK)
+	}
+	if string(result.Body) != `{"done":true}` {
+		t.Fatalf("Body = %q", string(result.Body))
+	}
+	if source.refreshCalls != 1 {
+		t.Fatalf("refreshCalls = %d, want 1", source.refreshCalls)
+	}
+}
+
+type testTokenSource struct {
+	token          string
+	refreshedToken string
+	refreshCalls   int
+}
+
+func (s *testTokenSource) Token(context.Context) (string, error) {
+	return s.token, nil
+}
+
+func (s *testTokenSource) Refresh(_ context.Context, previousToken string) (string, error) {
+	if previousToken != s.token {
+		return "", errors.New("unexpected previous token")
+	}
+	s.refreshCalls++
+	return s.refreshedToken, nil
 }

--- a/internal/konnect/auth/auth.go
+++ b/internal/konnect/auth/auth.go
@@ -12,7 +12,6 @@ import (
 	"net/http/cookiejar"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -20,7 +19,6 @@ import (
 	"github.com/google/uuid"
 
 	kk "github.com/Kong/sdk-konnect-go" // kk = Kong Konnect
-	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 	kkMetadata "github.com/Kong/sdk-konnect-go/pkg/metadata"
 
 	"github.com/kong/kongctl/internal/config"
@@ -102,7 +100,7 @@ type AccessToken struct {
 }
 
 func (t *AccessToken) IsExpired() bool {
-	return time.Now().After(t.ReceivedAt.Add(time.Duration(t.Token.ExpiresAfter) * time.Second))
+	return t.expiresWithin(0)
 }
 
 // trustedKonnectDomains is the allow list of Kong-owned domains accepted as
@@ -231,6 +229,7 @@ func RefreshAccessToken(
 	if err != nil {
 		return nil, err
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to refresh token: %s", res.Status)
 	}
@@ -350,9 +349,8 @@ func LoadAccessToken(
 	transportOptions httpclient.TransportOptions,
 	logger *slog.Logger,
 ) (*AccessToken, error) {
-	profile := cfg.GetProfile()
-	cfgPath := filepath.Dir(cfg.GetPath())
-	credsPath := filepath.Join(cfgPath, getCredentialFileName(profile))
+	logger = loggerOrDiscard(logger)
+	credsPath := credentialFilePath(cfg)
 
 	creds, err := loadAccessTokenFromDisk(credsPath)
 	if err != nil {
@@ -398,19 +396,11 @@ func loadAccessTokenFromDisk(path string) (*AccessToken, error) {
 }
 
 func SaveAccessToken(cfg config.Hook, token *AccessToken) error {
-	profile := cfg.GetProfile()
-	cfgPath := filepath.Dir(cfg.GetPath())
-	credsPath := filepath.Join(cfgPath, getCredentialFileName(profile))
-
-	return saveAccessTokenToDisk(credsPath, token)
+	return saveAccessTokenToDisk(credentialFilePath(cfg), token)
 }
 
 func DeleteAccessToken(cfg config.Hook) (bool, error) {
-	profile := cfg.GetProfile()
-	cfgPath := filepath.Dir(cfg.GetPath())
-	credsPath := filepath.Join(cfgPath, getCredentialFileName(profile))
-
-	err := os.Remove(credsPath)
+	err := os.Remove(credentialFilePath(cfg))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return false, nil
@@ -437,7 +427,7 @@ func saveAccessTokenToDisk(path string, token *AccessToken) error {
 
 func GetAuthenticatedClient(
 	baseURL string,
-	token string,
+	tokenSource *TokenSource,
 	timeout time.Duration,
 	transportOptions httpclient.TransportOptions,
 	logger *slog.Logger,
@@ -449,9 +439,9 @@ func GetAuthenticatedClient(
 
 	opts := []kk.SDKOption{
 		kk.WithServerURL(baseURL),
-		kk.WithSecurity(kkComps.Security{
-			PersonalAccessToken: new(token),
-		}),
+	}
+	if tokenSource != nil {
+		opts = append(opts, kk.WithSecuritySource(tokenSource.Security))
 	}
 
 	loggingClient := httpclient.NewLoggingHTTPClientWithClient(
@@ -461,7 +451,8 @@ func GetAuthenticatedClient(
 		}),
 		logger,
 	)
-	opts = append(opts, kk.WithClient(loggingClient))
+	refreshingClient := NewRefreshingHTTPClient(loggingClient, tokenSource)
+	opts = append(opts, kk.WithClient(refreshingClient))
 
-	return kk.New(opts...), loggingClient, nil
+	return kk.New(opts...), refreshingClient, nil
 }

--- a/internal/konnect/auth/auth_test.go
+++ b/internal/konnect/auth/auth_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kong/kongctl/internal/konnect/httpclient"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
 )
@@ -140,6 +141,160 @@ func TestJWTExpiresIn_APIResponseMismatch(t *testing.T) {
 	require.InDelta(t, int(jwtLifetime.Seconds()), secs, 5)
 }
 
+func TestTokenSourcePATIsStatic(t *testing.T) {
+	source := NewTokenSource(nil, TokenSourceOptions{
+		PAT: "pat-token",
+	})
+
+	token, err := source.Token(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "pat-token", token)
+	require.False(t, source.Refreshable())
+
+	_, err = source.Refresh(t.Context(), "pat-token")
+	require.ErrorIs(t, err, ErrTokenRefreshUnsupported)
+}
+
+func TestTokenSourceRefreshesNearExpiryAndSaves(t *testing.T) {
+	dir := t.TempDir()
+	cfg := stubConfig{
+		profile: "default",
+		path:    filepath.Join(dir, "config.yaml"),
+	}
+	oldToken := &AccessToken{
+		Token: &AccessTokenResponse{
+			AuthToken:    "old-token",
+			RefreshToken: "old-refresh",
+			ExpiresAfter: 30,
+		},
+		ReceivedAt: time.Now(),
+	}
+	require.NoError(t, saveAccessTokenToDisk(credentialFilePath(cfg), oldToken))
+
+	var gotRefreshURL, gotRefreshToken string
+	source := NewTokenSource(cfg, TokenSourceOptions{
+		RefreshURL: "https://us.api.konghq.com/kauth/api/v1/refresh",
+		ExpirySkew: time.Minute,
+		Refresh: func(refreshURL string, refreshToken string, _ time.Duration,
+			_ httpclient.TransportOptions, _ *slog.Logger,
+		) (*AccessToken, error) {
+			gotRefreshURL = refreshURL
+			gotRefreshToken = refreshToken
+			return &AccessToken{
+				Token: &AccessTokenResponse{
+					AuthToken:    "new-token",
+					RefreshToken: "new-refresh",
+					ExpiresAfter: 900,
+				},
+				ReceivedAt: time.Now(),
+			}, nil
+		},
+	})
+
+	token, err := source.Token(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "new-token", token)
+	require.Equal(t, "https://us.api.konghq.com/kauth/api/v1/refresh", gotRefreshURL)
+	require.Equal(t, "old-refresh", gotRefreshToken)
+
+	saved, err := loadAccessTokenFromDisk(credentialFilePath(cfg))
+	require.NoError(t, err)
+	require.Equal(t, "new-token", saved.Token.AuthToken)
+	require.Equal(t, "new-refresh", saved.Token.RefreshToken)
+}
+
+func TestTokenSourceForcedRefreshUsesAlreadyUpdatedToken(t *testing.T) {
+	dir := t.TempDir()
+	cfg := stubConfig{
+		profile: "default",
+		path:    filepath.Join(dir, "config.yaml"),
+	}
+	currentToken := &AccessToken{
+		Token: &AccessTokenResponse{
+			AuthToken:    "current-token",
+			RefreshToken: "current-refresh",
+			ExpiresAfter: 900,
+		},
+		ReceivedAt: time.Now(),
+	}
+	require.NoError(t, saveAccessTokenToDisk(credentialFilePath(cfg), currentToken))
+
+	source := NewTokenSource(cfg, TokenSourceOptions{
+		RefreshURL: "https://us.api.konghq.com/kauth/api/v1/refresh",
+		Refresh: func(string, string, time.Duration, httpclient.TransportOptions, *slog.Logger) (*AccessToken, error) {
+			t.Fatal("refresh should not be called when another worker already updated the token")
+			return nil, nil
+		},
+	})
+
+	token, err := source.Refresh(t.Context(), "stale-token")
+	require.NoError(t, err)
+	require.Equal(t, "current-token", token)
+}
+
+func TestRefreshingHTTPClientRetries401WithRefreshedToken(t *testing.T) {
+	dir := t.TempDir()
+	cfg := stubConfig{
+		profile: "default",
+		path:    filepath.Join(dir, "config.yaml"),
+	}
+	require.NoError(t, saveAccessTokenToDisk(credentialFilePath(cfg), &AccessToken{
+		Token: &AccessTokenResponse{
+			AuthToken:    "old-token",
+			RefreshToken: "old-refresh",
+			ExpiresAfter: 900,
+		},
+		ReceivedAt: time.Now(),
+	}))
+
+	source := NewTokenSource(cfg, TokenSourceOptions{
+		RefreshURL: "https://us.api.konghq.com/kauth/api/v1/refresh",
+		Refresh: func(string, string, time.Duration, httpclient.TransportOptions, *slog.Logger) (*AccessToken, error) {
+			return &AccessToken{
+				Token: &AccessTokenResponse{
+					AuthToken:    "new-token",
+					RefreshToken: "new-refresh",
+					ExpiresAfter: 900,
+				},
+				ReceivedAt: time.Now(),
+			}, nil
+		},
+	})
+
+	var attempts int
+	client := NewRefreshingHTTPClient(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		attempts++
+		switch attempts {
+		case 1:
+			require.Equal(t, "Bearer old-token", req.Header.Get("Authorization"))
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Body:       io.NopCloser(strings.NewReader(`{"error":"expired"}`)),
+				Header:     make(http.Header),
+			}, nil
+		case 2:
+			require.Equal(t, "Bearer new-token", req.Header.Get("Authorization"))
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+				Header:     make(http.Header),
+			}, nil
+		default:
+			t.Fatalf("unexpected attempt %d", attempts)
+			return nil, nil
+		}
+	}), source)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer old-token")
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 2, attempts)
+}
+
 func TestValidateKonnectURL(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -262,3 +417,4 @@ func TestRequestDeviceCode_NonOKStatus(t *testing.T) {
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+func (f roundTripFunc) Do(r *http.Request) (*http.Response, error)        { return f(r) }

--- a/internal/konnect/auth/refreshing_client.go
+++ b/internal/konnect/auth/refreshing_client.go
@@ -1,0 +1,83 @@
+package auth
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	kk "github.com/Kong/sdk-konnect-go"
+
+	"github.com/kong/kongctl/internal/util/httpheaders"
+)
+
+// RefreshingHTTPClient retries one replayable request after a recoverable 401.
+type RefreshingHTTPClient struct {
+	base        kk.HTTPClient
+	tokenSource *TokenSource
+}
+
+func NewRefreshingHTTPClient(base kk.HTTPClient, tokenSource *TokenSource) *RefreshingHTTPClient {
+	return &RefreshingHTTPClient{
+		base:        base,
+		tokenSource: tokenSource,
+	}
+}
+
+func (c *RefreshingHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	if c == nil || c.base == nil {
+		return nil, fmt.Errorf("http client is not configured")
+	}
+	if req == nil {
+		return nil, fmt.Errorf("request is nil")
+	}
+
+	resp, err := c.base.Do(req)
+	if err != nil || resp == nil || resp.StatusCode != http.StatusUnauthorized || c.tokenSource == nil {
+		return resp, err
+	}
+
+	if !requestCanBeReplayed(req) {
+		return resp, nil
+	}
+
+	previousToken := bearerToken(req.Header.Get(httpheaders.HeaderAuthorization))
+	refreshedToken, refreshErr := c.tokenSource.Refresh(req.Context(), previousToken)
+	if refreshErr != nil {
+		if errors.Is(refreshErr, ErrTokenRefreshUnsupported) {
+			return resp, nil
+		}
+		resp.Body.Close()
+		return nil, fmt.Errorf("refresh Konnect access token after HTTP 401: %w", refreshErr)
+	}
+
+	resp.Body.Close()
+
+	retryReq := req.Clone(req.Context())
+	if req.Body != nil && req.Body != http.NoBody {
+		body, err := req.GetBody()
+		if err != nil {
+			return nil, fmt.Errorf("replay request after Konnect token refresh: %w", err)
+		}
+		retryReq.Body = body
+	}
+	httpheaders.SetBearerAuthorization(retryReq, refreshedToken)
+
+	return c.base.Do(retryReq)
+}
+
+func requestCanBeReplayed(req *http.Request) bool {
+	return req.Body == nil || req.Body == http.NoBody || req.GetBody != nil
+}
+
+func bearerToken(header string) string {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return ""
+	}
+	prefix := httpheaders.BearerAuthorizationPrefix
+	if len(header) >= len(prefix) && strings.EqualFold(header[:len(prefix)], prefix) {
+		return strings.TrimSpace(header[len(prefix):])
+	}
+	return ""
+}

--- a/internal/konnect/auth/token_source.go
+++ b/internal/konnect/auth/token_source.go
@@ -1,0 +1,211 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+
+	"github.com/kong/kongctl/internal/config"
+	"github.com/kong/kongctl/internal/konnect/httpclient"
+)
+
+const DefaultAccessTokenExpirySkew = time.Minute
+
+var ErrTokenRefreshUnsupported = errors.New("token refresh is not supported")
+
+// TokenSource provides the current Konnect bearer token for each request.
+// It is safe for concurrent use by future parallel executor workers.
+type TokenSource struct {
+	cfg              config.Hook
+	pat              string
+	refreshURL       string
+	timeout          time.Duration
+	transportOptions httpclient.TransportOptions
+	logger           *slog.Logger
+	expirySkew       time.Duration
+	refresh          refreshAccessTokenFunc
+
+	mu     sync.Mutex
+	loaded bool
+	token  *AccessToken
+}
+
+type refreshAccessTokenFunc func(
+	refreshURL string,
+	refreshToken string,
+	timeout time.Duration,
+	transportOptions httpclient.TransportOptions,
+	logger *slog.Logger,
+) (*AccessToken, error)
+
+type TokenSourceOptions struct {
+	PAT              string
+	RefreshURL       string
+	Timeout          time.Duration
+	TransportOptions httpclient.TransportOptions
+	Logger           *slog.Logger
+	ExpirySkew       time.Duration
+	Refresh          refreshAccessTokenFunc
+}
+
+func NewTokenSource(cfg config.Hook, opts TokenSourceOptions) *TokenSource {
+	skew := opts.ExpirySkew
+	if skew <= 0 {
+		skew = DefaultAccessTokenExpirySkew
+	}
+	refresh := opts.Refresh
+	if refresh == nil {
+		refresh = RefreshAccessToken
+	}
+
+	return &TokenSource{
+		cfg:              cfg,
+		pat:              strings.TrimSpace(opts.PAT),
+		refreshURL:       strings.TrimSpace(opts.RefreshURL),
+		timeout:          opts.Timeout,
+		transportOptions: opts.TransportOptions,
+		logger:           loggerOrDiscard(opts.Logger),
+		expirySkew:       skew,
+		refresh:          refresh,
+	}
+}
+
+func (s *TokenSource) Token(ctx context.Context) (string, error) {
+	return s.currentToken(ctx, false, "")
+}
+
+func (s *TokenSource) Refresh(ctx context.Context, previousToken string) (string, error) {
+	return s.currentToken(ctx, true, previousToken)
+}
+
+func (s *TokenSource) Refreshable() bool {
+	return s != nil && s.pat == ""
+}
+
+func (s *TokenSource) Security(ctx context.Context) (kkComps.Security, error) {
+	token, err := s.Token(ctx)
+	if err != nil {
+		return kkComps.Security{}, err
+	}
+	return kkComps.Security{
+		PersonalAccessToken: &token,
+	}, nil
+}
+
+func (s *TokenSource) currentToken(ctx context.Context, forceRefresh bool, previousToken string) (string, error) {
+	if s == nil {
+		return "", fmt.Errorf("konnect token source is not configured")
+	}
+	if err := ctxErr(ctx); err != nil {
+		return "", err
+	}
+	if s.pat != "" {
+		if forceRefresh {
+			return "", ErrTokenRefreshUnsupported
+		}
+		return s.pat, nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := ctxErr(ctx); err != nil {
+		return "", err
+	}
+
+	if err := s.loadOnce(); err != nil {
+		return "", err
+	}
+	if s.token == nil || s.token.Token == nil || strings.TrimSpace(s.token.Token.AuthToken) == "" {
+		return "", fmt.Errorf("konnect access token is empty")
+	}
+
+	if forceRefresh && previousToken != "" && s.token.Token.AuthToken != previousToken &&
+		!s.token.expiresWithin(s.expirySkew) {
+		return s.token.Token.AuthToken, nil
+	}
+
+	if forceRefresh || s.token.expiresWithin(s.expirySkew) {
+		if strings.TrimSpace(s.token.Token.RefreshToken) == "" {
+			return "", fmt.Errorf("konnect refresh token is empty")
+		}
+		if strings.TrimSpace(s.refreshURL) == "" {
+			return "", fmt.Errorf("konnect refresh URL is empty")
+		}
+
+		s.logger.Info("Token expired or near expiry, refreshing", "refresh_url", s.refreshURL)
+		refreshed, err := s.refresh(
+			s.refreshURL,
+			s.token.Token.RefreshToken,
+			s.timeout,
+			s.transportOptions,
+			s.logger,
+		)
+		if err != nil {
+			return "", fmt.Errorf("refresh Konnect access token: %w", err)
+		}
+		if refreshed == nil || refreshed.Token == nil || strings.TrimSpace(refreshed.Token.AuthToken) == "" {
+			return "", fmt.Errorf("refresh Konnect access token: empty token response")
+		}
+
+		if err := saveAccessTokenToDisk(credentialFilePath(s.cfg), refreshed); err != nil {
+			return "", fmt.Errorf("save refreshed Konnect access token: %w", err)
+		}
+		s.token = refreshed
+	}
+
+	return s.token.Token.AuthToken, nil
+}
+
+func (s *TokenSource) loadOnce() error {
+	if s.loaded {
+		return nil
+	}
+	if s.cfg == nil {
+		return fmt.Errorf("konnect config is not available")
+	}
+
+	creds, err := loadAccessTokenFromDisk(credentialFilePath(s.cfg))
+	if err != nil {
+		return err
+	}
+	s.token = creds
+	s.loaded = true
+	return nil
+}
+
+func credentialFilePath(cfg config.Hook) string {
+	profile := cfg.GetProfile()
+	cfgPath := filepath.Dir(cfg.GetPath())
+	return filepath.Join(cfgPath, getCredentialFileName(profile))
+}
+
+func (t *AccessToken) expiresWithin(skew time.Duration) bool {
+	if t == nil || t.Token == nil {
+		return true
+	}
+	expiresAt := t.ReceivedAt.Add(time.Duration(t.Token.ExpiresAfter) * time.Second)
+	return !time.Now().Add(skew).Before(expiresAt)
+}
+
+func ctxErr(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	return ctx.Err()
+}
+
+func loggerOrDiscard(logger *slog.Logger) *slog.Logger {
+	if logger != nil {
+		return logger
+	}
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}

--- a/internal/konnect/helpers/api_publications.go
+++ b/internal/konnect/helpers/api_publications.go
@@ -32,10 +32,11 @@ type APIPublicationAPI interface {
 
 // APIPublicationAPIImpl provides an implementation of the APIPublicationAPI interface
 type APIPublicationAPIImpl struct {
-	SDK        *kkSDK.SDK
-	BaseURL    string
-	Token      string
-	HTTPClient kkSDK.HTTPClient
+	SDK         *kkSDK.SDK
+	BaseURL     string
+	Token       string
+	TokenSource apiutil.TokenSource
+	HTTPClient  kkSDK.HTTPClient
 }
 
 // PublishAPIToPortal implements the APIPublicationAPI interface
@@ -202,16 +203,11 @@ func (a *APIPublicationAPIImpl) publishAPIToPortalWithMergedPayload(
 	}
 
 	path := fmt.Sprintf("/v3/apis/%s/publications/%s", url.PathEscape(request.APIID), url.PathEscape(request.PortalID))
-	result, err := apiutil.Request(
+	result, err := a.request(
 		ctx,
-		a.HTTPClient,
 		http.MethodPut,
-		a.BaseURL,
 		path,
-		a.Token,
-		map[string]string{
-			"Content-Type": "application/json",
-		},
+		map[string]string{"Content-Type": "application/json"},
 		bytes.NewReader(payload),
 	)
 	if err != nil {
@@ -247,6 +243,19 @@ func (a *APIPublicationAPIImpl) publishAPIToPortalWithMergedPayload(
 	response.APIPublicationResponse = &publicationResponse
 
 	return response, nil
+}
+
+func (a *APIPublicationAPIImpl) request(
+	ctx context.Context,
+	method string,
+	path string,
+	headers map[string]string,
+	body io.Reader,
+) (*apiutil.Result, error) {
+	if a.TokenSource != nil {
+		return apiutil.RequestWithTokenSource(ctx, a.HTTPClient, method, a.BaseURL, path, a.TokenSource, headers, body)
+	}
+	return apiutil.Request(ctx, a.HTTPClient, method, a.BaseURL, path, a.Token, headers, body)
 }
 
 func (a *APIPublicationAPIImpl) fetchExistingPublication(

--- a/internal/konnect/helpers/dcr_providers.go
+++ b/internal/konnect/helpers/dcr_providers.go
@@ -96,10 +96,11 @@ func NormalizeDCRProviderPayload(data any) (*NormalizedDCRProviderPayload, error
 
 // DCRProvidersAPIImpl provides an implementation of the DCRProvidersAPI interface
 type DCRProvidersAPIImpl struct {
-	SDK        *kkSDK.SDK
-	BaseURL    string
-	Token      string
-	HTTPClient kkSDK.HTTPClient
+	SDK         *kkSDK.SDK
+	BaseURL     string
+	Token       string
+	TokenSource apiutil.TokenSource
+	HTTPClient  kkSDK.HTTPClient
 }
 
 func (a *DCRProvidersAPIImpl) ListDcrProviders(ctx context.Context,
@@ -143,7 +144,7 @@ func (a *DCRProvidersAPIImpl) ListDcrProviderPayloads(
 		path += "?" + encoded
 	}
 
-	result, err := apiutil.Request(ctx, a.HTTPClient, http.MethodGet, a.BaseURL, path, a.Token, nil, nil)
+	result, err := a.request(ctx, http.MethodGet, path, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -171,16 +172,8 @@ func (a *DCRProvidersAPIImpl) CreateDcrProvider(ctx context.Context,
 			return nil, fmt.Errorf("failed to marshal DCR provider create request: %w", err)
 		}
 
-		result, err := apiutil.Request(
-			ctx,
-			a.HTTPClient,
-			http.MethodPost,
-			a.BaseURL,
-			"/v2/dcr-providers",
-			a.Token,
-			map[string]string{"Content-Type": "application/json"},
-			bytes.NewReader(payload),
-		)
+		result, err := a.request(ctx, http.MethodPost, "/v2/dcr-providers",
+			map[string]string{"Content-Type": "application/json"}, bytes.NewReader(payload))
 		if err != nil {
 			return nil, err
 		}
@@ -209,16 +202,8 @@ func (a *DCRProvidersAPIImpl) UpdateDcrProvider(ctx context.Context, id string,
 		}
 
 		path := fmt.Sprintf("/v2/dcr-providers/%s", url.PathEscape(id))
-		result, err := apiutil.Request(
-			ctx,
-			a.HTTPClient,
-			http.MethodPatch,
-			a.BaseURL,
-			path,
-			a.Token,
-			map[string]string{"Content-Type": "application/json"},
-			bytes.NewReader(payload),
-		)
+		result, err := a.request(ctx, http.MethodPatch, path,
+			map[string]string{"Content-Type": "application/json"}, bytes.NewReader(payload))
 		if err != nil {
 			return nil, err
 		}
@@ -242,16 +227,7 @@ func (a *DCRProvidersAPIImpl) DeleteDcrProvider(ctx context.Context,
 ) (*kkOPS.DeleteDcrProviderResponse, error) {
 	if a.canUseRawRequest() {
 		path := fmt.Sprintf("/v2/dcr-providers/%s", url.PathEscape(id))
-		result, err := apiutil.Request(
-			ctx,
-			a.HTTPClient,
-			http.MethodDelete,
-			a.BaseURL,
-			path,
-			a.Token,
-			nil,
-			nil,
-		)
+		result, err := a.request(ctx, http.MethodDelete, path, nil, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -274,6 +250,19 @@ func (a *DCRProvidersAPIImpl) canUseRawRequest() bool {
 	return a != nil &&
 		a.HTTPClient != nil &&
 		strings.TrimSpace(a.BaseURL) != ""
+}
+
+func (a *DCRProvidersAPIImpl) request(
+	ctx context.Context,
+	method string,
+	path string,
+	headers map[string]string,
+	body io.Reader,
+) (*apiutil.Result, error) {
+	if a.TokenSource != nil {
+		return apiutil.RequestWithTokenSource(ctx, a.HTTPClient, method, a.BaseURL, path, a.TokenSource, headers, body)
+	}
+	return apiutil.Request(ctx, a.HTTPClient, method, a.BaseURL, path, a.Token, headers, body)
 }
 
 func newDCRProviderRawResponse(result *apiutil.Result) *http.Response {

--- a/internal/konnect/helpers/portal_identity_providers.go
+++ b/internal/konnect/helpers/portal_identity_providers.go
@@ -13,6 +13,8 @@ import (
 	kkSDK "github.com/Kong/sdk-konnect-go"
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+
+	"github.com/kong/kongctl/internal/konnect/apiutil"
 )
 
 // PortalIdentityProviderAPI defines the interface for portal identity provider operations.
@@ -49,10 +51,11 @@ type PortalIdentityProviderAPI interface {
 
 // PortalIdentityProviderAPIImpl provides an implementation backed by the SDK.
 type PortalIdentityProviderAPIImpl struct {
-	SDK        *kkSDK.SDK
-	BaseURL    string
-	Token      string
-	HTTPClient kkSDK.HTTPClient
+	SDK         *kkSDK.SDK
+	BaseURL     string
+	Token       string
+	TokenSource apiutil.TokenSource
+	HTTPClient  kkSDK.HTTPClient
 }
 
 // ListPortalIdentityProviders lists identity providers for a portal.
@@ -94,13 +97,25 @@ func (p *PortalIdentityProviderAPIImpl) CreatePortalIdentityProvider(
 		return p.SDK.PortalAuthSettings.CreatePortalIdentityProvider(ctx, portalID, request, opts...)
 	}
 
-	sdk := kkSDK.New(
+	sdkOpts := []kkSDK.SDKOption{
 		kkSDK.WithServerURL(p.BaseURL),
-		kkSDK.WithSecurity(kkComps.Security{
-			PersonalAccessToken: &p.Token,
-		}),
 		kkSDK.WithClient(&portalIdentityProviderCreateHTTPClient{base: p.HTTPClient}),
-	)
+	}
+	if p.TokenSource != nil {
+		sdkOpts = append(sdkOpts, kkSDK.WithSecuritySource(func(ctx context.Context) (kkComps.Security, error) {
+			token, err := p.TokenSource.Token(ctx)
+			if err != nil {
+				return kkComps.Security{}, err
+			}
+			return kkComps.Security{PersonalAccessToken: &token}, nil
+		}))
+	} else {
+		sdkOpts = append(sdkOpts, kkSDK.WithSecurity(kkComps.Security{
+			PersonalAccessToken: &p.Token,
+		}))
+	}
+
+	sdk := kkSDK.New(sdkOpts...)
 	if sdk == nil || sdk.PortalAuthSettings == nil {
 		return nil, fmt.Errorf("failed to initialize SDK for portal identity provider create")
 	}

--- a/internal/konnect/helpers/sdk.go
+++ b/internal/konnect/helpers/sdk.go
@@ -6,6 +6,7 @@ import (
 	kkSDK "github.com/Kong/sdk-konnect-go" // kk = Kong Konnect
 
 	"github.com/kong/kongctl/internal/config"
+	"github.com/kong/kongctl/internal/konnect/apiutil"
 )
 
 const (
@@ -66,11 +67,12 @@ type SDKAPI interface {
 // This is the real implementation of the SDKAPI
 // which wraps the actual SDK implmentation
 type KonnectSDK struct {
-	SDK        *kkSDK.SDK
-	BaseURL    string
-	Token      string
-	HTTPClient kkSDK.HTTPClient
-	portalImpl *PortalAPIImpl
+	SDK         *kkSDK.SDK
+	BaseURL     string
+	Token       string
+	TokenSource apiutil.TokenSource
+	HTTPClient  kkSDK.HTTPClient
+	portalImpl  *PortalAPIImpl
 }
 
 // Returns the real implementation of the GetControlPlaneAPI
@@ -141,10 +143,11 @@ func (k *KonnectSDK) GetAPIPublicationAPI() APIPublicationAPI {
 	}
 
 	return &APIPublicationAPIImpl{
-		SDK:        k.SDK,
-		BaseURL:    k.BaseURL,
-		Token:      k.Token,
-		HTTPClient: k.HTTPClient,
+		SDK:         k.SDK,
+		BaseURL:     k.BaseURL,
+		Token:       k.Token,
+		TokenSource: k.TokenSource,
+		HTTPClient:  k.HTTPClient,
 	}
 }
 
@@ -173,10 +176,11 @@ func (k *KonnectSDK) GetDCRProvidersAPI() DCRProvidersAPI {
 	}
 
 	return &DCRProvidersAPIImpl{
-		SDK:        k.SDK,
-		BaseURL:    k.BaseURL,
-		Token:      k.Token,
-		HTTPClient: k.HTTPClient,
+		SDK:         k.SDK,
+		BaseURL:     k.BaseURL,
+		Token:       k.Token,
+		TokenSource: k.TokenSource,
+		HTTPClient:  k.HTTPClient,
 	}
 }
 
@@ -231,10 +235,11 @@ func (k *KonnectSDK) GetPortalIdentityProviderAPI() PortalIdentityProviderAPI {
 	}
 
 	return &PortalIdentityProviderAPIImpl{
-		SDK:        k.SDK,
-		BaseURL:    k.BaseURL,
-		Token:      k.Token,
-		HTTPClient: k.HTTPClient,
+		SDK:         k.SDK,
+		BaseURL:     k.BaseURL,
+		Token:       k.Token,
+		TokenSource: k.TokenSource,
+		HTTPClient:  k.HTTPClient,
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add a shared, concurrency-safe Konnect token source that resolves tokens at request time and refreshes near expiry.
- Wire SDK clients through `WithSecuritySource` and add a replayable 401 refresh retry.
- Move raw Konnect HTTP helper paths and deck planner/executor invocations to token-source backed authentication.
- Keep deck refresh scoped to immediately before each deck subprocess invocation; no in-flight subprocess token mutation.

Fixes #370.

## Verification
- `make format`
- `make lint`
- `make test`
- `make build`