### PR TITLE
Fix: Improve declarative `explain` and `scaffold` commands

### DIFF
--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -99,7 +99,6 @@ apis:
    attributes: object [string]array[string]
      key:
        - value
-   spec_content: string (OpenAPI or AsyncAPI content; json or yaml) # prefer: !file ./specs/api.yaml
    versions: # https://developer.konghq.com/api/konnect/api-builder/v3/#/operations/create-api-version
      - ref: string
        version: string
@@ -132,6 +131,10 @@ apis:
            slug: string (pattern: ^[\w-]+$)
            status: One of (published | unpublished)
 ```
+
+API specifications must be declared on API versions with `versions[].spec` or
+root-level `api_versions[].spec`; `apis[].spec_content` is not supported in
+declarative configuration.
 
 ## Application Auth Strategies
 

--- a/internal/declarative/loader/loader_test.go
+++ b/internal/declarative/loader/loader_test.go
@@ -787,6 +787,24 @@ apis:
 	assert.Contains(t, err.Error(), "use versions[].spec instead")
 }
 
+func TestLoader_LoadFile_APIUnknownField(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(`
+apis:
+  - ref: users-api
+    name: Users API
+    lables:
+      env: test
+`), 0o600)
+	require.NoError(t, err)
+
+	_, err = New().LoadFile(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown field 'lables'")
+	assert.Contains(t, err.Error(), "Did you mean 'labels'?")
+}
+
 func TestLoader_LoadFile_SeparateAPIChildResources(t *testing.T) {
 	loader := New()
 

--- a/internal/declarative/loader/loader_test.go
+++ b/internal/declarative/loader/loader_test.go
@@ -766,6 +766,27 @@ func TestLoader_LoadFile_APIWithChildren(t *testing.T) {
 	assert.Equal(t, "my-api", rs.APIImplementations[0].API) // Parent reference
 }
 
+func TestLoader_LoadFile_RejectsAPISpecContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(`
+apis:
+  - ref: users-api
+    name: Users API
+    spec_content: |
+      openapi: 3.0.0
+      info:
+        title: Users API
+        version: 1.0.0
+`), 0o600)
+	require.NoError(t, err)
+
+	_, err = New().LoadFile(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "apis[].spec_content is not supported in declarative configuration")
+	assert.Contains(t, err.Error(), "use versions[].spec instead")
+}
+
 func TestLoader_LoadFile_SeparateAPIChildResources(t *testing.T) {
 	loader := New()
 

--- a/internal/declarative/loader/testdata/valid/api-only.yaml
+++ b/internal/declarative/loader/testdata/valid/api-only.yaml
@@ -6,8 +6,3 @@ apis:
     version: "3.0.0"
     labels:
       team: identity
-    spec_content: |
-      openapi: 3.0.0
-      info:
-        title: Users API
-        version: 3.0.0

--- a/internal/declarative/planner/control_plane_planner_test.go
+++ b/internal/declarative/planner/control_plane_planner_test.go
@@ -339,7 +339,7 @@ func TestControlPlanePlanner_PlanDeleteSync(t *testing.T) {
 	assert.Equal(t, "cp-delete", plan.Changes[0].ResourceRef)
 }
 
-func TestControlPlanePlanner_PlanDeleteGroupDependsOnMemberDeletes(t *testing.T) {
+func TestControlPlanePlanner_PlanDeleteMembersDependOnGroupDelete(t *testing.T) {
 	planner := &Planner{
 		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
@@ -377,12 +377,17 @@ func TestControlPlanePlanner_PlanDeleteGroupDependsOnMemberDeletes(t *testing.T)
 	adjustControlPlaneGroupDeleteDependencies(plan.Changes)
 
 	require.Len(t, plan.Changes, 3)
+	memberAChange := plan.Changes[0]
+	assert.Equal(t, "member-a", memberAChange.ResourceRef)
+	assert.Equal(t, []string{"temp-3:d:control_plane:group-cp"}, memberAChange.DependsOn)
+
+	memberBChange := plan.Changes[1]
+	assert.Equal(t, "member-b", memberBChange.ResourceRef)
+	assert.Equal(t, []string{"temp-3:d:control_plane:group-cp"}, memberBChange.DependsOn)
+
 	groupChange := plan.Changes[2]
 	assert.Equal(t, "group-cp", groupChange.ResourceRef)
-	assert.ElementsMatch(t, []string{
-		"temp-1:d:control_plane:member-a",
-		"temp-2:d:control_plane:member-b",
-	}, groupChange.DependsOn)
+	assert.Empty(t, groupChange.DependsOn)
 	require.NotNil(t, groupChange.References)
 	assert.Equal(t, []string{"member-a-id", "member-b-id"}, groupChange.References[FieldMembers].Refs)
 }

--- a/internal/declarative/planner/planner.go
+++ b/internal/declarative/planner/planner.go
@@ -548,36 +548,37 @@ func toSnakeCase(value string) string {
 	return strings.Trim(string(out), "_")
 }
 
-// adjustControlPlaneGroupDeleteDependencies ensures control plane group DELETE
-// changes execute only after DELETE changes for their member control planes in
-// the same plan. Konnect rejects deleting a group while it still has members.
+// adjustControlPlaneGroupDeleteDependencies ensures member control plane DELETE
+// changes execute only after DELETE changes for their control plane groups in
+// the same plan. Konnect rejects deleting a member while it is still in a group.
 func adjustControlPlaneGroupDeleteDependencies(changes []PlannedChange) {
-	controlPlaneDeletesByID := make(map[string]string)
+	controlPlaneDeletesByID := make(map[string]int)
 	for i := range changes {
 		change := &changes[i]
 		if change.Action != ActionDelete || change.ResourceType != ResourceTypeControlPlane {
 			continue
 		}
 		if change.ResourceID != "" {
-			controlPlaneDeletesByID[change.ResourceID] = change.ID
+			controlPlaneDeletesByID[change.ResourceID] = i
 		}
 	}
 
 	for i := range changes {
-		change := &changes[i]
-		if change.Action != ActionDelete || change.ResourceType != ResourceTypeControlPlane {
+		groupChange := &changes[i]
+		if groupChange.Action != ActionDelete || groupChange.ResourceType != ResourceTypeControlPlane {
 			continue
 		}
 
-		refInfo, ok := change.References[FieldMembers]
+		refInfo, ok := groupChange.References[FieldMembers]
 		if !ok || len(refInfo.Refs) == 0 {
 			continue
 		}
 
 		for _, memberID := range refInfo.Refs {
-			depID, ok := controlPlaneDeletesByID[memberID]
-			if ok && depID != change.ID {
-				change.DependsOn = appendDependsOn(change.DependsOn, depID)
+			memberIdx, ok := controlPlaneDeletesByID[memberID]
+			if ok && memberIdx != i {
+				memberChange := &changes[memberIdx]
+				memberChange.DependsOn = appendDependsOn(memberChange.DependsOn, groupChange.ID)
 			}
 		}
 	}

--- a/internal/declarative/resources/api.go
+++ b/internal/declarative/resources/api.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"encoding/json"
 	"fmt"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
@@ -10,7 +11,9 @@ func init() {
 	registerResourceType(
 		ResourceTypeAPI,
 		func(rs *ResourceSet) *[]APIResource { return &rs.APIs },
-		AutoExplain[APIResource](),
+		AutoExplain[APIResource](
+			WithExplainSchemaBuilder(apiExplainNode),
+		),
 	)
 }
 
@@ -24,6 +27,24 @@ type APIResource struct {
 	Publications    []APIPublicationResource    `yaml:"publications,omitempty"    json:"publications,omitempty"`
 	Implementations []APIImplementationResource `yaml:"implementations,omitempty" json:"implementations,omitempty"`
 	Documents       []APIDocumentResource       `yaml:"documents,omitempty"       json:"documents,omitempty"`
+}
+
+func (a *APIResource) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if _, ok := raw["spec_content"]; ok {
+		return fmt.Errorf("apis[].spec_content is not supported in declarative configuration; use versions[].spec instead")
+	}
+
+	type apiResourceAlias APIResource
+	var decoded apiResourceAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*a = APIResource(decoded)
+	return nil
 }
 
 // GetType returns the resource type

--- a/internal/declarative/resources/api.go
+++ b/internal/declarative/resources/api.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -40,7 +41,9 @@ func (a *APIResource) UnmarshalJSON(data []byte) error {
 
 	type apiResourceAlias APIResource
 	var decoded apiResourceAlias
-	if err := json.Unmarshal(data, &decoded); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&decoded); err != nil {
 		return err
 	}
 	*a = APIResource(decoded)

--- a/internal/declarative/resources/auth_strategy.go
+++ b/internal/declarative/resources/auth_strategy.go
@@ -14,7 +14,9 @@ func init() {
 	registerResourceType(
 		ResourceTypeApplicationAuthStrategy,
 		func(rs *ResourceSet) *[]ApplicationAuthStrategyResource { return &rs.ApplicationAuthStrategies },
-		AutoExplain[ApplicationAuthStrategyResource](),
+		AutoExplain[ApplicationAuthStrategyResource](
+			WithExplainSchemaBuilder(applicationAuthStrategyExplainNode),
+		),
 	)
 }
 

--- a/internal/declarative/resources/event_gateway_backend_cluster.go
+++ b/internal/declarative/resources/event_gateway_backend_cluster.go
@@ -11,7 +11,9 @@ func init() {
 	registerResourceType(
 		ResourceTypeEventGatewayBackendCluster,
 		func(rs *ResourceSet) *[]EventGatewayBackendClusterResource { return &rs.EventGatewayBackendClusters },
-		AutoExplain[EventGatewayBackendClusterResource](),
+		AutoExplain[EventGatewayBackendClusterResource](
+			WithExplainSchemaBuilder(eventGatewayBackendClusterExplainNode),
+		),
 	)
 }
 

--- a/internal/declarative/resources/event_gateway_cluster_policy.go
+++ b/internal/declarative/resources/event_gateway_cluster_policy.go
@@ -12,7 +12,9 @@ func init() {
 	registerResourceType(
 		ResourceTypeEventGatewayClusterPolicy,
 		func(rs *ResourceSet) *[]EventGatewayClusterPolicyResource { return &rs.EventGatewayClusterPolicies },
-		AutoExplain[EventGatewayClusterPolicyResource](),
+		AutoExplain[EventGatewayClusterPolicyResource](
+			WithExplainSchemaBuilder(eventGatewayClusterPolicyExplainNode),
+		),
 	)
 }
 

--- a/internal/declarative/resources/event_gateway_consume_policy.go
+++ b/internal/declarative/resources/event_gateway_consume_policy.go
@@ -15,7 +15,9 @@ func init() {
 		func(rs *ResourceSet) *[]EventGatewayConsumePolicyResource {
 			return &rs.EventGatewayConsumePolicies
 		},
-		AutoExplain[EventGatewayConsumePolicyResource](),
+		AutoExplain[EventGatewayConsumePolicyResource](
+			WithExplainSchemaBuilder(eventGatewayConsumePolicyExplainNode),
+		),
 	)
 }
 

--- a/internal/declarative/resources/event_gateway_control_plane.go
+++ b/internal/declarative/resources/event_gateway_control_plane.go
@@ -10,7 +10,9 @@ func init() {
 	registerResourceType(
 		ResourceTypeEventGatewayControlPlane,
 		func(rs *ResourceSet) *[]EventGatewayControlPlaneResource { return &rs.EventGatewayControlPlanes },
-		AutoExplain[EventGatewayControlPlaneResource](),
+		AutoExplain[EventGatewayControlPlaneResource](
+			WithExplainAliases("egw"),
+		),
 	)
 }
 

--- a/internal/declarative/resources/event_gateway_listener_policy.go
+++ b/internal/declarative/resources/event_gateway_listener_policy.go
@@ -12,7 +12,9 @@ func init() {
 	registerResourceType(
 		ResourceTypeEventGatewayListenerPolicy,
 		func(rs *ResourceSet) *[]EventGatewayListenerPolicyResource { return &rs.EventGatewayListenerPolicies },
-		AutoExplain[EventGatewayListenerPolicyResource](),
+		AutoExplain[EventGatewayListenerPolicyResource](
+			WithExplainSchemaBuilder(eventGatewayListenerPolicyExplainNode),
+		),
 	)
 }
 

--- a/internal/declarative/resources/event_gateway_produce_policy.go
+++ b/internal/declarative/resources/event_gateway_produce_policy.go
@@ -14,7 +14,9 @@ func init() {
 	registerResourceType(
 		ResourceTypeEventGatewayProducePolicy,
 		func(rs *ResourceSet) *[]EventGatewayProducePolicyResource { return &rs.EventGatewayProducePolicies },
-		AutoExplain[EventGatewayProducePolicyResource](),
+		AutoExplain[EventGatewayProducePolicyResource](
+			WithExplainSchemaBuilder(eventGatewayProducePolicyExplainNode),
+		),
 	)
 }
 

--- a/internal/declarative/resources/event_gateway_schema_registry.go
+++ b/internal/declarative/resources/event_gateway_schema_registry.go
@@ -13,7 +13,9 @@ func init() {
 		func(rs *ResourceSet) *[]EventGatewaySchemaRegistryResource {
 			return &rs.EventGatewaySchemaRegistries
 		},
-		AutoExplain[EventGatewaySchemaRegistryResource](),
+		AutoExplain[EventGatewaySchemaRegistryResource](
+			WithExplainSchemaBuilder(eventGatewaySchemaRegistryExplainNode),
+		),
 	)
 }
 

--- a/internal/declarative/resources/event_gateway_virtual_cluster.go
+++ b/internal/declarative/resources/event_gateway_virtual_cluster.go
@@ -11,7 +11,9 @@ func init() {
 	registerResourceType(
 		ResourceTypeEventGatewayVirtualCluster,
 		func(rs *ResourceSet) *[]EventGatewayVirtualClusterResource { return &rs.EventGatewayVirtualClusters },
-		AutoExplain[EventGatewayVirtualClusterResource](),
+		AutoExplain[EventGatewayVirtualClusterResource](
+			WithExplainSchemaBuilder(eventGatewayVirtualClusterExplainNode),
+		),
 	)
 }
 

--- a/internal/declarative/resources/explain.go
+++ b/internal/declarative/resources/explain.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"encoding/json"
 	"fmt"
 	"maps"
 	"reflect"
@@ -181,7 +182,6 @@ var (
 		"version":      {},
 		"slug":         {},
 		"spec":         {},
-		"spec_content": {},
 	}
 	fileFieldSamples = map[string]string{
 		"content":            "./content.txt",
@@ -189,7 +189,6 @@ var (
 		"robots":             "./robots.txt",
 		"spec":               "./specs/openapi.yaml",
 		"spec.content":       "./specs/openapi.yaml",
-		"spec_content":       "./specs/openapi.yaml",
 		"custom_certificate": "./certs/cert.pem",
 		"custom_private_key": "./certs/key.pem",
 	}
@@ -682,8 +681,14 @@ func buildExplainDoc(rt ResourceType) (*ExplainDoc, error) {
 
 	rootKey := resourceSetRootKey(reg.typ)
 	aliases := []string{string(rt)}
+	if hyphenAlias := strings.ReplaceAll(string(rt), "_", "-"); hyphenAlias != string(rt) {
+		aliases = append(aliases, hyphenAlias)
+	}
 	if rootKey != "" {
 		aliases = append(aliases, rootKey)
+		if hyphenRootKey := strings.ReplaceAll(rootKey, "_", "-"); hyphenRootKey != rootKey {
+			aliases = append(aliases, hyphenRootKey)
+		}
 	}
 	aliases = append(aliases, reg.aliases...)
 	aliases = slices.Compact(aliases)
@@ -909,7 +914,12 @@ func autoExplainValueNode(
 
 	switch typ.Kind() {
 	case reflect.Struct:
-		if slices.Contains(stack, typ) {
+		if union, ok, err := autoExplainSDKUnionNode(typ, path, hints, stack); err != nil {
+			return nil, err
+		} else if ok {
+			union.Nullable = union.Nullable || nullable
+			node = union
+		} else if slices.Contains(stack, typ) {
 			child := recursiveExplainNode(typ)
 			child.Nullable = child.Nullable || nullable
 			node = child
@@ -1415,6 +1425,7 @@ func renderNestedTrail(write scaffoldWriter, trail []ExplainScaffoldNode, depth 
 }
 
 func firstScaffoldLine(node *ExplainNode, omit map[string]struct{}) string {
+	node = scaffoldActiveNode(node)
 	if field := firstScaffoldField(node, omit); field != nil {
 		return fmt.Sprintf("%s: %s", field.Name, scaffoldLiteral(field.Node))
 	}
@@ -1425,6 +1436,7 @@ func firstScaffoldLine(node *ExplainNode, omit map[string]struct{}) string {
 }
 
 func firstScaffoldField(node *ExplainNode, omit map[string]struct{}) *ExplainField {
+	node = scaffoldActiveNode(node)
 	if node.Kind != "object" {
 		return nil
 	}
@@ -1447,13 +1459,19 @@ func renderScaffoldObject(
 	omit map[string]struct{},
 	skipFirst bool,
 ) {
+	if node == nil {
+		return
+	}
+	if len(node.OneOf) > 0 {
+		renderScaffoldOneOfObject(write, node, depth, omit, false, scaffoldSkippedField(node, omit, skipFirst))
+		return
+	}
+	active := scaffoldActiveNode(node)
 	skipped := ""
 	if skipFirst {
-		if field := firstScaffoldField(node, omit); field != nil {
-			skipped = field.Name
-		}
+		skipped = scaffoldSkippedField(active, omit, true)
 	}
-	for _, field := range node.Properties {
+	for _, field := range active.Properties {
 		if _, ok := omit[field.Name]; ok {
 			continue
 		}
@@ -1473,18 +1491,19 @@ func renderScaffoldField(write scaffoldWriter, depth int, field *ExplainField, o
 		commentPrefix = "# "
 	}
 
-	if field.Node.Kind == explainKindObject && field.Node.Additional == nil && len(field.Node.OneOf) == 0 {
+	node := scaffoldActiveNode(field.Node)
+	if node.Kind == explainKindObject && node.Additional == nil {
 		write(indent + commentPrefix + field.Name + ":")
 		renderCommentedBlock(write, depth+1, field.Node, omit, comment)
 		return
 	}
 
-	if field.Node.Kind == explainKindArray {
+	if node.Kind == explainKindArray {
 		write(indent + commentPrefix + field.Name + ":")
-		itemLine := scaffoldLiteral(field.Node.Items)
-		if field.Node.Items != nil && field.Node.Items.Kind == explainKindObject {
-			write(strings.Repeat("  ", depth+1) + commentPrefix + "- " + firstScaffoldLine(field.Node.Items, omit))
-			renderCommentedBlock(write, depth+2, field.Node.Items, omit, comment)
+		itemLine := scaffoldLiteral(node.Items)
+		if node.Items != nil && node.Items.Kind == explainKindObject {
+			write(strings.Repeat("  ", depth+1) + commentPrefix + "- " + firstScaffoldLine(node.Items, omit))
+			renderCommentedBlockSkippingFirst(write, depth+2, node.Items, omit, comment)
 		} else {
 			write(strings.Repeat("  ", depth+1) + commentPrefix + "- " + itemLine)
 		}
@@ -1494,21 +1513,206 @@ func renderScaffoldField(write scaffoldWriter, depth int, field *ExplainField, o
 	write(indent + commentPrefix + field.Name + ": " + scaffoldLiteral(field.Node))
 }
 
+func renderScaffoldOneOfObject(
+	write scaffoldWriter,
+	node *ExplainNode,
+	depth int,
+	omit map[string]struct{},
+	comment bool,
+	skipped string,
+) {
+	common := scaffoldOneOfCommonFieldNames(node)
+	for _, field := range node.OneOf[0].Properties {
+		if _, ok := common[field.Name]; !ok {
+			continue
+		}
+		if _, ok := omit[field.Name]; ok {
+			continue
+		}
+		if skipped != "" && field.Name == skipped {
+			continue
+		}
+		required := field.Required || field.Recommended
+		renderScaffoldField(write, depth, field, omit, comment || !required)
+	}
+
+	for i, branch := range node.OneOf {
+		if branch == nil || branch.Kind != explainKindObject {
+			continue
+		}
+		fields := scaffoldRenderableBranchFields(branch, common, omit, skipped)
+		if len(fields) == 0 {
+			continue
+		}
+		branchComment := comment || i > 0
+		renderScaffoldOneOfOptionLabel(write, depth, branch, branchComment)
+		for _, field := range fields {
+			required := field.Required || field.Recommended
+			renderScaffoldField(write, depth, field, omit, branchComment || !required)
+		}
+	}
+}
+
+func scaffoldRenderableBranchFields(
+	branch *ExplainNode,
+	common map[string]struct{},
+	omit map[string]struct{},
+	skipped string,
+) []*ExplainField {
+	var fields []*ExplainField
+	for _, field := range branch.Properties {
+		if _, ok := common[field.Name]; ok {
+			continue
+		}
+		if _, ok := omit[field.Name]; ok {
+			continue
+		}
+		if skipped != "" && field.Name == skipped {
+			continue
+		}
+		fields = append(fields, field)
+	}
+	return fields
+}
+
+func renderScaffoldOneOfOptionLabel(write scaffoldWriter, depth int, branch *ExplainNode, comment bool) {
+	indent := strings.Repeat("  ", depth)
+	if label := scaffoldOneOfOptionLabel(branch); label != "" {
+		write(indent + "# oneOf option: " + label)
+		return
+	}
+	if comment {
+		write(indent + "# oneOf option")
+		return
+	}
+	write(indent + "# oneOf option")
+}
+
+func scaffoldOneOfOptionLabel(branch *ExplainNode) string {
+	for _, field := range branch.Properties {
+		if field.Node != nil && field.Node.Const != nil {
+			return fmt.Sprintf("%s=%v", field.Name, field.Node.Const)
+		}
+	}
+	for _, field := range branch.Properties {
+		if field.Required || field.Recommended {
+			return field.Name
+		}
+	}
+	return ""
+}
+
+func scaffoldOneOfCommonFieldNames(node *ExplainNode) map[string]struct{} {
+	common := make(map[string]struct{})
+	if node == nil || len(node.OneOf) < 2 || node.OneOf[0] == nil {
+		return common
+	}
+	for _, field := range node.OneOf[0].Properties {
+		signature := scaffoldFieldSignature(field)
+		foundInAll := true
+		for _, branch := range node.OneOf[1:] {
+			other, ok := branch.property(field.Name)
+			if !ok || scaffoldFieldSignature(other) != signature {
+				foundInAll = false
+				break
+			}
+		}
+		if foundInAll {
+			common[field.Name] = struct{}{}
+		}
+	}
+	return common
+}
+
+func scaffoldFieldSignature(field *ExplainField) string {
+	if field == nil {
+		return ""
+	}
+	payload := struct {
+		Required    bool        `json:"required"`
+		Recommended bool        `json:"recommended"`
+		Schema      *JSONSchema `json:"schema"`
+	}{
+		Required:    field.Required,
+		Recommended: field.Recommended,
+		Schema:      field.Node.toJSONSchema(),
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func scaffoldActiveNode(node *ExplainNode) *ExplainNode {
+	if node != nil && len(node.OneOf) > 0 {
+		return node.OneOf[0]
+	}
+	return node
+}
+
 func renderCommentedBlock(write scaffoldWriter, depth int, node *ExplainNode, omit map[string]struct{}, comment bool) {
+	renderCommentedBlockWithSkip(write, depth, node, omit, comment, "")
+}
+
+func renderCommentedBlockSkippingFirst(
+	write scaffoldWriter,
+	depth int,
+	node *ExplainNode,
+	omit map[string]struct{},
+	comment bool,
+) {
+	skipped := ""
+	if field := firstScaffoldField(node, omit); field != nil {
+		skipped = field.Name
+	}
+	renderCommentedBlockWithSkip(write, depth, node, omit, comment, skipped)
+}
+
+func renderCommentedBlockWithSkip(
+	write scaffoldWriter,
+	depth int,
+	node *ExplainNode,
+	omit map[string]struct{},
+	comment bool,
+	skipped string,
+) {
 	if node == nil || node.Kind != "object" {
 		return
 	}
+	if len(node.OneOf) > 0 {
+		renderScaffoldOneOfObject(write, node, depth, omit, comment, skipped)
+		return
+	}
+	node = scaffoldActiveNode(node)
 	for _, child := range node.Properties {
 		if _, ok := omit[child.Name]; ok {
+			continue
+		}
+		if skipped != "" && child.Name == skipped {
 			continue
 		}
 		renderScaffoldField(write, depth, child, omit, comment || !child.Required && !child.Recommended)
 	}
 }
 
+func scaffoldSkippedField(node *ExplainNode, omit map[string]struct{}, skipFirst bool) string {
+	if !skipFirst {
+		return ""
+	}
+	if field := firstScaffoldField(node, omit); field != nil {
+		return field.Name
+	}
+	return ""
+}
+
 func scaffoldLiteral(node *ExplainNode) string {
 	if node == nil {
 		return "null"
+	}
+	node = scaffoldActiveNode(node)
+	if node.Const != nil {
+		return fmt.Sprint(node.Const)
 	}
 	if node.Literal != "" {
 		return node.Literal
@@ -1560,7 +1764,16 @@ func (n *ExplainNode) lookup(path []string) (*ExplainNode, bool) {
 	for _, segment := range path {
 		field, ok := current.property(segment)
 		if !ok {
-			return nil, false
+			for _, branch := range current.OneOf {
+				if branchField, branchOK := branch.lookup([]string{segment}); branchOK {
+					field = &ExplainField{Node: branchField}
+					ok = true
+					break
+				}
+			}
+			if !ok {
+				return nil, false
+			}
 		}
 		current = field.Node
 		if current.Kind == explainKindArray && current.Items != nil {
@@ -1623,21 +1836,26 @@ func (n *ExplainNode) toJSONSchema() *JSONSchema {
 	}
 
 	schema.Type = schemaTypeValue(n.Kind, n.Nullable)
+	if len(n.OneOf) > 0 && !explainOneOfBranchesShareKind(n.OneOf) {
+		schema.Type = nil
+	}
 
 	switch n.Kind {
 	case "object":
-		if n.Additional != nil {
-			schema.Additional = n.Additional.toJSONSchema()
-		} else {
-			schema.Additional = false
-		}
-		if len(n.Properties) > 0 {
-			schema.Properties = make(map[string]*JSONSchema, len(n.Properties))
-		}
-		for _, field := range n.Properties {
-			schema.Properties[field.Name] = field.Node.toJSONSchema()
-			if field.Required {
-				schema.Required = append(schema.Required, field.Name)
+		if len(n.OneOf) == 0 {
+			if n.Additional != nil {
+				schema.Additional = n.Additional.toJSONSchema()
+			} else {
+				schema.Additional = false
+			}
+			if len(n.Properties) > 0 {
+				schema.Properties = make(map[string]*JSONSchema, len(n.Properties))
+			}
+			for _, field := range n.Properties {
+				schema.Properties[field.Name] = field.Node.toJSONSchema()
+				if field.Required {
+					schema.Required = append(schema.Required, field.Name)
+				}
 			}
 		}
 	case "array":
@@ -1651,6 +1869,19 @@ func (n *ExplainNode) toJSONSchema() *JSONSchema {
 	}
 
 	return schema
+}
+
+func explainOneOfBranchesShareKind(branches []*ExplainNode) bool {
+	if len(branches) == 0 || branches[0] == nil {
+		return true
+	}
+	kind := branches[0].Kind
+	for _, branch := range branches[1:] {
+		if branch == nil || branch.Kind != kind {
+			return false
+		}
+	}
+	return true
 }
 
 func schemaTypeValue(kind string, nullable bool) any {

--- a/internal/declarative/resources/explain_test.go
+++ b/internal/declarative/resources/explain_test.go
@@ -21,6 +21,16 @@ func TestResolveExplainSubject_Resource(t *testing.T) {
 	assert.Equal(t, "object", subject.Node.Kind)
 }
 
+func TestResolveExplainSubject_HyphenatedAlias(t *testing.T) {
+	subject, err := ResolveExplainSubject("event-gateway")
+	require.NoError(t, err)
+
+	assert.Equal(t, ResourceTypeEventGatewayControlPlane, subject.Doc.ResourceType)
+	assert.Contains(t, subject.Doc.Aliases, "event-gateway")
+	assert.Contains(t, subject.Doc.Aliases, "event-gateways")
+	assert.Contains(t, subject.Doc.Aliases, "egw")
+}
+
 func TestResolveExplainSubject_NestedChildResource(t *testing.T) {
 	subject, err := ResolveExplainSubject("api.versions")
 	require.NoError(t, err)
@@ -113,6 +123,31 @@ func TestRenderExplainSchema_Metadata(t *testing.T) {
 	assert.Equal(t, explainResourceClassTopLevel, schema.XClass)
 	require.NotNil(t, schema.XNestedDecl)
 	assert.False(t, *schema.XNestedDecl)
+}
+
+func TestRenderExplainSchema_ApplicationAuthStrategyUnion(t *testing.T) {
+	subject, err := ResolveExplainSubject("application_auth_strategies")
+	require.NoError(t, err)
+
+	schema := RenderExplainSchema(subject)
+	require.NotNil(t, schema)
+	require.Len(t, schema.OneOf, 2)
+	assert.Nil(t, schema.Properties)
+	assert.Nil(t, schema.Additional)
+
+	keyAuth := schema.OneOf[0]
+	require.NotNil(t, keyAuth.Properties["strategy_type"])
+	assert.Equal(t, "key_auth", keyAuth.Properties["strategy_type"].Const)
+	require.NotNil(t, keyAuth.Properties["configs"].Properties["key-auth"])
+	assert.Contains(t, keyAuth.Properties["configs"].Properties["key-auth"].Required, "key_names")
+
+	oidc := schema.OneOf[1]
+	require.NotNil(t, oidc.Properties["strategy_type"])
+	assert.Equal(t, "openid_connect", oidc.Properties["strategy_type"].Const)
+	require.NotNil(t, oidc.Properties["configs"].Properties["openid-connect"])
+
+	assert.Nil(t, keyAuth.Properties["app_auth_strategy_key_auth_request"])
+	assert.Nil(t, oidc.Properties["app_auth_strategy_open_i_d_connect_request"])
 }
 
 func TestRenderExplainText_ResourceSubject(t *testing.T) {
@@ -252,6 +287,48 @@ func TestRenderScaffoldYAML_RootResource(t *testing.T) {
 	assert.Contains(t, scaffold, "- ref: my-resource")
 	assert.Contains(t, scaffold, "name: my-resource")
 	assert.Contains(t, scaffold, "# versions:")
+	assert.NotContains(t, scaffold, "spec_content")
+}
+
+func TestRenderScaffoldYAML_ApplicationAuthStrategyUnion(t *testing.T) {
+	subject, err := ResolveExplainSubject("application_auth_strategies")
+	require.NoError(t, err)
+
+	scaffold, err := RenderScaffoldYAML(subject)
+	require.NoError(t, err)
+
+	assert.Contains(t, scaffold, "strategy_type: key_auth")
+	assert.Contains(t, scaffold, "configs:")
+	assert.Contains(t, scaffold, "key-auth:")
+	assert.Contains(t, scaffold, "key_names:")
+	assert.Contains(t, scaffold, "# oneOf option: strategy_type=key_auth")
+	assert.Contains(t, scaffold, "# oneOf option: strategy_type=openid_connect")
+	assert.Contains(t, scaffold, "# strategy_type: openid_connect")
+	assert.Contains(t, scaffold, "# openid-connect:")
+	assert.NotContains(t, scaffold, "# ref: my-resource")
+	assert.NotContains(t, scaffold, "# name: my-resource")
+	assert.NotContains(t, scaffold, "app_auth_strategy_key_auth_request")
+	assert.NotContains(t, scaffold, "app_auth_strategy_open_i_d_connect_request")
+}
+
+func TestRenderScaffoldYAML_EventGatewayListenerPolicyUnion(t *testing.T) {
+	subject, err := ResolveExplainSubject("event_gateway_listener_policy")
+	require.NoError(t, err)
+
+	scaffold, err := RenderScaffoldYAML(subject)
+	require.NoError(t, err)
+
+	assert.Contains(t, scaffold, "type: tls_server")
+	assert.Contains(t, scaffold, "# oneOf option: type=tls_server")
+	assert.Contains(t, scaffold, "# oneOf option: type=forward_to_virtual_cluster")
+	assert.Contains(t, scaffold, "# oneOf option: type=port_mapping")
+	assert.Contains(t, scaffold, "# type: forward_to_virtual_cluster")
+	assert.Contains(t, scaffold, "# type: port_mapping")
+	assert.Contains(t, scaffold, "# oneOf option: id")
+	assert.Contains(t, scaffold, "# oneOf option: name")
+	assert.NotContains(t, scaffold, "event_gateway_t_l_s_listener_policy")
+	assert.NotContains(t, scaffold, "forward_to_virtual_cluster_policy")
+	assert.NotContains(t, scaffold, "virtual_cluster_reference_by_i_d")
 }
 
 func TestRenderScaffoldYAML_NestedChildResource(t *testing.T) {

--- a/internal/declarative/resources/explain_test.go
+++ b/internal/declarative/resources/explain_test.go
@@ -125,6 +125,19 @@ func TestRenderExplainSchema_Metadata(t *testing.T) {
 	assert.False(t, *schema.XNestedDecl)
 }
 
+func TestRenderExplainSchema_APINameDefault(t *testing.T) {
+	subject, err := ResolveExplainSubject("api.name")
+	require.NoError(t, err)
+
+	schema := RenderExplainSchema(subject)
+	require.NotNil(t, schema)
+
+	assert.Equal(t, "ref", schema.XDefault)
+	require.NotNil(t, schema.XSubject)
+	assert.False(t, *schema.XSubject.Required)
+	assert.True(t, *schema.XSubject.Recommended)
+}
+
 func TestRenderExplainSchema_ApplicationAuthStrategyUnion(t *testing.T) {
 	subject, err := ResolveExplainSubject("application_auth_strategies")
 	require.NoError(t, err)
@@ -148,6 +161,36 @@ func TestRenderExplainSchema_ApplicationAuthStrategyUnion(t *testing.T) {
 
 	assert.Nil(t, keyAuth.Properties["app_auth_strategy_key_auth_request"])
 	assert.Nil(t, oidc.Properties["app_auth_strategy_open_i_d_connect_request"])
+}
+
+func TestRenderExplainSchema_ApplicationAuthStrategyUnionField(t *testing.T) {
+	subject, err := ResolveExplainSubject("application_auth_strategies.strategy_type")
+	require.NoError(t, err)
+
+	assert.True(t, subject.FieldRequired)
+	schema := RenderExplainSchema(subject)
+	require.NotNil(t, schema)
+	require.Len(t, schema.OneOf, 2)
+
+	assert.Equal(t, "key_auth", schema.OneOf[0].Const)
+	assert.Equal(t, "openid_connect", schema.OneOf[1].Const)
+	require.NotNil(t, schema.XSubject)
+	assert.True(t, *schema.XSubject.Required)
+}
+
+func TestRenderExplainSchema_ApplicationAuthStrategyConfigsUnionField(t *testing.T) {
+	subject, err := ResolveExplainSubject("application_auth_strategies.configs")
+	require.NoError(t, err)
+
+	assert.True(t, subject.FieldRequired)
+	schema := RenderExplainSchema(subject)
+	require.NotNil(t, schema)
+	require.Len(t, schema.OneOf, 2)
+
+	assert.Contains(t, schema.OneOf[0].Properties, "key-auth")
+	assert.Contains(t, schema.OneOf[1].Properties, "openid-connect")
+	require.NotNil(t, schema.XSubject)
+	assert.True(t, *schema.XSubject.Required)
 }
 
 func TestRenderExplainText_ResourceSubject(t *testing.T) {

--- a/internal/declarative/resources/explain_union_schemas.go
+++ b/internal/declarative/resources/explain_union_schemas.go
@@ -1,0 +1,508 @@
+package resources
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+)
+
+func autoExplainConcreteNode[T any](hints map[string]ExplainFieldHint) (*ExplainNode, error) {
+	if hints == nil {
+		hints = defaultExplainHints("")
+	}
+	return autoExplainNode(reflect.TypeFor[T](), nil, hints, nil)
+}
+
+func autoExplainSDKUnionNode(
+	typ reflect.Type,
+	path []string,
+	hints map[string]ExplainFieldHint,
+	stack []reflect.Type,
+) (*ExplainNode, bool, error) {
+	typ = derefExplainType(typ)
+	if typ.Kind() != reflect.Struct {
+		return nil, false, nil
+	}
+
+	var branches []*ExplainNode
+	for field := range typ.Fields() {
+		if field.Tag.Get("union") != "member" {
+			continue
+		}
+		memberType := derefExplainType(field.Type)
+		branch, err := autoExplainNode(memberType, path, hints, stack)
+		if err != nil {
+			return nil, true, err
+		}
+		if name, value, ok := explainConstDiscriminator(memberType); ok {
+			explainSetConstStringField(branch, name, value)
+		}
+		branches = append(branches, branch)
+	}
+
+	if len(branches) == 0 {
+		return nil, false, nil
+	}
+	return explainUnionNode(branches...), true, nil
+}
+
+func explainConstDiscriminator(typ reflect.Type) (string, string, bool) {
+	typ = derefExplainType(typ)
+	if typ.Kind() != reflect.Struct {
+		return "", "", false
+	}
+	for field := range typ.Fields() {
+		value := field.Tag.Get("const")
+		if value == "" {
+			continue
+		}
+		name, _, _, skip := explainFieldName(field, "json")
+		if skip || name == "" {
+			name, _, _, skip = explainFieldName(field, "yaml")
+		}
+		if skip || name == "" {
+			continue
+		}
+		return name, value, true
+	}
+	return "", "", false
+}
+
+func explainObject(fields ...*ExplainField) *ExplainNode {
+	node := &ExplainNode{
+		Kind:       explainKindObject,
+		Properties: []*ExplainField{},
+		propIndex:  make(map[string]*ExplainField),
+	}
+	for _, field := range fields {
+		node.addField(field)
+	}
+	return node
+}
+
+func explainField(name string, node *ExplainNode, required, recommended bool) *ExplainField {
+	return &ExplainField{Name: name, Node: node, Required: required, Recommended: recommended}
+}
+
+func explainStringNode(literal string) *ExplainNode {
+	return &ExplainNode{Kind: "string", Literal: literal}
+}
+
+func explainBoolNode(literal string) *ExplainNode {
+	return &ExplainNode{Kind: "boolean", Literal: literal}
+}
+
+func explainConstStringNode(value string) *ExplainNode {
+	return &ExplainNode{Kind: "string", Const: value, Literal: value, Enum: []any{value}}
+}
+
+func explainRefField(name string, kind ResourceType, required bool) *ExplainField {
+	node := explainStringNode(fmt.Sprintf("!ref my-%s", stringsForResourceRef(kind)))
+	node.RefKind = string(kind)
+	node.PreferredTag = "!ref"
+	return explainField(name, node, required, required)
+}
+
+func explainReferenceUnion(kind ResourceType) *ExplainNode {
+	return explainUnionNode(
+		explainObject(explainRefField("id", kind, true)),
+		explainObject(explainField("name", explainStringNode("my-resource"), true, true)),
+	)
+}
+
+func explainArrayOf(item *ExplainNode) *ExplainNode {
+	return &ExplainNode{Kind: explainKindArray, Items: item}
+}
+
+func stringsForResourceRef(kind ResourceType) string {
+	return strings.ReplaceAll(string(kind), "_", "-")
+}
+
+func explainKongctlField() *ExplainField {
+	return explainField("kongctl", explainObject(
+		explainField("protected", &ExplainNode{Kind: "boolean", Nullable: true, Literal: "false"}, false, false),
+		explainField("namespace", &ExplainNode{Kind: "string", Nullable: true, Literal: "default"}, false, false),
+	), false, false)
+}
+
+func explainResourceRefField() *ExplainField {
+	return explainField("ref", explainStringNode("my-resource"), true, true)
+}
+
+func explainUnionNode(branches ...*ExplainNode) *ExplainNode {
+	node := explainObject()
+	for _, branch := range branches {
+		for _, field := range branch.Properties {
+			if !node.propertyExists(field.Name) {
+				node.addField(&ExplainField{
+					Name:        field.Name,
+					Node:        field.Node.clone(),
+					Required:    false,
+					Recommended: field.Recommended,
+				})
+			}
+		}
+		node.OneOf = append(node.OneOf, branch)
+	}
+	return node
+}
+
+func explainWithCommonFields(branch *ExplainNode, fields ...*ExplainField) *ExplainNode {
+	node := explainObject()
+	for _, field := range fields {
+		node.addField(&ExplainField{
+			Name:        field.Name,
+			Node:        field.Node.clone(),
+			Required:    field.Required,
+			Recommended: field.Recommended,
+		})
+	}
+	for _, field := range branch.Properties {
+		if !node.propertyExists(field.Name) {
+			node.addField(field)
+		}
+	}
+	return node
+}
+
+func explainSetConstStringField(node *ExplainNode, name, value string) {
+	field := explainField(name, explainConstStringNode(value), true, true)
+	explainReplaceField(node, field)
+}
+
+func explainReplaceField(node *ExplainNode, field *ExplainField) {
+	if node == nil || field == nil {
+		return
+	}
+	for i, existing := range node.Properties {
+		if existing.Name == field.Name {
+			node.Properties[i] = field
+			if node.propIndex != nil {
+				node.propIndex[field.Name] = field
+			}
+			return
+		}
+	}
+	node.addField(field)
+}
+
+func explainRemoveField(node *ExplainNode, name string) {
+	if node == nil {
+		return
+	}
+	filtered := node.Properties[:0]
+	for _, field := range node.Properties {
+		if field.Name != name {
+			filtered = append(filtered, field)
+		}
+	}
+	node.Properties = filtered
+	if node.propIndex != nil {
+		delete(node.propIndex, name)
+	}
+	for _, branch := range node.OneOf {
+		explainRemoveField(branch, name)
+	}
+}
+
+func explainReplacePath(node *ExplainNode, path []string, replacement *ExplainNode) bool {
+	if len(path) == 0 {
+		return false
+	}
+	if len(path) == 1 {
+		if field, ok := node.property(path[0]); ok {
+			field.Node = replacement
+			return true
+		}
+		return false
+	}
+	field, ok := node.property(path[0])
+	if !ok {
+		return false
+	}
+	child := field.Node
+	if child.Kind == explainKindArray && child.Items != nil {
+		child = child.Items
+	}
+	return explainReplacePath(child, path[1:], replacement)
+}
+
+func explainSetPathRequired(node *ExplainNode, path []string) bool {
+	if len(path) == 0 {
+		return false
+	}
+	node = scaffoldActiveNode(node)
+	if len(path) == 1 {
+		if field, ok := node.property(path[0]); ok {
+			field.Required = true
+			field.Recommended = true
+			return true
+		}
+		return false
+	}
+	field, ok := node.property(path[0])
+	if !ok {
+		return false
+	}
+	child := field.Node
+	if child.Kind == explainKindArray && child.Items != nil {
+		child = child.Items
+	}
+	return explainSetPathRequired(child, path[1:])
+}
+
+func apiExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
+	node, err := autoExplainConcreteNode[APIResource](nil)
+	if err != nil {
+		return nil, err
+	}
+	explainRemoveField(node, "spec_content")
+	return node, nil
+}
+
+func applicationAuthStrategyExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
+	hints := defaultExplainHints(ResourceTypeApplicationAuthStrategy)
+	hints["name"] = ExplainFieldHint{DefaultFrom: "ref", Literal: "my-resource", Recommended: new(true)}
+	hints["dcr_provider_id"] = ExplainFieldHint{
+		PreferredTag: "!ref",
+		RefKind:      string(ResourceTypeDCRProvider),
+		Literal:      "!ref my-dcr-provider",
+	}
+
+	keyAuth, err := autoExplainConcreteNode[kkComps.AppAuthStrategyKeyAuthRequest](hints)
+	if err != nil {
+		return nil, err
+	}
+	explainSetConstStringField(keyAuth, "strategy_type", "key_auth")
+	explainSetPathRequired(keyAuth, []string{"configs", "key-auth", "key_names"})
+
+	oidc, err := autoExplainConcreteNode[kkComps.AppAuthStrategyOpenIDConnectRequest](hints)
+	if err != nil {
+		return nil, err
+	}
+	explainSetConstStringField(oidc, "strategy_type", "openid_connect")
+	explainSetPathRequired(oidc, []string{"configs", "openid-connect", "credential_claim"})
+	explainSetPathRequired(oidc, []string{"configs", "openid-connect", "scopes"})
+	explainSetPathRequired(oidc, []string{"configs", "openid-connect", "auth_methods"})
+
+	common := []*ExplainField{explainResourceRefField(), explainKongctlField()}
+	return explainUnionNode(
+		explainWithCommonFields(keyAuth, common...),
+		explainWithCommonFields(oidc, common...),
+	), nil
+}
+
+func eventGatewayVirtualClusterExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
+	node, err := autoExplainConcreteNode[EventGatewayVirtualClusterResource](nil)
+	if err != nil {
+		return nil, err
+	}
+	explainReplacePath(node, []string{"destination"}, explainReferenceUnion(ResourceTypeEventGatewayBackendCluster))
+	return node, nil
+}
+
+func eventGatewayBackendClusterExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
+	node, err := autoExplainConcreteNode[EventGatewayBackendClusterResource](nil)
+	if err != nil {
+		return nil, err
+	}
+	auth := explainDiscriminatedUnion("type",
+		explainVariant[kkComps.BackendClusterAuthenticationAnonymous]("type", "anonymous"),
+		explainVariant[kkComps.BackendClusterAuthenticationSaslPlain]("type", "sasl_plain"),
+		explainVariant[kkComps.BackendClusterAuthenticationSaslScram]("type", "sasl_scram"),
+	)
+	explainReplacePath(node, []string{"authentication"}, auth)
+	return node, nil
+}
+
+func eventGatewaySchemaRegistryExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
+	confluent, err := autoExplainConcreteNode[kkComps.SchemaRegistryConfluent](nil)
+	if err != nil {
+		return nil, err
+	}
+	explainSetConstStringField(confluent, "type", "confluent")
+	return explainUnionNode(explainWithCommonFields(
+		confluent,
+		explainResourceRefField(),
+		explainRefField("event_gateway", ResourceTypeEventGatewayControlPlane, false),
+	)), nil
+}
+
+func eventGatewayClusterPolicyExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
+	acls, err := autoExplainConcreteNode[kkComps.EventGatewayACLsPolicy](nil)
+	if err != nil {
+		return nil, err
+	}
+	explainSetConstStringField(acls, "type", "acls")
+	return explainUnionNode(explainWithCommonFields(
+		acls,
+		explainResourceRefField(),
+		explainRefField("virtual_cluster", ResourceTypeEventGatewayVirtualCluster, false),
+		explainRefField("event_gateway", ResourceTypeEventGatewayControlPlane, false),
+	)), nil
+}
+
+func eventGatewayProducePolicyExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
+	modifyHeaders, err := explainVariantNode[kkComps.EventGatewayModifyHeadersPolicyCreate]("type", "modify_headers")
+	if err != nil {
+		return nil, err
+	}
+	schemaValidation, err := explainVariantNode[kkComps.EventGatewayProduceSchemaValidationPolicy](
+		"type",
+		"schema_validation",
+	)
+	if err != nil {
+		return nil, err
+	}
+	encrypt, err := explainVariantNode[kkComps.EventGatewayEncryptPolicy]("type", "encrypt")
+	if err != nil {
+		return nil, err
+	}
+	return eventGatewayVirtualClusterPolicyUnion(modifyHeaders, schemaValidation, encrypt), nil
+}
+
+func eventGatewayConsumePolicyExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
+	modifyHeaders, err := explainVariantNode[kkComps.EventGatewayModifyHeadersPolicyCreate]("type", "modify_headers")
+	if err != nil {
+		return nil, err
+	}
+	schemaValidation, err := explainVariantNode[kkComps.EventGatewayConsumeSchemaValidationPolicy](
+		"type",
+		"schema_validation",
+	)
+	if err != nil {
+		return nil, err
+	}
+	decrypt, err := explainVariantNode[kkComps.EventGatewayDecryptPolicy]("type", "decrypt")
+	if err != nil {
+		return nil, err
+	}
+	skipRecord, err := explainVariantNode[kkComps.EventGatewaySkipRecordPolicyCreate]("type", "skip_record")
+	if err != nil {
+		return nil, err
+	}
+	return eventGatewayVirtualClusterPolicyUnion(modifyHeaders, schemaValidation, decrypt, skipRecord), nil
+}
+
+func eventGatewayVirtualClusterPolicyUnion(branches ...*ExplainNode) *ExplainNode {
+	common := []*ExplainField{
+		explainResourceRefField(),
+		explainRefField("virtual_cluster", ResourceTypeEventGatewayVirtualCluster, false),
+		explainRefField("event_gateway", ResourceTypeEventGatewayControlPlane, false),
+	}
+	withCommon := make([]*ExplainNode, 0, len(branches))
+	for _, branch := range branches {
+		withCommon = append(withCommon, explainWithCommonFields(branch, common...))
+	}
+	return explainUnionNode(withCommon...)
+}
+
+func eventGatewayListenerPolicyExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
+	tlsServer, err := explainVariantNode[kkComps.EventGatewayTLSListenerPolicy]("type", "tls_server")
+	if err != nil {
+		return nil, err
+	}
+	forward, err := explainVariantNode[kkComps.ForwardToVirtualClusterPolicy]("type", "forward_to_virtual_cluster")
+	if err != nil {
+		return nil, err
+	}
+	forwardConfig := explainDiscriminatedUnion("type",
+		explainVariant[kkComps.ForwardToClusterByPortMappingConfig]("type", "port_mapping"),
+		explainVariant[kkComps.ForwardToClusterBySNIConfig]("type", "sni"),
+	)
+	for _, branch := range forwardConfig.OneOf {
+		explainReplacePath(branch, []string{"destination"}, explainReferenceUnion(ResourceTypeEventGatewayVirtualCluster))
+	}
+	explainReplacePath(forward, []string{"config"}, forwardConfig)
+	explainReplacePath(
+		tlsServer,
+		[]string{"config", "client_authentication", "tls_trust_bundles"},
+		explainArrayOf(explainReferenceUnion(ResourceTypeEventGatewayTLSTrustBundle)),
+	)
+
+	common := []*ExplainField{
+		explainResourceRefField(),
+		explainRefField("listener", ResourceTypeEventGatewayListener, false),
+		explainRefField("event_gateway", ResourceTypeEventGatewayControlPlane, false),
+	}
+	return explainUnionNode(
+		explainWithCommonFields(tlsServer, common...),
+		explainWithCommonFields(forward, common...),
+	), nil
+}
+
+func portalIdentityProviderExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
+	oidc, err := autoExplainConcreteNode[kkComps.OIDCIdentityProviderConfig](nil)
+	if err != nil {
+		return nil, err
+	}
+	saml, err := autoExplainConcreteNode[kkComps.SAMLIdentityProviderConfigInput](nil)
+	if err != nil {
+		return nil, err
+	}
+	config := explainUnionNode(oidc, saml)
+	common := []*ExplainField{
+		explainResourceRefField(),
+		explainRefField("portal", ResourceTypePortal, false),
+		explainField("enabled", explainBoolNode("false"), false, false),
+		explainField("login_path", explainStringNode("/login"), false, false),
+	}
+	oidcBranch := explainObject(append(common,
+		explainField("type", explainConstStringNode("oidc"), true, true),
+		explainField("config", config.OneOf[0], true, true),
+	)...)
+	samlBranch := explainObject(append(common,
+		explainField("type", explainConstStringNode("saml"), true, true),
+		explainField("config", config.OneOf[1], true, true),
+	)...)
+	return explainUnionNode(oidcBranch, samlBranch), nil
+}
+
+func portalCustomDomainExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
+	node, err := autoExplainConcreteNode[PortalCustomDomainResource](nil)
+	if err != nil {
+		return nil, err
+	}
+	ssl := explainDiscriminatedUnion("domain_verification_method",
+		explainVariant[kkComps.HTTP]("domain_verification_method", "http"),
+		explainVariant[kkComps.CustomCertificate]("domain_verification_method", "custom_certificate"),
+	)
+	explainReplacePath(node, []string{"ssl"}, ssl)
+	return node, nil
+}
+
+func explainDiscriminatedUnion(discriminator string, variants ...explainVariantSpec) *ExplainNode {
+	branches := make([]*ExplainNode, 0, len(variants))
+	for _, variant := range variants {
+		if variant.Node == nil {
+			continue
+		}
+		explainSetConstStringField(variant.Node, discriminator, variant.Value)
+		branches = append(branches, variant.Node)
+	}
+	return explainUnionNode(branches...)
+}
+
+type explainVariantSpec struct {
+	Value string
+	Node  *ExplainNode
+}
+
+func explainVariant[T any](discriminator, value string) explainVariantSpec {
+	node, err := explainVariantNode[T](discriminator, value)
+	if err != nil {
+		return explainVariantSpec{}
+	}
+	return explainVariantSpec{Value: value, Node: node}
+}
+
+func explainVariantNode[T any](discriminator, value string) (*ExplainNode, error) {
+	node, err := autoExplainConcreteNode[T](nil)
+	if err != nil {
+		return nil, err
+	}
+	explainSetConstStringField(node, discriminator, value)
+	return node, nil
+}

--- a/internal/declarative/resources/explain_union_schemas.go
+++ b/internal/declarative/resources/explain_union_schemas.go
@@ -132,21 +132,119 @@ func explainResourceRefField() *ExplainField {
 }
 
 func explainUnionNode(branches ...*ExplainNode) *ExplainNode {
-	node := explainObject()
+	node := explainAggregateUnionNode(branches...)
+	node.OneOf = append(node.OneOf, branches...)
+	return node
+}
+
+func explainAggregateUnionNode(branches ...*ExplainNode) *ExplainNode {
+	if len(branches) == 0 {
+		return explainObject()
+	}
+
+	first := branches[0]
+	node := &ExplainNode{
+		Kind:         first.Kind,
+		Description:  first.Description,
+		Default:      first.Default,
+		DefaultFrom:  first.DefaultFrom,
+		Enum:         append([]any(nil), first.Enum...),
+		Nullable:     first.Nullable,
+		Recommended:  first.Recommended,
+		PreferredTag: first.PreferredTag,
+		RefKind:      first.RefKind,
+		Notes:        append([]string(nil), first.Notes...),
+		Literal:      first.Literal,
+		Additional:   first.Additional.clone(),
+	}
+
+	sameKind := true
+	for _, branch := range branches[1:] {
+		if branch.Kind != first.Kind {
+			sameKind = false
+			break
+		}
+	}
+	if !sameKind {
+		node.Kind = "any"
+	}
+
+	if sameKind && first.Kind == explainKindObject {
+		explainAddAggregateUnionFields(node, branches)
+	}
+
+	return node
+}
+
+func explainAddAggregateUnionFields(node *ExplainNode, branches []*ExplainNode) {
+	fieldNames := make([]string, 0)
+	fieldsByName := make(map[string][]*ExplainField)
+
 	for _, branch := range branches {
 		for _, field := range branch.Properties {
-			if !node.propertyExists(field.Name) {
-				node.addField(&ExplainField{
-					Name:        field.Name,
-					Node:        field.Node.clone(),
-					Required:    false,
-					Recommended: field.Recommended,
-				})
+			if _, ok := fieldsByName[field.Name]; !ok {
+				fieldNames = append(fieldNames, field.Name)
 			}
+			fieldsByName[field.Name] = append(fieldsByName[field.Name], field)
 		}
-		node.OneOf = append(node.OneOf, branch)
 	}
-	return node
+
+	for _, name := range fieldNames {
+		fields := fieldsByName[name]
+		node.addField(&ExplainField{
+			Name:        name,
+			Node:        explainAggregateUnionFieldNode(fields),
+			Required:    explainUnionFieldRequired(name, fields, branches),
+			Recommended: explainUnionFieldRecommended(fields),
+		})
+	}
+}
+
+func explainAggregateUnionFieldNode(fields []*ExplainField) *ExplainNode {
+	if len(fields) == 0 {
+		return nil
+	}
+	if len(fields) == 1 || explainUnionFieldsShareNode(fields) {
+		return fields[0].Node.clone()
+	}
+
+	branches := make([]*ExplainNode, 0, len(fields))
+	for _, field := range fields {
+		branches = append(branches, field.Node.clone())
+	}
+	return explainUnionNode(branches...)
+}
+
+func explainUnionFieldRequired(name string, fields []*ExplainField, branches []*ExplainNode) bool {
+	if len(fields) != len(branches) {
+		return false
+	}
+	for _, branch := range branches {
+		field, ok := branch.property(name)
+		if !ok || !field.Required {
+			return false
+		}
+	}
+	return true
+}
+
+func explainUnionFieldRecommended(fields []*ExplainField) bool {
+	for _, field := range fields {
+		if field.Recommended {
+			return true
+		}
+	}
+	return false
+}
+
+func explainUnionFieldsShareNode(fields []*ExplainField) bool {
+	first := fields[0].Node.toJSONSchema()
+	for _, field := range fields[1:] {
+		if !reflect.DeepEqual(first, field.Node.toJSONSchema()) {
+			return false
+		}
+	}
+	return true
 }
 
 func explainWithCommonFields(branch *ExplainNode, fields ...*ExplainField) *ExplainNode {
@@ -254,7 +352,7 @@ func explainSetPathRequired(node *ExplainNode, path []string) bool {
 }
 
 func apiExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
-	node, err := autoExplainConcreteNode[APIResource](nil)
+	node, err := autoExplainConcreteNode[APIResource](defaultExplainHints(ResourceTypeAPI))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/declarative/resources/portal_custom_domain.go
+++ b/internal/declarative/resources/portal_custom_domain.go
@@ -12,7 +12,9 @@ func init() {
 	registerResourceType(
 		ResourceTypePortalCustomDomain,
 		func(rs *ResourceSet) *[]PortalCustomDomainResource { return &rs.PortalCustomDomains },
-		AutoExplain[PortalCustomDomainResource](),
+		AutoExplain[PortalCustomDomainResource](
+			WithExplainSchemaBuilder(portalCustomDomainExplainNode),
+		),
 	)
 }
 

--- a/internal/declarative/resources/portal_identity_provider.go
+++ b/internal/declarative/resources/portal_identity_provider.go
@@ -11,7 +11,9 @@ func init() {
 	registerResourceType(
 		ResourceTypePortalIdentityProvider,
 		func(rs *ResourceSet) *[]PortalIdentityProviderResource { return &rs.PortalIdentityProviders },
-		AutoExplain[PortalIdentityProviderResource](),
+		AutoExplain[PortalIdentityProviderResource](
+			WithExplainSchemaBuilder(portalIdentityProviderExplainNode),
+		),
 	)
 }
 

--- a/skills/kongctl-declarative/SKILL.md
+++ b/skills/kongctl-declarative/SKILL.md
@@ -114,6 +114,13 @@ state is the best source of truth, such as when adopting existing resources.
   `-o json`/`-o yaml` for machine-readable schema.
 - Use `kongctl scaffold` to bootstrap YAML for new resource types and child
   resources. It writes YAML to stdout and does not support `-o/--output`.
+- For programmatic YAML generation, prefer `kongctl explain <path> -o json`
+  as the source of truth. It returns JSON Schema with kongctl metadata.
+- For resources with JSON Schema `oneOf`, choose exactly one branch. Use
+  discriminator `const` fields such as `type` or `strategy_type` to select the
+  branch, and do not merge branch-specific `config` or `configs` blocks.
+- In scaffold output, `# oneOf option: ...` marks mutually exclusive
+  alternatives. One branch is active and the other branches are commented.
 - Use resource and field paths such as `api`, `api.versions`,
   `api.publications.portal_id`, and `portal.pages` with `explain`.
 - Use resource and child-resource paths such as `api`, `api.versions`, and

