### PR TITLE
Fix: [Breaking Change] declarative `sync` scope defined by present keys only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ CLAUDE.local.md
 .e2e-artifacts/
 .benchmark-artifacts/
 .e2e_artifacts/
+.e2e-debug/
 .benchmark_artifacts/
 .cache/
 

--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -591,9 +591,8 @@ portal_ip_allow_lists:
     allowed_ips: array[string] required # IP addresses or CIDR blocks
 ```
 
-In sync mode, omitting `ip_allow_list` from a managed portal removes current
-portal IP allow-list entries. Omitted IP allow-list config is not deleted for
-external portals.
+In sync mode, omitted `ip_allow_list` configuration is ignored. Include the
+`ip_allow_list` block when the portal IP allow list is owned by the config.
 
 Portal audit-log webhooks can also be declared as root resources.
 
@@ -605,9 +604,8 @@ portal_audit_log_webhooks:
     audit_log_destination_id: string (uuid) # prefer: !ref
 ```
 
-In sync mode, omitting `audit_log_webhook` from a managed portal removes the
-portal webhook configuration. Omitted webhook config is not deleted for
-external portals.
+In sync mode, omitted `audit_log_webhook` configuration is ignored. Include the
+`audit_log_webhook` block when the portal webhook is owned by the config.
 
 ```yaml
 portals:

--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -521,8 +521,8 @@ audit-logs:
 `audit-logs.destinations` supports `_external.id` and
 `_external.selector.matchFields.name`. Destination resources cannot declare
 `kongctl` metadata and are not created, updated, or deleted by declarative
-apply. In sync mode, omitting `audit_log_webhook` from a managed portal removes
-the portal webhook configuration; external portals are not deleted this way.
+apply. In sync mode, omitted portal webhook configuration is ignored unless an
+`audit_log_webhook` block is explicitly present for that portal.
 
 #### Namespace Enforcement Flags
 
@@ -752,8 +752,10 @@ command usage, flags and options.
 ### plan
 
 Create a plan - a JSON file containing the set of planned changes to a set of resources.
-Plans are generated with either `--mode apply` or `--mode sync` which determines
-whether resources missing from the input configuration are planned for deletion or not.
+Plans are generated with either `--mode apply` or `--mode sync`. Apply mode
+creates and updates configured resources only. Sync mode also deletes managed
+resources, but only for resource collections that are explicitly present in the
+input configuration.
 
 Generate an apply plan and output to STDOUT:
 
@@ -772,8 +774,7 @@ kongctl plan -f config.yaml --mode sync
 Applying a configuration will create or update resources to match the desired state
 and will **not delete** resources. Because `apply` does not delete resources, it can
 be used for incremental application of resource configurations. For example, you could
-apply a `portal` in one command and then later apply `apis` in a separate command. With
-the `sync` command, this process is not possible as missing resources will be deleted.
+apply a `portal` in one command and then later apply `apis` in a separate command.
 
 Apply directly from config:
 
@@ -795,8 +796,37 @@ kongctl apply -f config.yaml --dry-run
 
 ### sync
 
-`sync` applies a set of configurations including deleting resources
-missing from the input configuration data.
+`sync` applies a set of configurations including deleting managed resources that
+are missing from explicitly scoped collections.
+
+Sync scope is based on YAML key presence:
+
+- Omitted resource collections are ignored.
+- Explicit empty root lists mean the desired count is zero. For example,
+  `apis: []` deletes managed APIs in the selected namespace.
+- Parent and child collections are scoped separately. A portal block without
+  `pages` does not delete portal pages. Use `pages: []` under that portal to
+  declare that the portal should have no pages.
+- Singleton child sections such as `customization` use the same key-presence
+  rule. Omit the key to ignore the section, or provide an object to manage it.
+  `customization: null` is rejected because sync does not infer reset or delete
+  semantics from null.
+- Empty child collections must be nested under a parent resource. Root-level
+  `api_documents: []` is rejected because it does not identify which API owns
+  the desired zero count.
+
+For federated ownership, include the parent resource entry in the team
+configuration and scope only the child collection that team owns. If a resource
+type supports `_external` parents, the parent can be declared as external;
+otherwise use a namespace or ownership boundary where listing that parent
+collection is safe.
+
+```yaml
+apis:
+  - ref: orders-api
+    name: Orders API
+    documents: []
+```
 
 Preview sync changes:
 

--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -522,7 +522,10 @@ audit-logs:
 `_external.selector.matchFields.name`. Destination resources cannot declare
 `kongctl` metadata and are not created, updated, or deleted by declarative
 apply. In sync mode, omitted portal webhook configuration is ignored unless an
-`audit_log_webhook` block is explicitly present for that portal.
+`audit_log_webhook` block is explicitly present for that portal. To remove an
+existing webhook while retaining the portal, declare `audit_log_webhook: {}`.
+`audit_log_webhook: null` is rejected because null is not a reset or delete
+signal.
 
 #### Namespace Enforcement Flags
 
@@ -807,10 +810,18 @@ Sync scope is based on YAML key presence:
 - Parent and child collections are scoped separately. A portal block without
   `pages` does not delete portal pages. Use `pages: []` under that portal to
   declare that the portal should have no pages.
-- Singleton child sections such as `customization` use the same key-presence
-  rule. Omit the key to ignore the section, or provide an object to manage it.
-  `customization: null` is rejected because sync does not infer reset or delete
-  semantics from null.
+- Map-shaped child collections use an empty object as the empty collection. For
+  example, `email_templates: {}` means the portal should have no customized
+  email templates.
+- Singleton child sections use the same key-presence rule, but `{}` and `null`
+  are intentionally different. Omit a singleton key to ignore that child.
+  Provide an object with fields to manage or update it. For optional,
+  delete-capable portal singletons such as `custom_domain`, `email_config`, and
+  `audit_log_webhook`, an empty object scopes the child with desired count zero:
+  `custom_domain: {}` deletes any existing managed custom domain for that
+  portal during sync. `null` is rejected because sync does not infer reset or
+  delete semantics from null. Update-only singleton sections, such as
+  `customization`, cannot be deleted by declaring `{}`.
 - Empty child collections must be nested under a parent resource. Root-level
   `api_documents: []` is rejected because it does not identify which API owns
   the desired zero count.

--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -816,10 +816,11 @@ Sync scope is based on YAML key presence:
   the desired zero count.
 
 For federated ownership, include the parent resource entry in the team
-configuration and scope only the child collection that team owns. If a resource
-type supports `_external` parents, the parent can be declared as external;
-otherwise use a namespace or ownership boundary where listing that parent
-collection is safe.
+configuration and scope only the child collection that team owns. When the
+parent is managed elsewhere and the resource type supports `_external`, declare
+the parent as external and nest the child collection under that parent. This
+allows `sync` to plan the child collection without treating the managed parent
+collection in the team's namespace as desired state.
 
 ```yaml
 apis:
@@ -827,6 +828,20 @@ apis:
     name: Orders API
     documents: []
 ```
+
+```yaml
+portals:
+  - ref: shared-docs-portal
+    _external:
+      selector:
+        matchFields:
+          name: "Shared Docs Portal"
+    pages: []
+```
+
+The external-parent pattern should not be combined with a namespace default
+unless the team also intends to scope managed parent resources in that
+namespace.
 
 Preview sync changes:
 

--- a/docs/examples/declarative/control-plane/README.md
+++ b/docs/examples/declarative/control-plane/README.md
@@ -31,7 +31,7 @@ Apply the configuration:
 kongctl apply -f control-plane.yaml
 ```
 
-Run in sync mode to delete unmanaged control planes in the namespace (use with caution):
+Run in sync mode to reconcile managed control planes in the namespace (use with caution):
 
 ```bash
 kongctl sync -f control-plane.yaml

--- a/docs/examples/declarative/deck/README.md
+++ b/docs/examples/declarative/deck/README.md
@@ -29,7 +29,7 @@ Apply the configuration:
 kongctl apply -f control-plane.yaml -f api.yaml
 ```
 
-Run in sync mode to delete managed resources in the namespace (use with caution):
+Run in sync mode to reconcile the scoped resources in the namespace (use with caution):
 
 ```bash
 kongctl sync -f control-plane.yaml -f api.yaml

--- a/docs/examples/declarative/namespace/README.md
+++ b/docs/examples/declarative/namespace/README.md
@@ -30,7 +30,7 @@ kongctl get apis -o json
 Because we are using `sync`, resources can be deleted. To remove all managed
 APIs in a namespace, pass an explicit empty API list with the namespace default:
 
-⚠️ Warning: This removes all resources in the namespace, so use with caution! ⚠️
+⚠️ Warning: This removes all managed APIs in the namespace. Use caution! ⚠️
 
 ```bash
 printf '_defaults: {kongctl: {namespace: team-beta}}\napis: []\n' | kongctl sync -f -

--- a/docs/examples/declarative/namespace/README.md
+++ b/docs/examples/declarative/namespace/README.md
@@ -27,17 +27,17 @@ Investigate the resources created and observe the namespace labels applied:
 kongctl get apis -o json
 ```
 
-Because we are using `sync`, resources can be deleted. One way to simulate the removing of resources for a 
-namespace is to pass an empty configuration file with a `_default` namespace value:
+Because we are using `sync`, resources can be deleted. To remove all managed
+APIs in a namespace, pass an explicit empty API list with the namespace default:
 
 ⚠️ Warning: This removes all resources in the namespace, so use with caution! ⚠️
 
 ```bash
-echo "_defaults: {kongctl: {namespace: team-beta}}" | kongctl sync -f -
+echo "_defaults: {kongctl: {namespace: team-beta}}\napis: []" | kongctl sync -f -
 ```
 
-Notice that only resources in the `team-beta` namespace will be removed. Check the list of apis again to 
-verify that `team-alpha` apis remains intact:
+Notice that only APIs in the `team-beta` namespace will be removed. Check the
+list of APIs again to verify that `team-alpha` APIs remain intact:
 
 ```bash
 kongctl get apis -o json

--- a/docs/examples/declarative/namespace/README.md
+++ b/docs/examples/declarative/namespace/README.md
@@ -33,7 +33,7 @@ APIs in a namespace, pass an explicit empty API list with the namespace default:
 ⚠️ Warning: This removes all resources in the namespace, so use with caution! ⚠️
 
 ```bash
-echo "_defaults: {kongctl: {namespace: team-beta}}\napis: []" | kongctl sync -f -
+printf '_defaults: {kongctl: {namespace: team-beta}}\napis: []\n' | kongctl sync -f -
 ```
 
 Notice that only APIs in the `team-beta` namespace will be removed. Check the

--- a/docs/examples/declarative/protected/README.md
+++ b/docs/examples/declarative/protected/README.md
@@ -53,8 +53,9 @@ And run the sync command again:
 kongctl sync -f protected.yaml
 ```
 
-Typically the `sync` command will look for resources that exist (in the current namespace) and plan to delete them. 
-With protection on, you should receive an error indicating that the resource is protected and cannot be deleted:
+When an API collection is in sync scope, removing an API from that collection
+plans a delete for the managed API. With protection on, you should receive an
+error indicating that the resource is protected and cannot be deleted:
 
 ```text
 Error: failed to generate plan: failed to plan API changes for namespace default: Cannot generate plan due to protected resources:

--- a/internal/cmd/root/verbs/help/templates/apply.md
+++ b/internal/cmd/root/verbs/help/templates/apply.md
@@ -293,7 +293,7 @@ Common validation issues:
 ## Related Commands
 
 - `kongctl plan` - Preview changes before applying
-- `kongctl sync` - Full state synchronization
+- `kongctl sync` - Scoped synchronization that can delete managed resources
 - `kongctl diff` - Show detailed differences
 
 ## See Also

--- a/internal/cmd/root/verbs/help/templates/diff.md
+++ b/internal/cmd/root/verbs/help/templates/diff.md
@@ -370,7 +370,7 @@ kongctl diff -f large-config/
 
 - `kongctl plan` - Generate execution plan
 - `kongctl apply` - Apply changes (no deletions)
-- `kongctl sync` - Full synchronization
+- `kongctl sync` - Scoped synchronization
 
 ## See Also
 

--- a/internal/cmd/root/verbs/help/templates/plan.md
+++ b/internal/cmd/root/verbs/help/templates/plan.md
@@ -207,7 +207,7 @@ This shows:
 
 - `kongctl diff` - Show detailed differences
 - `kongctl apply` - Apply changes (create/update only)
-- `kongctl sync` - Full synchronization (includes deletes)
+- `kongctl sync` - Scoped synchronization (can include deletes)
 
 ## See Also
 

--- a/internal/cmd/root/verbs/help/templates/sync.md
+++ b/internal/cmd/root/verbs/help/templates/sync.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-The `kongctl sync` command performs full state synchronization between your declarative configuration and Kong Konnect. Unlike `apply`, sync will CREATE, UPDATE, and DELETE resources to ensure the target state exactly matches your configuration.
+The `kongctl sync` command reconciles explicitly scoped declarative resource
+collections with Kong Konnect. Unlike `apply`, sync can CREATE, UPDATE, and
+DELETE managed resources, but omitted collections are ignored.
 
 ⚠️ **WARNING**: Sync can delete resources. Always review changes before executing.
 
@@ -35,13 +37,31 @@ kongctl sync [flags]
 
 ## How Sync Works
 
-1. **Identifies managed resources** using `KONGCTL-managed` labels
-2. **Compares** desired state (your config) with current state
-3. **Plans operations**:
+1. **Identifies scope** from resource keys present in your YAML
+2. **Identifies managed resources** using `KONGCTL-managed` labels
+3. **Compares** desired state (your config) with current state
+4. **Plans operations**:
    - CREATE for new resources
    - UPDATE for changed resources
-   - DELETE for resources not in config
-4. **Executes** all operations in dependency order
+   - DELETE for managed resources missing from scoped collections
+5. **Executes** all operations in dependency order
+
+## Sync Scope
+
+Sync distinguishes between omitted collections and explicit empty collections:
+
+- Omitted collections are ignored. If a file contains only `portals`, sync does
+  not list or delete APIs, auth strategies, or DCR providers.
+- Explicit empty root lists mean desired count zero. `apis: []` deletes managed
+  APIs in the selected namespace.
+- Child collections are scoped under each parent. A portal without `pages` leaves
+  pages alone; `pages: []` under that portal deletes managed pages for that
+  portal.
+- Singleton child sections such as `customization` are ignored when omitted and
+  managed when an object is provided. `customization: null` is rejected because
+  reset/delete semantics are not inferred from null.
+- Empty child lists must be nested under a parent resource. Root-level
+  `api_documents: []` is rejected because it does not identify the API.
 
 ## Managed Resources
 
@@ -85,7 +105,7 @@ kongctl sync -f team-configs/
 ### Empty Configuration Sync
 
 ```bash
-# Delete all managed resources in namespace
+# Delete all managed APIs in namespace
 echo 'apis: []' | kongctl sync -f -
 
 # Safer: dry run first

--- a/internal/cmd/root/verbs/help/templates/sync.md
+++ b/internal/cmd/root/verbs/help/templates/sync.md
@@ -57,9 +57,9 @@ Sync distinguishes between omitted collections and explicit empty collections:
 - Child collections are scoped under each parent. A portal without `pages` leaves
   pages alone; `pages: []` under that portal deletes managed pages for that
   portal.
-- Singleton child sections such as `customization` are ignored when omitted and
-  managed when an object is provided. `customization: null` is rejected because
-  reset/delete semantics are not inferred from null.
+- Singleton child sections such as `customization` are ignored when omitted
+  and managed when an object is provided. `customization: null` is rejected
+  because reset/delete semantics are not inferred from null.
 - Empty child lists must be nested under a parent resource. Root-level
   `api_documents: []` is rejected because it does not identify the API.
 

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -275,6 +275,9 @@ func (l *Loader) parseYAML(r io.Reader, sourcePath string, rootDir string) (*res
 	// Extract the clean ResourceSet
 	rs := temp.ResourceSet
 	placeholderRS := placeholderTemp.ResourceSet
+	if err := captureSyncScope(content, &rs); err != nil {
+		return nil, fmt.Errorf("failed to inspect sync scope in %s: %w", sourcePath, err)
+	}
 
 	// Apply file-level namespace and protected defaults
 	if err := l.applyNamespaceDefaults(&rs, temp.Defaults); err != nil {
@@ -476,6 +479,7 @@ func (l *Loader) appendResourcesWithDuplicateCheck(
 	accumulated.AppendAll(source)
 	appendOrganizationUsers(accumulated, source)
 	appendOrganizationSystemAccounts(accumulated, source)
+	accumulated.MergeSyncScope(source)
 
 	// Update the running index with newly added refs
 	maps.Copy(refIndex, seenRefs)

--- a/internal/declarative/loader/loader_test.go
+++ b/internal/declarative/loader/loader_test.go
@@ -185,6 +185,62 @@ portals:
 	assert.Equal(t, "portal-email-config", rs.PortalEmailConfigs[0].Ref)
 }
 
+func TestLoader_EmptyPortalSingletonChildrenAreScopeOnly(t *testing.T) {
+	tests := []struct {
+		name         string
+		childYAML    string
+		resourceType resources.ResourceType
+		assertEmpty  func(*testing.T, *resources.ResourceSet)
+	}{
+		{
+			name:         "custom domain",
+			childYAML:    "    custom_domain: {}\n",
+			resourceType: resources.ResourceTypePortalCustomDomain,
+			assertEmpty: func(t *testing.T, rs *resources.ResourceSet) {
+				t.Helper()
+				assert.Empty(t, rs.PortalCustomDomains)
+			},
+		},
+		{
+			name:         "email config",
+			childYAML:    "    email_config: {}\n",
+			resourceType: resources.ResourceTypePortalEmailConfig,
+			assertEmpty: func(t *testing.T, rs *resources.ResourceSet) {
+				t.Helper()
+				assert.Empty(t, rs.PortalEmailConfigs)
+			},
+		},
+		{
+			name:         "audit log webhook",
+			childYAML:    "    audit_log_webhook: {}\n",
+			resourceType: resources.ResourceTypePortalAuditLogWebhook,
+			assertEmpty: func(t *testing.T, rs *resources.ResourceSet) {
+				t.Helper()
+				assert.Empty(t, rs.PortalAuditLogWebhooks)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := `
+portals:
+  - ref: portal-email
+    name: portal-email
+` + tt.childYAML
+
+			loader := New()
+			rs, err := loader.parseYAML(strings.NewReader(content), "inline", "")
+			require.NoError(t, err)
+			require.NoError(t, loader.validateResourceSet(rs))
+
+			require.NotNil(t, rs.SyncScope)
+			assert.True(t, rs.SyncScope.ChildInScope(resources.ResourceTypePortal, "portal-email", tt.resourceType))
+			tt.assertEmpty(t, rs)
+		})
+	}
+}
+
 func TestLoader_FlattensPortalIntegration(t *testing.T) {
 	content := `
 portals:

