### PR TITLE
Feat: Add declarative portal team group mappings

### DIFF
--- a/docs/examples/declarative/portal-idp/README.md
+++ b/docs/examples/declarative/portal-idp/README.md
@@ -1,7 +1,7 @@
 # Portal Identity Provider Example
 
 This example shows how to configure a Developer Portal OIDC identity provider
-in declarative mode.
+and IdP group-to-team mapping in declarative mode.
 
 The OIDC issuer URL, client ID, and client secret are loaded from environment
 variables with `!env` so they do not need to be stored in plaintext in the
@@ -29,13 +29,21 @@ Move provider-specific values such as `oidc_issuer`, `oidc_client_id`,
 `oidc_client_secret`, `oidc_scopes`, `oidc_claim_mappings`, and the SAML
 equivalents to `identity_providers` or `portal_identity_providers`.
 
+Team group mappings belong to the portal, but the preferred nested shape
+keeps them next to the team they target. Use
+`portals[].teams[].group_mappings` when declaring them with a portal, or
+`portal_team_group_mappings` at the root of a config. `kongctl` warns instead
+of failing when it cannot verify that an OIDC or SAML identity provider is
+enabled, so externally managed IdP state remains supported.
+
 If you apply an old configuration, `kongctl` now fails validation and tells
 you to move that configuration to `identity_providers`.
 
 ## Files
 
-- `portal-idp.yaml` - creates a portal and configures a nested OIDC identity
-  provider. The `config.issuer_url`, `config.client_id`, and
+- `portal-idp.yaml` - creates a portal, enables IdP team mapping, configures a
+  nested OIDC identity provider, creates a portal team, and maps an IdP group
+  to that team. The `config.issuer_url`, `config.client_id`, and
   `config.client_secret` fields use `!env`.
 
 ## Usage

--- a/docs/examples/declarative/portal-idp/portal-idp.yaml
+++ b/docs/examples/declarative/portal-idp/portal-idp.yaml
@@ -7,6 +7,9 @@ portals:
     name: portal-idp-example
     display_name: Portal Identity Provider Example
     description: Portal OIDC identity provider values loaded from !env
+    auth_settings:
+      ref: portal-idp-auth-settings
+      idp_mapping_enabled: true
     identity_providers:
       - ref: portal-oidc
         type: oidc
@@ -22,3 +25,10 @@ portals:
             name: name
             email: email
             groups: groups
+    teams:
+      - ref: service-developers
+        name: Service Developers
+        group_mappings:
+          - ref: service-developers-idp-groups
+            groups:
+              - Service Developer

--- a/internal/cmd/root/verbs/dump/declarative_children_test.go
+++ b/internal/cmd/root/verbs/dump/declarative_children_test.go
@@ -145,6 +145,23 @@ func (s *stubDumpPortalAuthSettingsAPI) GetPortalAuthenticationSettings(
 	}, nil
 }
 
