### PR TITLE
Feat: Add declarative organization team roles resource support

### DIFF
--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -364,7 +364,8 @@ organization:
      roles:
        - ref: string
          role_name: string
-         entity_id: string (uuid) # prefer: !ref <api-ref> when entity_type_name=APIs
+         # Prefer: !ref <api-ref> when entity_type_name=APIs.
+         entity_id: string (uuid)
          entity_type_name: string
          entity_region: One of (us | eu | au | me | in | sg | *)
 ```
@@ -374,9 +375,11 @@ Organization team roles can also be declared as root resources.
 ```yaml
 organization_team_roles:
   - ref: string
-    team: string required # declarative organization team ref, not team name or UUID
+    # Declarative organization team ref, not team name or UUID.
+    team: string required
     role_name: string
-    entity_id: string (uuid) # prefer: !ref <api-ref> when entity_type_name=APIs
+    # Prefer: !ref <api-ref> when entity_type_name=APIs.
+    entity_id: string (uuid)
     entity_type_name: string
     entity_region: One of (us | eu | au | me | in | sg | *)
 ```

--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -361,7 +361,26 @@ organization:
      description: string (max 250 chars)
      labels: object [string]string
        key: value
+     roles:
+       - ref: string
+         role_name: string
+         entity_id: string (uuid) # prefer: !ref <api-ref> when entity_type_name=APIs
+         entity_type_name: string
+         entity_region: One of (us | eu | au | me | in | sg | *)
 ```
+
+Organization team roles can also be declared as root resources.
+
+```yaml
+organization_team_roles:
+  - ref: string
+    team: string required # declarative organization team ref, not team name or UUID
+    role_name: string
+    entity_id: string (uuid) # prefer: !ref <api-ref> when entity_type_name=APIs
+    entity_type_name: string
+    entity_region: One of (us | eu | au | me | in | sg | *)
+```
+
 ## Portals
 
 [API Specification](https://developer.konghq.com/api/konnect/portal-management/v3/#/operations/create-portal)

--- a/docs/examples/declarative/organization/README.md
+++ b/docs/examples/declarative/organization/README.md
@@ -1,0 +1,39 @@
+# Organization Examples
+
+These examples demonstrate how to manage Konnect organization resources with
+`kongctl` declarative configuration.
+
+## Files
+
+- `teams.yaml` - defines organization teams with namespaces.
+- `team-roles.yaml` - defines organization teams and assigns roles to an API.
+  The example shows both nested `organization.teams[].roles` declarations and
+  root-level `organization_team_roles` declarations.
+
+## Usage
+
+Preview the team role change set:
+
+```bash
+kongctl diff -f team-roles.yaml
+```
+
+Apply the team role configuration:
+
+```bash
+kongctl apply -f team-roles.yaml
+```
+
+Run in sync mode to remove omitted managed role assignments in the namespace:
+
+```bash
+kongctl sync -f team-roles.yaml
+```
+
+Dump organization teams with child role assignments:
+
+```bash
+kongctl dump declarative \
+  --resources=organization.teams,apis \
+  --include-child-resources
+```

--- a/docs/examples/declarative/organization/team-roles.yaml
+++ b/docs/examples/declarative/organization/team-roles.yaml
@@ -1,0 +1,38 @@
+_defaults:
+  kongctl:
+    namespace: organization-team-roles
+
+apis:
+  - ref: products-api
+    name: products-api
+    description: Product catalog API managed by the platform team.
+
+organization:
+  teams:
+    - ref: platform-team
+      name: Platform Engineering
+      description: Engineers who operate shared API platform services.
+      labels:
+        department: engineering
+        focus: platform
+      roles:
+        - ref: platform-products-viewer
+          role_name: Viewer
+          entity_id: !ref products-api#id
+          entity_type_name: APIs
+          entity_region: us
+
+    - ref: api-admins
+      name: API Administrators
+      description: Administrators who manage API lifecycle settings.
+      labels:
+        department: engineering
+        focus: api-governance
+
+organization_team_roles:
+  - ref: api-admins-products-admin
+    team: api-admins
+    role_name: Admin
+    entity_id: !ref products-api#id
+    entity_type_name: APIs
+    entity_region: us

--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -2321,6 +2321,7 @@ func createStateClient(kkClient helpers.SDKAPI) *state.Client {
 		EventGatewayStaticKeyAPI:            kkClient.GetEventGatewayStaticKeyAPI(),
 		EventGatewayTLSTrustBundleAPI:       kkClient.GetEventGatewayTLSTrustBundleAPI(),
 		// Organization APIs
-		OrganizationTeamAPI: kkClient.GetOrganizationTeamAPI(),
+		OrganizationTeamAPI:      kkClient.GetOrganizationTeamAPI(),
+		OrganizationTeamRolesAPI: kkClient.GetOrganizationTeamRolesAPI(),
 	})
 }

--- a/internal/cmd/root/products/konnect/organization/team/interactive_children.go
+++ b/internal/cmd/root/products/konnect/organization/team/interactive_children.go
@@ -13,6 +13,7 @@ import (
 
 func init() {
 	tableview.RegisterChildLoader(common.ViewParentOrganization, common.ViewFieldTeams, loadOrganizationTeams)
+	tableview.RegisterChildLoader(common.ViewParentTeam, common.ViewFieldTeamRoles, loadOrganizationTeamRolesForTeam)
 }
 
 func loadOrganizationTeams(_ context.Context, helper cmd.Helper, parent any) (tableview.ChildView, error) {
@@ -53,6 +54,53 @@ func organizationFromParent(parent any) (*kkComps.MeOrganization, error) {
 		return org, nil
 	case kkComps.MeOrganization:
 		return &org, nil
+	default:
+		return nil, fmt.Errorf("unexpected parent type %T", parent)
+	}
+}
+
+func loadOrganizationTeamRolesForTeam(_ context.Context, helper cmd.Helper, parent any) (tableview.ChildView, error) {
+	team, err := teamFromParent(parent)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+	if team.ID == nil || *team.ID == "" {
+		return tableview.ChildView{}, fmt.Errorf("team ID is required to load roles")
+	}
+
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	roles, err := fetchOrganizationTeamRoles(helper, sdk.GetOrganizationTeamRolesAPI(), *team.ID)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	return buildOrganizationTeamRolesChildView(*team.ID, roles), nil
+}
+
+func teamFromParent(parent any) (*kkComps.Team, error) {
+	if parent == nil {
+		return nil, fmt.Errorf("team parent is nil")
+	}
+
+	switch team := parent.(type) {
+	case *kkComps.Team:
+		return team, nil
+	case kkComps.Team:
+		return &team, nil
 	default:
 		return nil, fmt.Errorf("unexpected parent type %T", parent)
 	}

--- a/internal/cmd/root/products/konnect/organization/team/team.go
+++ b/internal/cmd/root/products/konnect/organization/team/team.go
@@ -45,7 +45,11 @@ func NewTeamCmd(
 
 	// Handle supported verbs
 	if verb == verbs.Get || verb == verbs.List {
-		return newGetTeamCmd(verb, &baseCmd, addParentFlags, parentPreRun).Command, nil
+		cmd := newGetTeamCmd(verb, &baseCmd, addParentFlags, parentPreRun)
+		if rolesCmd := newGetOrganizationTeamRolesCmd(verb, addParentFlags, parentPreRun); rolesCmd != nil {
+			cmd.AddCommand(rolesCmd)
+		}
+		return cmd.Command, nil
 	}
 
 	// Return base command for unsupported verbs

--- a/internal/cmd/root/products/konnect/organization/team/team_roles.go
+++ b/internal/cmd/root/products/konnect/organization/team/team_roles.go
@@ -1,0 +1,224 @@
+package team
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/table"
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/cmd"
+	cmdCommon "github.com/kong/kongctl/internal/cmd/common"
+	"github.com/kong/kongctl/internal/cmd/output/tableview"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
+	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/kong/kongctl/internal/konnect/helpers"
+	"github.com/segmentio/cli"
+	"github.com/spf13/cobra"
+)
+
+const (
+	teamRolesCommandName = "roles"
+	teamIDFlagName       = "team-id"
+	teamNameFlagName     = "team-name"
+)
+
+type organizationTeamRoleRecord struct {
+	ID             string `json:"id"               yaml:"id"`
+	TeamID         string `json:"team_id"          yaml:"team_id"`
+	RoleName       string `json:"role_name"        yaml:"role_name"`
+	EntityID       string `json:"entity_id"        yaml:"entity_id"`
+	EntityTypeName string `json:"entity_type_name" yaml:"entity_type_name"`
+	EntityRegion   string `json:"entity_region"    yaml:"entity_region"`
+}
+
+func newGetOrganizationTeamRolesCmd(
+	verb verbs.VerbValue,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) *cobra.Command {
+	c := &cobra.Command{
+		Use:     teamRolesCommandName,
+		Short:   "List organization team role assignments",
+		Long:    "List role assignments for a Konnect organization team.",
+		PreRunE: parentPreRun,
+		RunE: func(c *cobra.Command, args []string) error {
+			handler := organizationTeamRolesHandler{cmd: c}
+			return handler.run(args)
+		},
+	}
+
+	if addParentFlags != nil {
+		addParentFlags(verb, c)
+	}
+
+	c.Flags().String(teamIDFlagName, "", "Team ID to list roles for")
+	c.Flags().String(teamNameFlagName, "", "Team name to list roles for")
+
+	return c
+}
+
+type organizationTeamRolesHandler struct {
+	cmd *cobra.Command
+}
+
+func (h organizationTeamRolesHandler) run(args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("organization team roles does not accept positional arguments; use --team-id or --team-name")
+	}
+
+	helper := cmd.BuildHelper(h.cmd, args)
+	outType, err := helper.GetOutputFormat()
+	if err != nil {
+		return err
+	}
+
+	printer, err := cli.Format(outType.String(), helper.GetStreams().Out)
+	if err != nil {
+		return err
+	}
+	defer printer.Flush()
+
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return err
+	}
+
+	teamID, _ := h.cmd.Flags().GetString(teamIDFlagName)
+	teamName, _ := h.cmd.Flags().GetString(teamNameFlagName)
+	if strings.TrimSpace(teamID) != "" && strings.TrimSpace(teamName) != "" {
+		return fmt.Errorf("--team-id and --team-name cannot be used together")
+	}
+	if strings.TrimSpace(teamID) == "" && strings.TrimSpace(teamName) == "" {
+		return fmt.Errorf("one of --team-id or --team-name is required")
+	}
+
+	if strings.TrimSpace(teamName) != "" {
+		teams, err := runListByName(teamName, sdk.GetOrganizationTeamAPI(), helper, cfg, false)
+		if err != nil {
+			return err
+		}
+		if len(teams) != 1 {
+			return fmt.Errorf("organization team name %q matched %d teams; use --team-id", teamName, len(teams))
+		}
+		if teams[0].ID == nil || *teams[0].ID == "" {
+			return fmt.Errorf("organization team %q has no ID", teamName)
+		}
+		teamID = *teams[0].ID
+	}
+
+	roles, err := fetchOrganizationTeamRoles(helper, sdk.GetOrganizationTeamRolesAPI(), teamID)
+	if err != nil {
+		return err
+	}
+
+	return renderOrganizationTeamRoles(helper, outType, printer, teamID, roles)
+}
+
+func fetchOrganizationTeamRoles(
+	helper cmd.Helper,
+	roleAPI helpers.OrganizationTeamRolesAPI,
+	teamID string,
+) ([]kkComps.AssignedRole, error) {
+	if roleAPI == nil {
+		return nil, fmt.Errorf("organization team roles client is not available")
+	}
+
+	res, err := roleAPI.ListTeamRoles(helper.GetContext(), teamID, nil)
+	if err != nil {
+		attrs := cmd.TryConvertErrorToAttrs(err)
+		return nil, cmd.PrepareExecutionError("Failed to list organization team roles", err, helper.GetCmd(), attrs...)
+	}
+	if res == nil || res.AssignedRoleCollection == nil {
+		return []kkComps.AssignedRole{}, nil
+	}
+
+	return res.AssignedRoleCollection.Data, nil
+}
+
+func organizationTeamRoleToRecord(role kkComps.AssignedRole, teamID string) organizationTeamRoleRecord {
+	record := organizationTeamRoleRecord{
+		TeamID: teamID,
+	}
+	if role.ID != nil {
+		record.ID = *role.ID
+	}
+	if role.RoleName != nil {
+		record.RoleName = *role.RoleName
+	}
+	if role.EntityID != nil {
+		record.EntityID = *role.EntityID
+	}
+	if role.EntityTypeName != nil {
+		record.EntityTypeName = *role.EntityTypeName
+	}
+	if role.EntityRegion != nil {
+		record.EntityRegion = string(*role.EntityRegion)
+	}
+	return record
+}
+
+func renderOrganizationTeamRoles(
+	helper cmd.Helper,
+	outType cmdCommon.OutputFormat,
+	printer cli.PrintFlusher,
+	teamID string,
+	roles []kkComps.AssignedRole,
+) error {
+	records := make([]organizationTeamRoleRecord, 0, len(roles))
+	for _, role := range roles {
+		records = append(records, organizationTeamRoleToRecord(role, teamID))
+	}
+
+	return tableview.RenderForFormat(helper,
+		false,
+		outType,
+		printer,
+		helper.GetStreams(),
+		records,
+		roles,
+		"",
+		tableview.WithRootLabel("roles"),
+		tableview.WithDetailHelper(helper),
+	)
+}
+
+func buildOrganizationTeamRolesChildView(teamID string, roles []kkComps.AssignedRole) tableview.ChildView {
+	records := make([]organizationTeamRoleRecord, 0, len(roles))
+	rows := make([]table.Row, 0, len(roles))
+	for _, role := range roles {
+		record := organizationTeamRoleToRecord(role, teamID)
+		records = append(records, record)
+		rows = append(rows, table.Row{record.RoleName, record.EntityTypeName, record.EntityRegion})
+	}
+
+	return tableview.ChildView{
+		Headers: []string{"ROLE", "ENTITY TYPE", "REGION"},
+		Rows:    rows,
+		DetailRenderer: func(index int) string {
+			if index < 0 || index >= len(records) {
+				return ""
+			}
+			r := records[index]
+			var b strings.Builder
+			fmt.Fprintf(&b, "id: %s\n", r.ID)
+			fmt.Fprintf(&b, "team_id: %s\n", r.TeamID)
+			fmt.Fprintf(&b, "role_name: %s\n", r.RoleName)
+			fmt.Fprintf(&b, "entity_id: %s\n", r.EntityID)
+			fmt.Fprintf(&b, "entity_type_name: %s\n", r.EntityTypeName)
+			fmt.Fprintf(&b, "entity_region: %s\n", r.EntityRegion)
+			return strings.TrimRight(b.String(), "\n")
+		},
+		Title:      "Roles",
+		ParentType: common.ViewParentTeam,
+	}
+}

--- a/internal/cmd/root/verbs/dump/declarative.go
+++ b/internal/cmd/root/verbs/dump/declarative.go
@@ -206,6 +206,7 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 			EventGatewayStaticKeyAPI:            sdk.GetEventGatewayStaticKeyAPI(),
 			EventGatewayTLSTrustBundleAPI:       sdk.GetEventGatewayTLSTrustBundleAPI(),
 			OrganizationTeamAPI:                 sdk.GetOrganizationTeamAPI(),
+			OrganizationTeamRolesAPI:            sdk.GetOrganizationTeamRolesAPI(),
 		})
 	}
 
@@ -300,6 +301,9 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 			)
 			if err != nil {
 				return err
+			}
+			if opts.includeChildResources {
+				populateOrganizationTeamChildren(ctx, logger, stateClient, teams)
 			}
 			// Wrap teams in organization grouping for the new format
 			if resourceSet.Organization == nil {

--- a/internal/cmd/root/verbs/dump/declarative_children.go
+++ b/internal/cmd/root/verbs/dump/declarative_children.go
@@ -679,6 +679,34 @@ func buildPortalTeams(
 	return results, nil
 }
 
+func populateOrganizationTeamChildren(
+	ctx context.Context,
+	logger *slog.Logger,
+	client *declstate.Client,
+	teams []declresources.OrganizationTeamResource,
+) {
+	for i := range teams {
+		roles, err := client.ListOrganizationTeamRoles(ctx, teams[i].Ref)
+		if err != nil {
+			logWarn(logger, "failed to load organization team roles", teams[i].Ref, teams[i].Name, err)
+			continue
+		}
+		if len(roles) == 0 {
+			continue
+		}
+		teams[i].Roles = make([]declresources.OrganizationTeamRoleResource, 0, len(roles))
+		for _, role := range roles {
+			teams[i].Roles = append(teams[i].Roles, declresources.OrganizationTeamRoleResource{
+				Ref:            role.ID,
+				RoleName:       role.RoleName,
+				EntityID:       role.EntityID,
+				EntityTypeName: role.EntityTypeName,
+				EntityRegion:   role.EntityRegion,
+			})
+		}
+	}
+}
+
 func buildPortalAuthSettings(
 	ctx context.Context,
 	client *declstate.Client,

--- a/internal/cmd/root/verbs/explain/explain_test.go
+++ b/internal/cmd/root/verbs/explain/explain_test.go
@@ -203,3 +203,54 @@ func TestExplainCmd_TextOutputIgnoresConfiguredDefaultJQExpression(t *testing.T)
 	require.NoError(t, err)
 	assert.Contains(t, outBuf.String(), "FIELD\nPATH: portal.description")
 }
+
+func TestExplainCmd_OrganizationTeamResources(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		wantResource string
+	}{
+		{
+			name:         "organization team root alias",
+			path:         "organization_team",
+			wantResource: "organization_team",
+		},
+		{
+			name:         "organization team grouped path",
+			path:         "organization.teams",
+			wantResource: "organization_team",
+		},
+		{
+			name:         "organization team role root alias",
+			path:         "organization_team_role",
+			wantResource: "organization_team_role",
+		},
+		{
+			name:         "organization team role nested path",
+			path:         "organization.teams.roles",
+			wantResource: "organization_team_role",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := newTestRootWithExplain(t, nil)
+
+			var outBuf, errBuf bytes.Buffer
+			streams := &iostreams.IOStreams{Out: &outBuf, ErrOut: &errBuf}
+			root.SetContext(context.WithValue(context.Background(), iostreams.StreamsKey, streams))
+			root.SetOut(&outBuf)
+			root.SetErr(&errBuf)
+			root.SetArgs([]string{
+				"explain", tt.path,
+				"--output", "json",
+				"--jq", `.["x-kongctl-resource"]`,
+				"--jq-raw-output",
+			})
+
+			err := root.Execute()
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantResource+"\n", outBuf.String())
+		})
+	}
+}

