### PR TITLE
Task: improve error reporting and usage output clarity

### DIFF
--- a/internal/cmd/root/products/konnect/adopt/analytics.go
+++ b/internal/cmd/root/products/konnect/adopt/analytics.go
@@ -3,6 +3,7 @@ package adopt
 import (
 	"fmt"
 
+	cmdpkg "github.com/kong/kongctl/internal/cmd"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	"github.com/kong/kongctl/internal/meta"
 	"github.com/kong/kongctl/internal/util/i18n"
@@ -45,9 +46,7 @@ func NewAnalyticsCmd(
 	cmd.Long = adoptAnalyticsLong
 	cmd.Example = adoptAnalyticsExample
 	cmd.Aliases = []string{"analytic"}
-	cmd.RunE = func(c *cobra.Command, _ []string) error {
-		return c.Help()
-	}
+	cmdpkg.ConfigureRequiresSubcommand(cmd)
 
 	dashboardCmd, err := NewDashboardCmd(verb, &cobra.Command{}, addParentFlags, parentPreRun)
 	if err != nil {

--- a/internal/cmd/root/products/konnect/auditlogs/get.go
+++ b/internal/cmd/root/products/konnect/auditlogs/get.go
@@ -80,8 +80,9 @@ regional webhook configuration.`
 		if _, err := helper.GetOutputFormat(); err != nil {
 			return err
 		}
-		return cmdObj.Help()
+		return cmd.RequireSubcommand(cmdObj, args)
 	}
+	cmd.MarkRequiresSubcommand(baseCmd)
 
 	baseCmd.AddCommand(newGetAuditLogsDestinationsCmd(verb, addParentFlags, parentPreRun))
 	baseCmd.AddCommand(newGetAuditLogDestinationCmd(verb, addParentFlags, parentPreRun))

--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -444,10 +444,10 @@ func runPlan(command *cobra.Command, args []string) error {
 
 	// Reject --output/-o flag: plan always outputs JSON; use --output-file to save to a file
 	if outputFlag := command.Flag(cmdcommon.OutputFlagName); outputFlag != nil && outputFlag.Changed {
-		return fmt.Errorf(
+		return &cmd.UsageError{Err: fmt.Errorf(
 			"flags -o/--%s are not supported for the plan command; use --output-file to save the plan to a file",
 			cmdcommon.OutputFlagName,
-		)
+		)}
 	}
 
 	ctx := command.Context()

--- a/internal/cmd/root/products/konnect/gateway/gateway.go
+++ b/internal/cmd/root/products/konnect/gateway/gateway.go
@@ -1,8 +1,7 @@
 package gateway
 
 import (
-	"fmt"
-
+	cmdpkg "github.com/kong/kongctl/internal/cmd"
 	_ "github.com/kong/kongctl/internal/cmd/root/products/konnect/gateway/consumergroup" // register consumer-group child loaders
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/gateway/controlplane"
 	_ "github.com/kong/kongctl/internal/cmd/root/products/konnect/gateway/plugin"   // register plugin child loaders
@@ -29,16 +28,8 @@ func NewGatewayCmd(verb verbs.VerbValue,
 		Short:   gatewayShort,
 		Long:    gatewayLong,
 		Aliases: []string{"gw", "GW"},
-		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) > 0 {
-				return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
-			}
-			return nil
-		},
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
 	}
+	cmdpkg.ConfigureRequiresSubcommand(cmd)
 
 	c, e := controlplane.NewControlPlaneCmd(verb, addParentFlags, parentPreRun)
 	if e != nil {

--- a/internal/cmd/root/products/konnect/konnect.go
+++ b/internal/cmd/root/products/konnect/konnect.go
@@ -324,8 +324,9 @@ func NewKonnectCmd(verb verbs.VerbValue) (*cobra.Command, error) {
 			if _, err := helper.GetOutputFormat(); err != nil {
 				return err
 			}
-			return c.Help()
+			return cmdpkg.RequireSubcommand(c, args)
 		}
+		cmdpkg.MarkRequiresSubcommand(cmd)
 	}
 
 	return cmd, e

--- a/internal/cmd/root/products/konnect/organization/adoptOrganization.go
+++ b/internal/cmd/root/products/konnect/organization/adoptOrganization.go
@@ -1,6 +1,7 @@
 package organization
 
 import (
+	cmdpkg "github.com/kong/kongctl/internal/cmd"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/adopt/organization/team"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	"github.com/spf13/cobra"
@@ -24,9 +25,7 @@ func newAdoptOrganizationCmd(
 	cmd.Long = "Manage organization-level resources such as teams for adoption into namespace management"
 
 	// Make org command require a subcommand - it should not run on its own
-	cmd.RunE = func(c *cobra.Command, _ []string) error {
-		return c.Help()
-	}
+	cmdpkg.ConfigureRequiresSubcommand(cmd.Command)
 
 	teamCmd, err := team.NewTeamCmd(verb, &cobra.Command{}, addParentFlags, parentPreRun)
 	if err == nil && teamCmd != nil {

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -11,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/kong/kongctl/internal/build"
-	"github.com/kong/kongctl/internal/cmd"
+	cmdpkg "github.com/kong/kongctl/internal/cmd"
 	"github.com/kong/kongctl/internal/cmd/common"
 	konnectcommon "github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
 	"github.com/kong/kongctl/internal/cmd/root/verbs/adopt"
@@ -73,14 +74,14 @@ var (
 	streams    *iostreams.IOStreams
 	pMgr       profile.Manager
 
-	outputFormat = cmd.NewDeferredEnum([]string{
+	outputFormat = cmdpkg.NewDeferredEnum([]string{
 		common.JSON.String(),
 		common.YAML.String(),
 		common.TEXT.String(),
 	},
 		common.TEXT.String())
 
-	logLevel = cmd.NewEnum([]string{
+	logLevel = cmdpkg.NewEnum([]string{
 		common.TRACE.String(),
 		common.DEBUG.String(),
 		common.INFO.String(),
@@ -179,12 +180,14 @@ func validateOutputFormat(cmd *cobra.Command) error {
 
 func newRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use:   meta.CLIName,
-		Short: rootShort,
-		Long:  rootLong,
+		Use:           meta.CLIName,
+		Short:         rootShort,
+		Long:          rootLong,
+		SilenceUsage:  true,
+		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := validateOutputFormat(cmd); err != nil {
-				return err
+				return &cmdpkg.ConfigurationError{Err: err}
 			}
 			ctx := context.WithValue(cmd.Context(), config.ConfigKey, currConfig)
 			ctx = context.WithValue(ctx, iostreams.StreamsKey, streams)
@@ -403,8 +406,21 @@ func addCommands() error {
 
 	// Add help command
 	rootCmd.AddCommand(help.NewHelpCmd())
+	installUsageErrorFallbacks(rootCmd)
 
 	return nil
+}
+
+func installUsageErrorFallbacks(command *cobra.Command) {
+	if command == nil {
+		return
+	}
+	if !command.Hidden && command.HasAvailableSubCommands() && !command.Runnable() {
+		cmdpkg.ConfigureRequiresSubcommand(command)
+	}
+	for _, child := range command.Commands() {
+		installUsageErrorFallbacks(child)
+	}
 }
 
 func sampleThemeNames() []string {
@@ -612,6 +628,7 @@ func initConfig() {
 
 func Execute(ctx context.Context, s *iostreams.IOStreams, bi *build.Info) {
 	var err error
+	executedCmd := rootCmd
 	buildInfo = bi
 	version := meta.DefaultCLIVersion
 	if bi != nil {
@@ -633,13 +650,11 @@ func Execute(ctx context.Context, s *iostreams.IOStreams, bi *build.Info) {
 		err = registerExtensions()
 	}
 	if err == nil {
-		err = rootCmd.ExecuteContext(ctx)
+		executedCmd, err = rootCmd.ExecuteContextC(ctx)
 	}
 	if err != nil {
 		// If there was an execution error, use the logger to write it out and exit
-		// If it was a configuration error, we want the cobra framework to also
-		// show the usage information, so we don't also print the error here
-		var executionError *cmd.ExecutionError
+		var executionError *cmdpkg.ExecutionError
 		if errors.Is(err, context.Canceled) {
 			logger.Info("Operation canceled")
 		} else if errors.As(err, &executionError) {
@@ -648,6 +663,8 @@ func Execute(ctx context.Context, s *iostreams.IOStreams, bi *build.Info) {
 			} else {
 				logger.Error(executionError.Err.Error(), executionError.Attrs...)
 			}
+		} else {
+			renderCommandError(streams.ErrOut, executedCmd, err)
 		}
 		closeLogFile()
 		os.Exit(1)
@@ -668,4 +685,70 @@ func closeLogFile() {
 		_ = logFile.Close()
 		logFile = nil
 	}
+}
+
+func renderCommandError(w io.Writer, command *cobra.Command, err error) {
+	if cmdpkg.IsUsageError(err) {
+		renderCommandUsageError(w, command, err)
+		return
+	}
+	renderPlainCommandError(w, err)
+}
+
+func renderPlainCommandError(w io.Writer, err error) {
+	if w == nil || err == nil {
+		return
+	}
+	errorText := strings.TrimSpace(err.Error())
+	if errorText == "" {
+		errorText = "an unknown error occurred"
+	}
+	fmt.Fprintf(w, "Error: %s\n", errorText)
+}
+
+func renderCommandUsageError(w io.Writer, command *cobra.Command, err error) {
+	if w == nil || err == nil {
+		return
+	}
+
+	errorText := strings.TrimSpace(stripCobraSuggestion(err.Error()))
+	if errorText == "" {
+		errorText = "invalid command usage"
+	}
+
+	fmt.Fprintf(w, "Error: %s\n", errorText)
+	fmt.Fprintf(w, "Run '%s --help' for usage.\n", commandPath(command))
+
+	suggestion := cmdpkg.SuggestionForError(command, err)
+	if len(suggestion.Values) == 0 {
+		return
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, suggestionHeader(suggestion.Kind, len(suggestion.Values)))
+	for _, value := range suggestion.Values {
+		fmt.Fprintf(w, "  %s\n", value)
+	}
+}
+
+func stripCobraSuggestion(message string) string {
+	message, _, _ = strings.Cut(message, "\n\nDid you mean")
+	return message
+}
+
+func commandPath(command *cobra.Command) string {
+	if command == nil {
+		return meta.CLIName
+	}
+	return command.CommandPath()
+}
+
+func suggestionHeader(kind string, count int) string {
+	if kind == "" {
+		kind = "suggestion"
+	}
+	if count == 1 {
+		return fmt.Sprintf("Did you mean this %s?", kind)
+	}
+	return fmt.Sprintf("Did you mean one of these %ss?", kind)
 }

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -2,12 +2,20 @@ package root
 
 import (
 	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	cmdpkg "github.com/kong/kongctl/internal/cmd"
 	"github.com/kong/kongctl/internal/cmd/common"
 	configpkg "github.com/kong/kongctl/internal/config"
+	"github.com/kong/kongctl/internal/iostreams"
+	"github.com/kong/kongctl/internal/log"
+	"github.com/kong/kongctl/internal/profile"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -112,4 +120,425 @@ func TestValidateOutputFormatUsesResolvedConfigValue(t *testing.T) {
 	if err := validateOutputFormat(cmd); err != nil {
 		t.Fatalf("expected helm from config to be allowed with command opt-in: %v", err)
 	}
+}
+
+func TestRootErrorUX(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		wantErr      []string
+		wantOut      []string
+		wantExit     int
+		forbidErr    []string
+		forbidOut    []string
+		expectStderr bool
+		expectStdout bool
+	}{
+		{
+			name: "bare root requires command",
+			args: []string{},
+			wantErr: []string{
+				`Error: command "kongctl" requires a subcommand`,
+				`Run 'kongctl --help' for usage.`,
+			},
+			wantExit:     1,
+			forbidErr:    []string{"Usage:"},
+			expectStderr: true,
+		},
+		{
+			name: "bare command group requires subcommand",
+			args: []string{"get"},
+			wantErr: []string{
+				`Error: command "kongctl get" requires a subcommand`,
+				`Run 'kongctl get --help' for usage.`,
+			},
+			wantExit:     1,
+			forbidErr:    []string{"Usage:"},
+			expectStderr: true,
+		},
+		{
+			name: "unknown top level command suggests close match",
+			args: []string{"aply"},
+			wantErr: []string{
+				`Error: unknown command "aply" for "kongctl"`,
+				`Run 'kongctl --help' for usage.`,
+				"Did you mean this command?",
+				"  apply",
+			},
+			wantExit:     1,
+			forbidErr:    []string{"Usage:"},
+			expectStderr: true,
+		},
+		{
+			name: "unknown nested command suggests close match",
+			args: []string{"get", "gatewy"},
+			wantErr: []string{
+				`Error: unknown command "gatewy" for "kongctl get"`,
+				`Run 'kongctl get --help' for usage.`,
+				"Did you mean this command?",
+				"  gateway",
+			},
+			wantExit:     1,
+			forbidErr:    []string{"Usage:"},
+			expectStderr: true,
+		},
+		{
+			name: "unknown flag suggests close match",
+			args: []string{"version", "--log-leve", "error"},
+			wantErr: []string{
+				`Error: unknown flag: --log-leve`,
+				`Run 'kongctl version --help' for usage.`,
+				"Did you mean this flag?",
+				"  --log-level",
+			},
+			wantExit:     1,
+			forbidErr:    []string{"Usage:"},
+			expectStderr: true,
+		},
+		{
+			name: "argument validation uses concise help hint",
+			args: []string{"scaffold"},
+			wantErr: []string{
+				`Error: accepts 1 arg(s), received 0`,
+				`Run 'kongctl scaffold --help' for usage.`,
+			},
+			wantExit:     1,
+			forbidErr:    []string{"Usage:"},
+			expectStderr: true,
+		},
+		{
+			name: "custom flag error remains actionable",
+			args: []string{"plan", "-o", "plan.json"},
+			wantErr: []string{
+				`Error: flags -o/--output are not supported for the plan command; use --output-file to save the plan to a file`,
+				`Run 'kongctl plan --help' for usage.`,
+			},
+			wantExit:     1,
+			forbidErr:    []string{"Usage:"},
+			expectStderr: true,
+		},
+		{
+			name: "explicit help still renders full help",
+			args: []string{"get", "--help"},
+			wantOut: []string{
+				"Usage:",
+				"kongctl get [command]",
+			},
+			wantExit:     0,
+			forbidErr:    []string{"Error:"},
+			expectStdout: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := executeRootForTest(t, tt.args...)
+			if result.exitCode != tt.wantExit {
+				t.Fatalf("expected exit code %d, got %d\nstdout:\n%s\nstderr:\n%s",
+					tt.wantExit, result.exitCode, result.stdout, result.stderr)
+			}
+			if tt.expectStderr && strings.TrimSpace(result.stderr) == "" {
+				t.Fatalf("expected stderr output")
+			}
+			if tt.expectStdout && strings.TrimSpace(result.stdout) == "" {
+				t.Fatalf("expected stdout output")
+			}
+			for _, want := range tt.wantErr {
+				if !strings.Contains(result.stderr, want) {
+					t.Fatalf("expected stderr to contain %q\nstderr:\n%s", want, result.stderr)
+				}
+			}
+			for _, want := range tt.wantOut {
+				if !strings.Contains(result.stdout, want) {
+					t.Fatalf("expected stdout to contain %q\nstdout:\n%s", want, result.stdout)
+				}
+			}
+			for _, forbidden := range tt.forbidErr {
+				if strings.Contains(result.stderr, forbidden) {
+					t.Fatalf("expected stderr not to contain %q\nstderr:\n%s", forbidden, result.stderr)
+				}
+			}
+			for _, forbidden := range tt.forbidOut {
+				if strings.Contains(result.stdout, forbidden) {
+					t.Fatalf("expected stdout not to contain %q\nstdout:\n%s", forbidden, result.stdout)
+				}
+			}
+		})
+	}
+}
+
+func TestPlainCommandErrorDoesNotShowUsageHint(t *testing.T) {
+	var stderr bytes.Buffer
+	command := &cobra.Command{Use: "runtime"}
+
+	renderCommandError(&stderr, command, errors.New("runtime operation failed"))
+
+	output := stderr.String()
+	if !strings.Contains(output, "Error: runtime operation failed") {
+		t.Fatalf("expected plain error output, got:\n%s", output)
+	}
+	if strings.Contains(output, "Run '") {
+		t.Fatalf("expected no usage hint for plain runtime error, got:\n%s", output)
+	}
+	if strings.Contains(output, "Usage:") {
+		t.Fatalf("expected no usage text for plain runtime error, got:\n%s", output)
+	}
+}
+
+func TestUnknownFlagErrorUXCoversCommandTree(t *testing.T) {
+	paths := collectCommandPathsForTest(t)
+	for _, path := range paths {
+		t.Run(commandPathForTest(path), func(t *testing.T) {
+			args := append([]string{}, path...)
+			args = append(args, "--definitely-not-a-real-kongctl-flag")
+
+			result := executeRootForTest(t, args...)
+			if result.exitCode != 1 {
+				t.Fatalf("expected exit code 1, got %d\nstdout:\n%s\nstderr:\n%s",
+					result.exitCode, result.stdout, result.stderr)
+			}
+			assertConciseErrorUX(t, result.stderr, commandPathForTest(path))
+			if !strings.Contains(result.stderr, "Error: unknown flag: --definitely-not-a-real-kongctl-flag") {
+				t.Fatalf("expected unknown flag error\nstderr:\n%s", result.stderr)
+			}
+		})
+	}
+}
+
+func TestRequiresSubcommandErrorUXCoversCommandGroups(t *testing.T) {
+	paths := collectRequiresSubcommandPathsForTest(t)
+	for _, path := range paths {
+		t.Run(commandPathForTest(path), func(t *testing.T) {
+			result := executeRootForTest(t, path...)
+			if result.exitCode != 1 {
+				t.Fatalf("expected exit code 1, got %d\nstdout:\n%s\nstderr:\n%s",
+					result.exitCode, result.stdout, result.stderr)
+			}
+			assertConciseErrorUX(t, result.stderr, commandPathForTest(path))
+			if !strings.Contains(result.stderr, "requires a subcommand") {
+				t.Fatalf("expected missing subcommand error\nstderr:\n%s", result.stderr)
+			}
+		})
+	}
+}
+
+func TestUnknownSubcommandErrorUXCoversCommandGroups(t *testing.T) {
+	commands := collectRequiresSubcommandCommandsForTest(t)
+	for _, item := range commands {
+		t.Run(commandPathForTest(item.path), func(t *testing.T) {
+			child := firstAvailableChildName(item.command)
+			if child == "" {
+				t.Skip("command has no available children")
+			}
+			args := append([]string{}, item.path...)
+			args = append(args, typoForTest(child))
+
+			result := executeRootForTest(t, args...)
+			if result.exitCode != 1 {
+				t.Fatalf("expected exit code 1, got %d\nstdout:\n%s\nstderr:\n%s",
+					result.exitCode, result.stdout, result.stderr)
+			}
+			assertConciseErrorUX(t, result.stderr, commandPathForTest(item.path))
+			if !strings.Contains(result.stderr, "unknown command") {
+				t.Fatalf("expected unknown command error\nstderr:\n%s", result.stderr)
+			}
+		})
+	}
+}
+
+type rootCommandResult struct {
+	stdout   string
+	stderr   string
+	exitCode int
+}
+
+func executeRootForTest(t *testing.T, args ...string) rootCommandResult {
+	t.Helper()
+
+	oldRootCmd := rootCmd
+	oldDefaultConfigFilePath := defaultConfigFilePath
+	oldConfigFilePath := configFilePath
+	oldCurrProfile := currProfile
+	oldCurrConfig := currConfig
+	oldStreams := streams
+	oldLogger := logger
+	oldBuildInfo := buildInfo
+	oldOutputFormat := outputFormat
+	oldLogLevel := logLevel
+	oldLogFile := logFile
+	oldEnableTraverseRunHooks := cobra.EnableTraverseRunHooks
+	t.Cleanup(func() {
+		rootCmd = oldRootCmd
+		defaultConfigFilePath = oldDefaultConfigFilePath
+		configFilePath = oldConfigFilePath
+		currProfile = oldCurrProfile
+		currConfig = oldCurrConfig
+		streams = oldStreams
+		logger = oldLogger
+		buildInfo = oldBuildInfo
+		outputFormat = oldOutputFormat
+		logLevel = oldLogLevel
+		if logFile != nil && logFile != oldLogFile {
+			_ = logFile.Close()
+		}
+		logFile = oldLogFile
+		cobra.EnableTraverseRunHooks = oldEnableTraverseRunHooks
+	})
+
+	cobra.EnableTraverseRunHooks = true
+	configHome := filepath.Join(t.TempDir(), "config")
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+
+	var err error
+	defaultConfigFilePath, err = configpkg.GetDefaultConfigFilePath()
+	requireNoError(t, err)
+	configFilePath = ""
+	currProfile = profile.DefaultProfile
+	currConfig = nil
+	buildInfo = nil
+	outputFormat = cmdpkg.NewDeferredEnum([]string{
+		common.JSON.String(),
+		common.YAML.String(),
+		common.TEXT.String(),
+	}, common.TEXT.String())
+	logLevel = cmdpkg.NewEnum([]string{
+		common.TRACE.String(),
+		common.DEBUG.String(),
+		common.INFO.String(),
+		common.WARN.String(),
+		common.ERROR.String(),
+	}, common.ERROR.String())
+
+	var stdout, stderr bytes.Buffer
+	streams = &iostreams.IOStreams{
+		In:     &bytes.Buffer{},
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+	logger = slog.New(log.NewFriendlyErrorHandler(&stderr))
+
+	rootCmd = newRootCmd()
+	requireNoError(t, addCommands())
+	rootCmd.SetArgs(args)
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+
+	executed, err := rootCmd.ExecuteContextC(context.Background())
+	exitCode := 0
+	if err != nil {
+		renderCommandError(&stderr, executed, err)
+		exitCode = 1
+	}
+	closeLogFile()
+
+	return rootCommandResult{
+		stdout:   stdout.String(),
+		stderr:   stderr.String(),
+		exitCode: exitCode,
+	}
+}
+
+func collectCommandPathsForTest(t *testing.T) [][]string {
+	t.Helper()
+	root := newRootCmd()
+	requireNoError(t, addCommandsWithRootForTest(root))
+
+	paths := [][]string{{}}
+	walkCommandsForTest(root, nil, func(command *cobra.Command, path []string) {
+		if command == root || command.Hidden || command.DisableFlagParsing {
+			return
+		}
+		paths = append(paths, append([]string{}, path...))
+	})
+	return paths
+}
+
+func collectRequiresSubcommandPathsForTest(t *testing.T) [][]string {
+	t.Helper()
+	items := collectRequiresSubcommandCommandsForTest(t)
+	paths := make([][]string, 0, len(items))
+	for _, item := range items {
+		paths = append(paths, item.path)
+	}
+	return paths
+}
+
+type commandPathItem struct {
+	command *cobra.Command
+	path    []string
+}
+
+func collectRequiresSubcommandCommandsForTest(t *testing.T) []commandPathItem {
+	t.Helper()
+	root := newRootCmd()
+	requireNoError(t, addCommandsWithRootForTest(root))
+
+	items := []commandPathItem{}
+	walkCommandsForTest(root, nil, func(command *cobra.Command, path []string) {
+		if command.Hidden || !cmdpkg.CommandRequiresSubcommand(command) {
+			return
+		}
+		items = append(items, commandPathItem{
+			command: command,
+			path:    append([]string{}, path...),
+		})
+	})
+	return items
+}
+
+func addCommandsWithRootForTest(command *cobra.Command) error {
+	oldRootCmd := rootCmd
+	rootCmd = command
+	defer func() {
+		rootCmd = oldRootCmd
+	}()
+	return addCommands()
+}
+
+func walkCommandsForTest(command *cobra.Command, path []string, visit func(*cobra.Command, []string)) {
+	visit(command, path)
+	for _, child := range command.Commands() {
+		if child.Hidden {
+			continue
+		}
+		childPath := append(append([]string{}, path...), child.Name())
+		walkCommandsForTest(child, childPath, visit)
+	}
+}
+
+func assertConciseErrorUX(t *testing.T, stderr, commandPath string) {
+	t.Helper()
+	if !strings.Contains(stderr, "Error:") {
+		t.Fatalf("expected Error line\nstderr:\n%s", stderr)
+	}
+	if strings.Contains(stderr, "Usage:") {
+		t.Fatalf("expected no full usage text\nstderr:\n%s", stderr)
+	}
+	help := fmt.Sprintf("Run '%s --help' for usage.", commandPath)
+	if !strings.Contains(stderr, help) {
+		t.Fatalf("expected help hint %q\nstderr:\n%s", help, stderr)
+	}
+}
+
+func commandPathForTest(path []string) string {
+	if len(path) == 0 {
+		return "kongctl"
+	}
+	return "kongctl " + strings.Join(path, " ")
+}
+
+func firstAvailableChildName(command *cobra.Command) string {
+	for _, child := range command.Commands() {
+		if child.IsAvailableCommand() {
+			return child.Name()
+		}
+	}
+	return ""
+}
+
+func typoForTest(value string) string {
+	if len(value) == 0 {
+		return "x"
+	}
+	return value + "x"
 }

--- a/internal/cmd/root/verbs/del/del.go
+++ b/internal/cmd/root/verbs/del/del.go
@@ -64,7 +64,9 @@ func NewDeleteCmd() (*cobra.Command, error) {
 			if len(filenames) > 0 || planFile != "" {
 				return declDeleteCmd.RunE(c, args)
 			}
-			return c.Help()
+			return &cmdpkg.UsageError{
+				Err: fmt.Errorf("command %q requires -f/--filename or --plan", c.CommandPath()),
+			}
 		},
 		PersistentPreRunE: func(c *cobra.Command, args []string) error {
 			ctx := c.Context()

--- a/internal/cmd/root/verbs/dump/dump.go
+++ b/internal/cmd/root/verbs/dump/dump.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	cmdpkg "github.com/kong/kongctl/internal/cmd"
 	konnectCommon "github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	"github.com/kong/kongctl/internal/konnect/helpers"
@@ -69,10 +70,8 @@ func NewDumpCmd() (*cobra.Command, error) {
 		Long:    dumpLong,
 		Example: dumpExamples,
 		Aliases: []string{"d", "D"},
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
 	}
+	cmdpkg.ConfigureRequiresSubcommand(dumpCommand)
 
 	dumpCommand.PersistentPreRun = func(cmd *cobra.Command, _ []string) {
 		cmd.SetContext(context.WithValue(cmd.Context(), verbs.Verb, Verb))

--- a/internal/cmd/root/verbs/extensions/extensions.go
+++ b/internal/cmd/root/verbs/extensions/extensions.go
@@ -109,13 +109,11 @@ func NewLinkCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "link",
 		Short: i18n.T("root.verbs.link.short", "Link locally developed features"),
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
 		PersistentPreRun: func(c *cobra.Command, _ []string) {
 			c.SetContext(context.WithValue(c.Context(), verbs.Verb, verbs.Link))
 		},
 	}
+	cmdpkg.ConfigureRequiresSubcommand(cmd)
 	cmd.AddCommand(newLinkExtensionCmd())
 	return cmd, nil
 }
@@ -124,13 +122,11 @@ func NewUninstallCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "uninstall",
 		Short: i18n.T("root.verbs.uninstall.short", "Uninstall features"),
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
 		PersistentPreRun: func(c *cobra.Command, _ []string) {
 			c.SetContext(context.WithValue(c.Context(), verbs.Verb, verbs.Uninstall))
 		},
 	}
+	cmdpkg.ConfigureRequiresSubcommand(cmd)
 	cmd.AddCommand(newUninstallExtensionCmd())
 	return cmd, nil
 }
@@ -139,13 +135,11 @@ func NewUpgradeCmd() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "upgrade",
 		Short: i18n.T("root.verbs.upgrade.short", "Upgrade kongctl features"),
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
 		PersistentPreRun: func(c *cobra.Command, _ []string) {
 			c.SetContext(context.WithValue(c.Context(), verbs.Verb, verbs.Upgrade))
 		},
 	}
+	cmdpkg.ConfigureRequiresSubcommand(cmd)
 	cmd.AddCommand(newUpgradeExtensionCmd())
 	return cmd, nil
 }

--- a/internal/cmd/root/verbs/get/get.go
+++ b/internal/cmd/root/verbs/get/get.go
@@ -100,8 +100,9 @@ Setting this value overrides tokens obtained from the login command.
 		if _, err := helper.GetOutputFormat(); err != nil {
 			return err
 		}
-		return c.Help()
+		return cmdpkg.RequireSubcommand(c, args)
 	}
+	cmdpkg.MarkRequiresSubcommand(cmd)
 
 	c, e := konnect.NewKonnectCmd(Verb)
 	if e != nil {

--- a/internal/cmd/root/verbs/install/install.go
+++ b/internal/cmd/root/verbs/install/install.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	cmdpkg "github.com/kong/kongctl/internal/cmd"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	extensioncmd "github.com/kong/kongctl/internal/cmd/root/verbs/extensions"
 	"github.com/kong/kongctl/internal/meta"
@@ -44,13 +45,11 @@ func NewInstallCmd() (*cobra.Command, error) {
 		Short:   installShort,
 		Long:    installLong,
 		Example: installExamples,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
 		PersistentPreRun: func(c *cobra.Command, _ []string) {
 			c.SetContext(context.WithValue(c.Context(), verbs.Verb, Verb))
 		},
 	}
+	cmdpkg.ConfigureRequiresSubcommand(cmd)
 
 	cmd.AddCommand(extensioncmd.NewInstallExtensionCmd())
 	cmd.AddCommand(newInstallSkillsCmd())

--- a/internal/cmd/root/verbs/list/list.go
+++ b/internal/cmd/root/verbs/list/list.go
@@ -61,6 +61,7 @@ func NewListCmd() (*cobra.Command, error) {
 			return bindKonnectFlags(c, args)
 		},
 	}
+	cmdpkg.ConfigureRequiresSubcommand(cmd)
 
 	// Add Konnect-specific flags as persistent flags so they appear in help
 	cmd.PersistentFlags().String(common.BaseURLFlagName, "",

--- a/internal/cmd/root/verbs/patch/patch.go
+++ b/internal/cmd/root/verbs/patch/patch.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	cmdpkg "github.com/kong/kongctl/internal/cmd"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	"github.com/kong/kongctl/internal/meta"
 	"github.com/kong/kongctl/internal/util/i18n"
@@ -46,13 +47,11 @@ func NewPatchCmd() (*cobra.Command, error) {
 		Long:    patchLong,
 		Example: patchExamples,
 		Aliases: []string{"p"},
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
 		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 			cmd.SetContext(context.WithValue(cmd.Context(), verbs.Verb, Verb))
 		},
 	}
+	cmdpkg.ConfigureRequiresSubcommand(cmd)
 
 	cmd.AddCommand(newFileCmd())
 

--- a/internal/cmd/root/verbs/plan/plan.go
+++ b/internal/cmd/root/verbs/plan/plan.go
@@ -2,9 +2,11 @@ package plan
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
+	cmdpkg "github.com/kong/kongctl/internal/cmd"
 	cmdcommon "github.com/kong/kongctl/internal/cmd/common"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
@@ -73,7 +75,7 @@ func NewPlanCmd() (*cobra.Command, error) {
 	cmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
 		if strings.Contains(err.Error(), fmt.Sprintf("--%s", cmdcommon.OutputFlagName)) ||
 			strings.Contains(err.Error(), fmt.Sprintf("-%s", cmdcommon.OutputFlagShort)) {
-			return fmt.Errorf("%s", outputFlagMsg)
+			return &cmdpkg.UsageError{Err: errors.New(outputFlagMsg)}
 		}
 		return err
 	})

--- a/internal/cmd/root/verbs/scaffold/scaffold.go
+++ b/internal/cmd/root/verbs/scaffold/scaffold.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	cmdpkg "github.com/kong/kongctl/internal/cmd"
 	cmdcommon "github.com/kong/kongctl/internal/cmd/common"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	"github.com/kong/kongctl/internal/declarative/resources"
@@ -60,7 +61,7 @@ func NewScaffoldCmd() (*cobra.Command, error) {
 	cmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
 		if strings.Contains(err.Error(), "--"+cmdcommon.OutputFlagName) ||
 			strings.Contains(err.Error(), "-"+cmdcommon.OutputFlagShort) {
-			return errors.New(outputFlagUnsupportedMsg)
+			return &cmdpkg.UsageError{Err: errors.New(outputFlagUnsupportedMsg)}
 		}
 		return err
 	})
@@ -77,7 +78,7 @@ func runScaffold(command *cobra.Command, args []string) error {
 	command.SilenceUsage = true
 
 	if outputFlag := command.Flag(cmdcommon.OutputFlagName); outputFlag != nil && outputFlag.Changed {
-		return errors.New(outputFlagUnsupportedMsg)
+		return &cmdpkg.UsageError{Err: errors.New(outputFlagUnsupportedMsg)}
 	}
 
 	subject, err := resources.ResolveExplainSubject(args[0])

--- a/internal/cmd/usage_error.go
+++ b/internal/cmd/usage_error.go
@@ -1,0 +1,292 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const RequiresSubcommandAnnotation = "kongctl/requires-subcommand"
+
+type Suggestion struct {
+	Kind   string
+	Values []string
+}
+
+type UsageError struct {
+	Err        error
+	Suggestion Suggestion
+}
+
+func (e *UsageError) Error() string {
+	if e == nil || e.Err == nil {
+		return "invalid command usage"
+	}
+	return e.Err.Error()
+}
+
+func (e *UsageError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func ConfigureRequiresSubcommand(command *cobra.Command) {
+	if command == nil {
+		return
+	}
+	MarkRequiresSubcommand(command)
+	command.RunE = RequireSubcommand
+}
+
+func MarkRequiresSubcommand(command *cobra.Command) {
+	if command == nil {
+		return
+	}
+	if command.Annotations == nil {
+		command.Annotations = map[string]string{}
+	}
+	command.Annotations[RequiresSubcommandAnnotation] = "true"
+}
+
+func CommandRequiresSubcommand(command *cobra.Command) bool {
+	if command == nil || command.Annotations == nil {
+		return false
+	}
+	return command.Annotations[RequiresSubcommandAnnotation] == "true"
+}
+
+func RequireSubcommand(command *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return MissingSubcommandError(command)
+	}
+	return UnknownSubcommandError(command, args[0])
+}
+
+func MissingSubcommandError(command *cobra.Command) error {
+	return &UsageError{
+		Err: fmt.Errorf("command %q requires a subcommand", commandPath(command)),
+	}
+}
+
+func UnknownSubcommandError(command *cobra.Command, arg string) error {
+	return &UsageError{
+		Err: fmt.Errorf("unknown command %q for %q", arg, commandPath(command)),
+		Suggestion: Suggestion{
+			Kind:   "command",
+			Values: SuggestSimilarCommands(command, arg),
+		},
+	}
+}
+
+func SuggestionForError(command *cobra.Command, err error) Suggestion {
+	var usageErr *UsageError
+	if errors.As(err, &usageErr) {
+		return usageErr.Suggestion
+	}
+	if suggestion := SuggestSimilarFlags(command, err); len(suggestion.Values) > 0 {
+		return suggestion
+	}
+	return Suggestion{}
+}
+
+func IsUsageError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var usageErr *UsageError
+	if errors.As(err, &usageErr) {
+		return true
+	}
+
+	var configErr *ConfigurationError
+	if errors.As(err, &configErr) {
+		return true
+	}
+
+	var notExistErr *pflag.NotExistError
+	if errors.As(err, &notExistErr) {
+		return true
+	}
+
+	var valueRequiredErr *pflag.ValueRequiredError
+	if errors.As(err, &valueRequiredErr) {
+		return true
+	}
+
+	var invalidValueErr *pflag.InvalidValueError
+	if errors.As(err, &invalidValueErr) {
+		return true
+	}
+
+	var invalidSyntaxErr *pflag.InvalidSyntaxError
+	if errors.As(err, &invalidSyntaxErr) {
+		return true
+	}
+
+	return isCobraArgumentError(err.Error())
+}
+
+func isCobraArgumentError(message string) bool {
+	message = strings.TrimSpace(message)
+	return strings.HasPrefix(message, "accepts ") ||
+		strings.HasPrefix(message, "requires at least ") ||
+		strings.HasPrefix(message, "required flag(s) ") ||
+		strings.HasPrefix(message, "unknown command ") ||
+		strings.HasPrefix(message, "unexpected argument ")
+}
+
+func SuggestSimilarCommands(command *cobra.Command, typed string) []string {
+	if command == nil || strings.TrimSpace(typed) == "" {
+		return nil
+	}
+
+	type candidate struct {
+		name  string
+		score int
+	}
+	candidates := []candidate{}
+	typed = strings.ToLower(strings.TrimSpace(typed))
+	bestScore := 3
+
+	for _, child := range command.Commands() {
+		if !child.IsAvailableCommand() {
+			continue
+		}
+		name := child.Name()
+		score := levenshtein(typed, strings.ToLower(name))
+		if strings.HasPrefix(strings.ToLower(name), typed) {
+			score = 0
+		}
+		for _, explicit := range child.SuggestFor {
+			if strings.EqualFold(typed, explicit) {
+				score = 0
+				break
+			}
+		}
+		if score > 2 {
+			continue
+		}
+		if score < bestScore {
+			bestScore = score
+			candidates = candidates[:0]
+		}
+		if score == bestScore {
+			candidates = append(candidates, candidate{name: name, score: score})
+		}
+	}
+
+	suggestions := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		suggestions = append(suggestions, candidate.name)
+	}
+	slices.Sort(suggestions)
+	return suggestions
+}
+
+func SuggestSimilarFlags(command *cobra.Command, err error) Suggestion {
+	if command == nil || err == nil {
+		return Suggestion{}
+	}
+
+	var flagErr *pflag.NotExistError
+	if !errors.As(err, &flagErr) {
+		return Suggestion{}
+	}
+
+	name := flagErr.GetSpecifiedName()
+	if name == "" {
+		return Suggestion{}
+	}
+
+	shortnames := flagErr.GetSpecifiedShortnames()
+	if shortnames != "" {
+		return suggestSimilarShorthandFlags(command, name)
+	}
+	return suggestSimilarLongFlags(command, name)
+}
+
+func suggestSimilarLongFlags(command *cobra.Command, typed string) Suggestion {
+	candidates := make([]string, 0)
+	command.Flags().VisitAll(func(flag *pflag.Flag) {
+		if flag.Hidden {
+			return
+		}
+		if similar(typed, flag.Name) {
+			candidates = append(candidates, "--"+flag.Name)
+		}
+	})
+	slices.Sort(candidates)
+	return Suggestion{Kind: "flag", Values: candidates}
+}
+
+func suggestSimilarShorthandFlags(command *cobra.Command, typed string) Suggestion {
+	candidates := make([]string, 0)
+	command.Flags().VisitAll(func(flag *pflag.Flag) {
+		if flag.Hidden || flag.Shorthand == "" {
+			return
+		}
+		if similar(typed, flag.Shorthand) {
+			candidates = append(candidates, "-"+flag.Shorthand)
+		}
+	})
+	slices.Sort(candidates)
+	return Suggestion{Kind: "flag", Values: candidates}
+}
+
+func similar(a, b string) bool {
+	a = strings.ToLower(strings.TrimSpace(a))
+	b = strings.ToLower(strings.TrimSpace(b))
+	if a == "" || b == "" {
+		return false
+	}
+	return strings.HasPrefix(b, a) || levenshtein(a, b) <= 2
+}
+
+func levenshtein(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if len(a) == 0 {
+		return len(b)
+	}
+	if len(b) == 0 {
+		return len(a)
+	}
+
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for j := range len(prev) {
+		prev[j] = j
+	}
+
+	for i, ca := range a {
+		curr[0] = i + 1
+		for j, cb := range b {
+			cost := 1
+			if ca == cb {
+				cost = 0
+			}
+			curr[j+1] = min(
+				curr[j]+1,
+				prev[j+1]+1,
+				prev[j]+cost,
+			)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
+}
+
+func commandPath(command *cobra.Command) string {
+	if command == nil {
+		return "kongctl"
+	}
+	return command.CommandPath()
+}


### PR DESCRIPTION
## Summary

- Suppress full Cobra usage dumps for usage/configuration errors.
- Render concise error output with an explicit follow-up help command.
- Add command and flag suggestions for close matches.
- Convert help-only command groups to concise missing/unknown subcommand errors.
- Add command-tree coverage for unknown flags, missing subcommands, and unknown subcommands.

## Why

Usage output was being printed after many errors, which could push the actual error out of view. This makes errors visible first and gives users a clear next command to run for full usage details.

## Validation

- `go test ./internal/cmd/root`
- `go test ./internal/cmd/...`
- `make format`
- `make lint`
- `make test`
- `make build`
- Manual smoke checks for `kongctl get`, `kongctl aply`, `kongctl get gatewy`, `kongctl version --log-leve error`, `kongctl plan -o plan.json`, and `kongctl get --help`.

Closes #1048