### PR TITLE
test: add e2e concurrency controls

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -179,6 +179,7 @@ jobs:
       KONGCTL_E2E_MATRIX_ORG: ${{ matrix.org_name }}
       KONGCTL_E2E_BIN: ${{ github.workspace }}/kongctl
       KONGCTL_E2E_TEST_BIN: ${{ github.workspace }}/e2e.test
+      KONGCTL_E2E_TEST_TIMEOUT: ${{ vars.KONGCTL_E2E_TEST_TIMEOUT || '55m' }}
       KONGCTL_E2E_KONNECT_PAT: ${{ secrets.KONGCTL_E2E_KONNECT_PAT }}
       KONGCTL_E2E_KONNECT_BASE_URL: ${{ vars.KONGCTL_E2E_KONNECT_BASE_URL || 'https://us.api.konghq.com' }}
       # Reset is enabled by default in the harness; set explicitly for clarity
@@ -327,7 +328,7 @@ jobs:
 
           run_started_at="$(date +%s)"
           set +e
-          "${KONGCTL_E2E_TEST_BIN}" -test.v -test.count=1 -test.run '^Test_Scenarios$' ${GOTESTFLAGS:-} \
+          "${KONGCTL_E2E_TEST_BIN}" -test.v -test.count=1 -test.timeout "${KONGCTL_E2E_TEST_TIMEOUT}" -test.run '^Test_Scenarios$' ${GOTESTFLAGS:-} \
             2>&1 | tee "${ART_DIR}/run.log"
           code=${PIPESTATUS[0]}
           set -e

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -X main.version=$(VERSION) -X main.commit=$(GIT_COMMIT) -X main.date=$(BUILD_DATE)
 LATEST_E2E_LINK ?= .latest-e2e
+KONGCTL_E2E_TEST_TIMEOUT ?= 55m
 LATEST_BENCHMARK_LINK ?= .latest-benchmark
 
 .PHONY: lint
@@ -91,7 +92,7 @@ test-e2e:
 	fi; \
 	mkdir -p "$$ART_DIR"; \
 	ART_DIR=$$(cd "$$ART_DIR" && pwd); \
-	( KONGCTL_E2E_ARTIFACTS_DIR="$$ART_DIR" go test -v -count=1 -tags=e2e $${GOTESTFLAGS} ./test/e2e/... ; echo $$? > "$$ART_DIR/.exit_code" ) | tee "$$ART_DIR/run.log"; \
+	( KONGCTL_E2E_ARTIFACTS_DIR="$$ART_DIR" go test -v -count=1 -tags=e2e -timeout "$(KONGCTL_E2E_TEST_TIMEOUT)" $${GOTESTFLAGS} ./test/e2e/... ; echo $$? > "$$ART_DIR/.exit_code" ) | tee "$$ART_DIR/run.log"; \
 	code=$$(cat "$$ART_DIR/.exit_code"); rm -f "$$ART_DIR/.exit_code"; \
 	echo "E2E artifacts: $$ART_DIR"; \
 	ln -sfn "$$ART_DIR" "$(LATEST_E2E_LINK)" || true; \
@@ -112,7 +113,7 @@ test-e2e-scenarios:
 	( KONGCTL_E2E_ARTIFACTS_DIR="$$ART_DIR" \
 	  KONGCTL_E2E_SCENARIO="${SCENARIO}" \
 	  KONGCTL_E2E_STOP_AFTER="${STOP_AFTER}" \
-	  go test -v -count=1 -tags=e2e -run '^Test_Scenarios$$' $${GOTESTFLAGS} ./test/e2e ; \
+	  go test -v -count=1 -tags=e2e -timeout "$(KONGCTL_E2E_TEST_TIMEOUT)" -run '^Test_Scenarios$$' $${GOTESTFLAGS} ./test/e2e ; \
 	  echo $$? > "$$ART_DIR/.exit_code" ) | tee "$$ART_DIR/run.log"; \
 	code=$$(cat "$$ART_DIR/.exit_code"); rm -f "$$ART_DIR/.exit_code"; \
 	echo "E2E artifacts: $$ART_DIR"; \

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -64,6 +64,20 @@ Core harness settings:
   logs in artifacts. Default: same as harness log level.
 - `KONGCTL_E2E_OUTPUT`: Default CLI output (`json|yaml|text`). Default:
   `json`.
