### PR TITLE
Task: Improve kongctl declarative skill guidance

### DIFF
--- a/skills/kongctl-declarative/SKILL.md
+++ b/skills/kongctl-declarative/SKILL.md
@@ -83,7 +83,7 @@ local `docs/` directory exists.
 Before hand-writing unfamiliar resources or fields, discover structure with:
 
 ```bash
-kongctl explain <resource-path> --extended
+kongctl explain <resource-path> -o text --extended
 kongctl scaffold <resource-path>
 ```
 

--- a/skills/kongctl-declarative/SKILL.md
+++ b/skills/kongctl-declarative/SKILL.md
@@ -3,8 +3,11 @@ name: kongctl-declarative
 description: Set up, initialize, and manage kongctl declarative configuration
   for Kong Konnect. Use when the user wants to configure a repository with
   Konnect declarative resources, create kongctl manifests (control planes,
-  portals, APIs), generate config from OpenAPI specs, run plan/diff/apply/sync
-  /delete/adopt workflows, or scaffold CI/CD pipelines for Konnect APIOps.
+  portals, APIs), use kongctl scaffold or kongctl explain to discover schemas
+  and bootstrap resource YAML, integrate decK gateway state through _deck,
+  generate Konnect API and Kong Gateway config from OpenAPI specs, run
+  plan/diff/apply/sync/delete/adopt workflows, or scaffold CI/CD pipelines
+  for Konnect APIOps.
 license: Apache-2.0
 metadata:
   product: kongctl
@@ -26,6 +29,10 @@ Choose the execution approach from user intent:
 ## Preconditions
 
 - Confirm CLI is installed and runnable: `kongctl version`
+- For Kong Gateway configuration, confirm decK is installed: `deck version`
+- Local schema helpers do not require Konnect authentication:
+  - `kongctl explain <resource-path>` inspects resource and field schemas.
+  - `kongctl scaffold <resource-path>` prints commented starter YAML.
 - Authenticate with one of:
   - `kongctl login` — preferred for interactive use (browser-based OAuth)
   - `export KONGCTL_DEFAULT_KONNECT_PAT=<token>` — for non-interactive or CI
@@ -36,6 +43,8 @@ Choose the execution approach from user intent:
   returns organization info, auth is confirmed. Do not guess or try other
   commands to check auth.
 - Verify command syntax when unsure:
+  - `kongctl explain --help`
+  - `kongctl scaffold --help`
   - `kongctl plan --help`
   - `kongctl dump declarative --help`
   - `kongctl adopt --help`
@@ -53,22 +62,33 @@ Choose the execution approach from user intent:
 Load only the reference file needed for the active task:
 
 - `references/commands.md`
-  - Use for command selection, plan based vs inline execution, and safety flags.
+  - Use for schema helpers, command selection, plan based vs inline execution,
+    and safety flags.
 - `references/resources.md`
-  - Use for resource skeletons, `_defaults`, `!file`, and `!ref` patterns.
+  - Use for schema-first authoring, resource skeletons, `_defaults`, `!file`,
+    and `!ref` patterns.
 - `references/troubleshooting.md`
   - Use for common failures and fast remediation steps.
 - `references/cicd-github-actions.md`
   - Use for GitHub Actions workflow patterns for declarative CI/CD.
 - `references/apiops-openapi.md`
   - Use for OpenAPI source-of-truth patterns for APIs and API versions.
+- `references/deck-gateway.md`
+  - Use when configuring Kong Gateway services, routes, plugins, consumers,
+    or OpenAPI-to-Gateway APIOps with decK and `_deck`.
 
 This skill is designed to be portable across repositories. Do not assume a
 local `docs/` directory exists.
 
-If field-level uncertainty remains after reading `references/`, discover
-structure from live data using:
-`kongctl dump declarative --resources=<resource-type>`.
+Before hand-writing unfamiliar resources or fields, discover structure with:
+
+```bash
+kongctl explain <resource-path> --extended
+kongctl scaffold <resource-path>
+```
+
+Use `kongctl dump declarative --resources=<resource-type>` when live Konnect
+state is the best source of truth, such as when adopting existing resources.
 
 ## Operating Rules
 
@@ -89,6 +109,15 @@ structure from live data using:
 - Use `apply` for create/update workflows when the user asks to execute.
 - Use `-o text` for interactive mutating commands. `-o json` and `-o yaml`
   require `--auto-approve` or `--dry-run` on `apply`, `sync`, and `delete`.