--- a/internal/cmd/root/verbs/scaffold/scaffold_test.go
+++ b/internal/cmd/root/verbs/scaffold/scaffold_test.go
@@ -91,3 +91,70 @@ func TestScaffoldCmd_IgnoresConfiguredOutputDefault(t *testing.T) {
 	assert.Contains(t, output.String(), "apis:")
 	assert.Contains(t, output.String(), "ref:")
 }
+
+func TestScaffoldCmd_OrganizationTeamResources(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		contains []string
+	}{
+		{
+			name: "organization team root alias",
+			path: "organization_team",
+			contains: []string{
+				"organization:",
+				"  teams:",
+				"    - ref: my-resource",
+				"      name: my-resource",
+			},
+		},
+		{
+			name: "organization team grouped path",
+			path: "organization.teams",
+			contains: []string{
+				"organization:",
+				"  teams:",
+				"    - ref: my-resource",
+				"      name: my-resource",
+			},
+		},
+		{
+			name: "organization team role root alias",
+			path: "organization_team_role",
+			contains: []string{
+				"organization_team_roles:",
+				"  - ref: my-resource",
+				"    team: value",
+				"    role_name: viewer",
+			},
+		},
+		{
+			name: "organization team role nested path",
+			path: "organization.teams.roles",
+			contains: []string{
+				"organization:",
+				"  teams:",
+				"      roles:",
+				"        - ref: my-resource",
+				"          role_name: viewer",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := newTestRootWithScaffold(t, common.TEXT.String())
+
+			var output bytes.Buffer
+			root.SetOut(&output)
+			root.SetErr(&output)
+			root.SetArgs([]string{"scaffold", tt.path})
+
+			err := root.Execute()
+			require.NoError(t, err)
+			for _, want := range tt.contains {
+				assert.Contains(t, output.String(), want)
+			}
+		})
+	}
+}

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -46,6 +46,7 @@ type Executor struct {
 	catalogServiceExecutor                   *BaseExecutor[kkComps.CreateCatalogService, kkComps.UpdateCatalogService]
 	eventGatewayControlPlaneExecutor         *BaseExecutor[kkComps.CreateGatewayRequest, kkComps.UpdateGatewayRequest]
 	organizationTeamExecutor                 *BaseExecutor[kkComps.CreateTeam, kkComps.UpdateTeam]
+	organizationTeamRoleExecutor             *BaseExecutor[kkComps.AssignRole, kkComps.AssignRole]
 	controlPlaneDataPlaneCertificateExecutor *BaseCreateDeleteExecutor[kkComps.DataPlaneClientCertificateRequest]
 
 	// Event Gateway child resource executors
@@ -185,6 +186,11 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 	)
 	e.organizationTeamExecutor = NewBaseExecutor[kkComps.CreateTeam, kkComps.UpdateTeam](
 		NewOrganizationTeamAdapter(client),
+		client,
+		dryRun,
+	)
+	e.organizationTeamRoleExecutor = NewBaseExecutor[kkComps.AssignRole, kkComps.AssignRole](
+		NewOrganizationTeamRoleAdapter(client),
 		client,
 		dryRun,
 	)
@@ -950,6 +956,39 @@ func (e *Executor) resolvePortalTeamRef(
 	}
 
 	return "", fmt.Errorf("portal team not found: ref=%s, looked up by name=%s", refInfo.Ref, lookupValue)
+}
+
+func (e *Executor) resolveOrganizationTeamRef(ctx context.Context, refInfo planner.ReferenceInfo) (string, error) {
+	if refInfo.ID != "" {
+		return refInfo.ID, nil
+	}
+
+	if teams, ok := e.refToID[planner.ResourceTypeOrganizationTeam]; ok {
+		if id, found := teams[refInfo.Ref]; found && id != "" {
+			return id, nil
+		}
+	}
+
+	lookupValue := refInfo.Ref
+	if refInfo.LookupFields != nil {
+		if name, hasName := refInfo.LookupFields[planner.FieldName]; hasName && name != "" {
+			lookupValue = name
+		}
+	}
+
+	team, err := e.client.GetOrganizationTeamByName(ctx, lookupValue)
+	if err != nil {
+		return "", fmt.Errorf("failed to get organization team by name: %w", err)
+	}
+	if team == nil {
+		return "", fmt.Errorf("organization team not found: ref=%s, looked up by name=%s", refInfo.Ref, lookupValue)
+	}
+
+	if team.ID == nil {
+		return "", fmt.Errorf("organization team %s has no ID", lookupValue)
+	}
+
+	return *team.ID, nil
 }
 
 func (e *Executor) resolveControlPlaneRef(ctx context.Context, refInfo planner.ReferenceInfo) (string, error) {
@@ -2043,6 +2082,25 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 		return e.eventGatewayVirtualClusterExecutor.Create(ctx, *change)
 	case planner.ResourceTypeOrganizationTeam:
 		return e.organizationTeamExecutor.Create(ctx, *change)
+	case planner.ResourceTypeOrganizationTeamRole:
+		if teamRef, ok := change.References[planner.FieldTeamID]; ok && teamRef.ID == "" {
+			teamID, err := e.resolveOrganizationTeamRef(ctx, teamRef)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve organization team reference: %w", err)
+			}
+			teamRef.ID = teamID
+			change.References[planner.FieldTeamID] = teamRef
+		}
+		if entityRef, ok := change.References[planner.FieldEntityID]; ok &&
+			(entityRef.ID == "" || entityRef.ID == "[unknown]") {
+			apiID, err := e.resolveAPIRef(ctx, entityRef)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve entity reference: %w", err)
+			}
+			entityRef.ID = apiID
+			change.References[planner.FieldEntityID] = entityRef
+		}
+		return e.organizationTeamRoleExecutor.Create(ctx, *change)
 
 	case planner.ResourceTypeEventGatewayListener:
 		// Resolve event gateway reference if needed
@@ -2828,6 +2886,16 @@ func (e *Executor) deleteResource(ctx context.Context, change *planner.PlannedCh
 		return e.eventGatewayConsumePolicyExecutor.Delete(ctx, *change)
 	case planner.ResourceTypeOrganizationTeam:
 		return e.organizationTeamExecutor.Delete(ctx, *change)
+	case planner.ResourceTypeOrganizationTeamRole:
+		if teamRef, ok := change.References[planner.FieldTeamID]; ok && teamRef.ID == "" {
+			teamID, err := e.resolveOrganizationTeamRef(ctx, teamRef)
+			if err != nil {
+				return fmt.Errorf("failed to resolve organization team reference: %w", err)
+			}
+			teamRef.ID = teamID
+			change.References[planner.FieldTeamID] = teamRef
+		}
+		return e.organizationTeamRoleExecutor.Delete(ctx, *change)
 	default:
 		return fmt.Errorf("delete operation not yet implemented for %s", change.ResourceType)
 	}

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -976,7 +976,7 @@ func (e *Executor) resolveOrganizationTeamRef(ctx context.Context, refInfo plann
 		}
 	}
 
-	team, err := e.client.GetOrganizationTeamByName(ctx, lookupValue)
+	team, err := e.client.GetOrganizationTeamByNameUnfiltered(ctx, lookupValue)
 	if err != nil {
 		return "", fmt.Errorf("failed to get organization team by name: %w", err)
 	}

--- a/internal/declarative/executor/organization_team_role_adapter.go
+++ b/internal/declarative/executor/organization_team_role_adapter.go
@@ -1,0 +1,204 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/log"
+)
+
+// OrganizationTeamRoleAdapter implements ResourceOperations for organization team roles.
+type OrganizationTeamRoleAdapter struct {
+	client *state.Client
+}
+
+func NewOrganizationTeamRoleAdapter(client *state.Client) *OrganizationTeamRoleAdapter {
+	return &OrganizationTeamRoleAdapter{client: client}
+}
+
+func (o *OrganizationTeamRoleAdapter) MapCreateFields(
+	_ context.Context, execCtx *ExecutionContext, fields map[string]any, create *kkComps.AssignRole,
+) error {
+	roleName, ok := fields[planner.FieldRoleName].(string)
+	if !ok || roleName == "" {
+		return fmt.Errorf("role_name is required")
+	}
+	role := kkComps.RoleName(roleName)
+	create.RoleName = &role
+
+	entityID := ""
+	if execCtx != nil && execCtx.PlannedChange != nil {
+		if refInfo, ok := execCtx.PlannedChange.References[planner.FieldEntityID]; ok && refInfo.ID != "" &&
+			refInfo.ID != "[unknown]" {
+			entityID = refInfo.ID
+		}
+	}
+	if entityID == "" {
+		value, ok := fields[planner.FieldEntityID].(string)
+		if ok && value != "" {
+			entityID = value
+		}
+	}
+	if entityID == "" {
+		return fmt.Errorf("entity_id is required")
+	}
+	create.EntityID = &entityID
+
+	entityTypeName, ok := fields[planner.FieldEntityTypeName].(string)
+	if !ok || entityTypeName == "" {
+		return fmt.Errorf("entity_type_name is required")
+	}
+	entityType := kkComps.EntityTypeName(entityTypeName)
+	create.EntityTypeName = &entityType
+
+	entityRegion, ok := fields[planner.FieldEntityRegion].(string)
+	if !ok || entityRegion == "" {
+		return fmt.Errorf("entity_region is required")
+	}
+	region := kkComps.AssignRoleEntityRegion(entityRegion)
+	create.EntityRegion = &region
+
+	return nil
+}
+
+func (o *OrganizationTeamRoleAdapter) MapUpdateFields(
+	_ context.Context, _ *ExecutionContext, _ map[string]any, _ *kkComps.AssignRole, _ map[string]string,
+) error {
+	return nil
+}
+
+func (o *OrganizationTeamRoleAdapter) Create(
+	ctx context.Context,
+	req kkComps.AssignRole,
+	namespace string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	teamID, err := o.getTeamID(execCtx)
+	if err != nil {
+		return "", err
+	}
+
+	if logger := organizationTeamRoleLogger(ctx); logger != nil {
+		logger.LogAttrs(ctx, slog.LevelDebug, "Assigning organization team role",
+			slog.String("team_id", teamID),
+			slog.String("role_name", getAssignRoleName(req)),
+			slog.String("entity_id", getAssignRoleEntityID(req)),
+		)
+	}
+
+	return o.client.AssignOrganizationTeamRole(ctx, teamID, req, namespace)
+}
+
+func (o *OrganizationTeamRoleAdapter) Update(
+	_ context.Context, _ string, _ kkComps.AssignRole, _ string, _ *ExecutionContext,
+) (string, error) {
+	return "", fmt.Errorf("organization team roles do not support update operations")
+}
+
+func (o *OrganizationTeamRoleAdapter) Delete(ctx context.Context, id string, execCtx *ExecutionContext) error {
+	teamID, err := o.getTeamID(execCtx)
+	if err != nil {
+		return err
+	}
+
+	return o.client.RemoveOrganizationTeamRole(ctx, teamID, id)
+}
+
+func (o *OrganizationTeamRoleAdapter) GetByName(_ context.Context, _ string) (ResourceInfo, error) {
+	return nil, nil
+}
+
+func (o *OrganizationTeamRoleAdapter) GetByID(
+	ctx context.Context, id string, execCtx *ExecutionContext,
+) (ResourceInfo, error) {
+	teamID, err := o.getTeamID(execCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	roles, err := o.client.ListOrganizationTeamRoles(ctx, teamID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list organization team roles: %w", err)
+	}
+	for _, role := range roles {
+		if role.ID == id {
+			return &OrganizationTeamRoleResourceInfo{role: &role}, nil
+		}
+	}
+	return nil, nil
+}
+
+func (o *OrganizationTeamRoleAdapter) ResourceType() string {
+	return planner.ResourceTypeOrganizationTeamRole
+}
+
+func (o *OrganizationTeamRoleAdapter) RequiredFields() []string {
+	return []string{planner.FieldRoleName, planner.FieldEntityID, planner.FieldEntityTypeName, planner.FieldEntityRegion}
+}
+
+func (o *OrganizationTeamRoleAdapter) SupportsUpdate() bool {
+	return false
+}
+
+func (o *OrganizationTeamRoleAdapter) getTeamID(execCtx *ExecutionContext) (string, error) {
+	if execCtx == nil || execCtx.PlannedChange == nil {
+		return "", fmt.Errorf("execution context is required for organization team role operations")
+	}
+
+	change := *execCtx.PlannedChange
+	if teamRef, ok := change.References[planner.FieldTeamID]; ok && teamRef.ID != "" {
+		return teamRef.ID, nil
+	}
+	if change.Parent != nil && change.Parent.ID != "" {
+		return change.Parent.ID, nil
+	}
+
+	return "", fmt.Errorf("team ID is required for organization team role operations")
+}
+
+// OrganizationTeamRoleResourceInfo implements ResourceInfo for organization team roles.
+type OrganizationTeamRoleResourceInfo struct {
+	role *state.OrganizationTeamRole
+}
+
+func (o *OrganizationTeamRoleResourceInfo) GetID() string {
+	return o.role.ID
+}
+
+func (o *OrganizationTeamRoleResourceInfo) GetName() string {
+	return fmt.Sprintf("%s:%s", o.role.RoleName, o.role.EntityID)
+}
+
+func (o *OrganizationTeamRoleResourceInfo) GetLabels() map[string]string {
+	return make(map[string]string)
+}
+
+func (o *OrganizationTeamRoleResourceInfo) GetNormalizedLabels() map[string]string {
+	return make(map[string]string)
+}
+
+func getAssignRoleName(req kkComps.AssignRole) string {
+	if req.RoleName == nil {
+		return ""
+	}
+	return string(*req.RoleName)
+}
+
+func getAssignRoleEntityID(req kkComps.AssignRole) string {
+	if req.EntityID == nil {
+		return ""
+	}
+	return *req.EntityID
+}
+
+func organizationTeamRoleLogger(ctx context.Context) *slog.Logger {
+	if ctx == nil {
+		return nil
+	}
+	logger, _ := ctx.Value(log.LoggerKey).(*slog.Logger)
+	return logger
+}

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -675,28 +675,42 @@ func (l *Loader) applyNamespaceDefaults(rs *resources.ResourceSet, fileDefaults 
 		}
 	}
 
