### PR TITLE
Simplify: references to avoid hardcoding and confusion

### DIFF
--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -822,8 +822,12 @@ func (e *Executor) resolveDCRProviderRef(ctx context.Context, refInfo planner.Re
 	return provider.ID, nil
 }
 
+// unresolvedReferenceID reports whether an ID string does not yet hold a
+// concrete Konnect UUID. Prefer calling ReferenceInfo.NeedsResolution() on
+// a full ReferenceInfo value; this helper exists for the narrow cases where
+// only a bare string is available (e.g. refToID cache lookups).
 func unresolvedReferenceID(id string) bool {
-	return id == "" || id == "[unknown]"
+	return id == planner.RefIDPendingLookup || id == planner.RefIDPendingCreation
 }
 
 func (e *Executor) syncResolvedRef(
@@ -842,7 +846,7 @@ func (e *Executor) syncResolvedRef(
 		return nil
 	}
 
-	if unresolvedReferenceID(ref.ID) {
+	if ref.NeedsResolution() {
 		id, err := resolver(ctx, ref)
 		if err != nil {
 			return fmt.Errorf("%s: %w", errMsg, err)
@@ -884,8 +888,8 @@ func (e *Executor) syncResolvedPortalDefaultAuthStrategyID(
 
 // resolvePortalRef resolves a portal reference to its ID
 func (e *Executor) resolvePortalRef(ctx context.Context, refInfo planner.ReferenceInfo) (string, error) {
-	// First check if the reference already has an ID (resolved from dependency)
-	if refInfo.ID != "" {
+	// First check if the reference already has a concrete ID (resolved from dependency).
+	if refInfo.IsResolved() {
 		return refInfo.ID, nil
 	}
 
@@ -961,7 +965,7 @@ func (e *Executor) resolveControlPlaneRef(ctx context.Context, refInfo planner.R
 	}
 
 	if controlPlanes, ok := e.refToID[planner.ResourceTypeControlPlane]; ok {
-		if id, found := controlPlanes[lookupRef]; found && id != "" && id != "[unknown]" {
+		if id, found := controlPlanes[lookupRef]; found && !unresolvedReferenceID(id) {
 			return id, nil
 		}
 	}
@@ -1577,7 +1581,7 @@ func (e *Executor) resolvePortalPageRef(
 func (e *Executor) resolveAPIDocumentRef(
 	ctx context.Context, apiID string, refInfo planner.ReferenceInfo,
 ) (string, error) {
-	if refInfo.ID != "" && refInfo.ID != "[unknown]" {
+	if refInfo.IsResolved() {
 		return refInfo.ID, nil
 	}
 
@@ -1963,7 +1967,7 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 		}
 
 		if entityRef, ok := change.References[planner.FieldEntityID]; ok &&
-			(entityRef.ID == "" || entityRef.ID == "[unknown]") {
+			entityRef.NeedsResolution() {
 			apiID, err := e.resolveAPIRef(ctx, entityRef)
 			if err != nil {
 				return "", fmt.Errorf("failed to resolve entity reference: %w", err)

--- a/internal/declarative/executor/executor_test.go
+++ b/internal/declarative/executor/executor_test.go
@@ -207,7 +207,7 @@ func TestExecutor_syncResolvedDCRProviderID_UpdatesFieldsFromResolvedReference(t
 		References: map[string]planner.ReferenceInfo{
 			planner.FieldDCRProviderID: {
 				Ref: "__REF__:okta-dcr#id",
-				ID:  "[unknown]",
+				ID:  planner.RefIDPendingCreation,
 			},
 		},
 	}
@@ -240,7 +240,7 @@ func TestExecutor_syncResolvedPortalDefaultAuthStrategyID_UpdatesFieldsFromResol
 		References: map[string]planner.ReferenceInfo{
 			planner.FieldDefaultApplicationStrategyID: {
 				Ref: "__REF__:portal-default-strategy#id",
-				ID:  "[unknown]",
+				ID:  planner.RefIDPendingCreation,
 			},
 		},
 	}

--- a/internal/declarative/executor/portal_operations_test.go
+++ b/internal/declarative/executor/portal_operations_test.go
@@ -270,7 +270,7 @@ func TestExecutor_createResourcePortalResolvesUnknownAuthStrategyReferenceBefore
 		References: map[string]planner.ReferenceInfo{
 			planner.FieldDefaultApplicationStrategyID: {
 				Ref: "__REF__:portal-default-strategy#id",
-				ID:  "[unknown]",
+				ID:  planner.RefIDPendingCreation,
 			},
 		},
 	}

--- a/internal/declarative/planner/dependencies.go
+++ b/internal/declarative/planner/dependencies.go
@@ -53,7 +53,7 @@ func (d *DependencyResolver) ResolveDependencies(changes []PlannedChange) ([]str
 		}
 
 		// Parent dependencies
-		if change.Parent != nil && change.Parent.ID == "[unknown]" {
+		if change.Parent != nil && !change.Parent.IsResolved() {
 			parentDep := d.findParentChange(change.Parent.Ref, change.ResourceType, changes)
 			if parentDep != "" && !contains(change.DependsOn, parentDep) {
 				graph[parentDep] = append(graph[parentDep], changeID)
@@ -124,7 +124,7 @@ func (d *DependencyResolver) findImplicitDependencies(change PlannedChange, allC
 			}
 			continue
 		}
-		if refInfo.ID == "[unknown]" {
+		if refInfo.NeedsResolution() {
 			ref := refInfo.Ref
 			if tags.IsRefPlaceholder(ref) {
 				parsedRef, _, ok := tags.ParseRefPlaceholder(ref)

--- a/internal/declarative/planner/dependencies_test.go
+++ b/internal/declarative/planner/dependencies_test.go
@@ -55,7 +55,7 @@ func TestResolveDependencies_ImplicitReferenceDependencies(t *testing.T) {
 			References: map[string]ReferenceInfo{
 				"default_application_auth_strategy_id": {
 					Ref: "basic-auth",
-					ID:  "[unknown]",
+					ID:  RefIDPendingCreation,
 				},
 			},
 		},
@@ -93,7 +93,7 @@ func TestResolveDependencies_ImplicitReferenceDependencies_WithPlaceholder(t *te
 			References: map[string]ReferenceInfo{
 				FieldDCRProviderID: {
 					Ref: "__REF__:http-dcr#id",
-					ID:  "[unknown]",
+					ID:  RefIDPendingCreation,
 				},
 			},
 		},
@@ -129,7 +129,7 @@ func TestResolveDependencies_ParentChildRelationship(t *testing.T) {
 			Action:       ActionCreate,
 			Parent: &ParentInfo{
 				Ref: "my-api",
-				ID:  "[unknown]",
+				ID:  RefIDPendingCreation,
 			},
 		},
 		{
@@ -172,7 +172,7 @@ func TestResolveDependencies_ComplexDependencies(t *testing.T) {
 			References: map[string]ReferenceInfo{
 				"default_application_auth_strategy_id": {
 					Ref: "basic-auth",
-					ID:  "[unknown]",
+					ID:  RefIDPendingCreation,
 				},
 			},
 		},
@@ -190,7 +190,7 @@ func TestResolveDependencies_ComplexDependencies(t *testing.T) {
 			Action:       ActionCreate,
 			Parent: &ParentInfo{
 				Ref: "my-api",
-				ID:  "[unknown]",
+				ID:  RefIDPendingCreation,
 			},
 		},
 		{
@@ -201,7 +201,7 @@ func TestResolveDependencies_ComplexDependencies(t *testing.T) {
 			References: map[string]ReferenceInfo{
 				"default_application_auth_strategy_id": {
 					Ref: "basic-auth",
-					ID:  "[unknown]",
+					ID:  RefIDPendingCreation,
 				},
 			},
 		},
@@ -337,7 +337,7 @@ func TestResolveDependencies_DuplicateDependencies(t *testing.T) {
 			References: map[string]ReferenceInfo{
 				"default_application_auth_strategy_id": {
 					Ref: "basic-auth",
-					ID:  "[unknown]", // Implicit dependency (same as explicit)
+					ID:  RefIDPendingCreation, // Implicit dependency (same as explicit)
 				},
 			},
 		},

--- a/internal/declarative/planner/event_gateway_backend_cluster_planner.go
+++ b/internal/declarative/planner/event_gateway_backend_cluster_planner.go
@@ -214,13 +214,9 @@ func (p *Planner) planBackendClusterCreate(
 	} else {
 		// Gateway doesn't exist yet, add reference for runtime resolution
 		change.References = map[string]ReferenceInfo{
-			FieldEventGatewayID: {
-				Ref: gatewayRef,
-				ID:  "", // to be resolved at runtime
-				LookupFields: map[string]string{
-					FieldName: gatewayName,
-				},
-			},
+			FieldEventGatewayID: NewPendingLookupRef(gatewayRef, map[string]string{
+				FieldName: gatewayName,
+			}),
 		}
 	}
 

--- a/internal/declarative/planner/event_gateway_data_plane_certificate_planner.go
+++ b/internal/declarative/planner/event_gateway_data_plane_certificate_planner.go
@@ -192,13 +192,9 @@ func (p *Planner) planDataPlaneCertificateCreate(
 	} else {
 		// Gateway doesn't exist yet, add reference for runtime resolution
 		change.References = map[string]ReferenceInfo{
-			FieldEventGatewayID: {
-				Ref: gatewayRef,
-				ID:  "", // to be resolved at runtime
-				LookupFields: map[string]string{
-					FieldName: gatewayName,
-				},
-			},
+			FieldEventGatewayID: NewPendingLookupRef(gatewayRef, map[string]string{
+				FieldName: gatewayName,
+			}),
 		}
 	}
 

--- a/internal/declarative/planner/event_gateway_listener_planner.go
+++ b/internal/declarative/planner/event_gateway_listener_planner.go
@@ -236,13 +236,9 @@ func (p *Planner) planListenerCreate(
 	} else {
 		// Gateway doesn't exist yet, add reference for runtime resolution
 		change.References = map[string]ReferenceInfo{
-			FieldEventGatewayID: {
-				Ref: gatewayRef,
-				ID:  "", // to be resolved at runtime
-				LookupFields: map[string]string{
-					FieldName: gatewayName,
-				},
-			},
+			FieldEventGatewayID: NewPendingLookupRef(gatewayRef, map[string]string{
+				FieldName: gatewayName,
+			}),
 		}
 	}
 

--- a/internal/declarative/planner/event_gateway_schema_registry_planner.go
+++ b/internal/declarative/planner/event_gateway_schema_registry_planner.go
@@ -180,13 +180,9 @@ func (p *Planner) planSchemaRegistryCreate(
 		}
 	} else {
 		change.References = map[string]ReferenceInfo{
-			FieldEventGatewayID: {
-				Ref: gatewayRef,
-				ID:  "", // to be resolved at runtime
-				LookupFields: map[string]string{
-					FieldName: gatewayName,
-				},
-			},
+			FieldEventGatewayID: NewPendingLookupRef(gatewayRef, map[string]string{
+				FieldName: gatewayName,
+			}),
 		}
 	}
 

--- a/internal/declarative/planner/event_gateway_static_key_planner.go
+++ b/internal/declarative/planner/event_gateway_static_key_planner.go
@@ -189,13 +189,9 @@ func (p *Planner) planStaticKeyCreate(
 	} else {
 		// Gateway doesn't exist yet, add reference for runtime resolution
 		change.References = map[string]ReferenceInfo{
-			FieldEventGatewayID: {
-				Ref: gatewayRef,
-				ID:  "", // to be resolved at runtime
-				LookupFields: map[string]string{
-					FieldName: gatewayName,
-				},
-			},
+			FieldEventGatewayID: NewPendingLookupRef(gatewayRef, map[string]string{
+				FieldName: gatewayName,
+			}),
 		}
 	}
 

--- a/internal/declarative/planner/event_gateway_tls_trust_bundle_planner.go
+++ b/internal/declarative/planner/event_gateway_tls_trust_bundle_planner.go
@@ -178,13 +178,9 @@ func (p *Planner) planTrustBundleCreate(
 		}
 	} else {
 		change.References = map[string]ReferenceInfo{
-			FieldEventGatewayID: {
-				Ref: gatewayRef,
-				ID:  "", // to be resolved at runtime
-				LookupFields: map[string]string{
-					FieldName: gatewayName,
-				},
-			},
+			FieldEventGatewayID: NewPendingLookupRef(gatewayRef, map[string]string{
+				FieldName: gatewayName,
+			}),
 		}
 	}
 

--- a/internal/declarative/planner/event_gateway_virtual_cluster_planner.go
+++ b/internal/declarative/planner/event_gateway_virtual_cluster_planner.go
@@ -317,13 +317,9 @@ func (p *Planner) planVirtualClusterCreate(
 	} else {
 		// Gateway doesn't exist yet, add reference for runtime resolution
 		change.References = map[string]ReferenceInfo{
-			FieldEventGatewayID: {
-				Ref: gatewayRef,
-				ID:  "", // to be resolved at runtime
-				LookupFields: map[string]string{
-					FieldName: gatewayName,
-				},
-			},
+			FieldEventGatewayID: NewPendingLookupRef(gatewayRef, map[string]string{
+				FieldName: gatewayName,
+			}),
 		}
 	}
 

--- a/internal/declarative/planner/planner.go
+++ b/internal/declarative/planner/planner.go
@@ -380,10 +380,15 @@ func (p *Planner) GeneratePlan(ctx context.Context, rs *resources.ResourceSet, o
 					basePlan.Changes[i].References = make(map[string]ReferenceInfo)
 				}
 				for field, ref := range refs {
-					basePlan.Changes[i].References[field] = ReferenceInfo{
-						Ref: ref.Ref,
-						ID:  ref.ID,
+					existing := basePlan.Changes[i].References[field]
+					var merged ReferenceInfo
+					if ref.ID == RefIDPendingCreation {
+						merged = NewPendingCreationRef(ref.Ref, existing.LookupFields)
+					} else {
+						merged = NewResolvedRef(ref.Ref, ref.ID)
+						merged.LookupFields = existing.LookupFields
 					}
+					basePlan.Changes[i].References[field] = merged
 				}
 				break
 			}

--- a/internal/declarative/planner/portal_planner.go
+++ b/internal/declarative/planner/portal_planner.go
@@ -410,13 +410,12 @@ func (p *portalPlannerImpl) addAuthStrategyReference(change *PlannedChange, port
 		}
 
 		// Add the reference with lookup fields for resolution
-		change.References[FieldDefaultApplicationStrategyID] = ReferenceInfo{
-			Ref: authStrategyValue, // Keep full placeholder for later parsing
-			ID:  "",                // Will be resolved during execution
-			LookupFields: map[string]string{
+		change.References[FieldDefaultApplicationStrategyID] = NewPendingLookupRef(
+			authStrategyValue, // Keep full placeholder for later parsing
+			map[string]string{
 				FieldName: parsedRef, // Use ref as name for lookup
 			},
-		}
+		)
 
 		p.planner.logger.Debug("Added auth strategy reference to portal",
 			"portal_ref", portal.GetRef(),

--- a/internal/declarative/planner/resolver.go
+++ b/internal/declarative/planner/resolver.go
@@ -72,7 +72,7 @@ func (r *ReferenceResolver) ResolveReferences(ctx context.Context, changes []Pla
 				if _, inPlan := createdResources[resourceType][ref]; inPlan {
 					changeRefs[fieldName] = ResolvedReference{
 						Ref: ref,
-						ID:  "[unknown]", // Will be resolved at execution
+						ID:  RefIDPendingCreation, // Will be resolved at execution
 					}
 				} else {
 					// Resolve from existing resources
@@ -198,7 +198,7 @@ func (r *ReferenceResolver) resolveReference(ctx context.Context, resourceType, 
 				konnectID := resource.GetKonnectID()
 				if konnectID == "" {
 					// Resource exists but no Konnect ID (will be created)
-					return "[unknown]", nil // Trigger forward reference
+						return RefIDPendingCreation, nil // Trigger forward reference
 				}
 				return konnectID, nil
 			}

--- a/internal/declarative/planner/resolver.go
+++ b/internal/declarative/planner/resolver.go
@@ -198,7 +198,7 @@ func (r *ReferenceResolver) resolveReference(ctx context.Context, resourceType, 
 				konnectID := resource.GetKonnectID()
 				if konnectID == "" {
 					// Resource exists but no Konnect ID (will be created)
-						return RefIDPendingCreation, nil // Trigger forward reference
+					return RefIDPendingCreation, nil // Trigger forward reference
 				}
 				return konnectID, nil
 			}

--- a/internal/declarative/planner/types.go
+++ b/internal/declarative/planner/types.go
@@ -98,8 +98,10 @@ func (r ReferenceInfo) IsResolved() bool {
 // decide whether runtime lookup or in-plan propagation is still required.
 func (r ReferenceInfo) NeedsResolution() bool { return !r.IsResolved() }
 
-// NewPendingLookupRef creates a ReferenceInfo for a resource that exists in
-// Konnect but whose ID must be resolved by API name lookup at execution time.
+// NewPendingLookupRef creates a ReferenceInfo for a resource whose concrete
+// Konnect ID is not yet available during planning. The executor may resolve it
+// either by API lookup at execution time or via in-plan ref-to-ID propagation
+// when the referenced resource is created earlier in the same plan.
 func NewPendingLookupRef(ref string, lookupFields map[string]string) ReferenceInfo {
 	return ReferenceInfo{Ref: ref, LookupFields: lookupFields}
 }

--- a/internal/declarative/planner/types.go
+++ b/internal/declarative/planner/types.go
@@ -63,11 +63,22 @@ type PostResolutionTarget struct {
 	Selector         *ExternalToolSelector `json:"selector,omitempty"`
 }
 
+// RefIDPendingCreation is set by the ReferenceResolver when a reference points
+// to a resource that will be created within the same plan. The executor
+// propagates the real Konnect UUID after the CREATE change executes.
+// Callers must not set this value directly; use NewPendingCreationRef instead.
+const RefIDPendingCreation = "[unknown]"
+
+// RefIDPendingLookup is the zero value for ReferenceInfo.ID. It indicates
+// that the ID must be resolved by API name lookup at execution time.
+// Callers express this intent by omitting the ID field (NewPendingLookupRef).
+const RefIDPendingLookup = ""
+
 // ReferenceInfo tracks reference resolution
 type ReferenceInfo struct {
 	// Existing fields for single references
 	Ref          string            `json:"ref,omitempty"`
-	ID           string            `json:"id,omitempty"`            // May be "[unknown]" for resources in same plan
+	ID           string            `json:"id,omitempty"`            // RefIDPendingCreation, RefIDPendingLookup, or a UUID
 	LookupFields map[string]string `json:"lookup_fields,omitempty"` // Resource-specific identifying fields
 
 	// New fields for array references
@@ -77,10 +88,49 @@ type ReferenceInfo struct {
 	IsArray      bool                `json:"is_array,omitempty"`      // Flag to indicate array reference
 }
 
+// IsResolved returns true when the reference holds a concrete Konnect UUID that
+// is ready to use. Use this instead of comparing ID to sentinel strings directly.
+func (r ReferenceInfo) IsResolved() bool {
+	return r.ID != RefIDPendingLookup && r.ID != RefIDPendingCreation
+}
+
+// NeedsResolution is the inverse of IsResolved. The executor uses this to
+// decide whether runtime lookup or in-plan propagation is still required.
+func (r ReferenceInfo) NeedsResolution() bool { return !r.IsResolved() }
+
+// NewPendingLookupRef creates a ReferenceInfo for a resource that exists in
+// Konnect but whose ID must be resolved by API name lookup at execution time.
+func NewPendingLookupRef(ref string, lookupFields map[string]string) ReferenceInfo {
+	return ReferenceInfo{Ref: ref, LookupFields: lookupFields}
+}
+
+// NewPendingCreationRef creates a ReferenceInfo for a resource that will be
+// created in the same plan. Only the ReferenceResolver should call this; it
+// sets ID to RefIDPendingCreation so the executor can propagate the real UUID
+// after the CREATE change completes.
+func NewPendingCreationRef(ref string, lookupFields map[string]string) ReferenceInfo {
+	return ReferenceInfo{Ref: ref, ID: RefIDPendingCreation, LookupFields: lookupFields}
+}
+
+// NewResolvedRef creates a ReferenceInfo with a known Konnect UUID.
+func NewResolvedRef(ref, id string) ReferenceInfo {
+	return ReferenceInfo{Ref: ref, ID: id}
+}
+
+// NewArrayRef creates a ReferenceInfo for array-valued reference fields.
+func NewArrayRef(refs []string, lookupArrays map[string][]string) ReferenceInfo {
+	return ReferenceInfo{Refs: refs, IsArray: true, LookupArrays: lookupArrays}
+}
+
 // ParentInfo tracks parent relationships
 type ParentInfo struct {
 	Ref string `json:"ref"`
-	ID  string `json:"id"` // May be "[unknown]" for parents in same plan
+	ID  string `json:"id"` // RefIDPendingCreation, RefIDPendingLookup, or a UUID
+}
+
+// IsResolved returns true when the parent has a concrete Konnect UUID.
+func (p ParentInfo) IsResolved() bool {
+	return p.ID != RefIDPendingLookup && p.ID != RefIDPendingCreation
 }
 
 // ProtectingParentInfo identifies the top-level managed resource whose protection applies to a child change.


### PR DESCRIPTION
Rather than hardcoding ID as "" and "[unknown]", refactoring to use constants, and functions for initialising the types. This will make the code more readable.