+- Use `kongctl explain` before guessing at resource, child-resource, or field
+  structure. Use `--extended` for field summaries in text output, or
+  `-o json`/`-o yaml` for machine-readable schema.
+- Use `kongctl scaffold` to bootstrap YAML for new resource types and child
+  resources. It writes YAML to stdout and does not support `-o/--output`.
+- Use resource and field paths such as `api`, `api.versions`,
+  `api.publications.portal_id`, and `portal.pages` with `explain`.
+- Use resource and child-resource paths such as `api`, `api.versions`, and
+  `control_plane.data_plane_certificates` with `scaffold`.
 - Use `adopt` only to bring unmanaged resources into namespace management.
 - `adopt` only adds the `KONGCTL-namespace` label to the target resource.
 - Prefer `!ref` for cross-resource IDs and `!file` for large spec or
@@ -97,6 +126,15 @@ structure from live data using:
   derive fields from `!file` extraction and avoid stale duplicated literals.
 - Use existing OpenAPI file paths from the user repository. Do not require a
   `konnect/resources/specs` layout.
+- Use decK for Kong Gateway runtime entities such as services, routes,
+  plugins, consumers, consumer groups, upstreams, and targets.
+- Use kongctl resources for Konnect SaaS resources such as control planes,
+  portals, API catalog entries, publications, and API implementations.
+- When a user wants an API Gateway configured from OpenAPI, generate decK
+  state with `deck file openapi2kong`, then wire it to kongctl through
+  `control_planes[]._deck`.
+- Use `control_planes[].gateway_services` as external selectors for services
+  created by decK, then reference them from `apis[].implementations`.
 - Only place kongctl declarative resource files in the resources directory.
   Do not put OpenAPI specs, documentation, or other non-resource YAML there.
   `--recursive` loads all YAML files in the directory tree and will fail on
@@ -116,18 +154,20 @@ structure from live data using:
 ## Workflow
 
 1. Locate the Konnect declarative configuration directory and existing files.
-2. Generate or update YAML manifests and related files.
-3. Choose collaboration mode based on intent:
+2. For unfamiliar resource shapes, run `kongctl explain` or
+   `kongctl scaffold` before writing YAML.
+3. Generate or update YAML manifests and related files.
+4. Choose collaboration mode based on intent:
    - User-run mode (teach + provide commands)
    - Agent-run mode (execute commands directly)
-4. Load the relevant `references/*.md` file for the task.
-5. If execution is needed, pick execution style:
+5. Load the relevant `references/*.md` file for the task.
+6. If execution is needed, pick execution style:
    - Explicit plan artifact workflow (generate plan, then pass it to apply or
      sync)
    - Inline command workflow
-6. Validate and/or execute `diff`, `apply`, `sync`, `delete`, or `adopt` per
+7. Validate and/or execute `diff`, `apply`, `sync`, `delete`, or `adopt` per
    user ask.
-7. Report created files, commands run, and resulting plan or execution
+8. Report created files, commands run, and resulting plan or execution
    summary.
 
 ### Execution Style Selection
@@ -174,6 +214,7 @@ konnect/resources/
 ```
 
 For APIOps API modeling, load `references/apiops-openapi.md`.
+For Kong Gateway/deck integration, load `references/deck-gateway.md`.
 
 ## Pattern: Bootstrap control plane, portal, and APIs
 
@@ -191,6 +232,17 @@ Steps:
 6. In User-run mode, explain each command's purpose before listing it.
 
 Starter manifest pattern:
+
+When starting from scratch, prefer generating starter shapes first:
+
+```bash
+kongctl scaffold control_plane
+kongctl scaffold portal
+kongctl scaffold api
+```
+
+Then adapt the generated YAML to the repository layout and user intent. The
+static pattern below is a compact fallback and example of the expected result.
 
 ```yaml
 _defaults:
@@ -230,7 +282,8 @@ Relative `--base-dir` values resolve from the config file directory, not
 cwd, so always use an absolute path:
 
 ```bash
-kongctl diff -f konnect/resources --recursive --base-dir "$(pwd)" --mode apply -o text
+kongctl diff -f konnect/resources --recursive \
+  --base-dir "$(pwd)" --mode apply -o text
 ```
 
 Use `--recursive` when the `-f` target is a directory.
@@ -243,22 +296,30 @@ Use for prompts like:
 
 - Generate an API declarative config from `@path-to/openapi-spec.yaml` and
   write it to `@path-to-existing/konnect/resources`.