--- a/internal/declarative/loader/sync_scope.go
+++ b/internal/declarative/loader/sync_scope.go
@@ -336,6 +336,8 @@ var eventGatewayChildCollectionScopes = []childCollectionScope{
 
 func captureSyncScope(content []byte, rs *resources.ResourceSet) error {
 	var raw map[string]any
+	// Called after strict parsing succeeds; use a relaxed pass only to inspect
+	// YAML key presence before nested resources are extracted.
 	if err := yaml.Unmarshal(content, &raw); err != nil {
 		return fmt.Errorf("failed to inspect sync scope: %w", err)
 	}
@@ -460,6 +462,8 @@ func captureNestedPortalScopes(scope *resources.SyncScope, raw map[string]any) e
 			if _, ok := portal[child.key]; ok {
 				scope.AddChild(resources.ResourceTypePortal, portalRef, child.resourceType)
 				if child.resourceType == resources.ResourceTypePortalTeam {
+					// Team role declarations are nested under teams, so a teams
+					// key scopes both the teams and their role assignments.
 					scope.AddChild(resources.ResourceTypePortal, portalRef, resources.ResourceTypePortalTeamRole)
 				}
 			}

--- a/internal/declarative/loader/sync_scope.go
+++ b/internal/declarative/loader/sync_scope.go
@@ -1,0 +1,630 @@
+package loader
+
+import (
+	"fmt"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"sigs.k8s.io/yaml"
+)
+
+type rootCollectionScope struct {
+	key          string
+	resourceType resources.ResourceType
+}
+
+type childCollectionScope struct {
+	key          string
+	resourceType resources.ResourceType
+	parentKey    string
+	parentType   resources.ResourceType
+}
+
+var rootCollectionScopes = []rootCollectionScope{
+	{key: "portals", resourceType: resources.ResourceTypePortal},
+	{key: "application_auth_strategies", resourceType: resources.ResourceTypeApplicationAuthStrategy},
+	{key: "dcr_providers", resourceType: resources.ResourceTypeDCRProvider},
+	{key: "control_planes", resourceType: resources.ResourceTypeControlPlane},
+	{key: "catalog_services", resourceType: resources.ResourceTypeCatalogService},
+	{key: "apis", resourceType: resources.ResourceTypeAPI},
+	{key: "event_gateways", resourceType: resources.ResourceTypeEventGatewayControlPlane},
+}
+
+var rootChildCollectionScopes = []childCollectionScope{
+	{
+		key:          "control_plane_data_plane_certificates",
+		resourceType: resources.ResourceTypeControlPlaneDataPlaneCertificate,
+		parentKey:    "control_plane",
+		parentType:   resources.ResourceTypeControlPlane,
+	},
+	{
+		key:          "api_versions",
+		resourceType: resources.ResourceTypeAPIVersion,
+		parentKey:    "api",
+		parentType:   resources.ResourceTypeAPI,
+	},
+	{
+		key:          "api_publications",
+		resourceType: resources.ResourceTypeAPIPublication,
+		parentKey:    "api",
+		parentType:   resources.ResourceTypeAPI,
+	},
+	{
+		key:          "api_implementations",
+		resourceType: resources.ResourceTypeAPIImplementation,
+		parentKey:    "api",
+		parentType:   resources.ResourceTypeAPI,
+	},
+	{
+		key:          "api_documents",
+		resourceType: resources.ResourceTypeAPIDocument,
+		parentKey:    "api",
+		parentType:   resources.ResourceTypeAPI,
+	},
+	{
+		key:          "portal_customizations",
+		resourceType: resources.ResourceTypePortalCustomization,
+		parentKey:    "portal",
+		parentType:   resources.ResourceTypePortal,
+	},
+	{
+		key:          "portal_auth_settings",
+		resourceType: resources.ResourceTypePortalAuthSettings,
+		parentKey:    "portal",
+		parentType:   resources.ResourceTypePortal,
+	},
+	{
+		key:          "portal_ip_allow_lists",
+		resourceType: resources.ResourceTypePortalIPAllowList,
+		parentKey:    "portal",
+		parentType:   resources.ResourceTypePortal,
+	},
+	{
+		key:          "portal_integrations",
+		resourceType: resources.ResourceTypePortalIntegration,
+		parentKey:    "portal",
+		parentType:   resources.ResourceTypePortal,
+	},
+	{
+		key:          "portal_identity_providers",
+		resourceType: resources.ResourceTypePortalIdentityProvider,
+		parentKey:    "portal",
+		parentType:   resources.ResourceTypePortal,
+	},
+	{
+		key:          "portal_custom_domains",
+		resourceType: resources.ResourceTypePortalCustomDomain,
+		parentKey:    "portal",
+		parentType:   resources.ResourceTypePortal,
+	},
+	{
+		key:          "portal_pages",
+		resourceType: resources.ResourceTypePortalPage,
+		parentKey:    "portal",
+		parentType:   resources.ResourceTypePortal,
+	},
+	{
+		key:          "portal_snippets",
+		resourceType: resources.ResourceTypePortalSnippet,
+		parentKey:    "portal",
+		parentType:   resources.ResourceTypePortal,
+	},
+	{
+		key:          "portal_teams",
+		resourceType: resources.ResourceTypePortalTeam,
+		parentKey:    "portal",
+		parentType:   resources.ResourceTypePortal,
+	},
+	{
+		key:          "portal_team_roles",
+		resourceType: resources.ResourceTypePortalTeamRole,
+		parentKey:    "portal",
+		parentType:   resources.ResourceTypePortal,
+	},
+	{
+		key:          "portal_asset_logos",
+		resourceType: resources.ResourceTypePortalAssetLogo,
+		parentKey:    "portal",
+		parentType:   resources.ResourceTypePortal,
+	},
+	{
+		key:          "portal_asset_favicons",
+		resourceType: resources.ResourceTypePortalAssetFavicon,
+		parentKey:    "portal",
+		parentType:   resources.ResourceTypePortal,
+	},
+	{
+		key:          "portal_email_configs",
+		resourceType: resources.ResourceTypePortalEmailConfig,
+		parentKey:    "portal",
+		parentType:   resources.ResourceTypePortal,
+	},
+	{
+		key:          "portal_email_templates",
+		resourceType: resources.ResourceTypePortalEmailTemplate,
+		parentKey:    "portal",
+		parentType:   resources.ResourceTypePortal,
+	},
+	{
+		key:          "portal_audit_log_webhooks",
+		resourceType: resources.ResourceTypePortalAuditLogWebhook,
+		parentKey:    "portal",
+		parentType:   resources.ResourceTypePortal,
+	},
+	{
+		key:          "event_gateway_backend_clusters",
+		resourceType: resources.ResourceTypeEventGatewayBackendCluster,
+		parentKey:    "event_gateway",
+		parentType:   resources.ResourceTypeEventGatewayControlPlane,
+	},
+	{
+		key:          "event_gateway_virtual_clusters",
+		resourceType: resources.ResourceTypeEventGatewayVirtualCluster,
+		parentKey:    "event_gateway",
+		parentType:   resources.ResourceTypeEventGatewayControlPlane,
+	},
+	{
+		key:          "event_gateway_listeners",
+		resourceType: resources.ResourceTypeEventGatewayListener,
+		parentKey:    "event_gateway",
+		parentType:   resources.ResourceTypeEventGatewayControlPlane,
+	},
+	{
+		key:          "event_gateway_data_plane_certificates",
+		resourceType: resources.ResourceTypeEventGatewayDataPlaneCertificate,
+		parentKey:    "event_gateway",
+		parentType:   resources.ResourceTypeEventGatewayControlPlane,
+	},
+	{
+		key:          "event_gateway_schema_registries",
+		resourceType: resources.ResourceTypeEventGatewaySchemaRegistry,
+		parentKey:    "event_gateway",
+		parentType:   resources.ResourceTypeEventGatewayControlPlane,
+	},
+	{
+		key:          "event_gateway_static_keys",
+		resourceType: resources.ResourceTypeEventGatewayStaticKey,
+		parentKey:    "event_gateway",
+		parentType:   resources.ResourceTypeEventGatewayControlPlane,
+	},
+	{
+		key:          "event_gateway_tls_trust_bundles",
+		resourceType: resources.ResourceTypeEventGatewayTLSTrustBundle,
+		parentKey:    "event_gateway",
+		parentType:   resources.ResourceTypeEventGatewayControlPlane,
+	},
+	{
+		key:          "event_gateway_listener_policies",
+		resourceType: resources.ResourceTypeEventGatewayListenerPolicy,
+		parentKey:    "listener",
+		parentType:   resources.ResourceTypeEventGatewayListener,
+	},
+	{
+		key:          "event_gateway_virtual_cluster_cluster_policies",
+		resourceType: resources.ResourceTypeEventGatewayClusterPolicy,
+		parentKey:    "virtual_cluster",
+		parentType:   resources.ResourceTypeEventGatewayVirtualCluster,
+	},
+	{
+		key:          "event_gateway_virtual_cluster_produce_policies",
+		resourceType: resources.ResourceTypeEventGatewayProducePolicy,
+		parentKey:    "virtual_cluster",
+		parentType:   resources.ResourceTypeEventGatewayVirtualCluster,
+	},
+	{
+		key:          "event_gateway_virtual_cluster_consume_policies",
+		resourceType: resources.ResourceTypeEventGatewayConsumePolicy,
+		parentKey:    "virtual_cluster",
+		parentType:   resources.ResourceTypeEventGatewayVirtualCluster,
+	},
+	{
+		key:          "organization_team_roles",
+		resourceType: resources.ResourceTypeOrganizationTeamRole,
+		parentKey:    "team",
+		parentType:   resources.ResourceTypeOrganizationTeam,
+	},
+}
+
+var apiChildCollectionScopes = []childCollectionScope{
+	{key: "versions", resourceType: resources.ResourceTypeAPIVersion, parentType: resources.ResourceTypeAPI},
+	{key: "publications", resourceType: resources.ResourceTypeAPIPublication, parentType: resources.ResourceTypeAPI},
+	{
+		key:          "implementations",
+		resourceType: resources.ResourceTypeAPIImplementation,
+		parentType:   resources.ResourceTypeAPI,
+	},
+	{key: "documents", resourceType: resources.ResourceTypeAPIDocument, parentType: resources.ResourceTypeAPI},
+}
+
+var portalChildCollectionScopes = []childCollectionScope{
+	{
+		key:          "customization",
+		resourceType: resources.ResourceTypePortalCustomization,
+		parentType:   resources.ResourceTypePortal,
+	},
+	{
+		key:          "auth_settings",
+		resourceType: resources.ResourceTypePortalAuthSettings,
+		parentType:   resources.ResourceTypePortal,
+	},
+	{
+		key:          "ip_allow_list",
+		resourceType: resources.ResourceTypePortalIPAllowList,
+		parentType:   resources.ResourceTypePortal,
+	},
+	{
+		key:          "integrations",
+		resourceType: resources.ResourceTypePortalIntegration,
+		parentType:   resources.ResourceTypePortal,
+	},
+	{
+		key:          "identity_providers",
+		resourceType: resources.ResourceTypePortalIdentityProvider,
+		parentType:   resources.ResourceTypePortal,
+	},
+	{
+		key:          "custom_domain",
+		resourceType: resources.ResourceTypePortalCustomDomain,
+		parentType:   resources.ResourceTypePortal,
+	},
+	{key: "pages", resourceType: resources.ResourceTypePortalPage, parentType: resources.ResourceTypePortal},
+	{key: "snippets", resourceType: resources.ResourceTypePortalSnippet, parentType: resources.ResourceTypePortal},
+	{key: "teams", resourceType: resources.ResourceTypePortalTeam, parentType: resources.ResourceTypePortal},
+	{
+		key:          "email_config",
+		resourceType: resources.ResourceTypePortalEmailConfig,
+		parentType:   resources.ResourceTypePortal,
+	},
+	{
+		key:          "email_templates",
+		resourceType: resources.ResourceTypePortalEmailTemplate,
+		parentType:   resources.ResourceTypePortal,
+	},
+	{
+		key:          "audit_log_webhook",
+		resourceType: resources.ResourceTypePortalAuditLogWebhook,
+		parentType:   resources.ResourceTypePortal,
+	},
+}
+
+var portalSingletonChildKeys = map[string]struct{}{
+	"customization":     {},
+	"auth_settings":     {},
+	"ip_allow_list":     {},
+	"integrations":      {},
+	"custom_domain":     {},
+	"email_config":      {},
+	"audit_log_webhook": {},
+}
+
+var eventGatewayChildCollectionScopes = []childCollectionScope{
+	{
+		key:          "backend_clusters",
+		resourceType: resources.ResourceTypeEventGatewayBackendCluster,
+		parentType:   resources.ResourceTypeEventGatewayControlPlane,
+	},
+	{
+		key:          "virtual_clusters",
+		resourceType: resources.ResourceTypeEventGatewayVirtualCluster,
+		parentType:   resources.ResourceTypeEventGatewayControlPlane,
+	},
+	{
+		key:          "listeners",
+		resourceType: resources.ResourceTypeEventGatewayListener,
+		parentType:   resources.ResourceTypeEventGatewayControlPlane,
+	},
+	{
+		key:          "data_plane_certificates",
+		resourceType: resources.ResourceTypeEventGatewayDataPlaneCertificate,
+		parentType:   resources.ResourceTypeEventGatewayControlPlane,
+	},
+	{
+		key:          "schema_registries",
+		resourceType: resources.ResourceTypeEventGatewaySchemaRegistry,
+		parentType:   resources.ResourceTypeEventGatewayControlPlane,
+	},
+	{
+		key:          "static_keys",
+		resourceType: resources.ResourceTypeEventGatewayStaticKey,
+		parentType:   resources.ResourceTypeEventGatewayControlPlane,
+	},
+	{
+		key:          "tls_trust_bundles",
+		resourceType: resources.ResourceTypeEventGatewayTLSTrustBundle,
+		parentType:   resources.ResourceTypeEventGatewayControlPlane,
+	},
+}
+
+func captureSyncScope(content []byte, rs *resources.ResourceSet) error {
+	var raw map[string]any
+	if err := yaml.Unmarshal(content, &raw); err != nil {
+		return fmt.Errorf("failed to inspect sync scope: %w", err)
+	}
+	if len(raw) == 0 {
+		return nil
+	}
+
+	scope := rs.EnsureSyncScope()
+	for _, entry := range rootCollectionScopes {
+		if _, ok := raw[entry.key]; ok {
+			scope.AddRoot(entry.resourceType)
+		}
+	}
+
+	for _, entry := range rootChildCollectionScopes {
+		captureRootChildScope(scope, raw, entry)
+	}
+
+	captureNestedCollectionScopes(scope, raw, "apis", resources.ResourceTypeAPI, apiChildCollectionScopes)
+	captureNestedCollectionScopes(
+		scope,
+		raw,
+		"control_planes",
+		resources.ResourceTypeControlPlane,
+		[]childCollectionScope{
+			{
+				key:          "data_plane_certificates",
+				resourceType: resources.ResourceTypeControlPlaneDataPlaneCertificate,
+				parentType:   resources.ResourceTypeControlPlane,
+			},
+		},
+	)
+	captureNestedCollectionScopes(
+		scope,
+		raw,
+		"event_gateways",
+		resources.ResourceTypeEventGatewayControlPlane,
+		eventGatewayChildCollectionScopes,
+	)
+	captureNestedEventGatewayScopes(scope, raw)
+	if err := captureNestedPortalScopes(scope, raw); err != nil {
+		return err
+	}
+	captureOrganizationScope(scope, raw)
+
+	return nil
+}
+
+func captureRootChildScope(scope *resources.SyncScope, raw map[string]any, entry childCollectionScope) {
+	value, ok := raw[entry.key]
+	if !ok {
+		return
+	}
+	items, ok := asSlice(value)
+	if !ok || len(items) == 0 {
+		scope.AddRootChildCollection(entry.resourceType)
+		return
+	}
+	for _, item := range items {
+		m, ok := asMap(item)
+		if !ok {
+			continue
+		}
+		if parentRef := stringValue(m[entry.parentKey]); parentRef != "" {
+			scope.AddChild(entry.parentType, parentRef, entry.resourceType)
+		}
+	}
+}
+
+func captureNestedCollectionScopes(
+	scope *resources.SyncScope,
+	raw map[string]any,
+	rootKey string,
+	parentType resources.ResourceType,
+	childScopes []childCollectionScope,
+) {
+	items, ok := asSlice(raw[rootKey])
+	if !ok {
+		return
+	}
+	for _, item := range items {
+		parent, ok := asMap(item)
+		if !ok {
+			continue
+		}
+		parentRef := stringValue(parent["ref"])
+		if parentRef == "" {
+			continue
+		}
+		for _, child := range childScopes {
+			if _, ok := parent[child.key]; ok {
+				scope.AddChild(parentType, parentRef, child.resourceType)
+			}
+		}
+	}
+}
+
+func captureNestedPortalScopes(scope *resources.SyncScope, raw map[string]any) error {
+	items, ok := asSlice(raw["portals"])
+	if !ok {
+		return nil
+	}
+	for _, item := range items {
+		portal, ok := asMap(item)
+		if !ok {
+			continue
+		}
+		portalRef := stringValue(portal["ref"])
+		if portalRef == "" {
+			continue
+		}
+		for key := range portalSingletonChildKeys {
+			if value, ok := portal[key]; ok && value == nil {
+				return fmt.Errorf(
+					"portal %q child singleton %q cannot be null; omit the key to ignore it or provide an object to manage it",
+					portalRef,
+					key,
+				)
+			}
+		}
+		for _, child := range portalChildCollectionScopes {
+			if _, ok := portal[child.key]; ok {
+				scope.AddChild(resources.ResourceTypePortal, portalRef, child.resourceType)
+				if child.resourceType == resources.ResourceTypePortalTeam {
+					scope.AddChild(resources.ResourceTypePortal, portalRef, resources.ResourceTypePortalTeamRole)
+				}
+			}
+		}
+		assetsValue, assetsPresent := portal["assets"]
+		if assetsPresent && assetsValue == nil {
+			return fmt.Errorf(
+				"portal %q child singleton %q cannot be null; omit the key to ignore assets or provide an object to manage them",
+				portalRef,
+				"assets",
+			)
+		}
+		if assets, ok := asMap(assetsValue); ok {
+			if value, ok := assets["logo"]; ok {
+				if value == nil {
+					return fmt.Errorf(
+						"portal %q child singleton %q cannot be null; omit the key to ignore it or provide a value",
+						portalRef,
+						"assets.logo",
+					)
+				}
+				scope.AddChild(resources.ResourceTypePortal, portalRef, resources.ResourceTypePortalAssetLogo)
+			}
+			if value, ok := assets["favicon"]; ok {
+				if value == nil {
+					return fmt.Errorf(
+						"portal %q child singleton %q cannot be null; omit the key to ignore it or provide a value",
+						portalRef,
+						"assets.favicon",
+					)
+				}
+				scope.AddChild(resources.ResourceTypePortal, portalRef, resources.ResourceTypePortalAssetFavicon)
+			}
+		}
+	}
+	return nil
+}
+
+func captureNestedEventGatewayScopes(scope *resources.SyncScope, raw map[string]any) {
+	gateways, ok := asSlice(raw["event_gateways"])
+	if !ok {
+		return
+	}
+	for _, item := range gateways {
+		gateway, ok := asMap(item)
+		if !ok {
+			continue
+		}
+		captureVirtualClusterPolicyScopes(scope, gateway["virtual_clusters"])
+		captureListenerPolicyScopes(scope, gateway["listeners"])
+	}
+}
+
+func captureVirtualClusterPolicyScopes(scope *resources.SyncScope, value any) {
+	virtualClusters, ok := asSlice(value)
+	if !ok {
+		return
+	}
+	for _, item := range virtualClusters {
+		vc, ok := asMap(item)
+		if !ok {
+			continue
+		}
+		ref := stringValue(vc["ref"])
+		if ref == "" {
+			continue
+		}
+		if _, ok := vc["cluster_policies"]; ok {
+			scope.AddChild(
+				resources.ResourceTypeEventGatewayVirtualCluster,
+				ref,
+				resources.ResourceTypeEventGatewayClusterPolicy,
+			)
+		}
+		if _, ok := vc["produce_policies"]; ok {
+			scope.AddChild(
+				resources.ResourceTypeEventGatewayVirtualCluster,
+				ref,
+				resources.ResourceTypeEventGatewayProducePolicy,
+			)
+		}
+		if _, ok := vc["consume_policies"]; ok {
+			scope.AddChild(
+				resources.ResourceTypeEventGatewayVirtualCluster,
+				ref,
+				resources.ResourceTypeEventGatewayConsumePolicy,
+			)
+		}
+	}
+}
+
+func captureListenerPolicyScopes(scope *resources.SyncScope, value any) {
+	listeners, ok := asSlice(value)
+	if !ok {
+		return
+	}
+	for _, item := range listeners {
+		listener, ok := asMap(item)
+		if !ok {
+			continue
+		}
+		ref := stringValue(listener["ref"])
+		if ref == "" {
+			continue
+		}
+		if _, ok := listener["policies"]; ok {
+			scope.AddChild(
+				resources.ResourceTypeEventGatewayListener,
+				ref,
+				resources.ResourceTypeEventGatewayListenerPolicy,
+			)
+		}
+	}
+}
+
+func captureOrganizationScope(scope *resources.SyncScope, raw map[string]any) {
+	org, ok := asMap(raw["organization"])
+	if !ok {
+		return
+	}
+	if teams, ok := org["teams"]; ok {
+		scope.AddRoot(resources.ResourceTypeOrganizationTeam)
+		captureOrganizationTeamRoleScopes(scope, teams)
+	}
+	if _, ok := org["users"]; ok {
+		scope.MarkOrganizationUsersScoped()
+	}
+}
+
+func captureOrganizationTeamRoleScopes(scope *resources.SyncScope, value any) {
+	teams, ok := asSlice(value)
+	if !ok {
+		return
+	}
+	for _, item := range teams {
+		team, ok := asMap(item)
+		if !ok {
+			continue
+		}
+		ref := stringValue(team["ref"])
+		if ref == "" {
+			continue
+		}
+		if _, ok := team["roles"]; ok {
+			scope.AddChild(resources.ResourceTypeOrganizationTeam, ref, resources.ResourceTypeOrganizationTeamRole)
+		}
+	}
+}
+
+func asMap(value any) (map[string]any, bool) {
+	m, ok := value.(map[string]any)
+	return m, ok
+}
+
+func asSlice(value any) ([]any, bool) {
+	items, ok := value.([]any)
+	return items, ok
+}
+
+func stringValue(value any) string {
+	if value == nil {
+		return ""
+	}
+	if s, ok := value.(string); ok {
+		return s
+	}
+	return ""
+}

--- a/internal/declarative/loader/sync_scope.go
+++ b/internal/declarative/loader/sync_scope.go
@@ -591,6 +591,9 @@ func captureOrganizationScope(scope *resources.SyncScope, raw map[string]any) {
 	if _, ok := org["users"]; ok {
 		scope.MarkOrganizationUsersScoped()
 	}
+	if _, ok := org["system-accounts"]; ok {
+		scope.MarkOrganizationSystemAccountsScoped()
+	}
 }
 
 func captureOrganizationTeamRoleScopes(scope *resources.SyncScope, value any) {

--- a/internal/declarative/loader/sync_scope.go
+++ b/internal/declarative/loader/sync_scope.go
@@ -293,6 +293,7 @@ var portalSingletonChildKeys = map[string]struct{}{
 	"integrations":      {},
 	"custom_domain":     {},
 	"email_config":      {},
+	"email_templates":   {},
 	"audit_log_webhook": {},
 }
 

--- a/internal/declarative/loader/sync_scope_test.go
+++ b/internal/declarative/loader/sync_scope_test.go
@@ -53,6 +53,25 @@ func TestCaptureSyncScopeTracksRootLevelEmptyChildCollections(t *testing.T) {
 	)
 }
 
+func TestCaptureSyncScopeTracksOrganizationAssignments(t *testing.T) {
+	input := strings.NewReader(`
+organization:
+  users:
+    - ref: alice
+      id: user-123
+  system-accounts:
+    - ref: ci-bot
+      id: system-account-123
+`)
+
+	rs, err := New().parseYAML(input, "test.yaml", ".")
+	require.NoError(t, err)
+	require.NotNil(t, rs.SyncScope)
+
+	assert.True(t, rs.SyncScope.OrganizationUsersInScope())
+	assert.True(t, rs.SyncScope.OrganizationSystemAccountsInScope())
+}
+
 func TestCaptureSyncScopeRejectsNullPortalSingletonChildren(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/declarative/loader/sync_scope_test.go
+++ b/internal/declarative/loader/sync_scope_test.go
@@ -109,6 +109,11 @@ func TestCaptureSyncScopeRejectsNullPortalSingletonChildren(t *testing.T) {
 			want:      `child singleton "email_config" cannot be null`,
 		},
 		{
+			name:      "email templates",
+			childYAML: "    email_templates: null\n",
+			want:      `child singleton "email_templates" cannot be null`,
+		},
+		{
 			name:      "audit log webhook",
 			childYAML: "    audit_log_webhook: null\n",
 			want:      `child singleton "audit_log_webhook" cannot be null`,

--- a/internal/declarative/loader/sync_scope_test.go
+++ b/internal/declarative/loader/sync_scope_test.go
@@ -1,0 +1,127 @@
+package loader
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCaptureSyncScopeTracksExplicitRootAndNestedChildCollections(t *testing.T) {
+	input := strings.NewReader(`
+apis:
+  - ref: orders-api
+    name: Orders API
+    documents: []
+portals:
+  - ref: docs-portal
+    name: docs-portal
+    pages: []
+`)
+
+	rs, err := New().parseYAML(input, "test.yaml", ".")
+	require.NoError(t, err)
+	require.NotNil(t, rs.SyncScope)
+
+	assert.True(t, rs.SyncScope.RootInScope(resources.ResourceTypeAPI))
+	assert.True(t, rs.SyncScope.RootInScope(resources.ResourceTypePortal))
+	assert.True(t, rs.SyncScope.ChildInScope(
+		resources.ResourceTypeAPI,
+		"orders-api",
+		resources.ResourceTypeAPIDocument,
+	))
+	assert.True(t, rs.SyncScope.ChildInScope(
+		resources.ResourceTypePortal,
+		"docs-portal",
+		resources.ResourceTypePortalPage,
+	))
+}
+
+func TestCaptureSyncScopeTracksRootLevelEmptyChildCollections(t *testing.T) {
+	input := strings.NewReader(`api_documents: []`)
+
+	rs, err := New().parseYAML(input, "test.yaml", ".")
+	require.NoError(t, err)
+	require.NotNil(t, rs.SyncScope)
+
+	assert.Equal(
+		t,
+		[]resources.ResourceType{resources.ResourceTypeAPIDocument},
+		rs.SyncScope.RootChildCollectionTypes(),
+	)
+}
+
+func TestCaptureSyncScopeRejectsNullPortalSingletonChildren(t *testing.T) {
+	tests := []struct {
+		name      string
+		childYAML string
+		want      string
+	}{
+		{
+			name:      "customization",
+			childYAML: "    customization: null\n",
+			want:      `child singleton "customization" cannot be null`,
+		},
+		{
+			name:      "auth settings",
+			childYAML: "    auth_settings: null\n",
+			want:      `child singleton "auth_settings" cannot be null`,
+		},
+		{
+			name:      "ip allow list",
+			childYAML: "    ip_allow_list: null\n",
+			want:      `child singleton "ip_allow_list" cannot be null`,
+		},
+		{
+			name:      "integrations",
+			childYAML: "    integrations: null\n",
+			want:      `child singleton "integrations" cannot be null`,
+		},
+		{
+			name:      "custom domain",
+			childYAML: "    custom_domain: null\n",
+			want:      `child singleton "custom_domain" cannot be null`,
+		},
+		{
+			name:      "email config",
+			childYAML: "    email_config: null\n",
+			want:      `child singleton "email_config" cannot be null`,
+		},
+		{
+			name:      "audit log webhook",
+			childYAML: "    audit_log_webhook: null\n",
+			want:      `child singleton "audit_log_webhook" cannot be null`,
+		},
+		{
+			name:      "assets",
+			childYAML: "    assets: null\n",
+			want:      `child singleton "assets" cannot be null`,
+		},
+		{
+			name:      "asset logo",
+			childYAML: "    assets:\n      logo: null\n",
+			want:      `child singleton "assets.logo" cannot be null`,
+		},
+		{
+			name:      "asset favicon",
+			childYAML: "    assets:\n      favicon: null\n",
+			want:      `child singleton "assets.favicon" cannot be null`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := strings.NewReader(`
+portals:
+  - ref: docs-portal
+    name: docs-portal
+` + tt.childYAML)
+
+			_, err := New().parseYAML(input, "test.yaml", ".")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}

--- a/internal/declarative/planner/api_planner.go
+++ b/internal/declarative/planner/api_planner.go
@@ -729,31 +729,35 @@ func (p *Planner) planAPIChildResourceChanges(
 		parentNamespace = *desired.Kongctl.Namespace
 	}
 
-	// Plan version changes
-	if err := p.planAPIVersionChanges(
-		ctx, plannerCtx, parentNamespace, current.ID, desired.GetRef(), desired.Versions, plan,
-	); err != nil {
-		return fmt.Errorf("failed to plan API version changes: %w", err)
+	if p.shouldPlanChild(plan, resources.ResourceTypeAPI, desired.GetRef(), resources.ResourceTypeAPIVersion) {
+		if err := p.planAPIVersionChanges(
+			ctx, plannerCtx, parentNamespace, current.ID, desired.GetRef(), desired.Versions, plan,
+		); err != nil {
+			return fmt.Errorf("failed to plan API version changes: %w", err)
+		}
 	}
 
-	// Plan publication changes
-	if err := p.planAPIPublicationChanges(
-		ctx, plannerCtx, parentNamespace, current.ID, desired.GetRef(), desired.Publications, plan,
-	); err != nil {
-		return fmt.Errorf("failed to plan API publication changes: %w", err)
+	if p.shouldPlanChild(plan, resources.ResourceTypeAPI, desired.GetRef(), resources.ResourceTypeAPIPublication) {
+		if err := p.planAPIPublicationChanges(
+			ctx, plannerCtx, parentNamespace, current.ID, desired.GetRef(), desired.Publications, plan,
+		); err != nil {
+			return fmt.Errorf("failed to plan API publication changes: %w", err)
+		}
 	}
 
-	// Plan implementation changes
-	if err := p.planAPIImplementationChanges(
-		ctx, plannerCtx, parentNamespace, current.ID, desired.GetRef(), desired.Implementations, plan); err != nil {
-		return fmt.Errorf("failed to plan API implementation changes: %w", err)
+	if p.shouldPlanChild(plan, resources.ResourceTypeAPI, desired.GetRef(), resources.ResourceTypeAPIImplementation) {
+		if err := p.planAPIImplementationChanges(
+			ctx, plannerCtx, parentNamespace, current.ID, desired.GetRef(), desired.Implementations, plan); err != nil {
+			return fmt.Errorf("failed to plan API implementation changes: %w", err)
+		}
 	}
 
-	// Plan document changes
-	if err := p.planAPIDocumentChanges(
-		ctx, plannerCtx, parentNamespace, current.ID, desired.GetRef(), desired.Documents, plan,
-	); err != nil {
-		return fmt.Errorf("failed to plan API document changes: %w", err)
+	if p.shouldPlanChild(plan, resources.ResourceTypeAPI, desired.GetRef(), resources.ResourceTypeAPIDocument) {
+		if err := p.planAPIDocumentChanges(
+			ctx, plannerCtx, parentNamespace, current.ID, desired.GetRef(), desired.Documents, plan,
+		); err != nil {
+			return fmt.Errorf("failed to plan API document changes: %w", err)
+		}
 	}
 
 	return nil
@@ -1938,7 +1942,8 @@ func (p *Planner) planAPIDocumentCreate(
 
 		// Ensure the parent document change executes first if present in the plan
 		for _, depChange := range plan.Changes {
-			if depChange.ResourceType == ResourceTypeAPIDocument && depChange.ResourceRef == document.ParentDocumentRef {
+			if depChange.ResourceType == ResourceTypeAPIDocument &&
+				depChange.ResourceRef == document.ParentDocumentRef {
 				change.DependsOn = append(change.DependsOn, depChange.ID)
 				break
 			}
@@ -2048,7 +2053,8 @@ func (p *Planner) planAPIDocumentUpdate(
 
 		// If parent document change exists, ensure it runs before this update
 		for _, depChange := range plan.Changes {
-			if depChange.ResourceType == ResourceTypeAPIDocument && depChange.ResourceRef == document.ParentDocumentRef {
+			if depChange.ResourceType == ResourceTypeAPIDocument &&
+				depChange.ResourceRef == document.ParentDocumentRef {
 				change.DependsOn = append(change.DependsOn, depChange.ID)
 				break
 			}

--- a/internal/declarative/planner/control_plane_planner.go
+++ b/internal/declarative/planner/control_plane_planner.go
@@ -133,7 +133,12 @@ func (p *controlPlanePlannerImpl) PlanChanges(ctx context.Context, plannerCtx *C
 			controlPlaneID = current.ID
 		}
 
-		if len(dataPlaneCerts) > 0 || plan.Metadata.Mode == PlanModeSync {
+		if p.planner.shouldPlanChild(
+			plan,
+			resources.ResourceTypeControlPlane,
+			desiredCP.Ref,
+			resources.ResourceTypeControlPlaneDataPlaneCertificate,
+		) && (len(dataPlaneCerts) > 0 || plan.Metadata.Mode == PlanModeSync) {
 			if err := p.planner.planControlPlaneDataPlaneCertificateChanges(
 				ctx,
 				namespace,

--- a/internal/declarative/planner/egw_control_plane_planner.go
+++ b/internal/declarative/planner/egw_control_plane_planner.go
@@ -189,7 +189,12 @@ func (p *Planner) planEGWControlPlaneChanges(
 			gatewayID = current.ID
 		}
 
-		if len(backendClusters) > 0 || plan.Metadata.Mode == PlanModeSync {
+		if p.shouldPlanChild(
+			plan,
+			resources.ResourceTypeEventGatewayControlPlane,
+			desiredEGWCP.Ref,
+			resources.ResourceTypeEventGatewayBackendCluster,
+		) && (len(backendClusters) > 0 || plan.Metadata.Mode == PlanModeSync) {
 			if err := p.planEventGatewayBackendClusterChanges(
 				ctx, plannerCtx, namespace, desiredEGWCP.Name, gatewayID, desiredEGWCP.Ref,
 				gatewayChangeID, backendClusters, plan,
@@ -201,7 +206,12 @@ func (p *Planner) planEGWControlPlaneChanges(
 		// Plan virtual clusters for this gateway (whether it exists or is being created)
 		virtualClusters := p.resources.GetVirtualClustersForGateway(desiredEGWCP.Ref)
 
-		if len(virtualClusters) > 0 || plan.Metadata.Mode == PlanModeSync {
+		if p.shouldPlanChild(
+			plan,
+			resources.ResourceTypeEventGatewayControlPlane,
+			desiredEGWCP.Ref,
+			resources.ResourceTypeEventGatewayVirtualCluster,
+		) && (len(virtualClusters) > 0 || plan.Metadata.Mode == PlanModeSync) {
 			if err := p.planEventGatewayVirtualClusterChanges(
 				ctx, plannerCtx, namespace, desiredEGWCP.Name, gatewayID, desiredEGWCP.Ref,
 				gatewayChangeID, virtualClusters, plan,
@@ -213,7 +223,12 @@ func (p *Planner) planEGWControlPlaneChanges(
 		// Plan listeners for this gateway (whether it exists or is being created)
 		listeners := p.resources.GetListenersForEventGateway(desiredEGWCP.Ref)
 
-		if len(listeners) > 0 || plan.Metadata.Mode == PlanModeSync {
+		if p.shouldPlanChild(
+			plan,
+			resources.ResourceTypeEventGatewayControlPlane,
+			desiredEGWCP.Ref,
+			resources.ResourceTypeEventGatewayListener,
+		) && (len(listeners) > 0 || plan.Metadata.Mode == PlanModeSync) {
 			if err := p.planEventGatewayListenerChanges(
 				ctx, plannerCtx, namespace, desiredEGWCP.Name, gatewayID, desiredEGWCP.Ref,
 				gatewayChangeID, listeners, plan,
@@ -225,7 +240,12 @@ func (p *Planner) planEGWControlPlaneChanges(
 		// Plan data plane certificates for this gateway (whether it exists or is being created)
 		dataPlaneCerts := p.resources.GetDataPlaneCertificatesForGateway(desiredEGWCP.Ref)
 
-		if len(dataPlaneCerts) > 0 || plan.Metadata.Mode == PlanModeSync {
+		if p.shouldPlanChild(
+			plan,
+			resources.ResourceTypeEventGatewayControlPlane,
+			desiredEGWCP.Ref,
+			resources.ResourceTypeEventGatewayDataPlaneCertificate,
+		) && (len(dataPlaneCerts) > 0 || plan.Metadata.Mode == PlanModeSync) {
 			if err := p.planEventGatewayDataPlaneCertificateChanges(
 				ctx, plannerCtx, namespace, desiredEGWCP.Name, gatewayID, desiredEGWCP.Ref,
 				gatewayChangeID, dataPlaneCerts, plan,
@@ -237,7 +257,12 @@ func (p *Planner) planEGWControlPlaneChanges(
 		// Plan schema registries for this gateway (whether it exists or is being created)
 		schemaRegistries := p.resources.GetSchemaRegistriesForGateway(desiredEGWCP.Ref)
 
-		if len(schemaRegistries) > 0 || plan.Metadata.Mode == PlanModeSync {
+		if p.shouldPlanChild(
+			plan,
+			resources.ResourceTypeEventGatewayControlPlane,
+			desiredEGWCP.Ref,
+			resources.ResourceTypeEventGatewaySchemaRegistry,
+		) && (len(schemaRegistries) > 0 || plan.Metadata.Mode == PlanModeSync) {
 			if err := p.planEventGatewaySchemaRegistryChanges(
 				ctx, plannerCtx, namespace, desiredEGWCP.Name, gatewayID, desiredEGWCP.Ref,
 				gatewayChangeID, schemaRegistries, plan,
@@ -249,7 +274,12 @@ func (p *Planner) planEGWControlPlaneChanges(
 		// Plan static keys for this gateway (whether it exists or is being created)
 		staticKeys := p.resources.GetStaticKeysForGateway(desiredEGWCP.Ref)
 
-		if len(staticKeys) > 0 || plan.Metadata.Mode == PlanModeSync {
+		if p.shouldPlanChild(
+			plan,
+			resources.ResourceTypeEventGatewayControlPlane,
+			desiredEGWCP.Ref,
+			resources.ResourceTypeEventGatewayStaticKey,
+		) && (len(staticKeys) > 0 || plan.Metadata.Mode == PlanModeSync) {
 			if err := p.planEventGatewayStaticKeyChanges(
 				ctx, plannerCtx, namespace, desiredEGWCP.Name, gatewayID, desiredEGWCP.Ref,
 				gatewayChangeID, staticKeys, plan,
@@ -261,7 +291,12 @@ func (p *Planner) planEGWControlPlaneChanges(
 		// Plan TLS trust bundles for this gateway (whether it exists or is being created)
 		trustBundles := p.resources.GetTrustBundlesForGateway(desiredEGWCP.Ref)
 
-		if len(trustBundles) > 0 || plan.Metadata.Mode == PlanModeSync {
+		if p.shouldPlanChild(
+			plan,
+			resources.ResourceTypeEventGatewayControlPlane,
+			desiredEGWCP.Ref,
+			resources.ResourceTypeEventGatewayTLSTrustBundle,
+		) && (len(trustBundles) > 0 || plan.Metadata.Mode == PlanModeSync) {
 			if err := p.planEventGatewayTLSTrustBundleChanges(
 				ctx, plannerCtx, namespace, desiredEGWCP.Name, gatewayID, desiredEGWCP.Ref,
 				gatewayChangeID, trustBundles, plan,

--- a/internal/declarative/planner/env_placeholders_test.go
+++ b/internal/declarative/planner/env_placeholders_test.go
@@ -42,7 +42,7 @@ func TestGeneratePlan_PreservesDeferredEnvPlaceholders(t *testing.T) {
 					Page: kkComps.PageMeta{Total: 0},
 				},
 			},
-		}, nil)
+		}, nil).Maybe()
 	mockEmptyAPIsList(ctx, mockAPIAPI)
 
 	description := "resolved secret"

--- a/internal/declarative/planner/event_gateway_listener_planner.go
+++ b/internal/declarative/planner/event_gateway_listener_planner.go
@@ -93,7 +93,12 @@ func (p *Planner) planListenerChangesForExistingGateway(
 
 			// Plan listener policies for this new listener (depends on listener creation)
 			listenerPolicies := p.resources.GetPoliciesForListener(desiredListener.Ref)
-			if len(listenerPolicies) > 0 {
+			if p.shouldPlanChild(
+				plan,
+				resources.ResourceTypeEventGatewayListener,
+				desiredListener.Ref,
+				resources.ResourceTypeEventGatewayListenerPolicy,
+			) && len(listenerPolicies) > 0 {
 				if err := p.planEventGatewayListenerPolicyChanges(
 					ctx, nil, namespace, gatewayID, gatewayRef,
 					desiredListener.Name, "", desiredListener.Ref,
@@ -130,7 +135,12 @@ func (p *Planner) planListenerChangesForExistingGateway(
 
 			// Plan listener policies for this existing listener
 			listenerPolicies := p.resources.GetPoliciesForListener(desiredListener.Ref)
-			if len(listenerPolicies) > 0 || plan.Metadata.Mode == PlanModeSync {
+			if p.shouldPlanChild(
+				plan,
+				resources.ResourceTypeEventGatewayListener,
+				desiredListener.Ref,
+				resources.ResourceTypeEventGatewayListenerPolicy,
+			) && (len(listenerPolicies) > 0 || plan.Metadata.Mode == PlanModeSync) {
 				if err := p.planEventGatewayListenerPolicyChanges(
 					ctx, nil, namespace, gatewayID, gatewayRef,
 					desiredListener.Name, current.ID, desiredListener.Ref,
@@ -186,7 +196,12 @@ func (p *Planner) planListenerCreatesForNewGateway(
 
 		// Plan listener policies for this new listener (depends on listener creation)
 		listenerPolicies := p.resources.GetPoliciesForListener(listener.Ref)
-		if len(listenerPolicies) > 0 {
+		if p.shouldPlanChild(
+			plan,
+			resources.ResourceTypeEventGatewayListener,
+			listener.Ref,
+			resources.ResourceTypeEventGatewayListenerPolicy,
+		) && len(listenerPolicies) > 0 {
 			p.planListenerPolicyCreatesForNewListener(
 				namespace, gatewayRef, listener.Ref, listener.Name,
 				listenerChangeID, listenerPolicies, plan,

--- a/internal/declarative/planner/event_gateway_virtual_cluster_planner.go
+++ b/internal/declarative/planner/event_gateway_virtual_cluster_planner.go
@@ -94,7 +94,12 @@ func (p *Planner) planVirtualClusterChangesForExistingGateway(
 
 			// Plan cluster policies for this new virtual cluster (depends on virtual cluster creation)
 			clusterPolicies := p.resources.GetClusterPoliciesForVirtualCluster(desiredCluster.Ref)
-			if len(clusterPolicies) > 0 {
+			if p.shouldPlanChild(
+				plan,
+				resources.ResourceTypeEventGatewayVirtualCluster,
+				desiredCluster.Ref,
+				resources.ResourceTypeEventGatewayClusterPolicy,
+			) && len(clusterPolicies) > 0 {
 				if err := p.planEventGatewayClusterPolicyChanges(
 					ctx, nil, namespace, gatewayID, gatewayRef,
 					desiredCluster.Name, "", desiredCluster.Ref,
@@ -106,7 +111,12 @@ func (p *Planner) planVirtualClusterChangesForExistingGateway(
 
 			// Plan produce policies for this new virtual cluster (depends on virtual cluster creation)
 			producePolicies := p.resources.GetProducePoliciesForVirtualCluster(desiredCluster.Ref)
-			if len(producePolicies) > 0 {
+			if p.shouldPlanChild(
+				plan,
+				resources.ResourceTypeEventGatewayVirtualCluster,
+				desiredCluster.Ref,
+				resources.ResourceTypeEventGatewayProducePolicy,
+			) && len(producePolicies) > 0 {
 				if err := p.planEventGatewayVirtualClusterProducePolicyChanges(
 					ctx, nil, namespace, gatewayID, gatewayRef,
 					desiredCluster.Name, "", desiredCluster.Ref,
@@ -117,7 +127,12 @@ func (p *Planner) planVirtualClusterChangesForExistingGateway(
 			}
 			// Plan consume policies for this new virtual cluster (depends on virtual cluster creation)
 			consumePolicies := p.resources.GetConsumePoliciesForVirtualCluster(desiredCluster.Ref)
-			if len(consumePolicies) > 0 {
+			if p.shouldPlanChild(
+				plan,
+				resources.ResourceTypeEventGatewayVirtualCluster,
+				desiredCluster.Ref,
+				resources.ResourceTypeEventGatewayConsumePolicy,
+			) && len(consumePolicies) > 0 {
 				if err := p.planEventGatewayConsumePolicyChanges(
 					ctx, nil, namespace, gatewayID, gatewayRef,
 					desiredCluster.Name, "", desiredCluster.Ref,
@@ -154,7 +169,12 @@ func (p *Planner) planVirtualClusterChangesForExistingGateway(
 
 			// Plan cluster policies for this existing virtual cluster
 			clusterPolicies := p.resources.GetClusterPoliciesForVirtualCluster(desiredCluster.Ref)
-			if len(clusterPolicies) > 0 || plan.Metadata.Mode == PlanModeSync {
+			if p.shouldPlanChild(
+				plan,
+				resources.ResourceTypeEventGatewayVirtualCluster,
+				desiredCluster.Ref,
+				resources.ResourceTypeEventGatewayClusterPolicy,
+			) && (len(clusterPolicies) > 0 || plan.Metadata.Mode == PlanModeSync) {
 				if err := p.planEventGatewayClusterPolicyChanges(
 					ctx, nil, namespace, gatewayID, gatewayRef,
 					desiredCluster.Name, current.ID, desiredCluster.Ref,
@@ -166,7 +186,12 @@ func (p *Planner) planVirtualClusterChangesForExistingGateway(
 
 			// Plan produce policies for this existing virtual cluster
 			producePolicies := p.resources.GetProducePoliciesForVirtualCluster(desiredCluster.Ref)
-			if len(producePolicies) > 0 || plan.Metadata.Mode == PlanModeSync {
+			if p.shouldPlanChild(
+				plan,
+				resources.ResourceTypeEventGatewayVirtualCluster,
+				desiredCluster.Ref,
+				resources.ResourceTypeEventGatewayProducePolicy,
+			) && (len(producePolicies) > 0 || plan.Metadata.Mode == PlanModeSync) {
 				if err := p.planEventGatewayVirtualClusterProducePolicyChanges(
 					ctx, nil, namespace, gatewayID, gatewayRef,
 					desiredCluster.Name, current.ID, desiredCluster.Ref,
@@ -177,7 +202,12 @@ func (p *Planner) planVirtualClusterChangesForExistingGateway(
 			}
 			// Plan consume policies for this existing virtual cluster
 			consumePolicies := p.resources.GetConsumePoliciesForVirtualCluster(desiredCluster.Ref)
-			if len(consumePolicies) > 0 || plan.Metadata.Mode == PlanModeSync {
+			if p.shouldPlanChild(
+				plan,
+				resources.ResourceTypeEventGatewayVirtualCluster,
+				desiredCluster.Ref,
+				resources.ResourceTypeEventGatewayConsumePolicy,
+			) && (len(consumePolicies) > 0 || plan.Metadata.Mode == PlanModeSync) {
 				if err := p.planEventGatewayConsumePolicyChanges(
 					ctx, nil, namespace, gatewayID, gatewayRef,
 					desiredCluster.Name, current.ID, desiredCluster.Ref,
@@ -234,7 +264,12 @@ func (p *Planner) planVirtualClusterCreatesForNewGateway(
 
 		// Plan cluster policies for this new virtual cluster (depends on virtual cluster creation)
 		clusterPolicies := p.resources.GetClusterPoliciesForVirtualCluster(cluster.Ref)
-		if len(clusterPolicies) > 0 {
+		if p.shouldPlanChild(
+			plan,
+			resources.ResourceTypeEventGatewayVirtualCluster,
+			cluster.Ref,
+			resources.ResourceTypeEventGatewayClusterPolicy,
+		) && len(clusterPolicies) > 0 {
 			if err := p.planEventGatewayClusterPolicyChanges(
 				ctx, nil, namespace, "", gatewayRef,
 				cluster.Name, "", cluster.Ref,
@@ -246,7 +281,12 @@ func (p *Planner) planVirtualClusterCreatesForNewGateway(
 
 		// Plan produce policies for this new virtual cluster (depends on virtual cluster creation)
 		producePolicies := p.resources.GetProducePoliciesForVirtualCluster(cluster.Ref)
-		if len(producePolicies) > 0 {
+		if p.shouldPlanChild(
+			plan,
+			resources.ResourceTypeEventGatewayVirtualCluster,
+			cluster.Ref,
+			resources.ResourceTypeEventGatewayProducePolicy,
+		) && len(producePolicies) > 0 {
 			if err := p.planEventGatewayVirtualClusterProducePolicyChanges(
 				ctx, nil, namespace, "", gatewayRef,
 				cluster.Name, "", cluster.Ref,
@@ -257,7 +297,12 @@ func (p *Planner) planVirtualClusterCreatesForNewGateway(
 		}
 		// Plan consume policies for this new virtual cluster (depends on virtual cluster creation)
 		consumePolicies := p.resources.GetConsumePoliciesForVirtualCluster(cluster.Ref)
-		if len(consumePolicies) > 0 {
+		if p.shouldPlanChild(
+			plan,
+			resources.ResourceTypeEventGatewayVirtualCluster,
+			cluster.Ref,
+			resources.ResourceTypeEventGatewayConsumePolicy,
+		) && len(consumePolicies) > 0 {
 			if err := p.planEventGatewayConsumePolicyChanges(
 				ctx, nil, namespace, "", gatewayRef,
 				cluster.Name, "", cluster.Ref,

--- a/internal/declarative/planner/organization_team_planner.go
+++ b/internal/declarative/planner/organization_team_planner.go
@@ -138,8 +138,14 @@ func (t *OrganizationTeamPlannerImpl) PlanChanges(ctx context.Context, plannerCt
 			}
 
 			// Validate protection change
-			err := t.ValidateProtectionWithChange(ResourceTypeOrganizationTeam, desiredTeam.Name, currentProtected, ActionUpdate,
-				protectionChange, needsUpdate)
+			err := t.ValidateProtectionWithChange(
+				ResourceTypeOrganizationTeam,
+				desiredTeam.Name,
+				currentProtected,
+				ActionUpdate,
+				protectionChange,
+				needsUpdate,
+			)
 			protectionErrors.Add(err)
 			if err == nil {
 				t.planOrganizationTeamProtectionChangeWithFields(
@@ -169,15 +175,18 @@ func (t *OrganizationTeamPlannerImpl) PlanChanges(ctx context.Context, plannerCt
 	if err := t.planOrganizationTeamRoleChanges(ctx, namespace, desired, currentByName, plan); err != nil {
 		return err
 	}
-	if err := t.planOrganizationUserAssignmentChanges(ctx, namespace, desired, currentByName, plan); err != nil {
-		return err
+	if t.planner.shouldPlanOrganizationUsers(plan) {
+		if err := t.planOrganizationUserAssignmentChanges(ctx, namespace, desired, currentByName, plan); err != nil {
+			return err
+		}
 	}
 	if err := t.planOrganizationSystemAccountAssignmentChanges(ctx, namespace, desired, currentByName, plan); err != nil {
 		return err
 	}
 
 	// Check for managed resources to delete (sync mode only)
-	if plan.Metadata.Mode == PlanModeSync {
+	if plan.Metadata.Mode == PlanModeSync &&
+		t.planner.shouldPlanRoot(PlanModeSync, resources.ResourceTypeOrganizationTeam) {
 		// Build set of desired team names
 		desiredNames := make(map[string]bool)
 		for _, team := range desired {
@@ -276,7 +285,14 @@ func (t *OrganizationTeamPlannerImpl) planOrganizationTeamRoleChanges(
 	teamByRef := make(map[string]resources.OrganizationTeamResource)
 	for _, team := range desiredTeams {
 		teamByRef[team.Ref] = team
-		if plan.Metadata.Mode == PlanModeSync && !team.IsExternal() {
+		if plan.Metadata.Mode == PlanModeSync &&
+			!team.IsExternal() &&
+			t.planner.shouldPlanChild(
+				plan,
+				resources.ResourceTypeOrganizationTeam,
+				team.Ref,
+				resources.ResourceTypeOrganizationTeamRole,
+			) {
 			if _, ok := rolesByTeam[team.Ref]; !ok {
 				rolesByTeam[team.Ref] = []resources.OrganizationTeamRoleResource{}
 			}
@@ -292,6 +308,14 @@ func (t *OrganizationTeamPlannerImpl) planOrganizationTeamRoleChanges(
 
 	for teamRef, roles := range rolesByTeam {
 		if teamsDeleted[teamRef] {
+			continue
+		}
+		if !t.planner.shouldPlanChild(
+			plan,
+			resources.ResourceTypeOrganizationTeam,
+			teamRef,
+			resources.ResourceTypeOrganizationTeamRole,
+		) {
 			continue
 		}
 
@@ -328,7 +352,12 @@ func (t *OrganizationTeamPlannerImpl) planOrganizationTeamRoleChanges(
 				return fmt.Errorf("failed to list organization team roles for team %s: %w", teamID, err)
 			}
 			for _, role := range currentRoles {
-				key := buildOrganizationTeamRoleKey(role.RoleName, role.EntityID, role.EntityTypeName, role.EntityRegion)
+				key := buildOrganizationTeamRoleKey(
+					role.RoleName,
+					role.EntityID,
+					role.EntityTypeName,
+					role.EntityRegion,
+				)
 				existingRoles[key] = role
 			}
 		}

--- a/internal/declarative/planner/organization_team_planner.go
+++ b/internal/declarative/planner/organization_team_planner.go
@@ -180,8 +180,10 @@ func (t *OrganizationTeamPlannerImpl) PlanChanges(ctx context.Context, plannerCt
 			return err
 		}
 	}
-	if err := t.planOrganizationSystemAccountAssignmentChanges(ctx, namespace, desired, currentByName, plan); err != nil {
-		return err
+	if t.planner.shouldPlanOrganizationSystemAccounts(plan) {
+		if err := t.planOrganizationSystemAccountAssignmentChanges(ctx, namespace, desired, currentByName, plan); err != nil {
+			return err
+		}
 	}
 
 	// Check for managed resources to delete (sync mode only)

--- a/internal/declarative/planner/planner.go
+++ b/internal/declarative/planner/planner.go
@@ -142,6 +142,15 @@ func (p *Planner) GeneratePlan(ctx context.Context, rs *resources.ResourceSet, o
 
 	// Create base plan
 	basePlan := NewPlan("1.0", generator, opts.Mode)
+	p.resources = rs
+
+	if opts.Mode == PlanModeSync {
+		ensurePlanningSyncScope(rs)
+		basePlan.Metadata.SyncScope = syncScopeMetadata(rs.SyncScope)
+		if err := validateSyncScope(rs.SyncScope); err != nil {
+			return nil, err
+		}
+	}
 
 	// Pre-resolution phase: Resolve resource identities before planning
 	if err := p.resolveResourceIdentities(
@@ -258,78 +267,94 @@ func (p *Planner) GeneratePlan(ctx context.Context, rs *resources.ResourceSet, o
 		// Create planner context with namespace
 		plannerCtx := NewConfig(actualNamespace)
 
-		if err := namespacePlanner.dcrProviderPlanner.PlanChanges(
-			withPlannerHTTPLogContext(namespaceCtx, opts, plannerComponent(namespacePlanner.dcrProviderPlanner), ""),
-			plannerCtx,
-			namespacePlan,
-		); err != nil {
-			return nil, fmt.Errorf("failed to plan DCR provider changes for namespace %s: %w", namespace, err)
+		if namespacePlanner.shouldPlanRoot(opts.Mode, resources.ResourceTypeDCRProvider) {
+			if err := namespacePlanner.dcrProviderPlanner.PlanChanges(
+				withPlannerHTTPLogContext(namespaceCtx, opts, plannerComponent(namespacePlanner.dcrProviderPlanner), ""),
+				plannerCtx,
+				namespacePlan,
+			); err != nil {
+				return nil, fmt.Errorf("failed to plan DCR provider changes for namespace %s: %w", namespace, err)
+			}
 		}
 
-		if err := namespacePlanner.authStrategyPlanner.PlanChanges(
-			withPlannerHTTPLogContext(namespaceCtx, opts, plannerComponent(namespacePlanner.authStrategyPlanner), ""),
-			plannerCtx,
-			namespacePlan,
-		); err != nil {
-			return nil, fmt.Errorf("failed to plan auth strategy changes for namespace %s: %w", namespace, err)
+		if namespacePlanner.shouldPlanRoot(opts.Mode, resources.ResourceTypeApplicationAuthStrategy) {
+			if err := namespacePlanner.authStrategyPlanner.PlanChanges(
+				withPlannerHTTPLogContext(namespaceCtx, opts, plannerComponent(namespacePlanner.authStrategyPlanner), ""),
+				plannerCtx,
+				namespacePlan,
+			); err != nil {
+				return nil, fmt.Errorf("failed to plan auth strategy changes for namespace %s: %w", namespace, err)
+			}
 		}
 
-		if err := namespacePlanner.controlPlanePlanner.PlanChanges(
-			withPlannerHTTPLogContext(namespaceCtx, opts, plannerComponent(namespacePlanner.controlPlanePlanner), ""),
-			plannerCtx,
-			namespacePlan,
-		); err != nil {
-			return nil, fmt.Errorf("failed to plan control plane changes for namespace %s: %w", namespace, err)
+		if namespacePlanner.shouldPlanRoot(opts.Mode, resources.ResourceTypeControlPlane) {
+			if err := namespacePlanner.controlPlanePlanner.PlanChanges(
+				withPlannerHTTPLogContext(namespaceCtx, opts, plannerComponent(namespacePlanner.controlPlanePlanner), ""),
+				plannerCtx,
+				namespacePlan,
+			); err != nil {
+				return nil, fmt.Errorf("failed to plan control plane changes for namespace %s: %w", namespace, err)
+			}
 		}
 
-		if err := namespacePlanner.portalPlanner.PlanChanges(
-			withPlannerHTTPLogContext(namespaceCtx, opts, plannerComponent(namespacePlanner.portalPlanner), ""),
-			plannerCtx,
-			namespacePlan,
-		); err != nil {
-			return nil, fmt.Errorf("failed to plan portal changes for namespace %s: %w", namespace, err)
+		if namespacePlanner.shouldPlanRoot(opts.Mode, resources.ResourceTypePortal) {
+			if err := namespacePlanner.portalPlanner.PlanChanges(
+				withPlannerHTTPLogContext(namespaceCtx, opts, plannerComponent(namespacePlanner.portalPlanner), ""),
+				plannerCtx,
+				namespacePlan,
+			); err != nil {
+				return nil, fmt.Errorf("failed to plan portal changes for namespace %s: %w", namespace, err)
+			}
 		}
 
-		if err := namespacePlanner.catalogServicePlanner.PlanChanges(
-			withPlannerHTTPLogContext(namespaceCtx, opts, plannerComponent(namespacePlanner.catalogServicePlanner), ""),
-			plannerCtx,
-			namespacePlan,
-		); err != nil {
-			return nil, fmt.Errorf("failed to plan catalog service changes for namespace %s: %w", namespace, err)
+		if namespacePlanner.shouldPlanRoot(opts.Mode, resources.ResourceTypeCatalogService) {
+			if err := namespacePlanner.catalogServicePlanner.PlanChanges(
+				withPlannerHTTPLogContext(namespaceCtx, opts, plannerComponent(namespacePlanner.catalogServicePlanner), ""),
+				plannerCtx,
+				namespacePlan,
+			); err != nil {
+				return nil, fmt.Errorf("failed to plan catalog service changes for namespace %s: %w", namespace, err)
+			}
 		}
 
 		// Plan API changes (includes child resources)
-		if err := namespacePlanner.apiPlanner.PlanChanges(
-			withPlannerHTTPLogContext(namespaceCtx, opts, plannerComponent(namespacePlanner.apiPlanner), ""),
-			plannerCtx,
-			namespacePlan,
-		); err != nil {
-			return nil, fmt.Errorf("failed to plan API changes for namespace %s: %w", namespace, err)
+		if namespacePlanner.shouldPlanRoot(opts.Mode, resources.ResourceTypeAPI) {
+			if err := namespacePlanner.apiPlanner.PlanChanges(
+				withPlannerHTTPLogContext(namespaceCtx, opts, plannerComponent(namespacePlanner.apiPlanner), ""),
+				plannerCtx,
+				namespacePlan,
+			); err != nil {
+				return nil, fmt.Errorf("failed to plan API changes for namespace %s: %w", namespace, err)
+			}
 		}
 
-		if err := namespacePlanner.eventGatewayControlPlanePlanner.PlanChanges(
-			withPlannerHTTPLogContext(
-				namespaceCtx,
-				opts,
-				plannerComponent(namespacePlanner.eventGatewayControlPlanePlanner),
-				"",
-			),
-			plannerCtx,
-			namespacePlan,
-		); err != nil {
-			return nil, fmt.Errorf(
-				"failed to plan Event Gateway Control Plane changes for namespace %s: %w",
-				namespace,
-				err,
-			)
+		if namespacePlanner.shouldPlanRoot(opts.Mode, resources.ResourceTypeEventGatewayControlPlane) {
+			if err := namespacePlanner.eventGatewayControlPlanePlanner.PlanChanges(
+				withPlannerHTTPLogContext(
+					namespaceCtx,
+					opts,
+					plannerComponent(namespacePlanner.eventGatewayControlPlanePlanner),
+					"",
+				),
+				plannerCtx,
+				namespacePlan,
+			); err != nil {
+				return nil, fmt.Errorf(
+					"failed to plan Event Gateway Control Plane changes for namespace %s: %w",
+					namespace,
+					err,
+				)
+			}
 		}
 
-		if err := namespacePlanner.organizationTeamPlanner.PlanChanges(
-			withPlannerHTTPLogContext(namespaceCtx, opts, plannerComponent(namespacePlanner.organizationTeamPlanner), ""),
-			plannerCtx,
-			namespacePlan,
-		); err != nil {
-			return nil, fmt.Errorf("failed to plan Team changes for namespace %s: %w", namespace, err)
+		if namespacePlanner.shouldPlanOrganization(namespacePlan) {
+			if err := namespacePlanner.organizationTeamPlanner.PlanChanges(
+				withPlannerHTTPLogContext(namespaceCtx, opts, plannerComponent(namespacePlanner.organizationTeamPlanner), ""),
+				plannerCtx,
+				namespacePlan,
+			); err != nil {
+				return nil, fmt.Errorf("failed to plan Team changes for namespace %s: %w", namespace, err)
+			}
 		}
 
 		if err := namespacePlanner.applyInheritedProtection(namespaceCtx, namespacePlan); err != nil {

--- a/internal/declarative/planner/planner_test.go
+++ b/internal/declarative/planner/planner_test.go
@@ -38,7 +38,7 @@ func (m *MockStateClient) GetPortalByName(ctx context.Context, name string) (*st
 	return args.Get(0).(*state.Portal), args.Error(1)
 }
 
-// mockEmptyAPIsList adds a mock for empty APIs list, needed in sync mode
+// mockEmptyAPIsList adds an optional mock for tests that still exercise API sync paths.
 func mockEmptyAPIsList(_ context.Context, mockAPIAPI *MockAPIAPI) {
 	mockAPIAPI.On("ListApis", mock.Anything, mock.Anything).Return(&kkOps.ListApisResponse{
 		StatusCode: 200,
@@ -50,7 +50,7 @@ func mockEmptyAPIsList(_ context.Context, mockAPIAPI *MockAPIAPI) {
 				},
 			},
 		},
-	}, nil)
+	}, nil).Maybe()
 }
 
 func newListPortal(id, name string, labels map[string]string) kkComps.ListPortalsResponsePortal {
@@ -283,7 +283,7 @@ func TestGeneratePlan_CreatePortal(t *testing.T) {
 					},
 				},
 			},
-		}, nil)
+		}, nil).Maybe()
 
 	// Mock empty APIs list (needed because we're in sync mode)
 	mockEmptyAPIsList(ctx, mockAPIAPI)
@@ -371,7 +371,7 @@ func TestGeneratePlan_UpdatePortal(t *testing.T) {
 				},
 			},
 		},
-	}, nil)
+	}, nil).Maybe()
 
 	// Mock empty auth strategies list
 	mockAppAuthAPI.On("ListAppAuthStrategies", mock.Anything, mock.Anything).
@@ -384,7 +384,7 @@ func TestGeneratePlan_UpdatePortal(t *testing.T) {
 					},
 				},
 			},
-		}, nil)
+		}, nil).Maybe()
 
 	// Mock empty APIs list (needed because we're in sync mode)
 	mockEmptyAPIsList(ctx, mockAPIAPI)
@@ -466,7 +466,7 @@ func TestGeneratePlan_ProtectionChange(t *testing.T) {
 				},
 			},
 		},
-	}, nil)
+	}, nil).Maybe()
 
 	// Mock empty auth strategies list
 	mockAppAuthAPI.On("ListAppAuthStrategies", mock.Anything, mock.Anything).
@@ -479,7 +479,7 @@ func TestGeneratePlan_ProtectionChange(t *testing.T) {
 					},
 				},
 			},
-		}, nil)
+		}, nil).Maybe()
 
 	// Mock empty APIs list (needed because we're in sync mode)
 	mockEmptyAPIsList(ctx, mockAPIAPI)
@@ -555,7 +555,7 @@ func TestGeneratePlan_WithReferences(t *testing.T) {
 				},
 			},
 		},
-	}, nil)
+	}, nil).Maybe()
 
 	// Mock empty auth strategies list
 	mockAppAuthAPI.On("ListAppAuthStrategies", mock.Anything, mock.Anything).
@@ -568,7 +568,7 @@ func TestGeneratePlan_WithReferences(t *testing.T) {
 					},
 				},
 			},
-		}, nil)
+		}, nil).Maybe()
 
 	// Mock empty APIs list (needed because we're in sync mode)
 	mockEmptyAPIsList(ctx, mockAPIAPI)
@@ -686,7 +686,7 @@ func TestGeneratePlan_NoChangesNeeded(t *testing.T) {
 				},
 			},
 		},
-	}, nil)
+	}, nil).Maybe()
 
 	// Mock empty auth strategies list
 	mockAppAuthAPI.On("ListAppAuthStrategies", mock.Anything, mock.Anything).
@@ -699,7 +699,7 @@ func TestGeneratePlan_NoChangesNeeded(t *testing.T) {
 					},
 				},
 			},
-		}, nil)
+		}, nil).Maybe()
 
 	// Mock empty APIs list (needed because we're in sync mode)
 	mockEmptyAPIsList(ctx, mockAPIAPI)
@@ -854,7 +854,7 @@ func TestGeneratePlan_ApplyModeNoDeletes(t *testing.T) {
 				},
 			},
 		},
-	}, nil)
+	}, nil).Maybe()
 
 	// Create resource set with only one portal (missing the existing one)
 	displayName := "New Portal"
@@ -935,14 +935,17 @@ func TestGeneratePlan_SyncModeWithDeletes(t *testing.T) {
 					},
 				},
 			},
-		}, nil)
+		}, nil).Maybe()
 
 	// Mock empty APIs list (needed because we're in sync mode)
 	mockEmptyAPIsList(ctx, mockAPIAPI)
 
 	// Create empty resource set (all managed resources should be deleted)
+	scope := resources.NewSyncScope()
+	scope.AddRoot(resources.ResourceTypePortal)
 	rs := &resources.ResourceSet{
-		Portals: []resources.PortalResource{},
+		Portals:   []resources.PortalResource{},
+		SyncScope: scope,
 	}
 
 	// Generate plan in sync mode
@@ -997,7 +1000,7 @@ func TestGeneratePlan_ProtectedResourceFailsUpdate(t *testing.T) {
 				},
 			},
 		},
-	}, nil)
+	}, nil).Maybe()
 
 	// Mock empty auth strategies list
 	mockAppAuthAPI.On("ListAppAuthStrategies", mock.Anything, mock.Anything).
@@ -1010,7 +1013,7 @@ func TestGeneratePlan_ProtectedResourceFailsUpdate(t *testing.T) {
 					},
 				},
 			},
-		}, nil)
+		}, nil).Maybe()
 
 	// Mock empty APIs list (needed because we're in sync mode)
 	mockEmptyAPIsList(ctx, mockAPIAPI)
@@ -1081,7 +1084,7 @@ func TestGeneratePlan_ProtectedResourceFailsDelete(t *testing.T) {
 				},
 			},
 		},
-	}, nil)
+	}, nil).Maybe()
 
 	// Mock empty auth strategies list
 	mockAppAuthAPI.On("ListAppAuthStrategies", mock.Anything, mock.Anything).
@@ -1094,11 +1097,14 @@ func TestGeneratePlan_ProtectedResourceFailsDelete(t *testing.T) {
 					},
 				},
 			},
-		}, nil)
+		}, nil).Maybe()
 
 	// Empty resource set (would delete all)
+	scope := resources.NewSyncScope()
+	scope.AddRoot(resources.ResourceTypePortal)
 	rs := &resources.ResourceSet{
-		Portals: []resources.PortalResource{},
+		Portals:   []resources.PortalResource{},
+		SyncScope: scope,
 	}
 
 	// Generate plan in sync mode should fail
@@ -1159,7 +1165,7 @@ func TestGeneratePlan_ProtectionChangeAllowed(t *testing.T) {
 					},
 				},
 			},
-		}, nil)
+		}, nil).Maybe()
 
 	// Mock empty APIs list (needed because we're in sync mode)
 	mockEmptyAPIsList(ctx, mockAPIAPI)
@@ -1220,7 +1226,7 @@ func TestGeneratePlan_SyncDeletesRespectAuthStrategyDependencies(t *testing.T) {
 				Page: kkComps.PageMeta{Total: 0},
 			},
 		},
-	}, nil)
+	}, nil).Maybe()
 
 	mockAPIAPI.On("ListApis", mock.Anything, mock.Anything).Return(&kkOps.ListApisResponse{
 		ListAPIResponse: &kkComps.ListAPIResponse{
@@ -1272,7 +1278,7 @@ func TestGeneratePlan_SyncDeletesRespectAuthStrategyDependencies(t *testing.T) {
 					Page: kkComps.PageMeta{Total: 1},
 				},
 			},
-		}, nil)
+		}, nil).Maybe()
 
 	publicationResponse := &kkOps.ListAPIPublicationsResponse{
 		ListAPIPublicationResponse: &kkComps.ListAPIPublicationResponse{
@@ -1305,8 +1311,12 @@ func TestGeneratePlan_SyncDeletesRespectAuthStrategyDependencies(t *testing.T) {
 
 	planner := NewPlanner(client, slog.Default())
 
+	scope := resources.NewSyncScope()
+	scope.AddRoot(resources.ResourceTypeAPI)
+	scope.AddRoot(resources.ResourceTypeApplicationAuthStrategy)
+
 	opts := Options{Mode: PlanModeSync}
-	plan, err := planner.GeneratePlan(ctx, &resources.ResourceSet{}, opts)
+	plan, err := planner.GeneratePlan(ctx, &resources.ResourceSet{SyncScope: scope}, opts)
 	require.NoError(t, err)
 
 	var (

--- a/internal/declarative/planner/portal_planner.go
+++ b/internal/declarative/planner/portal_planner.go
@@ -775,6 +775,9 @@ func (p *portalPlannerImpl) planPortalChildResourcesCreate(
 
 	// Get the main planner instance to access child resource planning methods
 	planner := p.planner
+	childInScope := func(rt resources.ResourceType) bool {
+		return planner.shouldPlanChild(plan, resources.ResourceTypePortal, desired.Ref, rt)
+	}
 
 	// Extract parent namespace for child resources
 	parentNamespace := DefaultNamespace
@@ -793,11 +796,13 @@ func (p *portalPlannerImpl) planPortalChildResourcesCreate(
 		}
 	}
 	// Note: Passing empty portalID for new portal
-	if err := planner.planPortalPagesChanges(ctx, parentNamespace, "", desired.Ref, pages, plan); err != nil {
-		// Log error but don't fail - portal creation should still proceed
-		planner.logger.Debug("Failed to plan portal pages for new portal",
-			"portal", desired.Ref,
-			"error", err.Error())
+	if childInScope(resources.ResourceTypePortalPage) {
+		if err := planner.planPortalPagesChanges(ctx, parentNamespace, "", desired.Ref, pages, plan); err != nil {
+			// Log error but don't fail - portal creation should still proceed
+			planner.logger.Debug("Failed to plan portal pages for new portal",
+				"portal", desired.Ref,
+				"error", err.Error())
+		}
 	}
 
 	// Plan snippets
@@ -807,10 +812,12 @@ func (p *portalPlannerImpl) planPortalChildResourcesCreate(
 			snippets = append(snippets, snippet)
 		}
 	}
-	if err := planner.planPortalSnippetsChanges(ctx, parentNamespace, "", desired.Ref, snippets, plan); err != nil {
-		planner.logger.Debug("Failed to plan portal snippets for new portal",
-			"portal", desired.Ref,
-			"error", err.Error())
+	if childInScope(resources.ResourceTypePortalSnippet) {
+		if err := planner.planPortalSnippetsChanges(ctx, parentNamespace, "", desired.Ref, snippets, plan); err != nil {
+			planner.logger.Debug("Failed to plan portal snippets for new portal",
+				"portal", desired.Ref,
+				"error", err.Error())
+		}
 	}
 
 	// Plan auth settings
@@ -820,10 +827,12 @@ func (p *portalPlannerImpl) planPortalChildResourcesCreate(
 			settings = append(settings, auth)
 		}
 	}
-	if err := planner.planPortalAuthSettingsChanges(ctx, plannerCtx, parentNamespace, settings, plan); err != nil {
-		planner.logger.Debug("Failed to plan portal auth settings for new portal",
-			"portal", desired.Ref,
-			"error", err.Error())
+	if childInScope(resources.ResourceTypePortalAuthSettings) {
+		if err := planner.planPortalAuthSettingsChanges(ctx, plannerCtx, parentNamespace, settings, plan); err != nil {
+			planner.logger.Debug("Failed to plan portal auth settings for new portal",
+				"portal", desired.Ref,
+				"error", err.Error())
+		}
 	}
 
 	// Plan IP allow list
@@ -833,10 +842,12 @@ func (p *portalPlannerImpl) planPortalChildResourcesCreate(
 			allowLists = append(allowLists, allowList)
 		}
 	}
-	if err := planner.planPortalIPAllowListsChanges(ctx, parentNamespace, "", desired.Ref, allowLists, plan); err != nil {
-		planner.logger.Debug("Failed to plan portal IP allow list for new portal",
-			"portal", desired.Ref,
-			"error", err.Error())
+	if childInScope(resources.ResourceTypePortalIPAllowList) {
+		if err := planner.planPortalIPAllowListsChanges(ctx, parentNamespace, "", desired.Ref, allowLists, plan); err != nil {
+			planner.logger.Debug("Failed to plan portal IP allow list for new portal",
+				"portal", desired.Ref,
+				"error", err.Error())
+		}
 	}
 
 	// Plan integrations
@@ -846,12 +857,14 @@ func (p *portalPlannerImpl) planPortalChildResourcesCreate(
 			integrations = append(integrations, integration)
 		}
 	}
-	if err := planner.planPortalIntegrationsChanges(
-		ctx, parentNamespace, "", desired.Ref, integrations, plan,
-	); err != nil {
-		planner.logger.Debug("Failed to plan portal integrations for new portal",
-			"portal", desired.Ref,
-			"error", err.Error())
+	if childInScope(resources.ResourceTypePortalIntegration) {
+		if err := planner.planPortalIntegrationsChanges(
+			ctx, parentNamespace, "", desired.Ref, integrations, plan,
+		); err != nil {
+			planner.logger.Debug("Failed to plan portal integrations for new portal",
+				"portal", desired.Ref,
+				"error", err.Error())
+		}
 	}
 
 	// Plan identity providers
@@ -861,17 +874,19 @@ func (p *portalPlannerImpl) planPortalChildResourcesCreate(
 			identityProviders = append(identityProviders, provider)
 		}
 	}
-	if err := planner.planPortalIdentityProvidersChanges(
-		ctx,
-		parentNamespace,
-		"",
-		desired.Ref,
-		identityProviders,
-		plan,
-	); err != nil {
-		planner.logger.Debug("Failed to plan portal identity providers for new portal",
-			"portal", desired.Ref,
-			"error", err.Error())
+	if childInScope(resources.ResourceTypePortalIdentityProvider) {
+		if err := planner.planPortalIdentityProvidersChanges(
+			ctx,
+			parentNamespace,
+			"",
+			desired.Ref,
+			identityProviders,
+			plan,
+		); err != nil {
+			planner.logger.Debug("Failed to plan portal identity providers for new portal",
+				"portal", desired.Ref,
+				"error", err.Error())
+		}
 	}
 
 	// Plan email config
@@ -881,12 +896,14 @@ func (p *portalPlannerImpl) planPortalChildResourcesCreate(
 			emailConfigs = append(emailConfigs, cfg)
 		}
 	}
-	if err := planner.planPortalEmailConfigsChanges(
-		ctx, parentNamespace, "", desired.Ref, emailConfigs, plan,
-	); err != nil {
-		planner.logger.Debug("Failed to plan portal email config for new portal",
-			"portal", desired.Ref,
-			"error", err.Error())
+	if childInScope(resources.ResourceTypePortalEmailConfig) {
+		if err := planner.planPortalEmailConfigsChanges(
+			ctx, parentNamespace, "", desired.Ref, emailConfigs, plan,
+		); err != nil {
+			planner.logger.Debug("Failed to plan portal email config for new portal",
+				"portal", desired.Ref,
+				"error", err.Error())
+		}
 	}
 
 	// Plan audit-log webhook
@@ -896,12 +913,14 @@ func (p *portalPlannerImpl) planPortalChildResourcesCreate(
 			auditLogWebhooks = append(auditLogWebhooks, webhook)
 		}
 	}
-	if err := planner.planPortalAuditLogWebhooksChanges(
-		ctx, parentNamespace, "", desired.Ref, auditLogWebhooks, plan,
-	); err != nil {
-		planner.logger.Debug("Failed to plan portal audit-log webhook for new portal",
-			"portal", desired.Ref,
-			"error", err.Error())
+	if childInScope(resources.ResourceTypePortalAuditLogWebhook) {
+		if err := planner.planPortalAuditLogWebhooksChanges(
+			ctx, parentNamespace, "", desired.Ref, auditLogWebhooks, plan,
+		); err != nil {
+			planner.logger.Debug("Failed to plan portal audit-log webhook for new portal",
+				"portal", desired.Ref,
+				"error", err.Error())
+		}
 	}
 
 	// Plan email templates
@@ -911,12 +930,14 @@ func (p *portalPlannerImpl) planPortalChildResourcesCreate(
 			templates = append(templates, tpl)
 		}
 	}
-	if err := planner.planPortalEmailTemplatesChanges(
-		ctx, parentNamespace, "", desired.Ref, desired.Name, templates, plan,
-	); err != nil {
-		planner.logger.Debug("Failed to plan portal email templates for new portal",
-			"portal", desired.Ref,
-			"error", err.Error())
+	if childInScope(resources.ResourceTypePortalEmailTemplate) {
+		if err := planner.planPortalEmailTemplatesChanges(
+			ctx, parentNamespace, "", desired.Ref, desired.Name, templates, plan,
+		); err != nil {
+			planner.logger.Debug("Failed to plan portal email templates for new portal",
+				"portal", desired.Ref,
+				"error", err.Error())
+		}
 	}
 
 	// Plan customization
@@ -926,10 +947,14 @@ func (p *portalPlannerImpl) planPortalChildResourcesCreate(
 			customizations = append(customizations, customization)
 		}
 	}
-	if err := planner.planPortalCustomizationsChanges(ctx, plannerCtx, parentNamespace, customizations, plan); err != nil {
-		planner.logger.Debug("Failed to plan portal customizations for new portal",
-			"portal", desired.Ref,
-			"error", err.Error())
+	if childInScope(resources.ResourceTypePortalCustomization) {
+		if err := planner.planPortalCustomizationsChanges(
+			ctx, plannerCtx, parentNamespace, customizations, plan,
+		); err != nil {
+			planner.logger.Debug("Failed to plan portal customizations for new portal",
+				"portal", desired.Ref,
+				"error", err.Error())
+		}
 	}
 
 	// Plan teams
@@ -939,18 +964,22 @@ func (p *portalPlannerImpl) planPortalChildResourcesCreate(
 			teams = append(teams, team)
 		}
 	}
-	if err := planner.planPortalTeamsChanges(ctx, parentNamespace, "", desired.Ref, teams, plan); err != nil {
-		planner.logger.Debug("Failed to plan portal teams for new portal",
-			"portal", desired.Ref,
-			"error", err.Error())
+	if childInScope(resources.ResourceTypePortalTeam) {
+		if err := planner.planPortalTeamsChanges(ctx, parentNamespace, "", desired.Ref, teams, plan); err != nil {
+			planner.logger.Debug("Failed to plan portal teams for new portal",
+				"portal", desired.Ref,
+				"error", err.Error())
+		}
 	}
 
-	if err := planner.planPortalTeamRolesChanges(
-		ctx, parentNamespace, "", desired.Ref, desired.Name, plan,
-	); err != nil {
-		planner.logger.Debug("Failed to plan portal team roles for new portal",
-			"portal", desired.Ref,
-			"error", err.Error())
+	if childInScope(resources.ResourceTypePortalTeamRole) {
+		if err := planner.planPortalTeamRolesChanges(
+			ctx, parentNamespace, "", desired.Ref, desired.Name, plan,
+		); err != nil {
+			planner.logger.Debug("Failed to plan portal team roles for new portal",
+				"portal", desired.Ref,
+				"error", err.Error())
+		}
 	}
 
 	// Plan custom domain
@@ -960,10 +989,12 @@ func (p *portalPlannerImpl) planPortalChildResourcesCreate(
 			domains = append(domains, domain)
 		}
 	}
-	if err := planner.planPortalCustomDomainsChanges(ctx, parentNamespace, "", desired.Ref, domains, plan); err != nil {
-		planner.logger.Debug("Failed to plan portal custom domains for new portal",
-			"portal", desired.Ref,
-			"error", err.Error())
+	if childInScope(resources.ResourceTypePortalCustomDomain) {
+		if err := planner.planPortalCustomDomainsChanges(ctx, parentNamespace, "", desired.Ref, domains, plan); err != nil {
+			planner.logger.Debug("Failed to plan portal custom domains for new portal",
+				"portal", desired.Ref,
+				"error", err.Error())
+		}
 	}
 
 	// Plan asset logo
@@ -973,10 +1004,12 @@ func (p *portalPlannerImpl) planPortalChildResourcesCreate(
 			logos = append(logos, logo)
 		}
 	}
-	if err := planner.planPortalAssetLogosChanges(ctx, plannerCtx, parentNamespace, logos, plan); err != nil {
-		planner.logger.Debug("Failed to plan portal asset logos for new portal",
-			"portal", desired.Ref,
-			"error", err.Error())
+	if childInScope(resources.ResourceTypePortalAssetLogo) {
+		if err := planner.planPortalAssetLogosChanges(ctx, plannerCtx, parentNamespace, logos, plan); err != nil {
+			planner.logger.Debug("Failed to plan portal asset logos for new portal",
+				"portal", desired.Ref,
+				"error", err.Error())
+		}
 	}
 
 	// Plan asset favicon
@@ -986,16 +1019,19 @@ func (p *portalPlannerImpl) planPortalChildResourcesCreate(
 			favicons = append(favicons, favicon)
 		}
 	}
-	if err := planner.planPortalAssetFaviconsChanges(ctx, plannerCtx, parentNamespace, favicons, plan); err != nil {
-		planner.logger.Debug("Failed to plan portal asset favicons for new portal",
-			"portal", desired.Ref,
-			"error", err.Error())
+	if childInScope(resources.ResourceTypePortalAssetFavicon) {
+		if err := planner.planPortalAssetFaviconsChanges(ctx, plannerCtx, parentNamespace, favicons, plan); err != nil {
+			planner.logger.Debug("Failed to plan portal asset favicons for new portal",
+				"portal", desired.Ref,
+				"error", err.Error())
+		}
 	}
 
 	// Plan nested assets (from portal.Assets.Logo and portal.Assets.Favicon fields)
 	if !desired.IsExternal() && desired.Assets != nil {
 		if desired.Assets.Logo != nil && *desired.Assets.Logo != "" {
-			if !plan.HasChange(ResourceTypePortalAssetLogo, fmt.Sprintf("%s-logo", desired.Ref)) {
+			if childInScope(resources.ResourceTypePortalAssetLogo) &&
+				!plan.HasChange(ResourceTypePortalAssetLogo, fmt.Sprintf("%s-logo", desired.Ref)) {
 				planner.planPortalAssetLogoUpdate(
 					parentNamespace,
 					desired.Ref,
@@ -1008,7 +1044,8 @@ func (p *portalPlannerImpl) planPortalChildResourcesCreate(
 			}
 		}
 		if desired.Assets.Favicon != nil && *desired.Assets.Favicon != "" {
-			if !plan.HasChange(ResourceTypePortalAssetFavicon, fmt.Sprintf("%s-favicon", desired.Ref)) {
+			if childInScope(resources.ResourceTypePortalAssetFavicon) &&
+				!plan.HasChange(ResourceTypePortalAssetFavicon, fmt.Sprintf("%s-favicon", desired.Ref)) {
 				planner.planPortalAssetFaviconUpdate(
 					parentNamespace,
 					desired.Ref,
@@ -1029,6 +1066,9 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 ) error {
 	// Get the main planner instance to access child resource planning methods
 	planner := p.planner
+	childInScope := func(rt resources.ResourceType) bool {
+		return planner.shouldPlanChild(plan, resources.ResourceTypePortal, desired.Ref, rt)
+	}
 
 	// Extract parent namespace for child resources
 	parentNamespace := DefaultNamespace
@@ -1045,8 +1085,10 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			pages = append(pages, page)
 		}
 	}
-	if err := planner.planPortalPagesChanges(ctx, parentNamespace, current.ID, desired.Ref, pages, plan); err != nil {
-		return fmt.Errorf("failed to plan portal page changes: %w", err)
+	if childInScope(resources.ResourceTypePortalPage) {
+		if err := planner.planPortalPagesChanges(ctx, parentNamespace, current.ID, desired.Ref, pages, plan); err != nil {
+			return fmt.Errorf("failed to plan portal page changes: %w", err)
+		}
 	}
 
 	// Plan snippets - pass empty array if no snippets defined
@@ -1058,10 +1100,12 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			snippets = append(snippets, snippet)
 		}
 	}
-	if err := planner.planPortalSnippetsChanges(
-		ctx, parentNamespace, current.ID, desired.Ref, snippets, plan,
-	); err != nil {
-		return fmt.Errorf("failed to plan portal snippet changes: %w", err)
+	if childInScope(resources.ResourceTypePortalSnippet) {
+		if err := planner.planPortalSnippetsChanges(
+			ctx, parentNamespace, current.ID, desired.Ref, snippets, plan,
+		); err != nil {
+			return fmt.Errorf("failed to plan portal snippet changes: %w", err)
+		}
 	}
 
 	// Plan auth settings (singleton)
@@ -1071,8 +1115,10 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			authSettings = append(authSettings, auth)
 		}
 	}
-	if err := planner.planPortalAuthSettingsChanges(ctx, plannerCtx, parentNamespace, authSettings, plan); err != nil {
-		return fmt.Errorf("failed to plan portal auth settings changes: %w", err)
+	if childInScope(resources.ResourceTypePortalAuthSettings) {
+		if err := planner.planPortalAuthSettingsChanges(ctx, plannerCtx, parentNamespace, authSettings, plan); err != nil {
+			return fmt.Errorf("failed to plan portal auth settings changes: %w", err)
+		}
 	}
 
 	// Plan IP allow list (singleton)
@@ -1082,10 +1128,12 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			allowLists = append(allowLists, allowList)
 		}
 	}
-	if err := planner.planPortalIPAllowListsChanges(
-		ctx, parentNamespace, current.ID, desired.Ref, allowLists, plan,
-	); err != nil {
-		return fmt.Errorf("failed to plan portal IP allow list changes: %w", err)
+	if childInScope(resources.ResourceTypePortalIPAllowList) {
+		if err := planner.planPortalIPAllowListsChanges(
+			ctx, parentNamespace, current.ID, desired.Ref, allowLists, plan,
+		); err != nil {
+			return fmt.Errorf("failed to plan portal IP allow list changes: %w", err)
+		}
 	}
 
 	// Plan integrations (singleton)
@@ -1095,10 +1143,12 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			integrations = append(integrations, integration)
 		}
 	}
-	if err := planner.planPortalIntegrationsChanges(
-		ctx, parentNamespace, current.ID, desired.Ref, integrations, plan,
-	); err != nil {
-		return fmt.Errorf("failed to plan portal integration changes: %w", err)
+	if childInScope(resources.ResourceTypePortalIntegration) {
+		if err := planner.planPortalIntegrationsChanges(
+			ctx, parentNamespace, current.ID, desired.Ref, integrations, plan,
+		); err != nil {
+			return fmt.Errorf("failed to plan portal integration changes: %w", err)
+		}
 	}
 
 	// Plan identity providers
@@ -1108,15 +1158,17 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			identityProviders = append(identityProviders, provider)
 		}
 	}
-	if err := planner.planPortalIdentityProvidersChanges(
-		ctx,
-		parentNamespace,
-		current.ID,
-		desired.Ref,
-		identityProviders,
-		plan,
-	); err != nil {
-		return fmt.Errorf("failed to plan portal identity provider changes: %w", err)
+	if childInScope(resources.ResourceTypePortalIdentityProvider) {
+		if err := planner.planPortalIdentityProvidersChanges(
+			ctx,
+			parentNamespace,
+			current.ID,
+			desired.Ref,
+			identityProviders,
+			plan,
+		); err != nil {
+			return fmt.Errorf("failed to plan portal identity provider changes: %w", err)
+		}
 	}
 
 	// Plan email config (singleton resource)
@@ -1126,10 +1178,12 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			emailConfigs = append(emailConfigs, cfg)
 		}
 	}
-	if err := planner.planPortalEmailConfigsChanges(
-		ctx, parentNamespace, current.ID, desired.Ref, emailConfigs, plan,
-	); err != nil {
-		return fmt.Errorf("failed to plan portal email config changes: %w", err)
+	if childInScope(resources.ResourceTypePortalEmailConfig) {
+		if err := planner.planPortalEmailConfigsChanges(
+			ctx, parentNamespace, current.ID, desired.Ref, emailConfigs, plan,
+		); err != nil {
+			return fmt.Errorf("failed to plan portal email config changes: %w", err)
+		}
 	}
 
 	// Plan audit-log webhook (singleton resource)
@@ -1139,10 +1193,12 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			auditLogWebhooks = append(auditLogWebhooks, webhook)
 		}
 	}
-	if err := planner.planPortalAuditLogWebhooksChanges(
-		ctx, parentNamespace, current.ID, desired.Ref, auditLogWebhooks, plan,
-	); err != nil {
-		return fmt.Errorf("failed to plan portal audit-log webhook changes: %w", err)
+	if childInScope(resources.ResourceTypePortalAuditLogWebhook) {
+		if err := planner.planPortalAuditLogWebhooksChanges(
+			ctx, parentNamespace, current.ID, desired.Ref, auditLogWebhooks, plan,
+		); err != nil {
+			return fmt.Errorf("failed to plan portal audit-log webhook changes: %w", err)
+		}
 	}
 
 	// Plan email templates (set applies create/update only in apply mode)
@@ -1152,10 +1208,12 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			templates = append(templates, tpl)
 		}
 	}
-	if err := planner.planPortalEmailTemplatesChanges(
-		ctx, parentNamespace, current.ID, desired.Ref, desired.Name, templates, plan,
-	); err != nil {
-		return fmt.Errorf("failed to plan portal email template changes: %w", err)
+	if childInScope(resources.ResourceTypePortalEmailTemplate) {
+		if err := planner.planPortalEmailTemplatesChanges(
+			ctx, parentNamespace, current.ID, desired.Ref, desired.Name, templates, plan,
+		); err != nil {
+			return fmt.Errorf("failed to plan portal email template changes: %w", err)
+		}
 	}
 
 	// Plan customization (singleton resource)
@@ -1165,8 +1223,12 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			customizations = append(customizations, customization)
 		}
 	}
-	if err := planner.planPortalCustomizationsChanges(ctx, plannerCtx, parentNamespace, customizations, plan); err != nil {
-		return fmt.Errorf("failed to plan portal customization changes: %w", err)
+	if childInScope(resources.ResourceTypePortalCustomization) {
+		if err := planner.planPortalCustomizationsChanges(
+			ctx, plannerCtx, parentNamespace, customizations, plan,
+		); err != nil {
+			return fmt.Errorf("failed to plan portal customization changes: %w", err)
+		}
 	}
 
 	// Plan teams
@@ -1176,16 +1238,20 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			teams = append(teams, team)
 		}
 	}
-	if err := planner.planPortalTeamsChanges(
-		ctx, parentNamespace, current.ID, desired.Ref, teams, plan,
-	); err != nil {
-		return fmt.Errorf("failed to plan portal team changes: %w", err)
+	if childInScope(resources.ResourceTypePortalTeam) {
+		if err := planner.planPortalTeamsChanges(
+			ctx, parentNamespace, current.ID, desired.Ref, teams, plan,
+		); err != nil {
+			return fmt.Errorf("failed to plan portal team changes: %w", err)
+		}
 	}
 
-	if err := planner.planPortalTeamRolesChanges(
-		ctx, parentNamespace, current.ID, desired.Ref, desired.Name, plan,
-	); err != nil {
-		return fmt.Errorf("failed to plan portal team role changes: %w", err)
+	if childInScope(resources.ResourceTypePortalTeamRole) {
+		if err := planner.planPortalTeamRolesChanges(
+			ctx, parentNamespace, current.ID, desired.Ref, desired.Name, plan,
+		); err != nil {
+			return fmt.Errorf("failed to plan portal team role changes: %w", err)
+		}
 	}
 
 	// Plan custom domain (singleton resource)
@@ -1195,15 +1261,17 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			domains = append(domains, domain)
 		}
 	}
-	if err := planner.planPortalCustomDomainsChanges(
-		ctx,
-		parentNamespace,
-		current.ID,
-		desired.Ref,
-		domains,
-		plan,
-	); err != nil {
-		return fmt.Errorf("failed to plan portal custom domain changes: %w", err)
+	if childInScope(resources.ResourceTypePortalCustomDomain) {
+		if err := planner.planPortalCustomDomainsChanges(
+			ctx,
+			parentNamespace,
+			current.ID,
+			desired.Ref,
+			domains,
+			plan,
+		); err != nil {
+			return fmt.Errorf("failed to plan portal custom domain changes: %w", err)
+		}
 	}
 
 	// Plan asset logo (singleton resource)
@@ -1213,8 +1281,10 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			logos = append(logos, logo)
 		}
 	}
-	if err := planner.planPortalAssetLogosChanges(ctx, plannerCtx, parentNamespace, logos, plan); err != nil {
-		return fmt.Errorf("failed to plan portal asset logo changes: %w", err)
+	if childInScope(resources.ResourceTypePortalAssetLogo) {
+		if err := planner.planPortalAssetLogosChanges(ctx, plannerCtx, parentNamespace, logos, plan); err != nil {
+			return fmt.Errorf("failed to plan portal asset logo changes: %w", err)
+		}
 	}
 
 	// Plan asset favicon (singleton resource)
@@ -1224,14 +1294,17 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			favicons = append(favicons, favicon)
 		}
 	}
-	if err := planner.planPortalAssetFaviconsChanges(ctx, plannerCtx, parentNamespace, favicons, plan); err != nil {
-		return fmt.Errorf("failed to plan portal asset favicon changes: %w", err)
+	if childInScope(resources.ResourceTypePortalAssetFavicon) {
+		if err := planner.planPortalAssetFaviconsChanges(ctx, plannerCtx, parentNamespace, favicons, plan); err != nil {
+			return fmt.Errorf("failed to plan portal asset favicon changes: %w", err)
+		}
 	}
 
 	// Plan nested assets (from portal.Assets.Logo and portal.Assets.Favicon fields)
 	if !desired.IsExternal() && desired.Assets != nil {
 		if desired.Assets.Logo != nil && *desired.Assets.Logo != "" {
-			if !plan.HasChange(ResourceTypePortalAssetLogo, fmt.Sprintf("%s-logo", desired.Ref)) {
+			if childInScope(resources.ResourceTypePortalAssetLogo) &&
+				!plan.HasChange(ResourceTypePortalAssetLogo, fmt.Sprintf("%s-logo", desired.Ref)) {
 				needsUpdate, currentDataURL, err := planner.portalAssetNeedsUpdate(
 					ctx,
 					current.ID,
@@ -1259,7 +1332,8 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			}
 		}
 		if desired.Assets.Favicon != nil && *desired.Assets.Favicon != "" {
-			if !plan.HasChange(ResourceTypePortalAssetFavicon, fmt.Sprintf("%s-favicon", desired.Ref)) {
+			if childInScope(resources.ResourceTypePortalAssetFavicon) &&
+				!plan.HasChange(ResourceTypePortalAssetFavicon, fmt.Sprintf("%s-favicon", desired.Ref)) {
 				needsUpdate, currentDataURL, err := planner.portalAssetNeedsUpdate(
 					ctx,
 					current.ID,

--- a/internal/declarative/planner/sync_scope.go
+++ b/internal/declarative/planner/sync_scope.go
@@ -1,0 +1,331 @@
+package planner
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+)
+
+func syncScopeMetadata(scope *resources.SyncScope) *PlanSyncScope {
+	if scope == nil || !scope.HasAny() {
+		return nil
+	}
+
+	metadata := &PlanSyncScope{
+		RootResourceTypes:      make([]string, 0, len(scope.RootTypes())),
+		ChildResourceTypes:     make([]PlanSyncChildScope, 0, len(scope.ChildScopes())),
+		RootChildResourceTypes: make([]string, 0, len(scope.RootChildCollectionTypes())),
+		OrganizationUsers:      scope.OrganizationUsersScoped,
+	}
+	for _, rt := range scope.RootTypes() {
+		metadata.RootResourceTypes = append(metadata.RootResourceTypes, string(rt))
+	}
+	for _, child := range scope.ChildScopes() {
+		metadata.ChildResourceTypes = append(metadata.ChildResourceTypes, PlanSyncChildScope{
+			ParentType:   string(child.ParentType),
+			ParentRef:    child.ParentRef,
+			ResourceType: string(child.ResourceType),
+		})
+	}
+	for _, rt := range scope.RootChildCollectionTypes() {
+		metadata.RootChildResourceTypes = append(metadata.RootChildResourceTypes, string(rt))
+	}
+
+	return metadata
+}
+
+func ensurePlanningSyncScope(rs *resources.ResourceSet) {
+	if rs == nil || rs.SyncScope != nil || rs.IsEmpty() {
+		return
+	}
+
+	scope := rs.EnsureSyncScope()
+	addRootIfPresent(scope, resources.ResourceTypePortal, len(rs.Portals))
+	addRootIfPresent(scope, resources.ResourceTypeApplicationAuthStrategy, len(rs.ApplicationAuthStrategies))
+	addRootIfPresent(scope, resources.ResourceTypeDCRProvider, len(rs.DCRProviders))
+	addRootIfPresent(scope, resources.ResourceTypeControlPlane, len(rs.ControlPlanes))
+	addRootIfPresent(scope, resources.ResourceTypeCatalogService, len(rs.CatalogServices))
+	addRootIfPresent(scope, resources.ResourceTypeAPI, len(rs.APIs))
+	addRootIfPresent(scope, resources.ResourceTypeEventGatewayControlPlane, len(rs.EventGatewayControlPlanes))
+	addRootIfPresent(scope, resources.ResourceTypeOrganizationTeam, len(rs.OrganizationTeams))
+
+	for _, cert := range rs.ControlPlaneDataPlaneCertificates {
+		scope.AddChild(
+			resources.ResourceTypeControlPlane,
+			cert.ControlPlane,
+			resources.ResourceTypeControlPlaneDataPlaneCertificate,
+		)
+	}
+	for _, version := range rs.APIVersions {
+		scope.AddChild(resources.ResourceTypeAPI, version.API, resources.ResourceTypeAPIVersion)
+	}
+	for _, publication := range rs.APIPublications {
+		scope.AddChild(resources.ResourceTypeAPI, publication.API, resources.ResourceTypeAPIPublication)
+	}
+	for _, implementation := range rs.APIImplementations {
+		scope.AddChild(resources.ResourceTypeAPI, implementation.API, resources.ResourceTypeAPIImplementation)
+	}
+	for _, document := range rs.APIDocuments {
+		scope.AddChild(resources.ResourceTypeAPI, document.API, resources.ResourceTypeAPIDocument)
+	}
+
+	addPortalChildScopes(scope, rs)
+	addEventGatewayChildScopes(scope, rs)
+	addOrganizationChildScopes(scope, rs)
+}
+
+func addRootIfPresent(scope *resources.SyncScope, rt resources.ResourceType, count int) {
+	if count > 0 {
+		scope.AddRoot(rt)
+	}
+}
+
+func addPortalChildScopes(scope *resources.SyncScope, rs *resources.ResourceSet) {
+	for _, child := range rs.PortalCustomizations {
+		scope.AddChild(resources.ResourceTypePortal, child.Portal, resources.ResourceTypePortalCustomization)
+	}
+	for _, child := range rs.PortalAuthSettings {
+		scope.AddChild(resources.ResourceTypePortal, child.Portal, resources.ResourceTypePortalAuthSettings)
+	}
+	for _, child := range rs.PortalIPAllowLists {
+		scope.AddChild(resources.ResourceTypePortal, child.Portal, resources.ResourceTypePortalIPAllowList)
+	}
+	for _, child := range rs.PortalIntegrations {
+		scope.AddChild(resources.ResourceTypePortal, child.Portal, resources.ResourceTypePortalIntegration)
+	}
+	for _, child := range rs.PortalIdentityProviders {
+		scope.AddChild(resources.ResourceTypePortal, child.Portal, resources.ResourceTypePortalIdentityProvider)
+	}
+	for _, child := range rs.PortalCustomDomains {
+		scope.AddChild(resources.ResourceTypePortal, child.Portal, resources.ResourceTypePortalCustomDomain)
+	}
+	for _, child := range rs.PortalPages {
+		scope.AddChild(resources.ResourceTypePortal, child.Portal, resources.ResourceTypePortalPage)
+	}
+	for _, child := range rs.PortalSnippets {
+		scope.AddChild(resources.ResourceTypePortal, child.Portal, resources.ResourceTypePortalSnippet)
+	}
+	for _, child := range rs.PortalTeams {
+		scope.AddChild(resources.ResourceTypePortal, child.Portal, resources.ResourceTypePortalTeam)
+	}
+	for _, child := range rs.PortalTeamRoles {
+		scope.AddChild(resources.ResourceTypePortal, child.Portal, resources.ResourceTypePortalTeamRole)
+	}
+	for _, child := range rs.PortalAssetLogos {
+		scope.AddChild(resources.ResourceTypePortal, child.Portal, resources.ResourceTypePortalAssetLogo)
+	}
+	for _, child := range rs.PortalAssetFavicons {
+		scope.AddChild(resources.ResourceTypePortal, child.Portal, resources.ResourceTypePortalAssetFavicon)
+	}
+	for _, child := range rs.PortalEmailConfigs {
+		scope.AddChild(resources.ResourceTypePortal, child.Portal, resources.ResourceTypePortalEmailConfig)
+	}
+	for _, child := range rs.PortalEmailTemplates {
+		scope.AddChild(resources.ResourceTypePortal, child.Portal, resources.ResourceTypePortalEmailTemplate)
+	}
+	for _, child := range rs.PortalAuditLogWebhooks {
+		scope.AddChild(resources.ResourceTypePortal, child.Portal, resources.ResourceTypePortalAuditLogWebhook)
+	}
+}
+
+func addEventGatewayChildScopes(scope *resources.SyncScope, rs *resources.ResourceSet) {
+	for _, child := range rs.EventGatewayBackendClusters {
+		scope.AddChild(
+			resources.ResourceTypeEventGatewayControlPlane,
+			child.EventGateway,
+			resources.ResourceTypeEventGatewayBackendCluster,
+		)
+	}
+	for _, child := range rs.EventGatewayVirtualClusters {
+		scope.AddChild(
+			resources.ResourceTypeEventGatewayControlPlane,
+			child.EventGateway,
+			resources.ResourceTypeEventGatewayVirtualCluster,
+		)
+	}
+	for _, child := range rs.EventGatewayListeners {
+		scope.AddChild(
+			resources.ResourceTypeEventGatewayControlPlane,
+			child.EventGateway,
+			resources.ResourceTypeEventGatewayListener,
+		)
+	}
+	for _, child := range rs.EventGatewayDataPlaneCertificates {
+		scope.AddChild(
+			resources.ResourceTypeEventGatewayControlPlane,
+			child.EventGateway,
+			resources.ResourceTypeEventGatewayDataPlaneCertificate,
+		)
+	}
+	for _, child := range rs.EventGatewaySchemaRegistries {
+		scope.AddChild(
+			resources.ResourceTypeEventGatewayControlPlane,
+			child.EventGateway,
+			resources.ResourceTypeEventGatewaySchemaRegistry,
+		)
+	}
+	for _, child := range rs.EventGatewayStaticKeys {
+		scope.AddChild(
+			resources.ResourceTypeEventGatewayControlPlane,
+			child.EventGateway,
+			resources.ResourceTypeEventGatewayStaticKey,
+		)
+	}
+	for _, child := range rs.EventGatewayTLSTrustBundles {
+		scope.AddChild(
+			resources.ResourceTypeEventGatewayControlPlane,
+			child.EventGateway,
+			resources.ResourceTypeEventGatewayTLSTrustBundle,
+		)
+	}
+	for _, child := range rs.EventGatewayListenerPolicies {
+		scope.AddChild(
+			resources.ResourceTypeEventGatewayListener,
+			child.EventGatewayListener,
+			resources.ResourceTypeEventGatewayListenerPolicy,
+		)
+	}
+	for _, child := range rs.EventGatewayClusterPolicies {
+		scope.AddChild(
+			resources.ResourceTypeEventGatewayVirtualCluster,
+			child.VirtualCluster,
+			resources.ResourceTypeEventGatewayClusterPolicy,
+		)
+	}
+	for _, child := range rs.EventGatewayProducePolicies {
+		scope.AddChild(
+			resources.ResourceTypeEventGatewayVirtualCluster,
+			child.VirtualCluster,
+			resources.ResourceTypeEventGatewayProducePolicy,
+		)
+	}
+	for _, child := range rs.EventGatewayConsumePolicies {
+		scope.AddChild(
+			resources.ResourceTypeEventGatewayVirtualCluster,
+			child.VirtualCluster,
+			resources.ResourceTypeEventGatewayConsumePolicy,
+		)
+	}
+}
+
+func addOrganizationChildScopes(scope *resources.SyncScope, rs *resources.ResourceSet) {
+	for _, role := range rs.OrganizationTeamRoles {
+		scope.AddChild(resources.ResourceTypeOrganizationTeam, role.Team, resources.ResourceTypeOrganizationTeamRole)
+	}
+	if len(rs.OrganizationUserTeamMemberships) > 0 || len(rs.OrganizationUserRoles) > 0 {
+		scope.MarkOrganizationUsersScoped()
+	}
+}
+
+func validateSyncScope(scope *resources.SyncScope) error {
+	rootChildTypes := scope.RootChildCollectionTypes()
+	if len(rootChildTypes) == 0 {
+		return validateParentScopes(scope)
+	}
+
+	names := make([]string, 0, len(rootChildTypes))
+	for _, rt := range rootChildTypes {
+		names = append(names, string(rt))
+	}
+
+	return fmt.Errorf(
+		"sync requires empty child collections to be scoped under a parent resource; "+
+			"%s cannot be used at the root with an empty list. "+
+			"Move the empty collection under the parent resource, for example apis: [{ref: my-api, documents: []}]",
+		strings.Join(names, ", "),
+	)
+}
+
+func validateParentScopes(scope *resources.SyncScope) error {
+	if scope == nil {
+		return nil
+	}
+	for _, child := range scope.ChildScopes() {
+		if !syncRootParentType(child.ParentType) || scope.RootInScope(child.ParentType) {
+			continue
+		}
+		return fmt.Errorf(
+			"sync child collection %s for %s %q requires the parent collection to be present; "+
+				"add the parent resource collection or move the child collection under that parent",
+			child.ResourceType,
+			child.ParentType,
+			child.ParentRef,
+		)
+	}
+	return nil
+}
+
+func syncRootParentType(rt resources.ResourceType) bool {
+	// This switch intentionally handles only resource types that can own nested sync scope.
+	//nolint:exhaustive
+	switch rt {
+	case resources.ResourceTypeAPI,
+		resources.ResourceTypePortal,
+		resources.ResourceTypeControlPlane,
+		resources.ResourceTypeEventGatewayControlPlane,
+		resources.ResourceTypeOrganizationTeam:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *Planner) shouldPlanRoot(mode PlanMode, rt resources.ResourceType) bool {
+	if mode != PlanModeSync {
+		return true
+	}
+	if p == nil || p.resources == nil {
+		return false
+	}
+	ensurePlanningSyncScope(p.resources)
+	if p.resources.SyncScope == nil {
+		return false
+	}
+	return p.resources.SyncScope.RootInScope(rt)
+}
+
+func (p *Planner) shouldPlanChild(
+	plan *Plan,
+	parentType resources.ResourceType,
+	parentRef string,
+	rt resources.ResourceType,
+) bool {
+	if plan == nil || plan.Metadata.Mode != PlanModeSync {
+		return true
+	}
+	if p == nil || p.resources == nil {
+		return false
+	}
+	ensurePlanningSyncScope(p.resources)
+	if p.resources.SyncScope == nil {
+		return false
+	}
+	return p.resources.SyncScope.ChildInScope(parentType, parentRef, rt)
+}
+
+func (p *Planner) shouldPlanOrganization(plan *Plan) bool {
+	if plan == nil || plan.Metadata.Mode != PlanModeSync {
+		return true
+	}
+	if p == nil || p.resources == nil {
+		return false
+	}
+	ensurePlanningSyncScope(p.resources)
+	if p.resources.SyncScope == nil {
+		return false
+	}
+	scope := p.resources.SyncScope
+	return scope.RootInScope(resources.ResourceTypeOrganizationTeam) || scope.OrganizationUsersScoped
+}
+
+func (p *Planner) shouldPlanOrganizationUsers(plan *Plan) bool {
+	if plan == nil || plan.Metadata.Mode != PlanModeSync {
+		return true
+	}
+	if p == nil || p.resources == nil {
+		return false
+	}
+	ensurePlanningSyncScope(p.resources)
+	return p.resources.SyncScope != nil && p.resources.SyncScope.OrganizationUsersScoped
+}

--- a/internal/declarative/planner/sync_scope.go
+++ b/internal/declarative/planner/sync_scope.go
@@ -12,23 +12,26 @@ func syncScopeMetadata(scope *resources.SyncScope) *PlanSyncScope {
 		return nil
 	}
 
+	rootTypes := scope.RootTypes()
+	childScopes := scope.ChildScopes()
+	rootChildTypes := scope.RootChildCollectionTypes()
 	metadata := &PlanSyncScope{
-		RootResourceTypes:      make([]string, 0, len(scope.RootTypes())),
-		ChildResourceTypes:     make([]PlanSyncChildScope, 0, len(scope.ChildScopes())),
-		RootChildResourceTypes: make([]string, 0, len(scope.RootChildCollectionTypes())),
+		RootResourceTypes:      make([]string, 0, len(rootTypes)),
+		ChildResourceTypes:     make([]PlanSyncChildScope, 0, len(childScopes)),
+		RootChildResourceTypes: make([]string, 0, len(rootChildTypes)),
 		OrganizationUsers:      scope.OrganizationUsersScoped,
 	}
-	for _, rt := range scope.RootTypes() {
+	for _, rt := range rootTypes {
 		metadata.RootResourceTypes = append(metadata.RootResourceTypes, string(rt))
 	}
-	for _, child := range scope.ChildScopes() {
+	for _, child := range childScopes {
 		metadata.ChildResourceTypes = append(metadata.ChildResourceTypes, PlanSyncChildScope{
 			ParentType:   string(child.ParentType),
 			ParentRef:    child.ParentRef,
 			ResourceType: string(child.ResourceType),
 		})
 	}
-	for _, rt := range scope.RootChildCollectionTypes() {
+	for _, rt := range rootChildTypes {
 		metadata.RootChildResourceTypes = append(metadata.RootChildResourceTypes, string(rt))
 	}
 
@@ -108,6 +111,7 @@ func addPortalChildScopes(scope *resources.SyncScope, rs *resources.ResourceSet)
 	}
 	for _, child := range rs.PortalTeams {
 		scope.AddChild(resources.ResourceTypePortal, child.Portal, resources.ResourceTypePortalTeam)
+		scope.AddChild(resources.ResourceTypePortal, child.Portal, resources.ResourceTypePortalTeamRole)
 	}
 	for _, child := range rs.PortalTeamRoles {
 		scope.AddChild(resources.ResourceTypePortal, child.Portal, resources.ResourceTypePortalTeamRole)
@@ -245,12 +249,17 @@ func validateParentScopes(scope *resources.SyncScope) error {
 		if !syncRootParentType(child.ParentType) || scope.RootInScope(child.ParentType) {
 			continue
 		}
+		guidance := "add the parent resource collection or move the child collection under that parent"
+		if syncParentTypeSupportsExternal(child.ParentType) {
+			guidance += "; if the parent is managed elsewhere, declare it with _external in the parent " +
+				"collection and nest the child collection there"
+		}
 		return fmt.Errorf(
-			"sync child collection %s for %s %q requires the parent collection to be present; "+
-				"add the parent resource collection or move the child collection under that parent",
+			"sync child collection %s for %s %q requires the parent collection to be present; %s",
 			child.ResourceType,
 			child.ParentType,
 			child.ParentRef,
+			guidance,
 		)
 	}
 	return nil
@@ -271,6 +280,18 @@ func syncRootParentType(rt resources.ResourceType) bool {
 	}
 }
 
+func syncParentTypeSupportsExternal(rt resources.ResourceType) bool {
+	//nolint:exhaustive
+	switch rt {
+	case resources.ResourceTypePortal,
+		resources.ResourceTypeControlPlane,
+		resources.ResourceTypeOrganizationTeam:
+		return true
+	default:
+		return false
+	}
+}
+
 func (p *Planner) shouldPlanRoot(mode PlanMode, rt resources.ResourceType) bool {
 	if mode != PlanModeSync {
 		return true
@@ -279,9 +300,6 @@ func (p *Planner) shouldPlanRoot(mode PlanMode, rt resources.ResourceType) bool 
 		return false
 	}
 	ensurePlanningSyncScope(p.resources)
-	if p.resources.SyncScope == nil {
-		return false
-	}
 	return p.resources.SyncScope.RootInScope(rt)
 }
 
@@ -298,9 +316,6 @@ func (p *Planner) shouldPlanChild(
 		return false
 	}
 	ensurePlanningSyncScope(p.resources)
-	if p.resources.SyncScope == nil {
-		return false
-	}
 	return p.resources.SyncScope.ChildInScope(parentType, parentRef, rt)
 }
 
@@ -312,11 +327,8 @@ func (p *Planner) shouldPlanOrganization(plan *Plan) bool {
 		return false
 	}
 	ensurePlanningSyncScope(p.resources)
-	if p.resources.SyncScope == nil {
-		return false
-	}
 	scope := p.resources.SyncScope
-	return scope.RootInScope(resources.ResourceTypeOrganizationTeam) || scope.OrganizationUsersScoped
+	return scope.RootInScope(resources.ResourceTypeOrganizationTeam) || scope.OrganizationUsersInScope()
 }
 
 func (p *Planner) shouldPlanOrganizationUsers(plan *Plan) bool {
@@ -327,5 +339,5 @@ func (p *Planner) shouldPlanOrganizationUsers(plan *Plan) bool {
 		return false
 	}
 	ensurePlanningSyncScope(p.resources)
-	return p.resources.SyncScope != nil && p.resources.SyncScope.OrganizationUsersScoped
+	return p.resources.SyncScope.OrganizationUsersInScope()
 }

--- a/internal/declarative/planner/sync_scope.go
+++ b/internal/declarative/planner/sync_scope.go
@@ -16,10 +16,11 @@ func syncScopeMetadata(scope *resources.SyncScope) *PlanSyncScope {
 	childScopes := scope.ChildScopes()
 	rootChildTypes := scope.RootChildCollectionTypes()
 	metadata := &PlanSyncScope{
-		RootResourceTypes:      make([]string, 0, len(rootTypes)),
-		ChildResourceTypes:     make([]PlanSyncChildScope, 0, len(childScopes)),
-		RootChildResourceTypes: make([]string, 0, len(rootChildTypes)),
-		OrganizationUsers:      scope.OrganizationUsersScoped,
+		RootResourceTypes:          make([]string, 0, len(rootTypes)),
+		ChildResourceTypes:         make([]PlanSyncChildScope, 0, len(childScopes)),
+		RootChildResourceTypes:     make([]string, 0, len(rootChildTypes)),
+		OrganizationUsers:          scope.OrganizationUsersScoped,
+		OrganizationSystemAccounts: scope.OrganizationSystemAccountsScoped,
 	}
 	for _, rt := range rootTypes {
 		metadata.RootResourceTypes = append(metadata.RootResourceTypes, string(rt))
@@ -39,7 +40,10 @@ func syncScopeMetadata(scope *resources.SyncScope) *PlanSyncScope {
 }
 
 func ensurePlanningSyncScope(rs *resources.ResourceSet) {
-	if rs == nil || rs.SyncScope != nil || rs.IsEmpty() {
+	if rs == nil || rs.SyncScope != nil {
+		return
+	}
+	if rs.IsEmpty() && !hasOrganizationAssignmentSelectors(rs) {
 		return
 	}
 
@@ -76,6 +80,11 @@ func ensurePlanningSyncScope(rs *resources.ResourceSet) {
 	addPortalChildScopes(scope, rs)
 	addEventGatewayChildScopes(scope, rs)
 	addOrganizationChildScopes(scope, rs)
+}
+
+func hasOrganizationAssignmentSelectors(rs *resources.ResourceSet) bool {
+	return rs != nil && rs.Organization != nil &&
+		(len(rs.Organization.Users) > 0 || len(rs.Organization.SystemAccounts) > 0)
 }
 
 func addRootIfPresent(scope *resources.SyncScope, rt resources.ResourceType, count int) {
@@ -217,8 +226,15 @@ func addOrganizationChildScopes(scope *resources.SyncScope, rs *resources.Resour
 	for _, role := range rs.OrganizationTeamRoles {
 		scope.AddChild(resources.ResourceTypeOrganizationTeam, role.Team, resources.ResourceTypeOrganizationTeamRole)
 	}
-	if len(rs.OrganizationUserTeamMemberships) > 0 || len(rs.OrganizationUserRoles) > 0 {
+	if (rs.Organization != nil && len(rs.Organization.Users) > 0) ||
+		len(rs.OrganizationUserTeamMemberships) > 0 ||
+		len(rs.OrganizationUserRoles) > 0 {
 		scope.MarkOrganizationUsersScoped()
+	}
+	if (rs.Organization != nil && len(rs.Organization.SystemAccounts) > 0) ||
+		len(rs.OrganizationSystemAccountTeamMemberships) > 0 ||
+		len(rs.OrganizationSystemAccountRoles) > 0 {
+		scope.MarkOrganizationSystemAccountsScoped()
 	}
 }
 
@@ -328,7 +344,9 @@ func (p *Planner) shouldPlanOrganization(plan *Plan) bool {
 	}
 	ensurePlanningSyncScope(p.resources)
 	scope := p.resources.SyncScope
-	return scope.RootInScope(resources.ResourceTypeOrganizationTeam) || scope.OrganizationUsersInScope()
+	return scope.RootInScope(resources.ResourceTypeOrganizationTeam) ||
+		scope.OrganizationUsersInScope() ||
+		scope.OrganizationSystemAccountsInScope()
 }
 
 func (p *Planner) shouldPlanOrganizationUsers(plan *Plan) bool {
@@ -340,4 +358,15 @@ func (p *Planner) shouldPlanOrganizationUsers(plan *Plan) bool {
 	}
 	ensurePlanningSyncScope(p.resources)
 	return p.resources.SyncScope.OrganizationUsersInScope()
+}
+
+func (p *Planner) shouldPlanOrganizationSystemAccounts(plan *Plan) bool {
+	if plan == nil || plan.Metadata.Mode != PlanModeSync {
+		return true
+	}
+	if p == nil || p.resources == nil {
+		return false
+	}
+	ensurePlanningSyncScope(p.resources)
+	return p.resources.SyncScope.OrganizationSystemAccountsInScope()
 }

--- a/internal/declarative/planner/sync_scope_test.go
+++ b/internal/declarative/planner/sync_scope_test.go
@@ -1,0 +1,96 @@
+package planner
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratePlan_SyncWithNoScopeDoesNotListResources(t *testing.T) {
+	ctx := context.Background()
+	mockPortalAPI := new(MockPortalAPI)
+	mockAPIAPI := new(MockAPIAPI)
+	mockAppAuthAPI := new(MockAppAuthStrategiesAPI)
+	client := state.NewClient(state.ClientConfig{
+		PortalAPI:  mockPortalAPI,
+		APIAPI:     mockAPIAPI,
+		AppAuthAPI: mockAppAuthAPI,
+	})
+
+	plan, err := NewPlanner(
+		client,
+		slog.Default(),
+	).GeneratePlan(ctx, &resources.ResourceSet{}, Options{Mode: PlanModeSync})
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+	assert.Empty(t, plan.Changes)
+
+	mockPortalAPI.AssertNotCalled(t, "ListPortals", mock.Anything, mock.Anything)
+	mockAPIAPI.AssertNotCalled(t, "ListApis", mock.Anything, mock.Anything)
+	mockAppAuthAPI.AssertNotCalled(t, "ListAppAuthStrategies", mock.Anything, mock.Anything)
+}
+
+func TestGeneratePlan_SyncPortalScopeDoesNotListUnscopedRoots(t *testing.T) {
+	ctx := context.Background()
+	mockPortalAPI := new(MockPortalAPI)
+	mockAPIAPI := new(MockAPIAPI)
+	mockAppAuthAPI := new(MockAppAuthStrategiesAPI)
+	client := state.NewClient(state.ClientConfig{
+		PortalAPI:  mockPortalAPI,
+		APIAPI:     mockAPIAPI,
+		AppAuthAPI: mockAppAuthAPI,
+	})
+
+	mockPortalAPI.On("ListPortals", mock.Anything, mock.Anything).Return(&kkOps.ListPortalsResponse{
+		ListPortalsResponse: &kkComps.ListPortalsResponse{
+			Data: []kkComps.ListPortalsResponsePortal{},
+			Meta: kkComps.PaginatedMeta{
+				Page: kkComps.PageMeta{Total: 0},
+			},
+		},
+	}, nil).Once()
+
+	scope := resources.NewSyncScope()
+	scope.AddRoot(resources.ResourceTypePortal)
+	rs := &resources.ResourceSet{
+		Portals: []resources.PortalResource{
+			{
+				CreatePortal: kkComps.CreatePortal{Name: "docs"},
+				BaseResource: resources.BaseResource{Ref: "docs"},
+			},
+		},
+		SyncScope: scope,
+	}
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(ctx, rs, Options{Mode: PlanModeSync})
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	assert.Equal(t, ResourceTypePortal, plan.Changes[0].ResourceType)
+
+	mockPortalAPI.AssertExpectations(t)
+	mockAPIAPI.AssertNotCalled(t, "ListApis", mock.Anything, mock.Anything)
+	mockAppAuthAPI.AssertNotCalled(t, "ListAppAuthStrategies", mock.Anything, mock.Anything)
+}
+
+func TestGeneratePlan_SyncRejectsRootLevelEmptyChildCollections(t *testing.T) {
+	scope := resources.NewSyncScope()
+	scope.AddRootChildCollection(resources.ResourceTypeAPIDocument)
+
+	plan, err := NewPlanner(state.NewClient(state.ClientConfig{}), slog.Default()).GeneratePlan(
+		context.Background(),
+		&resources.ResourceSet{SyncScope: scope},
+		Options{Mode: PlanModeSync},
+	)
+	require.Error(t, err)
+	require.Nil(t, plan)
+	assert.Contains(t, err.Error(), "empty child collections")
+	assert.Contains(t, err.Error(), "api_document")
+}

--- a/internal/declarative/planner/sync_scope_test.go
+++ b/internal/declarative/planner/sync_scope_test.go
@@ -164,3 +164,40 @@ func TestEnsurePlanningSyncScopeInfersPortalTeamRolesWithTeams(t *testing.T) {
 		resources.ResourceTypePortalTeamRole,
 	))
 }
+
+func TestEnsurePlanningSyncScopeInfersOrganizationAssignmentScope(t *testing.T) {
+	rs := &resources.ResourceSet{
+		Organization: &resources.OrganizationResource{
+			Users: []resources.OrganizationUserResource{
+				{
+					Ref: "alice",
+					ID:  "user-123",
+				},
+			},
+			SystemAccounts: []resources.OrganizationSystemAccountResource{
+				{
+					Ref: "ci-bot",
+					ID:  "system-account-123",
+				},
+			},
+		},
+	}
+
+	ensurePlanningSyncScope(rs)
+	require.NotNil(t, rs.SyncScope)
+	assert.True(t, rs.SyncScope.OrganizationUsersInScope())
+	assert.True(t, rs.SyncScope.OrganizationSystemAccountsInScope())
+}
+
+func TestShouldPlanOrganizationSystemAccountsRequiresScope(t *testing.T) {
+	plan := NewPlan("1.0", "test", PlanModeSync)
+	scope := resources.NewSyncScope()
+	planner := &Planner{
+		resources: &resources.ResourceSet{SyncScope: scope},
+	}
+
+	assert.False(t, planner.shouldPlanOrganizationSystemAccounts(plan))
+
+	scope.MarkOrganizationSystemAccountsScoped()
+	assert.True(t, planner.shouldPlanOrganizationSystemAccounts(plan))
+}

--- a/internal/declarative/planner/sync_scope_test.go
+++ b/internal/declarative/planner/sync_scope_test.go
@@ -80,6 +80,37 @@ func TestGeneratePlan_SyncPortalScopeDoesNotListUnscopedRoots(t *testing.T) {
 	mockAppAuthAPI.AssertNotCalled(t, "ListAppAuthStrategies", mock.Anything, mock.Anything)
 }
 
+func TestGeneratePlan_SyncAuthStrategyScopeListsAuthStrategies(t *testing.T) {
+	ctx := context.Background()
+	mockAppAuthAPI := new(MockAppAuthStrategiesAPI)
+	client := state.NewClient(state.ClientConfig{
+		AppAuthAPI: mockAppAuthAPI,
+	})
+
+	mockAppAuthAPI.On("ListAppAuthStrategies", mock.Anything, mock.Anything).
+		Return(&kkOps.ListAppAuthStrategiesResponse{
+			ListAppAuthStrategiesResponse: &kkComps.ListAppAuthStrategiesResponse{
+				Data: []kkComps.AppAuthStrategy{},
+				Meta: kkComps.PaginatedMeta{
+					Page: kkComps.PageMeta{Total: 0},
+				},
+			},
+		}, nil).Once()
+
+	scope := resources.NewSyncScope()
+	scope.AddRoot(resources.ResourceTypeApplicationAuthStrategy)
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(
+		ctx,
+		&resources.ResourceSet{SyncScope: scope},
+		Options{Mode: PlanModeSync},
+	)
+	require.NoError(t, err)
+	require.Empty(t, plan.Changes)
+
+	mockAppAuthAPI.AssertExpectations(t)
+}
+
 func TestGeneratePlan_SyncRejectsRootLevelEmptyChildCollections(t *testing.T) {
 	scope := resources.NewSyncScope()
 	scope.AddRootChildCollection(resources.ResourceTypeAPIDocument)
@@ -93,4 +124,43 @@ func TestGeneratePlan_SyncRejectsRootLevelEmptyChildCollections(t *testing.T) {
 	require.Nil(t, plan)
 	assert.Contains(t, err.Error(), "empty child collections")
 	assert.Contains(t, err.Error(), "api_document")
+}
+
+func TestGeneratePlan_SyncChildScopeWithoutParentSuggestsExternalWhenSupported(t *testing.T) {
+	scope := resources.NewSyncScope()
+	scope.AddChild(resources.ResourceTypePortal, "docs-portal", resources.ResourceTypePortalPage)
+
+	plan, err := NewPlanner(state.NewClient(state.ClientConfig{}), slog.Default()).GeneratePlan(
+		context.Background(),
+		&resources.ResourceSet{SyncScope: scope},
+		Options{Mode: PlanModeSync},
+	)
+	require.Error(t, err)
+	require.Nil(t, plan)
+	assert.Contains(t, err.Error(), "requires the parent collection")
+	assert.Contains(t, err.Error(), "_external")
+}
+
+func TestEnsurePlanningSyncScopeInfersPortalTeamRolesWithTeams(t *testing.T) {
+	rs := &resources.ResourceSet{
+		PortalTeams: []resources.PortalTeamResource{
+			{
+				Ref:    "team-a",
+				Portal: "docs-portal",
+			},
+		},
+	}
+
+	ensurePlanningSyncScope(rs)
+	require.NotNil(t, rs.SyncScope)
+	assert.True(t, rs.SyncScope.ChildInScope(
+		resources.ResourceTypePortal,
+		"docs-portal",
+		resources.ResourceTypePortalTeam,
+	))
+	assert.True(t, rs.SyncScope.ChildInScope(
+		resources.ResourceTypePortal,
+		"docs-portal",
+		resources.ResourceTypePortalTeamRole,
+	))
 }

--- a/internal/declarative/planner/types.go
+++ b/internal/declarative/planner/types.go
@@ -42,10 +42,11 @@ type PlanMetadata struct {
 
 // PlanSyncScope records the explicit resource collections used for sync planning.
 type PlanSyncScope struct {
-	RootResourceTypes      []string             `json:"root_resource_types,omitempty"`
-	ChildResourceTypes     []PlanSyncChildScope `json:"child_resource_types,omitempty"`
-	RootChildResourceTypes []string             `json:"root_child_resource_types,omitempty"`
-	OrganizationUsers      bool                 `json:"organization_users,omitempty"`
+	RootResourceTypes          []string             `json:"root_resource_types,omitempty"`
+	ChildResourceTypes         []PlanSyncChildScope `json:"child_resource_types,omitempty"`
+	RootChildResourceTypes     []string             `json:"root_child_resource_types,omitempty"`
+	OrganizationUsers          bool                 `json:"organization_users,omitempty"`
+	OrganizationSystemAccounts bool                 `json:"organization_system_accounts,omitempty"`
 }
 
 // PlanSyncChildScope identifies a child collection scoped under one parent.

--- a/internal/declarative/planner/types.go
+++ b/internal/declarative/planner/types.go
@@ -33,10 +33,26 @@ const (
 
 // PlanMetadata contains plan generation information
 type PlanMetadata struct {
-	Version     string    `json:"version"`
-	GeneratedAt time.Time `json:"generated_at"`
-	Generator   string    `json:"generator"`
-	Mode        PlanMode  `json:"mode"`
+	Version     string         `json:"version"`
+	GeneratedAt time.Time      `json:"generated_at"`
+	Generator   string         `json:"generator"`
+	Mode        PlanMode       `json:"mode"`
+	SyncScope   *PlanSyncScope `json:"sync_scope,omitempty"`
+}
+
+// PlanSyncScope records the explicit resource collections used for sync planning.
+type PlanSyncScope struct {
+	RootResourceTypes      []string             `json:"root_resource_types,omitempty"`
+	ChildResourceTypes     []PlanSyncChildScope `json:"child_resource_types,omitempty"`
+	RootChildResourceTypes []string             `json:"root_child_resource_types,omitempty"`
+	OrganizationUsers      bool                 `json:"organization_users,omitempty"`
+}
+
+// PlanSyncChildScope identifies a child collection scoped under one parent.
+type PlanSyncChildScope struct {
+	ParentType   string `json:"parent_type"`
+	ParentRef    string `json:"parent_ref"`
+	ResourceType string `json:"resource_type"`
 }
 
 // PlannedChange represents a single resource change

--- a/internal/declarative/resources/portal.go
+++ b/internal/declarative/resources/portal.go
@@ -410,10 +410,13 @@ func (p *PortalResource) UnmarshalJSON(data []byte) error {
 	}
 
 	if v, ok := raw["custom_domain"]; ok {
-		if err := json.Unmarshal(v, &p.CustomDomain); err != nil {
+		if isEmptyJSONObject(v) {
+			delete(raw, "custom_domain")
+		} else if err := json.Unmarshal(v, &p.CustomDomain); err != nil {
 			return err
+		} else {
+			delete(raw, "custom_domain")
 		}
-		delete(raw, "custom_domain")
 	}
 
 	if v, ok := raw["pages"]; ok {
@@ -438,10 +441,13 @@ func (p *PortalResource) UnmarshalJSON(data []byte) error {
 	}
 
 	if v, ok := raw["email_config"]; ok {
-		if err := json.Unmarshal(v, &p.EmailConfig); err != nil {
+		if isEmptyJSONObject(v) {
+			delete(raw, "email_config")
+		} else if err := json.Unmarshal(v, &p.EmailConfig); err != nil {
 			return err
+		} else {
+			delete(raw, "email_config")
 		}
-		delete(raw, "email_config")
 	}
 
 	if v, ok := raw["email_templates"]; ok {
@@ -461,10 +467,13 @@ func (p *PortalResource) UnmarshalJSON(data []byte) error {
 	}
 
 	if v, ok := raw["audit_log_webhook"]; ok {
-		if err := json.Unmarshal(v, &p.AuditLogWebhook); err != nil {
+		if isEmptyJSONObject(v) {
+			delete(raw, "audit_log_webhook")
+		} else if err := json.Unmarshal(v, &p.AuditLogWebhook); err != nil {
 			return err
+		} else {
+			delete(raw, "audit_log_webhook")
 		}
-		delete(raw, "audit_log_webhook")
 	}
 
 	if v, ok := raw["assets"]; ok {
@@ -504,6 +513,14 @@ func (p *PortalResource) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
+}
+
+func isEmptyJSONObject(raw json.RawMessage) bool {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return false
+	}
+	return len(obj) == 0
 }
 
 // MarshalJSON ensures the embedded SDK model and Kongctl fields are preserved when serializing.

--- a/internal/declarative/resources/sync_scope.go
+++ b/internal/declarative/resources/sync_scope.go
@@ -1,0 +1,214 @@
+package resources
+
+import "slices"
+
+// SyncScope records the resource collections that were explicitly present in
+// declarative input. Sync planning uses this to distinguish omitted collections
+// from collections intentionally set to zero desired resources.
+type SyncScope struct {
+	RootResourceTypes       map[ResourceType]struct{}
+	ChildResourceTypes      map[ResourceType]map[string]map[ResourceType]struct{}
+	RootChildResourceTypes  map[ResourceType]struct{}
+	OrganizationUsersScoped bool
+}
+
+// ChildSyncScope identifies a child collection scoped under a specific parent.
+type ChildSyncScope struct {
+	ParentType   ResourceType
+	ParentRef    string
+	ResourceType ResourceType
+}
+
+// NewSyncScope creates an empty sync scope.
+func NewSyncScope() *SyncScope {
+	return &SyncScope{
+		RootResourceTypes:      make(map[ResourceType]struct{}),
+		ChildResourceTypes:     make(map[ResourceType]map[string]map[ResourceType]struct{}),
+		RootChildResourceTypes: make(map[ResourceType]struct{}),
+	}
+}
+
+// EnsureSyncScope returns the ResourceSet scope, creating it if necessary.
+func (rs *ResourceSet) EnsureSyncScope() *SyncScope {
+	if rs.SyncScope == nil {
+		rs.SyncScope = NewSyncScope()
+	}
+	return rs.SyncScope
+}
+
+// MergeSyncScope merges sync scope from another ResourceSet.
+func (rs *ResourceSet) MergeSyncScope(other *ResourceSet) {
+	if other == nil || other.SyncScope == nil {
+		return
+	}
+	rs.EnsureSyncScope().Merge(other.SyncScope)
+}
+
+// AddRoot marks a top-level resource collection as in scope.
+func (s *SyncScope) AddRoot(rt ResourceType) {
+	if s == nil {
+		return
+	}
+	if s.RootResourceTypes == nil {
+		s.RootResourceTypes = make(map[ResourceType]struct{})
+	}
+	s.RootResourceTypes[rt] = struct{}{}
+}
+
+// RootInScope reports whether a top-level resource collection is in scope.
+func (s *SyncScope) RootInScope(rt ResourceType) bool {
+	if s == nil {
+		return false
+	}
+	_, ok := s.RootResourceTypes[rt]
+	return ok
+}
+
+// AddChild marks a child resource collection as in scope for one parent ref.
+func (s *SyncScope) AddChild(parentType ResourceType, parentRef string, rt ResourceType) {
+	if s == nil || parentRef == "" {
+		return
+	}
+	if s.ChildResourceTypes == nil {
+		s.ChildResourceTypes = make(map[ResourceType]map[string]map[ResourceType]struct{})
+	}
+	if s.ChildResourceTypes[parentType] == nil {
+		s.ChildResourceTypes[parentType] = make(map[string]map[ResourceType]struct{})
+	}
+	if s.ChildResourceTypes[parentType][parentRef] == nil {
+		s.ChildResourceTypes[parentType][parentRef] = make(map[ResourceType]struct{})
+	}
+	s.ChildResourceTypes[parentType][parentRef][rt] = struct{}{}
+}
+
+// ChildInScope reports whether a child resource collection is in scope for a parent ref.
+func (s *SyncScope) ChildInScope(parentType ResourceType, parentRef string, rt ResourceType) bool {
+	if s == nil {
+		return false
+	}
+	byParentRef, ok := s.ChildResourceTypes[parentType]
+	if !ok {
+		return false
+	}
+	byChildType, ok := byParentRef[parentRef]
+	if !ok {
+		return false
+	}
+	_, ok = byChildType[rt]
+	return ok
+}
+
+// AddRootChildCollection records an explicit root-level empty child collection.
+// This cannot express a parent and is rejected by sync planning with guidance.
+func (s *SyncScope) AddRootChildCollection(rt ResourceType) {
+	if s == nil {
+		return
+	}
+	if s.RootChildResourceTypes == nil {
+		s.RootChildResourceTypes = make(map[ResourceType]struct{})
+	}
+	s.RootChildResourceTypes[rt] = struct{}{}
+}
+
+// RootChildCollectionTypes returns root-level child collection types with no parent scope.
+func (s *SyncScope) RootChildCollectionTypes() []ResourceType {
+	if s == nil {
+		return nil
+	}
+	types := make([]ResourceType, 0, len(s.RootChildResourceTypes))
+	for rt := range s.RootChildResourceTypes {
+		types = append(types, rt)
+	}
+	slices.Sort(types)
+	return types
+}
+
+// MarkOrganizationUsersScoped records that organization.users was present.
+func (s *SyncScope) MarkOrganizationUsersScoped() {
+	if s != nil {
+		s.OrganizationUsersScoped = true
+	}
+}
+
+// HasAny reports whether any scope was recorded.
+func (s *SyncScope) HasAny() bool {
+	if s == nil {
+		return false
+	}
+	return len(s.RootResourceTypes) > 0 ||
+		len(s.ChildResourceTypes) > 0 ||
+		len(s.RootChildResourceTypes) > 0 ||
+		s.OrganizationUsersScoped
+}
+
+// RootTypes returns sorted root resource types.
+func (s *SyncScope) RootTypes() []ResourceType {
+	if s == nil {
+		return nil
+	}
+	types := make([]ResourceType, 0, len(s.RootResourceTypes))
+	for rt := range s.RootResourceTypes {
+		types = append(types, rt)
+	}
+	slices.Sort(types)
+	return types
+}
+
+// ChildScopes returns sorted child collection scopes.
+func (s *SyncScope) ChildScopes() []ChildSyncScope {
+	if s == nil {
+		return nil
+	}
+	scopes := make([]ChildSyncScope, 0)
+	for parentType, byParentRef := range s.ChildResourceTypes {
+		for parentRef, byChildType := range byParentRef {
+			for rt := range byChildType {
+				scopes = append(scopes, ChildSyncScope{
+					ParentType:   parentType,
+					ParentRef:    parentRef,
+					ResourceType: rt,
+				})
+			}
+		}
+	}
+	slices.SortFunc(scopes, func(a, b ChildSyncScope) int {
+		if a.ParentType != b.ParentType {
+			return cmpString(string(a.ParentType), string(b.ParentType))
+		}
+		if a.ParentRef != b.ParentRef {
+			return cmpString(a.ParentRef, b.ParentRef)
+		}
+		return cmpString(string(a.ResourceType), string(b.ResourceType))
+	})
+	return scopes
+}
+
+// Merge copies another scope into this one.
+func (s *SyncScope) Merge(other *SyncScope) {
+	if s == nil || other == nil {
+		return
+	}
+	for _, rt := range other.RootTypes() {
+		s.AddRoot(rt)
+	}
+	for _, scope := range other.ChildScopes() {
+		s.AddChild(scope.ParentType, scope.ParentRef, scope.ResourceType)
+	}
+	for _, rt := range other.RootChildCollectionTypes() {
+		s.AddRootChildCollection(rt)
+	}
+	if other.OrganizationUsersScoped {
+		s.MarkOrganizationUsersScoped()
+	}
+}
+
+func cmpString(a, b string) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/declarative/resources/sync_scope.go
+++ b/internal/declarative/resources/sync_scope.go
@@ -9,10 +9,11 @@ import (
 // declarative input. Sync planning uses this to distinguish omitted collections
 // from collections intentionally set to zero desired resources.
 type SyncScope struct {
-	RootResourceTypes       map[ResourceType]struct{}
-	ChildResourceTypes      map[ResourceType]map[string]map[ResourceType]struct{}
-	RootChildResourceTypes  map[ResourceType]struct{}
-	OrganizationUsersScoped bool
+	RootResourceTypes                map[ResourceType]struct{}
+	ChildResourceTypes               map[ResourceType]map[string]map[ResourceType]struct{}
+	RootChildResourceTypes           map[ResourceType]struct{}
+	OrganizationUsersScoped          bool
+	OrganizationSystemAccountsScoped bool
 }
 
 // ChildSyncScope identifies a child collection scoped under a specific parent.
@@ -133,9 +134,21 @@ func (s *SyncScope) MarkOrganizationUsersScoped() {
 	}
 }
 
+// MarkOrganizationSystemAccountsScoped records that organization.system-accounts was present.
+func (s *SyncScope) MarkOrganizationSystemAccountsScoped() {
+	if s != nil {
+		s.OrganizationSystemAccountsScoped = true
+	}
+}
+
 // OrganizationUsersInScope reports whether organization.users was present.
 func (s *SyncScope) OrganizationUsersInScope() bool {
 	return s != nil && s.OrganizationUsersScoped
+}
+
+// OrganizationSystemAccountsInScope reports whether organization.system-accounts was present.
+func (s *SyncScope) OrganizationSystemAccountsInScope() bool {
+	return s != nil && s.OrganizationSystemAccountsScoped
 }
 
 // HasAny reports whether any scope was recorded.
@@ -146,7 +159,8 @@ func (s *SyncScope) HasAny() bool {
 	return len(s.RootResourceTypes) > 0 ||
 		len(s.ChildResourceTypes) > 0 ||
 		len(s.RootChildResourceTypes) > 0 ||
-		s.OrganizationUsersScoped
+		s.OrganizationUsersScoped ||
+		s.OrganizationSystemAccountsScoped
 }
 
 // RootTypes returns sorted root resource types.
@@ -207,5 +221,8 @@ func (s *SyncScope) Merge(other *SyncScope) {
 	}
 	if other.OrganizationUsersScoped {
 		s.MarkOrganizationUsersScoped()
+	}
+	if other.OrganizationSystemAccountsScoped {
+		s.MarkOrganizationSystemAccountsScoped()
 	}
 }

--- a/internal/declarative/resources/sync_scope.go
+++ b/internal/declarative/resources/sync_scope.go
@@ -1,6 +1,9 @@
 package resources
 
-import "slices"
+import (
+	"cmp"
+	"slices"
+)
 
 // SyncScope records the resource collections that were explicitly present in
 // declarative input. Sync planning uses this to distinguish omitted collections
@@ -46,7 +49,7 @@ func (rs *ResourceSet) MergeSyncScope(other *ResourceSet) {
 
 // AddRoot marks a top-level resource collection as in scope.
 func (s *SyncScope) AddRoot(rt ResourceType) {
-	if s == nil {
+	if s == nil || rt == "" {
 		return
 	}
 	if s.RootResourceTypes == nil {
@@ -101,7 +104,7 @@ func (s *SyncScope) ChildInScope(parentType ResourceType, parentRef string, rt R
 // AddRootChildCollection records an explicit root-level empty child collection.
 // This cannot express a parent and is rejected by sync planning with guidance.
 func (s *SyncScope) AddRootChildCollection(rt ResourceType) {
-	if s == nil {
+	if s == nil || rt == "" {
 		return
 	}
 	if s.RootChildResourceTypes == nil {
@@ -128,6 +131,11 @@ func (s *SyncScope) MarkOrganizationUsersScoped() {
 	if s != nil {
 		s.OrganizationUsersScoped = true
 	}
+}
+
+// OrganizationUsersInScope reports whether organization.users was present.
+func (s *SyncScope) OrganizationUsersInScope() bool {
+	return s != nil && s.OrganizationUsersScoped
 }
 
 // HasAny reports whether any scope was recorded.
@@ -172,13 +180,13 @@ func (s *SyncScope) ChildScopes() []ChildSyncScope {
 		}
 	}
 	slices.SortFunc(scopes, func(a, b ChildSyncScope) int {
-		if a.ParentType != b.ParentType {
-			return cmpString(string(a.ParentType), string(b.ParentType))
+		if c := cmp.Compare(a.ParentType, b.ParentType); c != 0 {
+			return c
 		}
-		if a.ParentRef != b.ParentRef {
-			return cmpString(a.ParentRef, b.ParentRef)
+		if c := cmp.Compare(a.ParentRef, b.ParentRef); c != 0 {
+			return c
 		}
-		return cmpString(string(a.ResourceType), string(b.ResourceType))
+		return cmp.Compare(a.ResourceType, b.ResourceType)
 	})
 	return scopes
 }
@@ -199,16 +207,5 @@ func (s *SyncScope) Merge(other *SyncScope) {
 	}
 	if other.OrganizationUsersScoped {
 		s.MarkOrganizationUsersScoped()
-	}
-}
-
-func cmpString(a, b string) int {
-	switch {
-	case a < b:
-		return -1
-	case a > b:
-		return 1
-	default:
-		return 0
 	}
 }

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -72,44 +72,44 @@ type ResourceRef struct {
 
 // ResourceSet contains all declarative resources from configuration files
 type ResourceSet struct {
-	Portals []PortalResource `yaml:"portals,omitempty"                               json:"portals,omitempty"`
+	Portals []PortalResource `yaml:"portals,omitempty"                                        json:"portals,omitempty"`
 	// AuditLogs contains organization-scoped audit-log resources.
-	AuditLogs AuditLogsResource `yaml:"audit-logs,omitempty" json:"audit-logs,omitempty"`
+	AuditLogs AuditLogsResource `yaml:"audit-logs,omitempty"                                     json:"audit-logs,omitempty"` //nolint:lll
 	// ApplicationAuthStrategies contains auth strategy configurations
-	ApplicationAuthStrategies []ApplicationAuthStrategyResource `yaml:"application_auth_strategies,omitempty"           json:"application_auth_strategies,omitempty"` //nolint:lll
-	DCRProviders              []DCRProviderResource             `yaml:"dcr_providers,omitempty"                        json:"dcr_providers,omitempty"`                //nolint:lll
+	ApplicationAuthStrategies []ApplicationAuthStrategyResource `yaml:"application_auth_strategies,omitempty"                    json:"application_auth_strategies,omitempty"` //nolint:lll
+	DCRProviders              []DCRProviderResource             `yaml:"dcr_providers,omitempty"                                  json:"dcr_providers,omitempty"`               //nolint:lll
 	// ControlPlanes contains control plane configurations
-	ControlPlanes                     []ControlPlaneResource                     `yaml:"control_planes,omitempty"                        json:"control_planes,omitempty"`                        //nolint:lll
-	CatalogServices                   []CatalogServiceResource                   `yaml:"catalog_services,omitempty"                      json:"catalog_services,omitempty"`                      //nolint:lll
-	APIs                              []APIResource                              `yaml:"apis,omitempty"                                  json:"apis,omitempty"`                                  //nolint:lll
-	GatewayServices                   []GatewayServiceResource                   `yaml:"gateway_services,omitempty"                      json:"gateway_services,omitempty"`                      //nolint:lll
-	ControlPlaneDataPlaneCertificates []ControlPlaneDataPlaneCertificateResource `yaml:"control_plane_data_plane_certificates,omitempty" json:"control_plane_data_plane_certificates,omitempty"` //nolint:lll
+	ControlPlanes                     []ControlPlaneResource                     `yaml:"control_planes,omitempty"                                 json:"control_planes,omitempty"`                        //nolint:lll
+	CatalogServices                   []CatalogServiceResource                   `yaml:"catalog_services,omitempty"                               json:"catalog_services,omitempty"`                      //nolint:lll
+	APIs                              []APIResource                              `yaml:"apis,omitempty"                                           json:"apis,omitempty"`                                  //nolint:lll
+	GatewayServices                   []GatewayServiceResource                   `yaml:"gateway_services,omitempty"                               json:"gateway_services,omitempty"`                      //nolint:lll
+	ControlPlaneDataPlaneCertificates []ControlPlaneDataPlaneCertificateResource `yaml:"control_plane_data_plane_certificates,omitempty"          json:"control_plane_data_plane_certificates,omitempty"` //nolint:lll
 	// API child resources can be defined at root level (with parent reference) or nested under APIs
-	APIVersions        []APIVersionResource        `yaml:"api_versions,omitempty"                          json:"api_versions,omitempty"`        //nolint:lll
-	APIPublications    []APIPublicationResource    `yaml:"api_publications,omitempty"                      json:"api_publications,omitempty"`    //nolint:lll
-	APIImplementations []APIImplementationResource `yaml:"api_implementations,omitempty"                   json:"api_implementations,omitempty"` //nolint:lll
-	APIDocuments       []APIDocumentResource       `yaml:"api_documents,omitempty"                         json:"api_documents,omitempty"`       //nolint:lll
+	APIVersions        []APIVersionResource        `yaml:"api_versions,omitempty"                                   json:"api_versions,omitempty"`        //nolint:lll
+	APIPublications    []APIPublicationResource    `yaml:"api_publications,omitempty"                               json:"api_publications,omitempty"`    //nolint:lll
+	APIImplementations []APIImplementationResource `yaml:"api_implementations,omitempty"                            json:"api_implementations,omitempty"` //nolint:lll
+	APIDocuments       []APIDocumentResource       `yaml:"api_documents,omitempty"                                  json:"api_documents,omitempty"`       //nolint:lll
 	// Portal child resources can be defined at root level (with parent reference) or nested under Portals
-	PortalCustomizations        []PortalCustomizationResource        `yaml:"portal_customizations,omitempty"                 json:"portal_customizations,omitempty"`          //nolint:lll
-	PortalAuthSettings          []PortalAuthSettingsResource         `yaml:"portal_auth_settings,omitempty"                  json:"portal_auth_settings,omitempty"`           //nolint:lll
-	PortalIPAllowLists          []PortalIPAllowListResource          `yaml:"portal_ip_allow_lists,omitempty"                 json:"portal_ip_allow_lists,omitempty"`          //nolint:lll
-	PortalIntegrations          []PortalIntegrationResource          `yaml:"portal_integrations,omitempty"                   json:"portal_integrations,omitempty"`            //nolint:lll
-	PortalIdentityProviders     []PortalIdentityProviderResource     `yaml:"portal_identity_providers,omitempty"             json:"portal_identity_providers,omitempty"`      //nolint:lll
-	PortalCustomDomains         []PortalCustomDomainResource         `yaml:"portal_custom_domains,omitempty"                 json:"portal_custom_domains,omitempty"`          //nolint:lll
-	PortalPages                 []PortalPageResource                 `yaml:"portal_pages,omitempty"                          json:"portal_pages,omitempty"`                   //nolint:lll
-	PortalSnippets              []PortalSnippetResource              `yaml:"portal_snippets,omitempty"                       json:"portal_snippets,omitempty"`                //nolint:lll
-	PortalTeams                 []PortalTeamResource                 `yaml:"portal_teams,omitempty"                          json:"portal_teams,omitempty"`                   //nolint:lll
-	PortalTeamRoles             []PortalTeamRoleResource             `yaml:"portal_team_roles,omitempty"                     json:"portal_team_roles,omitempty"`              //nolint:lll
-	PortalAssetLogos            []PortalAssetLogoResource            `yaml:"portal_asset_logos,omitempty"                    json:"portal_asset_logos,omitempty"`             //nolint:lll
-	PortalAssetFavicons         []PortalAssetFaviconResource         `yaml:"portal_asset_favicons,omitempty"                 json:"portal_asset_favicons,omitempty"`          //nolint:lll
-	PortalEmailConfigs          []PortalEmailConfigResource          `yaml:"portal_email_configs,omitempty"                  json:"portal_email_configs,omitempty"`           //nolint:lll
-	PortalEmailTemplates        []PortalEmailTemplateResource        `yaml:"portal_email_templates,omitempty"                json:"portal_email_templates,omitempty"`         //nolint:lll
-	PortalAuditLogWebhooks      []PortalAuditLogWebhookResource      `yaml:"portal_audit_log_webhooks,omitempty"            json:"portal_audit_log_webhooks,omitempty"`       //nolint:lll
-	EventGatewayControlPlanes   []EventGatewayControlPlaneResource   `yaml:"event_gateways,omitempty"                        json:"event_gateways,omitempty"`                 //nolint:lll
-	EventGatewayBackendClusters []EventGatewayBackendClusterResource `yaml:"event_gateway_backend_clusters,omitempty"        json:"event_gateway_backend_clusters,omitempty"` //nolint:lll
-	EventGatewayVirtualClusters []EventGatewayVirtualClusterResource `yaml:"event_gateway_virtual_clusters,omitempty"        json:"event_gateway_virtual_clusters,omitempty"` //nolint:lll
+	PortalCustomizations        []PortalCustomizationResource        `yaml:"portal_customizations,omitempty"                          json:"portal_customizations,omitempty"`          //nolint:lll
+	PortalAuthSettings          []PortalAuthSettingsResource         `yaml:"portal_auth_settings,omitempty"                           json:"portal_auth_settings,omitempty"`           //nolint:lll
+	PortalIPAllowLists          []PortalIPAllowListResource          `yaml:"portal_ip_allow_lists,omitempty"                          json:"portal_ip_allow_lists,omitempty"`          //nolint:lll
+	PortalIntegrations          []PortalIntegrationResource          `yaml:"portal_integrations,omitempty"                            json:"portal_integrations,omitempty"`            //nolint:lll
+	PortalIdentityProviders     []PortalIdentityProviderResource     `yaml:"portal_identity_providers,omitempty"                      json:"portal_identity_providers,omitempty"`      //nolint:lll
+	PortalCustomDomains         []PortalCustomDomainResource         `yaml:"portal_custom_domains,omitempty"                          json:"portal_custom_domains,omitempty"`          //nolint:lll
+	PortalPages                 []PortalPageResource                 `yaml:"portal_pages,omitempty"                                   json:"portal_pages,omitempty"`                   //nolint:lll
+	PortalSnippets              []PortalSnippetResource              `yaml:"portal_snippets,omitempty"                                json:"portal_snippets,omitempty"`                //nolint:lll
+	PortalTeams                 []PortalTeamResource                 `yaml:"portal_teams,omitempty"                                   json:"portal_teams,omitempty"`                   //nolint:lll
+	PortalTeamRoles             []PortalTeamRoleResource             `yaml:"portal_team_roles,omitempty"                              json:"portal_team_roles,omitempty"`              //nolint:lll
+	PortalAssetLogos            []PortalAssetLogoResource            `yaml:"portal_asset_logos,omitempty"                             json:"portal_asset_logos,omitempty"`             //nolint:lll
+	PortalAssetFavicons         []PortalAssetFaviconResource         `yaml:"portal_asset_favicons,omitempty"                          json:"portal_asset_favicons,omitempty"`          //nolint:lll
+	PortalEmailConfigs          []PortalEmailConfigResource          `yaml:"portal_email_configs,omitempty"                           json:"portal_email_configs,omitempty"`           //nolint:lll
+	PortalEmailTemplates        []PortalEmailTemplateResource        `yaml:"portal_email_templates,omitempty"                         json:"portal_email_templates,omitempty"`         //nolint:lll
+	PortalAuditLogWebhooks      []PortalAuditLogWebhookResource      `yaml:"portal_audit_log_webhooks,omitempty"                      json:"portal_audit_log_webhooks,omitempty"`      //nolint:lll
+	EventGatewayControlPlanes   []EventGatewayControlPlaneResource   `yaml:"event_gateways,omitempty"                                 json:"event_gateways,omitempty"`                 //nolint:lll
+	EventGatewayBackendClusters []EventGatewayBackendClusterResource `yaml:"event_gateway_backend_clusters,omitempty"                 json:"event_gateway_backend_clusters,omitempty"` //nolint:lll
+	EventGatewayVirtualClusters []EventGatewayVirtualClusterResource `yaml:"event_gateway_virtual_clusters,omitempty"                 json:"event_gateway_virtual_clusters,omitempty"` //nolint:lll
 	// Organization grouping - contains nested resources like teams
-	Organization *OrganizationResource `yaml:"organization,omitempty" json:"organization,omitempty"`
+	Organization *OrganizationResource `yaml:"organization,omitempty"                                   json:"organization,omitempty"` //nolint:lll
 	// Teams is populated internally from OrganizationTeams during loading
 	// It is not exposed in YAML/JSON to enforce the organization grouping format
 	OrganizationTeams                        []OrganizationTeamResource                        `yaml:"-" json:"-"`
@@ -129,10 +129,12 @@ type ResourceSet struct {
 	EventGatewayTLSTrustBundles              []EventGatewayTLSTrustBundleResource              `yaml:"event_gateway_tls_trust_bundles,omitempty"        json:"event_gateway_tls_trust_bundles,omitempty"`                        //nolint:lll
 	// DefaultNamespace tracks namespace from _defaults when no resources are present
 	// This is used by the planner to determine which namespace to check for deletions
-	DefaultNamespace  string   `yaml:"-"                                               json:"-"`
-	DefaultNamespaces []string `yaml:"-"                                               json:"-"`
+	DefaultNamespace  string   `yaml:"-"                                                        json:"-"`
+	DefaultNamespaces []string `yaml:"-"                                                        json:"-"`
 	// EnvSources tracks deferred !env placeholders by resource ref and field path.
-	EnvSources map[string]map[string]string `yaml:"-" json:"-"`
+	EnvSources map[string]map[string]string `yaml:"-"                                                        json:"-"`
+	// SyncScope tracks resource collection keys explicitly present in the input.
+	SyncScope *SyncScope `yaml:"-"                                                        json:"-"`
 }
 
 // NamespaceOrigin describes how a namespace value was supplied for a resource

--- a/planning/DECLARATIVE_RESOURCE_IMPLEMENTATION_GUIDE.md
+++ b/planning/DECLARATIVE_RESOURCE_IMPLEMENTATION_GUIDE.md
@@ -138,9 +138,17 @@ delete signal.
 - Empty child collections must be nested under the parent. Root-level empty
   child lists such as `foo_children: []` are rejected because they do not
   identify which parent owns the desired zero count.
-- Singleton child sections cannot use `null` to mean reset/delete. Omit the key
-  to ignore the singleton, or provide an object to manage it. Add loader
-  validation to reject `<singleton>: null`.
+- Map-shaped child collections follow the same rule with an empty object. For
+  example, `foo_templates: {}` means the parent should have no templates.
+- Singleton-shaped child sections are also scoped by key presence. Omit the key
+  to ignore the child. Provide a non-empty object or map to manage it. Reject
+  `null`; it is not a reset or delete signal.
+- For optional, delete-capable singleton children, support an explicit empty
+  object as desired count zero. For example, `custom_domain: {}` should scope
+  that child for the parent but produce no desired child resource, allowing
+  sync to delete an existing managed child. For update-only or always-present
+  singletons, do not document or implement `{}` as delete/reset unless the API
+  has explicit support for that behavior.
 
 When adding a resource, update the sync-scope plumbing:
 
@@ -153,6 +161,11 @@ When adding a resource, update the sync-scope plumbing:
   `portalChildCollectionScopes`, or the new parent-specific equivalent.
 - For nested singleton children, add null-key rejection in the loader before
   planning. Null is not a supported reset/delete semantic.
+- For optional, delete-capable nested singleton children, make empty-object
+  handling preserve sync scope while leaving the desired child absent. Scope is
+  captured before nested resource extraction; custom unmarshaling may need to
+  drop the empty raw key after scope capture instead of populating a zero-value
+  desired child.
 - If the resource has a new planner entry point, gate it in sync mode with
   `shouldPlanRoot(...)`.
 - If a parent planner prunes child resources, gate each child planner with
@@ -194,10 +207,11 @@ if p.shouldPlanChild(
 ```
 
 Programmatic tests that construct `ResourceSet` directly cannot express
-"explicit empty list" through a nil/empty slice alone. Set `ResourceSet.SyncScope`
-in those tests when asserting sync-delete behavior for an empty collection.
-Loader tests should cover YAML key presence, omitted collections, nested empty
-child lists, root-level empty child rejection, and singleton `null` rejection.
+"explicit empty list" through a nil/empty slice alone. Set
+`ResourceSet.SyncScope` in those tests when asserting sync-delete behavior for
+an empty collection. Loader tests should cover YAML key presence, omitted
+collections, nested empty child lists, root-level empty child rejection,
+singleton `null` rejection, and delete-capable singleton empty-object behavior.
 
 ### PARENT RESOURCE
 
@@ -1568,12 +1582,18 @@ func (e *Executor) executeFooChildChange(ctx context.Context, change planner.Pla
 
 ### SINGLETON CHILD RESOURCE
 
-**Pattern**: Same as child resource, but:
-1. **NO CREATE/DELETE**: Only UPDATE operations
-2. **Always exists**: For every parent instance
-3. **Planner always generates UPDATE**: Never checks if exists
+**Pattern**: A singleton child has at most one logical child per parent, but
+there are two important API shapes:
 
-**Example**: PortalCustomization
+1. **Update-only/always-present**: The child always exists for every parent.
+   There are no create or delete operations, and the planner only emits
+   updates. Example: `PortalCustomization`.
+2. **Optional/delete-capable**: The child may be absent and the API supports
+   delete. The planner may create, update, or delete the child. In sync mode,
+   omitted config means ignored; an empty object such as `custom_domain: {}`
+   means the child is in scope with desired count zero.
+
+The example below is the update-only/always-present pattern.
 
 **Key Differences**:
 
@@ -1617,6 +1637,13 @@ func (a *FooCustomizationAdapter) Create(...) { panic("not supported") }
 func (a *FooCustomizationAdapter) Delete(...) { panic("not supported") }
 func (a *FooCustomizationAdapter) SupportsUpdate() bool { return true }
 ```
+
+For optional/delete-capable singleton children, follow the normal child
+resource planner shape with one desired resource per parent. The planner must
+be gated with `shouldPlanChild(...)`; when the singleton key is in sync scope
+and the desired resource is absent because the user wrote `{}`, list/fetch the
+existing child and plan a DELETE if one exists. Do not infer delete/reset from
+`null`.
 
 ---
 

--- a/planning/DECLARATIVE_RESOURCE_IMPLEMENTATION_GUIDE.md
+++ b/planning/DECLARATIVE_RESOURCE_IMPLEMENTATION_GUIDE.md
@@ -125,6 +125,80 @@ resource, plan, or view contracts.
   declarative engine supports both, for example `api_version` and
   `api.versions`.
 
+### SYNC SCOPE (REQUIRED)
+
+`sync` uses explicit manifest scope. Do not treat omitted configuration as a
+delete signal.
+
+- Omitted root collections are ignored by sync.
+- Explicit empty root collections mean desired count zero. For example,
+  `foos: []` deletes managed foos in the selected namespace.
+- Child collections are scoped independently under each parent. A parent block
+  without a child key leaves that child collection alone.
+- Empty child collections must be nested under the parent. Root-level empty
+  child lists such as `foo_children: []` are rejected because they do not
+  identify which parent owns the desired zero count.
+- Singleton child sections cannot use `null` to mean reset/delete. Omit the key
+  to ignore the singleton, or provide an object to manage it. Add loader
+  validation to reject `<singleton>: null`.
+
+When adding a resource, update the sync-scope plumbing:
+
+- Add the root collection key to `rootCollectionScopes` in
+  `internal/declarative/loader/sync_scope.go`.
+- For root-level child declarations, add the canonical root key and parent ref
+  key to `rootChildCollectionScopes`.
+- For nested child declarations, add the nested child key to the relevant
+  nested scope list, such as `apiChildCollectionScopes`,
+  `portalChildCollectionScopes`, or the new parent-specific equivalent.
+- For nested singleton children, add null-key rejection in the loader before
+  planning. Null is not a supported reset/delete semantic.
+- If the resource has a new planner entry point, gate it in sync mode with
+  `shouldPlanRoot(...)`.
+- If a parent planner prunes child resources, gate each child planner with
+  `shouldPlanChild(...)`.
+- Update `docs/declarative.md`, `docs/declarative-resource-reference.md`, help
+  templates, examples, and e2e scenario fixtures so users can see the new
+  explicit empty-list behavior.
+
+Root planner gating pattern:
+
+```go
+if namespacePlanner.shouldPlanRoot(opts.Mode, resources.ResourceTypeFoo) {
+    if err := namespacePlanner.fooPlanner.PlanChanges(
+        withPlannerHTTPLogContext(namespaceCtx, opts, plannerComponent(namespacePlanner.fooPlanner), ""),
+        plannerCtx,
+        namespacePlan,
+    ); err != nil {
+        return nil, fmt.Errorf("failed to plan foo changes for namespace %s: %w", namespace, err)
+    }
+}
+```
+
+Child planner gating pattern:
+
+```go
+children := p.resources.GetFooChildrenForFoo(desiredFoo.Ref)
+if p.shouldPlanChild(
+    plan,
+    resources.ResourceTypeFoo,
+    desiredFoo.Ref,
+    resources.ResourceTypeFooChild,
+) && (len(children) > 0 || plan.Metadata.Mode == PlanModeSync) {
+    if err := p.planFooChildChanges(
+        ctx, plannerCtx, namespace, fooID, desiredFoo.Ref, children, plan,
+    ); err != nil {
+        return err
+    }
+}
+```
+
+Programmatic tests that construct `ResourceSet` directly cannot express
+"explicit empty list" through a nil/empty slice alone. Set `ResourceSet.SyncScope`
+in those tests when asserting sync-delete behavior for an empty collection.
+Loader tests should cover YAML key presence, omitted collections, nested empty
+child lists, root-level empty child rejection, and singleton `null` rejection.
+
 ### PARENT RESOURCE
 
 #### 1. RESOURCE DEFINITION
@@ -514,7 +588,9 @@ func (p *Planner) planFooChanges(
         }
     }
 
-    // 4. SYNC MODE: Delete unmanaged
+    // 4. SYNC MODE: Delete unmanaged.
+    // This block is safe only because GeneratePlan calls this planner when
+    // ResourceTypeFoo is in sync scope via shouldPlanRoot(...).
     if plan.Metadata.Mode == PlanModeSync {
         for name, current := range currentByName {
             if !desiredNames[name] {
@@ -674,9 +750,11 @@ func NewPlanner(client *state.Client, resourceSet *resources.ResourceSet) *Plann
 }
 
 func (p *Planner) GeneratePlan(...) {
-    // In namespace loop, add:
-    if err := p.fooPlannerImpl.PlanChanges(ctx, plannerCtx, plan); err != nil {
-        return nil, err
+    // In namespace loop, add root planning behind sync scope gating:
+    if p.shouldPlanRoot(opts.Mode, resources.ResourceTypeFoo) {
+        if err := p.fooPlannerImpl.PlanChanges(ctx, plannerCtx, plan); err != nil {
+            return nil, err
+        }
     }
 }
 ```
@@ -1107,8 +1185,11 @@ func (f *fooPlannerImpl) PlanChanges(ctx context.Context, plannerCtx *Config, pl
         return err
     }
 
-    // Plan root-level child resources
-    if err := f.planner.planFooChildrenChanges(ctx, plannerCtx, namespace, f.GetDesiredFooChildren(namespace), plan); err != nil {
+    // Plan root-level child resources. The child planner must check
+    // shouldPlanChild(...) before listing or pruning existing children in sync.
+    if err := f.planner.planFooChildrenChanges(
+        ctx, plannerCtx, namespace, f.GetDesiredFooChildren(namespace), plan,
+    ); err != nil {
         return err
     }
 
@@ -1184,7 +1265,9 @@ func (p *Planner) planFooChildChangesForExistingFoo(
         }
     }
 
-    // 4. SYNC MODE: Delete unmanaged
+    // 4. SYNC MODE: Delete unmanaged.
+    // The caller must reach this path only when shouldPlanChild(...) returned true
+    // for this parent ref and child resource type.
     if plan.Metadata.Mode == PlanModeSync {
         for slug, current := range currentBySlug {
             if !desiredSlugs[slug] {
@@ -1672,6 +1755,8 @@ application_auth_strategies:
 11. **Forgetting explain/scaffold hints for declarative-only fields or unions**
 12. **Skipping E2E coverage for new explain/scaffold-facing behavior**
 13. **Assuming imperative `get` commands are required for declarative support changes**
+14. **Forgetting sync-scope wiring, which can make omitted config destructive**
+15. **Allowing singleton child `null` values to imply unsupported reset/delete behavior**
 
 ---
 
@@ -1692,7 +1777,10 @@ After implementing new resource:
 - [ ] State client has CRUD methods
 - [ ] State client has ListManaged method with namespace filtering
 - [ ] Planner implementation with CREATE/UPDATE/DELETE logic
-- [ ] Planner added to GeneratePlan loop
+- [ ] Planner added to GeneratePlan loop and sync-gated with `shouldPlanRoot`
+- [ ] Sync scope loader tables updated for root, child, and nested child keys
+- [ ] Child pruning paths sync-gated with `shouldPlanChild`
+- [ ] Singleton child `null` values rejected when the key would otherwise look like managed scope
 - [ ] Executor adapter with MapCreateFields/MapUpdateFields
 - [ ] Executor adapter handles parent ID resolution (if child)
 - [ ] Executor change handler added to executeChange switch
@@ -1700,6 +1788,8 @@ After implementing new resource:
 - [ ] Literal audit completed for resource types, plan fields, references, and
       view identifiers
 - [ ] `docs/declarative-resource-reference.md` updated for new parent/child resources
+- [ ] `docs/declarative.md`, help templates, examples, and e2e fixtures updated
+      for sync omission, explicit empty-list, and nested child behavior
 
 ### Imperative Get Command
 - [ ] Add only if imperative support is in scope for the change

--- a/test/e2e/scenarios/control-plane/data-plane-certificate/overlays/002-empty-certificates/config.yaml
+++ b/test/e2e/scenarios/control-plane/data-plane-certificate/overlays/002-empty-certificates/config.yaml
@@ -9,4 +9,3 @@ control_planes:
     cluster_type: CLUSTER_TYPE_CONTROL_PLANE
     auth_type: pinned_client_certs
     data_plane_certificates: []
-control_plane_data_plane_certificates: []

--- a/test/e2e/scenarios/event-gateway/backend-cluster/overlays/002-sync-delete/egw-bc.yaml
+++ b/test/e2e/scenarios/event-gateway/backend-cluster/overlays/002-sync-delete/egw-bc.yaml
@@ -6,4 +6,4 @@ event_gateways:
   - ref: egw-cp-for-bc-test
     name: egw-cp-for-bc-test
     description: "EGW CP for Backend Cluster Test"
-    # No backend_clusters - they will be deleted by sync
+    backend_clusters: []

--- a/test/e2e/scenarios/event-gateway/backend-cluster/overlays/004-sync-delete-root-level-declaration/egw-bc.yaml
+++ b/test/e2e/scenarios/event-gateway/backend-cluster/overlays/004-sync-delete-root-level-declaration/egw-bc.yaml
@@ -6,3 +6,4 @@ event_gateways:
   - ref: egw-cp-for-bc-test
     name: egw-cp-for-bc-test
     description: "EGW CP for Backend Cluster Test"
+    backend_clusters: []

--- a/test/e2e/scenarios/event-gateway/backend-cluster/overlays/004-sync-delete-root-level-declaration/egw-bc.yaml
+++ b/test/e2e/scenarios/event-gateway/backend-cluster/overlays/004-sync-delete-root-level-declaration/egw-bc.yaml
@@ -2,6 +2,7 @@ _defaults:
   kongctl:
     namespace: event-gateways-bc-comprehensive-test
 
+# Legacy directory name; sync delete intent is now a nested empty child list.
 event_gateways:
   - ref: egw-cp-for-bc-test
     name: egw-cp-for-bc-test

--- a/test/e2e/scenarios/event-gateway/cluster-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/cluster-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -31,4 +31,4 @@ event_gateways:
          - type: anonymous
         acl_mode: enforce_on_gateway
         dns_label: vc-default
-event_gateway_virtual_cluster_cluster_policies: []
+        cluster_policies: []

--- a/test/e2e/scenarios/event-gateway/cluster-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/cluster-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -2,6 +2,7 @@ _defaults:
   kongctl:
     namespace: event-gateways-vc-cluster-policy-comprehensive-test
 
+# Legacy directory name; sync delete intent is now a nested empty child list.
 event_gateways:
   - ref: egw-cp-for-vc-cluster-policy-test
     name: egw-cp-for-vc-cluster-policy-test

--- a/test/e2e/scenarios/event-gateway/consume-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -2,6 +2,7 @@ _defaults:
   kongctl:
     namespace: event-gateways-vc-consume-policy-comprehensive-test
 
+# Legacy directory name; sync delete intent is now a nested empty child list.
 event_gateways:
   - ref: egw-cp-for-vc-consume-policy-test
     name: egw-cp-for-vc-consume-policy-test

--- a/test/e2e/scenarios/event-gateway/consume-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -31,4 +31,4 @@ event_gateways:
          - type: anonymous
         acl_mode: enforce_on_gateway
         dns_label: vc-default
-event_gateway_virtual_cluster_consume_policies: []
+        consume_policies: []

--- a/test/e2e/scenarios/event-gateway/dataplane-certificate/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/dataplane-certificate/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -6,4 +6,4 @@ event_gateways:
   - ref: egw-cp-for-dataplane-cert-test-ref
     name: egw-cp-for-dataplane-cert-test-name
     description: "EGW CP for Dataplane Cert Test"
-event_gateway_data_plane_certificates: []
+    data_plane_certificates: []

--- a/test/e2e/scenarios/event-gateway/dataplane-certificate/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/dataplane-certificate/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -2,6 +2,7 @@ _defaults:
   kongctl:
     namespace: event-gateways-dataplane-cert-comprehensive-test
 
+# Legacy directory name; sync delete intent is now a nested empty child list.
 event_gateways:
   - ref: egw-cp-for-dataplane-cert-test-ref
     name: egw-cp-for-dataplane-cert-test-name

--- a/test/e2e/scenarios/event-gateway/listener-policy/overlays/002-sync-delete/config.yaml
+++ b/test/e2e/scenarios/event-gateway/listener-policy/overlays/002-sync-delete/config.yaml
@@ -15,4 +15,4 @@ event_gateways:
           - "9093-9095"
         addresses:
           - localhost
-        # No listener_policies - they will be deleted by sync
+        policies: []

--- a/test/e2e/scenarios/event-gateway/listener-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/listener-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -15,3 +15,4 @@ event_gateways:
           - "9093-9095"
         addresses:
           - localhost
+        policies: []

--- a/test/e2e/scenarios/event-gateway/listener-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/listener-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -2,6 +2,7 @@ _defaults:
   kongctl:
     namespace: egw-listener-policy-comprehensive-test
 
+# Legacy directory name; sync delete intent is now a nested empty child list.
 event_gateways:
   - ref: egw-cp-for-listener-policy-test-ref
     name: egw-cp-for-listener-policy-test-name

--- a/test/e2e/scenarios/event-gateway/listener/overlays/002-sync-delete/config.yaml
+++ b/test/e2e/scenarios/event-gateway/listener/overlays/002-sync-delete/config.yaml
@@ -6,4 +6,4 @@ event_gateways:
   - ref: egw-cp-for-listener-test-ref
     name: egw-cp-for-listener-test-name
     description: "EGW CP for Listener Test"
-    # No listeners - they will be deleted by sync
+    listeners: []

--- a/test/e2e/scenarios/event-gateway/listener/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/listener/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -1,6 +1,7 @@
 _defaults:
   kongctl:
     namespace: event-gateways-listener-comprehensive-test
+# Legacy directory name; sync delete intent is now a nested empty child list.
 event_gateways:
   - ref: egw-cp-for-listener-test-ref
     name: egw-cp-for-listener-test-name

--- a/test/e2e/scenarios/event-gateway/listener/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/listener/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -5,3 +5,4 @@ event_gateways:
   - ref: egw-cp-for-listener-test-ref
     name: egw-cp-for-listener-test-name
     description: "EGW CP for Listener Test"
+    listeners: []

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/002-sync-delete/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/002-sync-delete/config.yaml
@@ -31,4 +31,4 @@ event_gateways:
          - type: anonymous
         acl_mode: enforce_on_gateway
         dns_label: vc-default
-        # produce_policies removed for sync delete test
+        produce_policies: []

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -2,6 +2,7 @@ _defaults:
   kongctl:
     namespace: event-gateways-vc-produce-policy-comprehensive-test
 
+# Legacy directory name; sync delete intent is now a nested empty child list.
 event_gateways:
   - ref: egw-cp-for-vc-produce-policy-test
     name: egw-cp-for-vc-produce-policy-test

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -31,6 +31,4 @@ event_gateways:
          - type: anonymous
         acl_mode: enforce_on_gateway
         dns_label: vc-default
-
-# event_gateway_virtual_cluster_produce_policies removed for sync delete test
-event_gateway_virtual_cluster_produce_policies: []
+        produce_policies: []

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/007-sync-delete-schema-validation/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/007-sync-delete-schema-validation/config.yaml
@@ -31,4 +31,4 @@ event_gateways:
          - type: anonymous
         acl_mode: enforce_on_gateway
         dns_label: vc-default
-        # produce_policies removed for sync delete test
+        produce_policies: []

--- a/test/e2e/scenarios/event-gateway/schema-registry/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/schema-registry/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -6,5 +6,4 @@ event_gateways:
   - ref: egw-cp-for-schema-registry-test-ref
     name: egw-cp-for-schema-registry-test-name
     description: "EGW CP for Schema Registry Test"
-
-event_gateway_schema_registries: []
+    schema_registries: []

--- a/test/e2e/scenarios/event-gateway/schema-registry/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/schema-registry/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -2,6 +2,7 @@ _defaults:
   kongctl:
     namespace: event-gateways-schema-registry-test
 
+# Legacy directory name; sync delete intent is now a nested empty child list.
 event_gateways:
   - ref: egw-cp-for-schema-registry-test-ref
     name: egw-cp-for-schema-registry-test-name

--- a/test/e2e/scenarios/event-gateway/static-key/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/static-key/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -6,5 +6,4 @@ event_gateways:
   - ref: egw-cp-for-static-key-test-ref
     name: egw-cp-for-static-key-test-name
     description: "EGW CP for Static Key Test"
-
-event_gateway_static_keys: []
+    static_keys: []

--- a/test/e2e/scenarios/event-gateway/static-key/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/static-key/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -2,6 +2,7 @@ _defaults:
   kongctl:
     namespace: event-gateways-static-key-test
 
+# Legacy directory name; sync delete intent is now a nested empty child list.
 event_gateways:
   - ref: egw-cp-for-static-key-test-ref
     name: egw-cp-for-static-key-test-name

--- a/test/e2e/scenarios/event-gateway/tls-trust-bundle/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/tls-trust-bundle/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -6,5 +6,4 @@ event_gateways:
   - ref: egw-cp-for-tls-trust-bundle-test-ref
     name: egw-cp-for-tls-trust-bundle-test-name
     description: "EGW CP for TLS Trust Bundle Test"
-
-event_gateway_tls_trust_bundles: []
+    tls_trust_bundles: []

--- a/test/e2e/scenarios/event-gateway/tls-trust-bundle/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/tls-trust-bundle/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -2,6 +2,7 @@ _defaults:
   kongctl:
     namespace: event-gateways-tls-trust-bundle-test
 
+# Legacy directory name; sync delete intent is now a nested empty child list.
 event_gateways:
   - ref: egw-cp-for-tls-trust-bundle-test-ref
     name: egw-cp-for-tls-trust-bundle-test-name

--- a/test/e2e/scenarios/event-gateway/virtual-cluster/overlays/002-sync-delete/config.yaml
+++ b/test/e2e/scenarios/event-gateway/virtual-cluster/overlays/002-sync-delete/config.yaml
@@ -21,3 +21,4 @@ event_gateways:
           tls_versions:
             - tls12
             - tls13
+    virtual_clusters: []

--- a/test/e2e/scenarios/event-gateway/virtual-cluster/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/virtual-cluster/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -21,3 +21,4 @@ event_gateways:
           tls_versions:
             - tls12
             - tls13
+    virtual_clusters: []

--- a/test/e2e/scenarios/event-gateway/virtual-cluster/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/virtual-cluster/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -2,6 +2,7 @@ _defaults:
   kongctl:
     namespace: event-gateways-vc-comprehensive-test
 
+# Legacy directory name; sync delete intent is now a nested empty child list.
 event_gateways:
   - ref: egw-cp-for-bc-vc-test
     name: egw-cp-for-bc-vc-test

--- a/test/e2e/scenarios/portal/audit-log-webhook/overlays/002-remove-webhook/config.yaml
+++ b/test/e2e/scenarios/portal/audit-log-webhook/overlays/002-remove-webhook/config.yaml
@@ -5,6 +5,7 @@ portals:
     description: "Portal used by the audit-log webhook e2e scenario"
     authentication_enabled: false
     rbac_enabled: false
+    audit_log_webhook: {}
 
 audit-logs:
   destinations:

--- a/test/e2e/scenarios/portal/custom-domain/overlays/006-remove-http-domain-retain-portal/config.yaml
+++ b/test/e2e/scenarios/portal/custom-domain/overlays/006-remove-http-domain-retain-portal/config.yaml
@@ -9,3 +9,4 @@ portals:
     description: "Portal using HTTP verification for its custom domain"
     kongctl:
       namespace: portal-custom-domain
+    custom_domain: {}

--- a/test/e2e/scenarios/portal/email/overlays/003-remove/config.yaml
+++ b/test/e2e/scenarios/portal/email/overlays/003-remove/config.yaml
@@ -8,3 +8,4 @@ portals:
     display_name: "Portal Email Config"
     kongctl:
       namespace: portal-email-config
+    email_config: {}

--- a/test/e2e/scenarios/portal/sync/overlays/003-remove-sms-publication/apis.yaml
+++ b/test/e2e/scenarios/portal/sync/overlays/003-remove-sms-publication/apis.yaml
@@ -1,7 +1,7 @@
 # API Resources — SMS API publication removed
-# The SMS API is kept intact (versions, documents) but its publications
-# block is intentionally omitted so that sync mode will plan a
-# DELETE for the api_publication resource.
+# The SMS API is kept intact (versions, documents), and the publications
+# block is explicitly empty so that sync mode will plan a DELETE for the
+# api_publication resource.
 
 apis:
   - ref: sms
@@ -45,7 +45,7 @@ apis:
         status: published
         content: !file apis/sms/docs/webhooks.md
 
-    # publications: intentionally absent to trigger sync-delete
+    publications: []
 
   - ref: voice
     name: !file apis/voice/openapi.yaml#info.title

--- a/test/e2e/scenarios/protected-resources/apis/overlays/002c-attempt-child-delete/apis.yaml
+++ b/test/e2e/scenarios/protected-resources/apis/overlays/002c-attempt-child-delete/apis.yaml
@@ -1,5 +1,5 @@
 # Overlay: Delete api_version child while parent API is protected
-# Sync mode with no versions listed causes DELETE plan for the child
+# Sync mode with an explicit empty versions list causes a DELETE plan for the child
 # This should fail because the parent API has the protected label
 
 _defaults:
@@ -14,6 +14,7 @@ apis:
     kongctl:
       protected: true
       namespace: default
+    versions: []
 
   - ref: test-api
     name: "Test API"

--- a/test/e2e/scenarios/protected-resources/apis/overlays/005-delete-child-unprotected/apis.yaml
+++ b/test/e2e/scenarios/protected-resources/apis/overlays/005-delete-child-unprotected/apis.yaml
@@ -1,5 +1,5 @@
 # Overlay: Delete api_version child after parent API is unprotected
-# Sync mode with no versions listed causes DELETE plan for the child
+# Sync mode with an explicit empty versions list causes a DELETE plan for the child
 # This should succeed now that the parent is no longer protected
 
 _defaults:
@@ -14,6 +14,7 @@ apis:
     kongctl:
       protected: false
       namespace: default
+    versions: []
 
   - ref: test-api
     name: "Test API"

--- a/test/e2e/scenarios/protected-resources/event-gateways/overlays/003-attempt-child-delete/event-gateways.yaml
+++ b/test/e2e/scenarios/protected-resources/event-gateways/overlays/003-attempt-child-delete/event-gateways.yaml
@@ -12,3 +12,4 @@ event_gateways:
     kongctl:
       namespace: "egw-protection"
       protected: true
+    backend_clusters: []

--- a/test/e2e/scenarios/protected-resources/event-gateways/overlays/006-delete-child-unprotected/event-gateways.yaml
+++ b/test/e2e/scenarios/protected-resources/event-gateways/overlays/006-delete-child-unprotected/event-gateways.yaml
@@ -12,3 +12,4 @@ event_gateways:
     kongctl:
       namespace: "egw-protection"
       protected: false
+    backend_clusters: []

--- a/test/e2e/scenarios/yaml-tags/env/overlays/003-sync/config.yaml
+++ b/test/e2e/scenarios/yaml-tags/env/overlays/003-sync/config.yaml
@@ -2,6 +2,8 @@ _defaults:
   kongctl:
     namespace: yaml-env-tags
 
+dcr_providers: []
+
 portals:
   - ref: env-portal
     name: env-portal

--- a/test/integration/declarative/sync_command_test.go
+++ b/test/integration/declarative/sync_command_test.go
@@ -20,12 +20,12 @@ import (
 )
 
 func TestSyncCommand_WithDeletes(t *testing.T) {
-	// Create a test configuration file that will cause deletions
+	// Create a test configuration file that will cause portal deletions
 	syncDir := t.TempDir()
 	syncConfigFile := filepath.Join(syncDir, "sync-config.yaml")
 
-	// Empty config will delete all managed resources
-	syncConfigContent := `# Empty configuration - will delete all managed resources
+	// Explicit empty root collections declare desired count zero for that resource type.
+	syncConfigContent := `portals: []
 `
 
 	err := os.WriteFile(syncConfigFile, []byte(syncConfigContent), 0o600)

--- a/test/integration/declarative/sync_command_test.go
+++ b/test/integration/declarative/sync_command_test.go
@@ -79,33 +79,6 @@ func TestSyncCommand_WithDeletes(t *testing.T) {
 			StatusCode: 204,
 		}, nil).Once()
 
-	// Mock empty APIs list
-	mockAPIAPI.On("ListApis", mock.Anything, mock.Anything).
-		Return(&kkOps.ListApisResponse{
-			StatusCode: 200,
-			ListAPIResponse: &kkComps.ListAPIResponse{
-				Data: []kkComps.APIResponseSchema{},
-				Meta: kkComps.PaginatedMeta{
-					Page: kkComps.PageMeta{
-						Total: 0,
-					},
-				},
-			},
-		}, nil)
-
-	// Mock empty auth strategies list
-	mockAppAuthAPI.On("ListAppAuthStrategies", mock.Anything, mock.Anything).
-		Return(&kkOps.ListAppAuthStrategiesResponse{
-			ListAppAuthStrategiesResponse: &kkComps.ListAppAuthStrategiesResponse{
-				Data: []kkComps.AppAuthStrategy{},
-				Meta: kkComps.PaginatedMeta{
-					Page: kkComps.PageMeta{
-						Total: 0,
-					},
-				},
-			},
-		}, nil)
-
 	// Create sync command using declarative command
 	cmd, err := declarative.NewDeclarativeCmd("sync")
 	require.NoError(t, err)
@@ -140,4 +113,6 @@ func TestSyncCommand_WithDeletes(t *testing.T) {
 	// Verify execution completed
 	assert.Contains(t, outputStr, "Complete.")
 	assert.Contains(t, outputStr, "Executed 1 changes.")
+	mockAPIAPI.AssertNotCalled(t, "ListApis", mock.Anything, mock.Anything)
+	mockAppAuthAPI.AssertNotCalled(t, "ListAppAuthStrategies", mock.Anything, mock.Anything)
 }


### PR DESCRIPTION
Fixes #945.

## Why

`sync` previously treated omitted configuration as desired absence, which made omission destructive. That is risky for federated ownership: a team syncing APIs may not own portals, DCR providers, or other top-level families, and even within one family a team may own only selected child collections.

This PR changes `sync` to use explicit manifest scope. Deletes now require a stronger signal: the relevant collection or child key must be present in the declarative input.

## User Impact

- Omitted root collections are ignored.
- Explicit empty root lists mean desired count zero, for example `apis: []` deletes managed APIs in scope.
- Child collections are scoped independently under each parent.
- A parent without a child key leaves that child collection alone.
- An empty child list under a parent means desired child count zero, for example `pages: []` under one portal deletes managed pages for that portal.
- Singleton child sections such as `customization` are ignored when omitted and managed when an object is provided.
- Child singletons wishing to be deleted must have empty object syntax: ex: `email_config: {}`  - 
- Singleton child sections set to `null`, such as `customization: null`, are rejected because null could reasonably be read as reset/delete intent, and sync does not infer those semantics.
- Root-level empty child lists such as `api_documents: []` are rejected because they do not identify which parent owns the desired zero count.

Users who relied on omission to delete resources now need to express that intent directly with an explicit empty list.