### PR TITLE
Feat: add portal IP allow list resource support

### DIFF
--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -411,6 +411,9 @@ portals:
      basic_auth_enabled: boolean
      konnect_mapping_enabled: boolean
      idp_mapping_enabled: boolean
+   ip_allow_list: # https://developer.konghq.com/api/konnect/portal-management/v3/#/operations/create-portal-ip-allow-list
+     ref: string
+     allowed_ips: array[string] required # IP addresses or CIDR blocks
    integrations: # https://developer.konghq.com/api/konnect/portal-management/v3/#/operations/upsert-portal-integrations
      ref: string
      google_tag_manager:
@@ -556,6 +559,19 @@ portal_integrations:
      logo: string # data URL image (png/jpeg/gif/ico/svg)
      favicon: string # data URL image (png/jpeg/gif/ico/svg)
 ```
+
+Portal IP allow lists can also be declared as root resources.
+
+```yaml
+portal_ip_allow_lists:
+  - ref: string
+    portal: string required # prefer: !ref <portal-ref>
+    allowed_ips: array[string] required # IP addresses or CIDR blocks
+```
+
+In sync mode, omitting `ip_allow_list` from a managed portal removes current
+portal IP allow-list entries. Omitted IP allow-list config is not deleted for
+external portals.
 
 Portal audit-log webhooks can also be declared as root resources.
 

--- a/docs/examples/declarative/portal/README.md
+++ b/docs/examples/declarative/portal/README.md
@@ -9,7 +9,7 @@ This example creates:
 - A developer portal with authentication disabled and public visibility
 - APIs published to the portal
 - Portal assets including logo and favicon
-- A portal IP allow list for trusted network access
+- An optional commented portal IP allow list for trusted network access
 - Portal integrations for Google Tag Manager and Google Analytics 4
 - Portal customization with theme colors and navigation menus
 - A hierarchy of pages including home, APIs, getting started, and guides
@@ -68,8 +68,10 @@ The `!file` tag automatically:
 Supported formats: PNG, JPEG, SVG, ICO
 
 ### Portal IP Allow List
-Portal IP allow lists can be configured as a singleton child of a portal. Use
-`allowed_ips` for trusted individual IP addresses or CIDR blocks:
+Portal IP allow lists can be configured as a singleton child of a portal. The
+example in `portal.yaml` is commented out so the public getting started portal
+remains browsable after applying the example. Uncomment it and replace
+`allowed_ips` with trusted individual IP addresses or CIDR blocks:
 
 ```yaml
 ip_allow_list:

--- a/docs/examples/declarative/portal/README.md
+++ b/docs/examples/declarative/portal/README.md
@@ -9,6 +9,7 @@ This example creates:
 - A developer portal with authentication disabled and public visibility
 - APIs published to the portal
 - Portal assets including logo and favicon
+- A portal IP allow list for trusted network access
 - Portal integrations for Google Tag Manager and Google Analytics 4
 - Portal customization with theme colors and navigation menus
 - A hierarchy of pages including home, APIs, getting started, and guides
@@ -65,6 +66,22 @@ The `!file` tag automatically:
 - Supports up to 10MB per file
 
 Supported formats: PNG, JPEG, SVG, ICO
+
+### Portal IP Allow List
+Portal IP allow lists can be configured as a singleton child of a portal. Use
+`allowed_ips` for trusted individual IP addresses or CIDR blocks:
+
+```yaml
+ip_allow_list:
+  ref: getting-started-ip-allow-list
+  allowed_ips:
+    - 198.51.100.10
+    - 203.0.113.0/24
+```
+
+The same resource can also be declared at the top level with
+`portal_ip_allow_lists` when keeping child resources separate from the portal
+definition.
 
 ### Portal Integrations
 Portal integrations are configured as a singleton child of the portal. This

--- a/docs/examples/declarative/portal/portal.yaml
+++ b/docs/examples/declarative/portal/portal.yaml
@@ -14,6 +14,13 @@ portals:
     default_api_visibility: "public"
     default_page_visibility: "public"
 
+    # Portal IP allow list for trusted network access
+    ip_allow_list:
+      ref: getting-started-ip-allow-list
+      allowed_ips:
+        - "198.51.100.10"
+        - "203.0.113.0/24"
+
     # Portal assets (logo and favicon)
     assets:
       logo: !file ./assets/logo.png

--- a/docs/examples/declarative/portal/portal.yaml
+++ b/docs/examples/declarative/portal/portal.yaml
@@ -14,12 +14,13 @@ portals:
     default_api_visibility: "public"
     default_page_visibility: "public"
 
-    # Portal IP allow list for trusted network access
-    ip_allow_list:
-      ref: getting-started-ip-allow-list
-      allowed_ips:
-        - "198.51.100.10"
-        - "203.0.113.0/24"
+    # Optional portal IP allow list for trusted network access.
+    # Uncomment and replace the example addresses before applying.
+    # ip_allow_list:
+    #   ref: getting-started-ip-allow-list
+    #   allowed_ips:
+    #     - "198.51.100.10"
+    #     - "203.0.113.0/24"
 
     # Portal assets (logo and favicon)
     assets:

