### PR TITLE
test: add e2e scenario environment assignments

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -208,6 +208,7 @@ jobs:
       KONGCTL_E2E_ARTIFACTS_DIR: ${{ github.workspace }}/.e2e-artifacts/${{ github.run_id }}-${{ matrix.org_name }}
       KONGCTL_E2E_SHARD_INDEX: ${{ strategy.job-index }}
       KONGCTL_E2E_SHARD_TOTAL: ${{ strategy.job-total }}
+      KONGCTL_E2E_ORGS_JSON: ${{ vars.KONGCTL_E2E_ORGS_JSON || '[{"org_name":"default"}]' }}
       KONGCTL_E2E_RUN_PORTAL_APPLICATIONS: ${{ github.event_name == 'workflow_dispatch' && inputs.run_portal_applications && '1' || '' }}
       KONGCTL_E2E_RUN_PORTAL_IDENTITY_PROVIDERS: ${{ vars.KONGCTL_E2E_RUN_PORTAL_IDENTITY_PROVIDERS || '' }}
       KONGCTL_E2E_CAPTURE_TCPDUMP: ${{ github.event_name == 'workflow_dispatch' && inputs.capture_tcpdump && '1' || vars.KONGCTL_E2E_CAPTURE_TCPDUMP || '' }}

--- a/docs/e2e-scenarios.md
+++ b/docs/e2e-scenarios.md
@@ -41,6 +41,8 @@ Schema (YAML)
 - vars: free-form variables usable in templates (e.g., for selectors or overlay files)
 - test:
   - enabledByEnvVar: optional opt-in env gate for the scenario
+  - assignedEnvironment: optional GitHub Actions environment / matrix org
+    name. When set, CI runs the scenario only in the matching matrix job.
   - requiresPAT: optional boolean, defaults to true
 - defaults:
   - retry:

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -126,6 +126,9 @@ Scenario selection and sharding:
 - `KONGCTL_E2E_SHARD_INDEX`: Zero-based shard index for this test process.
 - `KONGCTL_E2E_SHARD_TOTAL`: Total number of shards in the run.
 - `KONGCTL_E2E_MATRIX_ORG`: Optional diagnostic label for the current CI job.
+- `KONGCTL_E2E_ORGS_JSON`: JSON array of matrix org entries. Used in CI to
+  validate scenario environment assignments. Each entry must include
+  `org_name`.
 
 Authentication and opt-in scenarios:
 
@@ -179,6 +182,31 @@ Example with 10 scenarios and 4 shards:
 
 If `KONGCTL_E2E_SCENARIO` is set, sharding is bypassed so local single-scenario
 iteration stays predictable.
+
+A scenario can be pinned to a specific GitHub Actions environment by setting
+`test.assignedEnvironment` to the matrix `org_name`:
+
+```yaml
+test:
+  assignedEnvironment: kongctl-e2e-users
+```
+
+Pinned scenarios run only in the matrix job whose `KONGCTL_E2E_MATRIX_ORG`
+matches that value. They are excluded from normal modulo sharding so they do
+not run in any other org. Unpinned scenarios continue to be sharded by sorted
+position. In CI, the harness validates pinned environments against
+`KONGCTL_E2E_ORGS_JSON` and fails if a scenario names an environment that is
+not present in the org pool.
+
+For local full-suite runs without sharding, assignments are not enforced by
+default because the run targets a single developer-selected org. To emulate a
+CI environment locally, set `KONGCTL_E2E_MATRIX_ORG`:
+
+```bash
+KONGCTL_E2E_MATRIX_ORG=kongctl-e2e-users \
+KONGCTL_E2E_SCENARIO=org/teams/roles \
+make test-e2e-scenarios
+```
 
 ### Skipping Steps
 
@@ -284,6 +312,8 @@ The workflow derives sharding directly from GitHub Actions strategy context:
 
 - `KONGCTL_E2E_SHARD_INDEX=${{ strategy.job-index }}`
 - `KONGCTL_E2E_SHARD_TOTAL=${{ strategy.job-total }}`
