### PR TITLE
Task: refines behavior of the user agent workflow

### DIFF
--- a/.github/workflows/kongctl-feature-user-agent.lock.yml
+++ b/.github/workflows/kongctl-feature-user-agent.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"47016950a657147c373a2401fadc9b825824c99eb7f25a84a40cae45d8036720","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"edeed4f14a93b12e6818bffd53ca739cd61c260dade6786757d645d04dbcf6e3","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","KONGCTL_FEATURE_USER_AGENT_KONNECT_PAT"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -87,14 +87,16 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
         id: setup
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
-          job-name: ${{ github.job }}
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
         env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
+          INPUT_JOB_NAME: ${{ github.job }}
           GH_AW_SETUP_WORKFLOW_NAME: "User Agent Eval"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/kongctl-feature-user-agent.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
@@ -130,7 +132,6 @@ jobs:
           sparse-checkout: |
             .github
             .agents
-            actions/setup
             .claude
             .codex
             .crush
@@ -174,20 +175,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_ae15203d5dcb40a9_EOF'
+          cat << 'GH_AW_PROMPT_943fd8a13c6e07c9_EOF'
           <system>
-          GH_AW_PROMPT_ae15203d5dcb40a9_EOF
+          GH_AW_PROMPT_943fd8a13c6e07c9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_ae15203d5dcb40a9_EOF'
+          cat << 'GH_AW_PROMPT_943fd8a13c6e07c9_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_ae15203d5dcb40a9_EOF
+          GH_AW_PROMPT_943fd8a13c6e07c9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_ae15203d5dcb40a9_EOF'
+          cat << 'GH_AW_PROMPT_943fd8a13c6e07c9_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -219,12 +220,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_ae15203d5dcb40a9_EOF
+          GH_AW_PROMPT_943fd8a13c6e07c9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_ae15203d5dcb40a9_EOF'
+          cat << 'GH_AW_PROMPT_943fd8a13c6e07c9_EOF'
           </system>
           {{#runtime-import .github/workflows/kongctl-feature-user-agent.md}}
-          GH_AW_PROMPT_ae15203d5dcb40a9_EOF
+          GH_AW_PROMPT_943fd8a13c6e07c9_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -301,6 +302,13 @@ jobs:
             /tmp/gh-aw/base
           if-no-files-found: ignore
           retention-days: 1
+      - name: Clean Scripts
+        if: always()
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/clean.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
+          INPUT_JOB_NAME: ${{ github.job }}
 
   agent:
     needs: activation
@@ -335,18 +343,20 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
         id: setup
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
-          job-name: ${{ github.job }}
-          trace-id: ${{ needs.activation.outputs.setup-trace-id }}
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
         env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
+          INPUT_JOB_NAME: ${{ github.job }}
           GH_AW_SETUP_WORKFLOW_NAME: "User Agent Eval"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/kongctl-feature-user-agent.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
+          INPUT_TRACE_ID: ${{ needs.activation.outputs.setup-trace-id }}
       - name: Set runtime paths
         id: set-runtime-paths
         run: |
@@ -433,9 +443,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_5dabd4e9b8607b08_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_71d777518f0973d0_EOF'
           {"create_issue":{"expires":720,"labels":["automation","agentic-workflows","konnect"],"max":1,"title_prefix":"[agent-eval] "},"create_report_incomplete_issue":{},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_5dabd4e9b8607b08_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_71d777518f0973d0_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -635,7 +645,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_ca9d440106003dd2_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_96c12012b25b951a_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -676,7 +686,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_ca9d440106003dd2_EOF
+          GH_AW_MCP_CONFIG_96c12012b25b951a_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -908,6 +918,13 @@ jobs:
             /tmp/gh-aw/sandbox/firewall/audit/
             /tmp/gh-aw/sandbox/firewall/awf-reflect.json
           if-no-files-found: ignore
+      - name: Clean Scripts
+        if: always()
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/clean.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
+          INPUT_JOB_NAME: ${{ github.job }}
 
   conclusion:
     needs:
@@ -938,18 +955,20 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
         id: setup
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
-          job-name: ${{ github.job }}
-          trace-id: ${{ needs.activation.outputs.setup-trace-id }}
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
         env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
+          INPUT_JOB_NAME: ${{ github.job }}
           GH_AW_SETUP_WORKFLOW_NAME: "User Agent Eval"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/kongctl-feature-user-agent.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
+          INPUT_TRACE_ID: ${{ needs.activation.outputs.setup-trace-id }}
       - name: Download agent output artifact
         id: download-agent-output
         continue-on-error: true
@@ -1062,6 +1081,13 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/handle_agent_failure.cjs');
             await main();
+      - name: Clean Scripts
+        if: always()
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/clean.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
+          INPUT_JOB_NAME: ${{ github.job }}
 
   detection:
     needs:
@@ -1083,18 +1109,20 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
         id: setup
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
-          job-name: ${{ github.job }}
-          trace-id: ${{ needs.activation.outputs.setup-trace-id }}
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
         env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
+          INPUT_JOB_NAME: ${{ github.job }}
           GH_AW_SETUP_WORKFLOW_NAME: "User Agent Eval"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/kongctl-feature-user-agent.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
+          INPUT_TRACE_ID: ${{ needs.activation.outputs.setup-trace-id }}
       - name: Download agent output artifact
         id: download-agent-output
         continue-on-error: true
@@ -1298,18 +1326,20 @@ jobs:
           repository: github/gh-aw
           sparse-checkout: |
             actions
+          path: /tmp/gh-aw/actions-source
+          fetch-depth: 1
           persist-credentials: false
       - name: Setup Scripts
         id: setup
-        uses: ./actions/setup
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
-          job-name: ${{ github.job }}
-          trace-id: ${{ needs.activation.outputs.setup-trace-id }}
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
         env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
+          INPUT_JOB_NAME: ${{ github.job }}
           GH_AW_SETUP_WORKFLOW_NAME: "User Agent Eval"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/kongctl-feature-user-agent.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
+          INPUT_TRACE_ID: ${{ needs.activation.outputs.setup-trace-id }}
       - name: Download agent output artifact
         id: download-agent-output
         continue-on-error: true
@@ -1358,4 +1388,11 @@ jobs:
             /tmp/gh-aw/safe-output-items.jsonl
             /tmp/gh-aw/temporary-id-map.json
           if-no-files-found: ignore
+      - name: Clean Scripts
+        if: always()
+        run: |
+          bash /tmp/gh-aw/actions-source/actions/setup/clean.sh
+        env:
+          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
+          INPUT_JOB_NAME: ${{ github.job }}
 

--- a/.github/workflows/kongctl-feature-user-agent.lock.yml
+++ b/.github/workflows/kongctl-feature-user-agent.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"623416f964694ecb1a6375a448c95273c199f636eebb40f26c292a25c30b9dd9","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"758ca9818abfaa663950c9d06cdf3e5f19e8a1e99e996f07d034ebfbb4a8c226","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","KONGCTL_FEATURE_USER_AGENT_KONNECT_PAT"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -103,7 +103,7 @@ jobs:
         env:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
-          GH_AW_INFO_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || 'claude-sonnet-4.6' }}
+          GH_AW_INFO_MODEL: "claude-opus-4.6"
           GH_AW_INFO_VERSION: "1.0.40"
           GH_AW_INFO_AGENT_VERSION: "1.0.40"
           GH_AW_INFO_WORKFLOW_NAME: "Kongctl Feature User Agent"
@@ -174,20 +174,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_138ae4a3ec841f17_EOF'
+          cat << 'GH_AW_PROMPT_66041515a3122464_EOF'
           <system>
-          GH_AW_PROMPT_138ae4a3ec841f17_EOF
+          GH_AW_PROMPT_66041515a3122464_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_138ae4a3ec841f17_EOF'
+          cat << 'GH_AW_PROMPT_66041515a3122464_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_138ae4a3ec841f17_EOF
+          GH_AW_PROMPT_66041515a3122464_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_138ae4a3ec841f17_EOF'
+          cat << 'GH_AW_PROMPT_66041515a3122464_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -219,12 +219,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_138ae4a3ec841f17_EOF
+          GH_AW_PROMPT_66041515a3122464_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_138ae4a3ec841f17_EOF'
+          cat << 'GH_AW_PROMPT_66041515a3122464_EOF'
           </system>
           {{#runtime-import .github/workflows/kongctl-feature-user-agent.md}}
-          GH_AW_PROMPT_138ae4a3ec841f17_EOF
+          GH_AW_PROMPT_66041515a3122464_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -433,9 +433,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_6f7856781ea9deae_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_6f15eca2b07d5e61_EOF'
           {"create_issue":{"expires":720,"labels":["automation","agentic-workflows","konnect"],"max":1,"title_prefix":"[agent-eval] "},"create_report_incomplete_issue":{},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_6f7856781ea9deae_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_6f15eca2b07d5e61_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -635,7 +635,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_6104746fa5ff1296_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_e1a6c1bbd46d0db9_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -676,7 +676,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_6104746fa5ff1296_EOF
+          GH_AW_MCP_CONFIG_e1a6c1bbd46d0db9_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -716,7 +716,7 @@ jobs:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_API_KEY: dummy-byok-key-for-offline-mode
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || 'claude-sonnet-4.6' }}
+          COPILOT_MODEL: claude-opus-4.6
           GH_AW_MCP_CONFIG: /home/runner/.copilot/mcp-config.json
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
@@ -1204,7 +1204,7 @@ jobs:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_API_KEY: dummy-byok-key-for-offline-mode
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-          COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || 'claude-sonnet-4.6' }}
+          COPILOT_MODEL: claude-opus-4.6
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_VERSION: dev
@@ -1277,7 +1277,7 @@ jobs:
       GH_AW_DETECTION_REASON: ${{ needs.detection.outputs.detection_reason }}
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "copilot"
-      GH_AW_ENGINE_MODEL: ${{ needs.agent.outputs.model }}
+      GH_AW_ENGINE_MODEL: "claude-opus-4.6"
       GH_AW_ENGINE_VERSION: "1.0.40"
       GH_AW_TRACKER_ID: "kongctl-feature-user-agent"
       GH_AW_WORKFLOW_ID: "kongctl-feature-user-agent"

