### PR TITLE
Fix: portal auth settings explain and scaffold output

### DIFF
--- a/internal/declarative/resources/explain.go
+++ b/internal/declarative/resources/explain.go
@@ -1311,7 +1311,11 @@ func explainNestedFieldPaths(doc *ExplainDoc, relativePath []string) []string {
 	}
 	paths := make([]string, 0, len(doc.ParentRelations))
 	for _, relation := range doc.ParentRelations {
-		parts := []string{explainRelationParentPath(relation), relation.FieldName + "[]"}
+		fieldSegment := relation.FieldName
+		if relation.FieldArray {
+			fieldSegment += "[]"
+		}
+		parts := []string{explainRelationParentPath(relation), fieldSegment}
 		parts = append(parts, relativePath...)
 		paths = append(paths, strings.Join(parts, "."))
 	}

--- a/internal/declarative/resources/explain.go
+++ b/internal/declarative/resources/explain.go
@@ -51,6 +51,7 @@ type ExplainRelation struct {
 	ParentAlias   string `json:"parent_alias"   yaml:"parent_alias"`
 	ParentType    string `json:"parent_type"    yaml:"parent_type"`
 	FieldName     string `json:"field_name"     yaml:"field_name"`
+	FieldArray    bool   `json:"field_array"    yaml:"field_array"`
 	ChildAlias    string `json:"child_alias"    yaml:"child_alias"`
 	ParentRootKey string `json:"parent_root_key" yaml:"parent_root_key"`
 }
@@ -323,7 +324,7 @@ func ResolveExplainSubject(path string) (*ExplainSubject, error) {
 			relation := doc.ParentRelations[0]
 			subject.ScaffoldSteps = append(subject.ScaffoldSteps,
 				ExplainScaffoldStep{Name: relation.ParentRootKey, Array: true},
-				ExplainScaffoldStep{Name: relation.FieldName, Array: true},
+				ExplainScaffoldStep{Name: relation.FieldName, Array: relation.FieldArray},
 			)
 			if parentDoc, ok := explainDocByType(ResourceType(relation.ParentType)); ok {
 				subject.ScaffoldTrail = []ExplainScaffoldNode{
@@ -332,7 +333,7 @@ func ResolveExplainSubject(path string) (*ExplainSubject, error) {
 						Node: parentDoc.Schema.clone(),
 					},
 					{
-						Step: ExplainScaffoldStep{Name: relation.FieldName, Array: true},
+						Step: ExplainScaffoldStep{Name: relation.FieldName, Array: relation.FieldArray},
 						Node: doc.Schema.clone(),
 						Omit: scaffoldOmitFields([]ResourceType{ResourceType(relation.ParentType)}),
 					},
@@ -380,10 +381,13 @@ func ResolveExplainSubject(path string) (*ExplainSubject, error) {
 				if len(subject.ScaffoldSteps) == 0 {
 					subject.ScaffoldSteps = []ExplainScaffoldStep{{Name: currentDoc.RootKey, Array: true}}
 				}
-				subject.ScaffoldSteps = append(subject.ScaffoldSteps, ExplainScaffoldStep{Name: segment, Array: true})
+				subject.ScaffoldSteps = append(
+					subject.ScaffoldSteps,
+					ExplainScaffoldStep{Name: segment, Array: field.Node.Kind == explainKindArray},
+				)
 				ancestors = append(ancestors, currentDoc.ResourceType)
 				subject.ScaffoldTrail = append(subject.ScaffoldTrail, ExplainScaffoldNode{
-					Step: ExplainScaffoldStep{Name: segment, Array: true},
+					Step: ExplainScaffoldStep{Name: segment, Array: field.Node.Kind == explainKindArray},
 					Node: childDoc.Schema.clone(),
 					Omit: scaffoldOmitFields(ancestors),
 				})
@@ -1353,7 +1357,7 @@ func RenderScaffoldYAML(subject *ExplainSubject) (string, error) {
 						Node: parentDoc.Schema.clone(),
 					},
 					ExplainScaffoldNode{
-						Step: ExplainScaffoldStep{Name: relation.FieldName, Array: true},
+						Step: ExplainScaffoldStep{Name: relation.FieldName, Array: relation.FieldArray},
 						Node: subject.Doc.Schema.clone(),
 						Omit: scaffoldOmitFields([]ResourceType{ResourceType(relation.ParentType)}),
 					},
@@ -1936,6 +1940,7 @@ func explainNestedRelations(parentType ResourceType, parent reflect.Type) []Expl
 			ParentAlias:   string(parentType),
 			ParentType:    string(parentType),
 			FieldName:     name,
+			FieldArray:    derefExplainType(field.Type).Kind() == reflect.Slice,
 			ChildAlias:    string(childType),
 			ParentRootKey: resourceSetRootKey(parent),
 		})

--- a/internal/declarative/resources/explain_test.go
+++ b/internal/declarative/resources/explain_test.go
@@ -74,6 +74,18 @@ func TestResolveExplainSubject_OrganizationTeamRolesNestedResource(t *testing.T)
 	}, subject.ScaffoldSteps)
 }
 