+- Generate gateway services, routes, and plugins from an OpenAPI spec and
+  connect them to a Konnect API implementation.
 
 Steps:
 
 1. Choose target files under the existing resources tree, such as:
    - `<resources>/apis/<api-name>.yaml`
-2. Reference existing OpenAPI spec paths in the repository. Do not require
+2. If no local API manifest convention exists, run `kongctl scaffold api`
+   and adapt the generated shape.
+3. If the user wants Gateway runtime config, load
+   `references/deck-gateway.md` and create or update a decK state file.
+4. Reference existing OpenAPI spec paths in the repository. Do not require
    copying specs under the declarative resources directory.
-3. Preserve existing repo conventions when a layout already exists.
-4. Reference spec fields with `!file` extraction.
-5. If spec files are outside the resources directory, add `--base-dir` to
+5. Preserve existing repo conventions when a layout already exists.
+6. Reference spec fields with `!file` extraction.
+7. If spec files are outside the resources directory, add `--base-dir` to
    all `plan`/`diff`/`apply`/`sync` commands so `!file` paths resolve.
-6. Validate and execute based on requested style.
-7. In User-run mode, include where files were written and why.
+8. Validate and execute based on requested style.
+9. In User-run mode, include where files were written and why.
 
 Load `references/apiops-openapi.md` for the canonical API YAML template and
 `references/commands.md` for validation and execution commands.
+Load `references/deck-gateway.md` when the OpenAPI spec should also produce
+Gateway services, routes, plugins, or an API implementation backed by decK.
 
 ## Pattern: Adopt existing resources into declarative management
 

--- a/skills/kongctl-declarative/agents/openai.yaml
+++ b/skills/kongctl-declarative/agents/openai.yaml
@@ -1,8 +1,4 @@
 interface:
   display_name: "Kongctl Declarative"
-  short_description: >-
-    Generate and manage kongctl declarative Konnect configurations
-  default_prompt: >-
-    Generate declarative config, teach users how to run kongctl declarative
-    workflows, and choose user-run or agent-run execution with safe
-    plan/apply/sync/delete/dump/adopt patterns.
+  short_description: "Build schema-valid kongctl and decK configs"
+  default_prompt: "Use $kongctl-declarative to generate schema-valid Konnect and decK Gateway declarative config with scaffold/explain, then plan or diff it safely."

--- a/skills/kongctl-declarative/references/apiops-openapi.md
+++ b/skills/kongctl-declarative/references/apiops-openapi.md
@@ -34,9 +34,10 @@ OpenAPI can drive two related outputs:
 - Kong Gateway runtime config using decK (`services`, `routes`, `plugins`).
 
 When the user asks to "set up an API Gateway", "create routes/services", or
-"configure plugins" from OpenAPI, also load `deck-gateway.md`. Generate decK
-state with `deck file openapi2kong`, then wire the resulting service into
-kongctl with `control_planes[]._deck`, external `gateway_services`, and
+"configure plugins" from OpenAPI, also load
+`references/deck-gateway.md`. Generate decK state with
+`deck file openapi2kong`, then wire the resulting service into kongctl with
+`control_planes[]._deck`, external `gateway_services`, and
 `apis[].implementations`.
 
 ## Canonical Example

--- a/skills/kongctl-declarative/references/apiops-openapi.md
+++ b/skills/kongctl-declarative/references/apiops-openapi.md
@@ -25,6 +25,20 @@ aligned with spec changes.
 4. Populate API metadata from `info.*` in each OpenAPI file.
 5. Keep `versions[].spec` pointing to the full OpenAPI document file.
 
+## Gateway APIOps Split
+
+OpenAPI can drive two related outputs:
+
+- Konnect API catalog config (`apis`, `versions`, `publications`) using
+  `!file` extraction.
+- Kong Gateway runtime config using decK (`services`, `routes`, `plugins`).
+
+When the user asks to "set up an API Gateway", "create routes/services", or
+"configure plugins" from OpenAPI, also load `deck-gateway.md`. Generate decK
+state with `deck file openapi2kong`, then wire the resulting service into
+kongctl with `control_planes[]._deck`, external `gateway_services`, and
+`apis[].implementations`.
+
 ## Canonical Example
 
 ```yaml
@@ -47,6 +61,7 @@ apis:
 When working in the `kongctl` repository, use this concrete example:
 
 - `docs/examples/declarative/portal/apis.yaml`
+- `docs/examples/declarative/deck/`
 
 ## Validation Loop
 
@@ -60,5 +75,6 @@ When OpenAPI specs are outside the resources directory, add `--base-dir`
 with the absolute project root:
 
 ```bash