--- a/.github/workflows/kongctl-feature-user-agent.lock.yml
+++ b/.github/workflows/kongctl-feature-user-agent.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"821545b7b0365287debcd46e00c5a8be141aadfce6668e7420e8535e468c2572","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ad9d6572c8bbba8c3315addaa8ae2bb44c24ecc96d37f90fee8b7c1a0143feaa","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","KONGCTL_FEATURE_USER_AGENT_KONNECT_PAT"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -167,20 +167,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_165281e60d0da101_EOF'
+          cat << 'GH_AW_PROMPT_c4448dea2da4085d_EOF'
           <system>
-          GH_AW_PROMPT_165281e60d0da101_EOF
+          GH_AW_PROMPT_c4448dea2da4085d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_165281e60d0da101_EOF'
+          cat << 'GH_AW_PROMPT_c4448dea2da4085d_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_165281e60d0da101_EOF
+          GH_AW_PROMPT_c4448dea2da4085d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_165281e60d0da101_EOF'
+          cat << 'GH_AW_PROMPT_c4448dea2da4085d_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -212,12 +212,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_165281e60d0da101_EOF
+          GH_AW_PROMPT_c4448dea2da4085d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_165281e60d0da101_EOF'
+          cat << 'GH_AW_PROMPT_c4448dea2da4085d_EOF'
           </system>
           {{#runtime-import .github/workflows/kongctl-feature-user-agent.md}}
-          GH_AW_PROMPT_165281e60d0da101_EOF
+          GH_AW_PROMPT_c4448dea2da4085d_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -419,9 +419,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_37cd110d9abf60bd_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_e905dbbf78405a02_EOF'
           {"create_issue":{"expires":720,"labels":["automation","agentic-workflows","konnect"],"max":1,"title_prefix":"[agent-eval] "},"create_report_incomplete_issue":{},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_37cd110d9abf60bd_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_e905dbbf78405a02_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -621,7 +621,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_a0b8cf390b587239_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_28252f09508d24ce_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -662,7 +662,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_a0b8cf390b587239_EOF
+          GH_AW_MCP_CONFIG_28252f09508d24ce_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -857,6 +857,9 @@ jobs:
           if [ ! -f /tmp/gh-aw/agent_output.json ]; then
             echo '{"items":[]}' > /tmp/gh-aw/agent_output.json
           fi
+      - if: always()
+        name: Append feature-user evaluation summary
+        run: "set -euo pipefail\n\nevidence_dir=\"/tmp/gh-aw/kongctl-feature-user-agent/sanitized\"\nsummary_file=\"${evidence_dir}/evaluation-summary.md\"\n\n{\n  echo \"## User Agent Eval\"\n  echo\n  echo \"- Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}\"\n  echo \"- Sanitized artifacts: \\`kongctl-feature-user-agent-sanitized\\`\"\n  echo\n} >> \"${GITHUB_STEP_SUMMARY}\"\n\nif [ ! -f \"${summary_file}\" ]; then\n  {\n    echo \"No sanitized evaluation summary was produced.\"\n    echo\n    echo \"Check the agent logs and sanitized artifact upload for details.\"\n  } >> \"${GITHUB_STEP_SUMMARY}\"\n  exit 0\nfi\n\nunsafe_pattern='([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}|Bearer[[:space:]]+[A-Za-z0-9._~+/-]+=*|Authorization:|X-Api-Key:|KONGCTL_[A-Z0-9_]*PAT=|https://[^[:space:]]*[?&](token|signature|X-Amz-Signature)=)'\nif grep -E -q \"${unsafe_pattern}\" \"${summary_file}\"; then\n  echo \"::error::Evaluation summary contains values that look unsafe. Redact or omit them before upload.\"\n  exit 1\nfi\n\ncat \"${summary_file}\" >> \"${GITHUB_STEP_SUMMARY}\"\n"
       - if: always()
         name: Check sanitized feature-user artifacts
         run: "set -euo pipefail\n\nevidence_dir=\"/tmp/gh-aw/kongctl-feature-user-agent/sanitized\"\nif [ ! -d \"${evidence_dir}\" ]; then\n  exit 0\nfi\n\nif find \"${evidence_dir}\" -type f -size +1048576c | grep -q .; then\n  echo \"::error::Sanitized artifact files must be 1 MiB or smaller.\"\n  exit 1\nfi\n\nunsafe_pattern='([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}|Bearer[[:space:]]+[A-Za-z0-9._~+/-]+=*|Authorization:|X-Api-Key:|KONGCTL_[A-Z0-9_]*PAT=|https://[^[:space:]]*[?&](token|signature|X-Amz-Signature)=)'\nif grep -R -E -q \"${unsafe_pattern}\" \"${evidence_dir}\"; then\n  echo \"::error::Sanitized artifacts contain values that look unsafe. Redact or omit them before upload.\"\n  exit 1\nfi\n"

--- a/.github/workflows/kongctl-feature-user-agent.lock.yml
+++ b/.github/workflows/kongctl-feature-user-agent.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"53d52cb208a4653c6ada9679f0cbf9403cc25240a164a450f4d394c2d9457cb2","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"821545b7b0365287debcd46e00c5a8be141aadfce6668e7420e8535e468c2572","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","KONGCTL_FEATURE_USER_AGENT_KONNECT_PAT"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -117,6 +117,27 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/generate_aw_info.cjs');
             await main(core, context);
+      - name: Checkout .github and .agents folders
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            .github
+            .agents
+            .claude
+            .codex
+            .crush
+            .gemini
+            .opencode
+            .pi
+          sparse-checkout-cone-mode: true
+          fetch-depth: 1
+      - name: Save agent config folders for base branch restoration
+        env:
+          GH_AW_AGENT_FOLDERS: ".agents .claude .codex .crush .gemini .github .opencode .pi"
+          GH_AW_AGENT_FILES: ".crush.json AGENTS.md CLAUDE.md GEMINI.md PI.md opencode.jsonc"
+        # poutine:ignore untrusted_checkout_exec
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/save_base_github_folders.sh"
       - name: Check workflow lock file
         id: check-lock-file
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -146,20 +167,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_9de19139267d63f9_EOF'
+          cat << 'GH_AW_PROMPT_165281e60d0da101_EOF'
           <system>
-          GH_AW_PROMPT_9de19139267d63f9_EOF
+          GH_AW_PROMPT_165281e60d0da101_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9de19139267d63f9_EOF'
+          cat << 'GH_AW_PROMPT_165281e60d0da101_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_9de19139267d63f9_EOF
+          GH_AW_PROMPT_165281e60d0da101_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_9de19139267d63f9_EOF'
+          cat << 'GH_AW_PROMPT_165281e60d0da101_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -191,12 +212,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_9de19139267d63f9_EOF
+          GH_AW_PROMPT_165281e60d0da101_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9de19139267d63f9_EOF'
+          cat << 'GH_AW_PROMPT_165281e60d0da101_EOF'
           </system>
           {{#runtime-import .github/workflows/kongctl-feature-user-agent.md}}
-          GH_AW_PROMPT_9de19139267d63f9_EOF
+          GH_AW_PROMPT_165281e60d0da101_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -398,9 +419,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_28fd0e91ee33156c_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_37cd110d9abf60bd_EOF'
           {"create_issue":{"expires":720,"labels":["automation","agentic-workflows","konnect"],"max":1,"title_prefix":"[agent-eval] "},"create_report_incomplete_issue":{},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_28fd0e91ee33156c_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_37cd110d9abf60bd_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -600,7 +621,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_8311b7c67611eff7_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_a0b8cf390b587239_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -641,7 +662,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_8311b7c67611eff7_EOF
+          GH_AW_MCP_CONFIG_a0b8cf390b587239_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/kongctl-feature-user-agent.lock.yml
+++ b/.github/workflows/kongctl-feature-user-agent.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"edeed4f14a93b12e6818bffd53ca739cd61c260dade6786757d645d04dbcf6e3","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","KONGCTL_FEATURE_USER_AGENT_KONNECT_PAT"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"53d52cb208a4653c6ada9679f0cbf9403cc25240a164a450f4d394c2d9457cb2","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","KONGCTL_FEATURE_USER_AGENT_KONNECT_PAT"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -39,6 +39,7 @@
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
 #   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+#   - github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
 #
 # Container images used:
 #   - ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504
@@ -81,22 +82,13 @@ jobs:
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
       stale_lock_file_failed: ${{ steps.check-lock-file.outputs.stale_lock_file_failed == 'true' }}
     steps:
-      - name: Checkout actions folder
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: github/gh-aw
-          sparse-checkout: |
-            actions
-          path: /tmp/gh-aw/actions-source
-          fetch-depth: 1
-          persist-credentials: false
       - name: Setup Scripts
         id: setup
-        run: |
-          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        uses: github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
+        with:
+          destination: ${{ runner.temp }}/gh-aw/actions
+          job-name: ${{ github.job }}
         env:
-          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
-          INPUT_JOB_NAME: ${{ github.job }}
           GH_AW_SETUP_WORKFLOW_NAME: "User Agent Eval"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/kongctl-feature-user-agent.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
@@ -125,27 +117,6 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/generate_aw_info.cjs');
             await main(core, context);
-      - name: Checkout .github and .agents folders
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          sparse-checkout: |
-            .github
-            .agents
-            .claude
-            .codex
-            .crush
-            .gemini
-            .opencode
-            .pi
-          sparse-checkout-cone-mode: true
-          fetch-depth: 1
-      - name: Save agent config folders for base branch restoration
-        env:
-          GH_AW_AGENT_FOLDERS: ".agents .claude .codex .crush .gemini .github .opencode .pi"
-          GH_AW_AGENT_FILES: ".crush.json AGENTS.md CLAUDE.md GEMINI.md PI.md opencode.jsonc"
-        # poutine:ignore untrusted_checkout_exec
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/save_base_github_folders.sh"
       - name: Check workflow lock file
         id: check-lock-file
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -175,20 +146,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_943fd8a13c6e07c9_EOF'
+          cat << 'GH_AW_PROMPT_9de19139267d63f9_EOF'
           <system>
-          GH_AW_PROMPT_943fd8a13c6e07c9_EOF
+          GH_AW_PROMPT_9de19139267d63f9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_943fd8a13c6e07c9_EOF'
+          cat << 'GH_AW_PROMPT_9de19139267d63f9_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_943fd8a13c6e07c9_EOF
+          GH_AW_PROMPT_9de19139267d63f9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_943fd8a13c6e07c9_EOF'
+          cat << 'GH_AW_PROMPT_9de19139267d63f9_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -220,12 +191,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_943fd8a13c6e07c9_EOF
+          GH_AW_PROMPT_9de19139267d63f9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_943fd8a13c6e07c9_EOF'
+          cat << 'GH_AW_PROMPT_9de19139267d63f9_EOF'
           </system>
           {{#runtime-import .github/workflows/kongctl-feature-user-agent.md}}
-          GH_AW_PROMPT_943fd8a13c6e07c9_EOF
+          GH_AW_PROMPT_9de19139267d63f9_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -302,13 +273,6 @@ jobs:
             /tmp/gh-aw/base
           if-no-files-found: ignore
           retention-days: 1
-      - name: Clean Scripts
-        if: always()
-        run: |
-          bash /tmp/gh-aw/actions-source/actions/setup/clean.sh
-        env:
-          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
-          INPUT_JOB_NAME: ${{ github.job }}
 
   agent:
     needs: activation
@@ -337,26 +301,17 @@ jobs:
       output_types: ${{ steps.collect_output.outputs.output_types }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
     steps:
-      - name: Checkout actions folder
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: github/gh-aw
-          sparse-checkout: |
-            actions
-          path: /tmp/gh-aw/actions-source
-          fetch-depth: 1
-          persist-credentials: false
       - name: Setup Scripts
         id: setup
-        run: |
-          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        uses: github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
+        with:
+          destination: ${{ runner.temp }}/gh-aw/actions
+          job-name: ${{ github.job }}
+          trace-id: ${{ needs.activation.outputs.setup-trace-id }}
         env:
-          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
-          INPUT_JOB_NAME: ${{ github.job }}
           GH_AW_SETUP_WORKFLOW_NAME: "User Agent Eval"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/kongctl-feature-user-agent.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
-          INPUT_TRACE_ID: ${{ needs.activation.outputs.setup-trace-id }}
       - name: Set runtime paths
         id: set-runtime-paths
         run: |
@@ -443,9 +398,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_71d777518f0973d0_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_28fd0e91ee33156c_EOF'
           {"create_issue":{"expires":720,"labels":["automation","agentic-workflows","konnect"],"max":1,"title_prefix":"[agent-eval] "},"create_report_incomplete_issue":{},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_71d777518f0973d0_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_28fd0e91ee33156c_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -645,7 +600,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_96c12012b25b951a_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_8311b7c67611eff7_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -686,7 +641,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_96c12012b25b951a_EOF
+          GH_AW_MCP_CONFIG_8311b7c67611eff7_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -918,13 +873,6 @@ jobs:
             /tmp/gh-aw/sandbox/firewall/audit/
             /tmp/gh-aw/sandbox/firewall/awf-reflect.json
           if-no-files-found: ignore
-      - name: Clean Scripts
-        if: always()
-        run: |
-          bash /tmp/gh-aw/actions-source/actions/setup/clean.sh
-        env:
-          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
-          INPUT_JOB_NAME: ${{ github.job }}
 
   conclusion:
     needs:
@@ -949,26 +897,17 @@ jobs:
       tools_reported: ${{ steps.missing_tool.outputs.tools_reported }}
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
-      - name: Checkout actions folder
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: github/gh-aw
-          sparse-checkout: |
-            actions
-          path: /tmp/gh-aw/actions-source
-          fetch-depth: 1
-          persist-credentials: false
       - name: Setup Scripts
         id: setup
-        run: |
-          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        uses: github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
+        with:
+          destination: ${{ runner.temp }}/gh-aw/actions
+          job-name: ${{ github.job }}
+          trace-id: ${{ needs.activation.outputs.setup-trace-id }}
         env:
-          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
-          INPUT_JOB_NAME: ${{ github.job }}
           GH_AW_SETUP_WORKFLOW_NAME: "User Agent Eval"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/kongctl-feature-user-agent.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
-          INPUT_TRACE_ID: ${{ needs.activation.outputs.setup-trace-id }}
       - name: Download agent output artifact
         id: download-agent-output
         continue-on-error: true
@@ -1081,13 +1020,6 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/handle_agent_failure.cjs');
             await main();
-      - name: Clean Scripts
-        if: always()
-        run: |
-          bash /tmp/gh-aw/actions-source/actions/setup/clean.sh
-        env:
-          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
-          INPUT_JOB_NAME: ${{ github.job }}
 
   detection:
     needs:
@@ -1103,26 +1035,17 @@ jobs:
       detection_reason: ${{ steps.detection_conclusion.outputs.reason }}
       detection_success: ${{ steps.detection_conclusion.outputs.success }}
     steps:
-      - name: Checkout actions folder
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: github/gh-aw
-          sparse-checkout: |
-            actions
-          path: /tmp/gh-aw/actions-source
-          fetch-depth: 1
-          persist-credentials: false
       - name: Setup Scripts
         id: setup
-        run: |
-          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        uses: github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
+        with:
+          destination: ${{ runner.temp }}/gh-aw/actions
+          job-name: ${{ github.job }}
+          trace-id: ${{ needs.activation.outputs.setup-trace-id }}
         env:
-          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
-          INPUT_JOB_NAME: ${{ github.job }}
           GH_AW_SETUP_WORKFLOW_NAME: "User Agent Eval"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/kongctl-feature-user-agent.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
-          INPUT_TRACE_ID: ${{ needs.activation.outputs.setup-trace-id }}
       - name: Download agent output artifact
         id: download-agent-output
         continue-on-error: true
@@ -1320,26 +1243,17 @@ jobs:
       process_safe_outputs_processed_count: ${{ steps.process_safe_outputs.outputs.processed_count }}
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
-      - name: Checkout actions folder
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: github/gh-aw
-          sparse-checkout: |
-            actions
-          path: /tmp/gh-aw/actions-source
-          fetch-depth: 1
-          persist-credentials: false
       - name: Setup Scripts
         id: setup
-        run: |
-          bash /tmp/gh-aw/actions-source/actions/setup/setup.sh
+        uses: github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
+        with:
+          destination: ${{ runner.temp }}/gh-aw/actions
+          job-name: ${{ github.job }}
+          trace-id: ${{ needs.activation.outputs.setup-trace-id }}
         env:
-          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
-          INPUT_JOB_NAME: ${{ github.job }}
           GH_AW_SETUP_WORKFLOW_NAME: "User Agent Eval"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/kongctl-feature-user-agent.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
-          INPUT_TRACE_ID: ${{ needs.activation.outputs.setup-trace-id }}
       - name: Download agent output artifact
         id: download-agent-output
         continue-on-error: true
@@ -1388,11 +1302,4 @@ jobs:
             /tmp/gh-aw/safe-output-items.jsonl
             /tmp/gh-aw/temporary-id-map.json
           if-no-files-found: ignore
-      - name: Clean Scripts
-        if: always()
-        run: |
-          bash /tmp/gh-aw/actions-source/actions/setup/clean.sh
-        env:
-          INPUT_DESTINATION: ${{ runner.temp }}/gh-aw/actions
-          INPUT_JOB_NAME: ${{ github.job }}
 

--- a/.github/workflows/kongctl-feature-user-agent.lock.yml
+++ b/.github/workflows/kongctl-feature-user-agent.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"758ca9818abfaa663950c9d06cdf3e5f19e8a1e99e996f07d034ebfbb4a8c226","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"47016950a657147c373a2401fadc9b825824c99eb7f25a84a40cae45d8036720","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","KONGCTL_FEATURE_USER_AGENT_KONNECT_PAT"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -48,7 +48,7 @@
 #   - ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959
 #   - node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
 
-name: "Kongctl Feature User Agent"
+name: "User Agent Eval"
 "on":
   workflow_dispatch:
     inputs:
@@ -64,7 +64,7 @@ concurrency:
   cancel-in-progress: false
   group: konnect-feature-user-agent
 
-run-name: "Kongctl Feature User Agent"
+run-name: "User Agent Eval"
 
 jobs:
   activation:
@@ -95,7 +95,7 @@ jobs:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Kongctl Feature User Agent"
+          GH_AW_SETUP_WORKFLOW_NAME: "User Agent Eval"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/kongctl-feature-user-agent.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
       - name: Generate agentic run info
@@ -106,7 +106,7 @@ jobs:
           GH_AW_INFO_MODEL: "claude-opus-4.6"
           GH_AW_INFO_VERSION: "1.0.40"
           GH_AW_INFO_AGENT_VERSION: "1.0.40"
-          GH_AW_INFO_WORKFLOW_NAME: "Kongctl Feature User Agent"
+          GH_AW_INFO_WORKFLOW_NAME: "User Agent Eval"
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
@@ -174,20 +174,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_66041515a3122464_EOF'
+          cat << 'GH_AW_PROMPT_ae15203d5dcb40a9_EOF'
           <system>
-          GH_AW_PROMPT_66041515a3122464_EOF
+          GH_AW_PROMPT_ae15203d5dcb40a9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_66041515a3122464_EOF'
+          cat << 'GH_AW_PROMPT_ae15203d5dcb40a9_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_66041515a3122464_EOF
+          GH_AW_PROMPT_ae15203d5dcb40a9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_66041515a3122464_EOF'
+          cat << 'GH_AW_PROMPT_ae15203d5dcb40a9_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -219,12 +219,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_66041515a3122464_EOF
+          GH_AW_PROMPT_ae15203d5dcb40a9_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_66041515a3122464_EOF'
+          cat << 'GH_AW_PROMPT_ae15203d5dcb40a9_EOF'
           </system>
           {{#runtime-import .github/workflows/kongctl-feature-user-agent.md}}
-          GH_AW_PROMPT_66041515a3122464_EOF
+          GH_AW_PROMPT_ae15203d5dcb40a9_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -344,7 +344,7 @@ jobs:
           job-name: ${{ github.job }}
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Kongctl Feature User Agent"
+          GH_AW_SETUP_WORKFLOW_NAME: "User Agent Eval"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/kongctl-feature-user-agent.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
       - name: Set runtime paths
@@ -433,9 +433,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_6f15eca2b07d5e61_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_5dabd4e9b8607b08_EOF'
           {"create_issue":{"expires":720,"labels":["automation","agentic-workflows","konnect"],"max":1,"title_prefix":"[agent-eval] "},"create_report_incomplete_issue":{},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_6f15eca2b07d5e61_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_5dabd4e9b8607b08_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -635,7 +635,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_e1a6c1bbd46d0db9_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_ca9d440106003dd2_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -676,7 +676,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_e1a6c1bbd46d0db9_EOF
+          GH_AW_MCP_CONFIG_ca9d440106003dd2_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -947,7 +947,7 @@ jobs:
           job-name: ${{ github.job }}
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Kongctl Feature User Agent"
+          GH_AW_SETUP_WORKFLOW_NAME: "User Agent Eval"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/kongctl-feature-user-agent.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
       - name: Download agent output artifact
@@ -970,7 +970,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: "1"
-          GH_AW_WORKFLOW_NAME: "Kongctl Feature User Agent"
+          GH_AW_WORKFLOW_NAME: "User Agent Eval"
           GH_AW_TRACKER_ID: "kongctl-feature-user-agent"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
@@ -987,7 +987,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Kongctl Feature User Agent"
+          GH_AW_WORKFLOW_NAME: "User Agent Eval"
           GH_AW_TRACKER_ID: "kongctl-feature-user-agent"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_DETECTION_CONCLUSION: ${{ needs.detection.outputs.detection_conclusion }}
@@ -1005,7 +1005,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_MISSING_TOOL_CREATE_ISSUE: "true"
-          GH_AW_WORKFLOW_NAME: "Kongctl Feature User Agent"
+          GH_AW_WORKFLOW_NAME: "User Agent Eval"
           GH_AW_TRACKER_ID: "kongctl-feature-user-agent"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
@@ -1020,7 +1020,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_REPORT_INCOMPLETE_CREATE_ISSUE: "true"
-          GH_AW_WORKFLOW_NAME: "Kongctl Feature User Agent"
+          GH_AW_WORKFLOW_NAME: "User Agent Eval"
           GH_AW_TRACKER_ID: "kongctl-feature-user-agent"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
@@ -1035,7 +1035,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "Kongctl Feature User Agent"
+          GH_AW_WORKFLOW_NAME: "User Agent Eval"
           GH_AW_TRACKER_ID: "kongctl-feature-user-agent"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
@@ -1092,7 +1092,7 @@ jobs:
           job-name: ${{ github.job }}
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Kongctl Feature User Agent"
+          GH_AW_SETUP_WORKFLOW_NAME: "User Agent Eval"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/kongctl-feature-user-agent.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
       - name: Download agent output artifact
@@ -1159,7 +1159,7 @@ jobs:
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          WORKFLOW_NAME: "Kongctl Feature User Agent"
+          WORKFLOW_NAME: "User Agent Eval"
           WORKFLOW_DESCRIPTION: "Runs a manual feature-user evaluation of one advertised kongctl workflow\nagainst a disposable Konnect org and files actionable friction only."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
@@ -1281,7 +1281,7 @@ jobs:
       GH_AW_ENGINE_VERSION: "1.0.40"
       GH_AW_TRACKER_ID: "kongctl-feature-user-agent"
       GH_AW_WORKFLOW_ID: "kongctl-feature-user-agent"
-      GH_AW_WORKFLOW_NAME: "Kongctl Feature User Agent"
+      GH_AW_WORKFLOW_NAME: "User Agent Eval"
     outputs:
       code_push_failure_count: ${{ steps.process_safe_outputs.outputs.code_push_failure_count }}
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}
@@ -1307,7 +1307,7 @@ jobs:
           job-name: ${{ github.job }}
           trace-id: ${{ needs.activation.outputs.setup-trace-id }}
         env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Kongctl Feature User Agent"
+          GH_AW_SETUP_WORKFLOW_NAME: "User Agent Eval"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/kongctl-feature-user-agent.lock.yml@${{ github.ref }}
           GH_AW_INFO_VERSION: "1.0.40"
       - name: Download agent output artifact

--- a/.github/workflows/kongctl-feature-user-agent.md
+++ b/.github/workflows/kongctl-feature-user-agent.md
@@ -10,7 +10,9 @@ permissions:
   issues: read
 checkout:
   fetch-depth: 0
-engine: copilot
+engine:
+  id: copilot
+  model: claude-opus-4.6
 strict: true
 timeout-minutes: 60
 environment: kongctl-user-agent-eval

--- a/.github/workflows/kongctl-feature-user-agent.md
+++ b/.github/workflows/kongctl-feature-user-agent.md
@@ -15,7 +15,6 @@ engine:
   model: claude-opus-4.6
 features:
   action-mode: "action"
-  action-tag: "v0.71.5"
 strict: true
 timeout-minutes: 60
 environment: kongctl-user-agent-eval

--- a/.github/workflows/kongctl-feature-user-agent.md
+++ b/.github/workflows/kongctl-feature-user-agent.md
@@ -171,6 +171,7 @@ APIs directly.
 - Repository: `${{ github.repository }}`
 - Workspace: `${{ github.workspace }}`
 - Run URL: `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`
+- Run seed: `${{ github.run_id }}`
 - Built binary: `./kongctl`
 - Auth env file: `/tmp/gh-aw/kongctl-feature-user-agent/auth.env`
 - Sanitized artifact directory:
@@ -189,8 +190,12 @@ dedicated Konnect org with the existing e2e reset helper.
 - Treat the Konnect org as disposable.
 - Discover features from `README.md`, `docs/`, `kongctl --help`, command help,
   and public Kong developer docs.
-- Pick one advertised feature or workflow without persona steering, feature
-  selection memory, repo memory, or history-based steering.
+- Build a candidate set of advertised feature workflows before choosing one.
+- Select one candidate with the deterministic run-seeded procedure below.
+- Do not choose the most prominent, obvious, or familiar workflow unless the
+  run-seeded selection lands on it.
+- Do not use persona steering, feature selection memory, repo memory, or
+  history-based steering.
 - Prefer one realistic, bounded workflow over broad coverage.
 - Capture commands, exit codes, sanitized stdout/stderr excerpts, generated
   config, expected vs. actual behavior, and cleanup result.
@@ -204,27 +209,47 @@ dedicated Konnect org with the existing e2e reset helper.
 
 1. Read the local docs and command help just enough to identify advertised
    workflows.
-2. Select exactly one feature workflow and state the reason in your private
-   notes or sanitized evidence.
-3. Exercise the workflow using `./kongctl` and PAT-based environment auth.
-4. Keep command output excerpts short. Prefer command shapes, exit codes, and
+2. Build a candidate set before selecting a workflow:
+   - Aim for 8 to 12 viable candidates when discoverable; if fewer are
+     discoverable, include all viable candidates.
+   - Prefer breadth across command surfaces, user intents, product resources,
+     and lifecycle phases.
+   - For each candidate, record a short stable title, advertised source,
+     likely user intent, surface or command family, resource or scope,
+     preconditions, expected commands, cleanup path, and feasibility risk.
+   - Keep candidates product-derived. Do not invent workflows that are not
+     supported by docs or command help.
+3. Select exactly one candidate with this deterministic procedure:
+   - Sort candidates by stable title using lowercase lexical order.
+   - Compute selected index as `run seed modulo candidate count`, using
+     zero-based indexing.
+   - If the selected candidate proves impossible after deeper inspection, skip
+     it, select the next candidate cyclically, and document why it was skipped.
+   - Do not re-rank candidates by model preference after sorting.
+4. Exercise the selected workflow using `./kongctl` and PAT-based environment
+   auth.
+5. Keep command output excerpts short. Prefer command shapes, exit codes, and
    non-identifying error text.
-5. If you create resources and can identify them safely, attempt cleanup.
-6. Write sanitized evidence files only under:
+6. If you create resources and can identify them safely, attempt cleanup.
+7. Write sanitized evidence files only under:
    `/tmp/gh-aw/kongctl-feature-user-agent/sanitized`.
-7. Write `/tmp/gh-aw/kongctl-feature-user-agent/sanitized/evaluation-summary.md`
+8. Write `/tmp/gh-aw/kongctl-feature-user-agent/sanitized/evaluation-summary.md`
    with these sections:
+   - `Run Seed`: the seed value and candidate count.
+   - `Candidate Set`: the sorted candidate titles, selected index, and any
+     skipped candidate.
    - `Feature Workflow Selected`: the use case derived from the docs/help.
-   - `Why This Workflow`: which input assets led you to choose it.
+   - `Why This Workflow`: which input assets advertised it, and how the
+     run-seeded selection chose it.
    - `Commands Attempted`: command shapes and exit codes.
    - `Observed Result`: what happened, including short sanitized excerpts.
    - `Success Criteria`: how you decided the workflow succeeded or failed.
    - `Friction Assessment`: why you did or did not find actionable friction.
    - `Cleanup`: cleanup attempted and result.
    - `Safe Output`: whether you emitted `create_issue` or `noop`, and why.
-8. Before final output, run a sanitization check over the issue body and every
+9. Before final output, run a sanitization check over the issue body and every
    file in the sanitized artifact directory. Rewrite or omit unsafe content.
-9. Emit exactly one safe output.
+10. Emit exactly one safe output.
 
 ## Redaction Rules
 

--- a/.github/workflows/kongctl-feature-user-agent.md
+++ b/.github/workflows/kongctl-feature-user-agent.md
@@ -14,7 +14,8 @@ engine:
   id: copilot
   model: claude-opus-4.6
 features:
-  action-mode: "script"
+  action-mode: "action"
+  action-tag: "v0.71.5"
 strict: true
 timeout-minutes: 60
 environment: kongctl-user-agent-eval

--- a/.github/workflows/kongctl-feature-user-agent.md
+++ b/.github/workflows/kongctl-feature-user-agent.md
@@ -86,6 +86,38 @@ pre-agent-steps:
       test -x ./kongctl
       make reset-org
 post-steps:
+  - name: Append feature-user evaluation summary
+    if: always()
+    run: |
+      set -euo pipefail
+
+      evidence_dir="/tmp/gh-aw/kongctl-feature-user-agent/sanitized"
+      summary_file="${evidence_dir}/evaluation-summary.md"
+
+      {
+        echo "## User Agent Eval"
+        echo
+        echo "- Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+        echo "- Sanitized artifacts: \`kongctl-feature-user-agent-sanitized\`"
+        echo
+      } >> "${GITHUB_STEP_SUMMARY}"
+
+      if [ ! -f "${summary_file}" ]; then
+        {
+          echo "No sanitized evaluation summary was produced."
+          echo
+          echo "Check the agent logs and sanitized artifact upload for details."
+        } >> "${GITHUB_STEP_SUMMARY}"
+        exit 0
+      fi
+
+      unsafe_pattern='([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}|Bearer[[:space:]]+[A-Za-z0-9._~+/-]+=*|Authorization:|X-Api-Key:|KONGCTL_[A-Z0-9_]*PAT=|https://[^[:space:]]*[?&](token|signature|X-Amz-Signature)=)'
+      if grep -E -q "${unsafe_pattern}" "${summary_file}"; then
+        echo "::error::Evaluation summary contains values that look unsafe. Redact or omit them before upload."
+        exit 1
+      fi
+
+      cat "${summary_file}" >> "${GITHUB_STEP_SUMMARY}"
   - name: Check sanitized feature-user artifacts
     if: always()
     run: |
@@ -162,6 +194,8 @@ dedicated Konnect org with the existing e2e reset helper.
 - Prefer one realistic, bounded workflow over broad coverage.
 - Capture commands, exit codes, sanitized stdout/stderr excerpts, generated
   config, expected vs. actual behavior, and cleanup result.
+- Always write a sanitized `evaluation-summary.md` file in the sanitized
+  artifact directory.
 - Attempt cleanup when created resources are easy to identify.
 - File an issue only for concrete, reproducible friction.
 - Emit `noop` when no actionable friction is found.
@@ -178,9 +212,19 @@ dedicated Konnect org with the existing e2e reset helper.
 5. If you create resources and can identify them safely, attempt cleanup.
 6. Write sanitized evidence files only under:
    `/tmp/gh-aw/kongctl-feature-user-agent/sanitized`.
-7. Before final output, run a sanitization check over the issue body and every
+7. Write `/tmp/gh-aw/kongctl-feature-user-agent/sanitized/evaluation-summary.md`
+   with these sections:
+   - `Feature Workflow Selected`: the use case derived from the docs/help.
+   - `Why This Workflow`: which input assets led you to choose it.
+   - `Commands Attempted`: command shapes and exit codes.
+   - `Observed Result`: what happened, including short sanitized excerpts.
+   - `Success Criteria`: how you decided the workflow succeeded or failed.
+   - `Friction Assessment`: why you did or did not find actionable friction.
+   - `Cleanup`: cleanup attempted and result.
+   - `Safe Output`: whether you emitted `create_issue` or `noop`, and why.
+8. Before final output, run a sanitization check over the issue body and every
    file in the sanitized artifact directory. Rewrite or omit unsafe content.
-8. Emit exactly one safe output.
+9. Emit exactly one safe output.
 
 ## Redaction Rules
 

--- a/.github/workflows/kongctl-feature-user-agent.md
+++ b/.github/workflows/kongctl-feature-user-agent.md
@@ -13,6 +13,8 @@ checkout:
 engine:
   id: copilot
   model: claude-opus-4.6
+features:
+  action-mode: "script"
 strict: true
 timeout-minutes: 60
 environment: kongctl-user-agent-eval

--- a/.github/workflows/kongctl-feature-user-agent.md
+++ b/.github/workflows/kongctl-feature-user-agent.md
@@ -1,5 +1,5 @@
 ---
-name: Kongctl Feature User Agent
+name: User Agent Eval
 description: |
   Runs a manual feature-user evaluation of one advertised kongctl workflow
   against a disposable Konnect org and files actionable friction only.
@@ -115,7 +115,7 @@ post-steps:
 tracker-id: kongctl-feature-user-agent
 ---
 
-# Kongctl Feature User Agent
+# User Agent Eval
 
 You are a feature user evaluating `kongctl` as a command-line product.
 


### PR DESCRIPTION
## Summary

- Pins the kongctl feature user agent workflow to Claude Opus 4.6 through `engine.model`.
- Recompiles the gh-aw lockfile so the generated Copilot model env uses `claude-opus-4.6`.

Related to #1068.

This PR intentionally does not close #1068; the workflow can be manually dispatched from this branch and refined before the issue is marked complete.

## Verification

- `go run github.com/github/gh-aw/cmd/gh-aw@v0.71.5 compile --strict --approve kongctl-feature-user-agent`