### PR TITLE
Fix: improve analytics dashboard declarative management guidance

### DIFF
--- a/docs/examples/declarative/analytics/dashboards/README.md
+++ b/docs/examples/declarative/analytics/dashboards/README.md
@@ -14,6 +14,37 @@ YAML file with `!file`. When using an exported API response, keep the dashboard
 `definition` object and omit API-managed fields such as `id`, `created_at`,
 `created_by`, and `updated_at`.
 
+Inline dashboard definitions use chart tiles. The query `datasource` selects
+the analytics source and must be one of `api_usage`, `llm_usage`, or
+`agentic_usage`.
+
+```yaml
+analytics:
+  dashboards:
+    - ref: request-summary
+      name: Request Summary
+      definition:
+        tiles:
+          - layout:
+              position:
+                col: 0
+                row: 0
+              size:
+                cols: 6
+                rows: 2
+            type: chart
+            definition:
+              query:
+                datasource: api_usage
+                metrics:
+                  - request_count
+                dimensions:
+                  - time
+              chart:
+                chart_title: Request count
+                type: timeseries_line
+```
+
 To bring a dashboard created in the Konnect UI into GitOps, adopt it first and
 then dump the declarative definition:
 

--- a/internal/cmd/root/verbs/explain/explain.go
+++ b/internal/cmd/root/verbs/explain/explain.go
@@ -41,6 +41,8 @@ retrieve the same machine-readable schema document in different serializations.`
 		%[1]s explain api.versions
 		# Explain a specific field
 		%[1]s explain api.publications.portal_id
+		# Explain analytics dashboard tiles and valid discriminator values
+		%[1]s explain analytics.dashboards --extended
 		# Retrieve the machine-readable schema as JSON Schema
 		%[1]s explain api --output json
 		# Retrieve the same schema serialized as YAML

--- a/internal/cmd/root/verbs/explain/explain_test.go
+++ b/internal/cmd/root/verbs/explain/explain_test.go
@@ -58,6 +58,7 @@ func TestNewExplainCmd_AddsJQFlags(t *testing.T) {
 	assert.NotNil(t, cmd.PersistentFlags().Lookup(jqoutput.FlagName))
 	assert.NotNil(t, cmd.PersistentFlags().Lookup(jqoutput.RawOutputFlagName))
 	assert.NotNil(t, cmd.Flags().Lookup(extendedFlagName))
+	assert.Contains(t, cmd.Example, "explain analytics.dashboards --extended")
 }
 
 func TestExplainCmd_AppliesJQFilterToJSON(t *testing.T) {

--- a/internal/cmd/root/verbs/scaffold/scaffold.go
+++ b/internal/cmd/root/verbs/scaffold/scaffold.go
@@ -41,6 +41,8 @@ such as apply or sync.`))
 		%[1]s scaffold api_version
 		# Generate a nested child scaffold
 		%[1]s scaffold api.versions