--- a/skills/kongctl-declarative/references/commands.md
+++ b/skills/kongctl-declarative/references/commands.md
@@ -93,6 +93,11 @@ output when field details are needed. Use `-o json` or `-o yaml` when an
 agent needs machine-readable JSON Schema, required fields, root keys,
 resource class, or nesting metadata.
 
+For programmatic authoring, treat JSON Schema as the source of truth. When a
+schema contains `oneOf`, choose exactly one branch. Branches commonly use a
+discriminator field with `const`, such as `strategy_type: key_auth` or
+`type: tls_server`.
+
 ## Scaffold Command Detail
 
 `kongctl scaffold` prints commented YAML starter configuration for a resource
@@ -112,6 +117,13 @@ Important behavior:
   `kongctl scaffold api > konnect/resources/apis.yaml`
 - Replace placeholder refs and values such as `my-resource` before planning.
 - Un-comment optional fields only when the user needs them.
+- `# oneOf option: ...` marks mutually exclusive alternatives.
+- One `oneOf` branch is active and the other branches are commented.
+- To switch variants, uncomment one whole branch and comment or remove the
+  previously active branch.
+- Common fields outside `# oneOf option: ...` blocks apply to all variants.
+- Do not merge branch-specific `config` or `configs` blocks from multiple
+  `oneOf` options.
 
 ## decK APIOps Command Detail
 