--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -2288,6 +2288,7 @@ func createStateClient(kkClient helpers.SDKAPI) *state.Client {
 		// Portal child resource APIs
 		PortalPageAPI:             kkClient.GetPortalPageAPI(),
 		PortalAuthSettingsAPI:     kkClient.GetPortalAuthSettingsAPI(),
+		PortalIPAllowListAPI:      kkClient.GetPortalIPAllowListAPI(),
 		PortalIntegrationsAPI:     kkClient.GetPortalIntegrationsAPI(),
 		PortalIdentityProviderAPI: kkClient.GetPortalIdentityProviderAPI(),
 		PortalCustomizationAPI:    kkClient.GetPortalCustomizationAPI(),

--- a/internal/cmd/root/verbs/dump/declarative.go
+++ b/internal/cmd/root/verbs/dump/declarative.go
@@ -177,6 +177,7 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 			CatalogServiceAPI:                   sdk.GetCatalogServicesAPI(),
 			PortalPageAPI:                       sdk.GetPortalPageAPI(),
 			PortalAuthSettingsAPI:               sdk.GetPortalAuthSettingsAPI(),
+			PortalIPAllowListAPI:                sdk.GetPortalIPAllowListAPI(),
 			PortalIntegrationsAPI:               sdk.GetPortalIntegrationsAPI(),
 			PortalIdentityProviderAPI:           sdk.GetPortalIdentityProviderAPI(),
 			PortalCustomizationAPI:              sdk.GetPortalCustomizationAPI(),

--- a/internal/cmd/root/verbs/dump/declarative_children.go
+++ b/internal/cmd/root/verbs/dump/declarative_children.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
@@ -62,6 +63,12 @@ func populatePortalChildren(
 			logWarn(logger, "failed to load portal auth settings", portalID, portal.Name, err)
 		} else if authSettings != nil {
 			portal.AuthSettings = authSettings
+		}
+
+		if allowList, err := buildPortalIPAllowList(ctx, client, portalID); err != nil {
+			logWarn(logger, "failed to load portal IP allow list", portalID, portal.Name, err)
+		} else if allowList != nil {
+			portal.IPAllowList = allowList
 		}
 
 		if integration, err := buildPortalIntegration(ctx, client, portalID); err != nil {
@@ -696,6 +703,48 @@ func buildPortalAuthSettings(
 	}
 
 	return &resource, nil
+}
+
+func buildPortalIPAllowList(
+	ctx context.Context,
+	client *declstate.Client,
+	portalID string,
+) (*declresources.PortalIPAllowListResource, error) {
+	entries, err := client.ListPortalIPAllowLists(ctx, portalID)
+	if err != nil {
+		if isNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	seen := make(map[string]struct{})
+	allowedIPs := make([]string, 0)
+	for _, entry := range entries {
+		for _, value := range entry.AllowedIPs {
+			trimmed := strings.TrimSpace(value)
+			if trimmed == "" {
+				continue
+			}
+			if _, exists := seen[trimmed]; exists {
+				continue
+			}
+			seen[trimmed] = struct{}{}
+			allowedIPs = append(allowedIPs, trimmed)
+		}
+	}
+	if len(allowedIPs) == 0 {
+		return nil, nil
+	}
+
+	slices.Sort(allowedIPs)
+	return &declresources.PortalIPAllowListResource{
+		Ref:        buildChildRef("portal-ip-allow-list", portalID, strings.Join(allowedIPs, ",")),
+		AllowedIPs: allowedIPs,
+	}, nil
 }
 
 func buildPortalIntegration(

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -82,6 +82,9 @@ type Executor struct {
 	portalAssetFaviconExecutor     *BaseSingletonExecutor[kkComps.ReplacePortalImageAsset]
 	portalDomainExecutor           *BaseExecutor[kkComps.CreatePortalCustomDomainRequest,
 		kkComps.UpdatePortalCustomDomainRequest]
+	portalIPAllowListExecutor *BaseExecutor[
+		kkComps.CreatePortalSourceIPRestriction,
+		kkComps.UpdatePortalSourceIPRestriction]
 	portalPageExecutor            *BaseExecutor[kkComps.CreatePortalPageRequest, kkComps.UpdatePortalPageRequest]
 	portalSnippetExecutor         *BaseExecutor[kkComps.CreatePortalSnippetRequest, kkComps.UpdatePortalSnippetRequest]
 	portalTeamExecutor            *BaseExecutor[kkComps.PortalCreateTeamRequest, kkComps.PortalUpdateTeamRequest]
@@ -297,6 +300,14 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 	e.portalDomainExecutor = NewBaseExecutor[kkComps.CreatePortalCustomDomainRequest,
 		kkComps.UpdatePortalCustomDomainRequest](
 		NewPortalDomainAdapter(client),
+		client,
+		dryRun,
+	)
+	e.portalIPAllowListExecutor = NewBaseExecutor[
+		kkComps.CreatePortalSourceIPRestriction,
+		kkComps.UpdatePortalSourceIPRestriction,
+	](
+		NewPortalIPAllowListAdapter(client),
 		client,
 		dryRun,
 	)
@@ -1825,6 +1836,16 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 			return "", err
 		}
 		return e.portalAuthSettingsExecutor.Update(ctx, *change, portalID)
+	case planner.ResourceTypePortalIPAllowList:
+		if portalRef, ok := change.References[planner.FieldPortalID]; ok && portalRef.ID == "" {
+			portalID, err := e.resolvePortalRef(ctx, portalRef)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve portal reference: %w", err)
+			}
+			portalRef.ID = portalID
+			change.References[planner.FieldPortalID] = portalRef
+		}
+		return e.portalIPAllowListExecutor.Create(ctx, *change)
 	case planner.ResourceTypePortalIntegration:
 		portalID, err := e.resolvePortalRef(ctx, change.References[planner.FieldPortalID])
 		if err != nil {
@@ -2302,6 +2323,16 @@ func (e *Executor) updateResource(ctx context.Context, change *planner.PlannedCh
 			return "", err
 		}
 		return e.portalAuthSettingsExecutor.Update(ctx, *change, portalID)
+	case planner.ResourceTypePortalIPAllowList:
+		if portalRef, ok := change.References[planner.FieldPortalID]; ok && portalRef.ID == "" {
+			portalID, err := e.resolvePortalRef(ctx, portalRef)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve portal reference: %w", err)
+			}
+			portalRef.ID = portalID
+			change.References[planner.FieldPortalID] = portalRef
+		}
+		return e.portalIPAllowListExecutor.Update(ctx, *change)
 	case planner.ResourceTypePortalIntegration:
 		portalID, err := e.resolvePortalRef(ctx, change.References[planner.FieldPortalID])
 		if err != nil {
@@ -2648,6 +2679,16 @@ func (e *Executor) deleteResource(ctx context.Context, change *planner.PlannedCh
 	case planner.ResourceTypePortalCustomDomain:
 		// No references to resolve for portal_custom_domain
 		return e.portalDomainExecutor.Delete(ctx, *change)
+	case planner.ResourceTypePortalIPAllowList:
+		if portalRef, ok := change.References[planner.FieldPortalID]; ok && portalRef.ID == "" {
+			portalID, err := e.resolvePortalRef(ctx, portalRef)
+			if err != nil {
+				return fmt.Errorf("failed to resolve portal reference: %w", err)
+			}
+			portalRef.ID = portalID
+			change.References[planner.FieldPortalID] = portalRef
+		}
+		return e.portalIPAllowListExecutor.Delete(ctx, *change)
 	case planner.ResourceTypePortalIdentityProvider:
 		if portalRef, ok := change.References[planner.FieldPortalID]; ok && portalRef.ID == "" {
 			portalID, err := e.resolvePortalRef(ctx, portalRef)

--- a/internal/declarative/executor/portal_ip_allow_list_adapter.go
+++ b/internal/declarative/executor/portal_ip_allow_list_adapter.go
@@ -1,0 +1,201 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/kong/kongctl/internal/declarative/state"
+)
+
+// PortalIPAllowListAdapter implements ResourceOperations for portal IP allow lists.
+type PortalIPAllowListAdapter struct {
+	client *state.Client
+}
+
+// NewPortalIPAllowListAdapter creates a new portal IP allow list adapter.
+func NewPortalIPAllowListAdapter(client *state.Client) *PortalIPAllowListAdapter {
+	return &PortalIPAllowListAdapter{client: client}
+}
+
+func (p *PortalIPAllowListAdapter) MapCreateFields(
+	_ context.Context,
+	_ *ExecutionContext,
+	fields map[string]any,
+	create *kkComps.CreatePortalSourceIPRestriction,
+) error {
+	allowedIPs, err := portalIPAllowListAllowedIPs(fields)
+	if err != nil {
+		return err
+	}
+	create.AllowedIps = allowedIPs
+	return nil
+}
+
+func (p *PortalIPAllowListAdapter) MapUpdateFields(
+	_ context.Context,
+	_ *ExecutionContext,
+	fields map[string]any,
+	update *kkComps.UpdatePortalSourceIPRestriction,
+	_ map[string]string,
+) error {
+	allowedIPs, err := portalIPAllowListAllowedIPs(fields)
+	if err != nil {
+		return err
+	}
+	update.AllowedIps = allowedIPs
+	return nil
+}
+
+func (p *PortalIPAllowListAdapter) Create(
+	ctx context.Context,
+	req kkComps.CreatePortalSourceIPRestriction,
+	namespace string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	portalID, err := p.portalIDFromExecutionContext(execCtx)
+	if err != nil {
+		return "", err
+	}
+	return p.client.CreatePortalIPAllowList(ctx, portalID, req, namespace)
+}
+
+func (p *PortalIPAllowListAdapter) Update(
+	ctx context.Context,
+	id string,
+	req kkComps.UpdatePortalSourceIPRestriction,
+	namespace string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	portalID, err := p.portalIDFromExecutionContext(execCtx)
+	if err != nil {
+		return "", err
+	}
+	return p.client.UpdatePortalIPAllowList(ctx, portalID, id, req, namespace)
+}
+
+func (p *PortalIPAllowListAdapter) Delete(ctx context.Context, id string, execCtx *ExecutionContext) error {
+	portalID, err := p.portalIDFromExecutionContext(execCtx)
+	if err != nil {
+		return err
+	}
+	return p.client.DeletePortalIPAllowList(ctx, portalID, id)
+}
+
+func (p *PortalIPAllowListAdapter) GetByName(_ context.Context, _ string) (ResourceInfo, error) {
+	return nil, nil
+}
+
+func (p *PortalIPAllowListAdapter) GetByID(
+	ctx context.Context,
+	id string,
+	execCtx *ExecutionContext,
+) (ResourceInfo, error) {
+	if id == "" {
+		return nil, nil
+	}
+
+	portalID, err := p.portalIDFromExecutionContext(execCtx)
+	if err != nil {
+		return nil, err
+	}
+	entry, err := p.client.GetPortalIPAllowList(ctx, portalID, id)
+	if err != nil || entry == nil {
+		return nil, err
+	}
+
+	return &PortalIPAllowListResourceInfo{
+		id:         entry.ID,
+		allowedIPs: entry.AllowedIPs,
+	}, nil
+}
+
+func (p *PortalIPAllowListAdapter) ResourceType() string {
+	return planner.ResourceTypePortalIPAllowList
+}
+
+func (p *PortalIPAllowListAdapter) RequiredFields() []string {
+	return []string{planner.FieldAllowedIPs}
+}
+
+func (p *PortalIPAllowListAdapter) SupportsUpdate() bool {
+	return true
+}
+
+func (p *PortalIPAllowListAdapter) portalIDFromExecutionContext(execCtx *ExecutionContext) (string, error) {
+	if execCtx == nil || execCtx.PlannedChange == nil {
+		return "", fmt.Errorf("execution context is required for portal IP allow list operations")
+	}
+
+	change := *execCtx.PlannedChange
+	if portalRef, ok := change.References[planner.FieldPortalID]; ok && portalRef.ID != "" {
+		return portalRef.ID, nil
+	}
+	if change.Parent != nil && change.Parent.ID != "" {
+		return change.Parent.ID, nil
+	}
+
+	return "", fmt.Errorf("portal ID is required for portal IP allow list operations")
+}
+
+func portalIPAllowListAllowedIPs(fields map[string]any) ([]string, error) {
+	raw, ok := fields[planner.FieldAllowedIPs]
+	if !ok {
+		return nil, fmt.Errorf("allowed_ips is required")
+	}
+
+	var values []string
+	switch typed := raw.(type) {
+	case []string:
+		values = append(values, typed...)
+	case []any:
+		values = make([]string, 0, len(typed))
+		for i, item := range typed {
+			value, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("allowed_ips[%d] must be a string", i)
+			}
+			values = append(values, value)
+		}
+	default:
+		return nil, fmt.Errorf("allowed_ips must be a list of strings")
+	}
+
+	normalized := make([]string, 0, len(values))
+	for i, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			return nil, fmt.Errorf("allowed_ips[%d] cannot be empty", i)
+		}
+		normalized = append(normalized, trimmed)
+	}
+	if len(normalized) == 0 {
+		return nil, fmt.Errorf("allowed_ips must contain at least one IP address or CIDR block")
+	}
+
+	return normalized, nil
+}
+
+// PortalIPAllowListResourceInfo implements ResourceInfo for portal IP allow lists.
+type PortalIPAllowListResourceInfo struct {
+	id         string
+	allowedIPs []string
+}
+
+func (p *PortalIPAllowListResourceInfo) GetID() string {
+	return p.id
+}
+
+func (p *PortalIPAllowListResourceInfo) GetName() string {
+	return strings.Join(p.allowedIPs, ",")
+}
+
+func (p *PortalIPAllowListResourceInfo) GetLabels() map[string]string {
+	return make(map[string]string)
+}
+
+func (p *PortalIPAllowListResourceInfo) GetNormalizedLabels() map[string]string {
+	return make(map[string]string)
+}

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -841,6 +841,13 @@ func (l *Loader) extractNestedResources(rs *resources.ResourceSet) {
 			rs.PortalAuthSettings = append(rs.PortalAuthSettings, authSettings)
 		}
 
+		// Extract IP allow list (single resource)
+		if portal.IPAllowList != nil {
+			allowList := *portal.IPAllowList
+			allowList.Portal = portal.Ref
+			rs.PortalIPAllowLists = append(rs.PortalIPAllowLists, allowList)
+		}
+
 		// Extract integrations configuration (single resource)
 		if portal.Integrations != nil {
 			integration := *portal.Integrations
@@ -920,6 +927,7 @@ func (l *Loader) extractNestedResources(rs *resources.ResourceSet) {
 		// Clear nested resources from Portal
 		portal.Customization = nil
 		portal.AuthSettings = nil
+		portal.IPAllowList = nil
 		portal.Integrations = nil
 		portal.IdentityProviders = nil
 		portal.CustomDomain = nil

--- a/internal/declarative/loader/loader_test.go
+++ b/internal/declarative/loader/loader_test.go
@@ -209,6 +209,29 @@ portals:
 	assert.Nil(t, rs.Portals[0].Integrations)
 }
 
+func TestLoader_FlattensPortalIPAllowList(t *testing.T) {
+	content := `
+portals:
+  - ref: portal-ip-allow-list
+    name: portal-ip-allow-list
+    ip_allow_list:
+      ref: portal-ip-allow-list-config
+      allowed_ips:
+        - 192.0.2.10
+        - 198.51.100.0/24
+`
+
+	loader := New()
+	rs, err := loader.parseYAML(strings.NewReader(content), "inline", "")
+	require.NoError(t, err)
+
+	require.Len(t, rs.Portals, 1)
+	require.Len(t, rs.PortalIPAllowLists, 1)
+	assert.Equal(t, "portal-ip-allow-list", rs.PortalIPAllowLists[0].Portal)
+	assert.Equal(t, "portal-ip-allow-list-config", rs.PortalIPAllowLists[0].Ref)
+	assert.Nil(t, rs.Portals[0].IPAllowList)
+}
+
 func TestLoader_RejectsSingularPortalIntegrationKey(t *testing.T) {
 	content := `
 portals:

--- a/internal/declarative/loader/ref_resolver.go
+++ b/internal/declarative/loader/ref_resolver.go
@@ -209,6 +209,13 @@ func ResolveReferences(ctx context.Context, rs *resources.ResourceSet) error {
 		processCount++
 	}
 
+	for i := range rs.PortalIPAllowLists {
+		if err := resolveResourceFields(ctx, &rs.PortalIPAllowLists[i], rs, resolver, resolutionPath, logger); err != nil {
+			return fmt.Errorf("resolving portal IP allow list %s: %w", rs.PortalIPAllowLists[i].GetRef(), err)
+		}
+		processCount++
+	}
+
 	for i := range rs.PortalIntegrations {
 		if err := resolveResourceFields(ctx, &rs.PortalIntegrations[i], rs, resolver, resolutionPath, logger); err != nil {
 			return fmt.Errorf("resolving portal integration %s: %w", rs.PortalIntegrations[i].GetRef(), err)

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -529,6 +529,12 @@ func (l *Loader) validateCrossReferences(rs *resources.ResourceSet) error {
 		}
 	}
 
+	for i := range rs.PortalIPAllowLists {
+		if err := l.validateResourceReferences(&rs.PortalIPAllowLists[i], rs); err != nil {
+			return err
+		}
+	}
+
 	for i := range rs.PortalAuditLogWebhooks {
 		if err := l.validateResourceReferences(&rs.PortalAuditLogWebhooks[i], rs); err != nil {
 			return err
@@ -678,6 +684,33 @@ func (l *Loader) validateSeparateAPIChildResources(rs *resources.ResourceSet) er
 				)
 			}
 		}
+	}
+
+	// Validate portal IP allow lists (singleton per portal)
+	portalAllowListRefs := make(map[string]bool)
+	portalToAllowListRef := make(map[string]string)
+	for i := range rs.PortalIPAllowLists {
+		allowList := &rs.PortalIPAllowLists[i]
+		if err := allowList.Validate(); err != nil {
+			return fmt.Errorf("invalid portal_ip_allow_list %q: %w", allowList.GetRef(), err)
+		}
+		if allowList.Portal == "" {
+			return fmt.Errorf("portal_ip_allow_list %q must specify portal", allowList.GetRef())
+		}
+		if portalAllowListRefs[allowList.GetRef()] {
+			return fmt.Errorf("duplicate ref '%s' (already defined as portal_ip_allow_list)", allowList.GetRef())
+		}
+		portalAllowListRefs[allowList.GetRef()] = true
+
+		if existingRef, ok := portalToAllowListRef[allowList.Portal]; ok {
+			return fmt.Errorf(
+				"multiple portal_ip_allow_list entries target portal %q (%s and %s)",
+				allowList.Portal,
+				existingRef,
+				allowList.GetRef(),
+			)
+		}
+		portalToAllowListRef[allowList.Portal] = allowList.GetRef()
 	}
 
 	// Validate portal integrations (singleton per portal)

--- a/internal/declarative/loader/validator_test.go
+++ b/internal/declarative/loader/validator_test.go
@@ -879,3 +879,33 @@ func TestLoader_validateResourceSet_AllowsMixedPortalIdentityProviderTypesPerPor
 	err := loader.validateResourceSet(rs)
 	assert.NoError(t, err)
 }
+
+func TestLoader_validateResourceSet_RejectsDuplicatePortalIPAllowListsPerPortal(t *testing.T) {
+	loader := New()
+	rs := &resources.ResourceSet{
+		Portals: []resources.PortalResource{{
+			BaseResource: resources.BaseResource{Ref: "portal-1"},
+			CreatePortal: kkComps.CreatePortal{Name: "portal-one"},
+		}},
+		PortalIPAllowLists: []resources.PortalIPAllowListResource{
+			{
+				Ref:        "portal-allow-list-a",
+				Portal:     "portal-1",
+				AllowedIPs: []string{"192.0.2.10"},
+			},
+			{
+				Ref:        "portal-allow-list-b",
+				Portal:     "portal-1",
+				AllowedIPs: []string{"198.51.100.0/24"},
+			},
+		},
+	}
+
+	err := loader.validateResourceSet(rs)
+	assert.Error(t, err)
+	assert.Contains(
+		t,
+		err.Error(),
+		"multiple portal_ip_allow_list entries target portal \"portal-1\"",
+	)
+}

--- a/internal/declarative/planner/base_planner.go
+++ b/internal/declarative/planner/base_planner.go
@@ -115,6 +115,11 @@ func (b *BasePlanner) GetDesiredPortalAuthSettings(namespace string) []resources
 	return b.planner.resources.GetPortalAuthSettingsByNamespace(namespace)
 }
 
+// GetDesiredPortalIPAllowLists returns desired portal IP allow list resources from the specified namespace
+func (b *BasePlanner) GetDesiredPortalIPAllowLists(namespace string) []resources.PortalIPAllowListResource {
+	return b.planner.resources.GetPortalIPAllowListsByNamespace(namespace)
+}
+
 // GetDesiredPortalIntegrations returns desired portal integration resources from the specified namespace
 func (b *BasePlanner) GetDesiredPortalIntegrations(namespace string) []resources.PortalIntegrationResource {
 	return b.planner.resources.GetPortalIntegrationsByNamespace(namespace)

--- a/internal/declarative/planner/constants.go
+++ b/internal/declarative/planner/constants.go
@@ -107,6 +107,7 @@ const (
 // Common portal plan field identifiers.
 const (
 	FieldAuthenticationEnabled        = "authentication_enabled"
+	FieldAllowedIPs                   = "allowed_ips"
 	FieldAutoApproveApplications      = "auto_approve_applications"
 	FieldAutoApproveDevelopers        = "auto_approve_developers"
 	FieldAutoApproveRegistrations     = "auto_approve_registrations"
@@ -186,6 +187,7 @@ const (
 	ResourceTypePortalCustomization        = string(resources.ResourceTypePortalCustomization)
 	ResourceTypePortalCustomDomain         = string(resources.ResourceTypePortalCustomDomain)
 	ResourceTypePortalAuthSettings         = string(resources.ResourceTypePortalAuthSettings)
+	ResourceTypePortalIPAllowList          = string(resources.ResourceTypePortalIPAllowList)
 	ResourceTypePortalIntegration          = string(resources.ResourceTypePortalIntegration)
 	ResourceTypePortalIdentityProvider     = string(resources.ResourceTypePortalIdentityProvider)
 	ResourceTypePortalPage                 = string(resources.ResourceTypePortalPage)

--- a/internal/declarative/planner/planner.go
+++ b/internal/declarative/planner/planner.go
@@ -87,6 +87,7 @@ type Planner struct {
 	desiredPortalTeamRoles         []resources.PortalTeamRoleResource
 	desiredPortalCustomizations    []resources.PortalCustomizationResource
 	desiredPortalAuthSettings      []resources.PortalAuthSettingsResource
+	desiredPortalIPAllowLists      []resources.PortalIPAllowListResource
 	desiredPortalIntegrations      []resources.PortalIntegrationResource
 	desiredPortalIdentityProviders []resources.PortalIdentityProviderResource
 	desiredPortalCustomDomains     []resources.PortalCustomDomainResource
@@ -231,6 +232,7 @@ func (p *Planner) GeneratePlan(ctx context.Context, rs *resources.ResourceSet, o
 		namespacePlanner.desiredPortalTeamRoles = rs.PortalTeamRoles
 		namespacePlanner.desiredPortalCustomizations = rs.PortalCustomizations
 		namespacePlanner.desiredPortalAuthSettings = rs.PortalAuthSettings
+		namespacePlanner.desiredPortalIPAllowLists = rs.PortalIPAllowLists
 		namespacePlanner.desiredPortalIntegrations = rs.PortalIntegrations
 		namespacePlanner.desiredPortalIdentityProviders = rs.PortalIdentityProviders
 		namespacePlanner.desiredPortalCustomDomains = rs.PortalCustomDomains

--- a/internal/declarative/planner/portal_child_planner.go
+++ b/internal/declarative/planner/portal_child_planner.go
@@ -264,6 +264,18 @@ func (p *Planner) planPortalIPAllowListsChanges(
 	}
 
 	portalName := p.findPortalName(portalRef)
+	identifier := portalIPAllowListPortalIdentifier(portalRef, portalID)
+	if desiredAllowList != nil {
+		if err := p.client.ValidatePortalIPAllowListAPI(); err != nil {
+			return fmt.Errorf(
+				"cannot manage portal IP allow list %q for portal %q: %w",
+				desiredAllowList.GetRef(),
+				identifier,
+				err,
+			)
+		}
+	}
+
 	if portalID == "" {
 		if desiredAllowList != nil {
 			p.planPortalIPAllowListCreate(parentNamespace, *desiredAllowList, portalID, portalRef, portalName, plan)
@@ -275,27 +287,23 @@ func (p *Planner) planPortalIPAllowListsChanges(
 	if err != nil {
 		var apiErr *state.APIClientError
 		if errors.As(err, &apiErr) && apiErr.ClientType == "portal IP allow list API" {
-			if desiredAllowList != nil {
-				changeID := p.planPortalIPAllowListCreate(
-					parentNamespace,
-					*desiredAllowList,
-					portalID,
-					portalRef,
-					portalName,
-					plan,
-				)
+			if plan.Metadata.Mode == PlanModeSync && !p.isPortalExternal(portalRef) {
 				plan.AddWarning(
-					changeID,
-					"unable to inspect existing portal IP allow list - assuming create is required",
+					"",
+					fmt.Sprintf(
+						"unable to inspect portal IP allow list for portal %q; skipping IP allow-list sync: %v",
+						identifier,
+						err,
+					),
 				)
+			}
+			if desiredAllowList != nil {
+				return fmt.Errorf("cannot manage portal IP allow list %q for portal %q: %w",
+					desiredAllowList.GetRef(), identifier, err)
 			}
 			return nil
 		}
 
-		identifier := portalRef
-		if identifier == "" {
-			identifier = portalID
-		}
 		return fmt.Errorf("failed to list portal IP allow lists for portal %q: %w", identifier, err)
 	}
 
@@ -361,7 +369,7 @@ func (p *Planner) planPortalIPAllowListCreate(
 	portalRef string,
 	portalName string,
 	plan *Plan,
-) string {
+) {
 	fields := portalIPAllowListFields(allowList)
 	deps := p.portalChildDependencies(plan, allowList.Portal)
 	change := PlannedChange{
@@ -385,7 +393,6 @@ func (p *Planner) planPortalIPAllowListCreate(
 		"fields", fields,
 	)
 	plan.AddChange(change)
-	return change.ID
 }
 
 func (p *Planner) planPortalIPAllowListUpdate(
@@ -533,6 +540,16 @@ func portalIPAllowListDeleteRef(portalRef string, portalID string, entryID strin
 		prefix = "portal"
 	}
 	return fmt.Sprintf("%s__ip_allow_list__%s", prefix, entryID)
+}
+
+func portalIPAllowListPortalIdentifier(portalRef string, portalID string) string {
+	if portalRef != "" {
+		return portalRef
+	}
+	if portalID != "" {
+		return portalID
+	}
+	return "unknown"
 }
 
 // Portal Integrations planning (singleton)

--- a/internal/declarative/planner/portal_child_planner.go
+++ b/internal/declarative/planner/portal_child_planner.go
@@ -244,6 +244,297 @@ func (p *Planner) buildAllPortalAuthSettingsFields(settings resources.PortalAuth
 	return fields
 }
 
+// Portal IP allow list planning (singleton per portal)
+
+func (p *Planner) planPortalIPAllowListsChanges(
+	ctx context.Context,
+	parentNamespace string,
+	portalID string,
+	portalRef string,
+	desired []resources.PortalIPAllowListResource,
+	plan *Plan,
+) error {
+	var desiredAllowList *resources.PortalIPAllowListResource
+	for i := range desired {
+		if plan.HasChange(ResourceTypePortalIPAllowList, desired[i].GetRef()) {
+			continue
+		}
+		desiredAllowList = &desired[i]
+		break
+	}
+
+	portalName := p.findPortalName(portalRef)
+	if portalID == "" {
+		if desiredAllowList != nil {
+			p.planPortalIPAllowListCreate(parentNamespace, *desiredAllowList, portalID, portalRef, portalName, plan)
+		}
+		return nil
+	}
+
+	currentEntries, err := p.client.ListPortalIPAllowLists(ctx, portalID)
+	if err != nil {
+		var apiErr *state.APIClientError
+		if errors.As(err, &apiErr) && apiErr.ClientType == "portal IP allow list API" {
+			if desiredAllowList != nil {
+				changeID := p.planPortalIPAllowListCreate(
+					parentNamespace,
+					*desiredAllowList,
+					portalID,
+					portalRef,
+					portalName,
+					plan,
+				)
+				plan.AddWarning(
+					changeID,
+					"unable to inspect existing portal IP allow list - assuming create is required",
+				)
+			}
+			return nil
+		}
+
+		identifier := portalRef
+		if identifier == "" {
+			identifier = portalID
+		}
+		return fmt.Errorf("failed to list portal IP allow lists for portal %q: %w", identifier, err)
+	}
+
+	if desiredAllowList == nil {
+		if plan.Metadata.Mode == PlanModeSync && !p.isPortalExternal(portalRef) {
+			for i := range currentEntries {
+				p.planPortalIPAllowListDelete(
+					parentNamespace,
+					portalRef,
+					portalID,
+					portalName,
+					&currentEntries[i],
+					"",
+					plan,
+				)
+			}
+		}
+		return nil
+	}
+
+	if len(currentEntries) == 0 {
+		p.planPortalIPAllowListCreate(parentNamespace, *desiredAllowList, portalID, portalRef, portalName, plan)
+		return nil
+	}
+
+	selectedIndex := 0
+	for i := range currentEntries {
+		if portalIPAllowListEntriesEqual(currentEntries[i].AllowedIPs, desiredAllowList.AllowedIPs) {
+			selectedIndex = i
+			break
+		}
+	}
+
+	selected := currentEntries[selectedIndex]
+	if !portalIPAllowListEntriesEqual(selected.AllowedIPs, desiredAllowList.AllowedIPs) {
+		p.planPortalIPAllowListUpdate(parentNamespace, &selected, *desiredAllowList, portalID, portalRef, portalName, plan)
+	}
+
+	if plan.Metadata.Mode == PlanModeSync && !p.isPortalExternal(portalRef) {
+		for i := range currentEntries {
+			if i == selectedIndex {
+				continue
+			}
+			p.planPortalIPAllowListDelete(
+				parentNamespace,
+				portalRef,
+				portalID,
+				portalName,
+				&currentEntries[i],
+				"",
+				plan,
+			)
+		}
+	}
+
+	return nil
+}
+
+func (p *Planner) planPortalIPAllowListCreate(
+	parentNamespace string,
+	allowList resources.PortalIPAllowListResource,
+	portalID string,
+	portalRef string,
+	portalName string,
+	plan *Plan,
+) string {
+	fields := portalIPAllowListFields(allowList)
+	deps := p.portalChildDependencies(plan, allowList.Portal)
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionCreate, ResourceTypePortalIPAllowList, allowList.Ref),
+		ResourceType: ResourceTypePortalIPAllowList,
+		ResourceRef:  allowList.Ref,
+		Action:       ActionCreate,
+		Fields:       fields,
+		DependsOn:    uniqueStrings(deps),
+		Namespace:    parentNamespace,
+		ResourceMonikers: map[string]string{
+			FieldAllowedIPs: strings.Join(fields[FieldAllowedIPs].([]string), ","),
+		},
+	}
+
+	p.setPortalIPAllowListReferences(&change, allowList.Portal, portalID, portalRef, portalName)
+
+	p.logger.Debug("Enqueuing portal IP allow list create",
+		"portal_ref", allowList.Portal,
+		"allow_list_ref", allowList.Ref,
+		"fields", fields,
+	)
+	plan.AddChange(change)
+	return change.ID
+}
+
+func (p *Planner) planPortalIPAllowListUpdate(
+	parentNamespace string,
+	current *state.PortalIPAllowList,
+	allowList resources.PortalIPAllowListResource,
+	portalID string,
+	portalRef string,
+	portalName string,
+	plan *Plan,
+) string {
+	fields := portalIPAllowListFields(allowList)
+	changedFields := map[string]FieldChange{
+		FieldAllowedIPs: {
+			Old: normalizedPortalIPAllowListValues(current.AllowedIPs),
+			New: fields[FieldAllowedIPs],
+		},
+	}
+
+	change := PlannedChange{
+		ID:            p.nextChangeID(ActionUpdate, ResourceTypePortalIPAllowList, allowList.Ref),
+		ResourceType:  ResourceTypePortalIPAllowList,
+		ResourceRef:   allowList.Ref,
+		ResourceID:    current.ID,
+		Action:        ActionUpdate,
+		Fields:        fields,
+		ChangedFields: changedFields,
+		DependsOn:     uniqueStrings(p.portalChildDependencies(plan, allowList.Portal)),
+		Namespace:     parentNamespace,
+		ResourceMonikers: map[string]string{
+			FieldAllowedIPs: strings.Join(fields[FieldAllowedIPs].([]string), ","),
+		},
+	}
+
+	p.setPortalIPAllowListReferences(&change, allowList.Portal, portalID, portalRef, portalName)
+
+	p.logger.Debug("Enqueuing portal IP allow list update",
+		"portal_ref", allowList.Portal,
+		"allow_list_ref", allowList.Ref,
+		"allow_list_id", current.ID,
+		"fields", fields,
+	)
+	plan.AddChange(change)
+	return change.ID
+}
+
+func (p *Planner) planPortalIPAllowListDelete(
+	parentNamespace string,
+	portalRef string,
+	portalID string,
+	portalName string,
+	current *state.PortalIPAllowList,
+	allowListRef string,
+	plan *Plan,
+) {
+	ref := allowListRef
+	if ref == "" {
+		ref = portalIPAllowListDeleteRef(portalRef, portalID, current.ID)
+	}
+
+	fields := map[string]any{
+		FieldAllowedIPs: normalizedPortalIPAllowListValues(current.AllowedIPs),
+	}
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionDelete, ResourceTypePortalIPAllowList, ref),
+		ResourceType: ResourceTypePortalIPAllowList,
+		ResourceRef:  ref,
+		ResourceID:   current.ID,
+		Action:       ActionDelete,
+		Fields:       fields,
+		DependsOn:    uniqueStrings(p.portalChildDependencies(plan, portalRef)),
+		Namespace:    parentNamespace,
+		ResourceMonikers: map[string]string{
+			FieldAllowedIPs: strings.Join(fields[FieldAllowedIPs].([]string), ","),
+		},
+	}
+
+	p.setPortalIPAllowListReferences(&change, portalRef, portalID, portalRef, portalName)
+
+	p.logger.Debug("Enqueuing portal IP allow list delete",
+		"portal_ref", portalRef,
+		"allow_list_ref", ref,
+		"allow_list_id", current.ID,
+	)
+	plan.AddChange(change)
+}
+
+func (p *Planner) setPortalIPAllowListReferences(
+	change *PlannedChange,
+	allowListPortalRef string,
+	portalID string,
+	portalRef string,
+	portalName string,
+) {
+	ref := allowListPortalRef
+	if ref == "" {
+		ref = portalRef
+	}
+	if ref == "" && portalID == "" {
+		return
+	}
+
+	change.Parent = &ParentInfo{Ref: ref, ID: portalID}
+
+	refInfo := ReferenceInfo{
+		Ref: ref,
+		ID:  portalID,
+	}
+	if portalName != "" {
+		refInfo.LookupFields = map[string]string{FieldName: portalName}
+	}
+	change.References = map[string]ReferenceInfo{
+		FieldPortalID: refInfo,
+	}
+}
+
+func portalIPAllowListFields(allowList resources.PortalIPAllowListResource) map[string]any {
+	return map[string]any{
+		FieldAllowedIPs: normalizedPortalIPAllowListValues(allowList.AllowedIPs),
+	}
+}
+
+func portalIPAllowListEntriesEqual(current []string, desired []string) bool {
+	return slices.Equal(normalizedPortalIPAllowListValues(current), normalizedPortalIPAllowListValues(desired))
+}
+
+func normalizedPortalIPAllowListValues(values []string) []string {
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			normalized = append(normalized, trimmed)
+		}
+	}
+	slices.Sort(normalized)
+	return normalized
+}
+
+func portalIPAllowListDeleteRef(portalRef string, portalID string, entryID string) string {
+	prefix := portalRef
+	if prefix == "" {
+		prefix = portalID
+	}
+	if prefix == "" {
+		prefix = "portal"
+	}
+	return fmt.Sprintf("%s__ip_allow_list__%s", prefix, entryID)
+}
+
 // Portal Integrations planning (singleton)
 
 func (p *Planner) planPortalIntegrationsChanges(

--- a/internal/declarative/planner/portal_ip_allow_list_planner_test.go
+++ b/internal/declarative/planner/portal_ip_allow_list_planner_test.go
@@ -165,6 +165,39 @@ func TestPlanPortalIPAllowListsChangesSyncDeletesOmittedEntries(t *testing.T) {
 	require.Equal(t, []string{"192.0.2.10"}, change.Fields[FieldAllowedIPs])
 }
 
+func TestPlanPortalIPAllowListsChangesErrorsWhenClientMissingForDesiredResource(t *testing.T) {
+	client := state.NewClient(state.ClientConfig{})
+	planner := NewPlanner(client, slog.Default())
+	planner.desiredPortals = []resources.PortalResource{{
+		BaseResource: resources.BaseResource{Ref: "portal-ref"},
+		CreatePortal: kkComps.CreatePortal{
+			Name: "Portal",
+		},
+	}}
+	plan := NewPlan("1.0", "test", PlanModeApply)
+
+	err := planner.planPortalIPAllowListsChanges(
+		context.Background(),
+		DefaultNamespace,
+		"portal-id",
+		"portal-ref",
+		[]resources.PortalIPAllowListResource{{
+			Ref:        "portal-allow-list",
+			Portal:     "portal-ref",
+			AllowedIPs: []string{"192.0.2.10"},
+		}},
+		plan,
+	)
+
+	require.EqualError(
+		t,
+		err,
+		"cannot manage portal IP allow list \"portal-allow-list\" for portal \"portal-ref\": "+
+			"portal IP allow list API client not configured",
+	)
+	require.Empty(t, plan.Changes)
+}
+
 func newPortalIPAllowListPlanner(entries []kkComps.IPEntry) *Planner {
 	client := state.NewClient(state.ClientConfig{
 		PortalIPAllowListAPI: &stubPortalIPAllowListAPI{entries: entries},

--- a/internal/declarative/planner/portal_ip_allow_list_planner_test.go
+++ b/internal/declarative/planner/portal_ip_allow_list_planner_test.go
@@ -1,0 +1,180 @@
+package planner
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/stretchr/testify/require"
+)
+
+type stubPortalIPAllowListAPI struct {
+	entries []kkComps.IPEntry
+}
+
+func (s *stubPortalIPAllowListAPI) CreatePortalIPAllowList(
+	_ context.Context,
+	_ string,
+	_ *kkComps.CreatePortalSourceIPRestriction,
+	_ ...kkOps.Option,
+) (*kkOps.CreatePortalIPAllowListResponse, error) {
+	return &kkOps.CreatePortalIPAllowListResponse{IPEntry: &kkComps.IPEntry{ID: "created-entry"}}, nil
+}
+
+func (s *stubPortalIPAllowListAPI) ListPortalIPAllowList(
+	_ context.Context,
+	_ kkOps.ListPortalIPAllowListRequest,
+	_ ...kkOps.Option,
+) (*kkOps.ListPortalIPAllowListResponse, error) {
+	return &kkOps.ListPortalIPAllowListResponse{
+		PortalSourceIPRestrictionPaginatedResponse: &kkComps.PortalSourceIPRestrictionPaginatedResponse{
+			Meta: kkComps.CursorMetaPage{Size: 100},
+			Data: s.entries,
+		},
+	}, nil
+}
+
+func (s *stubPortalIPAllowListAPI) PutPortalIPAllowList(
+	_ context.Context,
+	_ kkOps.PutPortalIPAllowListRequest,
+	_ ...kkOps.Option,
+) (*kkOps.PutPortalIPAllowListResponse, error) {
+	return nil, nil
+}
+
+func (s *stubPortalIPAllowListAPI) UpdatePortalIPAllowList(
+	_ context.Context,
+	_ kkOps.UpdatePortalIPAllowListRequest,
+	_ ...kkOps.Option,
+) (*kkOps.UpdatePortalIPAllowListResponse, error) {
+	return &kkOps.UpdatePortalIPAllowListResponse{IPEntry: &kkComps.IPEntry{ID: "updated-entry"}}, nil
+}
+
+func (s *stubPortalIPAllowListAPI) DeletePortalIPAllowList(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ ...kkOps.Option,
+) (*kkOps.DeletePortalIPAllowListResponse, error) {
+	return &kkOps.DeletePortalIPAllowListResponse{}, nil
+}
+
+func TestPlanPortalIPAllowListsChangesCreatesWhenMissing(t *testing.T) {
+	planner := newPortalIPAllowListPlanner(nil)
+	plan := NewPlan("1.0", "test", PlanModeApply)
+
+	err := planner.planPortalIPAllowListsChanges(
+		context.Background(),
+		DefaultNamespace,
+		"portal-id",
+		"portal-ref",
+		[]resources.PortalIPAllowListResource{{
+			Ref:        "portal-allow-list",
+			Portal:     "portal-ref",
+			AllowedIPs: []string{"198.51.100.0/24", "192.0.2.10"},
+		}},
+		plan,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	change := plan.Changes[0]
+	require.Equal(t, ActionCreate, change.Action)
+	require.Equal(t, ResourceTypePortalIPAllowList, change.ResourceType)
+	require.Equal(t, []string{"192.0.2.10", "198.51.100.0/24"}, change.Fields[FieldAllowedIPs])
+	require.Equal(t, "portal-id", change.References[FieldPortalID].ID)
+}
+
+func TestPlanPortalIPAllowListsChangesSkipsEquivalentEntry(t *testing.T) {
+	planner := newPortalIPAllowListPlanner([]kkComps.IPEntry{{
+		ID:         "entry-1",
+		AllowedIps: []string{"198.51.100.0/24", "192.0.2.10"},
+	}})
+	plan := NewPlan("1.0", "test", PlanModeApply)
+
+	err := planner.planPortalIPAllowListsChanges(
+		context.Background(),
+		DefaultNamespace,
+		"portal-id",
+		"portal-ref",
+		[]resources.PortalIPAllowListResource{{
+			Ref:        "portal-allow-list",
+			Portal:     "portal-ref",
+			AllowedIPs: []string{"192.0.2.10", "198.51.100.0/24"},
+		}},
+		plan,
+	)
+
+	require.NoError(t, err)
+	require.Empty(t, plan.Changes)
+}
+
+func TestPlanPortalIPAllowListsChangesUpdatesDifferentEntry(t *testing.T) {
+	planner := newPortalIPAllowListPlanner([]kkComps.IPEntry{{
+		ID:         "entry-1",
+		AllowedIps: []string{"203.0.113.7"},
+	}})
+	plan := NewPlan("1.0", "test", PlanModeApply)
+
+	err := planner.planPortalIPAllowListsChanges(
+		context.Background(),
+		DefaultNamespace,
+		"portal-id",
+		"portal-ref",
+		[]resources.PortalIPAllowListResource{{
+			Ref:        "portal-allow-list",
+			Portal:     "portal-ref",
+			AllowedIPs: []string{"192.0.2.10"},
+		}},
+		plan,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	change := plan.Changes[0]
+	require.Equal(t, ActionUpdate, change.Action)
+	require.Equal(t, "entry-1", change.ResourceID)
+	require.Equal(t, []string{"192.0.2.10"}, change.Fields[FieldAllowedIPs])
+}
+
+func TestPlanPortalIPAllowListsChangesSyncDeletesOmittedEntries(t *testing.T) {
+	planner := newPortalIPAllowListPlanner([]kkComps.IPEntry{{
+		ID:         "entry-1",
+		AllowedIps: []string{"192.0.2.10"},
+	}})
+	plan := NewPlan("1.0", "test", PlanModeSync)
+
+	err := planner.planPortalIPAllowListsChanges(
+		context.Background(),
+		DefaultNamespace,
+		"portal-id",
+		"portal-ref",
+		nil,
+		plan,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	change := plan.Changes[0]
+	require.Equal(t, ActionDelete, change.Action)
+	require.Equal(t, "entry-1", change.ResourceID)
+	require.Equal(t, []string{"192.0.2.10"}, change.Fields[FieldAllowedIPs])
+}
+
+func newPortalIPAllowListPlanner(entries []kkComps.IPEntry) *Planner {
+	client := state.NewClient(state.ClientConfig{
+		PortalIPAllowListAPI: &stubPortalIPAllowListAPI{entries: entries},
+	})
+	planner := NewPlanner(client, slog.Default())
+	planner.desiredPortals = []resources.PortalResource{{
+		BaseResource: resources.BaseResource{Ref: "portal-ref"},
+		CreatePortal: kkComps.CreatePortal{
+			Name: "Portal",
+		},
+	}}
+	return planner
+}

--- a/internal/declarative/planner/portal_planner.go
+++ b/internal/declarative/planner/portal_planner.go
@@ -826,6 +826,19 @@ func (p *portalPlannerImpl) planPortalChildResourcesCreate(
 			"error", err.Error())
 	}
 
+	// Plan IP allow list
+	allowLists := make([]resources.PortalIPAllowListResource, 0)
+	for _, allowList := range planner.desiredPortalIPAllowLists {
+		if allowList.Portal == desired.Ref {
+			allowLists = append(allowLists, allowList)
+		}
+	}
+	if err := planner.planPortalIPAllowListsChanges(ctx, parentNamespace, "", desired.Ref, allowLists, plan); err != nil {
+		planner.logger.Debug("Failed to plan portal IP allow list for new portal",
+			"portal", desired.Ref,
+			"error", err.Error())
+	}
+
 	// Plan integrations
 	integrations := make([]resources.PortalIntegrationResource, 0)
 	for _, integration := range planner.desiredPortalIntegrations {
@@ -1060,6 +1073,19 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 	}
 	if err := planner.planPortalAuthSettingsChanges(ctx, plannerCtx, parentNamespace, authSettings, plan); err != nil {
 		return fmt.Errorf("failed to plan portal auth settings changes: %w", err)
+	}
+
+	// Plan IP allow list (singleton)
+	allowLists := make([]resources.PortalIPAllowListResource, 0)
+	for _, allowList := range planner.desiredPortalIPAllowLists {
+		if allowList.Portal == desired.Ref {
+			allowLists = append(allowLists, allowList)
+		}
+	}
+	if err := planner.planPortalIPAllowListsChanges(
+		ctx, parentNamespace, current.ID, desired.Ref, allowLists, plan,
+	); err != nil {
+		return fmt.Errorf("failed to plan portal IP allow list changes: %w", err)
 	}
 
 	// Plan integrations (singleton)

--- a/internal/declarative/protection/lookup.go
+++ b/internal/declarative/protection/lookup.go
@@ -112,6 +112,7 @@ func IsManagedResourceProtected(
 		resources.ResourceTypePortalCustomization,
 		resources.ResourceTypePortalCustomDomain,
 		resources.ResourceTypePortalAuthSettings,
+		resources.ResourceTypePortalIPAllowList,
 		resources.ResourceTypePortalIntegration,
 		resources.ResourceTypePortalIdentityProvider,
 		resources.ResourceTypePortalPage,

--- a/internal/declarative/resources/explain_test.go
+++ b/internal/declarative/resources/explain_test.go
@@ -99,7 +99,7 @@ func TestRenderExplainText_ResourceSubject(t *testing.T) {
 	assert.Contains(
 		t,
 		text,
-		"CHILD RESOURCES: audit_log_webhook, auth_settings, custom_domain, customization, email_config, identity_providers, integrations, pages, snippets, teams", //nolint:lll
+		"CHILD RESOURCES: audit_log_webhook, auth_settings, custom_domain, customization, email_config, identity_providers, integrations, ip_allow_list, pages, snippets, teams", //nolint:lll
 	)
 	assert.Contains(t, text, "\nFIELD DETAILS: use --extended")
 	assert.NotContains(t, text, "RESOURCE: portal")
@@ -135,7 +135,7 @@ func TestRenderExplainText_FieldSubject(t *testing.T) {
 	assert.Contains(
 		t,
 		text,
-		"CHILD RESOURCES: audit_log_webhook, auth_settings, custom_domain, customization, email_config, identity_providers, integrations, pages, snippets, teams", //nolint:lll
+		"CHILD RESOURCES: audit_log_webhook, auth_settings, custom_domain, customization, email_config, identity_providers, integrations, ip_allow_list, pages, snippets, teams", //nolint:lll
 	)
 	assert.NotContains(t, text, "PLACEMENT")
 	assert.NotContains(t, text, "YAML PATH:")

--- a/internal/declarative/resources/portal.go
+++ b/internal/declarative/resources/portal.go
@@ -25,6 +25,7 @@ type PortalResource struct {
 	// Child resources that match API endpoints
 	Customization     *PortalCustomizationResource           `yaml:"customization,omitempty"      json:"customization,omitempty"`      //nolint:lll
 	AuthSettings      *PortalAuthSettingsResource            `yaml:"auth_settings,omitempty"      json:"auth_settings,omitempty"`      //nolint:lll
+	IPAllowList       *PortalIPAllowListResource             `yaml:"ip_allow_list,omitempty"      json:"ip_allow_list,omitempty"`      //nolint:lll
 	Integrations      *PortalIntegrationResource             `yaml:"integrations,omitempty"       json:"integrations,omitempty"`       //nolint:lll
 	IdentityProviders []PortalIdentityProviderResource       `yaml:"identity_providers,omitempty" json:"identity_providers,omitempty"` //nolint:lll
 	CustomDomain      *PortalCustomDomainResource            `yaml:"custom_domain,omitempty"      json:"custom_domain,omitempty"`      //nolint:lll
@@ -120,6 +121,11 @@ func (p PortalResource) Validate() error {
 	if p.AuthSettings != nil {
 		if err := p.AuthSettings.Validate(); err != nil {
 			return fmt.Errorf("invalid portal auth settings: %w", err)
+		}
+	}
+	if p.IPAllowList != nil {
+		if err := p.IPAllowList.Validate(); err != nil {
+			return fmt.Errorf("invalid portal IP allow list: %w", err)
 		}
 	}
 	if p.Integrations != nil {
@@ -232,6 +238,10 @@ func (p *PortalResource) SetDefaults() {
 		p.AuthSettings.SetDefaults()
 	}
 
+	if p.IPAllowList != nil {
+		p.IPAllowList.SetDefaults()
+	}
+
 	if p.Integrations != nil {
 		p.Integrations.SetDefaults()
 	}
@@ -325,6 +335,7 @@ func (p *PortalResource) UnmarshalJSON(data []byte) error {
 		"kongctl",
 		"customization",
 		"auth_settings",
+		"ip_allow_list",
 		"integrations",
 		"identity_providers",
 		"custom_domain",
@@ -375,6 +386,13 @@ func (p *PortalResource) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		delete(raw, "auth_settings")
+	}
+
+	if v, ok := raw["ip_allow_list"]; ok {
+		if err := json.Unmarshal(v, &p.IPAllowList); err != nil {
+			return err
+		}
+		delete(raw, "ip_allow_list")
 	}
 
 	if v, ok := raw["integrations"]; ok {
@@ -505,6 +523,7 @@ type portalAlias struct {
 	Kongctl           *KongctlMeta                           `json:"kongctl,omitempty"            yaml:"kongctl,omitempty"`
 	Customization     *PortalCustomizationResource           `json:"customization,omitempty"      yaml:"customization,omitempty"`      //nolint:lll
 	AuthSettings      *PortalAuthSettingsResource            `json:"auth_settings,omitempty"      yaml:"auth_settings,omitempty"`      //nolint:lll
+	IPAllowList       *PortalIPAllowListResource             `json:"ip_allow_list,omitempty"      yaml:"ip_allow_list,omitempty"`      //nolint:lll
 	Integrations      *PortalIntegrationResource             `json:"integrations,omitempty"       yaml:"integrations,omitempty"`       //nolint:lll
 	IdentityProviders []PortalIdentityProviderResource       `json:"identity_providers,omitempty" yaml:"identity_providers,omitempty"` //nolint:lll
 	CustomDomain      *PortalCustomDomainResource            `json:"custom_domain,omitempty"      yaml:"custom_domain,omitempty"`      //nolint:lll
@@ -527,6 +546,7 @@ func (p PortalResource) portalAlias() portalAlias {
 		Kongctl:           p.Kongctl,
 		Customization:     p.Customization,
 		AuthSettings:      p.AuthSettings,
+		IPAllowList:       p.IPAllowList,
 		Integrations:      p.Integrations,
 		IdentityProviders: p.IdentityProviders,
 		CustomDomain:      p.CustomDomain,

--- a/internal/declarative/resources/portal_ip_allow_list.go
+++ b/internal/declarative/resources/portal_ip_allow_list.go
@@ -1,0 +1,159 @@
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"slices"
+	"strings"
+)
+
+func init() {
+	registerResourceType(
+		ResourceTypePortalIPAllowList,
+		func(rs *ResourceSet) *[]PortalIPAllowListResource { return &rs.PortalIPAllowLists },
+		AutoExplain[PortalIPAllowListResource](),
+	)
+}
+
+// PortalIPAllowListResource represents a portal IP allow-list entry.
+type PortalIPAllowListResource struct {
+	Ref        string   `yaml:"ref"                 json:"ref"`
+	Portal     string   `yaml:"portal,omitempty"    json:"portal,omitempty"`
+	AllowedIPs []string `yaml:"allowed_ips"         json:"allowed_ips"`
+
+	konnectID string `yaml:"-" json:"-"`
+}
+
+func (l PortalIPAllowListResource) GetRef() string {
+	return l.Ref
+}
+
+func (l PortalIPAllowListResource) Validate() error {
+	if err := ValidateRef(l.Ref); err != nil {
+		return fmt.Errorf("invalid portal IP allow list ref: %w", err)
+	}
+
+	if len(l.AllowedIPs) == 0 {
+		return fmt.Errorf("allowed_ips must contain at least one IP address or CIDR block")
+	}
+
+	seen := make(map[string]struct{}, len(l.AllowedIPs))
+	for i, value := range l.AllowedIPs {
+		normalized := strings.TrimSpace(value)
+		if normalized == "" {
+			return fmt.Errorf("allowed_ips[%d] cannot be empty", i)
+		}
+		if !isValidIPAddressOrCIDR(normalized) {
+			return fmt.Errorf("allowed_ips[%d] must be an IP address or CIDR block: %q", i, value)
+		}
+		if _, ok := seen[normalized]; ok {
+			return fmt.Errorf("allowed_ips[%d] duplicates %q", i, normalized)
+		}
+		seen[normalized] = struct{}{}
+	}
+
+	return nil
+}
+
+func (l *PortalIPAllowListResource) SetDefaults() {}
+
+func (l PortalIPAllowListResource) GetType() ResourceType {
+	return ResourceTypePortalIPAllowList
+}
+
+func (l PortalIPAllowListResource) GetMoniker() string {
+	return strings.Join(normalizedAllowedIPs(l.AllowedIPs), ",")
+}
+
+func (l PortalIPAllowListResource) GetDependencies() []ResourceRef {
+	if l.Portal == "" {
+		return []ResourceRef{}
+	}
+	return []ResourceRef{{Kind: ResourceTypePortal, Ref: l.Portal}}
+}
+
+func (l PortalIPAllowListResource) GetReferenceFieldMappings() map[string]string {
+	return map[string]string{
+		"portal": "portal",
+	}
+}
+
+func (l PortalIPAllowListResource) GetKonnectID() string {
+	return l.konnectID
+}
+
+func (l PortalIPAllowListResource) GetKonnectMonikerFilter() string {
+	return ""
+}
+
+func (l *PortalIPAllowListResource) TryMatchKonnectResource(_ any) bool {
+	// Matched via parent portal state; entries do not expose a stable declarative moniker.
+	return false
+}
+
+// GetParentRef implements ResourceWithParent for inheritance of namespace and protection.
+func (l PortalIPAllowListResource) GetParentRef() *ResourceRef {
+	if l.Portal == "" {
+		return nil
+	}
+	return &ResourceRef{Kind: ResourceTypePortal, Ref: l.Portal}
+}
+
+// UnmarshalJSON rejects kongctl metadata on child resources.
+func (l *PortalIPAllowListResource) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	allowedKeys := map[string]struct{}{
+		"ref":         {},
+		"portal":      {},
+		"allowed_ips": {},
+		"kongctl":     {},
+	}
+	for key := range raw {
+		if _, ok := allowedKeys[key]; !ok {
+			return fmt.Errorf("json: unknown field %q", key)
+		}
+	}
+
+	var temp struct {
+		Ref        string   `json:"ref"`
+		Portal     string   `json:"portal,omitempty"`
+		AllowedIPs []string `json:"allowed_ips"`
+		Kongctl    any      `json:"kongctl,omitempty"`
+	}
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return err
+	}
+	if temp.Kongctl != nil {
+		return fmt.Errorf("kongctl metadata not supported on portal IP allow lists")
+	}
+
+	l.Ref = temp.Ref
+	l.Portal = temp.Portal
+	l.AllowedIPs = temp.AllowedIPs
+	return nil
+}
+
+func normalizedAllowedIPs(values []string) []string {
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			normalized = append(normalized, trimmed)
+		}
+	}
+	slices.Sort(normalized)
+	return normalized
+}
+
+func isValidIPAddressOrCIDR(value string) bool {
+	if ip := net.ParseIP(value); ip != nil {
+		return true
+	}
+	_, _, err := net.ParseCIDR(value)
+	return err == nil
+}

--- a/internal/declarative/resources/portal_ip_allow_list_test.go
+++ b/internal/declarative/resources/portal_ip_allow_list_test.go
@@ -1,0 +1,69 @@
+package resources
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPortalIPAllowListResourceValidate(t *testing.T) {
+	tests := []struct {
+		name        string
+		resource    PortalIPAllowListResource
+		expectedErr string
+	}{
+		{
+			name: "valid IP and CIDR values",
+			resource: PortalIPAllowListResource{
+				Ref:        "portal-allow-list",
+				AllowedIPs: []string{"192.0.2.10", "2001:db8::/32", "198.51.100.0/24"},
+			},
+		},
+		{
+			name: "requires allowed_ips",
+			resource: PortalIPAllowListResource{
+				Ref: "portal-allow-list",
+			},
+			expectedErr: "allowed_ips must contain at least one IP address or CIDR block",
+		},
+		{
+			name: "rejects invalid IP value",
+			resource: PortalIPAllowListResource{
+				Ref:        "portal-allow-list",
+				AllowedIPs: []string{"not-an-ip"},
+			},
+			expectedErr: "allowed_ips[0] must be an IP address or CIDR block: \"not-an-ip\"",
+		},
+		{
+			name: "rejects duplicate values",
+			resource: PortalIPAllowListResource{
+				Ref:        "portal-allow-list",
+				AllowedIPs: []string{"192.0.2.10", "192.0.2.10"},
+			},
+			expectedErr: "allowed_ips[1] duplicates \"192.0.2.10\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.resource.Validate()
+			if tt.expectedErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.EqualError(t, err, tt.expectedErr)
+		})
+	}
+}
+
+func TestPortalIPAllowListResourceRejectsKongctlMetadata(t *testing.T) {
+	var resource PortalIPAllowListResource
+	err := json.Unmarshal([]byte(`{
+		"ref": "portal-allow-list",
+		"allowed_ips": ["192.0.2.10"],
+		"kongctl": {"protected": true}
+	}`), &resource)
+
+	require.EqualError(t, err, "kongctl metadata not supported on portal IP allow lists")
+}

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -22,6 +22,7 @@ const (
 	ResourceTypePortalCustomization              ResourceType = "portal_customization"
 	ResourceTypePortalCustomDomain               ResourceType = "portal_custom_domain"
 	ResourceTypePortalAuthSettings               ResourceType = "portal_auth_settings"
+	ResourceTypePortalIPAllowList                ResourceType = "portal_ip_allow_list"
 	ResourceTypePortalIntegration                ResourceType = "portal_integration"
 	ResourceTypePortalIdentityProvider           ResourceType = "portal_identity_provider"
 	ResourceTypePortalPage                       ResourceType = "portal_page"
@@ -84,6 +85,7 @@ type ResourceSet struct {
 	// Portal child resources can be defined at root level (with parent reference) or nested under Portals
 	PortalCustomizations        []PortalCustomizationResource        `yaml:"portal_customizations,omitempty"                 json:"portal_customizations,omitempty"`          //nolint:lll
 	PortalAuthSettings          []PortalAuthSettingsResource         `yaml:"portal_auth_settings,omitempty"                  json:"portal_auth_settings,omitempty"`           //nolint:lll
+	PortalIPAllowLists          []PortalIPAllowListResource          `yaml:"portal_ip_allow_lists,omitempty"                 json:"portal_ip_allow_lists,omitempty"`          //nolint:lll
 	PortalIntegrations          []PortalIntegrationResource          `yaml:"portal_integrations,omitempty"                   json:"portal_integrations,omitempty"`            //nolint:lll
 	PortalIdentityProviders     []PortalIdentityProviderResource     `yaml:"portal_identity_providers,omitempty"             json:"portal_identity_providers,omitempty"`      //nolint:lll
 	PortalCustomDomains         []PortalCustomDomainResource         `yaml:"portal_custom_domains,omitempty"                 json:"portal_custom_domains,omitempty"`          //nolint:lll
@@ -440,6 +442,25 @@ func (rs *ResourceSet) GetPortalAuthSettingsByNamespace(namespace string) []Port
 			}
 			if GetNamespace(portal.Kongctl) == namespace {
 				filtered = append(filtered, settings)
+			}
+		}
+	}
+	return filtered
+}
+
+// GetPortalIPAllowListsByNamespace returns all portal IP allow-list resources from the specified namespace.
+func (rs *ResourceSet) GetPortalIPAllowListsByNamespace(namespace string) []PortalIPAllowListResource {
+	var filtered []PortalIPAllowListResource
+	for _, allowList := range rs.PortalIPAllowLists {
+		if portal := rs.GetPortalByRef(allowList.Portal); portal != nil {
+			if portal.IsExternal() {
+				if namespace == NamespaceExternal {
+					filtered = append(filtered, allowList)
+				}
+				continue
+			}
+			if GetNamespace(portal.Kongctl) == namespace {
+				filtered = append(filtered, allowList)
 			}
 		}
 	}

--- a/internal/declarative/state/cache.go
+++ b/internal/declarative/state/cache.go
@@ -159,6 +159,13 @@ type PortalCustomDomain struct {
 	UpdatedAt                time.Time
 }
 
+// PortalIPAllowList represents a portal IP allow list entry.
+type PortalIPAllowList struct {
+	ID         string
+	PortalID   string
+	AllowedIPs []string
+}
+
 // PortalSnippet represents portal snippet
 type PortalSnippet struct {
 	ID               string

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -2719,9 +2719,17 @@ func (c *Client) UpdatePortalAuthSettings(
 	return nil
 }
 
+// ValidatePortalIPAllowListAPI returns an error if the portal IP allow list API is not configured.
+func (c *Client) ValidatePortalIPAllowListAPI() error {
+	if c == nil {
+		return NewAPIClientNotConfiguredError("portal IP allow list API")
+	}
+	return ValidateAPIClient(c.portalIPAllowListAPI, "portal IP allow list API")
+}
+
 // ListPortalIPAllowLists lists all IP allow list entries for a portal.
 func (c *Client) ListPortalIPAllowLists(ctx context.Context, portalID string) ([]PortalIPAllowList, error) {
-	if err := ValidateAPIClient(c.portalIPAllowListAPI, "portal IP allow list API"); err != nil {
+	if err := c.ValidatePortalIPAllowListAPI(); err != nil {
 		return nil, err
 	}
 

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"slices"
 	"strings"
 
@@ -2813,6 +2814,12 @@ func (c *Client) CreatePortalIPAllowList(
 
 	resp, err := c.portalIPAllowListAPI.CreatePortalIPAllowList(ctx, portalID, &req)
 	if err != nil {
+		if entry, recovered := portalIPAllowListEntryFromStatusOKSDKError(err); recovered {
+			if entry.ID == "" {
+				return "", NewResponseValidationError("create portal IP allow list", "IPEntry")
+			}
+			return entry.ID, nil
+		}
 		return "", WrapAPIError(err, "create portal IP allow list", &ErrorWrapperOptions{
 			ResourceType: string(resources.ResourceTypePortalIPAllowList),
 			ResourceName: portalID,
@@ -2848,6 +2855,12 @@ func (c *Client) UpdatePortalIPAllowList(
 		UpdatePortalSourceIPRestriction: &req,
 	})
 	if err != nil {
+		if entry, recovered := portalIPAllowListEntryFromStatusOKSDKError(err); recovered {
+			if entry.ID == "" {
+				return "", NewResponseValidationError("update portal IP allow list", "IPEntry")
+			}
+			return entry.ID, nil
+		}
 		return "", WrapAPIError(err, "update portal IP allow list", &ErrorWrapperOptions{
 			ResourceType: string(resources.ResourceTypePortalIPAllowList),
 			ResourceName: id,
@@ -2880,6 +2893,22 @@ func (c *Client) DeletePortalIPAllowList(ctx context.Context, portalID string, i
 		})
 	}
 	return nil
+}
+
+func portalIPAllowListEntryFromStatusOKSDKError(err error) (*kkComps.IPEntry, bool) {
+	var sdkErr *kkErrors.SDKError
+	if !errors.As(err, &sdkErr) ||
+		sdkErr.StatusCode != http.StatusOK ||
+		sdkErr.Message != "unknown status code returned" ||
+		strings.TrimSpace(sdkErr.Body) == "" {
+		return nil, false
+	}
+
+	var entry kkComps.IPEntry
+	if err := json.Unmarshal([]byte(sdkErr.Body), &entry); err != nil {
+		return nil, false
+	}
+	return &entry, true
 }
 
 // GetPortalIntegrations fetches current integration configuration for a portal.

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -38,6 +38,7 @@ type ClientConfig struct {
 	// Portal child resource APIs
 	PortalPageAPI             helpers.PortalPageAPI
 	PortalAuthSettingsAPI     helpers.PortalAuthSettingsAPI
+	PortalIPAllowListAPI      helpers.PortalIPAllowListAPI
 	PortalIntegrationsAPI     helpers.PortalIntegrationsAPI
 	PortalIdentityProviderAPI helpers.PortalIdentityProviderAPI
 	PortalCustomizationAPI    helpers.PortalCustomizationAPI
@@ -92,6 +93,7 @@ type Client struct {
 	// Portal child resource APIs
 	portalPageAPI             helpers.PortalPageAPI
 	portalAuthSettingsAPI     helpers.PortalAuthSettingsAPI
+	portalIPAllowListAPI      helpers.PortalIPAllowListAPI
 	portalIntegrationsAPI     helpers.PortalIntegrationsAPI
 	portalIdentityProviderAPI helpers.PortalIdentityProviderAPI
 	portalCustomizationAPI    helpers.PortalCustomizationAPI
@@ -147,6 +149,7 @@ func NewClient(config ClientConfig) *Client {
 		// Portal child resource APIs
 		portalPageAPI:             config.PortalPageAPI,
 		portalAuthSettingsAPI:     config.PortalAuthSettingsAPI,
+		portalIPAllowListAPI:      config.PortalIPAllowListAPI,
 		portalIntegrationsAPI:     config.PortalIntegrationsAPI,
 		portalIdentityProviderAPI: config.PortalIdentityProviderAPI,
 		portalCustomizationAPI:    config.PortalCustomizationAPI,
@@ -2712,6 +2715,161 @@ func (c *Client) UpdatePortalAuthSettings(
 	_, err := c.portalAuthSettingsAPI.UpdatePortalAuthenticationSettings(ctx, portalID, &settings)
 	if err != nil {
 		return WrapAPIError(err, "update portal auth settings", nil)
+	}
+	return nil
+}
+
+// ListPortalIPAllowLists lists all IP allow list entries for a portal.
+func (c *Client) ListPortalIPAllowLists(ctx context.Context, portalID string) ([]PortalIPAllowList, error) {
+	if err := ValidateAPIClient(c.portalIPAllowListAPI, "portal IP allow list API"); err != nil {
+		return nil, err
+	}
+
+	var entries []PortalIPAllowList
+	pageSize := int64(100)
+	var pageAfter *string
+
+	for {
+		req := kkOps.ListPortalIPAllowListRequest{
+			PortalID: portalID,
+			PageSize: &pageSize,
+		}
+		if pageAfter != nil {
+			req.PageAfter = pageAfter
+		}
+
+		resp, err := c.portalIPAllowListAPI.ListPortalIPAllowList(ctx, req)
+		if err != nil {
+			return nil, WrapAPIError(err, "list portal IP allow lists", &ErrorWrapperOptions{
+				ResourceType: string(resources.ResourceTypePortalIPAllowList),
+				ResourceName: portalID,
+				UseEnhanced:  true,
+			})
+		}
+		if err := ValidateResponse(resp, "list portal IP allow lists"); err != nil {
+			return nil, err
+		}
+
+		page := resp.GetPortalSourceIPRestrictionPaginatedResponse()
+		if page == nil {
+			return nil, NewResponseValidationError(
+				"list portal IP allow lists",
+				"PortalSourceIPRestrictionPaginatedResponse",
+			)
+		}
+
+		for _, entry := range page.GetData() {
+			entries = append(entries, PortalIPAllowList{
+				ID:         entry.ID,
+				PortalID:   portalID,
+				AllowedIPs: slices.Clone(entry.AllowedIps),
+			})
+		}
+
+		nextCursor := pagination.ExtractPageAfterCursor(page.Meta.Next)
+		if nextCursor == "" {
+			break
+		}
+		pageAfter = &nextCursor
+	}
+
+	return entries, nil
+}
+
+// GetPortalIPAllowList fetches a portal IP allow list entry by ID.
+func (c *Client) GetPortalIPAllowList(ctx context.Context, portalID string, id string) (*PortalIPAllowList, error) {
+	entries, err := c.ListPortalIPAllowLists(ctx, portalID)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range entries {
+		if entries[i].ID == id {
+			return &entries[i], nil
+		}
+	}
+
+	return nil, nil
+}
+
+// CreatePortalIPAllowList creates a portal IP allow list entry.
+func (c *Client) CreatePortalIPAllowList(
+	ctx context.Context,
+	portalID string,
+	req kkComps.CreatePortalSourceIPRestriction,
+	namespace string,
+) (string, error) {
+	if err := ValidateAPIClient(c.portalIPAllowListAPI, "portal IP allow list API"); err != nil {
+		return "", err
+	}
+
+	resp, err := c.portalIPAllowListAPI.CreatePortalIPAllowList(ctx, portalID, &req)
+	if err != nil {
+		return "", WrapAPIError(err, "create portal IP allow list", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypePortalIPAllowList),
+			ResourceName: portalID,
+			Namespace:    namespace,
+			UseEnhanced:  true,
+		})
+	}
+	if err := ValidateResponse(resp, "create portal IP allow list"); err != nil {
+		return "", err
+	}
+	if resp.IPEntry == nil {
+		return "", NewResponseValidationError("create portal IP allow list", "IPEntry")
+	}
+
+	return resp.IPEntry.ID, nil
+}
+
+// UpdatePortalIPAllowList updates a portal IP allow list entry.
+func (c *Client) UpdatePortalIPAllowList(
+	ctx context.Context,
+	portalID string,
+	id string,
+	req kkComps.UpdatePortalSourceIPRestriction,
+	namespace string,
+) (string, error) {
+	if err := ValidateAPIClient(c.portalIPAllowListAPI, "portal IP allow list API"); err != nil {
+		return "", err
+	}
+
+	resp, err := c.portalIPAllowListAPI.UpdatePortalIPAllowList(ctx, kkOps.UpdatePortalIPAllowListRequest{
+		PortalID:                        portalID,
+		ID:                              id,
+		UpdatePortalSourceIPRestriction: &req,
+	})
+	if err != nil {
+		return "", WrapAPIError(err, "update portal IP allow list", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypePortalIPAllowList),
+			ResourceName: id,
+			Namespace:    namespace,
+			UseEnhanced:  true,
+		})
+	}
+	if err := ValidateResponse(resp, "update portal IP allow list"); err != nil {
+		return "", err
+	}
+	if resp.IPEntry == nil {
+		return "", NewResponseValidationError("update portal IP allow list", "IPEntry")
+	}
+
+	return resp.IPEntry.ID, nil
+}
+
+// DeletePortalIPAllowList deletes a portal IP allow list entry.
+func (c *Client) DeletePortalIPAllowList(ctx context.Context, portalID string, id string) error {
+	if err := ValidateAPIClient(c.portalIPAllowListAPI, "portal IP allow list API"); err != nil {
+		return err
+	}
+
+	_, err := c.portalIPAllowListAPI.DeletePortalIPAllowList(ctx, portalID, id)
+	if err != nil {
+		return WrapAPIError(err, "delete portal IP allow list", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypePortalIPAllowList),
+			ResourceName: id,
+			UseEnhanced:  true,
+		})
 	}
 	return nil
 }

--- a/internal/declarative/state/client_portal_ip_allow_list_test.go
+++ b/internal/declarative/state/client_portal_ip_allow_list_test.go
@@ -1,0 +1,140 @@
+package state
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	kkErrors "github.com/Kong/sdk-konnect-go/models/sdkerrors"
+)
+
+type mockPortalIPAllowListAPI struct {
+	createFunc func(
+		context.Context,
+		string,
+		*kkComps.CreatePortalSourceIPRestriction,
+		...kkOps.Option,
+	) (*kkOps.CreatePortalIPAllowListResponse, error)
+	updateFunc func(
+		context.Context,
+		kkOps.UpdatePortalIPAllowListRequest,
+		...kkOps.Option,
+	) (*kkOps.UpdatePortalIPAllowListResponse, error)
+}
+
+func (m *mockPortalIPAllowListAPI) CreatePortalIPAllowList(
+	ctx context.Context,
+	portalID string,
+	request *kkComps.CreatePortalSourceIPRestriction,
+	opts ...kkOps.Option,
+) (*kkOps.CreatePortalIPAllowListResponse, error) {
+	if m.createFunc != nil {
+		return m.createFunc(ctx, portalID, request, opts...)
+	}
+	return nil, fmt.Errorf("CreatePortalIPAllowList not implemented")
+}
+
+func (m *mockPortalIPAllowListAPI) ListPortalIPAllowList(
+	_ context.Context,
+	_ kkOps.ListPortalIPAllowListRequest,
+	_ ...kkOps.Option,
+) (*kkOps.ListPortalIPAllowListResponse, error) {
+	return nil, fmt.Errorf("ListPortalIPAllowList not implemented")
+}
+
+func (m *mockPortalIPAllowListAPI) PutPortalIPAllowList(
+	_ context.Context,
+	_ kkOps.PutPortalIPAllowListRequest,
+	_ ...kkOps.Option,
+) (*kkOps.PutPortalIPAllowListResponse, error) {
+	return nil, fmt.Errorf("PutPortalIPAllowList not implemented")
+}
+
+func (m *mockPortalIPAllowListAPI) UpdatePortalIPAllowList(
+	ctx context.Context,
+	request kkOps.UpdatePortalIPAllowListRequest,
+	opts ...kkOps.Option,
+) (*kkOps.UpdatePortalIPAllowListResponse, error) {
+	if m.updateFunc != nil {
+		return m.updateFunc(ctx, request, opts...)
+	}
+	return nil, fmt.Errorf("UpdatePortalIPAllowList not implemented")
+}
+
+func (m *mockPortalIPAllowListAPI) DeletePortalIPAllowList(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ ...kkOps.Option,
+) (*kkOps.DeletePortalIPAllowListResponse, error) {
+	return nil, fmt.Errorf("DeletePortalIPAllowList not implemented")
+}
+
+func TestCreatePortalIPAllowListRecoversStatusOKSDKError(t *testing.T) {
+	client := NewClient(ClientConfig{
+		PortalIPAllowListAPI: &mockPortalIPAllowListAPI{
+			createFunc: func(
+				_ context.Context,
+				_ string,
+				_ *kkComps.CreatePortalSourceIPRestriction,
+				_ ...kkOps.Option,
+			) (*kkOps.CreatePortalIPAllowListResponse, error) {
+				return nil, kkErrors.NewSDKError(
+					"unknown status code returned",
+					http.StatusOK,
+					`{"allowed_ips":["198.51.100.10"],"id":"entry-1"}`,
+					nil,
+				)
+			},
+		},
+	})
+
+	id, err := client.CreatePortalIPAllowList(
+		testContextWithLogger(),
+		"portal-1",
+		kkComps.CreatePortalSourceIPRestriction{AllowedIps: []string{"198.51.100.10"}},
+		"default",
+	)
+	if err != nil {
+		t.Fatalf("CreatePortalIPAllowList returned error: %v", err)
+	}
+	if id != "entry-1" {
+		t.Fatalf("CreatePortalIPAllowList returned id %q, want %q", id, "entry-1")
+	}
+}
+
+func TestUpdatePortalIPAllowListRecoversStatusOKSDKError(t *testing.T) {
+	client := NewClient(ClientConfig{
+		PortalIPAllowListAPI: &mockPortalIPAllowListAPI{
+			updateFunc: func(
+				_ context.Context,
+				_ kkOps.UpdatePortalIPAllowListRequest,
+				_ ...kkOps.Option,
+			) (*kkOps.UpdatePortalIPAllowListResponse, error) {
+				return nil, kkErrors.NewSDKError(
+					"unknown status code returned",
+					http.StatusOK,
+					`{"allowed_ips":["198.51.100.20"],"id":"entry-2"}`,
+					nil,
+				)
+			},
+		},
+	})
+
+	id, err := client.UpdatePortalIPAllowList(
+		testContextWithLogger(),
+		"portal-1",
+		"entry-2",
+		kkComps.UpdatePortalSourceIPRestriction{AllowedIps: []string{"198.51.100.20"}},
+		"default",
+	)
+	if err != nil {
+		t.Fatalf("UpdatePortalIPAllowList returned error: %v", err)
+	}
+	if id != "entry-2" {
+		t.Fatalf("UpdatePortalIPAllowList returned id %q, want %q", id, "entry-2")
+	}
+}

--- a/internal/konnect/helpers/portal_ip_allow_lists.go
+++ b/internal/konnect/helpers/portal_ip_allow_lists.go
@@ -1,0 +1,108 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+
+	kkSDK "github.com/Kong/sdk-konnect-go"
+	kkComponents "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+)
+
+// PortalIPAllowListAPI defines the interface for portal IP allow list operations.
+type PortalIPAllowListAPI interface {
+	CreatePortalIPAllowList(
+		ctx context.Context,
+		portalID string,
+		request *kkComponents.CreatePortalSourceIPRestriction,
+		opts ...kkOps.Option,
+	) (*kkOps.CreatePortalIPAllowListResponse, error)
+	ListPortalIPAllowList(
+		ctx context.Context,
+		request kkOps.ListPortalIPAllowListRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.ListPortalIPAllowListResponse, error)
+	PutPortalIPAllowList(
+		ctx context.Context,
+		request kkOps.PutPortalIPAllowListRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.PutPortalIPAllowListResponse, error)
+	UpdatePortalIPAllowList(
+		ctx context.Context,
+		request kkOps.UpdatePortalIPAllowListRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.UpdatePortalIPAllowListResponse, error)
+	DeletePortalIPAllowList(
+		ctx context.Context,
+		portalID string,
+		id string,
+		opts ...kkOps.Option,
+	) (*kkOps.DeletePortalIPAllowListResponse, error)
+}
+
+// PortalIPAllowListAPIImpl provides an implementation using the Konnect SDK.
+type PortalIPAllowListAPIImpl struct {
+	SDK *kkSDK.SDK
+}
+
+// CreatePortalIPAllowList creates a portal IP allow list entry.
+func (p *PortalIPAllowListAPIImpl) CreatePortalIPAllowList(
+	ctx context.Context,
+	portalID string,
+	request *kkComponents.CreatePortalSourceIPRestriction,
+	opts ...kkOps.Option,
+) (*kkOps.CreatePortalIPAllowListResponse, error) {
+	if p.SDK == nil || p.SDK.PortalsIPAllowList == nil {
+		return nil, fmt.Errorf("SDK portal IP allow list API is nil")
+	}
+	return p.SDK.PortalsIPAllowList.CreatePortalIPAllowList(ctx, portalID, request, opts...)
+}
+
+// ListPortalIPAllowList lists portal IP allow list entries.
+func (p *PortalIPAllowListAPIImpl) ListPortalIPAllowList(
+	ctx context.Context,
+	request kkOps.ListPortalIPAllowListRequest,
+	opts ...kkOps.Option,
+) (*kkOps.ListPortalIPAllowListResponse, error) {
+	if p.SDK == nil || p.SDK.PortalsIPAllowList == nil {
+		return nil, fmt.Errorf("SDK portal IP allow list API is nil")
+	}
+	return p.SDK.PortalsIPAllowList.ListPortalIPAllowList(ctx, request, opts...)
+}
+
+// PutPortalIPAllowList replaces a portal IP allow list entry.
+func (p *PortalIPAllowListAPIImpl) PutPortalIPAllowList(
+	ctx context.Context,
+	request kkOps.PutPortalIPAllowListRequest,
+	opts ...kkOps.Option,
+) (*kkOps.PutPortalIPAllowListResponse, error) {
+	if p.SDK == nil || p.SDK.PortalsIPAllowList == nil {
+		return nil, fmt.Errorf("SDK portal IP allow list API is nil")
+	}
+	return p.SDK.PortalsIPAllowList.PutPortalIPAllowList(ctx, request, opts...)
+}
+
+// UpdatePortalIPAllowList updates a portal IP allow list entry.
+func (p *PortalIPAllowListAPIImpl) UpdatePortalIPAllowList(
+	ctx context.Context,
+	request kkOps.UpdatePortalIPAllowListRequest,
+	opts ...kkOps.Option,
+) (*kkOps.UpdatePortalIPAllowListResponse, error) {
+	if p.SDK == nil || p.SDK.PortalsIPAllowList == nil {
+		return nil, fmt.Errorf("SDK portal IP allow list API is nil")
+	}
+	return p.SDK.PortalsIPAllowList.UpdatePortalIPAllowList(ctx, request, opts...)
+}
+
+// DeletePortalIPAllowList deletes a portal IP allow list entry.
+func (p *PortalIPAllowListAPIImpl) DeletePortalIPAllowList(
+	ctx context.Context,
+	portalID string,
+	id string,
+	opts ...kkOps.Option,
+) (*kkOps.DeletePortalIPAllowListResponse, error) {
+	if p.SDK == nil || p.SDK.PortalsIPAllowList == nil {
+		return nil, fmt.Errorf("SDK portal IP allow list API is nil")
+	}
+	return p.SDK.PortalsIPAllowList.DeletePortalIPAllowList(ctx, portalID, id, opts...)
+}

--- a/internal/konnect/helpers/sdk.go
+++ b/internal/konnect/helpers/sdk.go
@@ -37,6 +37,7 @@ type SDKAPI interface {
 	// Portal child resource APIs
 	GetPortalPageAPI() PortalPageAPI
 	GetPortalAuthSettingsAPI() PortalAuthSettingsAPI
+	GetPortalIPAllowListAPI() PortalIPAllowListAPI
 	GetPortalIntegrationsAPI() PortalIntegrationsAPI
 	GetPortalIdentityProviderAPI() PortalIdentityProviderAPI
 	GetPortalCustomizationAPI() PortalCustomizationAPI
@@ -219,6 +220,15 @@ func (k *KonnectSDK) GetPortalAuthSettingsAPI() PortalAuthSettingsAPI {
 	}
 
 	return &PortalAuthSettingsAPIImpl{SDK: k.SDK}
+}
+
+// Returns the implementation of the PortalIPAllowListAPI interface
+func (k *KonnectSDK) GetPortalIPAllowListAPI() PortalIPAllowListAPI {
+	if k.SDK == nil || k.SDK.PortalsIPAllowList == nil {
+		return nil
+	}
+
+	return &PortalIPAllowListAPIImpl{SDK: k.SDK}
 }
 
 // Returns the implementation of the PortalIntegrationsAPI interface

--- a/internal/konnect/helpers/sdk_mock.go
+++ b/internal/konnect/helpers/sdk_mock.go
@@ -25,6 +25,7 @@ type MockKonnectSDK struct {
 	// Portal child resource factories
 	PortalPageFactory                    func() PortalPageAPI
 	PortalAuthSettingsFactory            func() PortalAuthSettingsAPI
+	PortalIPAllowListFactory             func() PortalIPAllowListAPI
 	PortalIntegrationsFactory            func() PortalIntegrationsAPI
 	PortalIdentityProviderFactory        func() PortalIdentityProviderAPI
 	PortalCustomizationFactory           func() PortalCustomizationAPI
@@ -168,6 +169,14 @@ func (m *MockKonnectSDK) GetPortalPageAPI() PortalPageAPI {
 func (m *MockKonnectSDK) GetPortalAuthSettingsAPI() PortalAuthSettingsAPI {
 	if m.PortalAuthSettingsFactory != nil {
 		return m.PortalAuthSettingsFactory()
+	}
+	return nil
+}
+
+// Returns a mock instance of the PortalIPAllowListAPI
+func (m *MockKonnectSDK) GetPortalIPAllowListAPI() PortalIPAllowListAPI {
+	if m.PortalIPAllowListFactory != nil {
+		return m.PortalIPAllowListFactory()
 	}
 	return nil
 }

--- a/test/e2e/scenarios/explain/command-coverage/scenario.yaml
+++ b/test/e2e/scenarios/explain/command-coverage/scenario.yaml
@@ -78,7 +78,7 @@ steps:
                 "contains(stdout, 'RESOURCE CLASS: top-level')": true
                 "contains(stdout, 'ROOT KEY: portals[]')": true
                 "contains(stdout, 'SUPPORTS NESTED DECLARATION: false')": true
-                "contains(stdout, 'CHILD RESOURCES: audit_log_webhook, auth_settings, custom_domain, customization, email_config, identity_providers, integrations, pages, snippets, teams')": true
+                "contains(stdout, 'CHILD RESOURCES: audit_log_webhook, auth_settings, custom_domain, customization, email_config, identity_providers, integrations, ip_allow_list, pages, snippets, teams')": true
                 "contains(stdout, 'FIELD DETAILS: use --extended')": true
                 "contains(stdout, 'FIELDS')": false
 

--- a/test/e2e/scenarios/portal/ip-allow-list/overlays/003-update-allow-lists/config.yaml
+++ b/test/e2e/scenarios/portal/ip-allow-list/overlays/003-update-allow-lists/config.yaml
@@ -1,0 +1,30 @@
+_defaults:
+  kongctl:
+    namespace: portal-ip-allow-list
+
+portals:
+  - ref: e2e-portal-ip-allow-list-nested
+    name: e2e-portal-ip-allow-list-nested
+    display_name: E2E Portal IP Allow List Nested
+    description: Portal with a nested declarative IP allow list
+    authentication_enabled: false
+    rbac_enabled: false
+    ip_allow_list:
+      ref: e2e-portal-ip-allow-list-nested-config
+      allowed_ips:
+        - 198.51.100.20
+        - 203.0.113.128/25
+
+  - ref: e2e-portal-ip-allow-list-root
+    name: e2e-portal-ip-allow-list-root
+    display_name: E2E Portal IP Allow List Root
+    description: Portal with a top-level declarative IP allow list
+    authentication_enabled: false
+    rbac_enabled: false
+
+portal_ip_allow_lists:
+  - ref: e2e-portal-ip-allow-list-root-config
+    portal: e2e-portal-ip-allow-list-root
+    allowed_ips:
+      - 192.0.2.50
+      - 198.51.100.128/25

--- a/test/e2e/scenarios/portal/ip-allow-list/scenario.yaml
+++ b/test/e2e/scenarios/portal/ip-allow-list/scenario.yaml
@@ -1,0 +1,241 @@
+baseInputsPath: testdata
+
+env:
+  KONGCTL_LOG_LEVEL: info
+
+vars:
+  namespace: portal-ip-allow-list
+  nestedPortalRef: e2e-portal-ip-allow-list-nested
+  nestedAllowListRef: e2e-portal-ip-allow-list-nested-config
+  rootPortalRef: e2e-portal-ip-allow-list-root
+  rootAllowListRef: e2e-portal-ip-allow-list-root-config
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - change_id
+      - resource_id
+      - generated_at
+      - created_at
+      - updated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-plan-apply-allow-lists
+    commands:
+      - name: 000-plan-allow-lists
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-allow-lists.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 4
+                by_action.CREATE: 4
+          - select: >-
+              changes[?resource_type=='portal_ip_allow_list' &&
+              resource_ref=='{{ .vars.nestedAllowListRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                parent.ref: "{{ .vars.nestedPortalRef }}"
+                references.portal_id.ref: "{{ .vars.nestedPortalRef }}"
+                "contains(fields.allowed_ips, '198.51.100.10')": true
+                "contains(fields.allowed_ips, '203.0.113.0/24')": true
+                "length(fields.allowed_ips)": 2
+                "length(depends_on)": 1
+          - select: >-
+              changes[?resource_type=='portal_ip_allow_list' &&
+              resource_ref=='{{ .vars.rootAllowListRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                parent.ref: "{{ .vars.rootPortalRef }}"
+                references.portal_id.ref: "{{ .vars.rootPortalRef }}"
+                "contains(fields.allowed_ips, '192.0.2.25')": true
+                "contains(fields.allowed_ips, '198.51.100.0/24')": true
+                "length(fields.allowed_ips)": 2
+                "length(depends_on)": 1
+      - name: 001-apply-allow-lists
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-allow-lists.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 4
+                failed: 0
+
+  - name: 002-dump-and-plan-round-trip
+    commands:
+      - name: 000-dump-portals-with-allow-lists
+        run:
+          - dump
+          - declarative
+          - "--resources=portals"
+          - --include-child-resources
+          - "--default-namespace={{ .vars.namespace }}"
+        outputFormat: none
+        parseAs: yaml
+        stdoutFile: "{{ .workdir }}/dump.yaml"
+        assertions:
+          - select: >-
+              portals[?name=='{{ .vars.nestedPortalRef }}'] | [0].ip_allow_list.allowed_ips
+            expect:
+              fields:
+                "contains(@, '198.51.100.10')": true
+                "contains(@, '203.0.113.0/24')": true
+                "length(@)": 2
+          - select: >-
+              portals[?name=='{{ .vars.rootPortalRef }}'] | [0].ip_allow_list.allowed_ips
+            expect:
+              fields:
+                "contains(@, '192.0.2.25')": true
+                "contains(@, '198.51.100.0/24')": true
+                "length(@)": 2
+      - name: 001-plan-no-op
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+
+  - name: 003-update-allow-lists
+    inputOverlayDirs:
+      - overlays/003-update-allow-lists
+    commands:
+      - name: 000-plan-allow-list-update
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-allow-list-update.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 2
+                by_action.UPDATE: 2
+          - select: >-
+              changes[?resource_type=='portal_ip_allow_list' &&
+              resource_ref=='{{ .vars.nestedAllowListRef }}'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                parent.ref: "{{ .vars.nestedPortalRef }}"
+                references.portal_id.ref: "{{ .vars.nestedPortalRef }}"
+                "contains(fields.allowed_ips, '198.51.100.20')": true
+                "contains(fields.allowed_ips, '203.0.113.128/25')": true
+                "length(fields.allowed_ips)": 2
+          - select: >-
+              changes[?resource_type=='portal_ip_allow_list' &&
+              resource_ref=='{{ .vars.rootAllowListRef }}'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                parent.ref: "{{ .vars.rootPortalRef }}"
+                references.portal_id.ref: "{{ .vars.rootPortalRef }}"
+                "contains(fields.allowed_ips, '192.0.2.50')": true
+                "contains(fields.allowed_ips, '198.51.100.128/25')": true
+                "length(fields.allowed_ips)": 2
+      - name: 001-apply-allow-list-update
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-allow-list-update.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 2
+                failed: 0
+      - name: 002-plan-update-no-op
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+      - name: 003-dump-updated-allow-lists
+        run:
+          - dump
+          - declarative
+          - "--resources=portals"
+          - --include-child-resources
+          - "--default-namespace={{ .vars.namespace }}"
+        outputFormat: none
+        parseAs: yaml
+        assertions:
+          - select: >-
+              portals[?name=='{{ .vars.nestedPortalRef }}'] | [0].ip_allow_list.allowed_ips
+            expect:
+              fields:
+                "contains(@, '198.51.100.20')": true
+                "contains(@, '203.0.113.128/25')": true
+                "length(@)": 2
+          - select: >-
+              portals[?name=='{{ .vars.rootPortalRef }}'] | [0].ip_allow_list.allowed_ips
+            expect:
+              fields:
+                "contains(@, '192.0.2.50')": true
+                "contains(@, '198.51.100.128/25')": true
+                "length(@)": 2
+
+  - name: 004-delete-cleanup
+    inputOverlayDirs:
+      - overlays/003-update-allow-lists
+    commands:
+      - name: 000-delete-portals
+        outputFormat: json
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/portal/ip-allow-list/testdata/config.yaml
+++ b/test/e2e/scenarios/portal/ip-allow-list/testdata/config.yaml
@@ -1,0 +1,30 @@
+_defaults:
+  kongctl:
+    namespace: portal-ip-allow-list
+
+portals:
+  - ref: e2e-portal-ip-allow-list-nested
+    name: e2e-portal-ip-allow-list-nested
+    display_name: E2E Portal IP Allow List Nested
+    description: Portal with a nested declarative IP allow list
+    authentication_enabled: false
+    rbac_enabled: false
+    ip_allow_list:
+      ref: e2e-portal-ip-allow-list-nested-config
+      allowed_ips:
+        - 198.51.100.10
+        - 203.0.113.0/24
+
+  - ref: e2e-portal-ip-allow-list-root
+    name: e2e-portal-ip-allow-list-root
+    display_name: E2E Portal IP Allow List Root
+    description: Portal with a top-level declarative IP allow list
+    authentication_enabled: false
+    rbac_enabled: false
+
+portal_ip_allow_lists:
+  - ref: e2e-portal-ip-allow-list-root-config
+    portal: e2e-portal-ip-allow-list-root
+    allowed_ips:
+      - 192.0.2.25
+      - 198.51.100.0/24


### PR DESCRIPTION
## Summary

Adds declarative support for Konnect Portal IP allow lists.

- Adds `portal_ip_allow_lists` root resources and nested `portals[].ip_allow_list` declarations.
- Wires validation, reference resolution, planning, execution, state client methods, SDK helper access, dump support, explain output, and docs.
- Models the allow-list declaration as singleton-per-portal because the API entries expose IDs and `allowed_ips` but no stable declarative name/ref for matching.
- In sync mode, removes undeclared current allow-list entries for managed portals while leaving external portals alone.

Fixes #860.

## Validation

- `go test ./...`
- `make format`
- `make build`
- `make lint`
- `make test`