### PR TITLE
test(e2e): extend portal IdP team group mapping scenario

### DIFF
--- a/test/e2e/scenarios/portal/idp_team_group_mappings_readback/overlays/001-add-second-group/config.yaml
+++ b/test/e2e/scenarios/portal/idp_team_group_mappings_readback/overlays/001-add-second-group/config.yaml
@@ -1,0 +1,38 @@
+_defaults:
+  kongctl:
+    namespace: portal-idp-team-group-mappings
+
+portals:
+  - ref: portal-idp-team-group-mappings
+    name: portal-idp-team-group-mappings
+    display_name: Portal IdP Team Group Mappings
+    description: Portal with an IdP-backed team group mapping
+    kongctl:
+      namespace: portal-idp-team-group-mappings
+    auth_settings:
+      ref: portal-idp-team-group-mappings-auth-settings
+      idp_mapping_enabled: true
+    identity_providers:
+      - ref: portal-oidc
+        type: oidc
+        enabled: true
+        config:
+          issuer_url: !env KONGCTL_E2E_PORTAL_IDP_ISSUER_URL
+          client_id: !env KONGCTL_E2E_PORTAL_IDP_CLIENT_ID
+          client_secret: !env KONGCTL_E2E_PORTAL_IDP_CLIENT_SECRET
+          scopes:
+            - openid
+            - profile
+          claim_mappings:
+            name: name
+            email: email
+            groups: groups
+    teams:
+      - ref: portal-developers
+        name: Portal Developers
+        description: Developers mapped from IdP groups
+        group_mappings:
+          - ref: portal-developers-idp-groups
+            groups:
+              - Portal Developers
+              - Platform Developers

--- a/test/e2e/scenarios/portal/idp_team_group_mappings_readback/overlays/002-update-mapping/config.yaml
+++ b/test/e2e/scenarios/portal/idp_team_group_mappings_readback/overlays/002-update-mapping/config.yaml
@@ -1,0 +1,37 @@
+_defaults:
+  kongctl:
+    namespace: portal-idp-team-group-mappings
+
+portals:
+  - ref: portal-idp-team-group-mappings
+    name: portal-idp-team-group-mappings
+    display_name: Portal IdP Team Group Mappings
+    description: Portal with an IdP-backed team group mapping
+    kongctl:
+      namespace: portal-idp-team-group-mappings
+    auth_settings:
+      ref: portal-idp-team-group-mappings-auth-settings
+      idp_mapping_enabled: true
+    identity_providers:
+      - ref: portal-oidc
+        type: oidc
+        enabled: true
+        config:
+          issuer_url: !env KONGCTL_E2E_PORTAL_IDP_ISSUER_URL
+          client_id: !env KONGCTL_E2E_PORTAL_IDP_CLIENT_ID
+          client_secret: !env KONGCTL_E2E_PORTAL_IDP_CLIENT_SECRET
+          scopes:
+            - openid
+            - profile
+          claim_mappings:
+            name: name
+            email: email
+            groups: groups
+    teams:
+      - ref: portal-developers
+        name: Portal Developers
+        description: Developers mapped from IdP groups
+        group_mappings:
+          - ref: portal-developers-idp-groups
+            groups:
+              - Platform Developers

--- a/test/e2e/scenarios/portal/idp_team_group_mappings_readback/overlays/003-clear-mapping/config.yaml
+++ b/test/e2e/scenarios/portal/idp_team_group_mappings_readback/overlays/003-clear-mapping/config.yaml
@@ -1,0 +1,36 @@
+_defaults:
+  kongctl:
+    namespace: portal-idp-team-group-mappings
+
+portals:
+  - ref: portal-idp-team-group-mappings
+    name: portal-idp-team-group-mappings
+    display_name: Portal IdP Team Group Mappings
+    description: Portal with an IdP-backed team group mapping
+    kongctl:
+      namespace: portal-idp-team-group-mappings
+    auth_settings:
+      ref: portal-idp-team-group-mappings-auth-settings
+      idp_mapping_enabled: true
+    identity_providers:
+      - ref: portal-oidc
+        type: oidc
+        enabled: true
+        config:
+          issuer_url: !env KONGCTL_E2E_PORTAL_IDP_ISSUER_URL
+          client_id: !env KONGCTL_E2E_PORTAL_IDP_CLIENT_ID
+          client_secret: !env KONGCTL_E2E_PORTAL_IDP_CLIENT_SECRET
+          scopes:
+            - openid
+            - profile
+          claim_mappings:
+            name: name
+            email: email
+            groups: groups
+    teams:
+      - ref: portal-developers
+        name: Portal Developers
+        description: Developers mapped from IdP groups
+        group_mappings:
+          - ref: portal-developers-idp-groups
+            groups: []

