### PR TITLE
Fix: plan control plane group removal before constiuent control planes

### DIFF
--- a/internal/declarative/planner/control_plane_planner_test.go
+++ b/internal/declarative/planner/control_plane_planner_test.go
@@ -339,7 +339,7 @@ func TestControlPlanePlanner_PlanDeleteSync(t *testing.T) {
 	assert.Equal(t, "cp-delete", plan.Changes[0].ResourceRef)
 }
 
-func TestControlPlanePlanner_PlanDeleteGroupDependsOnMemberDeletes(t *testing.T) {
+func TestControlPlanePlanner_PlanDeleteMembersDependOnGroupDelete(t *testing.T) {
 	planner := &Planner{
 		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
@@ -377,12 +377,17 @@ func TestControlPlanePlanner_PlanDeleteGroupDependsOnMemberDeletes(t *testing.T)
 	adjustControlPlaneGroupDeleteDependencies(plan.Changes)
 
 	require.Len(t, plan.Changes, 3)
+	memberAChange := plan.Changes[0]
+	assert.Equal(t, "member-a", memberAChange.ResourceRef)
+	assert.Equal(t, []string{"temp-3:d:control_plane:group-cp"}, memberAChange.DependsOn)
+
+	memberBChange := plan.Changes[1]
+	assert.Equal(t, "member-b", memberBChange.ResourceRef)
+	assert.Equal(t, []string{"temp-3:d:control_plane:group-cp"}, memberBChange.DependsOn)
+
 	groupChange := plan.Changes[2]
 	assert.Equal(t, "group-cp", groupChange.ResourceRef)
-	assert.ElementsMatch(t, []string{
-		"temp-1:d:control_plane:member-a",
-		"temp-2:d:control_plane:member-b",
-	}, groupChange.DependsOn)
+	assert.Empty(t, groupChange.DependsOn)
 	require.NotNil(t, groupChange.References)
 	assert.Equal(t, []string{"member-a-id", "member-b-id"}, groupChange.References[FieldMembers].Refs)
 }

--- a/internal/declarative/planner/planner.go
+++ b/internal/declarative/planner/planner.go
@@ -548,36 +548,37 @@ func toSnakeCase(value string) string {
 	return strings.Trim(string(out), "_")
 }
 
-// adjustControlPlaneGroupDeleteDependencies ensures control plane group DELETE
-// changes execute only after DELETE changes for their member control planes in
-// the same plan. Konnect rejects deleting a group while it still has members.
+// adjustControlPlaneGroupDeleteDependencies ensures member control plane DELETE
+// changes execute only after DELETE changes for their control plane groups in
+// the same plan. Konnect rejects deleting a member while it is still in a group.
 func adjustControlPlaneGroupDeleteDependencies(changes []PlannedChange) {
-	controlPlaneDeletesByID := make(map[string]string)
+	controlPlaneDeletesByID := make(map[string]int)
 	for i := range changes {
 		change := &changes[i]
 		if change.Action != ActionDelete || change.ResourceType != ResourceTypeControlPlane {
 			continue
 		}
 		if change.ResourceID != "" {
-			controlPlaneDeletesByID[change.ResourceID] = change.ID
+			controlPlaneDeletesByID[change.ResourceID] = i
 		}
 	}
 
 	for i := range changes {
-		change := &changes[i]
-		if change.Action != ActionDelete || change.ResourceType != ResourceTypeControlPlane {
+		groupChange := &changes[i]
+		if groupChange.Action != ActionDelete || groupChange.ResourceType != ResourceTypeControlPlane {
 			continue
 		}
 
-		refInfo, ok := change.References[FieldMembers]
+		refInfo, ok := groupChange.References[FieldMembers]
 		if !ok || len(refInfo.Refs) == 0 {
 			continue
 		}
 
 		for _, memberID := range refInfo.Refs {
-			depID, ok := controlPlaneDeletesByID[memberID]
-			if ok && depID != change.ID {
-				change.DependsOn = appendDependsOn(change.DependsOn, depID)
+			memberIdx, ok := controlPlaneDeletesByID[memberID]
+			if ok && memberIdx != i {
+				memberChange := &changes[memberIdx]
+				memberChange.DependsOn = appendDependsOn(memberChange.DependsOn, groupChange.ID)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- delete control plane groups before deleting their member control planes
- update the planner unit test to assert member deletes depend on the group delete

## Validation
- go test ./internal/declarative/planner ./internal/declarative/executor

## Notes
This isolates the planner fix that was exposed by the E2E all scenario failure in workflow run 2132.