### PR TITLE
Fix: improve `get / list profile` commands

### DIFF
--- a/internal/cmd/root/profile/profile.go
+++ b/internal/cmd/root/profile/profile.go
@@ -2,6 +2,8 @@ package profile
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/kong/kongctl/internal/cmd"
 	"github.com/kong/kongctl/internal/cmd/output/jq"
@@ -14,10 +16,10 @@ import (
 )
 
 var (
-	profileUse   = "profile"
-	profileShort = i18n.T("root.profile.profileShort", "Manage CLI profiles")
+	profileUse   = "profile [profile-name]"
+	profileShort = i18n.T("root.profile.profileShort", "Manage kongctl profiles")
 	profileLong  = normalizers.LongDesc(i18n.T("root.profile.profileLong",
-		`The profile command allows you to get, create, and delete profiles for the CLI.`))
+		`The profile command allows you to list kongctl profiles and inspect profile configuration.`))
 
 	profileManager profile.Manager
 )
@@ -72,7 +74,12 @@ func runGet(helper cmd.Helper) error {
 	// * If no argument is provided, the user is looking for information on all profiles
 	// * Use the profileManager to get all or one of the profiles and display it
 
-	// TODO: Parse arguments to determine if user is looking for all profiles or a specific profile
+	args := helper.GetArgs()
+	if len(args) > 1 {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf("too many arguments. Getting profiles requires 0 or 1 arguments (profile name)"),
+		}
+	}
 
 	outType, err := helper.GetOutputFormat()
 	if err != nil {
@@ -94,7 +101,10 @@ func runGet(helper cmd.Helper) error {
 		return err
 	}
 
-	payload := any(profileManager.GetProfiles())
+	payload, err := profilePayload(args)
+	if err != nil {
+		return err
+	}
 	if jq.HasFilter(jqSettings) {
 		filteredPayload, handled, err := jq.ApplyToRaw(payload, outType, jqSettings, helper.GetStreams().Out)
 		if err != nil {
@@ -116,6 +126,28 @@ func runGet(helper cmd.Helper) error {
 	p.Print(payload)
 
 	return nil
+}
+
+func profilePayload(args []string) (any, error) {
+	if len(args) == 0 {
+		profiles := slices.Clone(profileManager.GetProfiles())
+		slices.Sort(profiles)
+		return profiles, nil
+	}
+
+	name := strings.TrimSpace(args[0])
+	if name == "" {
+		return nil, &cmd.ConfigurationError{
+			Err: fmt.Errorf("profile name cannot be empty"),
+		}
+	}
+
+	profiles := profileManager.GetProfiles()
+	if !slices.Contains(profiles, name) {
+		return nil, fmt.Errorf("profile %q not found", name)
+	}
+
+	return profileManager.GetProfile(name)
 }
 
 //func runCreate(_ *cmd.RunBucket) error {

--- a/internal/cmd/root/profile/profile.go
+++ b/internal/cmd/root/profile/profile.go
@@ -60,7 +60,7 @@ func run(helper cmd.Helper) error {
 		return err
 	}
 
-	if v == verbs.Get {
+	if v == verbs.Get || v == verbs.List {
 		return runGet(helper)
 	}
 

--- a/internal/cmd/root/profile/profile_test.go
+++ b/internal/cmd/root/profile/profile_test.go
@@ -44,6 +44,7 @@ func (m profileTestManager) DeleteProfile(_ string) error {
 type profileTestHelper struct {
 	cmd     *cobra.Command
 	args    []string
+	verb    verbs.VerbValue
 	streams *iostreams.IOStreams
 	cfg     config.Hook
 }
@@ -57,7 +58,7 @@ func (h profileTestHelper) GetArgs() []string {
 }
 
 func (h profileTestHelper) GetVerb() (verbs.VerbValue, error) {
-	return verbs.Get, nil
+	return h.verb, nil
 }
 
 func (h profileTestHelper) GetProduct() (products.ProductValue, error) {
@@ -100,7 +101,7 @@ func TestNewProfileCmdDescribesKongctlProfiles(t *testing.T) {
 }
 
 func TestRunGetListsProfiles(t *testing.T) {
-	output := runGetForTest(t, nil, profileTestManager{
+	output := runGetForTest(t, nil, verbs.Get, profileTestManager{
 		profiles: []string{"team-b", "default", "team-a"},
 	})
 
@@ -110,7 +111,7 @@ func TestRunGetListsProfiles(t *testing.T) {
 }
 
 func TestRunGetShowsNamedProfileConfiguration(t *testing.T) {
-	output := runGetForTest(t, []string{"team-a"}, profileTestManager{
+	output := runGetForTest(t, []string{"team-a"}, verbs.Get, profileTestManager{
 		profiles: []string{"default", "team-a"},
 		data: map[string]map[string]any{
 			"team-a": {
@@ -128,9 +129,19 @@ func TestRunGetShowsNamedProfileConfiguration(t *testing.T) {
 	require.Equal(t, "https://us.api.konghq.com", got["konnect"].(map[string]any)["base_url"])
 }
 
+func TestRunListProfilesMatchesGetProfiles(t *testing.T) {
+	output := runForTest(t, nil, verbs.List, profileTestManager{
+		profiles: []string{"team-b", "default", "team-a"},
+	})
+
+	var got []string
+	require.NoError(t, json.Unmarshal([]byte(output), &got))
+	require.Equal(t, []string{"default", "team-a", "team-b"}, got)
+}
+
 func TestRunGetReturnsErrorForUnknownProfile(t *testing.T) {
 	var out bytes.Buffer
-	helper := newProfileTestHelper([]string{"missing"}, &out)
+	helper := newProfileTestHelper([]string{"missing"}, verbs.Get, &out)
 	oldProfileManager := profileManager
 	profileManager = profileTestManager{profiles: []string{"default"}}
 	t.Cleanup(func() {
@@ -142,11 +153,11 @@ func TestRunGetReturnsErrorForUnknownProfile(t *testing.T) {
 	require.ErrorContains(t, err, `profile "missing" not found`)
 }
 
-func runGetForTest(t *testing.T, args []string, manager profilepkg.Manager) string {
+func runGetForTest(t *testing.T, args []string, verb verbs.VerbValue, manager profilepkg.Manager) string {
 	t.Helper()
 
 	var out bytes.Buffer
-	helper := newProfileTestHelper(args, &out)
+	helper := newProfileTestHelper(args, verb, &out)
 	oldProfileManager := profileManager
 	profileManager = manager
 	t.Cleanup(func() {
@@ -157,10 +168,26 @@ func runGetForTest(t *testing.T, args []string, manager profilepkg.Manager) stri
 	return out.String()
 }
 
-func newProfileTestHelper(args []string, out *bytes.Buffer) profileTestHelper {
+func runForTest(t *testing.T, args []string, verb verbs.VerbValue, manager profilepkg.Manager) string {
+	t.Helper()
+
+	var out bytes.Buffer
+	helper := newProfileTestHelper(args, verb, &out)
+	oldProfileManager := profileManager
+	profileManager = manager
+	t.Cleanup(func() {
+		profileManager = oldProfileManager
+	})
+
+	require.NoError(t, run(helper))
+	return out.String()
+}
+
+func newProfileTestHelper(args []string, verb verbs.VerbValue, out *bytes.Buffer) profileTestHelper {
 	return profileTestHelper{
 		cmd:  &cobra.Command{Use: "profile"},
 		args: args,
+		verb: verb,
 		streams: &iostreams.IOStreams{
 			In:     &bytes.Buffer{},
 			Out:    out,

--- a/internal/cmd/root/profile/profile_test.go
+++ b/internal/cmd/root/profile/profile_test.go
@@ -1,0 +1,171 @@
+package profile
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/kong/kongctl/internal/build"
+	"github.com/kong/kongctl/internal/cmd/common"
+	"github.com/kong/kongctl/internal/cmd/root/products"
+	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/kong/kongctl/internal/config"
+	"github.com/kong/kongctl/internal/iostreams"
+	"github.com/kong/kongctl/internal/konnect/helpers"
+	profilepkg "github.com/kong/kongctl/internal/profile"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+type profileTestManager struct {
+	profiles []string
+	data     map[string]map[string]any
+}
+
+func (m profileTestManager) GetProfiles() []string {
+	return append([]string{}, m.profiles...)
+}
+
+func (m profileTestManager) GetProfile(name string) (map[string]any, error) {
+	return m.data[name], nil
+}
+
+func (m profileTestManager) CreateProfile(_ string) error {
+	return nil
+}
+
+func (m profileTestManager) DeleteProfile(_ string) error {
+	return nil
+}
+
+type profileTestHelper struct {
+	cmd     *cobra.Command
+	args    []string
+	streams *iostreams.IOStreams
+	cfg     config.Hook
+}
+
+func (h profileTestHelper) GetCmd() *cobra.Command {
+	return h.cmd
+}
+
+func (h profileTestHelper) GetArgs() []string {
+	return h.args
+}
+
+func (h profileTestHelper) GetVerb() (verbs.VerbValue, error) {
+	return verbs.Get, nil
+}
+
+func (h profileTestHelper) GetProduct() (products.ProductValue, error) {
+	return "", nil
+}
+
+func (h profileTestHelper) GetStreams() *iostreams.IOStreams {
+	return h.streams
+}
+
+func (h profileTestHelper) GetConfig() (config.Hook, error) {
+	return h.cfg, nil
+}
+
+func (h profileTestHelper) GetOutputFormat() (common.OutputFormat, error) {
+	return common.JSON, nil
+}
+
+func (h profileTestHelper) GetLogger() (*slog.Logger, error) {
+	return slog.Default(), nil
+}
+
+func (h profileTestHelper) GetBuildInfo() (*build.Info, error) {
+	return nil, nil
+}
+
+func (h profileTestHelper) GetContext() context.Context {
+	return context.Background()
+}
+
+func (h profileTestHelper) GetKonnectSDK(config.Hook, *slog.Logger) (helpers.SDKAPI, error) {
+	return nil, nil
+}
+
+func TestNewProfileCmdDescribesKongctlProfiles(t *testing.T) {
+	cmd := NewProfileCmd()
+
+	require.Equal(t, "profile [profile-name]", cmd.Use)
+	require.Equal(t, "Manage kongctl profiles", cmd.Short)
+}
+
+func TestRunGetListsProfiles(t *testing.T) {
+	output := runGetForTest(t, nil, profileTestManager{
+		profiles: []string{"team-b", "default", "team-a"},
+	})
+
+	var got []string
+	require.NoError(t, json.Unmarshal([]byte(output), &got))
+	require.Equal(t, []string{"default", "team-a", "team-b"}, got)
+}
+
+func TestRunGetShowsNamedProfileConfiguration(t *testing.T) {
+	output := runGetForTest(t, []string{"team-a"}, profileTestManager{
+		profiles: []string{"default", "team-a"},
+		data: map[string]map[string]any{
+			"team-a": {
+				"output": "json",
+				"konnect": map[string]any{
+					"base_url": "https://us.api.konghq.com",
+				},
+			},
+		},
+	})
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal([]byte(output), &got))
+	require.Equal(t, "json", got["output"])
+	require.Equal(t, "https://us.api.konghq.com", got["konnect"].(map[string]any)["base_url"])
+}
+
+func TestRunGetReturnsErrorForUnknownProfile(t *testing.T) {
+	var out bytes.Buffer
+	helper := newProfileTestHelper([]string{"missing"}, &out)
+	oldProfileManager := profileManager
+	profileManager = profileTestManager{profiles: []string{"default"}}
+	t.Cleanup(func() {
+		profileManager = oldProfileManager
+	})
+
+	err := runGet(helper)
+
+	require.ErrorContains(t, err, `profile "missing" not found`)
+}
+
+func runGetForTest(t *testing.T, args []string, manager profilepkg.Manager) string {
+	t.Helper()
+
+	var out bytes.Buffer
+	helper := newProfileTestHelper(args, &out)
+	oldProfileManager := profileManager
+	profileManager = manager
+	t.Cleanup(func() {
+		profileManager = oldProfileManager
+	})
+
+	require.NoError(t, runGet(helper))
+	return out.String()
+}
+
+func newProfileTestHelper(args []string, out *bytes.Buffer) profileTestHelper {
+	return profileTestHelper{
+		cmd:  &cobra.Command{Use: "profile"},
+		args: args,
+		streams: &iostreams.IOStreams{
+			In:     &bytes.Buffer{},
+			Out:    out,
+			ErrOut: &bytes.Buffer{},
+		},
+		cfg: config.BuildProfiledConfig(profilepkg.DefaultProfile, "", viper.New()),
+	}
+}

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -191,6 +191,25 @@ func TestDeleteHelpUsesDeclarativeExamples(t *testing.T) {
 	}
 }
 
+func TestListProfilesMatchesGetProfiles(t *testing.T) {
+	getResult := executeRootForTest(t, "get", "profiles", "--output", "json")
+	if getResult.exitCode != 0 {
+		t.Fatalf("expected get profiles to succeed, got %d\nstdout:\n%s\nstderr:\n%s",
+			getResult.exitCode, getResult.stdout, getResult.stderr)
+	}
+
+	listResult := executeRootForTest(t, "list", "profiles", "--output", "json")
+	if listResult.exitCode != 0 {
+		t.Fatalf("expected list profiles to succeed, got %d\nstdout:\n%s\nstderr:\n%s",
+			listResult.exitCode, listResult.stdout, listResult.stderr)
+	}
+
+	if listResult.stdout != getResult.stdout {
+		t.Fatalf("expected list profiles output to match get profiles\nget:\n%s\nlist:\n%s",
+			getResult.stdout, listResult.stdout)
+	}
+}
+
 func TestRootApplyHelpShowsExamples(t *testing.T) {
 	oldRootCmd := rootCmd
 	t.Cleanup(func() {

--- a/internal/cmd/root/verbs/list/list.go
+++ b/internal/cmd/root/verbs/list/list.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kong/kongctl/internal/cmd/output/jq"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
+	profileCmd "github.com/kong/kongctl/internal/cmd/root/profile"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	extensioncmd "github.com/kong/kongctl/internal/cmd/root/verbs/extensions"
 	"github.com/kong/kongctl/internal/meta"
@@ -96,6 +97,8 @@ Setting this value overrides tokens obtained from the login command.
 		return nil, e
 	}
 	cmd.AddCommand(c)
+
+	cmd.AddCommand(profileCmd.NewProfileCmd())
 
 	// Add portal command directly for Konnect-first pattern
 	portalCmd, err := NewDirectPortalCmd()


### PR DESCRIPTION
## Summary

- Update profile command help text to describe kongctl profiles.
- Support `kongctl get profile <profile-name>` by rendering the named profile configuration.
- Keep `kongctl get profile` listing all profiles, with deterministic sorted output.
- Make `kongctl list profiles` use the same profile listing behavior as `kongctl get profiles`.
- Add focused tests for profile help text, list output, named lookup, missing-profile errors, and root command parity between `get profiles` and `list profiles`.

## Rationale

Issue #1063 reports that `kongctl get profile <arg>` is not useful. The command already had the profile manager hooks in place, but `runGet` always rendered all profiles and ignored positional arguments. The `list` verb also did not register the profile command, so `kongctl list profiles` failed with an unknown-command error.

## Validation

- `go test ./internal/cmd/root/profile ./internal/cmd/root ./internal/cmd/root/verbs/list`
- `go test ./internal/cmd/root/...`
- `make test`
- `make build`
- `make lint`

Closes #1063