+func TestResolveExplainSubject_NestedSingletonChildResource(t *testing.T) {
+	subject, err := ResolveExplainSubject("portal.auth_settings")
+	require.NoError(t, err)
+
+	assert.Equal(t, ResourceTypePortalAuthSettings, subject.Doc.ResourceType)
+	assert.True(t, subject.ResourceTarget)
+	assert.Equal(t, []ExplainScaffoldStep{
+		{Name: "portals", Array: true},
+		{Name: "auth_settings"},
+	}, subject.ScaffoldSteps)
+}
+
 func TestResolveExplainSubject_FieldPath(t *testing.T) {
 	subject, err := ResolveExplainSubject("api.publications.portal_id")
 	require.NoError(t, err)
@@ -191,6 +203,22 @@ func TestRenderExplainSchema_ApplicationAuthStrategyConfigsUnionField(t *testing
 	assert.Contains(t, schema.OneOf[1].Properties, "openid-connect")
 	require.NotNil(t, schema.XSubject)
 	assert.True(t, *schema.XSubject.Required)
+}
+
+func TestRenderExplainSchema_PortalAuthSettingsOmitsDeprecatedFields(t *testing.T) {
+	subject, err := ResolveExplainSubject("portal.auth_settings")
+	require.NoError(t, err)
+
+	schema := RenderExplainSchema(subject)
+	require.NotNil(t, schema)
+
+	assert.Contains(t, schema.Properties, "basic_auth_enabled")
+	assert.Contains(t, schema.Properties, "konnect_mapping_enabled")
+	assert.Contains(t, schema.Properties, "idp_mapping_enabled")
+	assert.NotContains(t, schema.Properties, "oidc_auth_enabled")
+	assert.NotContains(t, schema.Properties, "saml_auth_enabled")
+	assert.NotContains(t, schema.Properties, "oidc_client_id")
+	assert.NotContains(t, schema.Properties, "oidc_claim_mappings")
 }
 
 func TestRenderExplainSchema_AnalyticsDashboardDiscriminators(t *testing.T) {
@@ -438,6 +466,21 @@ func TestRenderScaffoldYAML_NestedChildResource(t *testing.T) {
 	assert.Contains(t, scaffold, "- ref: my-resource")
 	assert.NotContains(t, scaffold, "api: value")
 	assert.NotContains(t, scaffold, "kongctl:")
+}
+
+func TestRenderScaffoldYAML_NestedSingletonChildResource(t *testing.T) {
+	subject, err := ResolveExplainSubject("portal.auth_settings")
+	require.NoError(t, err)
+
+	scaffold, err := RenderScaffoldYAML(subject)
+	require.NoError(t, err)
+
+	assert.Contains(t, scaffold, "portals:")
+	assert.Contains(t, scaffold, "auth_settings:")
+	assert.NotContains(t, scaffold, "auth_settings:\n      - ref:")
+	assert.NotContains(t, scaffold, "oidc_auth_enabled")
+	assert.NotContains(t, scaffold, "saml_auth_enabled")
+	assert.NotContains(t, scaffold, "oidc_client_id")
 }
 
 func TestRenderScaffoldYAML_OrganizationTeamResource(t *testing.T) {

--- a/internal/declarative/resources/portal_auth_settings.go
+++ b/internal/declarative/resources/portal_auth_settings.go
@@ -11,8 +11,32 @@ func init() {
 	registerResourceType(
 		ResourceTypePortalAuthSettings,
 		func(rs *ResourceSet) *[]PortalAuthSettingsResource { return &rs.PortalAuthSettings },
-		AutoExplain[PortalAuthSettingsResource](),
+		AutoExplain[PortalAuthSettingsResource](
+			WithExplainSchemaBuilder(portalAuthSettingsExplainNode),
+		),
 	)
+}
+
+func portalAuthSettingsExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
+	node, err := autoExplainConcreteNode[PortalAuthSettingsResource](defaultExplainHints(ResourceTypePortalAuthSettings))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, field := range []string{
+		"oidc_auth_enabled",
+		"saml_auth_enabled",
+		"oidc_team_mapping_enabled",
+		"oidc_issuer",
+		"oidc_client_id",
+		"oidc_client_secret",
+		"oidc_scopes",
+		"oidc_claim_mappings",
+	} {
+		explainRemoveField(node, field)
+	}
+
+	return node, nil
 }
 
 // PortalAuthSettingsResource represents portal authentication settings (singleton child).


### PR DESCRIPTION
## Summary

- Render nested singleton child resources, such as `portal.auth_settings`, as YAML objects instead of arrays in `kongctl scaffold` output.
- Remove deprecated portal auth OIDC/SAML fields from `kongctl explain` and `kongctl scaffold` output for `portal.auth_settings`.
- Add coverage for singleton child scaffolding and the filtered portal auth settings schema.

## Why

`portal_auth_settings` validation rejects the deprecated OIDC/SAML fields and instructs users to move identity provider configuration to `identity_providers`. The generated `explain` and `scaffold` output should match the accepted declarative shape, especially because documentation points users to those commands as the definitive schema source.

## Validation

- `go test ./internal/declarative/resources ./internal/cmd/root/verbs/scaffold ./internal/cmd/root/verbs/explain`
- `make build`
- `make lint`
- `git diff --check`
- Manual checks:
  - `./kongctl scaffold portal.auth_settings`
  - `./kongctl explain portal.auth_settings --output yaml`