-kongctl diff -f <resources-path> --recursive --base-dir "$(pwd)" --mode apply -o text
+kongctl diff -f <resources-path> --recursive \
+  --base-dir "$(pwd)" --mode apply -o text
 ```

--- a/skills/kongctl-declarative/references/cicd-github-actions.md
+++ b/skills/kongctl-declarative/references/cicd-github-actions.md
@@ -14,7 +14,7 @@ Use this file when asked to create or modify GitHub Actions workflows for
    - Deployment jobs can run `apply` or `sync`.
 3. Install required tooling:
    - `kong/setup-kongctl@v1`
-   - `kong/setup-deck@v1` when deck is required
+   - `kong/setup-deck@v1` when `_deck` is declared or APIOps scripts run
 4. Inject secrets via workflow `env` or step-level `env`.
 5. Upload artifacts for audit and troubleshooting.
 
@@ -60,6 +60,11 @@ steps:
 
 Use a repository script when available (`./scripts/konnect-sync.sh`) so CI
 logic and local developer flows stay aligned.
+
+When OpenAPI specs generate Gateway config, put the `deck file openapi2kong`,
+`deck file patch`, `deck file add-plugins`, and `deck file add-tags` calls in
+a repository script. Run that script before `kongctl plan`, `diff`, `apply`,
+or `sync` so `_deck.files` points at generated decK state.
 
 ## Auth and Environment Conventions
 

--- a/skills/kongctl-declarative/references/commands.md
+++ b/skills/kongctl-declarative/references/commands.md
@@ -75,7 +75,7 @@ Use these intent mappings:
 Konnect authentication and accepts resource, child-resource, and field paths.
 
 ```bash
