### PR TITLE
Task: hydrate agent eval replay prompts to feedback issue

### DIFF
--- a/.github/workflows/kongctl-feature-user-agent.lock.yml
+++ b/.github/workflows/kongctl-feature-user-agent.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"1303973ccc978e286e9dfe91d28dc40c3be47ca06ebba5e39b57dc463ccc35bf","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"99b0b0e3db5ea17e84febabaa2a235763ace2341b3fcd036279be8eddfecbcfb","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","KONGCTL_FEATURE_USER_AGENT_KONNECT_PAT"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -180,20 +180,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_31746d52b8cd549e_EOF'
+          cat << 'GH_AW_PROMPT_3a2186d4dccbb66c_EOF'
           <system>
-          GH_AW_PROMPT_31746d52b8cd549e_EOF
+          GH_AW_PROMPT_3a2186d4dccbb66c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_31746d52b8cd549e_EOF'
+          cat << 'GH_AW_PROMPT_3a2186d4dccbb66c_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_31746d52b8cd549e_EOF
+          GH_AW_PROMPT_3a2186d4dccbb66c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_31746d52b8cd549e_EOF'
+          cat << 'GH_AW_PROMPT_3a2186d4dccbb66c_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -225,12 +225,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_31746d52b8cd549e_EOF
+          GH_AW_PROMPT_3a2186d4dccbb66c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_31746d52b8cd549e_EOF'
+          cat << 'GH_AW_PROMPT_3a2186d4dccbb66c_EOF'
           </system>
           {{#runtime-import .github/workflows/kongctl-feature-user-agent.md}}
-          GH_AW_PROMPT_31746d52b8cd549e_EOF
+          GH_AW_PROMPT_3a2186d4dccbb66c_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -434,9 +434,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_2ed029a86c339b31_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_779d336fb93451c7_EOF'
           {"create_issue":{"expires":720,"labels":["automation","agentic-workflows","konnect"],"max":1,"title_prefix":"[agent-eval] "},"create_report_incomplete_issue":{},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_2ed029a86c339b31_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_779d336fb93451c7_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -636,7 +636,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_54b9c3709d183800_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_581cf153dc5493c5_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -677,7 +677,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_54b9c3709d183800_EOF
+          GH_AW_MCP_CONFIG_581cf153dc5493c5_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -878,6 +878,9 @@ jobs:
       - if: always()
         name: Check sanitized feature-user artifacts
         run: "set -euo pipefail\n\nevidence_dir=\"/tmp/gh-aw/kongctl-feature-user-agent/sanitized\"\nif [ ! -d \"${evidence_dir}\" ]; then\n  exit 0\nfi\n\nif find \"${evidence_dir}\" -type f -size +1048576c | grep -q .; then\n  echo \"::error::Sanitized artifact files must be 1 MiB or smaller.\"\n  exit 1\nfi\n\nunsafe_pattern='([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}|Bearer[[:space:]]+[A-Za-z0-9._~+/-]+=*|Authorization:|X-Api-Key:|KONGCTL_[A-Z0-9_]*PAT=|https://[^[:space:]]*[?&](token|signature|X-Amz-Signature)=)'\nif grep -R -E -q \"${unsafe_pattern}\" \"${evidence_dir}\"; then\n  echo \"::error::Sanitized artifacts contain values that look unsafe. Redact or omit them before upload.\"\n  exit 1\nfi\n"
+      - if: always()
+        name: Hydrate replay prompt into created issue safe output
+        run: "set -euo pipefail\n\nagent_output=\"/tmp/gh-aw/agent_output.json\"\nreplay_prompt=\"/tmp/gh-aw/kongctl-feature-user-agent/sanitized/selected-use-case-prompt.md\"\n\nif [ ! -f \"${agent_output}\" ] || [ ! -f \"${replay_prompt}\" ]; then\n  exit 0\nfi\n\nunsafe_pattern='([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}|Bearer[[:space:]]+[A-Za-z0-9._~+/-]+=*|Authorization:|X-Api-Key:|KONGCTL_[A-Z0-9_]*PAT=|https://[^[:space:]]*[?&](token|signature|X-Amz-Signature)=)'\nif grep -E -q \"${unsafe_pattern}\" \"${replay_prompt}\"; then\n  echo \"::error::Replay prompt contains values that look unsafe. Redact or omit them before issue creation.\"\n  exit 1\nfi\n\nnode <<'NODE'\nconst fs = require(\"fs\");\n\nconst agentOutputPath = \"/tmp/gh-aw/agent_output.json\";\nconst replayPromptPath = \"/tmp/gh-aw/kongctl-feature-user-agent/sanitized/selected-use-case-prompt.md\";\nconst artifactPath = replayPromptPath;\nconst maxInlinePromptLength = 30000;\nconst maxIssueBodyLength = 64000;\n\nconst data = JSON.parse(fs.readFileSync(agentOutputPath, \"utf8\"));\nconst rawReplayPrompt = fs.readFileSync(replayPromptPath, \"utf8\").trim();\nif (!rawReplayPrompt) {\n  process.exit(0);\n}\n\nfunction clippedReplayPrompt(maxLength) {\n  if (rawReplayPrompt.length <= maxLength) {\n    return rawReplayPrompt;\n  }\n\n  return `${rawReplayPrompt.slice(0, maxLength).trimEnd()}\n\n[Replay prompt truncated in issue; full sanitized prompt is available at ${artifactPath}.]`;\n}\n\nfunction markdownFenceFor(content) {\n  let fence = \"```\";\n  while (content.includes(fence)) {\n    fence += \"`\";\n  }\n  return fence;\n}\n\nfunction replayPromptSection(maxPromptLength = maxInlinePromptLength) {\n  const replayPrompt = clippedReplayPrompt(maxPromptLength);\n  const fence = markdownFenceFor(replayPrompt);\n\n  return `## Replay Prompt\n\nSanitized replay prompt from \\`${artifactPath}\\`:\n\n${fence}markdown\n${replayPrompt}\n${fence}`;\n}\n\nfunction hasInlineReplayPrompt(body) {\n  const match = body.match(/^## Replay Prompt\\s*$/im);\n  if (!match) {\n    return false;\n  }\n\n  const rest = body.slice(match.index);\n  const next = rest.slice(match[0].length).search(/\\n##\\s+/);\n  const section = next === -1 ? rest : rest.slice(0, match[0].length + next);\n\n  return section.includes(\"```\") && !/See artifact:\\s*\\/tmp\\/gh-aw\\/kongctl-feature-user-agent\\/sanitized\\/selected-use-case-prompt\\.md/i.test(section);\n}\n\nfunction hydrateBody(body) {\n  if (hasInlineReplayPrompt(body)) {\n    return body;\n  }\n\n  function buildHydratedBody(maxPromptLength) {\n    const section = replayPromptSection(maxPromptLength);\n    if (/^## Replay Prompt\\s*$/im.test(body)) {\n      return body.replace(\n        /(^|\\r?\\n)## Replay Prompt[^\\n]*\\r?\\n[\\s\\S]*?(?=\\r?\\n##\\s+|$)/i,\n        (_, prefix) => `${prefix}${section}`,\n      );\n    }\n\n    return `${body.trimEnd()}\n\n${section}`;\n  }\n\n  const hydrated = buildHydratedBody(maxInlinePromptLength);\n  if (hydrated.length <= maxIssueBodyLength) {\n    return hydrated;\n  }\n\n  const overflow = hydrated.length - maxIssueBodyLength;\n  const smallerPromptLength = Math.max(1000, maxInlinePromptLength - overflow - 500);\n\n  return buildHydratedBody(smallerPromptLength);\n}\n\nfunction createIssueArgs(value) {\n  if (!value || typeof value !== \"object\" || Array.isArray(value)) {\n    return undefined;\n  }\n\n  if (value.create_issue && typeof value.create_issue === \"object\") {\n    return value.create_issue;\n  }\n\n  const toolName = String(value.name || value.tool || value.tool_name || value.type || \"\").toLowerCase();\n  const isCreateIssue = toolName === \"create_issue\" || toolName.endsWith(\".create_issue\");\n  if (!isCreateIssue) {\n    return undefined;\n  }\n\n  for (const key of [\"arguments\", \"args\", \"input\", \"parameters\"]) {\n    if (value[key] && typeof value[key] === \"object\" && typeof value[key].body === \"string\") {\n      return value[key];\n    }\n  }\n\n  if (typeof value.body === \"string\") {\n    return value;\n  }\n\n  return undefined;\n}\n\nlet hydrated = 0;\nfunction visit(value) {\n  if (!value || typeof value !== \"object\") {\n    return;\n  }\n\n  const args = createIssueArgs(value);\n  if (args && typeof args.body === \"string\") {\n    const nextBody = hydrateBody(args.body);\n    if (nextBody !== args.body) {\n      args.body = nextBody;\n      hydrated += 1;\n    }\n  }\n\n  for (const child of Array.isArray(value) ? value : Object.values(value)) {\n    visit(child);\n  }\n}\n\nvisit(data);\n\nif (hydrated > 0) {\n  fs.writeFileSync(agentOutputPath, `${JSON.stringify(data, null, 2)}\\n`);\n  console.log(`Hydrated replay prompt into ${hydrated} create_issue safe output item(s).`);\n}\nNODE\n"
       - if: always()
         name: Upload sanitized feature-user artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -1341,3 +1344,4 @@ jobs:
             /tmp/gh-aw/safe-output-items.jsonl
             /tmp/gh-aw/temporary-id-map.json
           if-no-files-found: ignore
+

--- a/.github/workflows/kongctl-feature-user-agent.md
+++ b/.github/workflows/kongctl-feature-user-agent.md
@@ -143,6 +143,168 @@ post-steps:
         echo "::error::Sanitized artifacts contain values that look unsafe. Redact or omit them before upload."
         exit 1
       fi
+  - name: Hydrate replay prompt into created issue safe output
+    if: always()
+    run: |
+      set -euo pipefail
+
+      agent_output="/tmp/gh-aw/agent_output.json"
+      replay_prompt="/tmp/gh-aw/kongctl-feature-user-agent/sanitized/selected-use-case-prompt.md"
+
+      if [ ! -f "${agent_output}" ] || [ ! -f "${replay_prompt}" ]; then
+        exit 0
+      fi
+
+      unsafe_pattern='([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}|Bearer[[:space:]]+[A-Za-z0-9._~+/-]+=*|Authorization:|X-Api-Key:|KONGCTL_[A-Z0-9_]*PAT=|https://[^[:space:]]*[?&](token|signature|X-Amz-Signature)=)'
+      if grep -E -q "${unsafe_pattern}" "${replay_prompt}"; then
+        echo "::error::Replay prompt contains values that look unsafe. Redact or omit them before issue creation."
+        exit 1
+      fi
+
+      node <<'NODE'
+      const fs = require("fs");
+
+      const agentOutputPath = "/tmp/gh-aw/agent_output.json";
+      const replayPromptPath = "/tmp/gh-aw/kongctl-feature-user-agent/sanitized/selected-use-case-prompt.md";
+      const artifactPath = replayPromptPath;
+      const maxInlinePromptLength = 30000;
+      const maxIssueBodyLength = 64000;
+
+      const data = JSON.parse(fs.readFileSync(agentOutputPath, "utf8"));
+      const rawReplayPrompt = fs.readFileSync(replayPromptPath, "utf8").trim();
+      if (!rawReplayPrompt) {
+        process.exit(0);
+      }
+
+      function clippedReplayPrompt(maxLength) {
+        if (rawReplayPrompt.length <= maxLength) {
+          return rawReplayPrompt;
+        }
+
+        return `${rawReplayPrompt.slice(0, maxLength).trimEnd()}
+
+      [Replay prompt truncated in issue; full sanitized prompt is available at ${artifactPath}.]`;
+      }
+
+      function markdownFenceFor(content) {
+        let fence = "```";
+        while (content.includes(fence)) {
+          fence += "`";
+        }
+        return fence;
+      }
+
+      function replayPromptSection(maxPromptLength = maxInlinePromptLength) {
+        const replayPrompt = clippedReplayPrompt(maxPromptLength);
+        const fence = markdownFenceFor(replayPrompt);
+
+        return `## Replay Prompt
+
+      Sanitized replay prompt from \`${artifactPath}\`:
+
+      ${fence}markdown
+      ${replayPrompt}
+      ${fence}`;
+      }
+
+      function hasInlineReplayPrompt(body) {
+        const match = body.match(/^## Replay Prompt\s*$/im);
+        if (!match) {
+          return false;
+        }
+
+        const rest = body.slice(match.index);
+        const next = rest.slice(match[0].length).search(/\n##\s+/);
+        const section = next === -1 ? rest : rest.slice(0, match[0].length + next);
+
+        return section.includes("```") && !/See artifact:\s*\/tmp\/gh-aw\/kongctl-feature-user-agent\/sanitized\/selected-use-case-prompt\.md/i.test(section);
+      }
+
+      function hydrateBody(body) {
+        if (hasInlineReplayPrompt(body)) {
+          return body;
+        }
+
+        function buildHydratedBody(maxPromptLength) {
+          const section = replayPromptSection(maxPromptLength);
+          if (/^## Replay Prompt\s*$/im.test(body)) {
+            return body.replace(
+              /(^|\r?\n)## Replay Prompt[^\n]*\r?\n[\s\S]*?(?=\r?\n##\s+|$)/i,
+              (_, prefix) => `${prefix}${section}`,
+            );
+          }
+
+          return `${body.trimEnd()}
+
+      ${section}`;
+        }
+
+        const hydrated = buildHydratedBody(maxInlinePromptLength);
+        if (hydrated.length <= maxIssueBodyLength) {
+          return hydrated;
+        }
+
+        const overflow = hydrated.length - maxIssueBodyLength;
+        const smallerPromptLength = Math.max(1000, maxInlinePromptLength - overflow - 500);
+
+        return buildHydratedBody(smallerPromptLength);
+      }
+
+      function createIssueArgs(value) {
+        if (!value || typeof value !== "object" || Array.isArray(value)) {
+          return undefined;
+        }
+
+        if (value.create_issue && typeof value.create_issue === "object") {
+          return value.create_issue;
+        }
+
+        const toolName = String(value.name || value.tool || value.tool_name || value.type || "").toLowerCase();
+        const isCreateIssue = toolName === "create_issue" || toolName.endsWith(".create_issue");
+        if (!isCreateIssue) {
+          return undefined;
+        }
+
+        for (const key of ["arguments", "args", "input", "parameters"]) {
+          if (value[key] && typeof value[key] === "object" && typeof value[key].body === "string") {
+            return value[key];
+          }
+        }
+
+        if (typeof value.body === "string") {
+          return value;
+        }
+
+        return undefined;
+      }
+
+      let hydrated = 0;
+      function visit(value) {
+        if (!value || typeof value !== "object") {
+          return;
+        }
+
+        const args = createIssueArgs(value);
+        if (args && typeof args.body === "string") {
+          const nextBody = hydrateBody(args.body);
+          if (nextBody !== args.body) {
+            args.body = nextBody;
+            hydrated += 1;
+          }
+        }
+
+        for (const child of Array.isArray(value) ? value : Object.values(value)) {
+          visit(child);
+        }
+      }
+
+      visit(data);
+
+      if (hydrated > 0) {
+        fs.writeFileSync(agentOutputPath, `${JSON.stringify(data, null, 2)}\n`);
+        console.log(`Hydrated replay prompt into ${hydrated} create_issue safe output item(s).`);
+      }
+      NODE
   - name: Upload sanitized feature-user artifacts
     if: always()
     uses: actions/upload-artifact@v7.0.1
@@ -262,7 +424,7 @@ dedicated Konnect org with the existing e2e reset helper.
    - `Friction Assessment`: why you did or did not find actionable friction.
    - `Cleanup`: cleanup attempted and result.
    - `Selected Use-Case Prompt`: the path to the replay prompt artifact and a
-     compact excerpt when it is useful for a future rerun.
+     compact excerpt that is useful for a future rerun.
    - `Safe Output`: whether you emitted `create_issue` or `noop`, and why.
 10. Before final output, run a sanitization check over the issue body and every
    file in the sanitized artifact directory. Rewrite or omit unsafe content.
@@ -333,6 +495,9 @@ include:
 - The selected-use-case replay prompt, either in full or as a compact sanitized
   excerpt, plus the artifact path
   `/tmp/gh-aw/kongctl-feature-user-agent/sanitized/selected-use-case-prompt.md`.
+  Do not provide only an artifact path; the issue body must contain enough of
+  the replay prompt for a maintainer to understand and rerun the use case
+  without downloading artifacts.
 - The advertised feature/workflow that was evaluated.
 - The expected behavior from docs or command help.
 - The actual behavior observed.


### PR DESCRIPTION
## Summary

- Hydrate the sanitized selected-use-case replay prompt directly into `create_issue` safe-output bodies before issue creation.
- Keep the replay prompt artifact path, but replace bare artifact-only replay sections with an inline fenced prompt excerpt.
- Tighten the workflow instructions so filed issues contain enough replay context without requiring artifact download.

## Rationale

Issue #1115 showed the workflow filing only `See artifact: /tmp/gh-aw/.../selected-use-case-prompt.md`, which makes the replay prompt unclear in the issue itself. This keeps the artifact as source evidence while ensuring maintainers can read and rerun the selected use case from the filed issue.

## Validation

- `gh aw compile kongctl-feature-user-agent --no-check-update`
- `gh aw compile kongctl-feature-user-agent --no-emit --validate --no-check-update`
- Local hydration sample against the observed safe-output shape from run `26112275756` (`{ type: "create_issue", body: ... }`)