+func (s *stubDumpPortalAuthSettingsAPI) ListPortalTeamGroupMappings(
+	context.Context,
+	kkOps.ListPortalTeamGroupMappingsRequest,
+	...kkOps.Option,
+) (*kkOps.ListPortalTeamGroupMappingsResponse, error) {
+	return &kkOps.ListPortalTeamGroupMappingsResponse{}, nil
+}
+
+func (s *stubDumpPortalAuthSettingsAPI) UpdatePortalTeamGroupMappings(
+	context.Context,
+	string,
+	*kkComps.PortalTeamGroupMappingsUpdateRequest,
+	...kkOps.Option,
+) (*kkOps.UpdatePortalTeamGroupMappingsResponse, error) {
+	return &kkOps.UpdatePortalTeamGroupMappingsResponse{}, nil
+}
+
 type stubDumpPortalIdentityProviderAPI struct {
 	listResponse *kkOps.GetPortalIdentityProvidersResponse
 	listErr      error

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -103,12 +103,13 @@ type Executor struct {
 	portalIPAllowListExecutor *BaseExecutor[
 		kkComps.CreatePortalSourceIPRestriction,
 		kkComps.UpdatePortalSourceIPRestriction]
-	portalPageExecutor            *BaseExecutor[kkComps.CreatePortalPageRequest, kkComps.UpdatePortalPageRequest]
-	portalSnippetExecutor         *BaseExecutor[kkComps.CreatePortalSnippetRequest, kkComps.UpdatePortalSnippetRequest]
-	portalTeamExecutor            *BaseExecutor[kkComps.PortalCreateTeamRequest, kkComps.PortalUpdateTeamRequest]
-	portalTeamRoleExecutor        *BaseExecutor[kkComps.PortalAssignRoleRequest, kkComps.PortalAssignRoleRequest]
-	portalEmailConfigExecutor     *BaseExecutor[kkComps.PostPortalEmailConfig, kkComps.PatchPortalEmailConfig]
-	portalAuditLogWebhookExecutor *BaseExecutor[
+	portalPageExecutor             *BaseExecutor[kkComps.CreatePortalPageRequest, kkComps.UpdatePortalPageRequest]
+	portalSnippetExecutor          *BaseExecutor[kkComps.CreatePortalSnippetRequest, kkComps.UpdatePortalSnippetRequest]
+	portalTeamExecutor             *BaseExecutor[kkComps.PortalCreateTeamRequest, kkComps.PortalUpdateTeamRequest]
+	portalTeamGroupMappingExecutor *PortalTeamGroupMappingExecutor
+	portalTeamRoleExecutor         *BaseExecutor[kkComps.PortalAssignRoleRequest, kkComps.PortalAssignRoleRequest]
+	portalEmailConfigExecutor      *BaseExecutor[kkComps.PostPortalEmailConfig, kkComps.PatchPortalEmailConfig]
+	portalAuditLogWebhookExecutor  *BaseExecutor[
 		kkComps.UpdatePortalAuditLogWebhook,
 		kkComps.UpdatePortalAuditLogWebhook]
 	portalEmailTemplateExecutor *BaseExecutor[kkOps.UpdatePortalCustomEmailTemplateRequest,
@@ -397,6 +398,7 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 		client,
 		dryRun,
 	)
+	e.portalTeamGroupMappingExecutor = NewPortalTeamGroupMappingExecutor(client, dryRun)
 	e.portalTeamRoleExecutor = NewBaseExecutor[kkComps.PortalAssignRoleRequest, kkComps.PortalAssignRoleRequest](
 		NewPortalTeamRoleAdapter(client),
 		client,
@@ -964,7 +966,8 @@ func (e *Executor) validateChangePreExecution(ctx context.Context, change planne
 			change.ResourceType != planner.ResourceTypePortalAuthSettings &&
 			change.ResourceType != planner.ResourceTypePortalIntegration &&
 			change.ResourceType != planner.ResourceTypePortalAssetLogo &&
-			change.ResourceType != planner.ResourceTypePortalAssetFavicon {
+			change.ResourceType != planner.ResourceTypePortalAssetFavicon &&
+			change.ResourceType != planner.ResourceTypePortalTeamGroupMapping {
 			return fmt.Errorf("resource ID required for %s operation", change.Action)
 		}
 
@@ -2845,6 +2848,33 @@ func (e *Executor) updateResource(ctx context.Context, change *planner.PlannedCh
 			change.References[planner.FieldPortalID] = portalRef
 		}
 		return e.portalTeamExecutor.Update(ctx, *change)
+	case planner.ResourceTypePortalTeamGroupMapping:
+		if portalRef, ok := change.References[planner.FieldPortalID]; ok && portalRef.ID == "" {
+			portalID, err := e.resolvePortalRef(ctx, portalRef)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve portal reference: %w", err)
+			}
+			portalRef.ID = portalID
+			change.References[planner.FieldPortalID] = portalRef
+		}
+		if teamRef, ok := change.References[planner.FieldTeamID]; ok && teamRef.ID == "" {
+			portalID := ""
+			if portalInfo, exists := change.References[planner.FieldPortalID]; exists {
+				portalID = portalInfo.ID
+			}
+			if portalID == "" && change.Parent != nil {
+				portalID = change.Parent.ID
+			}
+			teamID, err := e.resolvePortalTeamRef(ctx, portalID, teamRef)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve portal team reference: %w", err)
+			}
+			teamRef.ID = teamID
+			change.References[planner.FieldTeamID] = teamRef
+			change.Fields[planner.FieldTeamID] = teamID
+			change.ResourceID = teamID
+		}
+		return e.portalTeamGroupMappingExecutor.Update(ctx, *change)
 	case planner.ResourceTypeAPIVersion:
 		// First resolve API reference if needed
 		if apiRef, ok := change.References[planner.FieldAPIID]; ok && apiRef.ID == "" {

--- a/internal/declarative/executor/executor_test.go
+++ b/internal/declarative/executor/executor_test.go
@@ -99,6 +99,19 @@ func TestExecutor_NewWithOptions_ConcurrencyBounds(t *testing.T) {
 	}
 }
 
+func TestValidateChangePreExecutionAllowsPortalTeamGroupMappingWithoutResourceID(t *testing.T) {
+	exec := New(nil, nil, false)
+	change := planner.PlannedChange{
+		ResourceType: planner.ResourceTypePortalTeamGroupMapping,
+		ResourceRef:  "team-groups",
+		Action:       planner.ActionUpdate,
+	}
+
+	err := exec.validateChangePreExecution(context.Background(), change)
+
+	require.NoError(t, err)
+}
+
 func TestExecutor_Execute_EmptyPlan(t *testing.T) {
 	reporter := &MockProgressReporter{}
 

--- a/internal/declarative/executor/portal_team_group_mapping_adapter.go
+++ b/internal/declarative/executor/portal_team_group_mapping_adapter.go
@@ -1,0 +1,78 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/kong/kongctl/internal/declarative/state"
+)
+
+// PortalTeamGroupMappingExecutor updates portal team IdP group mappings.
+type PortalTeamGroupMappingExecutor struct {
+	client *state.Client
+	dryRun bool
+}
+
+// NewPortalTeamGroupMappingExecutor creates a portal team group mapping executor.
+func NewPortalTeamGroupMappingExecutor(client *state.Client, dryRun bool) *PortalTeamGroupMappingExecutor {
+	return &PortalTeamGroupMappingExecutor{client: client, dryRun: dryRun}
+}
+
+// Update applies a partial mapping update for one team.
+func (p *PortalTeamGroupMappingExecutor) Update(ctx context.Context, change planner.PlannedChange) (string, error) {
+	portalID, err := portalIDFromChange(change)
+	if err != nil {
+		return "", err
+	}
+
+	teamID, err := teamIDFromChange(change)
+	if err != nil {
+		return "", err
+	}
+
+	groups, ok := change.Fields[planner.FieldGroups].([]string)
+	if !ok {
+		rawGroups, ok := change.Fields[planner.FieldGroups].([]any)
+		if !ok {
+			return "", fmt.Errorf("groups is required")
+		}
+		groups = make([]string, 0, len(rawGroups))
+		for _, rawGroup := range rawGroups {
+			group, ok := rawGroup.(string)
+			if !ok {
+				return "", fmt.Errorf("groups must contain strings")
+			}
+			groups = append(groups, group)
+		}
+	}
+
+	if p.dryRun {
+		return teamID, nil
+	}
+
+	if err := p.client.UpdatePortalTeamGroupMapping(ctx, portalID, teamID, groups); err != nil {
+		return "", err
+	}
+	return teamID, nil
+}
+
+func portalIDFromChange(change planner.PlannedChange) (string, error) {
+	if ref, ok := change.References[planner.FieldPortalID]; ok && ref.ID != "" {
+		return ref.ID, nil
+	}
+	if change.Parent != nil && change.Parent.ID != "" {
+		return change.Parent.ID, nil
+	}
+	return "", fmt.Errorf("portal ID is required for portal team group mapping")
+}
+
+func teamIDFromChange(change planner.PlannedChange) (string, error) {
+	if teamID, ok := change.Fields[planner.FieldTeamID].(string); ok && teamID != "" {
+		return teamID, nil
+	}
+	if ref, ok := change.References[planner.FieldTeamID]; ok && ref.ID != "" {
+		return ref.ID, nil
+	}
+	return "", fmt.Errorf("team ID is required for portal team group mapping")
+}

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -1005,7 +1005,14 @@ func (l *Loader) extractNestedResources(rs *resources.ResourceSet) {
 				role.Team = team.Ref
 				rs.PortalTeamRoles = append(rs.PortalTeamRoles, role)
 			}
+			for k := range team.GroupMappings {
+				mapping := team.GroupMappings[k]
+				mapping.Portal = portal.Ref
+				mapping.Team = team.Ref
+				rs.PortalTeamGroupMappings = append(rs.PortalTeamGroupMappings, mapping)
+			}
 			team.Roles = nil
+			team.GroupMappings = nil
 			rs.PortalTeams = append(rs.PortalTeams, team)
 		}
 

--- a/internal/declarative/loader/loader_test.go
+++ b/internal/declarative/loader/loader_test.go
@@ -16,6 +16,65 @@ func TestNew(t *testing.T) {
 	assert.NotNil(t, loader)
 }
 
+func TestLoaderPortalTeamGroupMappingsNestedAndRoot(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(`
+portals:
+  - ref: portal-1
+    name: Portal 1
+    teams:
+      - ref: developers
+        name: Developers
+        group_mappings:
+          - ref: developers-idp-groups
+            groups:
+              - Service Developer
+portal_team_group_mappings:
+  - ref: admins-idp-groups
+    portal: portal-1
+    team: admins
+    groups: []
+`), 0o600)
+	require.NoError(t, err)
+
+	rs, err := New().LoadFile(path)
+	require.NoError(t, err)
+	require.Len(t, rs.PortalTeamGroupMappings, 2)
+
+	byRef := map[string]resources.PortalTeamGroupMappingResource{}
+	for _, mapping := range rs.PortalTeamGroupMappings {
+		byRef[mapping.Ref] = mapping
+	}
+
+	assert.Equal(t, "portal-1", byRef["developers-idp-groups"].Portal)
+	assert.Equal(t, "developers", byRef["developers-idp-groups"].Team)
+	assert.Equal(t, []string{"Service Developer"}, byRef["developers-idp-groups"].Groups)
+	assert.Equal(t, "portal-1", byRef["admins-idp-groups"].Portal)
+	assert.Equal(t, "admins", byRef["admins-idp-groups"].Team)
+	assert.Empty(t, byRef["admins-idp-groups"].Groups)
+}
+
+func TestLoaderPortalTeamGroupMappingsPortalLevelNestedRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(`
+portals:
+  - ref: portal-1
+    name: Portal 1
+    team_group_mappings:
+      - ref: developers-idp-groups
+        team: developers
+        groups:
+          - Service Developer
+`), 0o600)
+	require.NoError(t, err)
+
+	_, err = New().LoadFile(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown field 'team_group_mappings'")
+}
+
 func TestLoader_LoadFile_ValidConfigs(t *testing.T) {
 	tests := []struct {
 		name                  string

--- a/internal/declarative/loader/sync_scope.go
+++ b/internal/declarative/loader/sync_scope.go
@@ -91,6 +91,12 @@ var rootChildCollectionScopes = []childCollectionScope{
 		parentType:   resources.ResourceTypePortal,
 	},
 	{
+		key:          "portal_team_group_mappings",
+		resourceType: resources.ResourceTypePortalTeamGroupMapping,
+		parentKey:    "portal",
+		parentType:   resources.ResourceTypePortal,
+	},
+	{
 		key:          "portal_custom_domains",
 		resourceType: resources.ResourceTypePortalCustomDomain,
 		parentKey:    "portal",
@@ -466,6 +472,13 @@ func captureNestedPortalScopes(scope *resources.SyncScope, raw map[string]any) e
 					// Team role declarations are nested under teams, so a teams
 					// key scopes both the teams and their role assignments.
 					scope.AddChild(resources.ResourceTypePortal, portalRef, resources.ResourceTypePortalTeamRole)
+					if portalTeamsIncludeGroupMappings(portal[child.key]) {
+						scope.AddChild(
+							resources.ResourceTypePortal,
+							portalRef,
+							resources.ResourceTypePortalTeamGroupMapping,
+						)
+					}
 				}
 			}
 		}
@@ -501,6 +514,23 @@ func captureNestedPortalScopes(scope *resources.SyncScope, raw map[string]any) e
 		}
 	}
 	return nil
