### PR TITLE
Task: improve default colors for terminal backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,10 +267,11 @@ flow token file so that subsequent commands prompt you to authenticate again wit
 
 Interactive experiences, such as `kongctl view`, share a configurable color
 theme. Use the `--color-theme` flag (or set the `color-theme` key in your
-configuration file) to select a palette. The default `kong-light` theme
-reflects the current brand styling, with a `kong-dark` option for dark
-terminals. The legacy `kong` name remains supported as an alias for
-`kong-light`, and you can also switch to any
+configuration file) to select a palette. The default `auto` setting detects
+whether the terminal uses a dark background and selects `kong-dark` or
+`kong-light` accordingly. You can still choose either Kong theme explicitly.
+The legacy `kong` name remains supported as an alias for `kong-light`, and you
+can also switch to any
 [`bubbletint`](https://github.com/lrstanley/bubbletint) theme by ID, for
 example:
 

--- a/internal/cmd/common/common.go
+++ b/internal/cmd/common/common.go
@@ -56,7 +56,7 @@ const (
 	// related to the --color-theme flag
 	ColorThemeFlagName   = "color-theme"
 	ColorThemeConfigPath = "color-theme"
-	DefaultColorTheme    = "kong-light"
+	DefaultColorTheme    = "auto"
 
 	// related to the --profile flag
 	ProfileFlagName  = "profile"

--- a/internal/cmd/output/tableview/tableview.go
+++ b/internal/cmd/output/tableview/tableview.go
@@ -201,7 +201,7 @@ func newStatusBoxStyle(p theme.Palette) lipgloss.Style {
 // NormalizeSelectedRow ensures that selected rows emitted by the table component
 // keep the highlight active across all columns when wrapped by another style.
 func NormalizeSelectedRow(content string, selected lipgloss.Style) string {
-	prefix, reset := selectionPrefix(selected)
+	prefix, _ := selectionPrefix(selected)
 	if prefix == "" || !strings.Contains(content, prefix) {
 		return content
 	}
@@ -212,13 +212,7 @@ func NormalizeSelectedRow(content string, selected lipgloss.Style) string {
 			continue
 		}
 
-		count := strings.Count(line, reset)
-		if count <= 1 {
-			continue
-		}
-
-		line = strings.ReplaceAll(line, reset+prefix, reset)
-		lines[i] = strings.Replace(line, reset, reset+prefix, count-1)
+		lines[i] = selected.Render(ansi.Strip(line))
 	}
 
 	return strings.Join(lines, "\n")
@@ -465,8 +459,8 @@ func Render(streams *iostreams.IOStreams, data any, opts ...Option) error {
 	styles.Cell = styles.Cell.
 		Foreground(palette.Adaptive(theme.ColorTextPrimary))
 	styles.Selected = styles.Selected.
-		Foreground(palette.Adaptive(theme.ColorAccentText)).
-		Background(palette.Adaptive(theme.ColorAccent))
+		Foreground(palette.Adaptive(theme.ColorSelectionText)).
+		Background(palette.Adaptive(theme.ColorSelection))
 	paddingWidth := max(
 		lipgloss.Width(styles.Header.Render("")),
 		lipgloss.Width(styles.Cell.Render("")),
@@ -1157,7 +1151,7 @@ func newDetailTableDecorator(
 	labelStyle := palette.ForegroundStyle(theme.ColorTextSecondary)
 	valueStyle := palette.ForegroundStyle(theme.ColorTextPrimary)
 	accentStyle := palette.ForegroundStyle(theme.ColorAccent)
-	selectedText := palette.ForegroundStyle(theme.ColorAccentText)
+	selectedText := palette.ForegroundStyle(theme.ColorSelectionText)
 	selectedPrefix, _ := selectionPrefix(selected)
 
 	return detailTableDecorator{
@@ -1962,8 +1956,8 @@ func buildDetailTable(
 		PaddingRight(0)
 	if highlight {
 		styles.Selected = styles.Selected.
-			Foreground(palette.Adaptive(theme.ColorAccentText)).
-			Background(palette.Adaptive(theme.ColorAccent))
+			Foreground(palette.Adaptive(theme.ColorSelectionText)).
+			Background(palette.Adaptive(theme.ColorSelection))
 	} else {
 		styles.Selected = lipgloss.NewStyle()
 	}
@@ -2018,8 +2012,8 @@ func buildChildTable(state *childViewState, width, height int, palette theme.Pal
 	styles.Cell = styles.Cell.
 		Foreground(palette.Adaptive(theme.ColorTextPrimary))
 	styles.Selected = styles.Selected.
-		Foreground(palette.Adaptive(theme.ColorAccentText)).
-		Background(palette.Adaptive(theme.ColorAccent))
+		Foreground(palette.Adaptive(theme.ColorSelectionText)).
+		Background(palette.Adaptive(theme.ColorSelection))
 
 	tbl := table.New(
 		table.WithColumns(columns),
@@ -2516,8 +2510,8 @@ func (m *bubbleModel) applyPalette(p theme.Palette) {
 	styles.Cell = styles.Cell.
 		Foreground(p.Adaptive(theme.ColorTextPrimary))
 	styles.Selected = styles.Selected.
-		Foreground(p.Adaptive(theme.ColorAccentText)).
-		Background(p.Adaptive(theme.ColorAccent))
+		Foreground(p.Adaptive(theme.ColorSelectionText)).
+		Background(p.Adaptive(theme.ColorSelection))
 	m.selectedStyle = styles.Selected
 	m.table.SetStyles(styles)
 

--- a/internal/cmd/output/tableview/tableview_test.go
+++ b/internal/cmd/output/tableview/tableview_test.go
@@ -90,15 +90,48 @@ func TestNormalizeSelectedRow_HandlesAnsiResetStyle(t *testing.T) {
 	selected := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#111111")).
 		Background(lipgloss.Color("#AABBCC"))
+	cell := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#FFFFFF"))
 
 	prefix, reset := selectionPrefix(selected)
 	require.NotEmpty(t, prefix)
 	require.Equal(t, ansi.ResetStyle, reset)
 
-	content := selected.Render("foo" + reset + "bar")
+	content := selected.Render(cell.Render("foo") + reset + "bar")
 	normalized := NormalizeSelectedRow(content, selected)
 
-	require.Contains(t, normalized, reset+prefix)
+	require.Equal(t, "foobar", ansi.Strip(normalized))
+	require.Contains(t, normalized, prefix)
+	require.NotContains(t, normalized, cell.Render("foo"))
+}
+
+func TestNormalizeSelectedRow_RepaintsTableCellForeground(t *testing.T) {
+	selected := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#000F06")).
+		Background(lipgloss.Color("#CCFF00"))
+	cell := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#FFFFFF"))
+
+	styles := table.DefaultStyles()
+	styles.Cell = styles.Cell.Foreground(lipgloss.Color("#FFFFFF"))
+	styles.Selected = selected
+
+	tbl := table.New(
+		table.WithColumns([]table.Column{{Title: "RESOURCE", Width: 10}}),
+		table.WithRows([]table.Row{{"apis"}}),
+		table.WithFocused(true),
+		table.WithStyles(styles),
+	)
+	tbl.SetCursor(0)
+	tbl.SetHeight(3)
+	tbl.SetWidth(20)
+
+	normalized := NormalizeSelectedRow(tbl.View(), selected)
+	prefix, _ := selectionPrefix(selected)
+
+	require.Contains(t, ansi.Strip(normalized), "apis")
+	require.Contains(t, normalized, prefix)
+	require.NotContains(t, normalized, cell.Render("apis"))
 }
 
 func TestNewDetailTableDecorator_TracksSelectedPrefix(t *testing.T) {

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -681,8 +681,8 @@ func initConfig() {
 		currConfig.SetString(common.ColorThemeConfigPath, common.DefaultColorTheme)
 		themeName = common.DefaultColorTheme
 	}
-	// Show the hint whenever the active theme is the built-in default.
-	// Users who have chosen any other theme have already discovered the feature.
+	// Show the hint when automatic theme selection is active. Users who have
+	// chosen a fixed theme have already discovered the feature.
 	theme.SetConfiguredExplicitly(themeName != common.DefaultColorTheme)
 
 	loggerOpts := &slog.HandlerOptions{

--- a/internal/cmd/root/verbs/list/themes.go
+++ b/internal/cmd/root/verbs/list/themes.go
@@ -322,8 +322,8 @@ func renderThemePreviewPanel(p theme.Palette) string {
 	styles.Cell = styles.Cell.
 		Foreground(p.Adaptive(theme.ColorTextPrimary))
 	styles.Selected = styles.Selected.
-		Foreground(p.Adaptive(theme.ColorAccentText)).
-		Background(p.Adaptive(theme.ColorAccent))
+		Foreground(p.Adaptive(theme.ColorSelectionText)).
+		Background(p.Adaptive(theme.ColorSelection))
 
 	tbl := table.New(
 		table.WithColumns(columns),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,8 +3,23 @@ package config
 import (
 	"testing"
 
+	"github.com/kong/kongctl/internal/cmd/common"
 	utilviper "github.com/kong/kongctl/internal/util/viper"
 )
+
+func TestDefaultConfigUsesAutomaticColorTheme(t *testing.T) {
+	cfg := getDefaultConfig("default", "config.yaml")
+	profile, ok := cfg["default"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected default profile config")
+	}
+	if got := profile[common.ColorThemeConfigPath]; got != common.DefaultColorTheme {
+		t.Fatalf("expected default color theme %q, got %v", common.DefaultColorTheme, got)
+	}
+	if common.DefaultColorTheme != "auto" {
+		t.Fatalf("expected automatic color theme default, got %q", common.DefaultColorTheme)
+	}
+}
 
 func TestBuildProfiledConfig_ProfileEnvWithDashes(t *testing.T) {
 	t.Setenv("KONGCTL_TEAM_A_B_C_KONNECT_PAT", "token-123")

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -682,7 +682,7 @@ func kongLightPalette() Palette {
 			ColorSurfaceText:   singleColor("#000F06"),
 			ColorPrimary:       singleColor("#000F06"),
 			ColorPrimaryText:   singleColor("#FFFFFF"),
-			ColorAccent:        singleColor("#2F5F16"),
+			ColorAccent:        singleColor("#005F28"),
 			ColorAccentText:    singleColor("#FFFFFF"),
 			ColorSelection:     singleColor("#CCFF00"),
 			ColorSelectionText: singleColor("#000F06"),

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -14,10 +14,17 @@ import (
 	"charm.land/lipgloss/v2"
 	tint "github.com/lrstanley/bubbletint/v2"
 	"github.com/lucasb-eyer/go-colorful"
+	"github.com/muesli/termenv"
 )
 
-// DefaultName is the built-in theme used when no override is provided.
+// AutoName selects a built-in Kong theme based on the terminal background.
+const AutoName = "auto"
+
+// DefaultName is the built-in Kong theme optimized for light terminal backgrounds.
 const DefaultName = "kong-light"
+
+// DarkName is the built-in Kong theme optimized for dark terminal backgrounds.
+const DarkName = "kong-dark"
 
 // LegacyName is the deprecated theme name kept for backward compatibility.
 const LegacyName = "kong"
@@ -36,6 +43,8 @@ const (
 	ColorPrimaryText   Token = "primary.text"
 	ColorAccent        Token = "accent"
 	ColorAccentText    Token = "accent.text"
+	ColorSelection     Token = "selection"
+	ColorSelectionText Token = "selection.text"
 	ColorSuccess       Token = "success"
 	ColorSuccessText   Token = "success.text"
 	ColorInfo          Token = "info"
@@ -123,16 +132,17 @@ func (p Palette) BackgroundStyle(token Token) lipgloss.Style {
 type contextKey struct{}
 
 var (
-	registryOnce         sync.Once
-	registryMu           sync.RWMutex
-	palettes             map[string]Palette
-	current              Palette
-	defaultPal           Palette
-	themeKey             contextKey
-	configuredExplicitly bool
-	darkBackgroundOnce   sync.Once
-	darkBackgroundCached bool
-	hasDarkBackground    = detectDarkBackground
+	registryOnce             sync.Once
+	registryMu               sync.RWMutex
+	palettes                 map[string]Palette
+	current                  Palette
+	defaultPal               Palette
+	themeKey                 contextKey
+	configuredExplicitly     bool
+	darkBackgroundOnce       sync.Once
+	darkBackgroundCached     bool
+	hasDarkBackground        = detectDarkBackground
+	termenvHasDarkBackground = termenv.HasDarkBackground
 )
 
 func detectDarkBackground() bool {
@@ -145,7 +155,10 @@ func detectDarkBackground() bool {
 
 func detectDarkBackgroundFromEnv() bool {
 	dark, ok := darkBackgroundFromColorFGBG(os.Getenv("COLORFGBG"))
-	return ok && dark
+	if ok {
+		return dark
+	}
+	return termenvHasDarkBackground()
 }
 
 func darkBackgroundFromColorFGBG(value string) (bool, bool) {
@@ -223,6 +236,10 @@ func AvailableDisplayNames() map[string]string {
 func Exists(name string) bool {
 	ensureRegistry()
 
+	if resolveName(name) == AutoName {
+		return true
+	}
+
 	registryMu.RLock()
 	defer registryMu.RUnlock()
 
@@ -234,10 +251,15 @@ func Exists(name string) bool {
 func Get(name string) (Palette, bool) {
 	ensureRegistry()
 
+	name = resolveName(name)
+	if name == AutoName {
+		name = DetectDefaultName()
+	}
+
 	registryMu.RLock()
 	defer registryMu.RUnlock()
 
-	p, ok := palettes[resolveName(name)]
+	p, ok := palettes[name]
 	return p, ok
 }
 
@@ -247,7 +269,10 @@ func SetCurrent(name string) error {
 
 	name = resolveName(name)
 	if name == "" {
-		name = DefaultName
+		name = AutoName
+	}
+	if name == AutoName {
+		name = DetectDefaultName()
 	}
 
 	registryMu.Lock()
@@ -259,6 +284,15 @@ func SetCurrent(name string) error {
 	}
 	current = p
 	return nil
+}
+
+// DetectDefaultName returns the built-in Kong theme that best matches the
+// detected terminal background.
+func DetectDefaultName() string {
+	if hasDarkBackground() {
+		return DarkName
+	}
+	return DefaultName
 }
 
 // SetConfiguredExplicitly records whether the active theme was set by the user
@@ -300,8 +334,11 @@ type Flag struct {
 // NewFlag returns a Flag with the provided default value.
 func NewFlag(defaultValue string) *Flag {
 	name := resolveName(defaultValue)
-	if name == "" || !Exists(name) {
-		name = DefaultName
+	if name == "" {
+		name = AutoName
+	}
+	if name != AutoName && !Exists(name) {
+		name = AutoName
 	}
 	return &Flag{value: name}
 }
@@ -309,7 +346,7 @@ func NewFlag(defaultValue string) *Flag {
 // String implements pflag.Value.
 func (f *Flag) String() string {
 	if f == nil {
-		return DefaultName
+		return AutoName
 	}
 	return f.value
 }
@@ -318,7 +355,7 @@ func (f *Flag) String() string {
 func (f *Flag) Set(v string) error {
 	name := resolveName(v)
 	if name == "" {
-		name = DefaultName
+		name = AutoName
 	}
 	if !Exists(name) {
 		return fmt.Errorf("invalid color theme %q", v)
@@ -402,6 +439,8 @@ func resolveName(name string) string {
 	switch normalized {
 	case "":
 		return ""
+	case AutoName:
+		return AutoName
 	case LegacyName:
 		return DefaultName
 	default:
@@ -443,6 +482,8 @@ func paletteFromTint(t *tint.Tint) Palette {
 		ColorPrimaryText:   singleColor(contrastColor(accent)),
 		ColorAccent:        pairColor(accentBright, accentBright),
 		ColorAccentText:    singleColor(contrastColor(accentBright)),
+		ColorSelection:     pairColor(accentBright, accentBright),
+		ColorSelectionText: singleColor(contrastColor(accentBright)),
 		ColorSuccess:       pairColor(success, success),
 		ColorSuccessText:   singleColor(contrastColor(success)),
 		ColorInfo:          pairColor(info, info),
@@ -641,8 +682,10 @@ func kongLightPalette() Palette {
 			ColorSurfaceText:   singleColor("#000F06"),
 			ColorPrimary:       singleColor("#000F06"),
 			ColorPrimaryText:   singleColor("#FFFFFF"),
-			ColorAccent:        singleColor("#CCFF00"),
-			ColorAccentText:    singleColor("#000F06"),
+			ColorAccent:        singleColor("#2F5F16"),
+			ColorAccentText:    singleColor("#FFFFFF"),
+			ColorSelection:     singleColor("#CCFF00"),
+			ColorSelectionText: singleColor("#000F06"),
 			ColorSuccess:       singleColor("#000F06"),
 			ColorSuccessText:   singleColor("#FFFFFF"),
 			ColorInfo:          singleColor("#B7BDB5"),
@@ -658,7 +701,7 @@ func kongLightPalette() Palette {
 
 func kongDarkPalette() Palette {
 	return Palette{
-		Name:        "kong-dark",
+		Name:        DarkName,
 		DisplayName: "Kong Dark",
 		About:       "Kong dark theme based on the 2026 brand guidelines.",
 		Colors: map[Token]Color{
@@ -670,8 +713,10 @@ func kongDarkPalette() Palette {
 			ColorSurfaceText:   singleColor("#FFFFFF"),
 			ColorPrimary:       singleColor("#CCFF00"),
 			ColorPrimaryText:   singleColor("#000F06"),
-			ColorAccent:        singleColor("#B7BDB5"),
+			ColorAccent:        singleColor("#CCFF00"),
 			ColorAccentText:    singleColor("#000F06"),
+			ColorSelection:     singleColor("#CCFF00"),
+			ColorSelectionText: singleColor("#000F06"),
 			ColorSuccess:       singleColor("#CCFF00"),
 			ColorSuccessText:   singleColor("#000F06"),
 			ColorInfo:          singleColor("#B7BDB5"),

--- a/internal/theme/theme_test.go
+++ b/internal/theme/theme_test.go
@@ -81,8 +81,11 @@ func TestKongLightAccentTextHasReadableContrast(t *testing.T) {
 	require.NoError(t, err)
 	accent, err := colorful.Hex(p.Color(ColorAccent).Light)
 	require.NoError(t, err)
+	primary, err := colorful.Hex(p.Color(ColorTextPrimary).Light)
+	require.NoError(t, err)
 
 	require.GreaterOrEqual(t, contrastRatio(surface, accent), 7.0)
+	require.GreaterOrEqual(t, accent.DistanceLab(primary), 0.35)
 }
 
 func TestDarkBackgroundFromColorFGBG(t *testing.T) {

--- a/internal/theme/theme_test.go
+++ b/internal/theme/theme_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	tint "github.com/lrstanley/bubbletint/v2"
+	"github.com/lucasb-eyer/go-colorful"
 	"github.com/stretchr/testify/require"
 )
 
@@ -62,6 +63,28 @@ func TestPaletteFromTintPreservesAbout(t *testing.T) {
 	require.Equal(t, "Tint: Example Theme\nTint credits:\n  * Alice (https://example.com)", p.About)
 }
 
+func TestKongDarkSelectedRowColorsHaveReadableContrast(t *testing.T) {
+	p := kongDarkPalette()
+	selection, err := colorful.Hex(p.Color(ColorSelection).Dark)
+	require.NoError(t, err)
+	text, err := colorful.Hex(p.Color(ColorSelectionText).Dark)
+	require.NoError(t, err)
+
+	require.Equal(t, "#CCFF00", p.Color(ColorSelection).Dark)
+	require.Equal(t, "#000F06", p.Color(ColorSelectionText).Dark)
+	require.GreaterOrEqual(t, contrastRatio(selection, text), 7.0)
+}
+
+func TestKongLightAccentTextHasReadableContrast(t *testing.T) {
+	p := kongLightPalette()
+	surface, err := colorful.Hex(p.Color(ColorSurface).Light)
+	require.NoError(t, err)
+	accent, err := colorful.Hex(p.Color(ColorAccent).Light)
+	require.NoError(t, err)
+
+	require.GreaterOrEqual(t, contrastRatio(surface, accent), 7.0)
+}
+
 func TestDarkBackgroundFromColorFGBG(t *testing.T) {
 	t.Parallel()
 
@@ -92,11 +115,28 @@ func TestDarkBackgroundFromColorFGBG(t *testing.T) {
 }
 
 func TestDetectDarkBackgroundFromEnv(t *testing.T) {
+	prev := termenvHasDarkBackground
+	t.Cleanup(func() {
+		termenvHasDarkBackground = prev
+	})
+	termenvHasDarkBackground = func() bool { return false }
+
 	t.Setenv("COLORFGBG", "15;0")
 	require.True(t, detectDarkBackgroundFromEnv())
 
 	t.Setenv("COLORFGBG", "bogus")
 	require.False(t, detectDarkBackgroundFromEnv())
+}
+
+func TestDetectDarkBackgroundFallsBackToTermenv(t *testing.T) {
+	prev := termenvHasDarkBackground
+	t.Cleanup(func() {
+		termenvHasDarkBackground = prev
+	})
+	termenvHasDarkBackground = func() bool { return true }
+
+	t.Setenv("COLORFGBG", "")
+	require.True(t, detectDarkBackgroundFromEnv())
 }
 
 func TestDetectDarkBackgroundMemoizesEnv(t *testing.T) {
@@ -112,4 +152,40 @@ func TestDetectDarkBackgroundMemoizesEnv(t *testing.T) {
 
 	t.Setenv("COLORFGBG", "0;15")
 	require.True(t, detectDarkBackground())
+}
+
+func TestSetCurrentAutoUsesDetectedBackground(t *testing.T) {
+	prev := hasDarkBackground
+	t.Cleanup(func() {
+		hasDarkBackground = prev
+		require.NoError(t, SetCurrent(DefaultName))
+	})
+
+	hasDarkBackground = func() bool { return true }
+	require.NoError(t, SetCurrent(AutoName))
+	require.Equal(t, DarkName, CurrentName())
+
+	hasDarkBackground = func() bool { return false }
+	require.NoError(t, SetCurrent(AutoName))
+	require.Equal(t, DefaultName, CurrentName())
+}
+
+func TestThemeFlagAcceptsAuto(t *testing.T) {
+	flag := NewFlag(AutoName)
+	require.Equal(t, AutoName, flag.String())
+
+	require.NoError(t, flag.Set(""))
+	require.Equal(t, AutoName, flag.String())
+
+	require.NoError(t, flag.Set(AutoName))
+	require.Equal(t, AutoName, flag.String())
+}
+
+func contrastRatio(a, b colorful.Color) float64 {
+	l1 := relativeLuminance(a)
+	l2 := relativeLuminance(b)
+	if l1 < l2 {
+		l1, l2 = l2, l1
+	}
+	return (l1 + 0.05) / (l2 + 0.05)
 }


### PR DESCRIPTION
## Summary

- Add automatic Kong theme selection based on terminal background detection.
- Keep selected rows consistent with Kong lime and Kong black text across root and child table views.
- Split selection colors from inline accent colors so highlighted values remain readable on light backgrounds.
- Update README theme guidance and add focused color contrast/table rendering tests.

Closes #1061

## Validation

- `go test ./internal/theme ./internal/cmd/output/tableview`
- `go test ./internal/cmd/output/tableview ./internal/theme ./internal/cmd/root/verbs/list`
- `make format`
- `make test`
- `make build`
- `make lint`