+- `KONGCTL_E2E_MATRIX_ORG=${{ matrix.org_name }}`
+- `KONGCTL_E2E_ORGS_JSON=${{ vars.KONGCTL_E2E_ORGS_JSON }}`
 
 The workflow also exposes the HTTP timeout and retry knobs above as repository
 or organization variables of the same names, so CI can tune reset and HTTP

--- a/test/e2e/harness/reset.go
+++ b/test/e2e/harness/reset.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -112,6 +113,7 @@ func deleteAll(
 	endpoint string,
 	deleteAPIVersion string,
 	deleteEndpoint string,
+	idField string,
 	filter filterFunc,
 	// preDeleteFn is called for each resource ID before deletion. It is used to clean up
 	// sub-resources. Any errors must be logged inside the function; the function must not
@@ -143,6 +145,10 @@ func deleteAll(
 	if filter == nil {
 		filter = shouldDeleteResource
 	}
+	idField = strings.TrimSpace(idField)
+	if idField == "" {
+		idField = "id"
+	}
 
 	const maxAttempts = 5
 	const retryDelay = 2 * time.Second
@@ -172,7 +178,7 @@ func deleteAll(
 		var idsToDelete []string
 		var skipped int
 		for _, item := range items {
-			id, ok := item["id"].(string)
+			id, ok := item[idField].(string)
 			if !ok || id == "" {
 				continue
 			}
@@ -314,6 +320,8 @@ type resetResourceSpec struct {
 	// Optional filter to exclude resources from deletion
 	// if nothing is passed default filter that skips konnect-managed resources is used
 	Filter filterFunc
+	// Optional resource identifier field. Defaults to "id".
+	IDField string
 	// PreDeleteFn is called for each resource ID before deletion. It is used to clean
 	// up sub-resources that Konnect does not cascade-delete automatically. Errors are
 	// logged but do not stop the deletion.
@@ -323,6 +331,7 @@ type resetResourceSpec struct {
 var resetSequence = []resetResourceSpec{
 	{Version: "v3", Endpoint: "apis"},
 	{Version: "v3", Endpoint: "portals", PreDeleteFn: tryDeletePortalCustomDomain},
+	{Version: "v3", Endpoint: "portals/email-domains", Filter: onlyE2EEmailDomains, IDField: "domain"},
 	{
 		Version:           "v3",
 		Endpoint:          "audit-log-destinations",
@@ -338,6 +347,14 @@ var resetSequence = []resetResourceSpec{
 	{Version: "v2", Endpoint: "control-planes"},
 	{Version: "v1", Endpoint: "catalog-services"},
 	{Version: "v1", Endpoint: "event-gateways"},
+}
+
+func onlyE2EEmailDomains(resource map[string]any) bool {
+	domain, ok := resource["domain"].(string)
+	if !ok {
+		return false
+	}
+	return strings.HasSuffix(domain, ".mail.kongctl-e2e.io")
 }
 
 // tryDeletePortalCustomDomain attempts to delete the custom domain for a portal before
@@ -413,6 +430,7 @@ func executeReset(baseURL, token string, policy HTTPRetryPolicy) (resetResult, e
 			step.Endpoint,
 			step.DeleteVersion,
 			step.DeleteEndpoint,
+			step.IDField,
 			step.Filter,
 			step.PreDeleteFn,
 			policy,
@@ -552,7 +570,7 @@ func deleteOne(client *http.Client, baseURL, token, id string) error {
 }
 
 func deleteOneWithContext(ctx context.Context, client *http.Client, baseURL, token, id string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, baseURL+"/"+id, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, baseURL+"/"+url.PathEscape(id), nil)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/harness/reset_test.go
+++ b/test/e2e/harness/reset_test.go
@@ -1,0 +1,37 @@
+//go:build e2e
+
+package harness
+
+import "testing"
+
+func TestOnlyE2EEmailDomains(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource map[string]any
+		want     bool
+	}{
+		{
+			name:     "e2e mail domain",
+			resource: map[string]any{"domain": "abc123.mail.kongctl-e2e.io"},
+			want:     true,
+		},
+		{
+			name:     "non e2e domain",
+			resource: map[string]any{"domain": "example.com"},
+			want:     false,
+		},
+		{
+			name:     "missing domain",
+			resource: map[string]any{"id": "abc123"},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := onlyE2EEmailDomains(tt.resource); got != tt.want {
+				t.Fatalf("onlyE2EEmailDomains() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/e2e/harness/scenario/types.go
+++ b/test/e2e/harness/scenario/types.go
@@ -19,11 +19,12 @@ type Defaults struct {
 }
 
 type ScenarioTest struct {
-	Enabled         *bool    `yaml:"enabled"`
-	EnabledByEnvVar string   `yaml:"enabledByEnvVar"`
-	RequiredEnvVars []string `yaml:"requiredEnvVars"`
-	RequiresPAT     *bool    `yaml:"requiresPAT"`
-	Info            string   `yaml:"info"`
+	Enabled             *bool    `yaml:"enabled"`
+	EnabledByEnvVar     string   `yaml:"enabledByEnvVar"`
+	RequiredEnvVars     []string `yaml:"requiredEnvVars"`
+	RequiresPAT         *bool    `yaml:"requiresPAT"`
+	AssignedEnvironment string   `yaml:"assignedEnvironment"`
+	Info                string   `yaml:"info"`
 }
 
 type Retry struct {

--- a/test/e2e/scenarios_assignment_e2e.go
+++ b/test/e2e/scenarios_assignment_e2e.go
@@ -1,0 +1,44 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+func loadScenarioAssignments(scenarios []string) (map[string]scenarioAssignment, error) {
+	assignments := make(map[string]scenarioAssignment)
+	for _, scenarioPath := range scenarios {
+		assignment, err := loadScenarioAssignment(scenarioPath)
+		if err != nil {
+			return nil, err
+		}
+		if assignment.Environment != "" {
+			assignments[normalizeScenarioPath(scenarioPath)] = assignment
+		}
+	}
+	return assignments, nil
+}
+
+func loadScenarioAssignment(path string) (scenarioAssignment, error) {
+	var raw struct {
+		Test struct {
+			AssignedEnvironment string `yaml:"assignedEnvironment"`
+		} `yaml:"test"`
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return scenarioAssignment{}, err
+	}
+	if err := yaml.Unmarshal(b, &raw); err != nil {
+		return scenarioAssignment{}, err
+	}
+
+	return scenarioAssignment{
+		Environment: strings.TrimSpace(raw.Test.AssignedEnvironment),
+	}, nil
+}

--- a/test/e2e/scenarios_shard.go
+++ b/test/e2e/scenarios_shard.go
@@ -1,9 +1,11 @@
 package e2e
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -13,26 +15,81 @@ type scenarioShard struct {
 	Total   int
 }
 
-func selectScenarios(scenarios []string, filter string, shard scenarioShard) []string {
-	selected := make([]string, 0, len(scenarios))
-	for _, p := range scenarios {
-		if filter != "" && !scenarioMatches(p, filter) {
-			continue
-		}
-		selected = append(selected, p)
-	}
+type scenarioAssignment struct {
+	Environment string
+}
 
-	if filter == "" && shard.Enabled {
-		sharded := make([]string, 0, len(selected))
-		for i, p := range selected {
-			if i%shard.Total == shard.Index {
-				sharded = append(sharded, p)
+type scenarioSelectionConfig struct {
+	Filter       string
+	Shard        scenarioShard
+	CurrentEnv   string
+	AllowedEnvs  []string
+	Assignments  map[string]scenarioAssignment
+	ValidateEnvs bool
+	EnforceEnv   bool
+}
+
+func selectScenarios(scenarios []string, filter string, shard scenarioShard) []string {
+	selected, _ := selectScenariosWithConfig(scenarios, scenarioSelectionConfig{
+		Filter: filter,
+		Shard:  shard,
+	})
+	return selected
+}
+
+func selectScenariosWithConfig(scenarios []string, cfg scenarioSelectionConfig) ([]string, error) {
+	if cfg.Filter != "" {
+		selected := make([]string, 0, len(scenarios))
+		for _, p := range scenarios {
+			if scenarioMatches(p, cfg.Filter) {
+				selected = append(selected, p)
 			}
 		}
-		selected = sharded
+		return selected, nil
 	}
 
-	return selected
+	if cfg.ValidateEnvs {
+		for scenarioPath, assignment := range cfg.Assignments {
+			if assignment.Environment == "" {
+				continue
+			}
+			if !slices.Contains(cfg.AllowedEnvs, assignment.Environment) {
+				return nil, fmt.Errorf(
+					"scenario %s is assigned to environment %q, but KONGCTL_E2E_ORGS_JSON does not include that org_name",
+					normalizeScenarioPath(scenarioPath),
+					assignment.Environment,
+				)
+			}
+		}
+	}
+
+	currentEnv := strings.TrimSpace(cfg.CurrentEnv)
+	enforceEnv := cfg.EnforceEnv || currentEnv != ""
+	unassigned := make([]string, 0, len(scenarios))
+	pinned := make([]string, 0)
+	for _, p := range scenarios {
+		assignment := cfg.Assignments[normalizeScenarioPath(p)]
+		if assignment.Environment != "" && enforceEnv {
+			if assignment.Environment == currentEnv {
+				pinned = append(pinned, p)
+			}
+			continue
+		}
+		unassigned = append(unassigned, p)
+	}
+
+	selected := unassigned
+	if cfg.Shard.Enabled {
+		selected = make([]string, 0, len(unassigned))
+		for i, p := range unassigned {
+			if i%cfg.Shard.Total == cfg.Shard.Index {
+				selected = append(selected, p)
+			}
+		}
+	}
+
+	selected = append(selected, pinned...)
+	return selected, nil
 }
 
 func scenarioMatches(scenarioPath, filter string) bool {
@@ -53,6 +110,29 @@ func normalizeScenarioPath(path string) string {
 	path = strings.TrimPrefix(path, "scenarios/")
 	path = strings.TrimPrefix(path, "test/e2e/scenarios/")
 	return strings.TrimSuffix(path, "/")
+}
+
+func loadScenarioOrgNames(raw string) ([]string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+
+	var orgs []struct {
+		OrgName string `json:"org_name"`
+	}
+	if err := json.Unmarshal([]byte(raw), &orgs); err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(orgs))
+	for _, org := range orgs {
+		name := strings.TrimSpace(org.OrgName)
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	return names, nil
 }
 
 func writeScenarioShardManifest(artifactsDir string, shard scenarioShard, selected []string) error {

--- a/test/e2e/scenarios_shard_test.go
+++ b/test/e2e/scenarios_shard_test.go
@@ -99,6 +99,172 @@ func TestSelectScenariosFilterIgnoresTrailingSlash(t *testing.T) {
 	}
 }
 
+func TestSelectScenariosPinsAssignedEnvironment(t *testing.T) {
+	scenarios := []string{
+		"test/e2e/scenarios/apis/basic/scenario.yaml",
+		"test/e2e/scenarios/portal/users/scenario.yaml",
+		"test/e2e/scenarios/smoke/version/scenario.yaml",
+	}
+
+	selected, err := selectScenariosWithConfig(scenarios, scenarioSelectionConfig{
+		Shard: scenarioShard{
+			Enabled: true,
+			Index:   1,
+			Total:   2,
+		},
+		CurrentEnv: "kongctl-e2e-users",
+		Assignments: map[string]scenarioAssignment{
+			"portal/users/scenario.yaml": {Environment: "kongctl-e2e-users"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("selectScenariosWithConfig() error = %v", err)
+	}
+
+	want := []string{
+		"test/e2e/scenarios/smoke/version/scenario.yaml",
+		"test/e2e/scenarios/portal/users/scenario.yaml",
+	}
+	if !slices.Equal(selected, want) {
+		t.Fatalf("unexpected selected scenarios: got %v want %v", selected, want)
+	}
+}
+
+func TestSelectScenariosExcludesPinnedScenarioFromOtherEnvironments(t *testing.T) {
+	scenarios := []string{
+		"test/e2e/scenarios/apis/basic/scenario.yaml",
+		"test/e2e/scenarios/portal/users/scenario.yaml",
+		"test/e2e/scenarios/smoke/version/scenario.yaml",
+	}
+
+	seen := make(map[string]int, len(scenarios))
+	for index, env := range []string{"kongctl-e2e-a", "kongctl-e2e-b"} {
+		selected, err := selectScenariosWithConfig(scenarios, scenarioSelectionConfig{
+			Shard: scenarioShard{
+				Enabled: true,
+				Index:   index,
+				Total:   2,
+			},
+			CurrentEnv: env,
+			Assignments: map[string]scenarioAssignment{
+				"portal/users/scenario.yaml": {Environment: "kongctl-e2e-b"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("selectScenariosWithConfig() error = %v", err)
+		}
+		for _, scenario := range selected {
+			seen[scenario]++
+		}
+	}
+
+	for _, scenario := range scenarios {
+		if seen[scenario] != 1 {
+			t.Fatalf("scenario %q assigned %d times, want exactly once", scenario, seen[scenario])
+		}
+	}
+}
+
+func TestSelectScenariosTreatsPinnedScenariosAsUnassignedWithoutEnvironmentEnforcement(t *testing.T) {
+	scenarios := []string{
+		"test/e2e/scenarios/apis/basic/scenario.yaml",
+		"test/e2e/scenarios/portal/users/scenario.yaml",
+	}
+
+	selected, err := selectScenariosWithConfig(scenarios, scenarioSelectionConfig{
+		Assignments: map[string]scenarioAssignment{
+			"portal/users/scenario.yaml": {Environment: "kongctl-e2e-users"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("selectScenariosWithConfig() error = %v", err)
+	}
+	if !slices.Equal(selected, scenarios) {
+		t.Fatalf("unexpected selected scenarios: got %v want %v", selected, scenarios)
+	}
+}
+
+func TestSelectScenariosExcludesPinnedScenarioWhenEnvironmentEnforcedWithoutCurrentEnvironment(t *testing.T) {
+	scenarios := []string{
+		"test/e2e/scenarios/apis/basic/scenario.yaml",
+		"test/e2e/scenarios/portal/users/scenario.yaml",
+	}
+
+	selected, err := selectScenariosWithConfig(scenarios, scenarioSelectionConfig{
+		EnforceEnv: true,
+		Assignments: map[string]scenarioAssignment{
+			"portal/users/scenario.yaml": {Environment: "kongctl-e2e-users"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("selectScenariosWithConfig() error = %v", err)
+	}
+
+	want := []string{"test/e2e/scenarios/apis/basic/scenario.yaml"}
+	if !slices.Equal(selected, want) {
+		t.Fatalf("unexpected selected scenarios: got %v want %v", selected, want)
+	}
+}
+
+func TestSelectScenariosFilterBypassesAssignedEnvironment(t *testing.T) {
+	scenarios := []string{
+		"test/e2e/scenarios/apis/basic/scenario.yaml",
+		"test/e2e/scenarios/portal/users/scenario.yaml",
+	}
+
+	selected, err := selectScenariosWithConfig(scenarios, scenarioSelectionConfig{
+		Filter:     "portal/users",
+		CurrentEnv: "kongctl-e2e-other",
+		Assignments: map[string]scenarioAssignment{
+			"portal/users/scenario.yaml": {Environment: "kongctl-e2e-users"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("selectScenariosWithConfig() error = %v", err)
+	}
+
+	want := []string{"test/e2e/scenarios/portal/users/scenario.yaml"}
+	if !slices.Equal(selected, want) {
+		t.Fatalf("unexpected selected scenarios: got %v want %v", selected, want)
+	}
+}
+
+func TestSelectScenariosFailsForMissingAssignedEnvironment(t *testing.T) {
+	scenarios := []string{
+		"test/e2e/scenarios/portal/users/scenario.yaml",
+	}
+
+	_, err := selectScenariosWithConfig(scenarios, scenarioSelectionConfig{
+		AllowedEnvs:  []string{"kongctl-e2e-a", "kongctl-e2e-b"},
+		ValidateEnvs: true,
+		Assignments: map[string]scenarioAssignment{
+			"portal/users/scenario.yaml": {Environment: "kongctl-e2e-users"},
+		},
+	})
+	if err == nil {
+		t.Fatalf("selectScenariosWithConfig() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "kongctl-e2e-users") {
+		t.Fatalf("selectScenariosWithConfig() error = %q, want assigned environment", err)
+	}
+}
+
+func TestLoadScenarioOrgNames(t *testing.T) {
+	got, err := loadScenarioOrgNames(`[
+		{"org_name":"kongctl-e2e-a"},
+		{"org_name":"  "},
+		{"org_name":"kongctl-e2e-b"}
+	]`)
+	if err != nil {
+		t.Fatalf("loadScenarioOrgNames() error = %v", err)
+	}
+
+	want := []string{"kongctl-e2e-a", "kongctl-e2e-b"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("loadScenarioOrgNames() = %v, want %v", got, want)
+	}
+}
+
 func TestWriteScenarioShardManifest(t *testing.T) {
 	dir := t.TempDir()
 	selected := []string{

--- a/test/e2e/scenarios_test.go
+++ b/test/e2e/scenarios_test.go
@@ -53,7 +53,27 @@ func Test_Scenarios(t *testing.T) {
 		}
 	}
 
-	selected := selectScenarios(scenarios, filt, shard)
+	assignments, err := loadScenarioAssignments(scenarios)
+	if err != nil {
+		t.Fatalf("load scenario assignments: %v", err)
+	}
+	allowedEnvs, err := loadScenarioOrgNames(os.Getenv("KONGCTL_E2E_ORGS_JSON"))
+	if err != nil {
+		t.Fatalf("parse KONGCTL_E2E_ORGS_JSON: %v", err)
+	}
+
+	selected, err := selectScenariosWithConfig(scenarios, scenarioSelectionConfig{
+		Filter:       filt,
+		Shard:        shard,
+		CurrentEnv:   os.Getenv("KONGCTL_E2E_MATRIX_ORG"),
+		AllowedEnvs:  allowedEnvs,
+		Assignments:  assignments,
+		ValidateEnvs: shard.Enabled && len(allowedEnvs) > 0,
+		EnforceEnv:   shard.Enabled,
+	})
+	if err != nil {
+		t.Fatalf("select scenarios: %v", err)
+	}
 	if err := writeScenarioShardManifest(os.Getenv("KONGCTL_E2E_ARTIFACTS_DIR"), shard, selected); err != nil {
 		t.Fatalf("write shard manifest: %v", err)
 	}
@@ -71,7 +91,6 @@ func Test_Scenarios(t *testing.T) {
 	}
 
 	for _, p := range selected {
-		p := p
 		t.Run(p, func(t *testing.T) {
 			if err := scenario.Run(t, p); err != nil {
 				t.Fatalf("scenario failed: %v", err)


### PR DESCRIPTION
## Summary

Adds scenario-level E2E environment assignment so a scenario can declare `test.assignedEnvironment` and run only on the matching GitHub Actions environment / matrix org during sharded CI runs.

Also updates reset cleanup to remove E2E-owned portal email domains ending in `.mail.kongctl-e2e.io`, which are created by portal email config scenarios and otherwise accumulate across runs.

## Details

- Adds `test.assignedEnvironment` to the E2E scenario schema.
- Passes `KONGCTL_E2E_ORGS_JSON` into the E2E workflow job for assignment validation.
- Keeps local unsharded runs usable by not enforcing assignments unless sharding or `KONGCTL_E2E_MATRIX_ORG` is active.
- Validates assigned environments against the configured org pool in sharded runs.
- Preserves manifest-based shard coverage verification.
- Documents local CI-environment emulation with `KONGCTL_E2E_MATRIX_ORG`.

## Validation

- `go test -count=1 ./test/e2e`
- `go test -count=1 -tags=e2e -run 'TestSelectScenarios|TestLoadScenarioOrgNames|TestWriteScenarioShardManifest' ./test/e2e`
- `go test -count=1 -tags=e2e ./test/e2e/harness`
- `make lint`
- `make test`