### PR TITLE
Task: improve command error, help, and usage text display

### DIFF
--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -131,8 +131,9 @@ const logFilePIDToken = "%PID%"
 func mergedFlagUsages(cmd *cobra.Command) string {
 	flags := pflag.NewFlagSet(cmd.DisplayName(), pflag.ContinueOnError)
 	flags.SortFlags = true
-	addFlagSetCopies(flags, cmd.LocalFlags())
-	addFlagSetCopies(flags, cmd.InheritedFlags())
+	hideOutput := common.IsOutputFormatValidationSkipped(cmd)
+	addFlagSetCopies(flags, cmd.LocalFlags(), hideOutput)
+	addFlagSetCopies(flags, cmd.InheritedFlags(), hideOutput)
 
 	if f := flags.Lookup(common.OutputFlagName); f != nil {
 		f.Usage = outputFlagUsage(common.AllowedOutputFormats(cmd))
@@ -141,11 +142,14 @@ func mergedFlagUsages(cmd *cobra.Command) string {
 	return strings.TrimRight(flags.FlagUsages(), "\n")
 }
 
-func addFlagSetCopies(dst, src *pflag.FlagSet) {
+func addFlagSetCopies(dst, src *pflag.FlagSet, hideOutput bool) {
 	if dst == nil || src == nil {
 		return
 	}
 	src.VisitAll(func(flag *pflag.Flag) {
+		if hideOutput && flag.Name == common.OutputFlagName {
+			return
+		}
 		flagCopy := *flag
 		if flag.Annotations != nil {
 			flagCopy.Annotations = make(map[string][]string, len(flag.Annotations))

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -54,9 +54,9 @@ import (
 
 var (
 	rootLong = normalizers.LongDesc(i18n.T("root.rootLong", `
-  Kong CLI is the official command line tool for Kong projects and products.
+  kongctl is the official command line tool for the Kong Konnect API platform.
 
-  Find more information at:
+Find more information at:
    https://developer.konghq.com/kongctl/`))
 
 	rootShort = i18n.T("root/rootShort", fmt.Sprintf("%s controls Kong", meta.CLIName))
@@ -185,6 +185,13 @@ func newRootCmd() *cobra.Command {
 		Long:          rootLong,
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return cmdpkg.UnknownSubcommandError(cmd, args[0])
+			}
+			renderRootOverview(cmd.OutOrStdout(), cmd)
+			return nil
+		},
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := validateOutputFormat(cmd); err != nil {
 				return &cmdpkg.ConfigurationError{Err: err}
@@ -207,6 +214,7 @@ func newRootCmd() *cobra.Command {
 	})
 	cobra.AddTemplateFunc("mergedFlagUsages", mergedFlagUsages)
 	rootCmd.SetUsageTemplate(mergedFlagsUsageTemplate)
+	rootCmd.SetFlagErrorFunc(rootFlagError)
 
 	// parses all flags not just the target command
 	rootCmd.TraverseChildren = true
@@ -421,6 +429,41 @@ func installUsageErrorFallbacks(command *cobra.Command) {
 	for _, child := range command.Commands() {
 		installUsageErrorFallbacks(child)
 	}
+}
+
+func renderRootOverview(w io.Writer, command *cobra.Command) {
+	if w == nil || command == nil {
+		return
+	}
+
+	if long := strings.TrimSpace(command.Long); long != "" {
+		fmt.Fprintln(w, long)
+		fmt.Fprintln(w)
+	}
+
+	if command.HasAvailableSubCommands() {
+		fmt.Fprintln(w, "Available Commands:")
+		for _, child := range command.Commands() {
+			if child.IsAvailableCommand() || child.Name() == "help" {
+				fmt.Fprintf(w, "  %-*s %s\n", child.NamePadding(), child.Name(), child.Short)
+			}
+		}
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, `Use "%s [command] --help" for more information about a command.`, command.CommandPath())
+		fmt.Fprintln(w)
+	}
+}
+
+func rootFlagError(command *cobra.Command, err error) error {
+	if command != nil && command.Root() == command {
+		for _, arg := range command.Flags().Args() {
+			if strings.TrimSpace(arg) == "" {
+				continue
+			}
+			return cmdpkg.UnknownSubcommandError(command, arg)
+		}
+	}
+	return err
 }
 
 func sampleThemeNames() []string {

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -455,15 +455,38 @@ func renderRootOverview(w io.Writer, command *cobra.Command) {
 }
 
 func rootFlagError(command *cobra.Command, err error) error {
-	if command != nil && command.Root() == command {
-		for _, arg := range command.Flags().Args() {
-			if strings.TrimSpace(arg) == "" {
-				continue
-			}
-			return cmdpkg.UnknownSubcommandError(command, arg)
+	if command == nil || command.Root() != command {
+		return err
+	}
+
+	var flagErr *pflag.NotExistError
+	if !errors.As(err, &flagErr) {
+		return err
+	}
+
+	for _, arg := range command.Flags().Args() {
+		arg = strings.TrimSpace(arg)
+		if arg == "" || strings.HasPrefix(arg, "-") {
+			continue
 		}
+		if rootCommandHasSubcommand(command, arg) {
+			return err
+		}
+		return cmdpkg.UnknownSubcommandError(command, arg)
 	}
 	return err
+}
+
+func rootCommandHasSubcommand(command *cobra.Command, name string) bool {
+	if command == nil || name == "" {
+		return false
+	}
+	for _, child := range command.Commands() {
+		if child.IsAvailableCommand() && (child.Name() == name || child.HasAlias(name)) {
+			return true
+		}
+	}
+	return false
 }
 
 func sampleThemeNames() []string {

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -119,6 +119,78 @@ func TestOutputFlagHelpVisibility(t *testing.T) {
 	}
 }
 
+func TestKonnectFirstHelpExamplesMatchExplicitTarget(t *testing.T) {
+	tests := []struct {
+		name         string
+		shorthand    []string
+		explicitForm []string
+	}{
+		{
+			name:         "apply",
+			shorthand:    []string{"apply", "--help"},
+			explicitForm: []string{"apply", "konnect", "--help"},
+		},
+		{
+			name:         "diff",
+			shorthand:    []string{"diff", "--help"},
+			explicitForm: []string{"diff", "konnect", "--help"},
+		},
+		{
+			name:         "plan",
+			shorthand:    []string{"plan", "--help"},
+			explicitForm: []string{"plan", "konnect", "--help"},
+		},
+		{
+			name:         "sync",
+			shorthand:    []string{"sync", "--help"},
+			explicitForm: []string{"sync", "konnect", "--help"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shorthand := executeRootForTest(t, tt.shorthand...)
+			explicitForm := executeRootForTest(t, tt.explicitForm...)
+			if shorthand.exitCode != 0 || explicitForm.exitCode != 0 {
+				t.Fatalf("expected help commands to succeed\nshorthand:\n%s\n%s\nexplicit:\n%s\n%s",
+					shorthand.stdout, shorthand.stderr, explicitForm.stdout, explicitForm.stderr)
+			}
+
+			shorthandExamples := helpSectionForTest(t, shorthand.stdout, "Examples:")
+			explicitExamples := helpSectionForTest(t, explicitForm.stdout, "Examples:")
+			if shorthandExamples != explicitExamples {
+				t.Fatalf("expected shorthand and explicit examples to match\nshorthand:\n%s\nexplicit:\n%s",
+					shorthandExamples, explicitExamples)
+			}
+		})
+	}
+}
+
+func TestDeleteHelpUsesDeclarativeExamples(t *testing.T) {
+	result := executeRootForTest(t, "delete", "--help")
+	if result.exitCode != 0 {
+		t.Fatalf("expected delete help to succeed, got %d\nstdout:\n%s\nstderr:\n%s",
+			result.exitCode, result.stdout, result.stderr)
+	}
+
+	examples := helpSectionForTest(t, result.stdout, "Examples:")
+	for _, want := range []string{
+		"# Delete Konnect resources defined in declarative configuration",
+		"kongctl delete -f config.yaml",
+		"# Preview deletions before executing them",
+		"kongctl delete -f config.yaml --dry-run",
+		"# Execute a reviewed delete plan without prompting",
+		"kongctl delete --plan delete-plan.json --auto-approve",
+	} {
+		if !strings.Contains(examples, want) {
+			t.Fatalf("expected delete examples to contain %q\nexamples:\n%s", want, examples)
+		}
+	}
+	if strings.Contains(examples, "kongctl delete -f ./configs/ --recursive") {
+		t.Fatalf("expected delete examples not to contain stale recursive example\nexamples:\n%s", examples)
+	}
+}
+
 func TestRootApplyHelpShowsExamples(t *testing.T) {
 	oldRootCmd := rootCmd
 	t.Cleanup(func() {
@@ -695,6 +767,25 @@ func commandPathForTest(path []string) string {
 		return "kongctl"
 	}
 	return "kongctl " + strings.Join(path, " ")
+}
+
+func helpSectionForTest(t *testing.T, help, header string) string {
+	t.Helper()
+	start := strings.Index(help, header)
+	if start < 0 {
+		t.Fatalf("expected help to contain %q\nhelp:\n%s", header, help)
+	}
+	section := help[start:]
+	if end := strings.Index(section, "\n\nAvailable Commands:"); end >= 0 {
+		return strings.TrimSpace(section[:end])
+	}
+	if end := strings.Index(section, "\n\nFlags:"); end >= 0 {
+		return strings.TrimSpace(section[:end])
+	}
+	if end := strings.Index(section, "\n\nUse \""); end >= 0 {
+		return strings.TrimSpace(section[:end])
+	}
+	return strings.TrimSpace(section)
 }
 
 func firstAvailableChildName(command *cobra.Command) string {

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -232,6 +232,35 @@ func TestRootErrorUX(t *testing.T) {
 			expectStderr: true,
 		},
 		{
+			name: "format flag suggests output when output is valid",
+			args: []string{"version", "--format", "yaml"},
+			wantErr: []string{
+				`Error: unknown flag: --format`,
+				`Run 'kongctl version --help' for usage.`,
+				"Did you mean this flag?",
+				"--output, -o",
+				"Configures the format of data written to STDOUT.",
+			},
+			wantExit:     1,
+			forbidErr:    []string{"Usage:"},
+			expectStderr: true,
+		},
+		{
+			name: "format flag does not suggest output when output is unsupported",
+			args: []string{"scaffold", "--format", "yaml", "api"},
+			wantErr: []string{
+				`Error: unknown flag: --format`,
+				`Run 'kongctl scaffold --help' for usage.`,
+			},
+			wantExit: 1,
+			forbidErr: []string{
+				"Usage:",
+				"Did you mean this flag?",
+				"--output",
+			},
+			expectStderr: true,
+		},
+		{
 			name: "unknown shorthand flag suggestions include descriptions",
 			args: []string{"diff", "-g", "config.yaml"},
 			wantErr: []string{

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -206,6 +206,20 @@ func TestRootErrorUX(t *testing.T) {
 			expectStderr: true,
 		},
 		{
+			name: "unknown root flag before known command stays flag error",
+			args: []string{"--definitely-not-a-real-kongctl-flag", "version"},
+			wantErr: []string{
+				`Error: unknown flag: --definitely-not-a-real-kongctl-flag`,
+				`Run 'kongctl --help' for usage.`,
+			},
+			wantExit: 1,
+			forbidErr: []string{
+				"Usage:",
+				`unknown command "version"`,
+			},
+			expectStderr: true,
+		},
+		{
 			name: "unknown nested command suggests close match",
 			args: []string{"get", "gatewy"},
 			wantErr: []string{

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -57,6 +57,68 @@ func TestMergedFlagUsagesUsesCommandSpecificOutputFormats(t *testing.T) {
 	}
 }
 
+func TestOutputFlagHelpVisibility(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantOut   []string
+		forbidOut []string
+	}{
+		{
+			name: "plan hides unsupported inherited output flag",
+			args: []string{"plan", "--help"},
+			forbidOut: []string{
+				"-o, --output string",
+				"Allowed    : [ json|yaml|text ]",
+			},
+		},
+		{
+			name: "plan konnect hides unsupported inherited output flag",
+			args: []string{"plan", "konnect", "--help"},
+			forbidOut: []string{
+				"-o, --output string",
+				"Allowed    : [ json|yaml|text ]",
+			},
+		},
+		{
+			name: "scaffold hides unsupported inherited output flag",
+			args: []string{"scaffold", "--help"},
+			forbidOut: []string{
+				"-o, --output string",
+				"Allowed    : [ json|yaml|text ]",
+			},
+		},
+		{
+			name: "explain keeps supported output flag",
+			args: []string{"explain", "--help"},
+			wantOut: []string{
+				"-o, --output string",
+				"Allowed    : [ json|yaml|text ]",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := executeRootForTest(t, tt.args...)
+			if result.exitCode != 0 {
+				t.Fatalf("expected exit code 0, got %d\nstdout:\n%s\nstderr:\n%s",
+					result.exitCode, result.stdout, result.stderr)
+			}
+			for _, want := range tt.wantOut {
+				if !strings.Contains(result.stdout, want) {
+					t.Fatalf("expected stdout to contain %q\nstdout:\n%s", want, result.stdout)
+				}
+			}
+			for _, forbidden := range tt.forbidOut {
+				if strings.Contains(result.stdout, forbidden) {
+					t.Fatalf("expected stdout not to contain %q\nstdout:\n%s", forbidden, result.stdout)
+				}
+			}
+		})
+	}
+}
+
 func TestRootApplyHelpShowsExamples(t *testing.T) {
 	oldRootCmd := rootCmd
 	t.Cleanup(func() {

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -135,15 +135,17 @@ func TestRootErrorUX(t *testing.T) {
 		expectStdout bool
 	}{
 		{
-			name: "bare root requires command",
+			name: "bare root shows help",
 			args: []string{},
-			wantErr: []string{
-				`Error: command "kongctl" requires a subcommand`,
-				`Run 'kongctl --help' for usage.`,
+			wantOut: []string{
+				`kongctl is the official command line tool for the Kong Konnect API platform.`,
+				"Find more information at:",
+				"Available Commands:",
 			},
-			wantExit:     1,
-			forbidErr:    []string{"Usage:"},
-			expectStderr: true,
+			wantExit:     0,
+			forbidErr:    []string{"Error:"},
+			forbidOut:    []string{"Flags:", "Usage:"},
+			expectStdout: true,
 		},
 		{
 			name: "bare command group requires subcommand",
@@ -170,6 +172,40 @@ func TestRootErrorUX(t *testing.T) {
 			expectStderr: true,
 		},
 		{
+			name: "unknown top level command before unsupported shorthand suggests command",
+			args: []string{"synch", "-f", "config.yaml"},
+			wantErr: []string{
+				`Error: unknown command "synch" for "kongctl"`,
+				`Run 'kongctl --help' for usage.`,
+				"Did you mean this command?",
+				"  sync",
+			},
+			wantExit: 1,
+			forbidErr: []string{
+				"Usage:",
+				"unknown shorthand flag",
+				"Did you mean one of these flags?",
+			},
+			expectStderr: true,
+		},
+		{
+			name: "unknown top level command typo before unsupported shorthand suggests command",
+			args: []string{"syk", "-f", "config.yaml"},
+			wantErr: []string{
+				`Error: unknown command "syk" for "kongctl"`,
+				`Run 'kongctl --help' for usage.`,
+				"Did you mean this command?",
+				"  sync",
+			},
+			wantExit: 1,
+			forbidErr: []string{
+				"Usage:",
+				"unknown shorthand flag",
+				"Did you mean one of these flags?",
+			},
+			expectStderr: true,
+		},
+		{
 			name: "unknown nested command suggests close match",
 			args: []string{"get", "gatewy"},
 			wantErr: []string{
@@ -190,6 +226,22 @@ func TestRootErrorUX(t *testing.T) {
 				`Run 'kongctl version --help' for usage.`,
 				"Did you mean this flag?",
 				"  --log-level",
+			},
+			wantExit:     1,
+			forbidErr:    []string{"Usage:"},
+			expectStderr: true,
+		},
+		{
+			name: "unknown shorthand flag suggestions include descriptions",
+			args: []string{"diff", "-g", "config.yaml"},
+			wantErr: []string{
+				`Error: unknown shorthand flag: 'g' in -g`,
+				`Run 'kongctl diff --help' for usage.`,
+				"Did you mean one of these flags?",
+				"-f, --filename",
+				"Filename or directory to files to use to create the resource",
+				"-R, --recursive",
+				"Process the directory used in -f, --filename recursively",
 			},
 			wantExit:     1,
 			forbidErr:    []string{"Usage:"},
@@ -223,6 +275,19 @@ func TestRootErrorUX(t *testing.T) {
 			wantOut: []string{
 				"Usage:",
 				"kongctl get [command]",
+			},
+			wantExit:     0,
+			forbidErr:    []string{"Error:"},
+			expectStdout: true,
+		},
+		{
+			name: "explicit root help still renders flags",
+			args: []string{"--help"},
+			wantOut: []string{
+				`kongctl is the official command line tool for the Kong Konnect API platform.`,
+				"Find more information at:",
+				"Usage:",
+				"Flags:",
 			},
 			wantExit:     0,
 			forbidErr:    []string{"Error:"},

--- a/internal/cmd/root/verbs/apply/apply.go
+++ b/internal/cmd/root/verbs/apply/apply.go
@@ -2,14 +2,12 @@ package apply
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/kong/kongctl/internal/cmd/root/products"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	"github.com/kong/kongctl/internal/konnect/helpers"
-	"github.com/kong/kongctl/internal/meta"
 	"github.com/kong/kongctl/internal/util/i18n"
 	"github.com/kong/kongctl/internal/util/normalizers"
 	"github.com/spf13/cobra"
@@ -26,16 +24,6 @@ var (
 
 	applyLong = normalizers.LongDesc(i18n.T("root.verbs.apply.applyLong",
 		`Apply configuration changes to Kong Konnect. Creates new resources and updates existing ones.`))
-
-	applyExamples = normalizers.Examples(i18n.T("root.verbs.apply.applyExamples",
-		fmt.Sprintf(`  # Apply Konnect configuration changes (Konnect is the default target)
-  %[1]s apply -f api.yaml
-
-  # Apply using the explicit Konnect target form
-  %[1]s apply konnect -f api.yaml
-
-  # Apply from a pre-generated plan
-  %[1]s apply --plan plan.json`, meta.CLIName)))
 )
 
 func NewApplyCmd() (*cobra.Command, error) {
@@ -49,7 +37,7 @@ func NewApplyCmd() (*cobra.Command, error) {
 		Use:     applyUse,
 		Short:   applyShort,
 		Long:    applyLong,
-		Example: applyExamples,
+		Example: konnectCmd.Example,
 		Aliases: []string{"a", "A"},
 		// Use the konnect command's RunE directly for Konnect-first pattern
 		RunE: konnectCmd.RunE,

--- a/internal/cmd/root/verbs/del/del.go
+++ b/internal/cmd/root/verbs/del/del.go
@@ -11,7 +11,6 @@ import (
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/declarative"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	"github.com/kong/kongctl/internal/konnect/helpers"
-	"github.com/kong/kongctl/internal/meta"
 	"github.com/kong/kongctl/internal/util/i18n"
 	"github.com/kong/kongctl/internal/util/normalizers"
 	"github.com/spf13/cobra"
@@ -32,14 +31,6 @@ var (
 Deletes all resources defined in the declarative configuration files from Konnect.
 This is equivalent to running:
   kongctl plan --mode delete -f <files> | kongctl sync --plan -`))
-
-	deleteExamples = normalizers.Examples(i18n.T("root.verbs.delete.deleteExamples",
-		fmt.Sprintf(`
-		# Delete resources defined in declarative configuration
-		%[1]s delete -f config.yaml
-		%[1]s delete -f ./configs/ --recursive
-		%[1]s delete -f config.yaml --dry-run
-		`, meta.CLIName)))
 )
 
 func NewDeleteCmd() (*cobra.Command, error) {
@@ -55,7 +46,7 @@ func NewDeleteCmd() (*cobra.Command, error) {
 		Use:     deleteuse,
 		Short:   deleteShort,
 		Long:    deleteLong,
-		Example: deleteExamples,
+		Example: declDeleteCmd.Example,
 		Aliases: []string{"d", "D", "del", "rm", "DEL", "RM"},
 		// When -f is provided, run declarative delete; otherwise show help
 		RunE: func(c *cobra.Command, args []string) error {

--- a/internal/cmd/root/verbs/diff/diff.go
+++ b/internal/cmd/root/verbs/diff/diff.go
@@ -2,11 +2,9 @@ package diff
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
-	"github.com/kong/kongctl/internal/meta"
 	"github.com/kong/kongctl/internal/util/i18n"
 	"github.com/kong/kongctl/internal/util/normalizers"
 	"github.com/spf13/cobra"
@@ -24,15 +22,6 @@ var (
 
 	diffLong = normalizers.LongDesc(i18n.T("root.verbs.diff.diffLong",
 		`Display differences between current and desired state.`))
-
-	diffExamples = normalizers.Examples(i18n.T("root.verbs.diff.diffExamples",
-		fmt.Sprintf(`  %[1]s diff -f api.yaml
-  %[1]s diff -f api.yaml --mode apply
-  %[1]s diff -f api.yaml --mode delete
-  %[1]s diff --plan plan.json
-  %[1]s diff -f config.yaml --output json
-
-Use "%[1]s help diff" for detailed documentation`, meta.CLIName)))
 )
 
 func NewDiffCmd() (*cobra.Command, error) {
@@ -46,7 +35,7 @@ func NewDiffCmd() (*cobra.Command, error) {
 		Use:     diffUse,
 		Short:   diffShort,
 		Long:    diffLong,
-		Example: diffExamples,
+		Example: konnectCmd.Example,
 		Args:    verbs.NoPositionalArgs,
 		// Use the konnect command's RunE directly for Konnect-first pattern
 		RunE: konnectCmd.RunE,

--- a/internal/cmd/root/verbs/diff/diff_test.go
+++ b/internal/cmd/root/verbs/diff/diff_test.go
@@ -59,8 +59,9 @@ func TestDiffCmdHelpText(t *testing.T) {
 	assert.Contains(t, cmd.Short, "Show declarative configuration", "Short should mention showing configuration")
 	assert.Contains(t, cmd.Long, "differences", "Long should mention differences")
 	assert.Contains(t, cmd.Example, "--plan", "Examples should show --plan flag usage")
-	assert.Contains(t, cmd.Example, "--output json", "Examples should show output format option")
-	assert.Contains(t, cmd.Example, "help diff", "Examples should mention extended help")
+	assert.Contains(t, cmd.Example, "diff konnect -f api.yaml", "Examples should show explicit Konnect usage")
+	assert.NotContains(t, cmd.Example, "--output json", "Examples should not use stale output example")
+	assert.NotContains(t, cmd.Example, "help diff", "Examples should come from Konnect declarative command")
 }
 
 func TestDiffCmd_Flags(t *testing.T) {

--- a/internal/cmd/root/verbs/export/export.go
+++ b/internal/cmd/root/verbs/export/export.go
@@ -2,11 +2,9 @@ package export
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
-	"github.com/kong/kongctl/internal/meta"
 	"github.com/kong/kongctl/internal/util/i18n"
 	"github.com/kong/kongctl/internal/util/normalizers"
 	"github.com/spf13/cobra"
@@ -28,21 +26,6 @@ var (
 This command retrieves the current configuration from the target environment
 and generates declarative configuration files that can be version controlled,
 modified, and applied to other environments.`))
-
-	exportExamples = normalizers.Examples(i18n.T("root.verbs.export.exportExamples",
-		fmt.Sprintf(`
-		# Export all resources to directory
-		%[1]s export -o ./exported-config
-		
-		# Export specific resource types
-		%[1]s export -o ./exported-config --resources portals,apis
-		
-		# Export to a specific structure
-		%[1]s export -o ./config --structure flat
-		
-		# Export with custom file naming
-		%[1]s export -o ./config --split-by-type
-		`, meta.CLIName)))
 )
 
 func NewExportCmd() (*cobra.Command, error) {
@@ -56,7 +39,7 @@ func NewExportCmd() (*cobra.Command, error) {
 		Use:     exportUse,
 		Short:   exportShort,
 		Long:    exportLong,
-		Example: exportExamples,
+		Example: konnectCmd.Example,
 		// Use the konnect command's RunE directly for Konnect-first pattern
 		RunE: konnectCmd.RunE,
 		PersistentPreRun: func(cmd *cobra.Command, _ []string) {

--- a/internal/cmd/root/verbs/plan/plan.go
+++ b/internal/cmd/root/verbs/plan/plan.go
@@ -10,7 +10,6 @@ import (
 	cmdcommon "github.com/kong/kongctl/internal/cmd/common"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
-	"github.com/kong/kongctl/internal/meta"
 	"github.com/kong/kongctl/internal/util/i18n"
 	"github.com/kong/kongctl/internal/util/normalizers"
 	"github.com/spf13/cobra"
@@ -28,13 +27,6 @@ var (
 
 	planLong = normalizers.LongDesc(i18n.T("root.verbs.plan.planLong",
 		`Generate an execution plan showing what changes will be made to a set of declarative configurations.`))
-
-	planExamples = normalizers.Examples(i18n.T("root.verbs.plan.planExamples",
-		fmt.Sprintf(`  %[1]s plan -f api.yaml
-  %[1]s plan -f ./configs/ --recursive
-  %[1]s plan -f config.yaml --output-file plan.json
-
-Use "%[1]s help plan" for detailed documentation`, meta.CLIName)))
 )
 
 func NewPlanCmd() (*cobra.Command, error) {
@@ -48,7 +40,7 @@ func NewPlanCmd() (*cobra.Command, error) {
 		Use:     planUse,
 		Short:   planShort,
 		Long:    planLong,
-		Example: planExamples,
+		Example: konnectCmd.Example,
 		Args:    verbs.NoPositionalArgs,
 		// Use the konnect command's RunE directly for Konnect-first pattern
 		RunE: konnectCmd.RunE,

--- a/internal/cmd/root/verbs/plan/plan_test.go
+++ b/internal/cmd/root/verbs/plan/plan_test.go
@@ -51,7 +51,9 @@ func TestPlanCmdHelpText(t *testing.T) {
 		"Short should mention preview changes")
 	assert.Contains(t, cmd.Long, "execution plan", "Long should mention execution plan")
 	assert.Contains(t, cmd.Example, "-f", "Examples should show -f flag usage")
-	assert.Contains(t, cmd.Example, "help plan", "Examples should mention extended help")
+	assert.Contains(t, cmd.Example, "plan konnect -f api.yaml", "Examples should show explicit Konnect usage")
+	assert.Contains(t, cmd.Example, "--output-file plan.json", "Examples should show plan artifact output")
+	assert.NotContains(t, cmd.Example, "help plan", "Examples should come from Konnect declarative command")
 }
 
 func TestPlanCmdSubcommandAccess(t *testing.T) {

--- a/internal/cmd/root/verbs/sync/sync.go
+++ b/internal/cmd/root/verbs/sync/sync.go
@@ -2,11 +2,9 @@ package sync
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
-	"github.com/kong/kongctl/internal/meta"
 	"github.com/kong/kongctl/internal/util/i18n"
 	"github.com/kong/kongctl/internal/util/normalizers"
 	"github.com/spf13/cobra"
@@ -24,13 +22,6 @@ var (
 
 	syncLong = normalizers.LongDesc(i18n.T("root.verbs.sync.syncLong",
 		`Synchronize configuration with Kong Konnect. Creates, updates, and DELETES resources.`))
-
-	syncExamples = normalizers.Examples(i18n.T("root.verbs.sync.syncExamples",
-		fmt.Sprintf(`  %[1]s sync -f api.yaml
-  %[1]s sync -f ./configs/ --dry-run
-  %[1]s sync --plan plan.json --auto-approve
-
-Use "%[1]s help sync" for detailed documentation`, meta.CLIName)))
 )
 
 func NewSyncCmd() (*cobra.Command, error) {
@@ -44,7 +35,7 @@ func NewSyncCmd() (*cobra.Command, error) {
 		Use:     syncUse,
 		Short:   syncShort,
 		Long:    syncLong,
-		Example: syncExamples,
+		Example: konnectCmd.Example,
 		Args:    verbs.NoPositionalArgs,
 		// Use the konnect command's RunE directly for Konnect-first pattern
 		RunE: konnectCmd.RunE,

--- a/internal/cmd/root/verbs/sync/sync_test.go
+++ b/internal/cmd/root/verbs/sync/sync_test.go
@@ -53,8 +53,10 @@ func TestSyncCmdHelpText(t *testing.T) {
 	assert.Contains(t, cmd.Short, "Synchronize declarative configuration", "Short should mention synchronization")
 	assert.Contains(t, cmd.Long, "Synchronize configuration", "Long should mention configuration")
 	assert.Contains(t, cmd.Example, "-f", "Examples should show -f flag usage")
-	assert.Contains(t, cmd.Example, "--dry-run", "Examples should show dry-run option")
-	assert.Contains(t, cmd.Example, "help sync", "Examples should mention extended help")
+	assert.Contains(t, cmd.Example, "sync konnect -f api.yaml", "Examples should show explicit Konnect usage")
+	assert.Contains(t, cmd.Example, "--plan plan.json --auto-approve", "Examples should show plan execution")
+	assert.NotContains(t, cmd.Example, "sync -f ./configs/ --dry-run", "Examples should not use stale dry-run example")
+	assert.NotContains(t, cmd.Example, "help sync", "Examples should come from Konnect declarative command")
 }
 
 func TestSyncCmd_Flags(t *testing.T) {

--- a/internal/cmd/usage_error.go
+++ b/internal/cmd/usage_error.go
@@ -6,11 +6,13 @@ import (
 	"slices"
 	"strings"
 
+	cmdcommon "github.com/kong/kongctl/internal/cmd/common"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
 const RequiresSubcommandAnnotation = "kongctl/requires-subcommand"
+const formatFlagName = "format"
 
 type Suggestion struct {
 	Kind   string
@@ -214,6 +216,11 @@ func SuggestSimilarFlags(command *cobra.Command, err error) Suggestion {
 
 func suggestSimilarLongFlags(command *cobra.Command, typed string) Suggestion {
 	candidates := make([]flagSuggestion, 0)
+	if strings.EqualFold(typed, formatFlagName) {
+		if output := suggestedOutputFlag(command); output != nil {
+			candidates = append(candidates, newFlagSuggestion(outputFlagSuggestionLabel(output), output))
+		}
+	}
 	command.Flags().VisitAll(func(flag *pflag.Flag) {
 		if flag.Hidden {
 			return
@@ -236,6 +243,24 @@ func suggestSimilarShorthandFlags(command *cobra.Command, typed string) Suggesti
 		}
 	})
 	return Suggestion{Kind: "flag", Values: formatFlagSuggestions(candidates)}
+}
+
+func suggestedOutputFlag(command *cobra.Command) *pflag.Flag {
+	if command == nil || cmdcommon.IsOutputFormatValidationSkipped(command) {
+		return nil
+	}
+	flag := command.Flags().Lookup(cmdcommon.OutputFlagName)
+	if flag == nil || flag.Hidden {
+		return nil
+	}
+	return flag
+}
+
+func outputFlagSuggestionLabel(flag *pflag.Flag) string {
+	if flag == nil || strings.TrimSpace(flag.Shorthand) == "" {
+		return "--" + cmdcommon.OutputFlagName
+	}
+	return fmt.Sprintf("--%s, -%s", cmdcommon.OutputFlagName, flag.Shorthand)
 }
 
 type flagSuggestion struct {

--- a/internal/cmd/usage_error.go
+++ b/internal/cmd/usage_error.go
@@ -213,31 +213,70 @@ func SuggestSimilarFlags(command *cobra.Command, err error) Suggestion {
 }
 
 func suggestSimilarLongFlags(command *cobra.Command, typed string) Suggestion {
-	candidates := make([]string, 0)
+	candidates := make([]flagSuggestion, 0)
 	command.Flags().VisitAll(func(flag *pflag.Flag) {
 		if flag.Hidden {
 			return
 		}
 		if similar(typed, flag.Name) {
-			candidates = append(candidates, "--"+flag.Name)
+			candidates = append(candidates, newFlagSuggestion("--"+flag.Name, flag))
 		}
 	})
-	slices.Sort(candidates)
-	return Suggestion{Kind: "flag", Values: candidates}
+	return Suggestion{Kind: "flag", Values: formatFlagSuggestions(candidates)}
 }
 
 func suggestSimilarShorthandFlags(command *cobra.Command, typed string) Suggestion {
-	candidates := make([]string, 0)
+	candidates := make([]flagSuggestion, 0)
 	command.Flags().VisitAll(func(flag *pflag.Flag) {
 		if flag.Hidden || flag.Shorthand == "" {
 			return
 		}
 		if similar(typed, flag.Shorthand) {
-			candidates = append(candidates, "-"+flag.Shorthand)
+			candidates = append(candidates, newFlagSuggestion(fmt.Sprintf("-%s, --%s", flag.Shorthand, flag.Name), flag))
 		}
 	})
-	slices.Sort(candidates)
-	return Suggestion{Kind: "flag", Values: candidates}
+	return Suggestion{Kind: "flag", Values: formatFlagSuggestions(candidates)}
+}
+
+type flagSuggestion struct {
+	label       string
+	description string
+}
+
+func newFlagSuggestion(label string, flag *pflag.Flag) flagSuggestion {
+	return flagSuggestion{
+		label:       label,
+		description: flagDescription(flag),
+	}
+}
+
+func formatFlagSuggestions(candidates []flagSuggestion) []string {
+	slices.SortFunc(candidates, func(a, b flagSuggestion) int {
+		return strings.Compare(a.label, b.label)
+	})
+
+	width := 0
+	for _, candidate := range candidates {
+		width = max(width, len(candidate.label))
+	}
+
+	suggestions := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.description == "" {
+			suggestions = append(suggestions, candidate.label)
+			continue
+		}
+		suggestions = append(suggestions, fmt.Sprintf("%-*s  %s", width, candidate.label, candidate.description))
+	}
+	return suggestions
+}
+
+func flagDescription(flag *pflag.Flag) string {
+	if flag == nil {
+		return ""
+	}
+	description, _, _ := strings.Cut(strings.TrimSpace(flag.Usage), "\n")
+	return strings.TrimSpace(description)
 }
 
 func similar(a, b string) bool {


### PR DESCRIPTION
## Summary

- Show a concise root overview for bare `kongctl` instead of a subcommand-required error.
- Keep full root help, including usage and flags, for `kongctl --help`.
- Prefer command typo errors over root flag errors when an unknown top-level command is followed by command-specific flags.
- Include flag descriptions in flag suggestion output.

## Validation

- `make test`
- `make lint`
- `make build`
- Manual checks for bare `kongctl`, `kongctl --help`, command typo suggestions, and `diff -g` flag suggestions.


Closes #1051 
Closes #1066