--- a/test/e2e/scenarios/portal/idp_team_group_mappings_readback/scenario.yaml
+++ b/test/e2e/scenarios/portal/idp_team_group_mappings_readback/scenario.yaml
@@ -16,7 +16,6 @@ test:
 vars:
   namespace: portal-idp-team-group-mappings
   portalRef: portal-idp-team-group-mappings
-  providerRef: portal-oidc
   teamRef: portal-developers
   mappingRef: portal-developers-idp-groups
   expectedGroup: Portal Developers
@@ -86,19 +85,7 @@ steps:
           name: portalID
           responsePath: id
 
-      - name: 003-record-provider-id
-        outputFormat: json
-        run:
-          - get
-          - portal
-          - identity-providers
-          - --portal-name
-          - "{{ .vars.portalRef }}"
-        recordVar:
-          name: providerID
-          responsePath: "[?type=='oidc'] | [0].id"
-
-      - name: 004-record-team-id
+      - name: 003-record-team-id
         outputFormat: json
         run:
           - get
@@ -110,32 +97,18 @@ steps:
           name: teamID
           responsePath: "[?name=='{{ .vars.expectedGroup }}'] | [0].id"
 
-      - name: 005-readback-idp-team-group-mappings
-        parseAs: json
-        exec:
-          - bash
-          - -c
-          - |
-            set -euo pipefail
-            base_url="${KONGCTL_E2E_KONNECT_BASE_URL:-https://us.api.konghq.com}"
-            token="${KONGCTL_E2E_KONNECT_PAT:-}"
-            if [ -z "$token" ]; then
-              echo "KONGCTL_E2E_KONNECT_PAT not set" >&2
-              exit 1
-            fi
-            curl --fail-with-body --silent --show-error \
-              -H "Authorization: Bearer ${token}" \
-              -H "Accept: application/json" \
-              "${base_url%/}/v3/portals/{{ .vars.portalID }}/identity-providers/{{ .vars.providerID }}/team-group-mappings"
+      - name: 004-readback-idp-team-group-mappings
+        outputFormat: json
+        run:
+          - api
+          - get
+          - "/v3/portals/{{ .vars.portalID }}/identity-provider/team-group-mappings"
         assertions:
-          - select: data
+          - select: "data[?team_id=='{{ .vars.teamID }}'] | [0]"
             expect:
               fields:
-                "contains([].group, 'Portal Developers')": true
-          - select: "data[?team_id=='{{ .vars.teamID }}' && group=='{{ .vars.expectedGroup }}']"
-            expect:
-              fields:
-                "length(@)": 1
+                "contains(groups, 'Portal Developers')": true
+                "length(groups)": 1
 
   - name: 002-add-second-team-group-mapping-value
     inputOverlayDirs:
@@ -179,32 +152,18 @@ steps:
                 failed: 0
 
       - name: 002-readback-added-second-idp-team-group-mapping-value
-        parseAs: json
-        exec:
-          - bash
-          - -c
-          - |
-            set -euo pipefail
-            base_url="${KONGCTL_E2E_KONNECT_BASE_URL:-https://us.api.konghq.com}"
-            token="${KONGCTL_E2E_KONNECT_PAT:-}"
-            if [ -z "$token" ]; then
-              echo "KONGCTL_E2E_KONNECT_PAT not set" >&2
-              exit 1
-            fi
-            curl --fail-with-body --silent --show-error \
-              -H "Authorization: Bearer ${token}" \
-              -H "Accept: application/json" \
-              "${base_url%/}/v3/portals/{{ .vars.portalID }}/identity-providers/{{ .vars.providerID }}/team-group-mappings"
+        outputFormat: json
+        run:
+          - api
+          - get
+          - "/v3/portals/{{ .vars.portalID }}/identity-provider/team-group-mappings"
         assertions:
-          - select: data
+          - select: "data[?team_id=='{{ .vars.teamID }}'] | [0]"
             expect:
               fields:
-                "contains([].group, 'Portal Developers')": true
-                "contains([].group, 'Platform Developers')": true
-          - select: "data[?team_id=='{{ .vars.teamID }}']"
-            expect:
-              fields:
-                "length(@)": 2
+                "contains(groups, 'Portal Developers')": true
+                "contains(groups, 'Platform Developers')": true
+                "length(groups)": 2
 
   - name: 003-update-team-group-mapping
     inputOverlayDirs:
@@ -247,32 +206,18 @@ steps:
                 failed: 0
 
       - name: 002-readback-updated-idp-team-group-mappings
-        parseAs: json
-        exec:
-          - bash
-          - -c
-          - |
-            set -euo pipefail
-            base_url="${KONGCTL_E2E_KONNECT_BASE_URL:-https://us.api.konghq.com}"
-            token="${KONGCTL_E2E_KONNECT_PAT:-}"
-            if [ -z "$token" ]; then
-              echo "KONGCTL_E2E_KONNECT_PAT not set" >&2
-              exit 1
-            fi
-            curl --fail-with-body --silent --show-error \
-              -H "Authorization: Bearer ${token}" \
-              -H "Accept: application/json" \
-              "${base_url%/}/v3/portals/{{ .vars.portalID }}/identity-providers/{{ .vars.providerID }}/team-group-mappings"
+        outputFormat: json
+        run:
+          - api
+          - get
+          - "/v3/portals/{{ .vars.portalID }}/identity-provider/team-group-mappings"
         assertions:
-          - select: data
+          - select: "data[?team_id=='{{ .vars.teamID }}'] | [0]"
             expect:
               fields:
-                "contains([].group, 'Platform Developers')": true
-                "contains([].group, 'Portal Developers')": false
-          - select: "data[?team_id=='{{ .vars.teamID }}']"
-            expect:
-              fields:
-                "length(@)": 1
+                "contains(groups, 'Platform Developers')": true
+                "contains(groups, 'Portal Developers')": false
+                "length(groups)": 1
 
   - name: 004-clear-team-group-mapping
     inputOverlayDirs:
@@ -315,24 +260,14 @@ steps:
                 failed: 0
 
       - name: 002-readback-cleared-idp-team-group-mappings
-        parseAs: json
-        exec:
-          - bash
-          - -c
-          - |
-            set -euo pipefail
-            base_url="${KONGCTL_E2E_KONNECT_BASE_URL:-https://us.api.konghq.com}"
-            token="${KONGCTL_E2E_KONNECT_PAT:-}"
-            if [ -z "$token" ]; then
-              echo "KONGCTL_E2E_KONNECT_PAT not set" >&2
-              exit 1
-            fi
-            curl --fail-with-body --silent --show-error \
-              -H "Authorization: Bearer ${token}" \
-              -H "Accept: application/json" \
-              "${base_url%/}/v3/portals/{{ .vars.portalID }}/identity-providers/{{ .vars.providerID }}/team-group-mappings"
+        outputFormat: json
+        run:
+          - api
+          - get
+          - "/v3/portals/{{ .vars.portalID }}/identity-provider/team-group-mappings"
         assertions:
           - select: "data[?team_id=='{{ .vars.teamID }}']"
             expect:
               fields:
-                "length(@)": 0
+                "[?length(groups) > `0`] | length(@)": 0
+                "length(@) <= `1`": true

