### PR TITLE
Fix: patch agent workflow interpolation

### DIFF
--- a/.github/workflows/benchmark-regression-analysis.lock.yml
+++ b/.github/workflows/benchmark-regression-analysis.lock.yml
@@ -550,14 +550,31 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/restore_base_github_folders.sh"
       - name: Download container images
         run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280 ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51 ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959 node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
-      - name: Generate Safe Outputs Config
+      - name: Write Safe Outputs Config
+        env:
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
         run: |
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a0d1d678cc90e91b_EOF'
-          {"add_comment":{"hide_older_comments":true,"max":1,"target":"${{ inputs.issue_number }}"},"create_report_incomplete_issue":{},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_a0d1d678cc90e91b_EOF
+          jq -n --arg target "${ISSUE_NUMBER}" '{
+            add_comment: {
+              hide_older_comments: true,
+              max: 1,
+              target: $target
+            },
+            create_report_incomplete_issue: {},
+            mentions: {
+              enabled: false
+            },
+            missing_data: {},
+            missing_tool: {},
+            noop: {
+              max: 1,
+              "report-as-issue": "false"
+            },
+            report_incomplete: {}
+          }' > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json"
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -1019,9 +1036,7 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      discussions: write
       issues: write
-      pull-requests: write
     concurrency:
       group: "gh-aw-conclusion-benchmark-regression-analysis"
       cancel-in-progress: false
@@ -1387,9 +1402,7 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      discussions: write
       issues: write
-      pull-requests: write
     timeout-minutes: 15
     env:
       GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/benchmark-regression-analysis"
@@ -1455,12 +1468,27 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1,\"target\":\"${{ inputs.issue_number }}\"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{}}"
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io, getOctokit);
+            process.env.GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG = JSON.stringify({
+              add_comment: {
+                hide_older_comments: true,
+                max: 1,
+                target: process.env.ISSUE_NUMBER
+              },
+              create_report_incomplete_issue: {},
+              missing_data: {},
+              missing_tool: {},
+              noop: {
+                max: 1,
+                "report-as-issue": "false"
+              },
+              report_incomplete: {}
+            });
             const { main } = require('${{ runner.temp }}/gh-aw/actions/safe_output_handler_manager.cjs');
             await main();
       - name: Upload Safe Outputs Items
@@ -1472,4 +1500,3 @@ jobs:
             /tmp/gh-aw/safe-output-items.jsonl
             /tmp/gh-aw/temporary-id-map.json
           if-no-files-found: ignore
-

--- a/scripts/patch-gh-aw-maintenance.sh
+++ b/scripts/patch-gh-aw-maintenance.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Temporary post-compile patches for gh-aw v0.71.1 generated workflows.
+# Temporary post-compile patches for gh-aw generated workflows.
 # Remove these once upstream gh-aw stops writing workflow inputs directly into
 # shell commands and emits least-privilege safe-output job permissions.
 if [ "$#" -gt 0 ]; then
@@ -69,12 +69,22 @@ def patch_maintenance(text):
 
 
 def patch_benchmark_safe_outputs_config(text):
-    start_marker = "      - name: Write Safe Outputs Config\n"
-    end_marker = "      - name: Write Safe Outputs Tools\n"
-    start = text.find(start_marker)
-    if start == -1:
+    end_markers = (
+        "      - name: Write Safe Outputs Tools\n",
+        "      - name: Generate Safe Outputs Tools\n",
+    )
+    start_markers = (
+        "      - name: Write Safe Outputs Config\n",
+        "      - name: Generate Safe Outputs Config\n",
+    )
+    start_marker = next((marker for marker in start_markers if marker in text), None)
+    if start_marker is None:
         raise SystemExit("expected generated block not found for benchmark safe-output config")
-    end = text.find(end_marker, start)
+    start = text.find(start_marker)
+    end = min(
+        (idx for marker in end_markers if (idx := text.find(marker, start)) != -1),
+        default=-1,
+    )
     if end == -1:
         raise SystemExit("expected generated block end not found for benchmark safe-output config")
 


### PR DESCRIPTION
## Summary

Fix the temporary gh-aw workflow patcher so it matches the current generated step names and applies the security patch to the benchmark regression workflow.

## Details

- Accept both `Write` and `Generate` Safe Outputs step names in `scripts/patch-gh-aw-maintenance.sh`.
- Re-run the patcher against `benchmark-regression-analysis.lock.yml`.
- Move the generated `inputs.issue_number` interpolation through environment variables and structured JSON construction instead of embedding it directly in shell/JSON strings.
- Preserve the least-privilege permission reduction already handled by the patcher.

## Validation

- `make patch-gh-aw-workflows`
- `bash -n scripts/patch-gh-aw-maintenance.sh`
- `git diff --check`
- `make test`

E2E tests were not run.