-kongctl explain <resource-path> --extended
+kongctl explain <resource-path> --extended -o text
 kongctl explain <resource-path> -o json
 kongctl explain <resource-path> -o yaml
 ```

--- a/skills/kongctl-declarative/references/commands.md
+++ b/skills/kongctl-declarative/references/commands.md
@@ -10,6 +10,8 @@ Use command help for ground-truth syntax in environments without local docs.
 
 ## Command Roles
 
+- `kongctl explain`: Inspect declarative schema for a resource path or field.
+- `kongctl scaffold`: Generate commented starter YAML for a resource path.
 - `kongctl plan`: Generate a plan artifact without executing changes.
 - `kongctl diff`: Preview planned changes in text, JSON, or YAML.
 - `kongctl apply`: Create and update resources. No deletes.
@@ -17,33 +19,119 @@ Use command help for ground-truth syntax in environments without local docs.
 - `kongctl delete`: Delete resources defined in the input files.
 - `kongctl dump declarative`: Export live resources into declarative YAML.
 - `kongctl adopt`: Label existing resources with `KONGCTL-namespace`.
+- `deck file openapi2kong`: Convert OpenAPI to decK Gateway state.
+- `deck file patch`: Apply JSONPath-based patches to decK files.
+- `deck file add-plugins`: Add plugins to selected decK entities.
+- `deck file add-tags`: Add tags to selected decK entities.
 
 ## Intent to Command
 
 Use these intent mappings:
 
-1. Preview create/update only
+1. Discover fields, required values, nesting, or YAML placement
+   `kongctl explain <resource-path> --extended`
+   `kongctl explain <resource-path> -o json`
+2. Generate starter YAML for a resource or child resource
+   `kongctl scaffold <resource-path>`
+3. Preview create/update only
    `kongctl diff -f <path> --mode apply -o text`
-2. Preview full converge including deletes
+4. Preview full converge including deletes
    `kongctl diff -f <path> --mode sync -o text`
-3. Generate a reviewable plan file
+5. Generate a reviewable plan file
    `kongctl plan -f <path> --mode <apply|sync|delete> --output-file <plan.json>`
-4. Execute a saved plan artifact
+6. Execute a saved plan artifact
    `kongctl apply --plan <plan.json>`
    `kongctl sync --plan <plan.json>`
-5. Execute create/update now (inline plan+execute)
+7. Execute create/update now (inline plan+execute)
    `kongctl apply -f <path> --dry-run -o text`
    `kongctl apply -f <path> -o text`
-6. Execute full converge now (inline plan+execute)
+8. Execute full converge now (inline plan+execute)
    `kongctl sync -f <path> --dry-run -o text`
    `kongctl sync -f <path> -o text`
-7. Execute delete workflow now
+9. Execute delete workflow now
    `kongctl delete -f <path> --dry-run -o text`
    `kongctl delete -f <path> -o text`
-8. Dump existing resources to declarative YAML
+10. Dump existing resources to declarative YAML
    `kongctl dump declarative --resources=<types> -o yaml --output-file <file>`
-9. Adopt unmanaged resource into a namespace
+11. Adopt unmanaged resource into a namespace
    `kongctl adopt <resource> <name-or-id> --namespace <namespace> -o json`
+12. Generate Gateway runtime config from OpenAPI
+   ```bash
+   deck file openapi2kong \
+     --spec <openapi.yaml> \
+     --select-tag <tag> \
+     --output-file <gateway.yaml>
+   ```
+13. Patch or enrich generated decK state
+   ```bash
+   deck file patch --state <gateway.yaml> --output-file <out.yaml>
+   deck file add-plugins --state <gateway.yaml> --output-file <out.yaml>
+   deck file add-tags --state <gateway.yaml> --output-file <out.yaml> <tag>
+   ```
+
+## Explain Command Detail
+
+`kongctl explain` is the first choice for schema questions. It works without
+Konnect authentication and accepts resource, child-resource, and field paths.
+
+```bash
+kongctl explain <resource-path> --extended
+kongctl explain <resource-path> -o json
+kongctl explain <resource-path> -o yaml
+```
+
+Resource path examples:
+
+- `api`
+- `api.versions`
+- `api.publications.portal_id`
+- `portal.pages`
+- `control_plane.data_plane_certificates`
+
+Use text output for human-readable summaries. Use `--extended` with text
+output when field details are needed. Use `-o json` or `-o yaml` when an
+agent needs machine-readable JSON Schema, required fields, root keys,
+resource class, or nesting metadata.
+
+## Scaffold Command Detail
+
+`kongctl scaffold` prints commented YAML starter configuration for a resource
+path. Use it before hand-writing new resource shapes.
+
+```bash
+kongctl scaffold api
+kongctl scaffold api.versions
+kongctl scaffold control_plane.data_plane_certificates
+```
+
+Important behavior:
+
+- It writes YAML to stdout.
+- It does not support `-o` or `--output`.
+- To save output in User-run mode, tell the user to redirect stdout:
+  `kongctl scaffold api > konnect/resources/apis.yaml`
+- Replace placeholder refs and values such as `my-resource` before planning.
+- Un-comment optional fields only when the user needs them.
+
+## decK APIOps Command Detail
+
+Use decK file commands when generating or modifying Kong Gateway runtime
+configuration files. These commands work on local files and are separate from
+the `kongctl apply/sync` execution that later runs decK through `_deck`.
+
+```bash
+deck file openapi2kong --spec <openapi.yaml> --select-tag <tag> \
+  --output-file <gateway.yaml>
+deck file patch --state <gateway.yaml> --selector '$..services[*]' \
+  --value 'read_timeout:30000' --output-file <patched.yaml>
+deck file add-plugins --state <gateway.yaml> --selector '$..services[*]' \
+  --config '{"name":"key-auth"}' --output-file <plugins.yaml>
+deck file add-tags --state <gateway.yaml> --selector 'services[*]' \
+  --output-file <tagged.yaml> <tag>
+```
+
+Load `references/deck-gateway.md` for `_deck`, select-tag, external
+`gateway_services`, and API implementation wiring patterns.
 
 ## Adopt Command Detail
 
@@ -139,6 +227,8 @@ and execution.
 When syntax is uncertain, check help text:
 
 ```bash
+kongctl explain --help
+kongctl scaffold --help
 kongctl plan --help
 kongctl diff --help
 kongctl apply --help
@@ -146,4 +236,8 @@ kongctl sync --help
 kongctl delete --help
 kongctl dump declarative --help
 kongctl adopt --help
