### PR TITLE
feat: support passing max concurrency using config file

### DIFF
--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -100,8 +100,8 @@ func addMaxConcurrencyFlag(cmd *cobra.Command) {
 	cmd.Flags().Int("max-concurrency", executor.DefaultMaxConcurrency,
 		fmt.Sprintf(`Maximum number of concurrent API operations during execution (min %d, max %d).
 When the plan contains execution_groups, operations within each group run
-concurrently up to this limit. Use 1 for sequential execution. (default %d).
-- Config path: [ %s ]`, executor.MinConcurrency, executor.MaxConcurrency, executor.DefaultMaxConcurrency, maxConcurrencyConfigPath))
+concurrently up to this limit. Use 1 for sequential execution.
+- Config path: [ %s ]`, executor.MinConcurrency, executor.MaxConcurrency, maxConcurrencyConfigPath))
 }
 
 func addRequireNamespaceFlags(cmd *cobra.Command) {

--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -55,6 +55,10 @@ const (
 	requireAnyNamespaceFlagName = "require-any-namespace"
 	// requireAnyNamespaceConfigPath is the config path backing the any namespace flag
 	requireAnyNamespaceConfigPath = "konnect.declarative." + requireAnyNamespaceFlagName
+	// maxConcurrencyFlagName is the CLI flag for maximum concurrency during execution
+	maxConcurrencyFlagName = "max-concurrency"
+	// maxConcurrencyConfigPath is the config path backing the max concurrency flag
+	maxConcurrencyConfigPath = "konnect.declarative." + maxConcurrencyFlagName
 )
 
 const diffFieldRedactedValue = "[REDACTED]"
@@ -96,8 +100,8 @@ func addMaxConcurrencyFlag(cmd *cobra.Command) {
 	cmd.Flags().Int("max-concurrency", executor.DefaultMaxConcurrency,
 		fmt.Sprintf(`Maximum number of concurrent API operations during execution (min %d, max %d).
 When the plan contains execution_groups, operations within each group run
-concurrently up to this limit. Use 1 for sequential execution.`,
-			executor.MinConcurrency, executor.MaxConcurrency))
+concurrently up to this limit. Use 1 for sequential execution. (default %d).
+- Config path: [ %s ]`, executor.MinConcurrency, executor.MaxConcurrency, executor.DefaultMaxConcurrency, maxConcurrencyConfigPath))
 }
 
 func addRequireNamespaceFlags(cmd *cobra.Command) {
@@ -1332,10 +1336,6 @@ func runApply(command *cobra.Command, args []string) error {
 	autoApprove, _ := command.Flags().GetBool("auto-approve")
 	outputFormat, _ := command.Flags().GetString("output")
 	filenames, _ := command.Flags().GetStringSlice("filename")
-	maxConcurrency, err := maxConcurrencyFromCmd(command)
-	if err != nil {
-		return err
-	}
 
 	// Early check for non-text output without auto-approve
 	if !dryRun && !autoApprove && outputFormat != textOutputFormat {
@@ -1357,6 +1357,10 @@ func runApply(command *cobra.Command, args []string) error {
 
 	// Get configuration
 	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+	maxConcurrency, err := maxConcurrencyFromCmd(command, cfg)
 	if err != nil {
 		return err
 	}
@@ -1819,10 +1823,6 @@ func runDelete(command *cobra.Command, args []string) error {
 	autoApprove, _ := command.Flags().GetBool("auto-approve")
 	outputFormat, _ := command.Flags().GetString("output")
 	filenames, _ := command.Flags().GetStringSlice("filename")
-	maxConcurrency, err := maxConcurrencyFromCmd(command)
-	if err != nil {
-		return err
-	}
 
 	// Early check for non-text output without auto-approve
 	if !dryRun && !autoApprove && outputFormat != textOutputFormat {
@@ -1844,6 +1844,10 @@ func runDelete(command *cobra.Command, args []string) error {
 
 	// Get configuration
 	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+	maxConcurrency, err := maxConcurrencyFromCmd(command, cfg)
 	if err != nil {
 		return err
 	}
@@ -2054,10 +2058,6 @@ func runSync(command *cobra.Command, args []string) error {
 	autoApprove, _ := command.Flags().GetBool("auto-approve")
 	outputFormat, _ := command.Flags().GetString("output")
 	filenames, _ := command.Flags().GetStringSlice("filename")
-	maxConcurrency, err := maxConcurrencyFromCmd(command)
-	if err != nil {
-		return err
-	}
 
 	// Early check for non-text output without auto-approve
 	if !dryRun && !autoApprove && outputFormat != textOutputFormat {
@@ -2079,6 +2079,10 @@ func runSync(command *cobra.Command, args []string) error {
 
 	// Get configuration
 	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+	maxConcurrency, err := maxConcurrencyFromCmd(command, cfg)
 	if err != nil {
 		return err
 	}
@@ -2297,11 +2301,17 @@ func runSync(command *cobra.Command, args []string) error {
 	return nil
 }
 
-// maxConcurrencyFromCmd reads and validates --max-concurrency.
-func maxConcurrencyFromCmd(cmd *cobra.Command) (int, error) {
-	v, err := cmd.Flags().GetInt("max-concurrency")
-	if err != nil {
-		return 0, err
+// maxConcurrencyFromCmd reads and validates --max-concurrency, falling back to config.
+func maxConcurrencyFromCmd(cmd *cobra.Command, cfg config.Hook) (int, error) {
+	v := executor.DefaultMaxConcurrency
+	if cmd.Flags().Changed(maxConcurrencyFlagName) {
+		flagValue, err := cmd.Flags().GetInt(maxConcurrencyFlagName)
+		if err != nil {
+			return 0, err
+		}
+		v = flagValue
+	} else if cfg != nil {
+		v = cfg.GetIntOrElse(maxConcurrencyConfigPath, executor.DefaultMaxConcurrency)
 	}
 	if v < executor.MinConcurrency || v > executor.MaxConcurrency {
 		return 0, fmt.Errorf(

--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -97,7 +97,7 @@ Defaults to each -f source root (file: its parent dir, dir: the directory itself
 }
 
 func addMaxConcurrencyFlag(cmd *cobra.Command) {
-	cmd.Flags().Int("max-concurrency", executor.DefaultMaxConcurrency,
+	cmd.Flags().Int(maxConcurrencyFlagName, executor.DefaultMaxConcurrency,
 		fmt.Sprintf(`Maximum number of concurrent API operations during execution (min %d, max %d).
 When the plan contains execution_groups, operations within each group run
 concurrently up to this limit. Use 1 for sequential execution.

--- a/internal/cmd/root/products/konnect/declarative/declarative_test.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/kong/kongctl/internal/config"
 	"github.com/kong/kongctl/internal/declarative/executor"
 	"github.com/kong/kongctl/internal/declarative/planner"
 	"github.com/kong/kongctl/internal/declarative/resources"
+	utilviper "github.com/kong/kongctl/internal/util/viper"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,9 +19,23 @@ func TestMaxConcurrencyFromCmd(t *testing.T) {
 		cmd := &cobra.Command{}
 		addMaxConcurrencyFlag(cmd)
 
-		got, err := maxConcurrencyFromCmd(cmd)
+		cfg := config.BuildProfiledConfig("default", "nonexistent.yaml", utilviper.NewViper("nonexistent.yaml"))
+
+		got, err := maxConcurrencyFromCmd(cmd, cfg)
 		require.NoError(t, err)
 		assert.Equal(t, executor.DefaultMaxConcurrency, got)
+	})
+
+	t.Run("uses config value when flag is not set", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		addMaxConcurrencyFlag(cmd)
+
+		cfg := config.BuildProfiledConfig("default", "nonexistent.yaml", utilviper.NewViper("nonexistent.yaml"))
+		cfg.Set(maxConcurrencyConfigPath, 17)
+
+		got, err := maxConcurrencyFromCmd(cmd, cfg)
+		require.NoError(t, err)
+		assert.Equal(t, 17, got)
 	})
 
 	t.Run("accepts value within range", func(t *testing.T) {
@@ -27,7 +43,22 @@ func TestMaxConcurrencyFromCmd(t *testing.T) {
 		addMaxConcurrencyFlag(cmd)
 		require.NoError(t, cmd.Flags().Set("max-concurrency", "42"))
 
-		got, err := maxConcurrencyFromCmd(cmd)
+		cfg := config.BuildProfiledConfig("default", "nonexistent.yaml", utilviper.NewViper("nonexistent.yaml"))
+
+		got, err := maxConcurrencyFromCmd(cmd, cfg)
+		require.NoError(t, err)
+		assert.Equal(t, 42, got)
+	})
+
+	t.Run("prefers flag value over config value", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		addMaxConcurrencyFlag(cmd)
+		require.NoError(t, cmd.Flags().Set("max-concurrency", "42"))
+
+		cfg := config.BuildProfiledConfig("default", "nonexistent.yaml", utilviper.NewViper("nonexistent.yaml"))
+		cfg.Set(maxConcurrencyConfigPath, 17)
+
+		got, err := maxConcurrencyFromCmd(cmd, cfg)
 		require.NoError(t, err)
 		assert.Equal(t, 42, got)
 	})
@@ -37,7 +68,9 @@ func TestMaxConcurrencyFromCmd(t *testing.T) {
 		addMaxConcurrencyFlag(cmd)
 		require.NoError(t, cmd.Flags().Set("max-concurrency", "0"))
 
-		_, err := maxConcurrencyFromCmd(cmd)
+		cfg := config.BuildProfiledConfig("default", "nonexistent.yaml", utilviper.NewViper("nonexistent.yaml"))
+
+		_, err := maxConcurrencyFromCmd(cmd, cfg)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "--max-concurrency must be between")
 	})
@@ -47,7 +80,9 @@ func TestMaxConcurrencyFromCmd(t *testing.T) {
 		addMaxConcurrencyFlag(cmd)
 		require.NoError(t, cmd.Flags().Set("max-concurrency", "1000"))
 
-		_, err := maxConcurrencyFromCmd(cmd)
+		cfg := config.BuildProfiledConfig("default", "nonexistent.yaml", utilviper.NewViper("nonexistent.yaml"))
+
+		_, err := maxConcurrencyFromCmd(cmd, cfg)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "--max-concurrency must be between")
 	})

--- a/internal/cmd/root/products/konnect/declarative/declarative_test.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative_test.go
@@ -86,6 +86,30 @@ func TestMaxConcurrencyFromCmd(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "--max-concurrency must be between")
 	})
+
+	t.Run("rejects out-of-range value from config (below minimum)", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		addMaxConcurrencyFlag(cmd)
+
+		cfg := config.BuildProfiledConfig("default", "nonexistent.yaml", utilviper.NewViper("nonexistent.yaml"))
+		cfg.Set(maxConcurrencyConfigPath, 0)
+
+		_, err := maxConcurrencyFromCmd(cmd, cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--max-concurrency must be between")
+	})
+
+	t.Run("rejects out-of-range value from config (above maximum)", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		addMaxConcurrencyFlag(cmd)
+
+		cfg := config.BuildProfiledConfig("default", "nonexistent.yaml", utilviper.NewViper("nonexistent.yaml"))
+		cfg.Set(maxConcurrencyConfigPath, 1000)
+
+		_, err := maxConcurrencyFromCmd(cmd, cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--max-concurrency must be between")
+	})
 }
 
 func Test_validateDeletePlan(t *testing.T) {


### PR DESCRIPTION
Max Concurrency can now be set in config file, and different values can be used in different profiles.

`kongctl apply -f myfile.yaml --config-file cfg.yaml --profile myprofile`

```
# cfg.yaml
myprofile:
  konnect:
      declarative:
        max-concurrency: 25
```

<img width="835" height="69" alt="Screenshot 2026-05-12 at 6 00 18 PM" src="https://github.com/user-attachments/assets/58ec73e8-2d02-49d5-ab39-4492b5d6f9e9" />