--- a/test/e2e/scenarios/portal/idp_team_group_mappings_readback/scenario.yaml
+++ b/test/e2e/scenarios/portal/idp_team_group_mappings_readback/scenario.yaml
@@ -1,0 +1,338 @@
+baseInputsPath: testdata
+
+env:
+  KONGCTL_LOG_LEVEL: debug
+
+test:
+  enabledByEnvVar: KONGCTL_E2E_RUN_PORTAL_IDENTITY_PROVIDERS
+  requiredEnvVars:
+    - KONGCTL_E2E_PORTAL_IDP_ISSUER_URL
+    - KONGCTL_E2E_PORTAL_IDP_CLIENT_ID
+    - KONGCTL_E2E_PORTAL_IDP_CLIENT_SECRET
+  info: >-
+    Requires real Dev Portal IdP values; set KONGCTL_E2E_RUN_PORTAL_IDENTITY_PROVIDERS=1
+    and provide the KONGCTL_E2E_PORTAL_IDP_* env vars to enable.
+
+vars:
+  namespace: portal-idp-team-group-mappings
+  portalRef: portal-idp-team-group-mappings
+  providerRef: portal-oidc
+  teamRef: portal-developers
+  mappingRef: portal-developers-idp-groups
+  expectedGroup: Portal Developers
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - change_id
+      - resource_id
+      - generated_at
+      - created_at
+      - updated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-apply-team-group-mapping
+    commands:
+      - name: 000-plan-team-group-mapping
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-team-group-mapping.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 5
+                by_action.CREATE: 3
+                by_action.UPDATE: 2
+          - select: >-
+              changes[?resource_type=='portal_team_group_mapping' && resource_ref=='{{ .vars.mappingRef }}'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                fields.groups[0]: "{{ .vars.expectedGroup }}"
+
+      - name: 001-apply-team-group-mapping
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-team-group-mapping.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 5
+                failed: 0
+
+      - name: 002-record-portal-id
+        outputFormat: json
+        run:
+          - get
+          - portal
+          - "{{ .vars.portalRef }}"
+        recordVar:
+          name: portalID
+          responsePath: id
+
+      - name: 003-record-provider-id
+        outputFormat: json
+        run:
+          - get
+          - portal
+          - identity-providers
+          - --portal-name
+          - "{{ .vars.portalRef }}"
+        recordVar:
+          name: providerID
+          responsePath: "[?type=='oidc'] | [0].id"
+
+      - name: 004-record-team-id
+        outputFormat: json
+        run:
+          - get
+          - portal
+          - teams
+          - --portal-name
+          - "{{ .vars.portalRef }}"
+        recordVar:
+          name: teamID
+          responsePath: "[?name=='{{ .vars.expectedGroup }}'] | [0].id"
+
+      - name: 005-readback-idp-team-group-mappings
+        parseAs: json
+        exec:
+          - bash
+          - -c
+          - |
+            set -euo pipefail
+            base_url="${KONGCTL_E2E_KONNECT_BASE_URL:-https://us.api.konghq.com}"
+            token="${KONGCTL_E2E_KONNECT_PAT:-}"
+            if [ -z "$token" ]; then
+              echo "KONGCTL_E2E_KONNECT_PAT not set" >&2
+              exit 1
+            fi
+            curl --fail-with-body --silent --show-error \
+              -H "Authorization: Bearer ${token}" \
+              -H "Accept: application/json" \
+              "${base_url%/}/v3/portals/{{ .vars.portalID }}/identity-providers/{{ .vars.providerID }}/team-group-mappings"
+        assertions:
+          - select: data
+            expect:
+              fields:
+                "contains([].group, 'Portal Developers')": true
+          - select: "data[?team_id=='{{ .vars.teamID }}' && group=='{{ .vars.expectedGroup }}']"
+            expect:
+              fields:
+                "length(@)": 1
+
+  - name: 002-add-second-team-group-mapping-value
+    inputOverlayDirs:
+      - overlays/001-add-second-group
+    commands:
+      - name: 000-plan-add-second-team-group-mapping-value
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-add-second-team-group-mapping-value.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+          - select: >-
+              changes[?resource_type=='portal_team_group_mapping' && resource_ref=='{{ .vars.mappingRef }}'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                fields.groups[0]: "{{ .vars.expectedGroup }}"
+                fields.groups[1]: Platform Developers
+
+      - name: 001-apply-add-second-team-group-mapping-value
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-add-second-team-group-mapping-value.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+
+      - name: 002-readback-added-second-idp-team-group-mapping-value
+        parseAs: json
+        exec:
+          - bash
+          - -c
+          - |
+            set -euo pipefail
+            base_url="${KONGCTL_E2E_KONNECT_BASE_URL:-https://us.api.konghq.com}"
+            token="${KONGCTL_E2E_KONNECT_PAT:-}"
+            if [ -z "$token" ]; then
+              echo "KONGCTL_E2E_KONNECT_PAT not set" >&2
+              exit 1
+            fi
+            curl --fail-with-body --silent --show-error \
+              -H "Authorization: Bearer ${token}" \
+              -H "Accept: application/json" \
+              "${base_url%/}/v3/portals/{{ .vars.portalID }}/identity-providers/{{ .vars.providerID }}/team-group-mappings"
+        assertions:
+          - select: data
+            expect:
+              fields:
+                "contains([].group, 'Portal Developers')": true
+                "contains([].group, 'Platform Developers')": true
+          - select: "data[?team_id=='{{ .vars.teamID }}']"
+            expect:
+              fields:
+                "length(@)": 2
+
+  - name: 003-update-team-group-mapping
+    inputOverlayDirs:
+      - overlays/002-update-mapping
+    commands:
+      - name: 000-plan-update-team-group-mapping
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-update-team-group-mapping.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+          - select: >-
+              changes[?resource_type=='portal_team_group_mapping' && resource_ref=='{{ .vars.mappingRef }}'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                fields.groups[0]: Platform Developers
+
+      - name: 001-apply-update-team-group-mapping
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-update-team-group-mapping.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+
+      - name: 002-readback-updated-idp-team-group-mappings
+        parseAs: json
+        exec:
+          - bash
+          - -c
+          - |
+            set -euo pipefail
+            base_url="${KONGCTL_E2E_KONNECT_BASE_URL:-https://us.api.konghq.com}"
+            token="${KONGCTL_E2E_KONNECT_PAT:-}"
+            if [ -z "$token" ]; then
+              echo "KONGCTL_E2E_KONNECT_PAT not set" >&2
+              exit 1
+            fi
+            curl --fail-with-body --silent --show-error \
+              -H "Authorization: Bearer ${token}" \
+              -H "Accept: application/json" \
+              "${base_url%/}/v3/portals/{{ .vars.portalID }}/identity-providers/{{ .vars.providerID }}/team-group-mappings"
+        assertions:
+          - select: data
+            expect:
+              fields:
+                "contains([].group, 'Platform Developers')": true
+                "contains([].group, 'Portal Developers')": false
+          - select: "data[?team_id=='{{ .vars.teamID }}']"
+            expect:
+              fields:
+                "length(@)": 1
+
+  - name: 004-clear-team-group-mapping
+    inputOverlayDirs:
+      - overlays/003-clear-mapping
+    commands:
+      - name: 000-plan-clear-team-group-mapping
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-clear-team-group-mapping.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+          - select: >-
+              changes[?resource_type=='portal_team_group_mapping' && resource_ref=='{{ .vars.mappingRef }}'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                fields.groups: []
+
+      - name: 001-apply-clear-team-group-mapping
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-clear-team-group-mapping.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+
+      - name: 002-readback-cleared-idp-team-group-mappings
+        parseAs: json
+        exec:
+          - bash
+          - -c
+          - |
+            set -euo pipefail
+            base_url="${KONGCTL_E2E_KONNECT_BASE_URL:-https://us.api.konghq.com}"
+            token="${KONGCTL_E2E_KONNECT_PAT:-}"
+            if [ -z "$token" ]; then
+              echo "KONGCTL_E2E_KONNECT_PAT not set" >&2
+              exit 1
+            fi
+            curl --fail-with-body --silent --show-error \
+              -H "Authorization: Bearer ${token}" \
+              -H "Accept: application/json" \
+              "${base_url%/}/v3/portals/{{ .vars.portalID }}/identity-providers/{{ .vars.providerID }}/team-group-mappings"
+        assertions:
+          - select: "data[?team_id=='{{ .vars.teamID }}']"
+            expect:
+              fields:
+                "length(@)": 0

--- a/test/e2e/scenarios/portal/idp_team_group_mappings_readback/testdata/config.yaml
+++ b/test/e2e/scenarios/portal/idp_team_group_mappings_readback/testdata/config.yaml
@@ -1,0 +1,37 @@
+_defaults:
+  kongctl:
+    namespace: portal-idp-team-group-mappings
+
+portals:
+  - ref: portal-idp-team-group-mappings
+    name: portal-idp-team-group-mappings
+    display_name: Portal IdP Team Group Mappings
+    description: Portal with an IdP-backed team group mapping
+    kongctl:
+      namespace: portal-idp-team-group-mappings
+    auth_settings:
+      ref: portal-idp-team-group-mappings-auth-settings
+      idp_mapping_enabled: true
+    identity_providers:
+      - ref: portal-oidc
+        type: oidc
+        enabled: true
+        config:
+          issuer_url: !env KONGCTL_E2E_PORTAL_IDP_ISSUER_URL
+          client_id: !env KONGCTL_E2E_PORTAL_IDP_CLIENT_ID
+          client_secret: !env KONGCTL_E2E_PORTAL_IDP_CLIENT_SECRET
+          scopes:
+            - openid
+            - profile
+          claim_mappings:
+            name: name
+            email: email
+            groups: groups
+    teams:
+      - ref: portal-developers
+        name: Portal Developers
+        description: Developers mapped from IdP groups
+        group_mappings:
+          - ref: portal-developers-idp-groups
+            groups:
+              - Portal Developers


### PR DESCRIPTION
## Summary

Adds an extended E2E scenario for portal IdP team group mappings. The scenario applies declarative portal IdP configuration and verifies Konnect readback for:

- initial team group mapping persistence
- adding a second mapped group value
- replacing the mapped group value
- clearing mapped groups

This is intentionally limited to `test/e2e/scenarios` and does not change `internal/` behavior.

Closes #1095

## Validation

- `make test-e2e-scenarios SCENARIO=portal/idp_team_group_mappings_readback`