+deck file openapi2kong --help
+deck file patch --help
+deck file add-plugins --help
+deck file add-tags --help
 ```

--- a/skills/kongctl-declarative/references/commands.md
+++ b/skills/kongctl-declarative/references/commands.md
@@ -29,7 +29,7 @@ Use command help for ground-truth syntax in environments without local docs.
 Use these intent mappings:
 
 1. Discover fields, required values, nesting, or YAML placement
-   `kongctl explain <resource-path> --extended`
+   `kongctl explain <resource-path> --extended -o text`
    `kongctl explain <resource-path> -o json`
 2. Generate starter YAML for a resource or child resource
    `kongctl scaffold <resource-path>`

--- a/skills/kongctl-declarative/references/deck-gateway.md
+++ b/skills/kongctl-declarative/references/deck-gateway.md
@@ -1,0 +1,156 @@
+# decK Gateway Integration
+
+Use this file when the user wants Kong Gateway runtime configuration:
+services, routes, plugins, consumers, upstreams, or Gateway config generated
+from OpenAPI. kongctl manages Konnect SaaS resources; decK manages Kong
+Gateway state. Combine them with `control_planes[]._deck`.
+
+## Decision Rule
+
+- Use kongctl `apis`, `portals`, and `api.versions` for API catalog,
+  portal publication, and spec storage in Konnect.
+- Use decK state files for Gateway services, routes, plugins, consumers,
+  consumer groups, upstreams, targets, and other runtime entities.
+- Use both when an OpenAPI spec should appear in the Konnect API catalog
+  and configure an actual Gateway route/service/plugin implementation.
+
+## Preconditions
+
+- Confirm decK is installed: `deck version`.
+- For CI, install both tools:
+  - `kong/setup-kongctl@v1`
+  - `kong/setup-deck@v1`
+- Use `deck file ... --help` for APIOps helper syntax when uncertain.
+
+## `_deck` Integration Pattern
+
+Declare `_deck` on a control plane. kongctl runs decK once per control plane
+that declares `_deck`, then resolves external gateway services by selector.
+
+```yaml
+control_planes:
+  - ref: example-cp
+    name: "example-cp"
+    cluster_type: "CLUSTER_TYPE_SERVERLESS_V1"
+    _deck:
+      files:
+        - "gateway.yaml"
+      flags:
+        - "--analytics=false"
+
+    gateway_services:
+      - ref: example-gw-svc
+        _external:
+          selector:
+            matchFields:
+              name: "example-service"
+
+apis:
+  - ref: example-api
+    name: "Example API"
+    implementations:
+      - ref: example-api-impl
+        service:
+          control_plane_id: !ref example-cp#id
+          id: !ref example-gw-svc#id
+```
+
+Rules:
+
+- `_deck` is allowed only on `control_planes`.
+- `_deck.files` must include at least one decK state file.
+- `_deck.flags` may contain extra decK flags, but not Konnect auth or output
+  flags. Do not set `--konnect-token`, `--konnect-control-plane-name`,
+  `--konnect-addr`, `--json-output`, or `--output`; kongctl injects those.
+- Relative `_deck.files` paths resolve from the kongctl config file that
+  declares `_deck`, and must stay inside the `--base-dir` boundary.
+- `gateway_services` that point at decK-created services must use
+  `_external.selector.matchFields.name`; match the service `name` in the
+  decK state file.
+- In `plan`/`diff`, kongctl runs `deck gateway diff`. In `apply`, kongctl
+  runs `deck gateway apply`. In `sync`, kongctl runs `deck gateway sync`.
+
+## decK State File Requirements
+
+Always scope decK state before using sync. Include `_info.select_tags` and
+matching `tags` on generated entities so `deck gateway sync` does not delete
+resources owned by other decK files.
+
+```yaml
+_format_version: "3.0"
+
+_info:
+  select_tags:
+    - "payments"
+
+services:
+  - name: payments-service
+    url: https://payments.example.com
+    tags:
+      - payments
+    routes:
+      - name: payments-route
+        paths:
+          - /payments
+        tags:
+          - payments
+```
+
+## OpenAPI to Gateway APIOps
+
+For prompts like "set up an API Gateway from this OpenAPI spec":
+
+1. Keep the OpenAPI file in its existing repository location.
+2. Generate decK state from the spec:
+   ```bash
+   deck file openapi2kong \
+     --spec <openapi.yaml> \
+     --select-tag <tag> \
+     --output-file <gateway.yaml>
+   ```
+3. Inspect the generated service and route names.
+4. Ensure `_info.select_tags` and entity `tags` match the chosen tag.
+5. Patch operational defaults when needed:
+   ```bash
+   deck file patch \
+     --state <gateway.yaml> \
+     --selector '$..services[*]' \
+     --value 'read_timeout:30000' \
+     --output-file <gateway-patched.yaml>
+   ```
+6. Add plugins when needed:
+   ```bash
+   deck file add-plugins \
+     --state <gateway.yaml> \
+     --selector '$..services[*]' \
+     --config '{"name":"key-auth"}' \
+     --output-file <gateway-plugins.yaml>
+   ```
+7. Add or normalize tags when needed:
+   ```bash
+   deck file add-tags \
+     --state <gateway.yaml> \
+     --selector 'services[*]' \
+     --output-file <gateway-tagged.yaml> \
+     <tag>
+   ```
+8. Add `_deck.files` to the target control plane.
+9. Add `control_planes[].gateway_services` external selectors for any
+   generated Gateway services that Konnect API implementations must reference.
+10. Add `apis[].implementations[].service` with `control_plane_id` pointing
+    to the control plane and `id` pointing to the external gateway service.
+11. Validate with `kongctl diff -f <resources> --mode apply -o text`.
+
+Prefer writing each APIOps command to a new output file, then promote the
+final state file after inspection. When a repository already has scripts for
+OpenAPI-to-decK generation, update those scripts instead of replacing them.
+
+## Repository Example
+
+When working inside the `kongctl` repository, use this concrete example:
+
+- `docs/examples/declarative/deck/control-plane.yaml`
+- `docs/examples/declarative/deck/gateway-services.yaml`
+- `docs/examples/declarative/deck/api.yaml`
+
+The same pattern applies in other repositories even when the paths differ.

--- a/skills/kongctl-declarative/references/resources.md
+++ b/skills/kongctl-declarative/references/resources.md
@@ -296,7 +296,7 @@ organization:
 When field-level uncertainty remains, inspect the local schema first:
 
 ```bash