+- `KONGCTL_E2E_TEST_TIMEOUT`: Go test timeout for local Make targets and the
+  CI scenario test binary. Default: `55m`.
+- `KONGCTL_E2E_KONNECT_DECLARATIVE_MAX_CONCURRENCY`: Standard `e2e`
+  profile env var for declarative execution concurrency. It maps to
+  `konnect.declarative.max-concurrency` and applies to all declarative
+  commands unless a command passes `--max-concurrency` or a scenario override
+  is set. Valid range: `1..200`.
+- `KONGCTL_E2E_MAX_CONCURRENCY_VALUES`: Optional suite-wide concurrency sweep.
+  When set, the harness hashes each scenario path and picks one value from the
+  comma-separated list, such as `1,2,5,10`, then injects that value as the
+  scenario's declarative concurrency default. Use this to run the same suite
+  with mixed concurrency settings without editing each scenario. Explicit
+  scenario YAML overrides and `KONGCTL_E2E_KONNECT_DECLARATIVE_MAX_CONCURRENCY`
+  take precedence.
 - `KONGCTL_E2E_CAPTURE`: Per-command artifact capture. `0` disables it.
 - `KONGCTL_E2E_JSON_STRICT`: When `1`, JSON parsing fails on unknown fields.
   Default: lenient.
@@ -292,11 +306,33 @@ The harness keeps artifacts by default for local debugging and CI upload.
 - Log level: the harness injects `--log-level` unless the command already sets
   one.
 - Profile config: the harness writes `config.yaml` for the `e2e` profile.
+- Declarative concurrency: scenarios can set `maxConcurrency` at the default,
+  step, or command level. Command wins over step, step wins over defaults, and
+  explicit `--max-concurrency` in `run` still has normal CLI precedence.
 - Sanitization: token-like env vars are redacted in `env.json` and logs.
 - HTTP dumps: when Konnect SDK dump env vars are enabled, the harness stores
   each exchange under the command’s `http-dumps/` directory.
 - Observations: `observation.json` is attached to captured commands for apply
   summaries and read observations.
+
+Example scenario concurrency overrides:
+
+```yaml
+defaults:
+  maxConcurrency: 5
+
+steps:
+  - name: cleanup
+    maxConcurrency: 1
+    commands:
+      - name: delete
+        maxConcurrency: 1
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+```
 
 ### CI Notes
 
@@ -315,9 +351,9 @@ The workflow derives sharding directly from GitHub Actions strategy context:
 - `KONGCTL_E2E_MATRIX_ORG=${{ matrix.org_name }}`
 - `KONGCTL_E2E_ORGS_JSON=${{ vars.KONGCTL_E2E_ORGS_JSON }}`
 
-The workflow also exposes the HTTP timeout and retry knobs above as repository
-or organization variables of the same names, so CI can tune reset and HTTP
-behavior without changing Go code.
+The workflow also exposes the test timeout, HTTP timeout, and retry knobs above
+as repository or organization variables of the same names, so CI can tune
+runtime behavior without changing Go code.
 
 For transport debugging, the workflow currently defaults to:
 

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -351,9 +351,9 @@ The workflow derives sharding directly from GitHub Actions strategy context:
 - `KONGCTL_E2E_MATRIX_ORG=${{ matrix.org_name }}`
 - `KONGCTL_E2E_ORGS_JSON=${{ vars.KONGCTL_E2E_ORGS_JSON }}`
 
-The workflow also exposes the test timeout, HTTP timeout, and retry knobs above
-as repository or organization variables of the same names, so CI can tune
-runtime behavior without changing Go code.
+The workflow also exposes the test timeout, HTTP timeout, and retry
+knobs above as repository or organization variables of the same names,
+so CI can tune runtime behavior without changing Go code.
 
 For transport debugging, the workflow currently defaults to:
 

--- a/internal/declarative/planner/control_plane_planner.go
+++ b/internal/declarative/planner/control_plane_planner.go
@@ -395,6 +395,7 @@ func (p *controlPlanePlannerImpl) planControlPlaneDelete(current state.ControlPl
 	}
 
 	generic := p.GetGenericPlanner()