+		# Generate an analytics dashboard scaffold with a starter tile
+		%[1]s scaffold analytics.dashboards
 		`, meta.CLIName)))
 )
 

--- a/internal/cmd/root/verbs/scaffold/scaffold_test.go
+++ b/internal/cmd/root/verbs/scaffold/scaffold_test.go
@@ -50,6 +50,7 @@ func TestNewScaffoldCmd(t *testing.T) {
 	assert.Contains(t, cmd.Short, "YAML scaffold")
 	assert.Contains(t, cmd.Long, "commented YAML starter")
 	assert.Contains(t, cmd.Example, "scaffold api")
+	assert.Contains(t, cmd.Example, "scaffold analytics.dashboards")
 }
 
 func TestScaffoldCmd_RejectsExplicitOutputFlag(t *testing.T) {

--- a/internal/declarative/loader/dashboard_test.go
+++ b/internal/declarative/loader/dashboard_test.go
@@ -54,6 +54,72 @@ analytics:
 	assert.Equal(t, map[string]string{"team": "platform"}, dashboard.Labels)
 }
 
+func TestLoaderLoadsDashboardDefinitionWithInlineChartTile(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+analytics:
+  dashboards:
+    - ref: traffic-summary
+      name: Traffic Summary
+      definition:
+        tiles:
+          - layout:
+              position:
+                col: 0
+                row: 0
+              size:
+                cols: 6
+                rows: 2
+            type: chart
+            definition:
+              query:
+                datasource: api_usage
+                metrics:
+                  - request_count
+                dimensions:
+                  - time
+              chart:
+                chart_title: Request count
+                type: timeseries_line
+`), 0o600))
+
+	rs, err := New().LoadFile(configPath)
+	require.NoError(t, err)
+	require.Len(t, rs.Dashboards, 1)
+	require.Len(t, rs.Dashboards[0].Definition.Tiles, 1)
+}
+
+func TestLoaderDashboardDefinitionInvalidQueryDatasourceMessage(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+analytics:
+  dashboards:
+    - ref: traffic-summary
+      name: Traffic Summary
+      definition:
+        tiles:
+          - layout:
+              position: { col: 0, row: 0 }
+              size: { cols: 6, rows: 2 }
+            type: chart
+            definition:
+              query:
+                datasource: basic
+                metrics:
+                  - request_count
+              chart:
+                chart_title: Request count
+                type: timeseries_line
+`), 0o600))
+
+	_, err := New().LoadFile(configPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid analytics dashboard tile query.datasource")
+	assert.Contains(t, err.Error(), "expected one of api_usage, llm_usage, agentic_usage")
+}
+
 func TestLoaderDashboardDefinitionPresenceFromYAML(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.yaml")

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -322,6 +322,9 @@ func formatYAMLParseError(l *Loader, sourcePath string, err error) error {
 
 	// Try to provide a more helpful error message for unknown fields.
 	errMsg := err.Error()
+	if msg := dashboardUnionParseError(sourcePath, errMsg); msg != "" {
+		return fmt.Errorf("%s: %w", msg, err)
+	}
 	if strings.Contains(errMsg, "unknown field") {
 		// Error format: "error unmarshaling JSON: while decoding JSON: json: unknown field \"fieldname\""
 		if match := regexp.MustCompile(`unknown field "(\w+)"`).FindStringSubmatch(errMsg); len(match) > 1 {
@@ -337,6 +340,32 @@ func formatYAMLParseError(l *Loader, sourcePath string, err error) error {
 	}
 
 	return fmt.Errorf("failed to parse YAML in %s: %w", sourcePath, err)
+}
+
+func dashboardUnionParseError(sourcePath string, errMsg string) string {
+	switch {
+	case strings.Contains(errMsg, "into any supported union types for Query"):
+		return fmt.Sprintf(
+			"failed to parse YAML in %s: invalid analytics dashboard tile query.datasource; "+
+				"expected one of api_usage, llm_usage, agentic_usage",
+			sourcePath,
+		)
+	case strings.Contains(errMsg, "into any supported union types for Chart"):
+		return fmt.Sprintf(
+			"failed to parse YAML in %s: invalid analytics dashboard tile chart.type; "+
+				"expected one of donut, timeseries_line, timeseries_bar, horizontal_bar, vertical_bar, "+
+				"single_value, choropleth_map",
+			sourcePath,
+		)
+	case strings.Contains(errMsg, "into any supported union types for TimeRange"):
+		return fmt.Sprintf(
+			"failed to parse YAML in %s: invalid analytics dashboard tile query.time_range.type; "+
+				"expected one of relative, absolute",
+			sourcePath,
+		)
+	default:
+		return ""
+	}
 }
 
 // loadSTDIN loads configuration from stdin

--- a/internal/declarative/resources/dashboard.go
+++ b/internal/declarative/resources/dashboard.go
@@ -15,6 +15,7 @@ func init() {
 		AutoExplain[DashboardResource](
 			WithExplainAliases("dashboards"),
 			WithExplainRecommendedFields("ref", "name", "definition"),
+			WithExplainSchemaBuilder(dashboardExplainNode),
 		),
 	)
 }

--- a/internal/declarative/resources/explain.go
+++ b/internal/declarative/resources/explain.go
@@ -1110,6 +1110,9 @@ func renderExplainFieldText(b *strings.Builder, subject *ExplainSubject) {
 	fmt.Fprintln(b, "FIELD")
 	fmt.Fprintf(b, "PATH: %s\n", subject.DisplayPath)
 	fmt.Fprintf(b, "TYPE: %s\n", explainTypeLabel(subject.Node))
+	if values := explainAllowedValues(subject.Node); len(values) > 0 {
+		fmt.Fprintf(b, "ALLOWED: %s\n", strings.Join(values, "|"))
+	}
 	fmt.Fprintf(b, "OPTIONAL: %t\n", !subject.FieldRequired)
 	if subject.FieldRecommended {
 		fmt.Fprintln(b, "RECOMMENDED: yes")
@@ -1169,7 +1172,8 @@ func renderExplainFields(b *strings.Builder, node *ExplainNode, path string, dep
 		if field.Required {
 			req = "required"
 		}
-		fmt.Fprintf(b, "%s- %s: %s %s\n", prefix, field.Name, explainTypeLabel(field.Node), req)
+		fmt.Fprintf(b, "%s- %s: %s %s%s\n", prefix, field.Name, explainTypeLabel(field.Node), req,
+			explainAllowedValuesLabel(field.Node))
 		renderExplainFields(b, field.Node, fieldPath, depth+1)
 	}
 }
@@ -2053,6 +2057,44 @@ func explainTypeLabel(node *ExplainNode) string {
 		}
 		return node.Kind
 	}
+}
+
+func explainAllowedValuesLabel(node *ExplainNode) string {
+	values := explainAllowedValues(node)
+	if len(values) == 0 {
+		return ""
+	}
+	return " allowed: " + strings.Join(values, "|")
+}
+
+func explainAllowedValues(node *ExplainNode) []string {
+	if node == nil {
+		return nil
+	}
+	if node.Const != nil {
+		return []string{fmt.Sprint(node.Const)}
+	}
+	if len(node.OneOf) > 0 {
+		values := make([]string, 0, len(node.OneOf))
+		for _, branch := range node.OneOf {
+			if branch == nil || branch.Const == nil {
+				values = nil
+				break
+			}
+			values = append(values, fmt.Sprint(branch.Const))
+		}
+		if len(values) > 0 {
+			return values
+		}
+	}
+	if len(node.Enum) > 0 {
+		values := make([]string, 0, len(node.Enum))
+		for _, value := range node.Enum {
+			values = append(values, fmt.Sprint(value))
+		}
+		return values
+	}
+	return nil
 }
 
 func scaffoldOmitFields(ancestors []ResourceType) []string {

--- a/internal/declarative/resources/explain_test.go
+++ b/internal/declarative/resources/explain_test.go
@@ -193,6 +193,38 @@ func TestRenderExplainSchema_ApplicationAuthStrategyConfigsUnionField(t *testing
 	assert.True(t, *schema.XSubject.Required)
 }
 
+func TestRenderExplainSchema_AnalyticsDashboardDiscriminators(t *testing.T) {
+	subject, err := ResolveExplainSubject("analytics.dashboards")
+	require.NoError(t, err)
+
+	schema := RenderExplainSchema(subject)
+	require.NotNil(t, schema)
+
+	tile := schema.Properties["definition"].Properties["tiles"].Items
+	require.NotNil(t, tile.Properties["type"])
+	assert.Equal(t, "chart", tile.Properties["type"].Const)
+
+	query := tile.Properties["definition"].Properties["query"]
+	require.Len(t, query.OneOf, 3)
+	assert.Equal(t, "api_usage", query.OneOf[0].Properties["datasource"].Const)
+	assert.Equal(t, "llm_usage", query.OneOf[1].Properties["datasource"].Const)
+	assert.Equal(t, "agentic_usage", query.OneOf[2].Properties["datasource"].Const)
+
+	chart := tile.Properties["definition"].Properties["chart"]
+	require.Len(t, chart.OneOf, 7)
+	assert.Equal(t, "timeseries_line", chart.OneOf[0].Properties["type"].Const)
+	assert.Equal(t, "horizontal_bar", chart.OneOf[2].Properties["type"].Const)
+}
+
+func TestRenderExplainText_AnalyticsDashboardAllowedValues(t *testing.T) {
+	subject, err := ResolveExplainSubject("analytics.dashboards.definition.tiles.definition.query.datasource")
+	require.NoError(t, err)
+
+	text := RenderExplainText(subject, false)
+
+	assert.Contains(t, text, "ALLOWED: api_usage|llm_usage|agentic_usage")
+}
+
 func TestRenderExplainText_ResourceSubject(t *testing.T) {
 	subject, err := ResolveExplainSubject("portal")
 	require.NoError(t, err)
@@ -352,6 +384,25 @@ func TestRenderScaffoldYAML_ApplicationAuthStrategyUnion(t *testing.T) {
 	assert.NotContains(t, scaffold, "# name: my-resource")
 	assert.NotContains(t, scaffold, "app_auth_strategy_key_auth_request")
 	assert.NotContains(t, scaffold, "app_auth_strategy_open_i_d_connect_request")
+}
+
+func TestRenderScaffoldYAML_AnalyticsDashboardStarterTile(t *testing.T) {
+	subject, err := ResolveExplainSubject("analytics.dashboards")
+	require.NoError(t, err)
+
+	scaffold, err := RenderScaffoldYAML(subject)
+	require.NoError(t, err)
+
+	assert.Contains(t, scaffold, "analytics:")
+	assert.Contains(t, scaffold, "  dashboards:")
+	assert.Contains(t, scaffold, "        tiles:")
+	assert.Contains(t, scaffold, "          - type: chart")
+	assert.Contains(t, scaffold, "                datasource: api_usage")
+	assert.Contains(t, scaffold, "                  - request_count")
+	assert.Contains(t, scaffold, "                  - time")
+	assert.Contains(t, scaffold, "                type: timeseries_line")
+	assert.NotContains(t, scaffold, "datasource: value")
+	assert.NotContains(t, scaffold, "# oneOf option: type\n")
 }
 
 func TestRenderScaffoldYAML_EventGatewayListenerPolicyUnion(t *testing.T) {

--- a/internal/declarative/resources/explain_union_schemas.go
+++ b/internal/declarative/resources/explain_union_schemas.go
@@ -360,6 +360,142 @@ func apiExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
 	return node, nil
 }
 
+func dashboardExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
+	hints := defaultExplainHints(ResourceTypeDashboard)
+	hints["name"] = ExplainFieldHint{DefaultFrom: "ref", Literal: "my-resource", Recommended: new(true)}
+
+	node, err := autoExplainConcreteNode[DashboardResource](hints)
+	if err != nil {
+		return nil, err
+	}
+	explainReplacePath(node, []string{"definition"}, dashboardDefinitionExplainNode())
+	return node, nil
+}
+
+func dashboardDefinitionExplainNode() *ExplainNode {
+	return explainObject(
+		explainField("tiles", explainArrayOf(dashboardTileExplainNode()), true, true),
+		explainField("preset_filters", explainArrayOf(dashboardFilterExplainNode()), false, false),
+	)
+}
+
+func dashboardTileExplainNode() *ExplainNode {
+	return explainObject(
+		explainField("type", explainConstStringNode("chart"), true, true),
+		explainField("layout", dashboardLayoutExplainNode(), true, true),
+		explainField("definition", dashboardTileDefinitionExplainNode(), true, true),
+	)
+}
+
+func dashboardLayoutExplainNode() *ExplainNode {
+	return explainObject(
+		explainField("position", explainObject(
+			explainField("col", &ExplainNode{Kind: "integer", Literal: "0"}, true, true),
+			explainField("row", &ExplainNode{Kind: "integer", Literal: "0"}, true, true),
+		), true, true),
+		explainField("size", explainObject(
+			explainField("cols", &ExplainNode{Kind: "integer", Literal: "6"}, true, true),
+			explainField("rows", &ExplainNode{Kind: "integer", Literal: "2"}, true, true),
+		), true, true),
+	)
+}
+
+func dashboardTileDefinitionExplainNode() *ExplainNode {
+	return explainObject(
+		explainField("query", dashboardQueryExplainNode(), true, true),
+		explainField("chart", dashboardChartExplainNode(), true, true),
+	)
+}
+
+func dashboardQueryExplainNode() *ExplainNode {
+	return explainUnionNode(
+		dashboardQueryBranch("api_usage", "request_count"),
+		dashboardQueryBranch("llm_usage", "total_tokens"),
+		dashboardQueryBranch("agentic_usage", "request_count"),
+	)
+}
+
+func dashboardQueryBranch(datasource string, metric string) *ExplainNode {
+	return explainObject(
+		explainField("datasource", explainConstStringNode(datasource), true, true),
+		explainField("metrics", explainArrayOf(explainStringNode(metric)), false, true),
+		explainField("dimensions", explainArrayOf(explainStringNode("time")), false, true),
+		explainField("filters", explainArrayOf(dashboardFilterExplainNode()), false, false),
+		explainField("granularity", &ExplainNode{Kind: "string", Nullable: true, Literal: "hourly"}, false, false),
+		explainField("time_range", dashboardTimeRangeExplainNode(), false, false),
+	)
+}
+
+func dashboardChartExplainNode() *ExplainNode {
+	return explainUnionNode(
+		dashboardChartBranch("timeseries_line", false, false),
+		dashboardChartBranch("timeseries_bar", true, false),
+		dashboardChartBranch("horizontal_bar", true, false),
+		dashboardChartBranch("vertical_bar", true, false),
+		dashboardChartBranch("single_value", false, true),
+		dashboardChartBranch("donut", false, false),
+		dashboardChartBranch("choropleth_map", false, false),
+	)
+}
+
+func dashboardChartBranch(chartType string, stacked bool, decimalPoints bool) *ExplainNode {
+	fields := []*ExplainField{
+		explainField("chart_title", &ExplainNode{Kind: "string", Nullable: true, Literal: "Request count"}, false, true),
+		explainField("type", explainConstStringNode(chartType), true, true),
+	}
+	if stacked {
+		fields = append(fields, explainField(
+			"stacked",
+			&ExplainNode{Kind: "boolean", Nullable: true, Literal: "false"},
+			false,
+			false,
+		))
+	}
+	if decimalPoints {
+		fields = append(fields, explainField(
+			"decimal_points",
+			&ExplainNode{Kind: "number", Nullable: true, Literal: "1"},
+			false,
+			false,
+		))
+	}
+	return explainObject(fields...)
+}
+
+func dashboardTimeRangeExplainNode() *ExplainNode {
+	return explainUnionNode(
+		explainObject(
+			explainField("tz", &ExplainNode{Kind: "string", Nullable: true, Literal: "Etc/UTC"}, false, false),
+			explainField("type", explainConstStringNode("relative"), true, true),
+			explainField("time_range", &ExplainNode{Kind: "string", Nullable: true, Literal: "1h"}, false, false),
+		),
+		explainObject(
+			explainField("tz", &ExplainNode{Kind: "string", Nullable: true, Literal: "Etc/UTC"}, false, false),
+			explainField("type", explainConstStringNode("absolute"), true, true),
+			explainField(
+				"start",
+				&ExplainNode{Kind: "string", Nullable: true, Literal: "2024-01-01T00:00:00Z"},
+				false,
+				false,
+			),
+			explainField(
+				"end",
+				&ExplainNode{Kind: "string", Nullable: true, Literal: "2024-01-01T01:00:00Z"},
+				false,
+				false,
+			),
+		),
+	)
+}
+
+func dashboardFilterExplainNode() *ExplainNode {
+	return explainObject(
+		explainField("field", explainStringNode("control_plane"), true, true),
+		explainField("operator", explainStringNode("in"), true, true),
+		explainField("value", &ExplainNode{Kind: "any", Literal: "value"}, false, false),
+	)
+}
+
 func applicationAuthStrategyExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
 	hints := defaultExplainHints(ResourceTypeApplicationAuthStrategy)
 	hints["name"] = ExplainFieldHint{DefaultFrom: "ref", Literal: "my-resource", Recommended: new(true)}

--- a/test/e2e/scenarios/analytics/dashboard-repro/scenario.yaml
+++ b/test/e2e/scenarios/analytics/dashboard-repro/scenario.yaml
@@ -1,0 +1,128 @@
+test:
+  requiresPAT: false
+
+baseInputsPath: testdata
+
+steps:
+  - name: 001-scaffold-dashboard-with-chart-tile
+    skipInputs: true
+    commands:
+      - name: 000-scaffold-analytics-dashboard
+        run:
+          - scaffold
+          - analytics.dashboards
+        outputFormat: disable
+        parseAs: raw
+        stdoutFile: "{{ .workdir }}/dashboard-scaffold.yaml"
+        assertions:
+          - expect:
+              fields:
+                "contains(stdout, 'analytics:')": true
+                "contains(stdout, 'dashboards:')": true
+                "contains(stdout, 'tiles:')": true
+                "contains(stdout, '- type: chart')": true
+                "contains(stdout, 'datasource: api_usage')": true
+                "contains(stdout, '- request_count')": true
+                "contains(stdout, '- time')": true
+                "contains(stdout, 'type: timeseries_line')": true
+                "contains(stdout, 'datasource: value')": false
+
+      - name: 001-apply-scaffold-dry-run
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/dashboard-scaffold.yaml"
+          - --auto-approve
+          - --dry-run
+        outputFormat: json
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+                by_resource.dashboard: 1
+          - select: summary
+            expect:
+              fields:
+                status: success
+                skipped: 1
+
+  - name: 002-explain-dashboard-discriminators
+    skipInputs: true
+    commands:
+      - name: 000-explain-query-datasource-text
+        run:
+          - explain
+          - analytics.dashboards.definition.tiles.definition.query.datasource
+          - --extended
+        outputFormat: text
+        parseAs: raw
+        assertions:
+          - expect:
+              fields:
+                "contains(stdout, 'ALLOWED: api_usage|llm_usage|agentic_usage')": true
+
+      - name: 001-explain-dashboard-json-schema
+        run:
+          - explain
+          - analytics.dashboards
+        outputFormat: json
+        assertions:
+          - select: properties.definition.properties.tiles.items.properties.type
+            expect:
+              fields:
+                const: chart
+          - select: properties.definition.properties.tiles.items.properties.definition.properties.query.oneOf[0].properties.datasource
+            expect:
+              fields:
+                const: api_usage
+          - select: properties.definition.properties.tiles.items.properties.definition.properties.query.oneOf[1].properties.datasource
+            expect:
+              fields:
+                const: llm_usage
+          - select: properties.definition.properties.tiles.items.properties.definition.properties.query.oneOf[2].properties.datasource
+            expect:
+              fields:
+                const: agentic_usage
+          - select: properties.definition.properties.tiles.items.properties.definition.properties.chart.oneOf[0].properties.type
+            expect:
+              fields:
+                const: timeseries_line
+
+  - name: 003-apply-inline-dashboard-tile
+    commands:
+      - name: 000-apply-valid-inline-dashboard-dry-run
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/valid-inline-dashboard.yaml"
+          - --auto-approve
+          - --dry-run
+        outputFormat: json
+        assertions:
+          - select: plan.changes[0]
+            expect:
+              fields:
+                resource_type: dashboard
+                action: CREATE
+                fields.definition.tiles[0].type: chart
+                fields.definition.tiles[0].definition.query.datasource: api_usage
+                fields.definition.tiles[0].definition.chart.type: timeseries_line
+          - select: summary
+            expect:
+              fields:
+                status: success
+                skipped: 1
+
+      - name: 001-apply-invalid-basic-datasource
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/invalid-basic-dashboard.yaml"
+          - --auto-approve
+          - --dry-run
+        outputFormat: disable
+        expectFailure:
+          exitCode: 1
+          contains: "invalid analytics dashboard tile query.datasource"

--- a/test/e2e/scenarios/analytics/dashboard-repro/testdata/invalid-basic-dashboard.yaml
+++ b/test/e2e/scenarios/analytics/dashboard-repro/testdata/invalid-basic-dashboard.yaml
@@ -1,0 +1,24 @@
+analytics:
+  dashboards:
+    - ref: issue-1107-dashboard
+      name: Issue 1107 Dashboard
+      definition:
+        tiles:
+          - type: chart
+            layout:
+              position:
+                col: 0
+                row: 0
+              size:
+                cols: 6
+                rows: 2
+            definition:
+              query:
+                datasource: basic
+                metrics:
+                  - request_count
+                dimensions:
+                  - time
+              chart:
+                chart_title: Request count
+                type: timeseries_line

--- a/test/e2e/scenarios/analytics/dashboard-repro/testdata/valid-inline-dashboard.yaml
+++ b/test/e2e/scenarios/analytics/dashboard-repro/testdata/valid-inline-dashboard.yaml
@@ -1,0 +1,24 @@
+analytics:
+  dashboards:
+    - ref: issue-1107-dashboard
+      name: Issue 1107 Dashboard
+      definition:
+        tiles:
+          - type: chart
+            layout:
+              position:
+                col: 0
+                row: 0
+              size:
+                cols: 6
+                rows: 2
+            definition:
+              query:
+                datasource: api_usage
+                metrics:
+                  - request_count
+                dimensions:
+                  - time
+              chart:
+                chart_title: Request count
+                type: timeseries_line


### PR DESCRIPTION
## Summary

- Add dashboard-specific explain schema coverage for analytics dashboard tile, query, chart, and time range discriminators.
- Make text explain output surface allowed discriminator values so users can discover valid `datasource`, chart `type`, and related options.
- Update scaffold/help/docs to provide a usable analytics dashboard tile example instead of ambiguous placeholder values.
- Improve dashboard union parse errors for invalid tile query datasource values.
- Add focused E2E scenario coverage for the issue #1107 reproduction path, including scaffold-to-apply dry run, explain discriminator output, valid inline tile dry run, and invalid `datasource: basic` failure messaging.

Fixes #1107

## Validation

- `git diff --check`
- `go test ./internal/declarative/resources ./internal/declarative/loader ./internal/cmd/root/verbs/scaffold ./internal/cmd/root/verbs/explain`
- `KONGCTL_E2E_SCENARIO=analytics/dashboard-repro go test -tags=e2e ./test/e2e -run Test_Scenarios -count=1`
- Previously in this session: `make build`, `make lint`, `make test`