### PR TITLE
Fix: handle masked deck env JSON output

### DIFF
--- a/internal/declarative/deck/json_output.go
+++ b/internal/declarative/deck/json_output.go
@@ -1,0 +1,58 @@
+package deck
+
+import "strings"
+
+const maskedDeckEnvValue = "[masked]"
+
+// NormalizeMaskedJSONOutput quotes bare [masked] values emitted by deck for
+// masked DECK_* numeric values. This is a temporary compatibility workaround
+// for Kong/deck#2047.
+func NormalizeMaskedJSONOutput(stdout string) (string, bool) {
+	if !strings.Contains(stdout, maskedDeckEnvValue) {
+		return stdout, false
+	}
+
+	var b strings.Builder
+	b.Grow(len(stdout))
+
+	changed := false
+	inString := false
+	escaped := false
+	for i := 0; i < len(stdout); i++ {
+		ch := stdout[i]
+		if inString {
+			b.WriteByte(ch)
+			if escaped {
+				escaped = false
+				continue
+			}
+			switch ch {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+
+		if ch == '"' {
+			inString = true
+			b.WriteByte(ch)
+			continue
+		}
+
+		if strings.HasPrefix(stdout[i:], maskedDeckEnvValue) {
+			b.WriteString(`"` + maskedDeckEnvValue + `"`)
+			i += len(maskedDeckEnvValue) - 1
+			changed = true
+			continue
+		}
+
+		b.WriteByte(ch)
+	}
+
+	if !changed {
+		return stdout, false
+	}
+	return b.String(), true
+}

--- a/internal/declarative/deck/json_output_test.go
+++ b/internal/declarative/deck/json_output_test.go
@@ -1,0 +1,69 @@
+package deck
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeMaskedJSONOutput(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		changed bool
+	}{
+		{
+			name:    "valid JSON without masked value",
+			input:   `{"summary":{"total":1}}`,
+			want:    `{"summary":{"total":1}}`,
+			changed: false,
+		},
+		{
+			name:    "quoted masked string unchanged",
+			input:   `{"name":"[masked]"}`,
+			want:    `{"name":"[masked]"}`,
+			changed: false,
+		},
+		{
+			name:    "bare masked object value quoted",
+			input:   `{"config":{"dimensions":[masked]}}`,
+			want:    `{"config":{"dimensions":"[masked]"}}`,
+			changed: true,
+		},
+		{
+			name:    "multiple bare masked values quoted",
+			input:   `{"input_cost":[masked],"output_cost":[masked]}`,
+			want:    `{"input_cost":"[masked]","output_cost":"[masked]"}`,
+			changed: true,
+		},
+		{
+			name:    "masked text inside string unchanged",
+			input:   `{"description":"literal [masked] value"}`,
+			want:    `{"description":"literal [masked] value"}`,
+			changed: false,
+		},
+		{
+			name:    "masked text inside escaped string unchanged",
+			input:   `{"description":"quoted \"[masked]\" value","cost":[masked]}`,
+			want:    `{"description":"quoted \"[masked]\" value","cost":"[masked]"}`,
+			changed: true,
+		},
+		{
+			name:    "bare masked array value quoted",
+			input:   `{"values":[[masked],1]}`,
+			want:    `{"values":["[masked]",1]}`,
+			changed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, changed := NormalizeMaskedJSONOutput(tt.input)
+			require.Equal(t, tt.changed, changed)
+			require.Equal(t, tt.want, got)
+			require.NoError(t, json.Unmarshal([]byte(got), new(any)))
+		})
+	}
+}