-kongctl explain <resource-path> --extended
+kongctl explain <resource-path> -o text --extended
 kongctl scaffold <resource-path>
 ```
 

--- a/skills/kongctl-declarative/references/resources.md
+++ b/skills/kongctl-declarative/references/resources.md
@@ -36,7 +36,7 @@ shape. These commands are local schema helpers and do not require Konnect
 authentication.
 
 ```bash
-kongctl explain api --extended
+kongctl explain api --extended -o text
 kongctl explain api.publications.portal_id
 kongctl scaffold api
 kongctl scaffold api.versions

--- a/skills/kongctl-declarative/references/resources.md
+++ b/skills/kongctl-declarative/references/resources.md
@@ -19,12 +19,42 @@ directory.
 ## Top-Level Resource Keys
 
 - `apis`
+- `audit-logs`
 - `application_auth_strategies`
 - `catalog_services`
 - `control_planes`
+- `dcr_providers`
 - `event_gateways`
+- `gateway_services`
 - `organization` (contains `teams`)
 - `portals`
+
+## Schema-First Authoring
+
+Use `kongctl explain` and `kongctl scaffold` before guessing at resource
+shape. These commands are local schema helpers and do not require Konnect
+authentication.
+
+```bash
+kongctl explain api --extended
+kongctl explain api.publications.portal_id
+kongctl scaffold api
+kongctl scaffold api.versions
+```
+
+Use `explain` to confirm:
+
+- accepted resource aliases and root YAML keys
+- required and recommended fields
+- field types, enum values, tags, and reference kinds
+- whether a child resource can be declared at root level, nested, or both
+- field placement paths for root and nested YAML declarations
+
+Use `scaffold` to generate a commented starter YAML shape. Edit the generated
+placeholder values, then validate with `diff` or `plan`.
+
+Use `dump declarative` when live Konnect state should drive the shape, such as
+adopting an existing resource into declarative management.
 
 ## Parent and Child Rules
 
@@ -81,7 +111,15 @@ Common fields:
 - `cloud_gateway`
 - `proxy_urls`
 - `labels`
+- `_deck`
+- `_external`
 - `kongctl`
+
+Common child blocks:
+
+- `gateway_services`
+- `data_plane_certificates`
+- `members`
 
 Example:
 
@@ -91,6 +129,9 @@ control_planes:
     name: "my-control-plane"
     cluster_type: "CLUSTER_TYPE_CONTROL_PLANE"
 ```
+
+Use `_deck` for control-plane scoped decK Gateway state. Load
+`deck-gateway.md` when adding `_deck` or `gateway_services` selectors.
 
 ### `portals`
 
@@ -168,6 +209,38 @@ apis:
         visibility: public
 ```
 
+### `gateway_services`
+
+Use `gateway_services` as external selectors for Kong Gateway services created
+by decK. Prefer nesting under the control plane that declares `_deck`.
+
+```yaml
+control_planes:
+  - ref: cp-main
+    name: "my-control-plane"
+    _deck:
+      files:
+        - "gateway.yaml"
+    gateway_services:
+      - ref: payments-gw-svc
+        _external:
+          selector:
+            matchFields:
+              name: "payments-service"
+```
+
+Reference the selected service from API implementations:
+
+```yaml
+apis:
+  - ref: payments-api
+    implementations:
+      - ref: payments-impl
+        service:
+          control_plane_id: !ref cp-main#id
+          id: !ref payments-gw-svc#id
+```
+
 ### `application_auth_strategies`
 
 Common fields:
@@ -220,7 +293,14 @@ organization:
 
 ## Schema Discovery Without Local Docs
 
-When field-level uncertainty remains, sample live schema with dump commands:
+When field-level uncertainty remains, inspect the local schema first:
+
+```bash
+kongctl explain <resource-path> --extended
+kongctl scaffold <resource-path>
+```
+
+Then sample live Konnect state with dump commands when needed:
 
 ```bash
 kongctl dump declarative --resources=portal --include-child-resources -o yaml

--- a/skills/kongctl-declarative/references/resources.md
+++ b/skills/kongctl-declarative/references/resources.md
@@ -131,7 +131,8 @@ control_planes:
 ```
 
 Use `_deck` for control-plane scoped decK Gateway state. Load
-`deck-gateway.md` when adding `_deck` or `gateway_services` selectors.
+`references/deck-gateway.md` when adding `_deck` or `gateway_services`
+selectors.
 
 ### `portals`
 

--- a/skills/kongctl-declarative/references/troubleshooting.md
+++ b/skills/kongctl-declarative/references/troubleshooting.md
@@ -34,6 +34,10 @@ Symptom: parser rejects a field name.
 
 Actions:
 
+- Run `kongctl explain <resource-path> --extended` to confirm accepted
+  fields and YAML placement.
+- Run `kongctl scaffold <resource-path>` when the whole resource shape is
+  uncertain.
 - Check field patterns in `references/resources.md`.
 - If uncertain, generate live examples with `dump declarative`.
 - Fix common typos like `lables` vs `labels`.
@@ -59,6 +63,34 @@ Actions:
 - Re-check with `diff --mode apply` to isolate create/update intent.
 - Restrict scope with `--require-namespace=<ns>`.
 - Use `--dry-run` before executing `sync` or `delete`.
+
+### Unexpected Deletes from decK Sync
+
+Symptom: a plan or sync involving `_deck` shows Gateway deletes outside the
+intended API or service.
+
+Actions:
+
+- Ensure the decK state file has `_info.select_tags`.
+- Ensure generated services, routes, plugins, consumers, and upstreams have
+  matching `tags`.
+- Prefer `deck gateway apply` behavior through `kongctl apply` when you only
+  want create/update behavior.
+- Load `references/deck-gateway.md` before changing `_deck` scope.
+
+### `_deck` Validation Errors
+
+Symptom: parser rejects `_deck` or gateway service selectors.
+
+Actions:
+
+- Put `_deck` only under `control_planes`.
+- Include at least one `_deck.files` entry.
+- Keep `_deck.files` as file paths, not flags.
+- Do not include Konnect auth or output flags in `_deck.flags`; kongctl
+  injects them.
+- Use `_external.selector.matchFields.name` as the only selector field for
+  decK-created `gateway_services`.
 
 ### Namespace Label and Adopt Conflicts
 

--- a/skills/kongctl-declarative/references/troubleshooting.md
+++ b/skills/kongctl-declarative/references/troubleshooting.md
@@ -34,8 +34,8 @@ Symptom: parser rejects a field name.
 
 Actions:
 
-- Run `kongctl explain <resource-path> --extended` to confirm accepted
-  fields and YAML placement.
+- Run `kongctl explain <resource-path> --extended -o text` to confirm
+  accepted fields and YAML placement.
 - Run `kongctl scaffold <resource-path>` when the whole resource shape is
   uncertain.
 - Check field patterns in `references/resources.md`.


### PR DESCRIPTION
## Summary

- Add schema-first guidance for `kongctl explain` and `kongctl scaffold` in the `kongctl-declarative` skill.
- Add a decK Gateway reference covering `_deck`, external `gateway_services`, OpenAPI-to-Gateway APIOps, select tags, and API implementation wiring.
- Update command, resource, troubleshooting, CI/CD, OpenAPI, and skill UI metadata so agents know when to use kongctl versus decK.

## Validation

- `python3 /home/rspurgeon/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/kongctl-declarative`
- `git diff --cached --check`
- Verified local decK command syntax with `deck version` and relevant `deck file ... --help` commands.

No Go tests were run because this is a skill documentation update.