### PR TITLE
Fix: ensure bare declarative commands show valid errors

### DIFF
--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -3,6 +3,7 @@ package declarative
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -63,6 +64,17 @@ const (
 )
 
 const diffFieldRedactedValue = "[REDACTED]"
+
+func parseDeclarativeSources(filenames []string) ([]loader.Source, error) {
+	sources, err := loader.ParseSources(filenames)
+	if err != nil {
+		if errors.Is(err, loader.ErrNoSources) {
+			return nil, &cmd.UsageError{Err: err}
+		}
+		return nil, fmt.Errorf("failed to parse sources: %w", err)
+	}
+	return sources, nil
+}
 
 var diffSensitiveExactFieldKeys = map[string]struct{}{
 	"access_token":        {},
@@ -464,6 +476,11 @@ func runPlan(command *cobra.Command, args []string) error {
 	ctx = withDeclarativeHTTPLogContext(ctx, command, verbs.Plan, planMode)
 	command.SetContext(ctx)
 
+	sources, err := parseDeclarativeSources(filenames)
+	if err != nil {
+		return err
+	}
+
 	// Build helper
 	helper := cmd.BuildHelper(command, args)
 	generator := planGenerator(helper)
@@ -490,12 +507,6 @@ func runPlan(command *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Parse sources from filenames
-	sources, err := loader.ParseSources(filenames)
-	if err != nil {
-		return fmt.Errorf("failed to parse sources: %w", err)
-	}
-
 	// Load configuration
 	ldr, err := newDeclarativeLoader(command, cfg)
 	if err != nil {
@@ -503,12 +514,6 @@ func runPlan(command *cobra.Command, args []string) error {
 	}
 	resourceSet, err := ldr.LoadFromSources(sources, recursive)
 	if err != nil {
-		// Provide more helpful error message for common cases
-		if len(filenames) == 0 && strings.Contains(err.Error(), "no YAML files found") {
-			return fmt.Errorf(
-				"no configuration files found in current directory. Use -f to specify files or directories",
-			)
-		}
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
 
@@ -520,13 +525,6 @@ func runPlan(command *cobra.Command, args []string) error {
 	}
 
 	if totalResources == 0 {
-		// Check if we're using default directory (no explicit sources)
-		if len(filenames) == 0 {
-			return fmt.Errorf(
-				"no configuration files found in current directory. Use -f to specify files or directories",
-			)
-		}
-
 		// In sync mode, empty config is valid - it means delete all managed resources
 		// In apply and delete modes, we need at least one resource
 		if planMode == planner.PlanModeApply || planMode == planner.PlanModeDelete {
@@ -784,6 +782,21 @@ func runDiff(command *cobra.Command, args []string) error {
 	ctx = withDeclarativeHTTPLogContext(ctx, command, verbs.Diff, planMode)
 	command.SetContext(ctx)
 
+	planFile, _ := command.Flags().GetString("plan")
+	if command.Flags().Changed("mode") && planFile != "" {
+		return fmt.Errorf("--mode cannot be used together with --plan; plan mode is read from the plan artifact")
+	}
+
+	filenames, _ := command.Flags().GetStringSlice("filename")
+	var sources []loader.Source
+	if planFile == "" {
+		var parseErr error
+		sources, parseErr = parseDeclarativeSources(filenames)
+		if parseErr != nil {
+			return parseErr
+		}
+	}
+
 	helper := cmd.BuildHelper(command, args)
 	cfg, err := helper.GetConfig()
 	if err != nil {
@@ -795,10 +808,6 @@ func runDiff(command *cobra.Command, args []string) error {
 		return err
 	}
 
-	planFile, _ := command.Flags().GetString("plan")
-	if command.Flags().Changed("mode") && planFile != "" {
-		return fmt.Errorf("--mode cannot be used together with --plan; plan mode is read from the plan artifact")
-	}
 	if requirement.Mode != validator.NamespaceRequirementNone && planFile != "" {
 		return fmt.Errorf(
 			"--%s cannot be used together with --plan; generate the plan with namespace enforcement enabled instead",
@@ -814,7 +823,6 @@ func runDiff(command *cobra.Command, args []string) error {
 			return err
 		}
 	} else {
-		filenames, _ := command.Flags().GetStringSlice("filename")
 		recursive, _ := command.Flags().GetBool("recursive")
 		generator := planGenerator(helper)
 
@@ -828,20 +836,12 @@ func runDiff(command *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to initialize Konnect client: %w", err)
 		}
 
-		sources, err := loader.ParseSources(filenames)
-		if err != nil {
-			return fmt.Errorf("failed to parse sources: %w", err)
-		}
-
 		ldr, err := newDeclarativeLoader(command, cfg)
 		if err != nil {
 			return err
 		}
 		resourceSet, err := ldr.LoadFromSources(sources, recursive)
 		if err != nil {
-			if len(filenames) == 0 && strings.Contains(err.Error(), "no YAML files found") {
-				return fmt.Errorf("no configuration files found. Use -f to specify files or --plan to use existing plan")
-			}
 			return fmt.Errorf("failed to load configuration: %w", err)
 		}
 
@@ -851,9 +851,6 @@ func runDiff(command *cobra.Command, args []string) error {
 
 		totalResources := resourceSet.ResourceCount()
 		if totalResources == 0 {
-			if len(filenames) == 0 {
-				return fmt.Errorf("no configuration files found. Use -f to specify files or --plan to use existing plan")
-			}
 			return fmt.Errorf("no resources found in configuration files")
 		}
 
@@ -1434,6 +1431,15 @@ func runApply(command *cobra.Command, args []string) error {
 		usingStdinForInput = planFile == "-" || (planFile == "" && slices.Contains(filenames, "-"))
 	}
 
+	var sources []loader.Source
+	if planFile == "" {
+		var parseErr error
+		sources, parseErr = parseDeclarativeSources(filenames)
+		if parseErr != nil {
+			return parseErr
+		}
+	}
+
 	// Build helper
 	helper := cmd.BuildHelper(command, args)
 	generator := planGenerator(helper)
@@ -1492,12 +1498,6 @@ func runApply(command *cobra.Command, args []string) error {
 		// Generate plan from configuration files
 		recursive, _ := command.Flags().GetBool("recursive")
 
-		// Parse sources from filenames
-		sources, err := loader.ParseSources(filenames)
-		if err != nil {
-			return fmt.Errorf("failed to parse sources: %w", err)
-		}
-
 		// Load configuration
 		ldr, err := newDeclarativeLoader(command, cfg)
 		if err != nil {
@@ -1505,10 +1505,6 @@ func runApply(command *cobra.Command, args []string) error {
 		}
 		resourceSet, err := ldr.LoadFromSources(sources, recursive)
 		if err != nil {
-			// Provide more helpful error message for common cases
-			if len(filenames) == 0 && strings.Contains(err.Error(), "no YAML files found") {
-				return fmt.Errorf("no configuration files found in current directory. Use -f to specify files or directories")
-			}
 			return fmt.Errorf("failed to load configuration: %w", err)
 		}
 
@@ -1520,10 +1516,6 @@ func runApply(command *cobra.Command, args []string) error {
 		totalResources := resourceSet.ResourceCount()
 
 		if totalResources == 0 {
-			// Check if we're using default directory (no explicit sources)
-			if len(filenames) == 0 {
-				return fmt.Errorf("no configuration files found in current directory. Use -f to specify files or directories")
-			}
 			return fmt.Errorf("no resources found in configuration files")
 		}
 
@@ -1926,6 +1918,15 @@ func runDelete(command *cobra.Command, args []string) error {
 		usingStdinForInput = planFile == "-" || (planFile == "" && slices.Contains(filenames, "-"))
 	}
 
+	var sources []loader.Source
+	if planFile == "" {
+		var parseErr error
+		sources, parseErr = parseDeclarativeSources(filenames)
+		if parseErr != nil {
+			return parseErr
+		}
+	}
+
 	// Build helper
 	helper := cmd.BuildHelper(command, args)
 	generator := planGenerator(helper)
@@ -1983,22 +1984,12 @@ func runDelete(command *cobra.Command, args []string) error {
 		// Generate plan from configuration files
 		recursive, _ := command.Flags().GetBool("recursive")
 
-		sources, err := loader.ParseSources(filenames)
-		if err != nil {
-			return fmt.Errorf("failed to parse sources: %w", err)
-		}
-
 		ldr, err := newDeclarativeLoader(command, cfg)
 		if err != nil {
 			return err
 		}
 		resourceSet, err := ldr.LoadFromSources(sources, recursive)
 		if err != nil {
-			if len(filenames) == 0 && strings.Contains(err.Error(), "no YAML files found") {
-				return fmt.Errorf(
-					"no configuration files found in current directory. " +
-						"Use -f to specify files or directories")
-			}
 			return fmt.Errorf("failed to load configuration: %w", err)
 		}
 
@@ -2008,11 +1999,6 @@ func runDelete(command *cobra.Command, args []string) error {
 
 		totalResources := resourceSet.ResourceCount()
 		if totalResources == 0 {
-			if len(filenames) == 0 {
-				return fmt.Errorf(
-					"no configuration files found in current directory. " +
-						"Use -f to specify files or directories")
-			}
 			return fmt.Errorf("no resources found in configuration files")
 		}
 
@@ -2161,6 +2147,15 @@ func runSync(command *cobra.Command, args []string) error {
 		usingStdinForInput = planFile == "-" || (planFile == "" && slices.Contains(filenames, "-"))
 	}
 
+	var sources []loader.Source
+	if planFile == "" {
+		var parseErr error
+		sources, parseErr = parseDeclarativeSources(filenames)
+		if parseErr != nil {
+			return parseErr
+		}
+	}
+
 	// Build helper
 	helper := cmd.BuildHelper(command, args)
 	generator := planGenerator(helper)
@@ -2220,12 +2215,6 @@ func runSync(command *cobra.Command, args []string) error {
 		// Generate plan from configuration files
 		recursive, _ := command.Flags().GetBool("recursive")
 
-		// Parse sources from filenames
-		sources, err := loader.ParseSources(filenames)
-		if err != nil {
-			return fmt.Errorf("failed to parse sources: %w", err)
-		}
-
 		// Load configuration
 		ldr, err := newDeclarativeLoader(command, cfg)
 		if err != nil {
@@ -2233,10 +2222,6 @@ func runSync(command *cobra.Command, args []string) error {
 		}
 		resourceSet, err := ldr.LoadFromSources(sources, recursive)
 		if err != nil {
-			// Provide more helpful error message for common cases
-			if len(filenames) == 0 && strings.Contains(err.Error(), "no YAML files found") {
-				return fmt.Errorf("no configuration files found in current directory. Use -f to specify files or directories")
-			}
 			return fmt.Errorf("failed to load configuration: %w", err)
 		}
 
@@ -2249,11 +2234,6 @@ func runSync(command *cobra.Command, args []string) error {
 
 		// In sync mode, allow empty configuration to detect resources to delete
 		if totalResources == 0 {
-			// Check if we're using default directory (no explicit sources)
-			if len(filenames) == 0 {
-				return fmt.Errorf("no configuration files found in current directory. Use -f to specify files or directories")
-			}
-
 			// In sync mode, empty config is valid - it means delete all managed resources
 			if outputFormat == textOutputFormat {
 				namespaces := resourceSet.DefaultNamespaces

--- a/internal/cmd/root/products/konnect/declarative/declarative_test.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	cmdpkg "github.com/kong/kongctl/internal/cmd"
 	"github.com/kong/kongctl/internal/config"
 	"github.com/kong/kongctl/internal/declarative/executor"
 	"github.com/kong/kongctl/internal/declarative/planner"
@@ -194,6 +195,28 @@ func Test_parsePlanMode(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, mode)
+		})
+	}
+}
+
+func TestDeclarativeCommandsRequireExplicitFilename(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  *cobra.Command
+	}{
+		{name: "plan", cmd: newDeclarativePlanCmd()},
+		{name: "apply", cmd: newDeclarativeApplyCmd()},
+		{name: "sync", cmd: newDeclarativeSyncCmd()},
+		{name: "diff", cmd: newDeclarativeDiffCmd()},
+		{name: "delete", cmd: newDeclarativeDeleteCmd()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cmd.RunE(tt.cmd, nil)
+			require.Error(t, err)
+			assert.True(t, cmdpkg.IsUsageError(err))
+			assert.Equal(t, "no configuration sources specified; use -f to specify files or directories", err.Error())
 		})
 	}
 }

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -796,6 +796,8 @@ func renderCommandUsageError(w io.Writer, command *cobra.Command, err error) {
 			fmt.Fprintf(w, "  %s\n", value)
 		}
 		fmt.Fprintln(w)
+	} else {
+		fmt.Fprintln(w)
 	}
 
 	fmt.Fprintf(w, "Run '%s --help' for usage\n", commandPath(command))

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -469,6 +469,18 @@ func TestRootErrorUX(t *testing.T) {
 			expectStderr: true,
 		},
 		{
+			name: "bare declarative plan requires filename with concise help hint",
+			args: []string{"plan"},
+			wantErr: []string{
+				`Error: no configuration sources specified; use -f to specify files or directories`,
+				"Error: no configuration sources specified; use -f to specify files or directories\n\n" +
+					`Run 'kongctl plan --help' for usage`,
+			},
+			wantExit:     1,
+			forbidErr:    []string{"Usage:"},
+			expectStderr: true,
+		},
+		{
 			name: "explicit help still renders full help",
 			args: []string{"get", "--help"},
 			wantOut: []string{

--- a/internal/cmd/root/verbs/apply/apply.go
+++ b/internal/cmd/root/verbs/apply/apply.go
@@ -39,6 +39,7 @@ func NewApplyCmd() (*cobra.Command, error) {
 		Long:    applyLong,
 		Example: konnectCmd.Example,
 		Aliases: []string{"a", "A"},
+		Args:    verbs.NoPositionalArgs,
 		// Use the konnect command's RunE directly for Konnect-first pattern
 		RunE: konnectCmd.RunE,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/declarative/loader/loader_test.go
+++ b/internal/declarative/loader/loader_test.go
@@ -1,6 +1,7 @@
 package loader
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -904,6 +905,7 @@ func TestLoader_ParseSources(t *testing.T) {
 		name     string
 		input    []string
 		expected []Source
+		err      error
 	}{
 		{
 			name:  "single file",
@@ -936,11 +938,14 @@ func TestLoader_ParseSources(t *testing.T) {
 			},
 		},
 		{
-			name:  "empty defaults to current directory",
+			name:  "empty rejects missing configuration source",
 			input: []string{},
-			expected: []Source{
-				{Path: ".", Type: SourceTypeDirectory},
-			},
+			err:   ErrNoSources,
+		},
+		{
+			name:  "empty comma-separated values reject missing configuration source",
+			input: []string{","},
+			err:   ErrNoSources,
 		},
 	}
 
@@ -949,8 +954,14 @@ func TestLoader_ParseSources(t *testing.T) {
 			// For testing, we need to mock file existence checks
 			// Since ParseSources checks if files exist, we'll test with stdin
 			// which doesn't require file existence
-			if tt.name == "stdin" || tt.name == "empty defaults to current directory" {
+			if tt.name == "stdin" || tt.err != nil {
 				sources, err := ParseSources(tt.input)
+				if tt.err != nil {
+					require.Error(t, err)
+					assert.True(t, errors.Is(err, tt.err))
+					assert.Nil(t, sources)
+					return
+				}
 				assert.NoError(t, err)
 				assert.Equal(t, len(tt.expected), len(sources))
 				for i, expected := range tt.expected {

--- a/internal/declarative/loader/sources.go
+++ b/internal/declarative/loader/sources.go
@@ -1,10 +1,14 @@
 package loader
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 )
+
+// ErrNoSources is returned when no configuration sources are provided.
+var ErrNoSources = errors.New("no configuration sources specified; use -f to specify files or directories")
 
 // SourceType represents the type of configuration source
 type SourceType int
@@ -49,12 +53,8 @@ func ParseSources(filenames []string) ([]Source, error) {
 		}
 	}
 
-	// If no sources provided, default to current directory
 	if len(sources) == 0 {
-		sources = append(sources, Source{
-			Path: ".",
-			Type: SourceTypeDirectory,
-		})
+		return nil, ErrNoSources
 	}
 
 	return sources, nil


### PR DESCRIPTION
## Summary

- Require declarative commands to receive explicit configuration sources via `-f` instead of scanning the current directory by default.
- Surface the missing-source case as a concise usage error with the standard `Run 'kongctl <command> --help' for usage` hint.
- Add regression coverage for loader source parsing, declarative command handling, root error rendering, and apply argument validation.

## Root Cause

`ParseSources` silently defaulted empty input to the current directory. Bare commands such as `kongctl plan` could therefore pick up unrelated YAML files like `.golangci.yml` and report confusing parse errors instead of telling users to provide a config source.

## Validation

- `go test ./internal/cmd/root ./internal/cmd/root/products/konnect/declarative ./internal/declarative/loader ./internal/cmd/root/verbs/apply`
- `make test`
- `make build`
- `make lint`
- Smoke checked bare `apply` and `diff` output includes a blank line before the help hint.

Closes #1078