--- a/internal/declarative/executor/deck_execution.go
+++ b/internal/declarative/executor/deck_execution.go
@@ -655,6 +655,8 @@ type deckSummary struct {
 }
 
 func deckSummaryFromJSON(stdout string) (deckSummary, bool) {
+	stdout, _ = deck.NormalizeMaskedJSONOutput(stdout)
+
 	var payload struct {
 		Summary  map[string]any `json:"summary"`
 		Warnings []any          `json:"warnings"`

--- a/internal/declarative/executor/deck_execution_test.go
+++ b/internal/declarative/executor/deck_execution_test.go
@@ -225,3 +225,20 @@ func TestExecuteDeckStepSkipsResolutionWithoutDependencies(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, runner.calls, 1)
 }
+
+func TestDeckSummaryFromJSONNormalizesBareMaskedDeckEnvValues(t *testing.T) {
+	stdout := `{
+		"summary":{"created":1,"updated":0,"deleted":0},
+		"changes":[{"kind":"plugin","config":{"minute":[masked]}}],
+		"warnings":[],
+		"errors":[]
+	}`
+
+	summary, ok := deckSummaryFromJSON(stdout)
+	require.True(t, ok)
+	require.Equal(t, "apply", summary.Kind)
+	require.Equal(t, 1, summary.Created)
+	require.Equal(t, 0, summary.Updated)
+	require.Equal(t, 0, summary.Deleted)
+	require.True(t, summary.HasSummary)
+}

--- a/internal/declarative/planner/deck_requirements.go
+++ b/internal/declarative/planner/deck_requirements.go
@@ -396,8 +396,15 @@ func (p *Planner) deckDiffHasChanges(
 		return false, fmt.Errorf("control_plane %s: deck diff returned no output", controlPlaneRef)
 	}
 
+	stdout, normalized := deck.NormalizeMaskedJSONOutput(result.Stdout)
+	if normalized {
+		p.logger.Debug("Normalized deck masked JSON output",
+			slog.String("control_plane_ref", controlPlaneRef),
+		)
+	}
+
 	var output deckDiffOutput
-	if err := json.Unmarshal([]byte(result.Stdout), &output); err != nil {
+	if err := json.Unmarshal([]byte(stdout), &output); err != nil {
 		return false, fmt.Errorf("control_plane %s: decode deck diff output: %w", controlPlaneRef, err)
 	}
 

--- a/internal/declarative/planner/deck_requirements_test.go
+++ b/internal/declarative/planner/deck_requirements_test.go
@@ -206,6 +206,34 @@ func TestPlanDeckDependenciesAdded(t *testing.T) {
 	require.Contains(t, apiChange.DependsOn, deckChange.ID)
 }
 
+func TestDeckDiffHasChangesNormalizesBareMaskedDeckEnvValues(t *testing.T) {
+	runner := &stubDeckRunner{
+		result: &deck.RunResult{
+			Stdout: `{
+				"summary":{"creating":1,"updating":0,"deleting":0,"total":1},
+				"changes":[{"kind":"plugin","config":{"minute":[masked]}}],
+				"errors":[]
+			}`,
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	p := NewPlanner(nil, logger)
+
+	changes, err := p.deckDiffHasChanges(context.Background(), "cp", "cp-name", t.TempDir(),
+		[]string{"gateway-service.yaml"},
+		nil,
+		Options{
+			Mode: PlanModeApply,
+			Deck: DeckOptions{
+				Runner:         runner,
+				KonnectToken:   "token-123",
+				KonnectAddress: "https://api.konghq.com",
+			},
+		})
+	require.NoError(t, err)
+	require.True(t, changes)
+}
+
 func TestResolveGatewayServiceIdentitiesDeckConfigNoMatch(t *testing.T) {
 	cpID := "11111111-1111-1111-1111-111111111111"
 

--- a/test/e2e/scenarios/deck/env-vars/scenario.yaml
+++ b/test/e2e/scenarios/deck/env-vars/scenario.yaml
@@ -1,0 +1,51 @@
+baseInputsPath: testdata
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-create-control-plane
+    commands:
+      - name: 000-apply-control-plane
+        outputFormat: json
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/control-plane.yaml"
+          - --auto-approve
+        assertions:
+          - select: "summary"
+            expect:
+              fields:
+                failed: 0
+                status: success
+          - select: >-
+              plan.changes[?resource_type=='control_plane' && action=='CREATE'] | [0]
+            expect:
+              fields:
+                resource_ref: e2e-deck-env-cp
+
+  - name: 002-apply-deck-env-vars
+    env:
+      DECK_RATE_LIMIT_MINUTE: "11"
+    commands:
+      - name: 000-apply-deck-env-vars
+        outputFormat: json
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/control-plane-with-deck-env.yaml"
+          - --auto-approve
+        assertions:
+          - select: "summary"
+            expect:
+              fields:
+                failed: 0
+                status: success
+          - select: "plan.changes[?resource_type=='_deck']"
+            expect:
+              fields:
+                "length(@)": 1
+

--- a/test/e2e/scenarios/deck/env-vars/testdata/control-plane-with-deck-env.yaml
+++ b/test/e2e/scenarios/deck/env-vars/testdata/control-plane-with-deck-env.yaml
@@ -1,0 +1,11 @@
+control_planes:
+  - ref: e2e-deck-env-cp
+    name: "e2e-deck-env-cp"
+    description: "E2E control plane for deck environment variables"
+    cluster_type: "CLUSTER_TYPE_SERVERLESS"
+    _deck:
+      files:
+        - "gateway-service-with-env.yaml"
+      flags:
+        - "--analytics=false"
+

--- a/test/e2e/scenarios/deck/env-vars/testdata/control-plane.yaml
+++ b/test/e2e/scenarios/deck/env-vars/testdata/control-plane.yaml
@@ -1,0 +1,6 @@
+control_planes:
+  - ref: e2e-deck-env-cp
+    name: "e2e-deck-env-cp"
+    description: "E2E control plane for deck environment variables"
+    cluster_type: "CLUSTER_TYPE_SERVERLESS"
+

--- a/test/e2e/scenarios/deck/env-vars/testdata/gateway-service-with-env.yaml
+++ b/test/e2e/scenarios/deck/env-vars/testdata/gateway-service-with-env.yaml
@@ -1,0 +1,18 @@
+_format_version: "3.0"
+
+_info:
+  select_tags:
+    - "kongctl-e2e-deck-env"
+
+services:
+  - name: "e2e-deck-env-svc"
+    url: "https://api.kong-air.com/"
+    tags:
+      - "kongctl-e2e-deck-env"
+    plugins:
+      - name: "rate-limiting"
+        config:
+          minute: ${{ env "DECK_RATE_LIMIT_MINUTE" }}
+        tags:
+          - "kongctl-e2e-deck-env"
+


### PR DESCRIPTION
## Summary

- Add a temporary deck JSON normalization helper for bare `[masked]` values emitted for masked `DECK_*` numeric fields.
- Use the helper when parsing `deck gateway diff --json-output` in planning and deck summary JSON in execution logging.
- Cover the helper plus planner and executor parsing paths with focused tests.

Fixes #990.

## Validation

- `go test ./internal/declarative/deck ./internal/declarative/planner ./internal/declarative/executor`
- `make test-e2e-scenarios SCENARIO=deck/env-vars`
- `make format`
- `make build`
- `make test`
- `make lint`