+}
+
+func portalTeamsIncludeGroupMappings(value any) bool {
+	teams, ok := asSlice(value)
+	if !ok {
+		return false
+	}
+	for _, item := range teams {
+		team, ok := asMap(item)
+		if !ok {
+			continue
+		}
+		if _, ok := team["group_mappings"]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func captureNestedEventGatewayScopes(scope *resources.SyncScope, raw map[string]any) {

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -1028,6 +1028,39 @@ func (l *Loader) validateSeparateAPIChildResources(rs *resources.ResourceSet) er
 		portalProviderTypes[provider.Portal][providerType] = provider.GetRef()
 	}
 
+	portalMappingRefs := make(map[string]bool)
+	portalTeamMappings := make(map[string]map[string]string)
+	for i := range rs.PortalTeamGroupMappings {
+		mapping := &rs.PortalTeamGroupMappings[i]
+		if err := mapping.Validate(); err != nil {
+			return fmt.Errorf("invalid portal_team_group_mapping %q: %w", mapping.GetRef(), err)
+		}
+		if mapping.Portal == "" {
+			return fmt.Errorf("portal_team_group_mapping %q must specify portal", mapping.GetRef())
+		}
+		if mapping.Team == "" {
+			return fmt.Errorf("portal_team_group_mapping %q must specify team", mapping.GetRef())
+		}
+		if portalMappingRefs[mapping.GetRef()] {
+			return fmt.Errorf("duplicate ref %s (already defined as portal_team_group_mapping)", mapping.GetRef())
+		}
+		portalMappingRefs[mapping.GetRef()] = true
+
+		if _, ok := portalTeamMappings[mapping.Portal]; !ok {
+			portalTeamMappings[mapping.Portal] = make(map[string]string)
+		}
+		if existingRef, ok := portalTeamMappings[mapping.Portal][mapping.Team]; ok {
+			return fmt.Errorf(
+				"multiple portal_team_group_mapping entries target portal %q and team %q (%s and %s)",
+				mapping.Portal,
+				mapping.Team,
+				existingRef,
+				mapping.GetRef(),
+			)
+		}
+		portalTeamMappings[mapping.Portal][mapping.Team] = mapping.GetRef()
+	}
+
 	// Validate portal custom domains
 	for i := range rs.PortalCustomDomains {
 		domain := &rs.PortalCustomDomains[i]

--- a/internal/declarative/planner/constants.go
+++ b/internal/declarative/planner/constants.go
@@ -136,6 +136,7 @@ const (
 	FieldLayout                       = "layout"
 	FieldLoginPath                    = "login_path"
 	FieldMenu                         = "menu"
+	FieldGroups                       = "groups"
 	FieldNPA                          = "npa"
 	FieldPreview                      = "preview"
 	FieldReplyToEmail                 = "reply_to_email"
@@ -192,6 +193,7 @@ const (
 	ResourceTypePortalIPAllowList          = string(resources.ResourceTypePortalIPAllowList)
 	ResourceTypePortalIntegration          = string(resources.ResourceTypePortalIntegration)
 	ResourceTypePortalIdentityProvider     = string(resources.ResourceTypePortalIdentityProvider)
+	ResourceTypePortalTeamGroupMapping     = string(resources.ResourceTypePortalTeamGroupMapping)
 	ResourceTypePortalPage                 = string(resources.ResourceTypePortalPage)
 	ResourceTypePortalSnippet              = string(resources.ResourceTypePortalSnippet)
 	ResourceTypePortalTeam                 = string(resources.ResourceTypePortalTeam)

--- a/internal/declarative/planner/planner.go
+++ b/internal/declarative/planner/planner.go
@@ -91,6 +91,7 @@ type Planner struct {
 	desiredPortalIPAllowLists      []resources.PortalIPAllowListResource
 	desiredPortalIntegrations      []resources.PortalIntegrationResource
 	desiredPortalIdentityProviders []resources.PortalIdentityProviderResource
+	desiredPortalTeamGroupMappings []resources.PortalTeamGroupMappingResource
 	desiredPortalCustomDomains     []resources.PortalCustomDomainResource
 	desiredPortalAssetLogos        []resources.PortalAssetLogoResource
 	desiredPortalAssetFavicons     []resources.PortalAssetFaviconResource
@@ -246,6 +247,7 @@ func (p *Planner) GeneratePlan(ctx context.Context, rs *resources.ResourceSet, o
 		namespacePlanner.desiredPortalIPAllowLists = rs.PortalIPAllowLists
 		namespacePlanner.desiredPortalIntegrations = rs.PortalIntegrations
 		namespacePlanner.desiredPortalIdentityProviders = rs.PortalIdentityProviders
+		namespacePlanner.desiredPortalTeamGroupMappings = rs.PortalTeamGroupMappings
 		namespacePlanner.desiredPortalCustomDomains = rs.PortalCustomDomains
 		namespacePlanner.desiredPortalAssetLogos = rs.PortalAssetLogos
 		namespacePlanner.desiredPortalAssetFavicons = rs.PortalAssetFavicons

--- a/internal/declarative/planner/portal_child_planner.go
+++ b/internal/declarative/planner/portal_child_planner.go
@@ -162,6 +162,10 @@ func (p *Planner) planPortalAuthSettingsUpdateWithFields(
 			}
 		}
 	}
+	if value, ok := fields[FieldIDPMappingEnabled].(bool); ok && value {
+		dependencies = append(dependencies, findEnabledPortalIdentityProviderDependencies(plan, settings.Portal)...)
+	}
+	dependencies = compactStrings(dependencies)
 
 	change := PlannedChange{
 		ID:            p.nextChangeID(ActionUpdate, ResourceTypePortalAuthSettings, settings.Ref),
@@ -4225,6 +4229,296 @@ func (p *Planner) planPortalTeamCreate(
 			slog.String("team_ref", team.GetRef()),
 			slog.String("portal_ref", team.Portal))
 	}
+}
+
+// Portal Team Group Mapping planning
+
+func (p *Planner) planPortalTeamGroupMappingsChanges(
+	ctx context.Context,
+	parentNamespace string,
+	portalID string,
+	portalRef string,
+	desired []resources.PortalTeamGroupMappingResource,
+	plan *Plan,
+) error {
+	if len(desired) == 0 {
+		return nil
+	}
+
+	existingTeamsByName := make(map[string]state.PortalTeam)
+	if portalID != "" {
+		teams, err := p.listPortalTeams(ctx, portalID)
+		if err != nil {
+			return fmt.Errorf("failed to list existing portal teams for portal %s: %w", portalID, err)
+		}
+		for _, team := range teams {
+			existingTeamsByName[team.Name] = team
+		}
+	}
+
+	existingMappings := make(map[string]state.PortalTeamGroupMapping)
+	if portalID != "" {
+		mappings, err := p.listPortalTeamGroupMappings(ctx, portalID)
+		if err != nil {
+			if state.IsAPIClientError(err) {
+				return nil
+			}
+			p.logger.Debug("Unable to verify portal team group mappings; planning updates",
+				slog.String("portal_ref", portalRef),
+				slog.Any("error", err))
+		}
+		for _, mapping := range mappings {
+			existingMappings[mapping.TeamID] = mapping
+		}
+	}
+
+	for _, mapping := range desired {
+		if plan.HasChange(ResourceTypePortalTeamGroupMapping, mapping.GetRef()) {
+			continue
+		}
+
+		teamID, teamName := p.resolvePortalTeamForMapping(mapping, portalRef, existingTeamsByName)
+		current, hasCurrent := existingMappings[teamID]
+		if teamID == "" {
+			hasCurrent = false
+		}
+
+		if hasCurrent && sameStringSet(current.Groups, mapping.Groups) {
+			continue
+		}
+
+		changedFields := map[string]FieldChange{
+			FieldGroups: {
+				Old: nil,
+				New: cloneStringSlicePreserveEmpty(mapping.Groups),
+			},
+		}
+		if hasCurrent {
+			changedFields[FieldGroups] = FieldChange{
+				Old: cloneStringSlicePreserveEmpty(current.Groups),
+				New: cloneStringSlicePreserveEmpty(mapping.Groups),
+			}
+		}
+
+		p.planPortalTeamGroupMappingUpdate(
+			ctx,
+			parentNamespace,
+			portalID,
+			portalRef,
+			teamID,
+			teamName,
+			mapping,
+			changedFields,
+			plan,
+		)
+	}
+
+	return nil
+}
+
+func (p *Planner) resolvePortalTeamForMapping(
+	mapping resources.PortalTeamGroupMappingResource,
+	portalRef string,
+	existingTeamsByName map[string]state.PortalTeam,
+) (string, string) {
+	for _, team := range p.desiredPortalTeams {
+		if team.Portal == portalRef && team.Ref == mapping.Team {
+			if existing, ok := existingTeamsByName[team.Name]; ok {
+				return existing.ID, team.Name
+			}
+			return "", team.Name
+		}
+	}
+	if existing, ok := existingTeamsByName[mapping.Team]; ok {
+		return existing.ID, existing.Name
+	}
+	return "", mapping.Team
+}
+
+func (p *Planner) planPortalTeamGroupMappingUpdate(
+	ctx context.Context,
+	parentNamespace string,
+	portalID string,
+	portalRef string,
+	teamID string,
+	teamName string,
+	mapping resources.PortalTeamGroupMappingResource,
+	changedFields map[string]FieldChange,
+	plan *Plan,
+) {
+	fields := map[string]any{
+		FieldGroups: cloneStringSlicePreserveEmpty(mapping.Groups),
+	}
+	if teamID != "" {
+		fields[FieldTeamID] = teamID
+	}
+
+	dependencies := findPortalTeamGroupMappingDependencies(plan, portalRef, mapping.Team)
+	references := make(map[string]ReferenceInfo)
+	if portalRef != "" {
+		references[FieldPortalID] = ReferenceInfo{
+			Ref:          portalRef,
+			ID:           portalID,
+			LookupFields: map[string]string{FieldName: p.portalLookupName(portalRef)},
+		}
+	}
+	references[FieldTeamID] = ReferenceInfo{
+		Ref:          mapping.Team,
+		ID:           teamID,
+		LookupFields: map[string]string{FieldName: teamName},
+	}
+
+	change := PlannedChange{
+		ID:            p.nextChangeID(ActionUpdate, ResourceTypePortalTeamGroupMapping, mapping.GetRef()),
+		ResourceType:  ResourceTypePortalTeamGroupMapping,
+		ResourceRef:   mapping.GetRef(),
+		ResourceID:    teamID,
+		Action:        ActionUpdate,
+		Fields:        fields,
+		ChangedFields: changedFields,
+		References:    references,
+		DependsOn:     dependencies,
+		Namespace:     parentNamespace,
+	}
+	if portalRef != "" {
+		change.Parent = &ParentInfo{Ref: portalRef, ID: portalID}
+	}
+
+	plan.AddChange(change)
+	p.addPortalTeamGroupMappingIDPWarning(ctx, portalID, portalRef, change.ID, plan)
+}
+
+func findPortalTeamGroupMappingDependencies(plan *Plan, portalRef string, teamRef string) []string {
+	var dependencies []string
+	if portalRef != "" {
+		dependencies = append(dependencies, findChangeID(plan, ResourceTypePortal, portalRef))
+	}
+	dependencies = append(dependencies, findChangeID(plan, ResourceTypePortalTeam, teamRef))
+	for _, change := range plan.Changes {
+		switch change.ResourceType {
+		case ResourceTypePortalIdentityProvider:
+		case ResourceTypePortalAuthSettings:
+		default:
+			continue
+		}
+		if change.Parent != nil && change.Parent.Ref == portalRef {
+			dependencies = append(dependencies, change.ID)
+			continue
+		}
+		if ref, ok := change.References[FieldPortalID]; ok && ref.Ref == portalRef {
+			dependencies = append(dependencies, change.ID)
+		}
+	}
+	return compactStrings(dependencies)
+}
+
+func findEnabledPortalIdentityProviderDependencies(plan *Plan, portalRef string) []string {
+	var dependencies []string
+	for _, change := range plan.Changes {
+		if change.ResourceType != ResourceTypePortalIdentityProvider {
+			continue
+		}
+		enabled, ok := change.Fields[FieldEnabled].(bool)
+		if !ok || !enabled {
+			continue
+		}
+		if providerType, ok := change.Fields[FieldType].(string); ok &&
+			providerType != string(kkComps.IdentityProviderTypeOidc) &&
+			providerType != string(kkComps.IdentityProviderTypeSaml) {
+			continue
+		}
+		if change.Parent != nil && change.Parent.Ref == portalRef {
+			dependencies = append(dependencies, change.ID)
+			continue
+		}
+		if ref, ok := change.References[FieldPortalID]; ok && ref.Ref == portalRef {
+			dependencies = append(dependencies, change.ID)
+		}
+	}
+	return compactStrings(dependencies)
+}
+
+func (p *Planner) addPortalTeamGroupMappingIDPWarning(
+	ctx context.Context,
+	portalID string,
+	portalRef string,
+	changeID string,
+	plan *Plan,
+) {
+	for _, provider := range p.desiredPortalIdentityProviders {
+		if provider.Portal != portalRef || provider.Enabled == nil || !*provider.Enabled || provider.Type == nil {
+			continue
+		}
+		if *provider.Type == kkComps.IdentityProviderTypeOidc || *provider.Type == kkComps.IdentityProviderTypeSaml {
+			return
+		}
+	}
+
+	if portalID != "" {
+		providers, err := p.listPortalIdentityProviders(ctx, portalID)
+		if err == nil {
+			for _, provider := range providers {
+				if provider.Enabled == nil || !*provider.Enabled {
+					continue
+				}
+				if provider.Type == kkComps.IdentityProviderTypeOidc || provider.Type == kkComps.IdentityProviderTypeSaml {
+					return
+				}
+			}
+		}
+	}
+
+	plan.AddWarning(
+		changeID,
+		fmt.Sprintf(
+			"portal_team_group_mapping for portal %q may be rejected by Konnect unless an OIDC or SAML "+
+				"identity provider is configured and enabled",
+			portalRef,
+		),
+	)
+}
+
+func (p *Planner) portalLookupName(portalRef string) string {
+	for _, portal := range p.desiredPortals {
+		if portal.Ref == portalRef {
+			return portal.Name
+		}
+	}
+	return portalRef
+}
+
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	left := append([]string(nil), a...)
+	right := append([]string(nil), b...)
+	slices.Sort(left)
+	slices.Sort(right)
+	return slices.Equal(left, right)
+}
+
+func cloneStringSlicePreserveEmpty(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	return append([]string{}, values...)
+}
+
+func compactStrings(values []string) []string {
+	compacted := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		compacted = append(compacted, value)
+	}
+	return compacted
 }
 
 func (p *Planner) shouldUpdatePortalTeam(

--- a/internal/declarative/planner/portal_child_test.go
+++ b/internal/declarative/planner/portal_child_test.go
@@ -156,6 +156,134 @@ func TestGeneratePlan_PortalCustomDomain(t *testing.T) {
 	assert.Contains(t, customDomainChange.DependsOn, "1:c:portal:dev-portal")
 }
 
+func TestFindPortalTeamGroupMappingDependenciesIncludesAuthSettings(t *testing.T) {
+	plan := &Plan{Changes: []PlannedChange{
+		{ID: "portal", ResourceType: ResourceTypePortal, ResourceRef: "portal-1"},
+		{ID: "team", ResourceType: ResourceTypePortalTeam, ResourceRef: "team-1"},
+		{
+			ID:           "provider",
+			ResourceType: ResourceTypePortalIdentityProvider,
+			ResourceRef:  "oidc",
+			Fields: map[string]any{
+				FieldEnabled: true,
+				FieldType:    string(kkComps.IdentityProviderTypeOidc),
+			},
+			References: map[string]ReferenceInfo{
+				FieldPortalID: {Ref: "portal-1"},
+			},
+		},
+		{
+			ID:           "auth-settings",
+			ResourceType: ResourceTypePortalAuthSettings,
+			ResourceRef:  "auth",
+			References: map[string]ReferenceInfo{
+				FieldPortalID: {Ref: "portal-1"},
+			},
+		},
+	}}
+
+	dependencies := findPortalTeamGroupMappingDependencies(plan, "portal-1", "team-1")
+
+	assert.ElementsMatch(t, []string{"portal", "team", "provider", "auth-settings"}, dependencies)
+}
+
+func TestFindEnabledPortalIdentityProviderDependencies(t *testing.T) {
+	plan := &Plan{Changes: []PlannedChange{
+		{
+			ID:           "enabled-oidc",
+			ResourceType: ResourceTypePortalIdentityProvider,
+			Fields: map[string]any{
+				FieldEnabled: true,
+				FieldType:    string(kkComps.IdentityProviderTypeOidc),
+			},
+			References: map[string]ReferenceInfo{
+				FieldPortalID: {Ref: "portal-1"},
+			},
+		},
+		{
+			ID:           "disabled-saml",
+			ResourceType: ResourceTypePortalIdentityProvider,
+			Fields: map[string]any{
+				FieldEnabled: false,
+				FieldType:    string(kkComps.IdentityProviderTypeSaml),
+			},
+			References: map[string]ReferenceInfo{
+				FieldPortalID: {Ref: "portal-1"},
+			},
+		},
+		{
+			ID:           "enabled-other-portal",
+			ResourceType: ResourceTypePortalIdentityProvider,
+			Fields: map[string]any{
+				FieldEnabled: true,
+				FieldType:    string(kkComps.IdentityProviderTypeOidc),
+			},
+			References: map[string]ReferenceInfo{
+				FieldPortalID: {Ref: "portal-2"},
+			},
+		},
+	}}
+
+	dependencies := findEnabledPortalIdentityProviderDependencies(plan, "portal-1")
+
+	assert.Equal(t, []string{"enabled-oidc"}, dependencies)
+}
+
+func TestPlanPortalTeamGroupMappingUpdatePreservesEmptyGroups(t *testing.T) {
+	planner := NewPlanner(nil, slog.Default())
+	plan := &Plan{}
+	mapping := resources.PortalTeamGroupMappingResource{
+		Ref:    "developers-groups",
+		Portal: "portal-1",
+		Team:   "developers",
+		Groups: []string{},
+	}
+
+	planner.planPortalTeamGroupMappingUpdate(
+		context.Background(),
+		"default",
+		"",
+		"portal-1",
+		"team-id",
+		"Developers",
+		mapping,
+		map[string]FieldChange{FieldGroups: {Old: []string{"old"}, New: []string{}}},
+		plan,
+	)
+
+	require.Len(t, plan.Changes, 1)
+	require.IsType(t, []string{}, plan.Changes[0].Fields[FieldGroups])
+	assert.Empty(t, plan.Changes[0].Fields[FieldGroups])
+	assert.NotNil(t, plan.Changes[0].Fields[FieldGroups])
+	assert.Equal(t, []string{}, plan.Changes[0].ChangedFields[FieldGroups].New)
+}
+
+func TestPlanPortalTeamGroupMappingsSkipsUnconfiguredPortalAuthSettingsAPI(t *testing.T) {
+	client := state.NewClient(state.ClientConfig{})
+	planner := NewPlanner(client, slog.Default())
+	planner.resourceCache.portalTeamsByPortalID["portal-id"] = []state.PortalTeam{
+		{ID: "team-id", Name: "Developers"},
+	}
+	plan := &Plan{}
+
+	err := planner.planPortalTeamGroupMappingsChanges(
+		context.Background(),
+		"default",
+		"portal-id",
+		"portal-1",
+		[]resources.PortalTeamGroupMappingResource{{
+			Ref:    "developers-groups",
+			Portal: "portal-1",
+			Team:   "Developers",
+			Groups: []string{"Developers"},
+		}},
+		plan,
+	)
+
+	require.NoError(t, err)
+	assert.Empty(t, plan.Changes)
+}
+
 func buildPortalCustomDomain(
 	host string,
 	enabled bool,

--- a/internal/declarative/planner/portal_planner.go
+++ b/internal/declarative/planner/portal_planner.go
@@ -820,21 +820,6 @@ func (p *portalPlannerImpl) planPortalChildResourcesCreate(
 		}
 	}
 
-	// Plan auth settings
-	settings := make([]resources.PortalAuthSettingsResource, 0)
-	for _, auth := range planner.desiredPortalAuthSettings {
-		if auth.Portal == desired.Ref {
-			settings = append(settings, auth)
-		}
-	}
-	if childInScope(resources.ResourceTypePortalAuthSettings) {
-		if err := planner.planPortalAuthSettingsChanges(ctx, plannerCtx, parentNamespace, settings, plan); err != nil {
-			planner.logger.Debug("Failed to plan portal auth settings for new portal",
-				"portal", desired.Ref,
-				"error", err.Error())
-		}
-	}
-
 	// Plan IP allow list
 	allowLists := make([]resources.PortalIPAllowListResource, 0)
 	for _, allowList := range planner.desiredPortalIPAllowLists {
@@ -884,6 +869,21 @@ func (p *portalPlannerImpl) planPortalChildResourcesCreate(
 			plan,
 		); err != nil {
 			planner.logger.Debug("Failed to plan portal identity providers for new portal",
+				"portal", desired.Ref,
+				"error", err.Error())
+		}
+	}
+
+	// Plan auth settings after identity providers so idp_mapping_enabled can depend on provider enablement.
+	settings := make([]resources.PortalAuthSettingsResource, 0)
+	for _, auth := range planner.desiredPortalAuthSettings {
+		if auth.Portal == desired.Ref {
+			settings = append(settings, auth)
+		}
+	}
+	if childInScope(resources.ResourceTypePortalAuthSettings) {
+		if err := planner.planPortalAuthSettingsChanges(ctx, plannerCtx, parentNamespace, settings, plan); err != nil {
+			planner.logger.Debug("Failed to plan portal auth settings for new portal",
 				"portal", desired.Ref,
 				"error", err.Error())
 		}
@@ -967,6 +967,22 @@ func (p *portalPlannerImpl) planPortalChildResourcesCreate(
 	if childInScope(resources.ResourceTypePortalTeam) {
 		if err := planner.planPortalTeamsChanges(ctx, parentNamespace, "", desired.Ref, teams, plan); err != nil {
 			planner.logger.Debug("Failed to plan portal teams for new portal",
+				"portal", desired.Ref,
+				"error", err.Error())
+		}
+	}
+
+	mappings := make([]resources.PortalTeamGroupMappingResource, 0)
+	for _, mapping := range planner.desiredPortalTeamGroupMappings {
+		if mapping.Portal == desired.Ref {
+			mappings = append(mappings, mapping)
+		}
+	}
+	if childInScope(resources.ResourceTypePortalTeamGroupMapping) {
+		if err := planner.planPortalTeamGroupMappingsChanges(
+			ctx, parentNamespace, "", desired.Ref, mappings, plan,
+		); err != nil {
+			planner.logger.Debug("Failed to plan portal team group mappings for new portal",
 				"portal", desired.Ref,
 				"error", err.Error())
 		}
@@ -1108,19 +1124,6 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 		}
 	}
 
-	// Plan auth settings (singleton)
-	authSettings := make([]resources.PortalAuthSettingsResource, 0)
-	for _, auth := range planner.desiredPortalAuthSettings {
-		if auth.Portal == desired.Ref {
-			authSettings = append(authSettings, auth)
-		}
-	}
-	if childInScope(resources.ResourceTypePortalAuthSettings) {
-		if err := planner.planPortalAuthSettingsChanges(ctx, plannerCtx, parentNamespace, authSettings, plan); err != nil {
-			return fmt.Errorf("failed to plan portal auth settings changes: %w", err)
-		}
-	}
-
 	// Plan IP allow list (singleton)
 	allowLists := make([]resources.PortalIPAllowListResource, 0)
 	for _, allowList := range planner.desiredPortalIPAllowLists {
@@ -1168,6 +1171,19 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			plan,
 		); err != nil {
 			return fmt.Errorf("failed to plan portal identity provider changes: %w", err)
+		}
+	}
+
+	// Plan auth settings after identity providers so idp_mapping_enabled can depend on provider enablement.
+	authSettings := make([]resources.PortalAuthSettingsResource, 0)
+	for _, auth := range planner.desiredPortalAuthSettings {
+		if auth.Portal == desired.Ref {
+			authSettings = append(authSettings, auth)
+		}
+	}
+	if childInScope(resources.ResourceTypePortalAuthSettings) {
+		if err := planner.planPortalAuthSettingsChanges(ctx, plannerCtx, parentNamespace, authSettings, plan); err != nil {
+			return fmt.Errorf("failed to plan portal auth settings changes: %w", err)
 		}
 	}
 
@@ -1243,6 +1259,20 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			ctx, parentNamespace, current.ID, desired.Ref, teams, plan,
 		); err != nil {
 			return fmt.Errorf("failed to plan portal team changes: %w", err)
+		}
+	}
+
+	mappings := make([]resources.PortalTeamGroupMappingResource, 0)
+	for _, mapping := range planner.desiredPortalTeamGroupMappings {
+		if mapping.Portal == desired.Ref {
+			mappings = append(mappings, mapping)
+		}
+	}
+	if childInScope(resources.ResourceTypePortalTeamGroupMapping) {
+		if err := planner.planPortalTeamGroupMappingsChanges(
+			ctx, parentNamespace, current.ID, desired.Ref, mappings, plan,
+		); err != nil {
+			return fmt.Errorf("failed to plan portal team group mapping changes: %w", err)
 		}
 	}
 

--- a/internal/declarative/planner/resource_cache.go
+++ b/internal/declarative/planner/resource_cache.go
@@ -43,6 +43,7 @@ type planningResourceCache struct {
 
 	portalTeamsByPortalID             map[string][]state.PortalTeam
 	portalIdentityProvidersByPortalID map[string][]state.PortalIdentityProvider
+	portalTeamGroupMappingsByPortalID map[string][]state.PortalTeamGroupMapping
 }
 
 func newPlanningResourceCache() *planningResourceCache {
@@ -57,6 +58,7 @@ func newPlanningResourceCache() *planningResourceCache {
 		managedOrganizationTeamsByKey:         make(map[string][]state.OrganizationTeam),
 		portalTeamsByPortalID:                 make(map[string][]state.PortalTeam),
 		portalIdentityProvidersByPortalID:     make(map[string][]state.PortalIdentityProvider),
+		portalTeamGroupMappingsByPortalID:     make(map[string][]state.PortalTeamGroupMapping),
 	}
 }
 
@@ -527,6 +529,33 @@ func (p *Planner) listPortalIdentityProviders(
 	}
 
 	return providers, nil
+}
+
+func (p *Planner) listPortalTeamGroupMappings(
+	ctx context.Context,
+	portalID string,
+) ([]state.PortalTeamGroupMapping, error) {
+	if portalID == "" {
+		return []state.PortalTeamGroupMapping{}, nil
+	}
+
+	cache := p.resourceCache
+	if cache != nil {
+		if cached, ok := cache.portalTeamGroupMappingsByPortalID[portalID]; ok {
+			return cached, nil
+		}
+	}
+
+	mappings, err := p.client.ListPortalTeamGroupMappings(ctx, portalID)
+	if err != nil {
+		return nil, err
+	}
+
+	if cache != nil {
+		cache.portalTeamGroupMappingsByPortalID[portalID] = mappings
+	}
+
+	return mappings, nil
 }
 
 func normalizeNamespaces(namespaces []string) []string {

--- a/internal/declarative/planner/sync_scope.go
+++ b/internal/declarative/planner/sync_scope.go
@@ -109,6 +109,9 @@ func addPortalChildScopes(scope *resources.SyncScope, rs *resources.ResourceSet)
 	for _, child := range rs.PortalIdentityProviders {
 		scope.AddChild(resources.ResourceTypePortal, child.Portal, resources.ResourceTypePortalIdentityProvider)
 	}
+	for _, child := range rs.PortalTeamGroupMappings {
+		scope.AddChild(resources.ResourceTypePortal, child.Portal, resources.ResourceTypePortalTeamGroupMapping)
+	}
 	for _, child := range rs.PortalCustomDomains {
 		scope.AddChild(resources.ResourceTypePortal, child.Portal, resources.ResourceTypePortalCustomDomain)
 	}

--- a/internal/declarative/protection/lookup.go
+++ b/internal/declarative/protection/lookup.go
@@ -115,6 +115,7 @@ func IsManagedResourceProtected(
 		resources.ResourceTypePortalIPAllowList,
 		resources.ResourceTypePortalIntegration,
 		resources.ResourceTypePortalIdentityProvider,
+		resources.ResourceTypePortalTeamGroupMapping,
 		resources.ResourceTypePortalPage,
 		resources.ResourceTypePortalSnippet,
 		resources.ResourceTypePortalTeam,

--- a/internal/declarative/resources/portal_team.go
+++ b/internal/declarative/resources/portal_team.go
@@ -23,7 +23,8 @@ type PortalTeamResource struct {
 	Portal string `yaml:"portal,omitempty" json:"portal,omitempty"`
 
 	// Child resources
-	Roles []PortalTeamRoleResource `yaml:"roles,omitempty" json:"roles,omitempty"`
+	Roles         []PortalTeamRoleResource         `yaml:"roles,omitempty"          json:"roles,omitempty"`
+	GroupMappings []PortalTeamGroupMappingResource `yaml:"group_mappings,omitempty" json:"group_mappings,omitempty"`
 
 	// Resolved Konnect ID (not serialized)
 	konnectID string `yaml:"-" json:"-"`
@@ -41,9 +42,10 @@ func (p PortalTeamResource) MarshalYAML() (any, error) {
 
 type portalTeamAlias struct {
 	portalCreateTeamAlias `                       json:",inline"          yaml:",inline"`
-	Ref                   string                   `json:"ref"              yaml:"ref"`
-	Portal                string                   `json:"portal,omitempty" yaml:"portal,omitempty"`
-	Roles                 []PortalTeamRoleResource `json:"roles,omitempty"  yaml:"roles,omitempty"`
+	Ref                   string                           `json:"ref"              yaml:"ref"`
+	Portal                string                           `json:"portal,omitempty" yaml:"portal,omitempty"`
+	Roles                 []PortalTeamRoleResource         `json:"roles,omitempty"  yaml:"roles,omitempty"`
+	GroupMappings         []PortalTeamGroupMappingResource `json:"group_mappings,omitempty" yaml:"group_mappings,omitempty"` //nolint:lll
 }
 
 type portalCreateTeamAlias kkComps.PortalCreateTeamRequest
@@ -54,6 +56,7 @@ func (p PortalTeamResource) portalTeamAlias() portalTeamAlias {
 		Ref:                   p.Ref,
 		Portal:                p.Portal,
 		Roles:                 p.Roles,
+		GroupMappings:         p.GroupMappings,
 	}
 }
 
@@ -105,6 +108,17 @@ func (p PortalTeamResource) Validate() error {
 		roleRefs[role.GetRef()] = true
 	}
 
+	mappingRefs := make(map[string]bool)
+	for i, mapping := range p.GroupMappings {
+		if err := mapping.Validate(); err != nil {
+			return fmt.Errorf("invalid team group mapping %d: %w", i, err)
+		}
+		if mappingRefs[mapping.GetRef()] {
+			return fmt.Errorf("duplicate team group mapping ref: %s", mapping.GetRef())
+		}
+		mappingRefs[mapping.GetRef()] = true
+	}
+
 	return nil
 }
 
@@ -113,6 +127,9 @@ func (p *PortalTeamResource) SetDefaults() {
 	// No defaults to apply for portal teams
 	for i := range p.Roles {
 		p.Roles[i].SetDefaults()
+	}
+	for i := range p.GroupMappings {
+		p.GroupMappings[i].SetDefaults()
 	}
 }
 
@@ -151,13 +168,14 @@ func (p PortalTeamResource) GetParentRef() *ResourceRef {
 // UnmarshalJSON custom unmarshaling to reject kongctl metadata on child resources
 func (p *PortalTeamResource) UnmarshalJSON(data []byte) error {
 	var temp struct {
-		Ref                string                   `json:"ref"`
-		Portal             string                   `json:"portal,omitempty"`
-		Name               string                   `json:"name"`
-		Description        *string                  `json:"description,omitempty"`
-		CanOwnApplications *bool                    `json:"can_own_applications"`
-		Roles              []PortalTeamRoleResource `json:"roles,omitempty"`
-		Kongctl            any                      `json:"kongctl,omitempty"`
+		Ref                string                           `json:"ref"`
+		Portal             string                           `json:"portal,omitempty"`
+		Name               string                           `json:"name"`
+		Description        *string                          `json:"description,omitempty"`
+		CanOwnApplications *bool                            `json:"can_own_applications"`
+		Roles              []PortalTeamRoleResource         `json:"roles,omitempty"`
+		GroupMappings      []PortalTeamGroupMappingResource `json:"group_mappings,omitempty"`
+		Kongctl            any                              `json:"kongctl,omitempty"`
 	}
 
 	if err := json.Unmarshal(data, &temp); err != nil {
@@ -174,6 +192,7 @@ func (p *PortalTeamResource) UnmarshalJSON(data []byte) error {
 	p.Description = temp.Description
 	p.CanOwnApplications = temp.CanOwnApplications
 	p.Roles = temp.Roles
+	p.GroupMappings = temp.GroupMappings
 
 	return nil
 }

--- a/internal/declarative/resources/portal_team_group_mapping.go
+++ b/internal/declarative/resources/portal_team_group_mapping.go
@@ -1,0 +1,139 @@
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func init() {
+	registerResourceType(
+		ResourceTypePortalTeamGroupMapping,
+		func(rs *ResourceSet) *[]PortalTeamGroupMappingResource { return &rs.PortalTeamGroupMappings },
+		AutoExplain[PortalTeamGroupMappingResource](),
+	)
+}
+
+// PortalTeamGroupMappingResource maps a portal team to IdP groups.
+type PortalTeamGroupMappingResource struct {
+	Ref    string   `yaml:"ref"              json:"ref"`
+	Portal string   `yaml:"portal,omitempty" json:"portal,omitempty"`
+	Team   string   `yaml:"team"             json:"team"`
+	Groups []string `yaml:"groups"           json:"groups"`
+}
+
+// MarshalJSON keeps kongctl metadata fields stable.
+func (p PortalTeamGroupMappingResource) MarshalJSON() ([]byte, error) {
+	type alias PortalTeamGroupMappingResource
+	return json.Marshal(alias(p))
+}
+
+// GetType returns the resource type.
+func (p PortalTeamGroupMappingResource) GetType() ResourceType {
+	return ResourceTypePortalTeamGroupMapping
+}
+
+// GetRef returns the reference identifier.
+func (p PortalTeamGroupMappingResource) GetRef() string {
+	return p.Ref
+}
+
+// GetMoniker returns the resource moniker.
+func (p PortalTeamGroupMappingResource) GetMoniker() string {
+	return p.Team
+}
+
+// GetDependencies returns parent and team dependencies.
+func (p PortalTeamGroupMappingResource) GetDependencies() []ResourceRef {
+	var deps []ResourceRef
+	if p.Portal != "" {
+		deps = append(deps, ResourceRef{Kind: ResourceTypePortal, Ref: p.Portal})
+	}
+	if p.Team != "" {
+		deps = append(deps, ResourceRef{Kind: ResourceTypePortalTeam, Ref: p.Team})
+	}
+	return deps
+}
+
+// Validate ensures the mapping has the required declarative identifiers.
+func (p PortalTeamGroupMappingResource) Validate() error {
+	if err := ValidateRef(p.Ref); err != nil {
+		return fmt.Errorf("invalid portal team group mapping ref: %w", err)
+	}
+	if p.Groups == nil {
+		return fmt.Errorf("groups is required")
+	}
+
+	seen := make(map[string]struct{}, len(p.Groups))
+	for _, group := range p.Groups {
+		if _, ok := seen[group]; ok {
+			return fmt.Errorf("duplicate group name %q", group)
+		}
+		seen[group] = struct{}{}
+	}
+
+	return nil
+}
+
+// SetDefaults applies default values to the resource.
+func (p *PortalTeamGroupMappingResource) SetDefaults() {}
+
+// GetKonnectID returns the resolved Konnect ID if available.
+func (p PortalTeamGroupMappingResource) GetKonnectID() string {
+	return ""
+}
+
+// GetKonnectMonikerFilter returns the filter string for Konnect API lookup.
+func (p PortalTeamGroupMappingResource) GetKonnectMonikerFilter() string {
+	return ""
+}
+
+// TryMatchKonnectResource attempts to match this resource with a Konnect resource.
+func (p *PortalTeamGroupMappingResource) TryMatchKonnectResource(_ any) bool {
+	return false
+}
+
+// GetParentRef implements ResourceWithParent.
+func (p PortalTeamGroupMappingResource) GetParentRef() *ResourceRef {
+	if p.Portal == "" {
+		return nil
+	}
+	return &ResourceRef{Kind: ResourceTypePortal, Ref: p.Portal}
+}
+
+// UnmarshalJSON rejects unsupported metadata on child resources.
+func (p *PortalTeamGroupMappingResource) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	allowedKeys := map[string]struct{}{
+		"ref":     {},
+		"portal":  {},
+		"team":    {},
+		"groups":  {},
+		"kongctl": {},
+	}
+	for key := range raw {
+		if _, ok := allowedKeys[key]; !ok {
+			return fmt.Errorf("json: unknown field %q", key)
+		}
+	}
+
+	if v, ok := raw["kongctl"]; ok {
+		var kongctl any
+		if err := json.Unmarshal(v, &kongctl); err != nil {
+			return err
+		}
+		if kongctl != nil {
+			return fmt.Errorf("kongctl metadata not supported on portal team group mappings")
+		}
+	}
+	type alias PortalTeamGroupMappingResource
+	var decoded alias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*p = PortalTeamGroupMappingResource(decoded)
+	return nil
+}

--- a/internal/declarative/resources/portal_team_group_mapping_test.go
+++ b/internal/declarative/resources/portal_team_group_mapping_test.go
@@ -1,0 +1,40 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPortalTeamGroupMappingValidateAllowsEmptyGroups(t *testing.T) {
+	mapping := PortalTeamGroupMappingResource{
+		Ref:    "developers-idp-groups",
+		Team:   "developers",
+		Groups: []string{},
+	}
+
+	require.NoError(t, mapping.Validate())
+}
+
+func TestPortalTeamGroupMappingValidateRejectsDuplicateGroups(t *testing.T) {
+	mapping := PortalTeamGroupMappingResource{
+		Ref:    "developers-idp-groups",
+		Team:   "developers",
+		Groups: []string{"Service Developer", "Service Developer"},
+	}
+
+	err := mapping.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `duplicate group name "Service Developer"`)
+}
+
+func TestPortalTeamGroupMappingValidateRequiresGroups(t *testing.T) {
+	mapping := PortalTeamGroupMappingResource{
+		Ref:  "developers-idp-groups",
+		Team: "developers",
+	}
+
+	err := mapping.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "groups is required")
+}

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -25,6 +25,7 @@ const (
 	ResourceTypePortalIPAllowList                       ResourceType = "portal_ip_allow_list"
 	ResourceTypePortalIntegration                       ResourceType = "portal_integration"
 	ResourceTypePortalIdentityProvider                  ResourceType = "portal_identity_provider"
+	ResourceTypePortalTeamGroupMapping                  ResourceType = "portal_team_group_mapping"
 	ResourceTypePortalPage                              ResourceType = "portal_page"
 	ResourceTypePortalSnippet                           ResourceType = "portal_snippet"
 	ResourceTypePortalTeam                              ResourceType = "portal_team"
@@ -95,6 +96,7 @@ type ResourceSet struct {
 	PortalIPAllowLists          []PortalIPAllowListResource          `yaml:"portal_ip_allow_lists,omitempty"                          json:"portal_ip_allow_lists,omitempty"`          //nolint:lll
 	PortalIntegrations          []PortalIntegrationResource          `yaml:"portal_integrations,omitempty"                            json:"portal_integrations,omitempty"`            //nolint:lll
 	PortalIdentityProviders     []PortalIdentityProviderResource     `yaml:"portal_identity_providers,omitempty"                      json:"portal_identity_providers,omitempty"`      //nolint:lll
+	PortalTeamGroupMappings     []PortalTeamGroupMappingResource     `yaml:"portal_team_group_mappings,omitempty"                    json:"portal_team_group_mappings,omitempty"`      //nolint:lll
 	PortalCustomDomains         []PortalCustomDomainResource         `yaml:"portal_custom_domains,omitempty"                          json:"portal_custom_domains,omitempty"`          //nolint:lll
 	PortalPages                 []PortalPageResource                 `yaml:"portal_pages,omitempty"                                   json:"portal_pages,omitempty"`                   //nolint:lll
 	PortalSnippets              []PortalSnippetResource              `yaml:"portal_snippets,omitempty"                                json:"portal_snippets,omitempty"`                //nolint:lll
@@ -513,6 +515,25 @@ func (rs *ResourceSet) GetPortalIdentityProvidersByNamespace(namespace string) [
 			}
 			if GetNamespace(portal.Kongctl) == namespace {
 				filtered = append(filtered, provider)
+			}
+		}
+	}
+	return filtered
+}
+
+// GetPortalTeamGroupMappingsByNamespace returns portal team group mappings from the specified namespace.
+func (rs *ResourceSet) GetPortalTeamGroupMappingsByNamespace(namespace string) []PortalTeamGroupMappingResource {
+	var filtered []PortalTeamGroupMappingResource
+	for _, mapping := range rs.PortalTeamGroupMappings {
+		if portal := rs.GetPortalByRef(mapping.Portal); portal != nil {
+			if portal.IsExternal() {
+				if namespace == NamespaceExternal {
+					filtered = append(filtered, mapping)
+				}
+				continue
+			}
+			if GetNamespace(portal.Kongctl) == namespace {
+				filtered = append(filtered, mapping)
 			}
 		}
 	}

--- a/internal/declarative/state/cache.go
+++ b/internal/declarative/state/cache.go
@@ -195,6 +195,12 @@ type PortalTeam struct {
 	CanOwnApplications *bool
 }
 
+// PortalTeamGroupMapping represents portal team IdP group mappings.
+type PortalTeamGroupMapping struct {
+	TeamID string
+	Groups []string
+}
+
 // PortalTeamRole represents an assigned role for a portal team
 type PortalTeamRole struct {
 	ID             string

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -2738,6 +2738,82 @@ func (c *Client) UpdatePortalAuthSettings(
 	return nil
 }
 
+// ListPortalTeamGroupMappings returns all team group mappings for a portal.
+func (c *Client) ListPortalTeamGroupMappings(ctx context.Context, portalID string) ([]PortalTeamGroupMapping, error) {
+	if err := ValidateAPIClient(c.portalAuthSettingsAPI, "portal auth settings API"); err != nil {
+		return nil, err
+	}
+
+	var allMappings []PortalTeamGroupMapping
+	var pageNumber int64 = 1
+	pageSize := int64(100)
+
+	for {
+		resp, err := c.portalAuthSettingsAPI.ListPortalTeamGroupMappings(ctx, kkOps.ListPortalTeamGroupMappingsRequest{
+			PortalID:   portalID,
+			PageSize:   &pageSize,
+			PageNumber: &pageNumber,
+		})
+		if err != nil {
+			return nil, WrapAPIError(err, "list portal team group mappings", &ErrorWrapperOptions{
+				ResourceType: string(resources.ResourceTypePortalTeamGroupMapping),
+				ResourceName: portalID,
+				UseEnhanced:  true,
+			})
+		}
+		if resp == nil || resp.PortalTeamGroupMappingResponse == nil {
+			return allMappings, nil
+		}
+
+		for _, item := range resp.PortalTeamGroupMappingResponse.Data {
+			teamID := ""
+			if item.TeamID != nil {
+				teamID = *item.TeamID
+			}
+			allMappings = append(allMappings, PortalTeamGroupMapping{
+				TeamID: teamID,
+				Groups: append([]string(nil), item.Groups...),
+			})
+		}
+
+		meta := resp.PortalTeamGroupMappingResponse.Meta
+		if meta == nil || meta.Page.Total <= float64(pageSize*pageNumber) {
+			break
+		}
+		pageNumber++
+	}
+
+	return allMappings, nil
+}
+
+// UpdatePortalTeamGroupMapping replaces one team's IdP group list.
+func (c *Client) UpdatePortalTeamGroupMapping(
+	ctx context.Context,
+	portalID string,
+	teamID string,
+	groups []string,
+) error {
+	if err := ValidateAPIClient(c.portalAuthSettingsAPI, "portal auth settings API"); err != nil {
+		return err
+	}
+
+	req := kkComps.PortalTeamGroupMappingsUpdateRequest{
+		Data: []kkComps.PortalTeamGroupMappingsUpdateRequestData{{
+			TeamID: &teamID,
+			Groups: groups,
+		}},
+	}
+
+	if _, err := c.portalAuthSettingsAPI.UpdatePortalTeamGroupMappings(ctx, portalID, &req); err != nil {
+		return WrapAPIError(err, "update portal team group mappings", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypePortalTeamGroupMapping),
+			ResourceName: teamID,
+			UseEnhanced:  true,
+		})
+	}
+	return nil
+}
+
 // ValidatePortalIPAllowListAPI returns an error if the portal IP allow list API is not configured.
 func (c *Client) ValidatePortalIPAllowListAPI() error {
 	if c == nil {

--- a/internal/declarative/state/client_portal_team_group_mapping_test.go
+++ b/internal/declarative/state/client_portal_team_group_mapping_test.go
@@ -1,0 +1,68 @@
+package state
+
+import (
+	"context"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/stretchr/testify/require"
+)
+
+type stubPortalAuthSettingsAPI struct {
+	updatePortalID string
+	updateReq      *kkComps.PortalTeamGroupMappingsUpdateRequest
+}
+
+func (s *stubPortalAuthSettingsAPI) UpdatePortalAuthenticationSettings(
+	context.Context,
+	string,
+	*kkComps.PortalAuthenticationSettingsUpdateRequest,
+	...kkOps.Option,
+) (*kkOps.UpdatePortalAuthenticationSettingsResponse, error) {
+	return &kkOps.UpdatePortalAuthenticationSettingsResponse{}, nil
+}
+
+func (s *stubPortalAuthSettingsAPI) GetPortalAuthenticationSettings(
+	context.Context,
+	string,
+	...kkOps.Option,
+) (*kkOps.GetPortalAuthenticationSettingsResponse, error) {
+	return &kkOps.GetPortalAuthenticationSettingsResponse{
+		PortalAuthenticationSettingsResponse: &kkComps.PortalAuthenticationSettingsResponse{},
+	}, nil
+}
+
+func (s *stubPortalAuthSettingsAPI) ListPortalTeamGroupMappings(
+	context.Context,
+	kkOps.ListPortalTeamGroupMappingsRequest,
+	...kkOps.Option,
+) (*kkOps.ListPortalTeamGroupMappingsResponse, error) {
+	return &kkOps.ListPortalTeamGroupMappingsResponse{
+		PortalTeamGroupMappingResponse: &kkComps.PortalTeamGroupMappingResponse{},
+	}, nil
+}
+
+func (s *stubPortalAuthSettingsAPI) UpdatePortalTeamGroupMappings(
+	_ context.Context,
+	portalID string,
+	request *kkComps.PortalTeamGroupMappingsUpdateRequest,
+	_ ...kkOps.Option,
+) (*kkOps.UpdatePortalTeamGroupMappingsResponse, error) {
+	s.updatePortalID = portalID
+	s.updateReq = request
+	return &kkOps.UpdatePortalTeamGroupMappingsResponse{}, nil
+}
+
+func TestUpdatePortalTeamGroupMappingRequestShape(t *testing.T) {
+	api := &stubPortalAuthSettingsAPI{}
+	client := NewClient(ClientConfig{PortalAuthSettingsAPI: api})
+
+	err := client.UpdatePortalTeamGroupMapping(t.Context(), "portal-id", "team-id", []string{})
+	require.NoError(t, err)
+	require.Equal(t, "portal-id", api.updatePortalID)
+	require.NotNil(t, api.updateReq)
+	require.Len(t, api.updateReq.Data, 1)
+	require.Equal(t, "team-id", *api.updateReq.Data[0].TeamID)
+	require.Empty(t, api.updateReq.Data[0].Groups)
+}

--- a/internal/konnect/helpers/portal_auth_settings.go
+++ b/internal/konnect/helpers/portal_auth_settings.go
@@ -22,6 +22,17 @@ type PortalAuthSettingsAPI interface {
 		portalID string,
 		opts ...kkOps.Option,
 	) (*kkOps.GetPortalAuthenticationSettingsResponse, error)
+	ListPortalTeamGroupMappings(
+		ctx context.Context,
+		request kkOps.ListPortalTeamGroupMappingsRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.ListPortalTeamGroupMappingsResponse, error)
+	UpdatePortalTeamGroupMappings(
+		ctx context.Context,
+		portalID string,
+		request *kkComponents.PortalTeamGroupMappingsUpdateRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.UpdatePortalTeamGroupMappingsResponse, error)
 }
 
 // PortalAuthSettingsAPIImpl provides an implementation using the Konnect SDK.
@@ -52,4 +63,29 @@ func (p *PortalAuthSettingsAPIImpl) GetPortalAuthenticationSettings(
 		return nil, fmt.Errorf("SDK is nil")
 	}
 	return p.SDK.PortalAuthSettings.GetPortalAuthenticationSettings(ctx, portalID, opts...)
+}
+
+// ListPortalTeamGroupMappings lists portal team IdP group mappings.
+func (p *PortalAuthSettingsAPIImpl) ListPortalTeamGroupMappings(
+	ctx context.Context,
+	request kkOps.ListPortalTeamGroupMappingsRequest,
+	opts ...kkOps.Option,
+) (*kkOps.ListPortalTeamGroupMappingsResponse, error) {
+	if p.SDK == nil {
+		return nil, fmt.Errorf("SDK is nil")
+	}
+	return p.SDK.PortalAuthSettings.ListPortalTeamGroupMappings(ctx, request, opts...)
+}
+
+// UpdatePortalTeamGroupMappings partially updates portal team IdP group mappings.
+func (p *PortalAuthSettingsAPIImpl) UpdatePortalTeamGroupMappings(
+	ctx context.Context,
+	portalID string,
+	request *kkComponents.PortalTeamGroupMappingsUpdateRequest,
+	opts ...kkOps.Option,
+) (*kkOps.UpdatePortalTeamGroupMappingsResponse, error) {
+	if p.SDK == nil {
+		return nil, fmt.Errorf("SDK is nil")
+	}
+	return p.SDK.PortalAuthSettings.UpdatePortalTeamGroupMappings(ctx, portalID, request, opts...)
 }

--- a/test/e2e/scenarios/portal/identity_providers/overlays/001-clear-mapping/config.yaml
+++ b/test/e2e/scenarios/portal/identity_providers/overlays/001-clear-mapping/config.yaml
@@ -33,5 +33,4 @@ portals:
         description: Developers mapped from IdP groups
         group_mappings:
           - ref: portal-developers-idp-groups
-            groups:
-              - Portal Developers
+            groups: []

--- a/test/e2e/scenarios/portal/identity_providers/overlays/001-root-mapping-update/config.yaml
+++ b/test/e2e/scenarios/portal/identity_providers/overlays/001-root-mapping-update/config.yaml
@@ -31,7 +31,11 @@ portals:
       - ref: portal-developers
         name: Portal Developers
         description: Developers mapped from IdP groups
-        group_mappings:
-          - ref: portal-developers-idp-groups
-            groups:
-              - Portal Developers
+
+portal_team_group_mappings:
+  - ref: portal-developers-idp-groups
+    portal: portal-idp
+    team: portal-developers
+    groups:
+      - Portal Developers
+      - Platform Developers

--- a/test/e2e/scenarios/portal/identity_providers/scenario.yaml
+++ b/test/e2e/scenarios/portal/identity_providers/scenario.yaml
@@ -20,6 +20,8 @@ vars:
   namespace: portal-identity-providers
   portalRef: portal-idp
   providerRef: portal-oidc
+  teamRef: portal-developers
+  mappingRef: portal-developers-idp-groups
 
 defaults:
   mask:
@@ -74,8 +76,9 @@ steps:
           - select: summary
             expect:
               fields:
-                total_changes: 2
-                by_action.CREATE: 2
+                total_changes: 5
+                by_action.CREATE: 3
+                by_action.UPDATE: 2
           - select: >-
               changes[?resource_type=='portal_identity_provider' && resource_ref=='{{ .vars.providerRef }}'] | [0].fields
             expect:
@@ -84,6 +87,18 @@ steps:
                 enabled: true
                 config.client_id: __ENV__:KONGCTL_E2E_PORTAL_IDP_CLIENT_ID
                 config.issuer_url: __ENV__:KONGCTL_E2E_PORTAL_IDP_ISSUER_URL
+          - select: >-
+              changes[?resource_type=='portal_team' && resource_ref=='{{ .vars.teamRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                fields.name: Portal Developers
+          - select: >-
+              changes[?resource_type=='portal_team_group_mapping' && resource_ref=='{{ .vars.mappingRef }}'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                fields.groups[0]: Portal Developers
       - name: 001-apply-identity-providers
         outputFormat: json
         run:
@@ -95,7 +110,7 @@ steps:
           - select: summary
             expect:
               fields:
-                applied: 2
+                applied: 5
                 failed: 0
       - name: 002-get-identity-providers
         run:
@@ -114,6 +129,111 @@ steps:
                 enabled: true
                 config.client_id: "{{ .vars.createClientID }}"
                 config.claim_mappings.email: email
+      - name: 003-plan-identity-providers-idempotent
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+
+  - name: 001b-plan-apply-root-level-team-group-mapping
+    inputOverlayDirs:
+      - overlays/001-root-mapping-update
+    commands:
+      - name: 000-plan-root-level-team-group-mapping
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-root-level-team-group-mapping.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+          - select: >-
+              changes[?resource_type=='portal_team_group_mapping' && resource_ref=='{{ .vars.mappingRef }}'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                fields.groups[0]: Portal Developers
+                fields.groups[1]: Platform Developers
+      - name: 001-apply-root-level-team-group-mapping
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-root-level-team-group-mapping.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 002-plan-root-level-team-group-mapping-idempotent
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+
+  - name: 001c-plan-apply-clear-team-group-mapping
+    inputOverlayDirs:
+      - overlays/001-clear-mapping
+    commands:
+      - name: 000-plan-clear-team-group-mapping
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-clear-team-group-mapping.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+          - select: >-
+              changes[?resource_type=='portal_team_group_mapping' && resource_ref=='{{ .vars.mappingRef }}'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                fields.groups: []
+      - name: 001-apply-clear-team-group-mapping
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-clear-team-group-mapping.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
 
   - name: 002-plan-apply-root-level-update
     inputOverlayDirs:

--- a/test/e2e/scenarios/portal/team_group_mappings_no_idp/scenario.yaml
+++ b/test/e2e/scenarios/portal/team_group_mappings_no_idp/scenario.yaml
@@ -1,0 +1,72 @@
+baseInputsPath: testdata
+
+env:
+  KONGCTL_LOG_LEVEL: debug
+
+vars:
+  namespace: portal-team-group-mappings-no-idp
+  portalRef: portal-no-idp
+  teamRef: portal-developers
+  mappingRef: portal-developers-idp-groups
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - change_id
+      - resource_id
+      - generated_at
+      - created_at
+      - updated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-plan-warns-without-idp
+    commands:
+      - name: 000-plan-team-group-mapping-without-idp
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-team-group-mapping-without-idp.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 3
+                by_action.CREATE: 2
+                by_action.UPDATE: 1
+          - select: >-
+              changes[?resource_type=='portal_team_group_mapping' && resource_ref=='{{ .vars.mappingRef }}'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                fields.groups[0]: Portal Developers
+          - select: >-
+              warnings[?contains(message, 'may be rejected by Konnect unless an OIDC or SAML identity provider is configured and enabled')]
+            expect:
+              fields:
+                "length(@)": 1
+
+      - name: 001-apply-team-group-mapping-without-idp
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-team-group-mapping-without-idp.json"
+          - --auto-approve
+        expectFailure:
+          exitCode: 1
+          contains: portal_team_group_mapping
+
+  - name: 002-cleanup
+    skipInputs: true
+    commands:
+      - resetOrg: true

--- a/test/e2e/scenarios/portal/team_group_mappings_no_idp/testdata/config.yaml
+++ b/test/e2e/scenarios/portal/team_group_mappings_no_idp/testdata/config.yaml
@@ -1,0 +1,19 @@
+_defaults:
+  kongctl:
+    namespace: portal-team-group-mappings-no-idp
+
+portals:
+  - ref: portal-no-idp
+    name: portal-no-idp
+    display_name: Portal Without IdP
+    description: Portal with team group mappings but no identity provider
+    kongctl:
+      namespace: portal-team-group-mappings-no-idp
+    teams:
+      - ref: portal-developers
+        name: Portal Developers
+        description: Developers mapped from IdP groups
+        group_mappings:
+          - ref: portal-developers-idp-groups
+            groups:
+              - Portal Developers


### PR DESCRIPTION
## Summary

Adds declarative support for portal team group mappings.

- Adds the `portal_team_group_mapping` resource type and root-level `portal_team_group_mappings` collection.
- Supports the preferred nested shape at `portals[].teams[].group_mappings`, inheriting portal and team references from the parent declarations.
- Plans mapping changes as updates against Konnect's team mapping endpoint, including explicit clears with `groups: []`.
- Adds IdP prerequisite dependency handling and warnings when an enabled OIDC/SAML provider cannot be verified.
- Extends portal identity provider e2e coverage for nested mappings, root-level mappings, and clear behavior.
- Updates the portal IdP declarative example and docs.

Closes #883

## Validation

- `go test ./internal/declarative/... -count=1`
- `go test -tags=e2e ./test/e2e/harness/scenario -count=1`
- `KONGCTL_E2E_SCENARIO=portal/identity_providers KONGCTL_E2E_RUN_PORTAL_IDENTITY_PROVIDERS=0 go test -tags=e2e ./test/e2e -run Test_Scenarios -count=1`
- `KONGCTL_E2E_SCENARIO=explain/command-coverage go test -tags=e2e ./test/e2e -run Test_Scenarios -count=1`
- `go build ./...`

The live Konnect portal IdP scenario was not run locally.