+	var change PlannedChange
 	if generic != nil {
 		config := DeleteConfig{
 			ResourceType: ResourceTypeControlPlane,
@@ -403,22 +404,28 @@ func (p *controlPlanePlannerImpl) planControlPlaneDelete(current state.ControlPl
 			ResourceID:   current.ID,
 			Namespace:    namespace,
 		}
-		change := generic.PlanDelete(context.Background(), config)
-		change.Fields = map[string]any{FieldName: current.Name}
-		plan.AddChange(change)
-		return
+		change = generic.PlanDelete(context.Background(), config)
+	} else {
+		changeID := p.NextChangeID(ActionDelete, ResourceTypeControlPlane, current.Name)
+		change = PlannedChange{
+			ID:           changeID,
+			ResourceType: ResourceTypeControlPlane,
+			ResourceRef:  current.Name,
+			ResourceID:   current.ID,
+			Action:       ActionDelete,
+			Namespace:    namespace,
+		}
 	}
 
-	changeID := p.NextChangeID(ActionDelete, ResourceTypeControlPlane, current.Name)
-	plan.AddChange(PlannedChange{
-		ID:           changeID,
-		ResourceType: ResourceTypeControlPlane,
-		ResourceRef:  current.Name,
-		ResourceID:   current.ID,
-		Action:       ActionDelete,
-		Fields:       map[string]any{FieldName: current.Name},
-		Namespace:    namespace,
-	})
+	change.Fields = map[string]any{FieldName: current.Name}
+	memberIDs := normalizers.NormalizeMemberIDs(current.GroupMembers)
+	if len(memberIDs) > 0 {
+		change.Fields[FieldMembers] = formatMemberField(memberIDs)
+		change.References = map[string]ReferenceInfo{
+			FieldMembers: p.buildMemberReferenceInfo(memberIDs),
+		}
+	}
+	plan.AddChange(change)
 }
 
 func (p *controlPlanePlannerImpl) shouldUpdateControlPlane(

--- a/internal/declarative/planner/control_plane_planner_test.go
+++ b/internal/declarative/planner/control_plane_planner_test.go
@@ -339,6 +339,54 @@ func TestControlPlanePlanner_PlanDeleteSync(t *testing.T) {
 	assert.Equal(t, "cp-delete", plan.Changes[0].ResourceRef)
 }
 
+func TestControlPlanePlanner_PlanDeleteGroupDependsOnMemberDeletes(t *testing.T) {
+	planner := &Planner{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	planner.genericPlanner = NewGenericPlanner(planner)
+
+	cpPlanner := &controlPlanePlannerImpl{BasePlanner: NewBasePlanner(planner)}
+	plan := NewPlan("1.0", "test", PlanModeDelete)
+
+	cpPlanner.planControlPlaneDelete(state.ControlPlane{
+		ControlPlane: kkComps.ControlPlane{
+			ID:   "member-a-id",
+			Name: "member-a",
+		},
+		NormalizedLabels: map[string]string{labels.NamespaceKey: "default"},
+	}, plan)
+	cpPlanner.planControlPlaneDelete(state.ControlPlane{
+		ControlPlane: kkComps.ControlPlane{
+			ID:   "member-b-id",
+			Name: "member-b",
+		},
+		NormalizedLabels: map[string]string{labels.NamespaceKey: "default"},
+	}, plan)
+	cpPlanner.planControlPlaneDelete(state.ControlPlane{
+		ControlPlane: kkComps.ControlPlane{
+			ID:   "group-id",
+			Name: "group-cp",
+			Config: kkComps.ControlPlaneConfig{
+				ClusterType: kkComps.ControlPlaneClusterTypeClusterTypeControlPlaneGroup,
+			},
+		},
+		NormalizedLabels: map[string]string{labels.NamespaceKey: "default"},
+		GroupMembers:     []string{"member-a-id", "member-b-id"},
+	}, plan)
+
+	adjustControlPlaneGroupDeleteDependencies(plan.Changes)
+
+	require.Len(t, plan.Changes, 3)
+	groupChange := plan.Changes[2]
+	assert.Equal(t, "group-cp", groupChange.ResourceRef)
+	assert.ElementsMatch(t, []string{
+		"temp-1:d:control_plane:member-a",
+		"temp-2:d:control_plane:member-b",
+	}, groupChange.DependsOn)
+	require.NotNil(t, groupChange.References)
+	assert.Equal(t, []string{"member-a-id", "member-b-id"}, groupChange.References[FieldMembers].Refs)
+}
+
 func TestControlPlanePlanner_ProtectionChange(t *testing.T) {
 	mockAPI := helpers.NewMockControlPlaneAPI(t)
 	current := kkComps.ControlPlane{

--- a/internal/declarative/planner/planner.go
+++ b/internal/declarative/planner/planner.go
@@ -422,6 +422,7 @@ func (p *Planner) GeneratePlan(ctx context.Context, rs *resources.ResourceSet, o
 
 	// Resolve dependencies and calculate execution order.
 	// Inject additional dependency constraints that span resource planners.
+	adjustControlPlaneGroupDeleteDependencies(basePlan.Changes)
 	adjustAuthStrategyDeleteDependencies(basePlan.Changes)
 	adjustDCRProviderDeleteDependencies(basePlan.Changes)
 
@@ -530,6 +531,41 @@ func toSnakeCase(value string) string {
 	}
 
 	return strings.Trim(string(out), "_")
+}
+
+// adjustControlPlaneGroupDeleteDependencies ensures control plane group DELETE
+// changes execute only after DELETE changes for their member control planes in
+// the same plan. Konnect rejects deleting a group while it still has members.
+func adjustControlPlaneGroupDeleteDependencies(changes []PlannedChange) {
+	controlPlaneDeletesByID := make(map[string]string)
+	for i := range changes {
+		change := &changes[i]
+		if change.Action != ActionDelete || change.ResourceType != ResourceTypeControlPlane {
+			continue
+		}
+		if change.ResourceID != "" {
+			controlPlaneDeletesByID[change.ResourceID] = change.ID
+		}
+	}
+
+	for i := range changes {
+		change := &changes[i]
+		if change.Action != ActionDelete || change.ResourceType != ResourceTypeControlPlane {
+			continue
+		}
+
+		refInfo, ok := change.References[FieldMembers]
+		if !ok || len(refInfo.Refs) == 0 {
+			continue
+		}
+
+		for _, memberID := range refInfo.Refs {
+			depID, ok := controlPlaneDeletesByID[memberID]
+			if ok && depID != change.ID {
+				change.DependsOn = appendDependsOn(change.DependsOn, depID)
+			}
+		}
+	}
 }
 
 // adjustAuthStrategyDeleteDependencies ensures auth strategy DELETE changes execute only

--- a/test/e2e/harness/cli.go
+++ b/test/e2e/harness/cli.go
@@ -177,8 +177,8 @@ func (c *CLI) WithEnv(kv map[string]string) *CLI {
 	if len(kv) == 0 {
 		return c
 	}
+	c.Env = mergeEnvSlices(c.Env, kv)
 	for k, v := range kv {
-		c.Env = append(c.Env, fmt.Sprintf("%s=%s", k, v))
 		Debugf("WithEnv: set %s", redactEnv(fmt.Sprintf("%s=%s", k, v)))
 	}
 	return c

--- a/test/e2e/harness/cli_test.go
+++ b/test/e2e/harness/cli_test.go
@@ -62,3 +62,27 @@ func TestWriteProfileConfigOmitsDisabledHTTPTimeouts(t *testing.T) {
 		t.Fatalf("config unexpectedly contains http-tcp-user-timeout: %s", content)
 	}
 }
+
+func TestWithEnvReplacesExistingKeys(t *testing.T) {
+	cli := &CLI{
+		Env: []string{
+			"EXISTING=old",
+			"OTHER=value",
+		},
+	}
+
+	cli.WithEnv(map[string]string{"EXISTING": "new"})
+
+	var existing []string
+	for _, kv := range cli.Env {
+		if strings.HasPrefix(kv, "EXISTING=") {
+			existing = append(existing, kv)
+		}
+	}
+	if len(existing) != 1 {
+		t.Fatalf("EXISTING entries = %v, want one", existing)
+	}
+	if existing[0] != "EXISTING=new" {
+		t.Fatalf("EXISTING entry = %q, want EXISTING=new", existing[0])
+	}
+}

--- a/test/e2e/harness/scenario/run.go
+++ b/test/e2e/harness/scenario/run.go
@@ -6,17 +6,25 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	jmespath "github.com/jmespath/go-jmespath"
+	"github.com/kong/kongctl/internal/declarative/executor"
 	"github.com/kong/kongctl/test/e2e/harness"
 	"sigs.k8s.io/yaml"
+)
+
+const (
+	maxConcurrencyEnvName       = "KONGCTL_E2E_KONNECT_DECLARATIVE_MAX_CONCURRENCY"
+	maxConcurrencyValuesEnvName = "KONGCTL_E2E_MAX_CONCURRENCY_VALUES"
 )
 
 // checkAndStopAfter checks if execution should stop after the current command.
@@ -60,6 +68,18 @@ func Run(t *testing.T, scenarioPath string) error {
 	}
 	if s.Vars == nil {
 		s.Vars = map[string]any{}
+	}
+	suiteMaxConcurrency, err := suiteMaxConcurrencyForScenario(scenarioPath)
+	if err != nil {
+		return err
+	}
+	if suiteMaxConcurrency != nil {
+		harness.Infof(
+			"Scenario maxConcurrency: %s=%d selected from %s",
+			maxConcurrencyEnvName,
+			*suiteMaxConcurrency,
+			maxConcurrencyValuesEnvName,
+		)
 	}
 
 	// Execute steps
@@ -489,6 +509,14 @@ func Run(t *testing.T, scenarioPath string) error {
 			for _, a := range cmd.Run {
 				ra := renderString(a, tmplCtx)
 				args = append(args, ra)
+			}
+			if maxConcurrency, ok, err := commandMaxConcurrency(cli, s, st, cmd, envOverrides, suiteMaxConcurrency); err != nil {
+				return fmt.Errorf("command %s maxConcurrency invalid: %w", cmdName, err)
+			} else if ok && !hasMaxConcurrencyArg(args) {
+				envOverrides = mergeEnvScopes(envOverrides, map[string]string{
+					maxConcurrencyEnvName: strconv.Itoa(maxConcurrency),
+				})
+				harness.Debugf("command %s using %s=%d", cmdName, maxConcurrencyEnvName, maxConcurrency)
 			}
 			var (
 				res harness.Result
@@ -1045,6 +1073,141 @@ func renderString(s string, data any) string {
 		}
 	}
 	return s
+}
+
+func suiteMaxConcurrencyForScenario(scenarioPath string) (*int, error) {
+	values, err := parseMaxConcurrencyValues(os.Getenv(maxConcurrencyValuesEnvName))
+	if err != nil {
+		return nil, err
+	}
+	if len(values) == 0 {
+		return nil, nil
+	}
+	key := stableScenarioKey(scenarioPath)
+	idx := stableIndex(key, len(values))
+	value := values[idx]
+	return &value, nil
+}
+
+func parseMaxConcurrencyValues(raw string) ([]int, error) {
+	clean := strings.TrimSpace(raw)
+	if clean == "" {
+		return nil, nil
+	}
+	parts := strings.Split(clean, ",")
+	values := make([]int, 0, len(parts))
+	for _, part := range parts {
+		token := strings.TrimSpace(part)
+		if token == "" {
+			return nil, fmt.Errorf("%s contains an empty value", maxConcurrencyValuesEnvName)
+		}
+		value, err := strconv.Atoi(token)
+		if err != nil {
+			return nil, fmt.Errorf("%s value %q is not an integer", maxConcurrencyValuesEnvName, token)
+		}
+		if err := validateMaxConcurrency(value); err != nil {
+			return nil, fmt.Errorf("%s value %q invalid: %w", maxConcurrencyValuesEnvName, token, err)
+		}
+		values = append(values, value)
+	}
+	return values, nil
+}
+
+func commandMaxConcurrency(
+	cli *harness.CLI,
+	sc Scenario,
+	st Step,
+	cmd Command,
+	env map[string]string,
+	suite *int,
+) (int, bool, error) {
+	value, ok, err := yamlMaxConcurrency(sc.Defaults.MaxConcurrency, st.MaxConcurrency, cmd.MaxConcurrency)
+	if err != nil {
+		return 0, false, err
+	}
+	if ok {
+		return value, true, nil
+	}
+	if suite == nil || maxConcurrencyEnvConfigured(cli, env) {
+		return 0, false, nil
+	}
+	return *suite, true, nil
+}
+
+func yamlMaxConcurrency(values ...*int) (int, bool, error) {
+	var (
+		selected int
+		ok       bool
+	)
+	for _, value := range values {
+		if value == nil {
+			continue
+		}
+		if err := validateMaxConcurrency(*value); err != nil {
+			return 0, false, err
+		}
+		selected = *value
+		ok = true
+	}
+	return selected, ok, nil
+}
+
+func validateMaxConcurrency(value int) error {
+	if value < executor.MinConcurrency || value > executor.MaxConcurrency {
+		return fmt.Errorf(
+			"must be between %d and %d (got %d)",
+			executor.MinConcurrency,
+			executor.MaxConcurrency,
+			value,
+		)
+	}
+	return nil
+}
+
+func maxConcurrencyEnvConfigured(cli *harness.CLI, env map[string]string) bool {
+	if strings.TrimSpace(env[maxConcurrencyEnvName]) != "" {
+		return true
+	}
+	if cli == nil {
+		return false
+	}
+	for _, kv := range cli.Env {
+		key, value, ok := strings.Cut(kv, "=")
+		if ok && key == maxConcurrencyEnvName && strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func hasMaxConcurrencyArg(args []string) bool {
+	for _, arg := range args {
+		if arg == "--max-concurrency" || strings.HasPrefix(arg, "--max-concurrency=") {
+			return true
+		}
+	}
+	return false
+}
+
+func stableScenarioKey(scenarioPath string) string {
+	root := repoRootFromScenario(scenarioPath)
+	abs, err := filepath.Abs(scenarioPath)
+	if err != nil {
+		abs = scenarioPath
+	}
+	if rel, err := filepath.Rel(root, abs); err == nil {
+		return filepath.ToSlash(rel)
+	}
+	return filepath.ToSlash(abs)
+}
+
+func stableIndex(key string, n int) int {
+	if n <= 0 {
+		return 0
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(key))
+	return int(h.Sum32() % uint32(n))
 }
 
 func effectiveRetry(d, s, c, a Retry) Retry {

--- a/test/e2e/harness/scenario/run_test.go
+++ b/test/e2e/harness/scenario/run_test.go
@@ -2,7 +2,16 @@
 
 package scenario
 
-import "testing"
+import (
+	"strconv"
+	"testing"
+
+	"github.com/kong/kongctl/test/e2e/harness"
+)
+
+func intPtr(v int) *int {
+	return &v
+}
 
 func TestMaybeRecordVarTemplatesResponsePath(t *testing.T) {
 	sc := &Scenario{
@@ -47,5 +56,150 @@ func TestRenderStringReplacesBin(t *testing.T) {
 	got := renderString("{{ .bin }} plan", tmplCtx)
 	if got != "/tmp/kongctl plan" {
 		t.Fatalf("renderString() = %q, want %q", got, "/tmp/kongctl plan")
+	}
+}
+
+func TestParseMaxConcurrencyValues(t *testing.T) {
+	got, err := parseMaxConcurrencyValues("1, 2,5")
+	if err != nil {
+		t.Fatalf("parseMaxConcurrencyValues() error = %v", err)
+	}
+	want := []int{1, 2, 5}
+	if len(got) != len(want) {
+		t.Fatalf("parseMaxConcurrencyValues() len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("parseMaxConcurrencyValues()[%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+}
+
+func TestParseMaxConcurrencyValuesRejectsInvalid(t *testing.T) {
+	for _, raw := range []string{"0", "201", "1,,2", "abc"} {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := parseMaxConcurrencyValues(raw); err == nil {
+				t.Fatalf("parseMaxConcurrencyValues(%q) expected error", raw)
+			}
+		})
+	}
+}
+
+func TestCommandMaxConcurrencyPrecedence(t *testing.T) {
+	suite := 2
+	cli := &harness.CLI{}
+	sc := Scenario{Defaults: Defaults{MaxConcurrency: intPtr(3)}}
+	st := Step{MaxConcurrency: intPtr(4)}
+	cmd := Command{MaxConcurrency: intPtr(6)}
+
+	got, ok, err := commandMaxConcurrency(cli, sc, st, cmd, nil, &suite)
+	if err != nil {
+		t.Fatalf("commandMaxConcurrency() error = %v", err)
+	}
+	if !ok || got != 6 {
+		t.Fatalf("commandMaxConcurrency() = (%d, %t), want (6, true)", got, ok)
+	}
+
+	cmd.MaxConcurrency = nil
+	got, ok, err = commandMaxConcurrency(cli, sc, st, cmd, nil, &suite)
+	if err != nil {
+		t.Fatalf("commandMaxConcurrency() error = %v", err)
+	}
+	if !ok || got != 4 {
+		t.Fatalf("commandMaxConcurrency() = (%d, %t), want (4, true)", got, ok)
+	}
+
+	st.MaxConcurrency = nil
+	got, ok, err = commandMaxConcurrency(cli, sc, st, cmd, nil, &suite)
+	if err != nil {
+		t.Fatalf("commandMaxConcurrency() error = %v", err)
+	}
+	if !ok || got != 3 {
+		t.Fatalf("commandMaxConcurrency() = (%d, %t), want (3, true)", got, ok)
+	}
+
+	sc.Defaults.MaxConcurrency = nil
+	got, ok, err = commandMaxConcurrency(cli, sc, st, cmd, nil, &suite)
+	if err != nil {
+		t.Fatalf("commandMaxConcurrency() error = %v", err)
+	}
+	if !ok || got != 2 {
+		t.Fatalf("commandMaxConcurrency() = (%d, %t), want (2, true)", got, ok)
+	}
+}
+
+func TestCommandMaxConcurrencyDoesNotOverrideConfiguredEnvWithSuiteValue(t *testing.T) {
+	suite := 2
+	cli := &harness.CLI{
+		Env: []string{maxConcurrencyEnvName + "=9"},
+	}
+
+	got, ok, err := commandMaxConcurrency(cli, Scenario{}, Step{}, Command{}, nil, &suite)
+	if err != nil {
+		t.Fatalf("commandMaxConcurrency() error = %v", err)
+	}
+	if ok {
+		t.Fatalf("commandMaxConcurrency() = (%d, %t), want no override", got, ok)
+	}
+
+	got, ok, err = commandMaxConcurrency(
+		&harness.CLI{},
+		Scenario{},
+		Step{},
+		Command{},
+		map[string]string{maxConcurrencyEnvName: "8"},
+		&suite,
+	)
+	if err != nil {
+		t.Fatalf("commandMaxConcurrency() with env override error = %v", err)
+	}
+	if ok {
+		t.Fatalf("commandMaxConcurrency() with env override = (%d, %t), want no override", got, ok)
+	}
+}
+
+func TestCommandMaxConcurrencyYAMLOverridesConfiguredEnv(t *testing.T) {
+	suite := 2
+	cli := &harness.CLI{
+		Env: []string{maxConcurrencyEnvName + "=9"},
+	}
+	cmd := Command{MaxConcurrency: intPtr(7)}
+
+	got, ok, err := commandMaxConcurrency(cli, Scenario{}, Step{}, cmd, nil, &suite)
+	if err != nil {
+		t.Fatalf("commandMaxConcurrency() error = %v", err)
+	}
+	if !ok || got != 7 {
+		t.Fatalf("commandMaxConcurrency() = (%d, %t), want (7, true)", got, ok)
+	}
+}
+
+func TestCommandMaxConcurrencyRejectsInvalidYAML(t *testing.T) {
+	for _, value := range []int{0, 201} {
+		t.Run(strconv.Itoa(value), func(t *testing.T) {
+			_, _, err := commandMaxConcurrency(
+				&harness.CLI{},
+				Scenario{Defaults: Defaults{MaxConcurrency: intPtr(value)}},
+				Step{},
+				Command{},
+				nil,
+				nil,
+			)
+			if err == nil {
+				t.Fatalf("commandMaxConcurrency() expected error for %d", value)
+			}
+		})
+	}
+}
+
+func TestStableIndexIsDeterministic(t *testing.T) {
+	key := "test/e2e/scenarios/portal/sync/scenario.yaml"
+	first := stableIndex(key, 4)
+	second := stableIndex(key, 4)
+	if first != second {
+		t.Fatalf("stableIndex() = %d then %d", first, second)
+	}
+	if first < 0 || first >= 4 {
+		t.Fatalf("stableIndex() = %d, want in [0,4)", first)
 	}
 }

--- a/test/e2e/harness/scenario/types.go
+++ b/test/e2e/harness/scenario/types.go
@@ -14,8 +14,9 @@ type Scenario struct {
 }
 
 type Defaults struct {
-	Retry Retry `yaml:"retry"`
-	Mask  Mask  `yaml:"mask"`
+	Retry          Retry `yaml:"retry"`
+	Mask           Mask  `yaml:"mask"`
+	MaxConcurrency *int  `yaml:"maxConcurrency"`
 }
 
 type ScenarioTest struct {
@@ -50,6 +51,7 @@ type Step struct {
 	Env                  map[string]string `yaml:"env"`
 	Mask                 Mask              `yaml:"mask"`
 	Retry                Retry             `yaml:"retry"`
+	MaxConcurrency       *int              `yaml:"maxConcurrency"`
 	Commands             []Command         `yaml:"commands"`
 }
 
@@ -61,25 +63,26 @@ type InlineOp struct {
 }
 
 type Command struct {
-	Name         string            `yaml:"name"`
-	Run          []string          `yaml:"run"`
-	Exec         []string          `yaml:"exec"`
-	Stdin        string            `yaml:"stdin"`
-	StdinFile    string            `yaml:"stdinFile"`
-	Env          map[string]string `yaml:"env"`
-	ResetOrg     bool              `yaml:"resetOrg"`
-	ResetRegions []string          `yaml:"resetOrgRegions"`
-	Workdir      string            `yaml:"workdir"`
-	Mask         Mask              `yaml:"mask"`
-	Retry        Retry             `yaml:"retry"`
-	Assertions   []Assertion       `yaml:"assertions"`
-	ExpectFail   *ExpectedFailure  `yaml:"expectFailure"`
-	Create       *CreateSpec       `yaml:"create"`
-	Delete       *DeleteSpec       `yaml:"delete"`
-	OutputFormat string            `yaml:"outputFormat"`
-	ParseAs      string            `yaml:"parseAs"`
-	StdoutFile   string            `yaml:"stdoutFile"`
-	RecordVar    *RecordVar        `yaml:"recordVar"`
+	Name           string            `yaml:"name"`
+	Run            []string          `yaml:"run"`
+	Exec           []string          `yaml:"exec"`
+	Stdin          string            `yaml:"stdin"`
+	StdinFile      string            `yaml:"stdinFile"`
+	Env            map[string]string `yaml:"env"`
+	ResetOrg       bool              `yaml:"resetOrg"`
+	ResetRegions   []string          `yaml:"resetOrgRegions"`
+	Workdir        string            `yaml:"workdir"`
+	Mask           Mask              `yaml:"mask"`
+	Retry          Retry             `yaml:"retry"`
+	Assertions     []Assertion       `yaml:"assertions"`
+	ExpectFail     *ExpectedFailure  `yaml:"expectFailure"`
+	Create         *CreateSpec       `yaml:"create"`
+	Delete         *DeleteSpec       `yaml:"delete"`
+	OutputFormat   string            `yaml:"outputFormat"`
+	MaxConcurrency *int              `yaml:"maxConcurrency"`
+	ParseAs        string            `yaml:"parseAs"`
+	StdoutFile     string            `yaml:"stdoutFile"`
+	RecordVar      *RecordVar        `yaml:"recordVar"`
 }
 
 type CreateSpec struct {

--- a/test/e2e/scenarios/all/scenario.yaml
+++ b/test/e2e/scenarios/all/scenario.yaml
@@ -408,7 +408,6 @@ steps:
     commands:
       - name: 000-delete-all
         outputFormat: json
-        maxConcurrency: 1
         run:
           - delete
           - -f

--- a/test/e2e/scenarios/all/scenario.yaml
+++ b/test/e2e/scenarios/all/scenario.yaml
@@ -408,12 +408,12 @@ steps:
     commands:
       - name: 000-delete-all
         outputFormat: json
+        maxConcurrency: 1
         run:
           - delete
           - -f
           - "{{ .workdir }}/config.yaml"
           - --auto-approve
-          - --max-concurrency=1
         assertions:
           - select: plan.metadata
             expect:

--- a/test/e2e/scenarios/control-plane/groups/scenario.yaml
+++ b/test/e2e/scenarios/control-plane/groups/scenario.yaml
@@ -45,12 +45,12 @@ steps:
   - name: 003-delete-cleanup
     commands:
       - name: 000-delete
+        maxConcurrency: 1
         run:
           - delete
           - -f
           - "{{ .workdir }}/control-plane.yaml"
           - --auto-approve
-          - --max-concurrency=1
         assertions:
           - select: "plan.metadata"
             expect:

--- a/test/e2e/scenarios/control-plane/sync-groups/scenario.yaml
+++ b/test/e2e/scenarios/control-plane/sync-groups/scenario.yaml
@@ -85,12 +85,12 @@ steps:
       - overlays/002-update-members
     commands:
       - name: 000-delete
+        maxConcurrency: 1
         run:
           - delete
           - -f
           - "{{ .workdir }}/control-plane.yaml"
           - --auto-approve
-          - --max-concurrency=1
         assertions:
           - select: "plan.metadata"
             expect:


### PR DESCRIPTION
## Summary

- add scenario-level `maxConcurrency` defaults, step overrides, and command overrides for declarative e2e operations
- add `KONGCTL_E2E_KONNECT_DECLARATIVE_MAX_CONCURRENCY` and suite sweep support via `KONGCTL_E2E_MAX_CONCURRENCY_VALUES`
- replace hard-coded `--max-concurrency=1` scenario args with YAML configuration
- make e2e test process timeouts explicit and configurable with `KONGCTL_E2E_TEST_TIMEOUT`, defaulting to `55m` locally and in CI

## Rationale

The CLI now supports standard config and environment configuration for declarative max concurrency. The e2e harness should use that path instead of embedding ad hoc flags in individual commands, while still allowing scenarios to pin sequential execution when ordering matters.

The previous e2e scenario invocation also inherited Go's default `10m` test timeout. Full scenario-suite runtime accumulates under a single `Test_Scenarios` process, so longer runs could fail based on total suite time rather than the active scenario.

## Validation

- `git diff --check`
- `go test -count=1 -tags=e2e ./test/e2e/harness/...`
- `go test -count=1 -tags=e2e ./test/e2e/... -run '^$'`
- `make -n test-e2e`
- `make -n test-e2e-scenarios`