### PR TITLE
fix: correct apply command example in help text

### DIFF
--- a/internal/cmd/root/products/konnect/konnect.go
+++ b/internal/cmd/root/products/konnect/konnect.go
@@ -37,8 +37,8 @@ var (
 	konnectLong  = normalizers.LongDesc(i18n.T("root.products.konnect.konnectLong",
 		`The konnect command allows you to manage Kong Konnect resources.`))
 	konnectExamples = normalizers.Examples(i18n.T("root.products.konnect.konnectExamples",
-		fmt.Sprintf(`# Retrieve the Konnect Kong Gateway control planes from the current organization
-		 %[1]s get konnect gateway control-planes`, meta.CLIName)))
+		fmt.Sprintf(`# Apply configuration from a file
+		 %[1]s apply -f config.yaml`, meta.CLIName)))
 )
 
 func addFlags(verb verbs.VerbValue, cmd *cobra.Command) {


### PR DESCRIPTION
## Summary

Fixes the example in `kongctl apply --help` which incorrectly showed `kongctl get konnect gateway control-planes` instead of an actual apply command example.

Before:
```
# Retrieve the Konnect Kong Gateway control planes from the current organization
kongctl get konnect gateway control-planes
```

After:
```
# Apply configuration from a file
kongctl apply -f config.yaml
```

Fixes #1052