--- a/skills/kongctl-declarative/references/resources.md
+++ b/skills/kongctl-declarative/references/resources.md
@@ -56,6 +56,27 @@ placeholder values, then validate with `diff` or `plan`.
 Use `dump declarative` when live Konnect state should drive the shape, such as
 adopting an existing resource into declarative management.
 
+## Union and `oneOf` Resources
+
+`kongctl explain <resource-path> -o json` emits JSON Schema. When the schema
+contains `oneOf`, choose exactly one branch.
+
+Common patterns:
+
+- A discriminator field with `const`, such as `strategy_type: key_auth`.
+- A discriminator field with `const`, such as `type: tls_server`.
+- Reference selector alternatives, such as an `id` object or a `name` object.
+
+Do not merge branch-specific fields from multiple options. For example, do not
+combine `configs.key-auth` and `configs.openid-connect` in the same
+`application_auth_strategies` item.
+
+`kongctl scaffold` marks these alternatives with `# oneOf option: ...`. One
+branch is active and the other branches are commented. To switch variants,
+uncomment one whole branch and comment or remove the previously active branch.
+Common fields shown outside the `# oneOf option: ...` blocks apply to all
+variants.
+
 ## Parent and Child Rules
 
 - Parent resources support `kongctl` metadata:
@@ -183,8 +204,11 @@ Common fields:
 - `slug`
 - `labels`
 - `attributes`