-	// Apply namespace defaults to teams
-	for i := range rs.OrganizationTeams {
-		if rs.OrganizationTeams[i].IsExternal() {
-			if rs.OrganizationTeams[i].Kongctl != nil {
+	assignOrganizationTeamDefaults := func(team *resources.OrganizationTeamResource) error {
+		if team.IsExternal() {
+			if team.Kongctl != nil {
 				return fmt.Errorf(
 					"team '%s' is marked as external and cannot use kongctl metadata",
-					rs.OrganizationTeams[i].Ref,
+					team.Ref,
 				)
 			}
-			continue
+			return nil
 		}
-		if err := assignNamespace(&rs.OrganizationTeams[i].Kongctl, "team", rs.OrganizationTeams[i].Ref); err != nil {
+		if err := assignNamespace(&team.Kongctl, "team", team.Ref); err != nil {
 			return err
 		}
 		// Apply protected default if not set
-		if rs.OrganizationTeams[i].Kongctl.Protected == nil && protectedDefault != nil {
-			rs.OrganizationTeams[i].Kongctl.Protected = protectedDefault
+		if team.Kongctl.Protected == nil && protectedDefault != nil {
+			team.Kongctl.Protected = protectedDefault
 		}
 		// Ensure protected has a value (false if still nil)
-		if rs.OrganizationTeams[i].Kongctl.Protected == nil {
+		if team.Kongctl.Protected == nil {
 			falseVal := false
-			rs.OrganizationTeams[i].Kongctl.Protected = &falseVal
+			team.Kongctl.Protected = &falseVal
+		}
+		return nil
+	}
+
+	// Apply namespace defaults to teams
+	for i := range rs.OrganizationTeams {
+		if err := assignOrganizationTeamDefaults(&rs.OrganizationTeams[i]); err != nil {
+			return err
+		}
+	}
+	if rs.Organization != nil {
+		for i := range rs.Organization.Teams {
+			if err := assignOrganizationTeamDefaults(&rs.Organization.Teams[i]); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -753,7 +767,16 @@ func (l *Loader) extractNestedResources(rs *resources.ResourceSet) {
 	if rs.Organization != nil {
 		org := rs.Organization
 		// Extract organization teams from organization
-		rs.OrganizationTeams = append(rs.OrganizationTeams, org.Teams...)
+		for i := range org.Teams {
+			team := org.Teams[i]
+			for j := range team.Roles {
+				role := team.Roles[j]
+				role.Team = team.Ref
+				rs.OrganizationTeamRoles = append(rs.OrganizationTeamRoles, role)
+			}
+			team.Roles = nil
+			rs.OrganizationTeams = append(rs.OrganizationTeams, team)
+		}
 
 		org.Teams = nil
 	}

--- a/internal/declarative/loader/loader_test.go
+++ b/internal/declarative/loader/loader_test.go
@@ -232,6 +232,44 @@ portals:
 	assert.Nil(t, rs.Portals[0].IPAllowList)
 }
 
+func TestLoader_FlattensOrganizationTeamRoles(t *testing.T) {
+	content := `
+organization:
+  teams:
+    - ref: platform-team
+      name: Platform Engineering
+      roles:
+        - ref: platform-admin
+          role_name: Admin
+          entity_id: "*"
+          entity_type_name: APIs
+          entity_region: us
+organization_team_roles:
+  - ref: platform-viewer
+    team: platform-team
+    role_name: Viewer
+    entity_id: "*"
+    entity_type_name: APIs
+    entity_region: us
+`
+
+	loader := New()
+	rs, err := loader.parseYAML(strings.NewReader(content), "inline", "")
+	require.NoError(t, err)
+
+	require.Len(t, rs.OrganizationTeams, 1)
+	require.Len(t, rs.OrganizationTeamRoles, 2)
+	assert.Empty(t, rs.OrganizationTeams[0].Roles)
+	rolesByRef := map[string]string{}
+	for _, role := range rs.OrganizationTeamRoles {
+		rolesByRef[role.Ref] = role.Team
+	}
+	assert.Equal(t, map[string]string{
+		"platform-admin":  "platform-team",
+		"platform-viewer": "platform-team",
+	}, rolesByRef)
+}
+
 func TestLoader_RejectsSingularPortalIntegrationKey(t *testing.T) {
 	content := `
 portals:

--- a/internal/declarative/loader/namespace_defaults_test.go
+++ b/internal/declarative/loader/namespace_defaults_test.go
@@ -52,6 +52,62 @@ apis:
 		assert.False(t, *rs.APIs[0].Kongctl.Protected)
 	})
 
+	t.Run("organization teams inherit namespace defaults when nested", func(t *testing.T) {
+		yaml := `
+_defaults:
+  kongctl:
+    namespace: organization-team-roles
+
+apis:
+  - ref: products-api
+    name: products-api
+
+organization:
+  teams:
+    - ref: platform-team
+      name: Platform Engineering
+      roles:
+        - ref: platform-products-viewer
+          role_name: Viewer
+          entity_id: !ref products-api#id
+          entity_type_name: APIs
+          entity_region: us
+    - ref: api-admins
+      name: API Administrators
+
+organization_team_roles:
+  - ref: api-admins-products-admin
+    team: api-admins
+    role_name: Admin
+    entity_id: !ref products-api#id
+    entity_type_name: APIs
+    entity_region: us
+`
+		dir := t.TempDir()
+		file := filepath.Join(dir, "test.yaml")
+		require.NoError(t, os.WriteFile(file, []byte(yaml), 0o600))
+
+		l := New()
+		rs, err := l.LoadFile(file)
+		require.NoError(t, err)
+
+		require.Len(t, rs.OrganizationTeams, 2)
+		for _, team := range rs.OrganizationTeams {
+			require.NotNil(t, team.Kongctl)
+			require.NotNil(t, team.Kongctl.Namespace)
+			assert.Equal(t, "organization-team-roles", *team.Kongctl.Namespace)
+			assert.Equal(t, resources.NamespaceOriginFileDefault, team.Kongctl.NamespaceOrigin)
+		}
+
+		roles := rs.GetOrganizationTeamRolesByNamespace("organization-team-roles")
+		require.Len(t, roles, 2)
+		assert.ElementsMatch(t, []string{"platform-products-viewer", "api-admins-products-admin"}, []string{
+			roles[0].Ref,
+			roles[1].Ref,
+		})
+		assert.Empty(t, rs.GetOrganizationTeamRolesByNamespace("default"))
+	})
+
 	t.Run("protected defaults from _defaults section", func(t *testing.T) {
 		yaml := `
 _defaults:

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -108,6 +108,43 @@ func (l *Loader) validateOrganizationTeamRoles(roles []resources.OrganizationTea
 			return fmt.Errorf("duplicate organization_team_role ref: %s", role.GetRef())
 		}
 		roleRefs[role.GetRef()] = true
+
+		if err := l.validateOrganizationTeamRoleReferences(role, rs); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (l *Loader) validateOrganizationTeamRoleReferences(
+	role *resources.OrganizationTeamRoleResource,
+	rs *resources.ResourceSet,
+) error {
+	if resource, found := rs.GetResourceByRef(role.Team); !found {
+		return fmt.Errorf("organization_team_role %q references unknown organization_team: %s",
+			role.GetRef(), role.Team)
+	} else if resource.GetType() != resources.ResourceTypeOrganizationTeam {
+		return fmt.Errorf("organization_team_role %q references %s but expected organization_team: %s",
+			role.GetRef(), resource.GetType(), role.Team)
+	}
+
+	if !tags.IsRefPlaceholder(role.EntityID) {
+		return nil
+	}
+
+	apiRef, _, ok := tags.ParseRefPlaceholder(role.EntityID)
+	if !ok || apiRef == "" {
+		return fmt.Errorf("organization_team_role %q has invalid entity_id reference: %s",
+			role.GetRef(), role.EntityID)
+	}
+
+	if resource, found := rs.GetResourceByRef(apiRef); !found {
+		return fmt.Errorf("organization_team_role %q references unknown api: %s (field: entity_id)",
+			role.GetRef(), apiRef)
+	} else if resource.GetType() != resources.ResourceTypeAPI {
+		return fmt.Errorf("organization_team_role %q references %s but expected api: %s (field: entity_id)",
+			role.GetRef(), resource.GetType(), apiRef)
 	}
 
 	return nil

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -69,6 +69,10 @@ func (l *Loader) validateResourceSet(rs *resources.ResourceSet) error {
 		return err
 	}
 
+	if err := l.validateOrganizationTeamRoles(rs.OrganizationTeamRoles, rs); err != nil {
+		return err
+	}
+
 	// Validate cross-resource references
 	if err := l.validateCrossReferences(rs); err != nil {
 		return err
@@ -77,6 +81,33 @@ func (l *Loader) validateResourceSet(rs *resources.ResourceSet) error {
 	// Validate namespaces
 	if err := l.validateNamespaces(rs); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (l *Loader) validateOrganizationTeamRoles(roles []resources.OrganizationTeamRoleResource,
+	rs *resources.ResourceSet,
+) error {
+	roleRefs := make(map[string]bool)
+
+	for i := range roles {
+		role := &roles[i]
+		if err := role.Validate(); err != nil {
+			return fmt.Errorf("invalid organization_team_role %q: %w", role.GetRef(), err)
+		}
+
+		if existing, found := rs.GetResourceByRef(role.GetRef()); found {
+			if existing.GetType() != resources.ResourceTypeOrganizationTeamRole {
+				return fmt.Errorf("duplicate ref '%s' (already defined as %s)",
+					role.GetRef(), existing.GetType())
+			}
+		}
+
+		if roleRefs[role.GetRef()] {
+			return fmt.Errorf("duplicate organization_team_role ref: %s", role.GetRef())
+		}
+		roleRefs[role.GetRef()] = true
 	}
 
 	return nil

--- a/internal/declarative/loader/validator_test.go
+++ b/internal/declarative/loader/validator_test.go
@@ -6,7 +6,9 @@ import (
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/tags"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoader_validateResourceSet_EmptyResourceSet(t *testing.T) {
@@ -590,6 +592,92 @@ func TestLoader_validateCrossReferences(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestLoader_validateOrganizationTeamRoles_ValidatesReferences(t *testing.T) {
+	loader := New()
+
+	tests := []struct {
+		name        string
+		rs          *resources.ResourceSet
+		expectError string
+	}{
+		{
+			name: "valid team and api refs",
+			rs: &resources.ResourceSet{
+				OrganizationTeams: []resources.OrganizationTeamResource{
+					{
+						BaseResource: resources.BaseResource{Ref: "platform-team"},
+						CreateTeam:   kkComps.CreateTeam{Name: "Platform"},
+					},
+				},
+				APIs: []resources.APIResource{
+					{BaseResource: resources.BaseResource{Ref: "products-api"}},
+				},
+				OrganizationTeamRoles: []resources.OrganizationTeamRoleResource{
+					{
+						Ref:            "platform-admin",
+						Team:           "platform-team",
+						RoleName:       "Admin",
+						EntityID:       tags.RefPlaceholderPrefix + "products-api#id",
+						EntityTypeName: "APIs",
+						EntityRegion:   "us",
+					},
+				},
+			},
+		},
+		{
+			name: "unknown team ref",
+			rs: &resources.ResourceSet{
+				OrganizationTeamRoles: []resources.OrganizationTeamRoleResource{
+					{
+						Ref:            "platform-admin",
+						Team:           "missing-team",
+						RoleName:       "Admin",
+						EntityID:       "*",
+						EntityTypeName: "APIs",
+						EntityRegion:   "us",
+					},
+				},
+			},
+			expectError: `organization_team_role "platform-admin" references unknown organization_team: missing-team`,
+		},
+		{
+			name: "unknown entity api ref",
+			rs: &resources.ResourceSet{
+				OrganizationTeams: []resources.OrganizationTeamResource{
+					{
+						BaseResource: resources.BaseResource{Ref: "platform-team"},
+						CreateTeam:   kkComps.CreateTeam{Name: "Platform"},
+					},
+				},
+				OrganizationTeamRoles: []resources.OrganizationTeamRoleResource{
+					{
+						Ref:            "platform-admin",
+						Team:           "platform-team",
+						RoleName:       "Admin",
+						EntityID:       tags.RefPlaceholderPrefix + "missing-api#id",
+						EntityTypeName: "APIs",
+						EntityRegion:   "us",
+					},
+				},
+			},
+			expectError: `organization_team_role "platform-admin" references unknown api: missing-api (field: entity_id)`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := loader.validateOrganizationTeamRoles(tt.rs.OrganizationTeamRoles, tt.rs)
+			if tt.expectError == "" {
+				assert.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
 		})
 	}
 }

--- a/internal/declarative/planner/base_planner.go
+++ b/internal/declarative/planner/base_planner.go
@@ -167,6 +167,11 @@ func (b *BasePlanner) GetDesiredOrganizationTeams(namespace string) []resources.
 	return b.planner.resources.GetOrganizationTeamsByNamespace(namespace)
 }
 
+// GetDesiredOrganizationTeamRoles returns desired organization_team_role resources from the specified namespace.
+func (b *BasePlanner) GetDesiredOrganizationTeamRoles(namespace string) []resources.OrganizationTeamRoleResource {
+	return b.planner.resources.GetOrganizationTeamRolesByNamespace(namespace)
+}
+
 // GetGenericPlanner returns the generic planner instance
 func (b *BasePlanner) GetGenericPlanner() *GenericPlanner {
 	if b == nil || b.planner == nil {

--- a/internal/declarative/planner/constants.go
+++ b/internal/declarative/planner/constants.go
@@ -214,6 +214,7 @@ const (
 	ResourceTypeEventGatewayStaticKey            = string(resources.ResourceTypeEventGatewayStaticKey)
 	ResourceTypeEventGatewayTLSTrustBundle       = string(resources.ResourceTypeEventGatewayTLSTrustBundle)
 	ResourceTypeOrganizationTeam                 = string(resources.ResourceTypeOrganizationTeam)
+	ResourceTypeOrganizationTeamRole             = string(resources.ResourceTypeOrganizationTeamRole)
 
 	// ResourceTypeDeck represents an internal deck execution step.
 	ResourceTypeDeck = "_deck"

--- a/internal/declarative/planner/organization_team_planner.go
+++ b/internal/declarative/planner/organization_team_planner.go
@@ -224,7 +224,7 @@ func (t *OrganizationTeamPlannerImpl) planOrganizationTeamRoleDeletesForDesired(
 
 	currentRoles, err := t.planner.client.ListOrganizationTeamRoles(ctx, teamID)
 	if err != nil {
-		if strings.Contains(err.Error(), "organization team roles API not configured") {
+		if state.IsAPIClientError(err) {
 			return nil
 		}
 		return fmt.Errorf("failed to list organization team roles for team %s: %w", teamID, err)
@@ -316,7 +316,7 @@ func (t *OrganizationTeamPlannerImpl) planOrganizationTeamRoleChanges(
 		if teamID != "" {
 			currentRoles, err := t.planner.client.ListOrganizationTeamRoles(ctx, teamID)
 			if err != nil {
-				if strings.Contains(err.Error(), "organization team roles API not configured") {
+				if state.IsAPIClientError(err) {
 					return nil
 				}
 				return fmt.Errorf("failed to list organization team roles for team %s: %w", teamID, err)
@@ -426,10 +426,11 @@ func (t *OrganizationTeamPlannerImpl) planOrganizationTeamRoleDelete(
 	role state.OrganizationTeamRole,
 	plan *Plan,
 ) {
+	roleRef := buildOrganizationTeamRoleDeleteRef(teamRef, role)
 	change := PlannedChange{
-		ID:           t.planner.nextChangeID(ActionDelete, ResourceTypeOrganizationTeamRole, role.RoleName),
+		ID:           t.planner.nextChangeID(ActionDelete, ResourceTypeOrganizationTeamRole, roleRef),
 		ResourceType: ResourceTypeOrganizationTeamRole,
-		ResourceRef:  role.RoleName,
+		ResourceRef:  roleRef,
 		ResourceID:   role.ID,
 		Action:       ActionDelete,
 		Fields: map[string]any{
@@ -475,6 +476,14 @@ func (t *OrganizationTeamPlannerImpl) resolveOrganizationTeamRoleEntityID(entity
 
 func buildOrganizationTeamRoleKey(roleName, entityID, entityTypeName, entityRegion string) string {
 	return fmt.Sprintf("%s|%s|%s|%s", roleName, entityID, entityTypeName, strings.ToLower(entityRegion))
+}
+
+func buildOrganizationTeamRoleDeleteRef(teamRef string, role state.OrganizationTeamRole) string {
+	roleKey := buildOrganizationTeamRoleKey(role.RoleName, role.EntityID, role.EntityTypeName, role.EntityRegion)
+	if teamRef == "" {
+		return roleKey
+	}
+	return fmt.Sprintf("%s|%s", teamRef, roleKey)
 }
 
 // extractTeamFields extracts fields from a organization_team resource for planner operations

--- a/internal/declarative/planner/organization_team_planner.go
+++ b/internal/declarative/planner/organization_team_planner.go
@@ -305,6 +305,9 @@ func (t *OrganizationTeamPlannerImpl) planOrganizationTeamRoleChanges(
 		if current, exists := currentByName[teamName]; exists {
 			teamID = util.GetString(current.ID)
 		}
+		if teamID == "" && team.GetKonnectID() != "" {
+			teamID = team.GetKonnectID()
+		}
 		if teamID == "" && team.IsExternal() && team.External.ID != "" {
 			teamID = team.External.ID
 		}

--- a/internal/declarative/planner/organization_team_planner.go
+++ b/internal/declarative/planner/organization_team_planner.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"strings"
 
 	"github.com/kong/kongctl/internal/declarative/labels"
 	"github.com/kong/kongctl/internal/declarative/resources"
 	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/declarative/tags"
 	"github.com/kong/kongctl/internal/util"
 )
 
@@ -82,6 +84,9 @@ func (t *OrganizationTeamPlannerImpl) PlanChanges(ctx context.Context, plannerCt
 			err := t.ValidateProtection(ResourceTypeOrganizationTeam, desiredTeam.Name, isProtected, ActionDelete)
 			protectionErrors.Add(err)
 			if err == nil {
+				if err := t.planOrganizationTeamRoleDeletesForDesired(ctx, namespace, desiredTeam, current, plan); err != nil {
+					return err
+				}
 				t.planOrganizationTeamDelete(current, plan)
 			}
 		}
@@ -161,6 +166,10 @@ func (t *OrganizationTeamPlannerImpl) PlanChanges(ctx context.Context, plannerCt
 		}
 	}
 
+	if err := t.planOrganizationTeamRoleChanges(ctx, namespace, desired, currentByName, plan); err != nil {
+		return err
+	}
+
 	// Check for managed resources to delete (sync mode only)
 	if plan.Metadata.Mode == PlanModeSync {
 		// Build set of desired team names
@@ -189,6 +198,271 @@ func (t *OrganizationTeamPlannerImpl) PlanChanges(ctx context.Context, plannerCt
 	}
 
 	return nil
+}
+
+func (t *OrganizationTeamPlannerImpl) planOrganizationTeamRoleDeletesForDesired(
+	ctx context.Context,
+	namespace string,
+	team resources.OrganizationTeamResource,
+	current state.OrganizationTeam,
+	plan *Plan,
+) error {
+	teamID := util.GetString(current.ID)
+	if teamID == "" {
+		return nil
+	}
+
+	var desiredRoles []resources.OrganizationTeamRoleResource
+	for _, role := range t.GetDesiredOrganizationTeamRoles(namespace) {
+		if role.Team == team.Ref {
+			desiredRoles = append(desiredRoles, role)
+		}
+	}
+	if len(desiredRoles) == 0 {
+		return nil
+	}
+
+	currentRoles, err := t.planner.client.ListOrganizationTeamRoles(ctx, teamID)
+	if err != nil {
+		if strings.Contains(err.Error(), "organization team roles API not configured") {
+			return nil
+		}
+		return fmt.Errorf("failed to list organization team roles for team %s: %w", teamID, err)
+	}
+
+	currentByKey := make(map[string]state.OrganizationTeamRole)
+	for _, role := range currentRoles {
+		key := buildOrganizationTeamRoleKey(role.RoleName, role.EntityID, role.EntityTypeName, role.EntityRegion)
+		currentByKey[key] = role
+	}
+	for _, desiredRole := range desiredRoles {
+		key := buildOrganizationTeamRoleKey(
+			desiredRole.RoleName,
+			t.resolveOrganizationTeamRoleEntityID(desiredRole.EntityID),
+			desiredRole.EntityTypeName,
+			desiredRole.EntityRegion,
+		)
+		if currentRole, ok := currentByKey[key]; ok {
+			t.planOrganizationTeamRoleDelete(namespace, team.Ref, team.Name, teamID, currentRole, plan)
+		}
+	}
+
+	return nil
+}
+
+func (t *OrganizationTeamPlannerImpl) planOrganizationTeamRoleChanges(
+	ctx context.Context,
+	namespace string,
+	desiredTeams []resources.OrganizationTeamResource,
+	currentByName map[string]state.OrganizationTeam,
+	plan *Plan,
+) error {
+	desiredRoles := t.GetDesiredOrganizationTeamRoles(namespace)
+	if len(desiredRoles) == 0 && plan.Metadata.Mode != PlanModeSync {
+		return nil
+	}
+
+	rolesByTeam := make(map[string][]resources.OrganizationTeamRoleResource)
+	for _, role := range desiredRoles {
+		rolesByTeam[role.Team] = append(rolesByTeam[role.Team], role)
+	}
+
+	teamByRef := make(map[string]resources.OrganizationTeamResource)
+	for _, team := range desiredTeams {
+		teamByRef[team.Ref] = team
+		if plan.Metadata.Mode == PlanModeSync && !team.IsExternal() {
+			if _, ok := rolesByTeam[team.Ref]; !ok {
+				rolesByTeam[team.Ref] = []resources.OrganizationTeamRoleResource{}
+			}
+		}
+	}
+
+	teamsDeleted := make(map[string]bool)
+	for _, change := range plan.Changes {
+		if change.ResourceType == ResourceTypeOrganizationTeam && change.Action == ActionDelete {
+			teamsDeleted[change.ResourceRef] = true
+		}
+	}
+
+	for teamRef, roles := range rolesByTeam {
+		if teamsDeleted[teamRef] {
+			continue
+		}
+
+		team, ok := teamByRef[teamRef]
+		if !ok {
+			continue
+		}
+
+		teamName := team.Name
+		teamID := ""
+		if current, exists := currentByName[teamName]; exists {
+			teamID = util.GetString(current.ID)
+		}
+
+		existingRoles := make(map[string]state.OrganizationTeamRole)
+		if teamID != "" {
+			currentRoles, err := t.planner.client.ListOrganizationTeamRoles(ctx, teamID)
+			if err != nil {
+				if strings.Contains(err.Error(), "organization team roles API not configured") {
+					return nil
+				}
+				return fmt.Errorf("failed to list organization team roles for team %s: %w", teamID, err)
+			}
+			for _, role := range currentRoles {
+				key := buildOrganizationTeamRoleKey(role.RoleName, role.EntityID, role.EntityTypeName, role.EntityRegion)
+				existingRoles[key] = role
+			}
+		}
+
+		desiredKeys := make(map[string]bool)
+		for _, role := range roles {
+			key := buildOrganizationTeamRoleKey(
+				role.RoleName,
+				t.resolveOrganizationTeamRoleEntityID(role.EntityID),
+				role.EntityTypeName,
+				role.EntityRegion,
+			)
+			if desiredKeys[key] {
+				return fmt.Errorf("duplicate organization team role assignment %q for team %q", key, teamRef)
+			}
+			desiredKeys[key] = true
+
+			if _, exists := existingRoles[key]; exists {
+				continue
+			}
+
+			t.planOrganizationTeamRoleCreate(namespace, teamRef, teamName, teamID, role, plan)
+		}
+
+		if plan.Metadata.Mode == PlanModeSync && teamID != "" && !team.IsExternal() {
+			for key, existingRole := range existingRoles {
+				if !desiredKeys[key] {
+					t.planOrganizationTeamRoleDelete(namespace, teamRef, teamName, teamID, existingRole, plan)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (t *OrganizationTeamPlannerImpl) planOrganizationTeamRoleCreate(
+	namespace string,
+	teamRef string,
+	teamName string,
+	teamID string,
+	role resources.OrganizationTeamRoleResource,
+	plan *Plan,
+) {
+	dependencies := []string{}
+	if teamChangeID := findChangeID(plan, ResourceTypeOrganizationTeam, teamRef); teamChangeID != "" {
+		dependencies = append(dependencies, teamChangeID)
+	}
+	if tags.IsRefPlaceholder(role.EntityID) {
+		if apiRef, _, ok := tags.ParseRefPlaceholder(role.EntityID); ok {
+			if apiChangeID := findChangeID(plan, string(resources.ResourceTypeAPI), apiRef); apiChangeID != "" {
+				dependencies = append(dependencies, apiChangeID)
+			}
+		}
+	}
+
+	refs := map[string]ReferenceInfo{
+		FieldTeamID: {
+			Ref: role.Team,
+			LookupFields: map[string]string{
+				FieldName: teamName,
+			},
+		},
+	}
+	if teamID != "" {
+		refs[FieldTeamID] = ReferenceInfo{
+			Ref: role.Team,
+			ID:  teamID,
+			LookupFields: map[string]string{
+				FieldName: teamName,
+			},
+		}
+	}
+	if tags.IsRefPlaceholder(role.EntityID) {
+		refs[FieldEntityID] = ReferenceInfo{Ref: role.EntityID}
+	}
+
+	change := PlannedChange{
+		ID:           t.planner.nextChangeID(ActionCreate, ResourceTypeOrganizationTeamRole, role.GetRef()),
+		ResourceType: ResourceTypeOrganizationTeamRole,
+		ResourceRef:  role.GetRef(),
+		Action:       ActionCreate,
+		Fields: map[string]any{
+			FieldRoleName:       role.RoleName,
+			FieldEntityID:       role.EntityID,
+			FieldEntityTypeName: role.EntityTypeName,
+			FieldEntityRegion:   role.EntityRegion,
+		},
+		DependsOn:  dependencies,
+		Namespace:  namespace,
+		References: refs,
+	}
+	plan.AddChange(change)
+}
+
+func (t *OrganizationTeamPlannerImpl) planOrganizationTeamRoleDelete(
+	namespace string,
+	teamRef string,
+	teamName string,
+	teamID string,
+	role state.OrganizationTeamRole,
+	plan *Plan,
+) {
+	change := PlannedChange{
+		ID:           t.planner.nextChangeID(ActionDelete, ResourceTypeOrganizationTeamRole, role.RoleName),
+		ResourceType: ResourceTypeOrganizationTeamRole,
+		ResourceRef:  role.RoleName,
+		ResourceID:   role.ID,
+		Action:       ActionDelete,
+		Fields: map[string]any{
+			FieldRoleName:       role.RoleName,
+			FieldEntityID:       role.EntityID,
+			FieldEntityTypeName: role.EntityTypeName,
+			FieldEntityRegion:   role.EntityRegion,
+		},
+		Namespace: namespace,
+		References: map[string]ReferenceInfo{
+			FieldTeamID: {
+				Ref: teamRef,
+				ID:  teamID,
+				LookupFields: map[string]string{
+					FieldName: teamName,
+				},
+			},
+		},
+		Parent: &ParentInfo{
+			Ref: teamRef,
+			ID:  teamID,
+		},
+	}
+	plan.AddChange(change)
+}
+
+func (t *OrganizationTeamPlannerImpl) resolveOrganizationTeamRoleEntityID(entityID string) string {
+	if t.planner.resources == nil || !tags.IsRefPlaceholder(entityID) {
+		return entityID
+	}
+
+	ref, field, ok := tags.ParseRefPlaceholder(entityID)
+	if !ok || (field != "" && field != FieldID && field != "ID") {
+		return entityID
+	}
+
+	if api := t.planner.resources.GetAPIByRef(ref); api != nil && api.GetKonnectID() != "" {
+		return api.GetKonnectID()
+	}
+
+	return entityID
+}
+
+func buildOrganizationTeamRoleKey(roleName, entityID, entityTypeName, entityRegion string) string {
+	return fmt.Sprintf("%s|%s|%s|%s", roleName, entityID, entityTypeName, strings.ToLower(entityRegion))
 }
 
 // extractTeamFields extracts fields from a organization_team resource for planner operations

--- a/internal/declarative/planner/organization_team_planner.go
+++ b/internal/declarative/planner/organization_team_planner.go
@@ -295,9 +295,18 @@ func (t *OrganizationTeamPlannerImpl) planOrganizationTeamRoleChanges(
 		}
 
 		teamName := team.Name
+		if team.IsExternal() && team.External.Selector != nil {
+			if selectorName := team.External.Selector.MatchFields[FieldName]; selectorName != "" {
+				teamName = selectorName
+			}
+		}
+
 		teamID := ""
 		if current, exists := currentByName[teamName]; exists {
 			teamID = util.GetString(current.ID)
+		}
+		if teamID == "" && team.IsExternal() && team.External.ID != "" {
+			teamID = team.External.ID
 		}
 
 		existingRoles := make(map[string]state.OrganizationTeamRole)

--- a/internal/declarative/planner/organization_team_planner_test.go
+++ b/internal/declarative/planner/organization_team_planner_test.go
@@ -1,0 +1,35 @@
+package planner
+
+import (
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrganizationTeamExternalConfigContributesExternalNamespace(t *testing.T) {
+	planner := &Planner{}
+	rs := &resources.ResourceSet{
+		OrganizationTeams: []resources.OrganizationTeamResource{
+			{
+				BaseResource: resources.BaseResource{Ref: "external-team"},
+				CreateTeam:   kkComps.CreateTeam{Name: "External Team"},
+				External:     &resources.ExternalBlock{ID: "team-123"},
+			},
+		},
+		OrganizationTeamRoles: []resources.OrganizationTeamRoleResource{
+			{
+				Ref:            "external-team-admin",
+				Team:           "external-team",
+				RoleName:       "Admin",
+				EntityID:       "*",
+				EntityTypeName: "APIs",
+				EntityRegion:   "us",
+			},
+		},
+	}
+
+	namespaces := planner.getResourceNamespaces(rs)
+	require.Equal(t, []string{resources.NamespaceExternal}, namespaces)
+}

--- a/internal/declarative/planner/organization_team_planner_test.go
+++ b/internal/declarative/planner/organization_team_planner_test.go
@@ -5,6 +5,7 @@ import (
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,4 +33,45 @@ func TestOrganizationTeamExternalConfigContributesExternalNamespace(t *testing.T
 
 	namespaces := planner.getResourceNamespaces(rs)
 	require.Equal(t, []string{resources.NamespaceExternal}, namespaces)
+}
+
+func TestOrganizationTeamRoleDeleteUsesUniqueCompositeRef(t *testing.T) {
+	planner := NewPlanner(nil, nil)
+	teamPlanner := NewOrganizationTeamPlanner(NewBasePlanner(planner)).(*OrganizationTeamPlannerImpl)
+	plan := NewPlan("1.0", "test", PlanModeSync)
+
+	teamPlanner.planOrganizationTeamRoleDelete(
+		"default",
+		"api-admins",
+		"API Admins",
+		"team-123",
+		state.OrganizationTeamRole{
+			ID:             "role-1",
+			RoleName:       "Admin",
+			EntityID:       "api-1",
+			EntityTypeName: "APIs",
+			EntityRegion:   "us",
+		},
+		plan,
+	)
+	teamPlanner.planOrganizationTeamRoleDelete(
+		"default",
+		"api-admins",
+		"API Admins",
+		"team-123",
+		state.OrganizationTeamRole{
+			ID:             "role-2",
+			RoleName:       "Admin",
+			EntityID:       "api-2",
+			EntityTypeName: "APIs",
+			EntityRegion:   "us",
+		},
+		plan,
+	)
+
+	require.Len(t, plan.Changes, 2)
+	require.NotEqual(t, plan.Changes[0].ResourceRef, plan.Changes[1].ResourceRef)
+	require.NotEqual(t, plan.Changes[0].ID, plan.Changes[1].ID)
+	require.Equal(t, "api-admins|Admin|api-1|APIs|us", plan.Changes[0].ResourceRef)
+	require.Equal(t, "api-admins|Admin|api-2|APIs|us", plan.Changes[1].ResourceRef)
 }

--- a/internal/declarative/planner/planner.go
+++ b/internal/declarative/planner/planner.go
@@ -1881,6 +1881,7 @@ func (p *Planner) resolveAuthStrategyIdentities(
 func (p *Planner) getResourceNamespaces(rs *resources.ResourceSet) []string {
 	namespaceSet := make(map[string]bool)
 	hasExternalPortals := false
+	hasExternalOrganizationTeams := false
 
 	// Extract namespaces from parent resources
 	for _, portal := range rs.Portals {
@@ -1924,6 +1925,7 @@ func (p *Planner) getResourceNamespaces(rs *resources.ResourceSet) []string {
 
 	for _, team := range rs.OrganizationTeams {
 		if team.IsExternal() {
+			hasExternalOrganizationTeams = true
 			continue
 		}
 		ns := resources.GetNamespace(team.Kongctl)
@@ -1939,7 +1941,7 @@ func (p *Planner) getResourceNamespaces(rs *resources.ResourceSet) []string {
 	// Sort for consistent processing order
 	sort.Strings(namespaces)
 
-	if hasExternalPortals {
+	if hasExternalPortals || hasExternalOrganizationTeams {
 		namespaces = append(namespaces, resources.NamespaceExternal)
 	}
 

--- a/internal/declarative/planner/planner.go
+++ b/internal/declarative/planner/planner.go
@@ -815,6 +815,10 @@ func (p *Planner) resolveResourceIdentities(ctx context.Context, rs *resources.R
 		return fmt.Errorf("failed to resolve portal identities: %w", err)
 	}
 
+	if err := p.resolveOrganizationTeamIdentities(ctx, rs.OrganizationTeams); err != nil {
+		return fmt.Errorf("failed to resolve organization team identities: %w", err)
+	}
+
 	// Resolve Auth Strategy identities
 	if err := p.resolveAuthStrategyIdentities(ctx, rs.ApplicationAuthStrategies); err != nil {
 		return fmt.Errorf("failed to resolve auth strategy identities: %w", err)
@@ -1796,6 +1800,57 @@ func (p *Planner) resolvePortalIdentities(ctx context.Context, portals []resourc
 			// Match found, update the resource
 			portal.TryMatchKonnectResource(konnectPortal)
 		}
+	}
+
+	return nil
+}
+
+func (p *Planner) resolveOrganizationTeamIdentities(
+	ctx context.Context,
+	teams []resources.OrganizationTeamResource,
+) error {
+	for i := range teams {
+		team := &teams[i]
+		if !team.IsExternal() || team.GetKonnectID() != "" {
+			continue
+		}
+
+		if team.External.ID != "" {
+			konnectTeam, err := p.client.GetOrganizationTeamByID(ctx, team.External.ID)
+			if err != nil {
+				return fmt.Errorf("failed to get external organization team %s by ID: %w", team.GetRef(), err)
+			}
+			if konnectTeam == nil {
+				return fmt.Errorf("external organization team not found with ID: %s", team.External.ID)
+			}
+
+			team.SetKonnectID(team.External.ID)
+			if konnectTeam.Name != nil && *konnectTeam.Name != "" {
+				team.Name = *konnectTeam.Name
+			}
+			continue
+		}
+
+		if team.External.Selector == nil {
+			continue
+		}
+
+		name, ok := team.External.Selector.MatchFields[FieldName]
+		if !ok || name == "" {
+			return fmt.Errorf("external organization team %s: only 'name' field selector is currently supported",
+				team.GetRef())
+		}
+
+		konnectTeam, err := p.client.GetOrganizationTeamByNameUnfiltered(ctx, name)
+		if err != nil {
+			return fmt.Errorf("failed to get external organization team %s by name: %w", team.GetRef(), err)
+		}
+		if konnectTeam == nil || konnectTeam.ID == nil || *konnectTeam.ID == "" {
+			return fmt.Errorf("external organization team not found with name: %s", name)
+		}
+
+		team.SetKonnectID(*konnectTeam.ID)
+		team.Name = name
 	}
 
 	return nil

--- a/internal/declarative/planner/planner.go
+++ b/internal/declarative/planner/planner.go
@@ -85,6 +85,7 @@ type Planner struct {
 	desiredPortalSnippets          []resources.PortalSnippetResource
 	desiredPortalTeams             []resources.PortalTeamResource
 	desiredPortalTeamRoles         []resources.PortalTeamRoleResource
+	desiredOrganizationTeamRoles   []resources.OrganizationTeamRoleResource
 	desiredPortalCustomizations    []resources.PortalCustomizationResource
 	desiredPortalAuthSettings      []resources.PortalAuthSettingsResource
 	desiredPortalIPAllowLists      []resources.PortalIPAllowListResource
@@ -230,6 +231,7 @@ func (p *Planner) GeneratePlan(ctx context.Context, rs *resources.ResourceSet, o
 		namespacePlanner.desiredPortalSnippets = rs.PortalSnippets
 		namespacePlanner.desiredPortalTeams = rs.PortalTeams
 		namespacePlanner.desiredPortalTeamRoles = rs.PortalTeamRoles
+		namespacePlanner.desiredOrganizationTeamRoles = rs.OrganizationTeamRoles
 		namespacePlanner.desiredPortalCustomizations = rs.PortalCustomizations
 		namespacePlanner.desiredPortalAuthSettings = rs.PortalAuthSettings
 		namespacePlanner.desiredPortalIPAllowLists = rs.PortalIPAllowLists
@@ -390,8 +392,8 @@ func (p *Planner) GeneratePlan(ctx context.Context, rs *resources.ResourceSet, o
 		}
 	}
 
-	// Ensure portal team roles depend on referenced APIs created in the same plan
-	adjustPortalTeamRoleDependencies(basePlan)
+	// Ensure team roles depend on referenced APIs created in the same plan
+	adjustTeamRoleDependencies(basePlan)
 
 	// Resolve dependencies and calculate execution order
 	// Inject additional dependency constraints that span resource planners

--- a/internal/declarative/planner/team_role_dependencies.go
+++ b/internal/declarative/planner/team_role_dependencies.go
@@ -5,9 +5,9 @@ import (
 	"github.com/kong/kongctl/internal/declarative/tags"
 )
 
-// adjustPortalTeamRoleDependencies wires portal_team_role changes to depend on API creations
-// when the entity_id is a reference placeholder pointing to an API being created in the same plan.
-func adjustPortalTeamRoleDependencies(plan *Plan) {
+// adjustTeamRoleDependencies wires team role changes to depend on API creations when
+// entity_id is a reference placeholder pointing to an API being created in the same plan.
+func adjustTeamRoleDependencies(plan *Plan) {
 	if plan == nil {
 		return
 	}
@@ -20,7 +20,7 @@ func adjustPortalTeamRoleDependencies(plan *Plan) {
 
 	for i := range plan.Changes {
 		change := &plan.Changes[i]
-		if change.ResourceType != ResourceTypePortalTeamRole {
+		if change.ResourceType != ResourceTypePortalTeamRole && change.ResourceType != ResourceTypeOrganizationTeamRole {
 			continue
 		}
 

--- a/internal/declarative/planner/team_role_dependencies.go
+++ b/internal/declarative/planner/team_role_dependencies.go
@@ -12,6 +12,13 @@ func adjustTeamRoleDependencies(plan *Plan) {
 		return
 	}
 
+	adjustTeamRoleCreateDependencies(plan)
+	adjustTeamRoleDeleteDependencies(plan)
+}
+
+// adjustTeamRoleCreateDependencies wires team role changes to depend on API creations when
+// entity_id is a reference placeholder pointing to an API being created in the same plan.
+func adjustTeamRoleCreateDependencies(plan *Plan) {
 	changeByKey := make(map[string]string) // resource_type|ref -> changeID
 	for _, change := range plan.Changes {
 		key := change.ResourceType + "|" + change.ResourceRef
@@ -46,4 +53,73 @@ func adjustTeamRoleDependencies(plan *Plan) {
 			}
 		}
 	}
+}
+
+// adjustTeamRoleDeleteDependencies ensures team role assignments are removed
+// before deleting the parent team or the API referenced by the role assignment.
+func adjustTeamRoleDeleteDependencies(plan *Plan) {
+	var roleDeletes []*PlannedChange
+	for i := range plan.Changes {
+		change := &plan.Changes[i]
+		if change.Action != ActionDelete {
+			continue
+		}
+		if change.ResourceType != ResourceTypeOrganizationTeamRole && change.ResourceType != ResourceTypePortalTeamRole {
+			continue
+		}
+		roleDeletes = append(roleDeletes, change)
+	}
+
+	if len(roleDeletes) == 0 {
+		return
+	}
+
+	for i := range plan.Changes {
+		change := &plan.Changes[i]
+		if change.Action != ActionDelete {
+			continue
+		}
+
+		switch change.ResourceType {
+		case ResourceTypeOrganizationTeam, ResourceTypePortalTeam:
+			for _, roleDelete := range roleDeletes {
+				if teamRoleBelongsToTeam(roleDelete, change.ResourceID) {
+					change.DependsOn = appendDependsOn(change.DependsOn, roleDelete.ID)
+				}
+			}
+		case ResourceTypeAPI:
+			for _, roleDelete := range roleDeletes {
+				if teamRoleReferencesEntity(roleDelete, change.ResourceID) {
+					change.DependsOn = appendDependsOn(change.DependsOn, roleDelete.ID)
+				}
+			}
+		}
+	}
+}
+
+func teamRoleBelongsToTeam(roleDelete *PlannedChange, teamID string) bool {
+	if roleDelete == nil || teamID == "" {
+		return false
+	}
+
+	if roleDelete.Parent != nil && roleDelete.Parent.ID == teamID {
+		return true
+	}
+
+	refInfo, ok := roleDelete.References[FieldTeamID]
+	return ok && refInfo.ID == teamID
+}
+
+func teamRoleReferencesEntity(roleDelete *PlannedChange, entityID string) bool {
+	if roleDelete == nil || entityID == "" {
+		return false
+	}
+
+	value, ok := roleDelete.Fields[FieldEntityID]
+	if !ok {
+		return false
+	}
+
+	entity, ok := value.(string)
+	return ok && entity == entityID
 }

--- a/internal/declarative/planner/team_role_dependencies_test.go
+++ b/internal/declarative/planner/team_role_dependencies_test.go
@@ -1,0 +1,106 @@
+package planner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdjustTeamRoleDeleteDependencies(t *testing.T) {
+	plan := NewPlan("1.0", "test", PlanModeDelete)
+	plan.AddChange(PlannedChange{
+		ID:           "3:d:api:org-team-roles-api",
+		ResourceType: ResourceTypeAPI,
+		ResourceRef:  "org-team-roles-api",
+		ResourceID:   "api-id",
+		Action:       ActionDelete,
+	})
+	plan.AddChange(PlannedChange{
+		ID:           "4:d:organization_team_role:Admin",
+		ResourceType: ResourceTypeOrganizationTeamRole,
+		ResourceRef:  "Admin",
+		ResourceID:   "admin-role-id",
+		Action:       ActionDelete,
+		Fields: map[string]any{
+			FieldEntityID: "api-id",
+		},
+		References: map[string]ReferenceInfo{
+			FieldTeamID: {
+				Ref: "platform-role-team",
+				ID:  "team-id",
+			},
+		},
+		Parent: &ParentInfo{
+			Ref: "platform-role-team",
+			ID:  "team-id",
+		},
+	})
+	plan.AddChange(PlannedChange{
+		ID:           "1:d:organization_team_role:Viewer",
+		ResourceType: ResourceTypeOrganizationTeamRole,
+		ResourceRef:  "Viewer",
+		ResourceID:   "viewer-role-id",
+		Action:       ActionDelete,
+		Fields: map[string]any{
+			FieldEntityID: "api-id",
+		},
+		References: map[string]ReferenceInfo{
+			FieldTeamID: {
+				Ref: "platform-role-team",
+				ID:  "team-id",
+			},
+		},
+		Parent: &ParentInfo{
+			Ref: "platform-role-team",
+			ID:  "team-id",
+		},
+	})
+	plan.AddChange(PlannedChange{
+		ID:           "2:d:organization_team:Platform Role Team",
+		ResourceType: ResourceTypeOrganizationTeam,
+		ResourceRef:  "Platform Role Team",
+		ResourceID:   "team-id",
+		Action:       ActionDelete,
+	})
+
+	adjustTeamRoleDependencies(plan)
+
+	apiDelete := findPlannedChange(t, plan, "3:d:api:org-team-roles-api")
+	teamDelete := findPlannedChange(t, plan, "2:d:organization_team:Platform Role Team")
+	require.ElementsMatch(t, []string{
+		"1:d:organization_team_role:Viewer",
+		"4:d:organization_team_role:Admin",
+	}, apiDelete.DependsOn)
+	require.ElementsMatch(t, []string{
+		"1:d:organization_team_role:Viewer",
+		"4:d:organization_team_role:Admin",
+	}, teamDelete.DependsOn)
+
+	order, err := NewDependencyResolver().ResolveDependencies(plan.Changes)
+	require.NoError(t, err)
+
+	viewerIndex := findChangeIndex(order, "1:d:organization_team_role:Viewer")
+	adminIndex := findChangeIndex(order, "4:d:organization_team_role:Admin")
+	apiIndex := findChangeIndex(order, "3:d:api:org-team-roles-api")
+	teamIndex := findChangeIndex(order, "2:d:organization_team:Platform Role Team")
+	require.NotEqual(t, -1, viewerIndex)
+	require.NotEqual(t, -1, adminIndex)
+	require.NotEqual(t, -1, apiIndex)
+	require.NotEqual(t, -1, teamIndex)
+	require.Less(t, viewerIndex, apiIndex)
+	require.Less(t, adminIndex, apiIndex)
+	require.Less(t, viewerIndex, teamIndex)
+	require.Less(t, adminIndex, teamIndex)
+}
+
+func findPlannedChange(t *testing.T, plan *Plan, id string) PlannedChange {
+	t.Helper()
+
+	for _, change := range plan.Changes {
+		if change.ID == id {
+			return change
+		}
+	}
+	t.Fatalf("planned change %q not found", id)
+	return PlannedChange{}
+}

--- a/internal/declarative/protection/lookup.go
+++ b/internal/declarative/protection/lookup.go
@@ -125,6 +125,7 @@ func IsManagedResourceProtected(
 		resources.ResourceTypePortalEmailTemplate,
 		resources.ResourceTypePortalAuditLogWebhook,
 		resources.ResourceTypeAuditLogWebhookDestination,
+		resources.ResourceTypeOrganizationTeamRole,
 		resources.ResourceTypeTeam,
 		resources.ResourceTypeEventGatewayBackendCluster,
 		resources.ResourceTypeEventGatewayVirtualCluster,

--- a/internal/declarative/resources/explain.go
+++ b/internal/declarative/resources/explain.go
@@ -281,6 +281,10 @@ func ResolveExplainSubject(path string) (*ExplainSubject, error) {
 	}
 
 	segments := strings.Split(path, ".")
+	if strings.TrimSpace(segments[0]) == "organization" {
+		return resolveOrganizationExplainSubject(path, segments)
+	}
+
 	doc, ok := explainDocByAlias(strings.TrimSpace(segments[0]))
 	if !ok {
 		return nil, fmt.Errorf("unsupported resource path %q", path)
@@ -302,6 +306,11 @@ func ResolveExplainSubject(path string) (*ExplainSubject, error) {
 	}
 
 	if len(segments) == 1 {
+		if doc.ResourceType == ResourceTypeOrganizationTeam {
+			if err := applyOrganizationTeamScaffold(subject); err != nil {
+				return nil, err
+			}
+		}
 		if !doc.SupportsRoot && len(doc.ParentRelations) > 0 {
 			relation := doc.ParentRelations[0]
 			subject.ScaffoldSteps = append(subject.ScaffoldSteps,
@@ -387,6 +396,130 @@ func ResolveExplainSubject(path string) (*ExplainSubject, error) {
 	subject.ScaffoldOmit = scaffoldOmitFields(ancestors)
 
 	return subject, nil
+}
+
+func resolveOrganizationExplainSubject(path string, segments []string) (*ExplainSubject, error) {
+	if len(segments) < 2 || strings.TrimSpace(segments[1]) != "teams" {
+		return nil, fmt.Errorf("unsupported resource path %q", path)
+	}
+
+	teamDoc, ok := explainDocByType(ResourceTypeOrganizationTeam)
+	if !ok {
+		return nil, fmt.Errorf("resource type %q does not have explain registration", ResourceTypeOrganizationTeam)
+	}
+
+	organizationNode, err := organizationExplainNode()
+	if err != nil {
+		return nil, err
+	}
+
+	subject := &ExplainSubject{
+		Doc:            teamDoc,
+		Node:           teamDoc.Schema.clone(),
+		DisplayPath:    path,
+		ResourceTarget: true,
+		FieldPath:      []string{"teams"},
+		ScaffoldSteps: []ExplainScaffoldStep{
+			{Name: "organization"},
+			{Name: "teams", Array: true},
+		},
+		ScaffoldTrail: []ExplainScaffoldNode{
+			{
+				Step: ExplainScaffoldStep{Name: "organization"},
+				Node: organizationNode,
+			},
+			{
+				Step: ExplainScaffoldStep{Name: "teams", Array: true},
+				Node: teamDoc.Schema.clone(),
+			},
+		},
+	}
+
+	if len(segments) == 2 {
+		subject.ScaffoldOmit = scaffoldOmitFields(nil)
+		return subject, nil
+	}
+
+	currentDoc := teamDoc
+	currentNode := subject.Node
+	var ancestors []ResourceType
+	var relativePath []string
+	for _, rawSegment := range segments[2:] {
+		segment := strings.TrimSpace(rawSegment)
+		field, ok := currentNode.property(segment)
+		if !ok {
+			return nil, fmt.Errorf("field %q not found in %q", segment, path)
+		}
+
+		nextNode := field.Node
+		resourceTarget := false
+		if nextNode.Kind == "array" && nextNode.Items != nil && nextNode.Items.Kind == explainKindObject {
+			nextNode = nextNode.Items.clone()
+			resourceTarget = true
+		} else {
+			nextNode = nextNode.clone()
+		}
+
+		subject.FieldPath = append(subject.FieldPath, segment)
+		relativePath = append(relativePath, segment)
+		subject.FieldRelativePath = append([]string(nil), relativePath...)
+		subject.FieldRequired = field.Required
+		subject.FieldRecommended = field.Recommended
+		currentNode = nextNode
+
+		if childType, ok := currentDoc.nestedFields[segment]; ok {
+			if childDoc, ok := explainDocByType(childType); ok {
+				subject.ScaffoldSteps = append(subject.ScaffoldSteps, ExplainScaffoldStep{Name: segment, Array: true})
+				ancestors = append(ancestors, currentDoc.ResourceType)
+				subject.ScaffoldTrail = append(subject.ScaffoldTrail, ExplainScaffoldNode{
+					Step: ExplainScaffoldStep{Name: segment, Array: true},
+					Node: childDoc.Schema.clone(),
+					Omit: scaffoldOmitFields(ancestors),
+				})
+				currentDoc = childDoc
+				currentNode = childDoc.Schema.clone()
+				resourceTarget = true
+				relativePath = nil
+				subject.FieldRelativePath = nil
+			}
+		}
+
+		subject.Node = currentNode
+		subject.ResourceTarget = resourceTarget
+	}
+
+	subject.Doc = currentDoc
+	subject.AncestorTypes = ancestors
+	subject.ScaffoldOmit = scaffoldOmitFields(ancestors)
+
+	return subject, nil
+}
+
+func applyOrganizationTeamScaffold(subject *ExplainSubject) error {
+	organizationNode, err := organizationExplainNode()
+	if err != nil {
+		return err
+	}
+
+	subject.ScaffoldSteps = []ExplainScaffoldStep{
+		{Name: "organization"},
+		{Name: "teams", Array: true},
+	}
+	subject.ScaffoldTrail = []ExplainScaffoldNode{
+		{
+			Step: ExplainScaffoldStep{Name: "organization"},
+			Node: organizationNode,
+		},
+		{
+			Step: ExplainScaffoldStep{Name: "teams", Array: true},
+			Node: subject.Doc.Schema.clone(),
+		},
+	}
+	return nil
+}
+
+func organizationExplainNode() (*ExplainNode, error) {
+	return autoExplainNode(reflect.TypeFor[OrganizationResource](), nil, defaultExplainHints(""), nil)
 }
 
 func explainDocByAlias(alias string) (*ExplainDoc, bool) {
@@ -1139,7 +1272,11 @@ func renderScaffoldTrail(write scaffoldWriter, trail []ExplainScaffoldNode, dept
 		renderScaffoldObject(write, current.Node, depth+1, omit, false)
 	}
 	if len(trail) > 1 {
-		renderNestedTrail(write, trail[1:], depth+2)
+		nextDepth := depth + 2
+		if !current.Step.Array {
+			nextDepth = depth + 1
+		}
+		renderNestedTrail(write, trail[1:], nextDepth)
 	}
 }
 

--- a/internal/declarative/resources/explain_test.go
+++ b/internal/declarative/resources/explain_test.go
@@ -34,6 +34,36 @@ func TestResolveExplainSubject_NestedChildResource(t *testing.T) {
 	assert.Equal(t, []ResourceType{ResourceTypeAPI}, subject.AncestorTypes)
 }
 
+func TestResolveExplainSubject_OrganizationTeamsGroupedResource(t *testing.T) {
+	subject, err := ResolveExplainSubject("organization.teams")
+	require.NoError(t, err)
+
+	assert.Equal(t, "organization.teams", subject.DisplayPath)
+	assert.Equal(t, ResourceTypeOrganizationTeam, subject.Doc.ResourceType)
+	assert.True(t, subject.ResourceTarget)
+	assert.Equal(t, []string{"teams"}, subject.FieldPath)
+	assert.Equal(t, []ExplainScaffoldStep{
+		{Name: "organization"},
+		{Name: "teams", Array: true},
+	}, subject.ScaffoldSteps)
+}
+
+func TestResolveExplainSubject_OrganizationTeamRolesNestedResource(t *testing.T) {
+	subject, err := ResolveExplainSubject("organization.teams.roles")
+	require.NoError(t, err)
+
+	assert.Equal(t, "organization.teams.roles", subject.DisplayPath)
+	assert.Equal(t, ResourceTypeOrganizationTeamRole, subject.Doc.ResourceType)
+	assert.True(t, subject.ResourceTarget)
+	assert.Equal(t, []string{"teams", "roles"}, subject.FieldPath)
+	assert.Equal(t, []ResourceType{ResourceTypeOrganizationTeam}, subject.AncestorTypes)
+	assert.Equal(t, []ExplainScaffoldStep{
+		{Name: "organization"},
+		{Name: "teams", Array: true},
+		{Name: "roles", Array: true},
+	}, subject.ScaffoldSteps)
+}
+
 func TestResolveExplainSubject_FieldPath(t *testing.T) {
 	subject, err := ResolveExplainSubject("api.publications.portal_id")
 	require.NoError(t, err)
@@ -237,4 +267,33 @@ func TestRenderScaffoldYAML_NestedChildResource(t *testing.T) {
 	assert.Contains(t, scaffold, "- ref: my-resource")
 	assert.NotContains(t, scaffold, "api: value")
 	assert.NotContains(t, scaffold, "kongctl:")
+}
+
+func TestRenderScaffoldYAML_OrganizationTeamResource(t *testing.T) {
+	subject, err := ResolveExplainSubject("organization_team")
+	require.NoError(t, err)
+
+	scaffold, err := RenderScaffoldYAML(subject)
+	require.NoError(t, err)
+
+	assert.Contains(t, scaffold, "organization:")
+	assert.Contains(t, scaffold, "  teams:")
+	assert.Contains(t, scaffold, "    - ref: my-resource")
+	assert.Contains(t, scaffold, "      name: my-resource")
+}
+
+func TestRenderScaffoldYAML_OrganizationTeamRoleNestedResource(t *testing.T) {
+	subject, err := ResolveExplainSubject("organization.teams.roles")
+	require.NoError(t, err)
+
+	scaffold, err := RenderScaffoldYAML(subject)
+	require.NoError(t, err)
+
+	assert.Contains(t, scaffold, "organization:")
+	assert.Contains(t, scaffold, "  teams:")
+	assert.Contains(t, scaffold, "    - ref: my-resource")
+	assert.Contains(t, scaffold, "      roles:")
+	assert.Contains(t, scaffold, "        - ref: my-resource")
+	assert.Contains(t, scaffold, "          role_name: viewer")
+	assert.NotContains(t, scaffold, "team: value")
 }

--- a/internal/declarative/resources/organization_team.go
+++ b/internal/declarative/resources/organization_team.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"encoding/json"
 	"fmt"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
@@ -18,7 +19,38 @@ func init() {
 type OrganizationTeamResource struct {
 	BaseResource
 	kkComps.CreateTeam `               yaml:",inline"             json:",inline"`
-	External           *ExternalBlock `yaml:"_external,omitempty" json:"_external,omitempty"`
+	External           *ExternalBlock                 `yaml:"_external,omitempty" json:"_external,omitempty"`
+	Roles              []OrganizationTeamRoleResource `yaml:"roles,omitempty"     json:"roles,omitempty"`
+}
+
+func (t OrganizationTeamResource) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.organizationTeamAlias())
+}
+
+func (t OrganizationTeamResource) MarshalYAML() (any, error) {
+	return t.organizationTeamAlias(), nil
+}
+
+type organizationTeamAlias struct {
+	Ref         string                         `json:"ref"                 yaml:"ref"`
+	Kongctl     *KongctlMeta                   `json:"kongctl,omitempty"   yaml:"kongctl,omitempty"`
+	External    *ExternalBlock                 `json:"_external,omitempty" yaml:"_external,omitempty"`
+	Name        string                         `json:"name"                yaml:"name"`
+	Description *string                        `json:"description,omitempty" yaml:"description,omitempty"`
+	Labels      map[string]string              `json:"labels,omitempty"    yaml:"labels,omitempty"`
+	Roles       []OrganizationTeamRoleResource `json:"roles,omitempty"     yaml:"roles,omitempty"`
+}
+
+func (t OrganizationTeamResource) organizationTeamAlias() organizationTeamAlias {
+	return organizationTeamAlias{
+		Ref:         t.Ref,
+		Kongctl:     t.Kongctl,
+		External:    t.External,
+		Name:        t.Name,
+		Description: t.Description,
+		Labels:      t.Labels,
+		Roles:       t.Roles,
+	}
 }
 
 // GetReferenceFieldMappings returns the field mappings for reference validation
@@ -41,6 +73,17 @@ func (t OrganizationTeamResource) Validate() error {
 			return fmt.Errorf("invalid _external block: %w", err)
 		}
 	}
+
+	roleRefs := make(map[string]bool)
+	for i, role := range t.Roles {
+		if err := role.Validate(); err != nil {
+			return fmt.Errorf("invalid team role %d: %w", i, err)
+		}
+		if roleRefs[role.GetRef()] {
+			return fmt.Errorf("duplicate team role ref: %s", role.GetRef())
+		}
+		roleRefs[role.GetRef()] = true
+	}
 	return nil
 }
 
@@ -49,6 +92,9 @@ func (t *OrganizationTeamResource) SetDefaults() {
 	// If Name is not set, use ref as default
 	if t.Name == "" {
 		t.Name = t.Ref
+	}
+	for i := range t.Roles {
+		t.Roles[i].SetDefaults()
 	}
 }
 

--- a/internal/declarative/resources/organization_team_role.go
+++ b/internal/declarative/resources/organization_team_role.go
@@ -12,7 +12,9 @@ func init() {
 	registerResourceType(
 		ResourceTypeOrganizationTeamRole,
 		func(rs *ResourceSet) *[]OrganizationTeamRoleResource { return &rs.OrganizationTeamRoles },
-		AutoExplain[OrganizationTeamRoleResource](),
+		AutoExplain[OrganizationTeamRoleResource](
+			WithExplainRecommendedFields("team"),
+		),
 	)
 }
 

--- a/internal/declarative/resources/organization_team_role.go
+++ b/internal/declarative/resources/organization_team_role.go
@@ -1,0 +1,199 @@
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/kong/kongctl/internal/declarative/tags"
+)
+
+func init() {
+	registerResourceType(
+		ResourceTypeOrganizationTeamRole,
+		func(rs *ResourceSet) *[]OrganizationTeamRoleResource { return &rs.OrganizationTeamRoles },
+		AutoExplain[OrganizationTeamRoleResource](),
+	)
+}
+
+// OrganizationTeamRoleResource represents an assigned role on an organization team.
+// This is a child resource (no kongctl metadata support).
+type OrganizationTeamRoleResource struct {
+	Ref string `yaml:"ref" json:"ref"`
+
+	// Parent team reference.
+	Team string `yaml:"team,omitempty" json:"team,omitempty"`
+
+	RoleName       string `yaml:"role_name"        json:"role_name"`
+	EntityID       string `yaml:"entity_id"        json:"entity_id"`
+	EntityTypeName string `yaml:"entity_type_name" json:"entity_type_name"`
+	EntityRegion   string `yaml:"entity_region"    json:"entity_region"`
+
+	konnectID string `yaml:"-" json:"-"`
+}
+
+func (r OrganizationTeamRoleResource) MarshalJSON() ([]byte, error) {
+	type alias struct {
+		Ref            string `json:"ref"`
+		Team           string `json:"team,omitempty"`
+		RoleName       string `json:"role_name"`
+		EntityID       string `json:"entity_id"`
+		EntityTypeName string `json:"entity_type_name"`
+		EntityRegion   string `json:"entity_region"`
+	}
+
+	return json.Marshal(alias{
+		Ref:            r.Ref,
+		Team:           r.Team,
+		RoleName:       r.RoleName,
+		EntityID:       r.EntityID,
+		EntityTypeName: r.EntityTypeName,
+		EntityRegion:   r.EntityRegion,
+	})
+}
+
+func (r OrganizationTeamRoleResource) MarshalYAML() (any, error) {
+	type alias struct {
+		Ref            string `json:"ref" yaml:"ref"`
+		Team           string `json:"team,omitempty" yaml:"team,omitempty"`
+		RoleName       string `json:"role_name" yaml:"role_name"`
+		EntityID       string `json:"entity_id" yaml:"entity_id"`
+		EntityTypeName string `json:"entity_type_name" yaml:"entity_type_name"`
+		EntityRegion   string `json:"entity_region" yaml:"entity_region"`
+	}
+
+	return alias{
+		Ref:            r.Ref,
+		Team:           r.Team,
+		RoleName:       r.RoleName,
+		EntityID:       r.EntityID,
+		EntityTypeName: r.EntityTypeName,
+		EntityRegion:   r.EntityRegion,
+	}, nil
+}
+
+func (r OrganizationTeamRoleResource) GetType() ResourceType {
+	return ResourceTypeOrganizationTeamRole
+}
+
+func (r OrganizationTeamRoleResource) GetRef() string {
+	return r.Ref
+}
+
+func (r OrganizationTeamRoleResource) GetMoniker() string {
+	return fmt.Sprintf("%s:%s:%s:%s", r.RoleName, r.EntityID, r.EntityTypeName, r.EntityRegion)
+}
+
+func (r OrganizationTeamRoleResource) GetDependencies() []ResourceRef {
+	deps := []ResourceRef{}
+
+	if r.Team != "" {
+		deps = append(deps, ResourceRef{
+			Kind: ResourceTypeOrganizationTeam,
+			Ref:  r.Team,
+		})
+	}
+
+	if tags.IsRefPlaceholder(r.EntityID) {
+		if ref, _, ok := tags.ParseRefPlaceholder(r.EntityID); ok && ref != "" {
+			deps = append(deps, ResourceRef{
+				Kind: ResourceTypeAPI,
+				Ref:  ref,
+			})
+		}
+	}
+
+	return deps
+}
+
+func (r OrganizationTeamRoleResource) Validate() error {
+	if err := ValidateRef(r.Ref); err != nil {
+		return fmt.Errorf("invalid organization team role ref: %w", err)
+	}
+	if r.Team == "" {
+		return fmt.Errorf("team is required")
+	}
+	if r.RoleName == "" {
+		return fmt.Errorf("role_name is required")
+	}
+	if r.EntityID == "" {
+		return fmt.Errorf("entity_id is required")
+	}
+	if r.EntityTypeName == "" {
+		return fmt.Errorf("entity_type_name is required")
+	}
+	if r.EntityRegion == "" {
+		return fmt.Errorf("entity_region is required")
+	}
+	return nil
+}
+
+func (r *OrganizationTeamRoleResource) SetDefaults() {}
+
+func (r OrganizationTeamRoleResource) GetKonnectID() string {
+	return r.konnectID
+}
+
+func (r OrganizationTeamRoleResource) GetKonnectMonikerFilter() string {
+	return ""
+}
+
+func (r *OrganizationTeamRoleResource) TryMatchKonnectResource(konnectResource any) bool {
+	role, ok := konnectResource.(map[string]any)
+	if !ok {
+		return false
+	}
+
+	roleName, _ := role["role_name"].(string)
+	entityID, _ := role["entity_id"].(string)
+	entityTypeName, _ := role["entity_type_name"].(string)
+	entityRegion, _ := role["entity_region"].(string)
+
+	if roleName == r.RoleName &&
+		entityID == r.EntityID &&
+		entityTypeName == r.EntityTypeName &&
+		strings.EqualFold(entityRegion, r.EntityRegion) {
+		if id, ok := role["id"].(string); ok {
+			r.konnectID = id
+		}
+		return true
+	}
+
+	return false
+}
+
+func (r OrganizationTeamRoleResource) GetParentRef() *ResourceRef {
+	if r.Team != "" {
+		return &ResourceRef{Kind: ResourceTypeOrganizationTeam, Ref: r.Team}
+	}
+	return nil
+}
+
+func (r *OrganizationTeamRoleResource) UnmarshalJSON(data []byte) error {
+	var temp struct {
+		Ref            string `json:"ref"`
+		Team           string `json:"team,omitempty"`
+		RoleName       string `json:"role_name"`
+		EntityID       string `json:"entity_id"`
+		EntityTypeName string `json:"entity_type_name"`
+		EntityRegion   string `json:"entity_region"`
+		Kongctl        any    `json:"kongctl,omitempty"`
+	}
+
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return err
+	}
+
+	if temp.Kongctl != nil {
+		return fmt.Errorf("kongctl metadata not supported on child resources (organization team roles)")
+	}
+
+	r.Ref = temp.Ref
+	r.Team = temp.Team
+	r.RoleName = temp.RoleName
+	r.EntityID = temp.EntityID
+	r.EntityTypeName = temp.EntityTypeName
+	r.EntityRegion = temp.EntityRegion
+
+	return nil
+}

--- a/internal/declarative/resources/organization_team_role_test.go
+++ b/internal/declarative/resources/organization_team_role_test.go
@@ -1,0 +1,41 @@
+package resources
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrganizationTeamRoleValidate(t *testing.T) {
+	role := OrganizationTeamRoleResource{
+		Ref:            "platform-admin",
+		Team:           "platform-team",
+		RoleName:       "Admin",
+		EntityID:       "*",
+		EntityTypeName: "APIs",
+		EntityRegion:   "us",
+	}
+
+	require.NoError(t, role.Validate())
+
+	role.EntityRegion = ""
+	assert.EqualError(t, role.Validate(), "entity_region is required")
+}
+
+func TestOrganizationTeamRoleRejectsKongctlMetadata(t *testing.T) {
+	var role OrganizationTeamRoleResource
+	err := json.Unmarshal([]byte(`{
+		"ref": "platform-admin",
+		"team": "platform-team",
+		"role_name": "Admin",
+		"entity_id": "*",
+		"entity_type_name": "APIs",
+		"entity_region": "us",
+		"kongctl": {"namespace": "team-a"}
+	}`), &role)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "kongctl metadata not supported")
+}

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -40,6 +40,7 @@ const (
 	ResourceTypeEventGatewayBackendCluster       ResourceType = "event_gateway_backend_cluster"
 	ResourceTypeEventGatewayVirtualCluster       ResourceType = "event_gateway_virtual_cluster"
 	ResourceTypeOrganizationTeam                 ResourceType = "organization_team"
+	ResourceTypeOrganizationTeamRole             ResourceType = "organization_team_role"
 	ResourceTypeTeam                             ResourceType = "team"
 	ResourceTypeEventGatewayListener             ResourceType = "event_gateway_listener"
 	ResourceTypeEventGatewayListenerPolicy       ResourceType = "event_gateway_listener_policy"
@@ -106,6 +107,7 @@ type ResourceSet struct {
 	// Teams is populated internally from OrganizationTeams during loading
 	// It is not exposed in YAML/JSON to enforce the organization grouping format
 	OrganizationTeams                 []OrganizationTeamResource                 `yaml:"-" json:"-"`
+	OrganizationTeamRoles             []OrganizationTeamRoleResource             `yaml:"organization_team_roles,omitempty" json:"organization_team_roles,omitempty"`                                               //nolint:lll
 	EventGatewayListeners             []EventGatewayListenerResource             `yaml:"event_gateway_listeners,omitempty" json:"event_gateway_listeners,omitempty"`                                               //nolint:lll
 	EventGatewayListenerPolicies      []EventGatewayListenerPolicyResource       `yaml:"event_gateway_listener_policies,omitempty" json:"event_gateway_listener_policies,omitempty"`                               //nolint:lll
 	EventGatewayClusterPolicies       []EventGatewayClusterPolicyResource        `yaml:"event_gateway_virtual_cluster_cluster_policies,omitempty" json:"event_gateway_virtual_cluster_cluster_policies,omitempty"` //nolint:lll
@@ -704,6 +706,30 @@ func (rs *ResourceSet) GetOrganizationTeamsByNamespace(namespace string) []Organ
 		}
 		if GetNamespace(team.Kongctl) == namespace {
 			filtered = append(filtered, team)
+		}
+	}
+	return filtered
+}
+
+// GetOrganizationTeamRolesByNamespace returns all organization_team_role resources from the specified namespace.
+func (rs *ResourceSet) GetOrganizationTeamRolesByNamespace(namespace string) []OrganizationTeamRoleResource {
+	teamByRef := make(map[string]OrganizationTeamResource)
+	for _, team := range rs.OrganizationTeams {
+		teamByRef[team.Ref] = team
+	}
+
+	var filtered []OrganizationTeamRoleResource
+	for _, role := range rs.OrganizationTeamRoles {
+		if team, ok := teamByRef[role.Team]; ok {
+			if team.IsExternal() {
+				if namespace == NamespaceExternal {
+					filtered = append(filtered, role)
+				}
+				continue
+			}
+			if GetNamespace(team.Kongctl) == namespace {
+				filtered = append(filtered, role)
+			}
 		}
 	}
 	return filtered

--- a/internal/declarative/state/cache.go
+++ b/internal/declarative/state/cache.go
@@ -205,3 +205,13 @@ type PortalTeamRole struct {
 	TeamID         string
 	PortalID       string
 }
+
+// OrganizationTeamRole represents an assigned role for an organization team.
+type OrganizationTeamRole struct {
+	ID             string
+	RoleName       string
+	EntityID       string
+	EntityTypeName string
+	EntityRegion   string
+	TeamID         string
+}

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -4691,6 +4691,62 @@ func (c *Client) ListManagedOrganizationTeams(ctx context.Context, namespaces []
 	return PaginateAll(ctx, lister)
 }
 
+// GetOrganizationTeamByNameUnfiltered finds an organization team by name without requiring kongctl-managed labels.
+func (c *Client) GetOrganizationTeamByNameUnfiltered(ctx context.Context, name string) (*OrganizationTeam, error) {
+	if err := ValidateAPIClient(c.organizationTeamAPI, "organization team API"); err != nil {
+		return nil, err
+	}
+
+	lister := func(ctx context.Context, pageSize, pageNumber int64) ([]OrganizationTeam, *PageMeta, error) {
+		req := kkOps.ListTeamsRequest{
+			PageSize:   &pageSize,
+			PageNumber: &pageNumber,
+		}
+
+		resp, err := c.organizationTeamAPI.ListOrganizationTeams(ctx, req)
+		if err != nil {
+			return nil, nil, WrapAPIError(err, "list teams", nil)
+		}
+
+		if resp.TeamCollection == nil {
+			return []OrganizationTeam{}, &PageMeta{Total: 0}, nil
+		}
+
+		teams := make([]OrganizationTeam, 0, len(resp.TeamCollection.Data))
+		for _, t := range resp.TeamCollection.Data {
+			normalized := t.Labels
+			if normalized == nil {
+				normalized = make(map[string]string)
+			}
+
+			teams = append(teams, OrganizationTeam{
+				Team:             t,
+				NormalizedLabels: normalized,
+			})
+		}
+
+		total := 0.0
+		if resp.TeamCollection.Meta != nil {
+			total = resp.TeamCollection.Meta.Page.Total
+		}
+
+		return teams, &PageMeta{Total: total}, nil
+	}
+
+	teams, err := PaginateAll(ctx, lister)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, t := range teams {
+		if t.Name != nil && *t.Name == name {
+			return &t, nil
+		}
+	}
+
+	return nil, nil
+}
+
 // GetOrganizationTeamByName finds a managed organization team by name
 func (c *Client) GetOrganizationTeamByName(ctx context.Context, name string) (*OrganizationTeam, error) {
 	// Search across all namespaces for backward compatibility

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -4247,8 +4247,8 @@ func (c *Client) RemovePortalTeamRole(ctx context.Context, portalID string, team
 
 // ListOrganizationTeamRoles returns all assigned roles for an organization team.
 func (c *Client) ListOrganizationTeamRoles(ctx context.Context, teamID string) ([]OrganizationTeamRole, error) {
-	if c.organizationTeamRolesAPI == nil {
-		return nil, fmt.Errorf("organization team roles API not configured")
+	if err := ValidateAPIClient(c.organizationTeamRolesAPI, "organization team roles API"); err != nil {
+		return nil, err
 	}
 
 	resp, err := c.organizationTeamRolesAPI.ListTeamRoles(ctx, teamID, nil)
@@ -4288,8 +4288,8 @@ func (c *Client) AssignOrganizationTeamRole(
 	req kkComps.AssignRole,
 	namespace string,
 ) (string, error) {
-	if c.organizationTeamRolesAPI == nil {
-		return "", fmt.Errorf("organization team roles API not configured")
+	if err := ValidateAPIClient(c.organizationTeamRolesAPI, "organization team roles API"); err != nil {
+		return "", err
 	}
 
 	resp, err := c.organizationTeamRolesAPI.TeamsAssignRole(ctx, teamID, &req)
@@ -4311,8 +4311,8 @@ func (c *Client) AssignOrganizationTeamRole(
 
 // RemoveOrganizationTeamRole removes an assigned role from an organization team.
 func (c *Client) RemoveOrganizationTeamRole(ctx context.Context, teamID string, roleID string) error {
-	if c.organizationTeamRolesAPI == nil {
-		return fmt.Errorf("organization team roles API not configured")
+	if err := ValidateAPIClient(c.organizationTeamRolesAPI, "organization team roles API"); err != nil {
+		return err
 	}
 
 	_, err := c.organizationTeamRolesAPI.TeamsRemoveRole(ctx, teamID, roleID)

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -75,7 +75,8 @@ type ClientConfig struct {
 	EventGatewayTLSTrustBundleAPI       helpers.EventGatewayTLSTrustBundleAPI
 
 	// Identity resources
-	OrganizationTeamAPI helpers.OrganizationTeamAPI
+	OrganizationTeamAPI      helpers.OrganizationTeamAPI
+	OrganizationTeamRolesAPI helpers.OrganizationTeamRolesAPI
 }
 
 // Client wraps Konnect SDK for state management
@@ -130,7 +131,8 @@ type Client struct {
 	eventGatewayTLSTrustBundleAPI       helpers.EventGatewayTLSTrustBundleAPI
 
 	// Organization resource APIs
-	organizationTeamAPI helpers.OrganizationTeamAPI
+	organizationTeamAPI      helpers.OrganizationTeamAPI
+	organizationTeamRolesAPI helpers.OrganizationTeamRolesAPI
 }
 
 // NewClient creates a new state client with the provided configuration
@@ -184,7 +186,8 @@ func NewClient(config ClientConfig) *Client {
 		eventGatewayTLSTrustBundleAPI:       config.EventGatewayTLSTrustBundleAPI,
 
 		// Identity resource APIs
-		organizationTeamAPI: config.OrganizationTeamAPI,
+		organizationTeamAPI:      config.OrganizationTeamAPI,
+		organizationTeamRolesAPI: config.OrganizationTeamRolesAPI,
 	}
 }
 
@@ -4242,6 +4245,87 @@ func (c *Client) RemovePortalTeamRole(ctx context.Context, portalID string, team
 	return nil
 }
 
+// ListOrganizationTeamRoles returns all assigned roles for an organization team.
+func (c *Client) ListOrganizationTeamRoles(ctx context.Context, teamID string) ([]OrganizationTeamRole, error) {
+	if c.organizationTeamRolesAPI == nil {
+		return nil, fmt.Errorf("organization team roles API not configured")
+	}
+
+	resp, err := c.organizationTeamRolesAPI.ListTeamRoles(ctx, teamID, nil)
+	if err != nil {
+		return nil, WrapAPIError(err, "list organization team roles", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeOrganizationTeamRole),
+			UseEnhanced:  true,
+		})
+	}
+
+	if resp == nil || resp.AssignedRoleCollection == nil {
+		return []OrganizationTeamRole{}, nil
+	}
+
+	roles := make([]OrganizationTeamRole, 0, len(resp.AssignedRoleCollection.Data))
+	for _, r := range resp.AssignedRoleCollection.Data {
+		role := OrganizationTeamRole{
+			ID:             getString(r.ID),
+			RoleName:       getString(r.RoleName),
+			EntityID:       getString(r.EntityID),
+			EntityTypeName: getString(r.EntityTypeName),
+			TeamID:         teamID,
+		}
+		if r.EntityRegion != nil {
+			role.EntityRegion = string(*r.EntityRegion)
+		}
+		roles = append(roles, role)
+	}
+
+	return roles, nil
+}
+
+// AssignOrganizationTeamRole assigns a role to an organization team.
+func (c *Client) AssignOrganizationTeamRole(
+	ctx context.Context,
+	teamID string,
+	req kkComps.AssignRole,
+	namespace string,
+) (string, error) {
+	if c.organizationTeamRolesAPI == nil {
+		return "", fmt.Errorf("organization team roles API not configured")
+	}
+
+	resp, err := c.organizationTeamRolesAPI.TeamsAssignRole(ctx, teamID, &req)
+	if err != nil {
+		return "", WrapAPIError(err, "assign organization team role", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeOrganizationTeamRole),
+			ResourceName: getRoleName(req.RoleName),
+			Namespace:    namespace,
+			UseEnhanced:  true,
+		})
+	}
+
+	if resp == nil || resp.AssignedRole == nil || resp.AssignedRole.ID == nil {
+		return "", fmt.Errorf("no response data from assign organization team role")
+	}
+
+	return *resp.AssignedRole.ID, nil
+}
+
+// RemoveOrganizationTeamRole removes an assigned role from an organization team.
+func (c *Client) RemoveOrganizationTeamRole(ctx context.Context, teamID string, roleID string) error {
+	if c.organizationTeamRolesAPI == nil {
+		return fmt.Errorf("organization team roles API not configured")
+	}
+
+	_, err := c.organizationTeamRolesAPI.TeamsRemoveRole(ctx, teamID, roleID)
+	if err != nil {
+		return WrapAPIError(err, "remove organization team role", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeOrganizationTeamRole),
+			UseEnhanced:  true,
+		})
+	}
+
+	return nil
+}
+
 func (c *Client) ListManagedEventGatewayControlPlanes(
 	ctx context.Context,
 	namespaces []string,
@@ -4717,6 +4801,13 @@ func getString(value *string) string {
 		return ""
 	}
 	return *value
+}
+
+func getRoleName(value *kkComps.RoleName) string {
+	if value == nil {
+		return ""
+	}
+	return string(*value)
 }
 
 // shouldIncludeNamespace checks if a resource's namespace should be included based on filter

--- a/internal/declarative/state/client_test.go
+++ b/internal/declarative/state/client_test.go
@@ -86,6 +86,62 @@ func (m *mockPortalAPI) DeletePortal(
 	return nil, fmt.Errorf("DeletePortal not implemented")
 }
 
+type mockOrganizationTeamAPI struct {
+	listOrganizationTeamsFunc  func(context.Context, kkOps.ListTeamsRequest) (*kkOps.ListTeamsResponse, error)
+	getOrganizationTeamFunc    func(context.Context, string) (*kkOps.GetTeamResponse, error)
+	createOrganizationTeamFunc func(context.Context, *kkComps.CreateTeam) (*kkOps.CreateTeamResponse, error)
+	updateOrganizationTeamFunc func(context.Context, string, *kkComps.UpdateTeam) (*kkOps.UpdateTeamResponse, error)
+	deleteOrganizationTeamFunc func(context.Context, string) (*kkOps.DeleteTeamResponse, error)
+}
+
+func (m *mockOrganizationTeamAPI) ListOrganizationTeams(
+	ctx context.Context,
+	request kkOps.ListTeamsRequest,
+) (*kkOps.ListTeamsResponse, error) {
+	if m.listOrganizationTeamsFunc != nil {
+		return m.listOrganizationTeamsFunc(ctx, request)
+	}
+	return nil, fmt.Errorf("ListOrganizationTeams not implemented")
+}
+
+func (m *mockOrganizationTeamAPI) GetOrganizationTeam(ctx context.Context, id string) (*kkOps.GetTeamResponse, error) {
+	if m.getOrganizationTeamFunc != nil {
+		return m.getOrganizationTeamFunc(ctx, id)
+	}
+	return nil, fmt.Errorf("GetOrganizationTeam not implemented")
+}
+
+func (m *mockOrganizationTeamAPI) CreateOrganizationTeam(
+	ctx context.Context,
+	team *kkComps.CreateTeam,
+) (*kkOps.CreateTeamResponse, error) {
+	if m.createOrganizationTeamFunc != nil {
+		return m.createOrganizationTeamFunc(ctx, team)
+	}
+	return nil, fmt.Errorf("CreateOrganizationTeam not implemented")
+}
+
+func (m *mockOrganizationTeamAPI) UpdateOrganizationTeam(
+	ctx context.Context,
+	id string,
+	team *kkComps.UpdateTeam,
+) (*kkOps.UpdateTeamResponse, error) {
+	if m.updateOrganizationTeamFunc != nil {
+		return m.updateOrganizationTeamFunc(ctx, id, team)
+	}
+	return nil, fmt.Errorf("UpdateOrganizationTeam not implemented")
+}
+
+func (m *mockOrganizationTeamAPI) DeleteOrganizationTeam(
+	ctx context.Context,
+	id string,
+) (*kkOps.DeleteTeamResponse, error) {
+	if m.deleteOrganizationTeamFunc != nil {
+		return m.deleteOrganizationTeamFunc(ctx, id)
+	}
+	return nil, fmt.Errorf("DeleteOrganizationTeam not implemented")
+}
+
 func TestListManagedPortals(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -569,6 +625,50 @@ func TestUpdatePortal(t *testing.T) {
 				tt.checkFunc(t, resp)
 			}
 		})
+	}
+}
+
+func TestGetOrganizationTeamByNameUnfilteredFindsUnmanagedTeam(t *testing.T) {
+	teamID := "team-123"
+	teamName := "External Team"
+	client := NewClient(ClientConfig{
+		OrganizationTeamAPI: &mockOrganizationTeamAPI{
+			listOrganizationTeamsFunc: func(_ context.Context,
+				req kkOps.ListTeamsRequest,
+			) (*kkOps.ListTeamsResponse, error) {
+				if req.PageNumber == nil || *req.PageNumber != 1 {
+					return &kkOps.ListTeamsResponse{
+						TeamCollection: &kkComps.TeamCollection{
+							Meta: &kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: 1}},
+						},
+					}, nil
+				}
+
+				return &kkOps.ListTeamsResponse{
+					TeamCollection: &kkComps.TeamCollection{
+						Data: []kkComps.Team{
+							{
+								ID:     &teamID,
+								Name:   &teamName,
+								Labels: map[string]string{"owner": "external"},
+							},
+						},
+						Meta: &kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: 1}},
+					},
+				}, nil
+			},
+		},
+	})
+
+	team, err := client.GetOrganizationTeamByNameUnfiltered(testContextWithLogger(), teamName)
+	if err != nil {
+		t.Fatalf("GetOrganizationTeamByNameUnfiltered() error = %v", err)
+	}
+	if team == nil {
+		t.Fatal("GetOrganizationTeamByNameUnfiltered() returned nil team")
+	}
+	if team.ID == nil || *team.ID != teamID {
+		t.Fatalf("GetOrganizationTeamByNameUnfiltered() ID = %v, want %s", team.ID, teamID)
 	}
 }
 

--- a/internal/declarative/state/error_utils_test.go
+++ b/internal/declarative/state/error_utils_test.go
@@ -1,9 +1,12 @@
 package state
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 )
 
 func TestValidateAPIClient_Success(t *testing.T) {
@@ -39,6 +42,25 @@ func TestValidateAPIClient_NilPointer(t *testing.T) {
 
 	if !IsAPIClientError(err) {
 		t.Errorf("Expected APIClientError, got: %T", err)
+	}
+}
+
+func TestOrganizationTeamRoleMethodsReturnAPIClientErrorWhenUnconfigured(t *testing.T) {
+	client := NewClient(ClientConfig{})
+
+	_, err := client.ListOrganizationTeamRoles(context.Background(), "team-id")
+	if !IsAPIClientError(err) {
+		t.Fatalf("Expected APIClientError from list, got %T: %v", err, err)
+	}
+
+	_, err = client.AssignOrganizationTeamRole(context.Background(), "team-id", kkComps.AssignRole{}, "default")
+	if !IsAPIClientError(err) {
+		t.Fatalf("Expected APIClientError from assign, got %T: %v", err, err)
+	}
+
+	err = client.RemoveOrganizationTeamRole(context.Background(), "team-id", "role-id")
+	if !IsAPIClientError(err) {
+		t.Fatalf("Expected APIClientError from remove, got %T: %v", err, err)
 	}
 }
 

--- a/internal/konnect/helpers/organization_team_roles.go
+++ b/internal/konnect/helpers/organization_team_roles.go
@@ -1,0 +1,65 @@
+package helpers
+
+import (
+	"context"
+
+	kkSDK "github.com/Kong/sdk-konnect-go"
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+)
+
+// OrganizationTeamRolesAPI defines the interface for organization team role operations.
+type OrganizationTeamRolesAPI interface {
+	ListTeamRoles(
+		ctx context.Context,
+		teamID string,
+		filter *kkOps.ListTeamRolesQueryParamFilter,
+		opts ...kkOps.Option,
+	) (*kkOps.ListTeamRolesResponse, error)
+	TeamsAssignRole(
+		ctx context.Context,
+		teamID string,
+		assignRole *kkComps.AssignRole,
+		opts ...kkOps.Option,
+	) (*kkOps.TeamsAssignRoleResponse, error)
+	TeamsRemoveRole(
+		ctx context.Context,
+		teamID string,
+		roleID string,
+		opts ...kkOps.Option,
+	) (*kkOps.TeamsRemoveRoleResponse, error)
+}
+
+// OrganizationTeamRolesAPIImpl provides an SDK-backed implementation of OrganizationTeamRolesAPI.
+type OrganizationTeamRolesAPIImpl struct {
+	SDK *kkSDK.SDK
+}
+
+func (o *OrganizationTeamRolesAPIImpl) ListTeamRoles(
+	ctx context.Context,
+	teamID string,
+	filter *kkOps.ListTeamRolesQueryParamFilter,
+	opts ...kkOps.Option,
+) (*kkOps.ListTeamRolesResponse, error) {
+	return o.SDK.Roles.ListTeamRoles(ctx, teamID, filter, opts...)
+}
+
+func (o *OrganizationTeamRolesAPIImpl) TeamsAssignRole(
+	ctx context.Context,
+	teamID string,
+	assignRole *kkComps.AssignRole,
+	opts ...kkOps.Option,
+) (*kkOps.TeamsAssignRoleResponse, error) {
+	return o.SDK.Roles.TeamsAssignRole(ctx, teamID, assignRole, opts...)
+}
+
+func (o *OrganizationTeamRolesAPIImpl) TeamsRemoveRole(
+	ctx context.Context,
+	teamID string,
+	roleID string,
+	opts ...kkOps.Option,
+) (*kkOps.TeamsRemoveRoleResponse, error) {
+	return o.SDK.Roles.TeamsRemoveRole(ctx, teamID, roleID, opts...)
+}
+
+var _ OrganizationTeamRolesAPI = (*OrganizationTeamRolesAPIImpl)(nil)

--- a/internal/konnect/helpers/sdk.go
+++ b/internal/konnect/helpers/sdk.go
@@ -34,6 +34,7 @@ type SDKAPI interface {
 	GetDataPlaneCertificateAPI() DataPlaneCertificateAPI
 	GetSystemAccountAPI() SystemAccountAPI
 	GetOrganizationTeamAPI() OrganizationTeamAPI
+	GetOrganizationTeamRolesAPI() OrganizationTeamRolesAPI
 	// Portal child resource APIs
 	GetPortalPageAPI() PortalPageAPI
 	GetPortalAuthSettingsAPI() PortalAuthSettingsAPI
@@ -325,6 +326,15 @@ func (k *KonnectSDK) GetPortalTeamRolesAPI() PortalTeamRolesAPI {
 	}
 
 	return &PortalTeamRolesAPIImpl{SDK: k.SDK}
+}
+
+// Returns the implementation of the OrganizationTeamRolesAPI interface.
+func (k *KonnectSDK) GetOrganizationTeamRolesAPI() OrganizationTeamRolesAPI {
+	if k.SDK == nil {
+		return nil
+	}
+
+	return &OrganizationTeamRolesAPIImpl{SDK: k.SDK}
 }
 
 // Returns the implementation of the PortalTeamMembershipAPI interface

--- a/internal/konnect/helpers/sdk_mock.go
+++ b/internal/konnect/helpers/sdk_mock.go
@@ -4,24 +4,25 @@ import "testing"
 
 // This is a mock implementation of the SDKAPI interface
 type MockKonnectSDK struct {
-	Token                       string
-	T                           *testing.T
-	CPAPIFactory                func() ControlPlaneAPI
-	ControlPlaneGroupsFactory   func() ControlPlaneGroupsAPI
-	PortalFactory               func() PortalAPI
-	APIFactory                  func() APIFullAPI
-	CatalogServicesFactory      func() CatalogServicesAPI
-	APIDocumentFactory          func() APIDocumentAPI
-	APIVersionFactory           func() APIVersionAPI
-	APIPublicationFactory       func() APIPublicationAPI
-	APIImplementationFactory    func() APIImplementationAPI
-	AppAuthStrategiesFactory    func() AppAuthStrategiesAPI
-	DCRProvidersFactory         func() DCRProvidersAPI
-	MeFactory                   func() MeAPI
-	GatewayServiceFactory       func() GatewayServiceAPI
-	DataPlaneCertificateFactory func() DataPlaneCertificateAPI
-	SystemAccountFactory        func() SystemAccountAPI
-	OrganizationTeamFactory     func() OrganizationTeamAPI
+	Token                        string
+	T                            *testing.T
+	CPAPIFactory                 func() ControlPlaneAPI
+	ControlPlaneGroupsFactory    func() ControlPlaneGroupsAPI
+	PortalFactory                func() PortalAPI
+	APIFactory                   func() APIFullAPI
+	CatalogServicesFactory       func() CatalogServicesAPI
+	APIDocumentFactory           func() APIDocumentAPI
+	APIVersionFactory            func() APIVersionAPI
+	APIPublicationFactory        func() APIPublicationAPI
+	APIImplementationFactory     func() APIImplementationAPI
+	AppAuthStrategiesFactory     func() AppAuthStrategiesAPI
+	DCRProvidersFactory          func() DCRProvidersAPI
+	MeFactory                    func() MeAPI
+	GatewayServiceFactory        func() GatewayServiceAPI
+	DataPlaneCertificateFactory  func() DataPlaneCertificateAPI
+	SystemAccountFactory         func() SystemAccountAPI
+	OrganizationTeamFactory      func() OrganizationTeamAPI
+	OrganizationTeamRolesFactory func() OrganizationTeamRolesAPI
 	// Portal child resource factories
 	PortalPageFactory                    func() PortalPageAPI
 	PortalAuthSettingsFactory            func() PortalAuthSettingsAPI
@@ -337,6 +338,14 @@ func (m *MockKonnectSDK) GetEventGatewayBackendClusterAPI() EventGatewayBackendC
 func (m *MockKonnectSDK) GetOrganizationTeamAPI() OrganizationTeamAPI {
 	if m.OrganizationTeamFactory != nil {
 		return m.OrganizationTeamFactory()
+	}
+	return nil
+}
+
+// Returns a mock instance of the OrganizationTeamRolesAPI.
+func (m *MockKonnectSDK) GetOrganizationTeamRolesAPI() OrganizationTeamRolesAPI {
+	if m.OrganizationTeamRolesFactory != nil {
+		return m.OrganizationTeamRolesFactory()
 	}
 	return nil
 }

--- a/test/e2e/scenarios/org/teams/external-role/scenario.yaml
+++ b/test/e2e/scenarios/org/teams/external-role/scenario.yaml
@@ -1,0 +1,166 @@
+baseInputsPath: ./testdata
+
+env:
+  KONGCTL_LOG_LEVEL: info
+
+vars:
+  teamName: e2e-external-role-team
+  teamRef: external-role-team
+  roleRef: external-team-api-admin
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - change_id
+      - resource_id
+      - generated_at
+      - created_at
+      - updated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-bootstrap-external-team
+    skipInputs: true
+    commands:
+      - name: 000-create-external-team
+        create:
+          resource: organization_team
+          payload:
+            inline:
+              name: "{{ .vars.teamName }}"
+              description: Team created outside declarative management
+          recordVar:
+            name: team_id
+            responsePath: id
+
+  - name: 002-plan-external-team-role
+    commands:
+      - name: 000-plan
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+          - select: >-
+              changes[?resource_type=='organization_team' &&
+                      resource_ref=='{{ .vars.teamRef }}']
+            expect:
+              fields:
+                "length(@)": 0
+          - select: >-
+              changes[?resource_type=='organization_team_role' &&
+                      resource_ref=='{{ .vars.roleRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                fields.role_name: Admin
+                fields.entity_id: "*"
+                fields.entity_type_name: APIs
+                fields.entity_region: us
+
+      - name: 001-diff-from-plan
+        run:
+          - diff
+          - --plan
+          - "{{ .workdir }}/plan.json"
+          - -o
+          - json
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+
+  - name: 003-apply-external-team-role
+    commands:
+      - name: 000-apply-from-config
+        outputFormat: json
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+                status: success
+
+      - name: 001-get-team-roles
+        run:
+          - get
+          - org
+          - team
+          - roles
+          - --team-name
+          - "{{ .vars.teamName }}"
+          - -o
+          - json
+        assertions:
+          - select: "[?role_name=='Admin' && entity_id=='*' && entity_type_name=='APIs'] | [0]"
+            expect:
+              fields:
+                role_name: Admin
+                entity_id: "*"
+                entity_type_name: APIs
+                entity_region: us
+
+  - name: 004-idempotency
+    commands:
+      - name: 000-diff-noop
+        run:
+          - diff
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - -o
+          - json
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+
+      - name: 001-plan-sync-noop
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+
+  - name: 005-reset-cleanup
+    skipInputs: true
+    commands:
+      - resetOrg: true

--- a/test/e2e/scenarios/org/teams/external-role/testdata/config.yaml
+++ b/test/e2e/scenarios/org/teams/external-role/testdata/config.yaml
@@ -1,0 +1,16 @@
+organization:
+  teams:
+    - ref: external-role-team
+      name: e2e-external-role-team
+      _external:
+        selector:
+          matchFields:
+            name: e2e-external-role-team
+
+organization_team_roles:
+  - ref: external-team-api-admin
+    team: external-role-team
+    role_name: Admin
+    entity_id: "*"
+    entity_type_name: APIs
+    entity_region: us

--- a/test/e2e/scenarios/org/teams/roles/overlays/002-add-root-role/config.yaml
+++ b/test/e2e/scenarios/org/teams/roles/overlays/002-add-root-role/config.yaml
@@ -1,0 +1,31 @@
+_defaults:
+  kongctl:
+    namespace: org-team-roles-e2e
+
+apis:
+  - ref: org-team-roles-api
+    name: org-team-roles-api
+    description: API used by the organization team roles E2E scenario
+
+organization:
+  teams:
+    - ref: platform-role-team
+      name: Platform Role Team
+      description: Team used by the organization team roles E2E scenario
+      labels:
+        department: engineering
+        focus: platform
+      roles:
+        - ref: platform-api-viewer
+          role_name: Viewer
+          entity_id: !ref org-team-roles-api#id
+          entity_type_name: APIs
+          entity_region: us
+
+organization_team_roles:
+  - ref: platform-api-admin
+    team: platform-role-team
+    role_name: Admin
+    entity_id: !ref org-team-roles-api#id
+    entity_type_name: APIs
+    entity_region: us

--- a/test/e2e/scenarios/org/teams/roles/overlays/003-remove-root-role/config.yaml
+++ b/test/e2e/scenarios/org/teams/roles/overlays/003-remove-root-role/config.yaml
@@ -1,0 +1,23 @@
+_defaults:
+  kongctl:
+    namespace: org-team-roles-e2e
+
+apis:
+  - ref: org-team-roles-api
+    name: org-team-roles-api
+    description: API used by the organization team roles E2E scenario
+
+organization:
+  teams:
+    - ref: platform-role-team
+      name: Platform Role Team
+      description: Team used by the organization team roles E2E scenario
+      labels:
+        department: engineering
+        focus: platform
+      roles:
+        - ref: platform-api-viewer
+          role_name: Viewer
+          entity_id: !ref org-team-roles-api#id
+          entity_type_name: APIs
+          entity_region: us

--- a/test/e2e/scenarios/org/teams/roles/scenario.yaml
+++ b/test/e2e/scenarios/org/teams/roles/scenario.yaml
@@ -1,0 +1,487 @@
+baseInputsPath: ./testdata
+
+env:
+  KONGCTL_LOG_LEVEL: info
+
+vars:
+  namespace: org-team-roles-e2e
+  apiRef: org-team-roles-api
+  apiName: org-team-roles-api
+  teamRef: platform-role-team
+  teamName: Platform Role Team
+  viewerRoleRef: platform-api-viewer
+  adminRoleRef: platform-api-admin
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - change_id
+      - resource_id
+      - generated_at
+      - created_at
+      - updated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-apply-from-config
+    commands:
+      - name: 000-apply-initial
+        outputFormat: json
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: apply
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 3
+                by_action.CREATE: 3
+          - select: summary
+            expect:
+              fields:
+                applied: 3
+                failed: 0
+                status: success
+          - select: >-
+              plan.changes[?resource_type=='api' && resource_ref=='{{ .vars.apiRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                namespace: "{{ .vars.namespace }}"
+          - select: >-
+              plan.changes[?resource_type=='organization_team' &&
+                            resource_ref=='{{ .vars.teamRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                namespace: "{{ .vars.namespace }}"
+                fields.name: "{{ .vars.teamName }}"
+          - select: >-
+              plan.changes[?resource_type=='organization_team_role' &&
+                            resource_ref=='{{ .vars.viewerRoleRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                namespace: "{{ .vars.namespace }}"
+                fields.role_name: Viewer
+                fields.entity_type_name: APIs
+                fields.entity_region: us
+          - expect:
+              fields:
+                "length(plan.changes[?resource_type=='organization_team' && namespace=='default'])": 0
+                "length(plan.changes[?resource_type=='organization_team_role' && namespace=='default'])": 0
+
+      - name: 001-get-team-roles
+        run:
+          - get
+          - org
+          - team
+          - roles
+          - --team-name
+          - "{{ .vars.teamName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 1
+          - select: "[?role_name=='Viewer'] | [0]"
+            expect:
+              fields:
+                role_name: Viewer
+                entity_type_name: APIs
+                entity_region: us
+
+  - name: 002-noop-diff-from-config
+    commands:
+      - name: 000-diff-noop
+        run:
+          - diff
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - -o
+          - json
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+          - select: changes
+            expect:
+              fields:
+                "length(@)": 0
+
+  - name: 003-plan-and-apply-root-role
+    inputOverlayDirs:
+      - overlays/002-add-root-role
+    commands:
+      - name: 000-plan-add-role
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-add-role.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+          - select: >-
+              changes[?resource_type=='organization_team_role' &&
+                      resource_ref=='{{ .vars.adminRoleRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                namespace: "{{ .vars.namespace }}"
+                fields.role_name: Admin
+                fields.entity_type_name: APIs
+                fields.entity_region: us
+
+      - name: 001-diff-from-plan
+        run:
+          - diff
+          - --plan
+          - "{{ .workdir }}/plan-add-role.json"
+          - -o
+          - json
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+          - select: >-
+              changes[?resource_type=='organization_team_role' &&
+                      resource_ref=='{{ .vars.adminRoleRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                namespace: "{{ .vars.namespace }}"
+
+      - name: 002-apply-from-plan
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-add-role.json"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+                status: success
+
+      - name: 003-get-team-roles
+        run:
+          - get
+          - org
+          - team
+          - roles
+          - --team-name
+          - "{{ .vars.teamName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 2
+          - select: "[?role_name=='Viewer'] | [0]"
+            expect:
+              fields:
+                role_name: Viewer
+                entity_type_name: APIs
+          - select: "[?role_name=='Admin'] | [0]"
+            expect:
+              fields:
+                role_name: Admin
+                entity_type_name: APIs
+
+  - name: 004-dump-with-children
+    skipInputs: true
+    commands:
+      - name: 000-dump-org-team-roles
+        outputFormat: none
+        parseAs: yaml
+        stdoutFile: "{{ .workdir }}/dump.yaml"
+        run:
+          - dump
+          - declarative
+          - "--resources=organization.teams,apis"
+          - --include-child-resources
+          - --default-namespace
+          - "{{ .vars.namespace }}"
+        assertions:
+          - select: _defaults.kongctl
+            expect:
+              fields:
+                namespace: "{{ .vars.namespace }}"
+          - select: "apis[?name=='{{ .vars.apiName }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.apiName }}"
+          - select: "organization.teams[?name=='{{ .vars.teamName }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.teamName }}"
+          - select: >-
+              organization.teams[?name=='{{ .vars.teamName }}'] |
+              [0].roles[?role_name=='Viewer'] | [0]
+            expect:
+              fields:
+                role_name: Viewer
+                entity_type_name: APIs
+                entity_region: us
+          - select: >-
+              organization.teams[?name=='{{ .vars.teamName }}'] |
+              [0].roles[?role_name=='Admin'] | [0]
+            expect:
+              fields:
+                role_name: Admin
+                entity_type_name: APIs
+                entity_region: us
+
+      - name: 001-plan-from-dump
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/dump.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+
+  - name: 005-sync-from-config
+    inputOverlayDirs:
+      - overlays/003-remove-root-role
+    commands:
+      - name: 000-sync-remove-root-role
+        outputFormat: json
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: sync
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: >-
+              plan.changes[?resource_type=='organization_team_role' &&
+                           action=='DELETE'] | [0]
+            expect:
+              fields:
+                resource_type: organization_team_role
+                action: DELETE
+                namespace: "{{ .vars.namespace }}"
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+                status: success
+
+      - name: 001-get-team-roles
+        run:
+          - get
+          - org
+          - team
+          - roles
+          - --team-name
+          - "{{ .vars.teamName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 1
+          - select: "[?role_name=='Admin']"
+            expect:
+              fields:
+                "length(@)": 0
+
+  - name: 006-diff-and-sync-from-plan
+    inputOverlayDirs:
+      - overlays/002-add-root-role
+    commands:
+      - name: 000-diff-from-config
+        run:
+          - diff
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+          - -o
+          - json
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+          - select: >-
+              changes[?resource_type=='organization_team_role' &&
+                      resource_ref=='{{ .vars.adminRoleRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                namespace: "{{ .vars.namespace }}"
+
+      - name: 001-plan-sync-readd-role
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-sync-readd-role.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: sync
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+          - select: >-
+              changes[?resource_type=='organization_team_role' &&
+                      resource_ref=='{{ .vars.adminRoleRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                namespace: "{{ .vars.namespace }}"
+
+      - name: 002-diff-sync-plan
+        run:
+          - diff
+          - --plan
+          - "{{ .workdir }}/plan-sync-readd-role.json"
+          - -o
+          - json
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: sync
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+          - select: >-
+              changes[?resource_type=='organization_team_role' &&
+                      resource_ref=='{{ .vars.adminRoleRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                namespace: "{{ .vars.namespace }}"
+
+      - name: 003-sync-from-plan
+        outputFormat: json
+        run:
+          - sync
+          - --plan
+          - "{{ .workdir }}/plan-sync-readd-role.json"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+                status: success
+
+      - name: 004-plan-sync-idempotent
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+
+  - name: 007-delete-cleanup
+    inputOverlayDirs:
+      - overlays/002-add-root-role
+    commands:
+      - name: 000-delete
+        outputFormat: json
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 4
+                by_action.DELETE: 4
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/org/teams/roles/testdata/config.yaml
+++ b/test/e2e/scenarios/org/teams/roles/testdata/config.yaml
@@ -1,0 +1,23 @@
+_defaults:
+  kongctl:
+    namespace: org-team-roles-e2e
+
+apis:
+  - ref: org-team-roles-api
+    name: org-team-roles-api
+    description: API used by the organization team roles E2E scenario
+
+organization:
+  teams:
+    - ref: platform-role-team
+      name: Platform Role Team
+      description: Team used by the organization team roles E2E scenario
+      labels:
+        department: engineering
+        focus: platform
+      roles:
+        - ref: platform-api-viewer
+          role_name: Viewer
+          entity_id: !ref org-team-roles-api#id
+          entity_type_name: APIs
+          entity_region: us


### PR DESCRIPTION
## Summary

Adds declarative support for organization team role assignments.

- Adds `organization_team_role` as a declarative child resource for organization teams.
- Supports nested `organization.teams[].roles` and root-level `organization_team_roles`.
- Uses the Konnect SDK role APIs for list, assign, and remove operations.
- Adds `get org team roles` for list-only imperative inspection.
- Extends dump with `--include-child-resources` so organization team roles are emitted under `organization.teams[].roles`.
- Adds user-facing organization examples and resource reference updates.

## Notes

Root-level organization team roles use `team` as a declarative team ref, matching the existing root-level child resource pattern used by resources such as `portal_pages[].portal`.

This also fixes `_defaults.kongctl.namespace` handling for teams nested under the singleton `organization` block. Previously those nested teams were flattened after namespace defaults were applied, so they fell back to the `default` namespace. The E2E scenario now asserts both `organization_team` and `organization_team_role` changes stay in the configured namespace.

## Validation

- `go test ./internal/declarative/loader`
- `KONGCTL_E2E_SCENARIO=org/teams/roles go test -tags=e2e ./test/e2e -run Test_Scenarios -count=1`
- `make build`
- `make lint`
- `make test`

Closes #261 