-- `spec_content`
 - `kongctl`
+
+Do not use `apis[].spec_content`; it is not supported in declarative
+configuration. Put specs on `apis[].versions[].spec` or root-level
+`api_versions[].spec`.
 
 Common child blocks:
 
@@ -262,7 +286,7 @@ application_auth_strategies:
     display_name: "My Key Auth"
     strategy_type: key_auth
     configs:
-      key_auth:
+      key-auth:
         key_names:
           - X-API-Key
 ```

--- a/test/e2e/scenarios/scaffold/command-coverage/scenario.yaml
+++ b/test/e2e/scenarios/scaffold/command-coverage/scenario.yaml
@@ -14,7 +14,7 @@ steps:
                 "contains(stdout, 'apis:')": true
                 "contains(stdout, '- ref: my-resource')": true
                 "contains(stdout, '# versions:')": true
-                "contains(stdout, 'spec_content: !file ./specs/openapi.yaml')": true
+                "contains(stdout, 'spec_content')": false
 
   - name: 002-scaffold-api-versions-nested
     skipInputs: true


### PR DESCRIPTION
## Summary
- generate explain JSON Schema oneOf branches for declarative union resources
- improve scaffold output for oneOf resources with explicit option markers and shared fields rendered once
- remove unsupported API spec_content guidance and reject it in declarative API configs
- update kongctl-declarative skill guidance for agents using explain/scaffold

Fixes #1086
Resolves #935

## Validation
- git diff --check
- go test ./internal/declarative/resources ./internal/declarative/loader ./internal/cmd/root/verbs/explain ./internal/cmd/root/verbs/scaffold
- make build
- make lint
- make test