### PR TITLE
Fix: skip team list for API-only plans

### DIFF
--- a/internal/declarative/planner/organization_team_planner.go
+++ b/internal/declarative/planner/organization_team_planner.go
@@ -33,8 +33,8 @@ func (t *OrganizationTeamPlannerImpl) PlannerComponent() string {
 func (t *OrganizationTeamPlannerImpl) PlanChanges(ctx context.Context, plannerCtx *Config, plan *Plan) error {
 	namespace := plannerCtx.Namespace
 	desired := t.GetDesiredOrganizationTeams(namespace)
-	shouldPlanUserAssignments := t.planner.shouldPlanOrganizationUsers(plan)
-	shouldPlanSystemAccountAssignments := t.planner.shouldPlanOrganizationSystemAccounts(plan)
+	shouldPlanUserAssignments := t.shouldPlanOrganizationUserAssignments(namespace, plan)
+	shouldPlanSystemAccountAssignments := t.shouldPlanOrganizationSystemAccountAssignments(namespace, plan)
 
 	// Skip if no teams to plan and not in sync mode
 	if len(desired) == 0 &&
@@ -220,6 +220,49 @@ func (t *OrganizationTeamPlannerImpl) PlanChanges(ctx context.Context, plannerCt
 	}
 
 	return nil
+}
+
+func (t *OrganizationTeamPlannerImpl) shouldPlanOrganizationUserAssignments(namespace string, plan *Plan) bool {
+	if plan != nil && plan.Metadata.Mode == PlanModeSync {
+		return t.planner.shouldPlanOrganizationUsers(plan)
+	}
+	return t.hasDesiredOrganizationUserAssignments(namespace)
+}
+
+func (t *OrganizationTeamPlannerImpl) shouldPlanOrganizationSystemAccountAssignments(
+	namespace string,
+	plan *Plan,
+) bool {
+	if plan != nil && plan.Metadata.Mode == PlanModeSync {
+		return t.planner.shouldPlanOrganizationSystemAccounts(plan)
+	}
+	return t.hasDesiredOrganizationSystemAccountAssignments(namespace)
+}
+
+func (t *OrganizationTeamPlannerImpl) hasDesiredOrganizationUserAssignments(namespace string) bool {
+	if len(t.GetDesiredOrganizationUserTeamMemberships(namespace)) > 0 ||
+		len(t.GetDesiredOrganizationUserRoles(namespace)) > 0 {
+		return true
+	}
+	for _, user := range t.organizationUsersByNamespace(namespace) {
+		if len(user.Teams) > 0 || len(user.Roles) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (t *OrganizationTeamPlannerImpl) hasDesiredOrganizationSystemAccountAssignments(namespace string) bool {
+	if len(t.GetDesiredOrganizationSystemAccountTeamMemberships(namespace)) > 0 ||
+		len(t.GetDesiredOrganizationSystemAccountRoles(namespace)) > 0 {
+		return true
+	}
+	for _, account := range t.organizationSystemAccountsByNamespace(namespace) {
+		if len(account.Teams) > 0 || len(account.Roles) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func (t *OrganizationTeamPlannerImpl) planOrganizationTeamRoleDeletesForDesired(

--- a/internal/declarative/planner/organization_team_planner_test.go
+++ b/internal/declarative/planner/organization_team_planner_test.go
@@ -1,13 +1,70 @@
 package planner
 
 import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
 	"testing"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
 	"github.com/kong/kongctl/internal/declarative/resources"
 	"github.com/kong/kongctl/internal/declarative/state"
 	"github.com/stretchr/testify/require"
 )
+
+type organizationTeamAPIStub struct {
+	listOrganizationTeams func(context.Context, kkOps.ListTeamsRequest) (*kkOps.ListTeamsResponse, error)
+}
+
+func (s *organizationTeamAPIStub) ListOrganizationTeams(
+	ctx context.Context,
+	req kkOps.ListTeamsRequest,
+) (*kkOps.ListTeamsResponse, error) {
+	if s.listOrganizationTeams != nil {
+		return s.listOrganizationTeams(ctx, req)
+	}
+	return &kkOps.ListTeamsResponse{
+		TeamCollection: &kkComps.TeamCollection{
+			Data: []kkComps.Team{},
+			Meta: &kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: 0}},
+		},
+	}, nil
+}
+
+func (s *organizationTeamAPIStub) GetOrganizationTeam(
+	_ context.Context,
+	_ string,
+) (*kkOps.GetTeamResponse, error) {
+	return nil, fmt.Errorf("GetOrganizationTeam not implemented")
+}
+
+func (s *organizationTeamAPIStub) CreateOrganizationTeam(
+	_ context.Context,
+	_ *kkComps.CreateTeam,
+) (*kkOps.CreateTeamResponse, error) {
+	return nil, fmt.Errorf("CreateOrganizationTeam not implemented")
+}
+
+func (s *organizationTeamAPIStub) UpdateOrganizationTeam(
+	_ context.Context,
+	_ string,
+	_ *kkComps.UpdateTeam,
+) (*kkOps.UpdateTeamResponse, error) {
+	return nil, fmt.Errorf("UpdateOrganizationTeam not implemented")
+}
+
+func (s *organizationTeamAPIStub) DeleteOrganizationTeam(
+	_ context.Context,
+	_ string,
+) (*kkOps.DeleteTeamResponse, error) {
+	return nil, fmt.Errorf("DeleteOrganizationTeam not implemented")
+}
+
+func discardPlannerLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
 
 func TestOrganizationTeamExternalConfigContributesExternalNamespace(t *testing.T) {
 	planner := &Planner{}
@@ -113,4 +170,135 @@ func TestOrganizationUserAssignmentPlansCreateChanges(t *testing.T) {
 	require.Equal(t, ResourceTypeOrganizationUserRole, plan.Changes[1].ResourceType)
 	require.Equal(t, "alice-products-viewer", plan.Changes[1].ResourceRef)
 	require.Equal(t, "__REF__:products-api#id", plan.Changes[1].References[FieldEntityID].Ref)
+}
+
+func TestAPIOnlyApplyDoesNotListOrganizationTeams(t *testing.T) {
+	var listTeamCalls int
+	apiClient := &MockAPIAPI{}
+	mockEmptyAPIsList(t.Context(), apiClient)
+	client := state.NewClient(state.ClientConfig{
+		APIAPI: apiClient,
+		OrganizationTeamAPI: &organizationTeamAPIStub{
+			listOrganizationTeams: func(context.Context, kkOps.ListTeamsRequest) (*kkOps.ListTeamsResponse, error) {
+				listTeamCalls++
+				return nil, fmt.Errorf("forbidden team list")
+			},
+		},
+	})
+	planner := NewPlanner(client, discardPlannerLogger())
+
+	plan, err := planner.GeneratePlan(t.Context(), &resources.ResourceSet{
+		APIs: []resources.APIResource{
+			{
+				BaseResource: resources.BaseResource{Ref: "api-only"},
+				CreateAPIRequest: kkComps.CreateAPIRequest{
+					Name: "API Only",
+				},
+			},
+		},
+	}, Options{Mode: PlanModeApply})
+
+	require.NoError(t, err)
+	require.Zero(t, listTeamCalls)
+	require.Len(t, plan.Changes, 1)
+	require.Equal(t, ResourceTypeAPI, plan.Changes[0].ResourceType)
+}
+
+func TestOrganizationAssignmentInputsStillListOrganizationTeams(t *testing.T) {
+	tests := []struct {
+		name      string
+		resource  *resources.ResourceSet
+		namespace string
+	}{
+		{
+			name: "user assignment",
+			resource: &resources.ResourceSet{
+				Organization: &resources.OrganizationResource{
+					Users: []resources.OrganizationUserResource{
+						{
+							Ref: "alice",
+							ID:  "user-123",
+						},
+					},
+				},
+				OrganizationUserRoles: []resources.OrganizationUserRoleResource{
+					{
+						Ref:            "alice-api-viewer",
+						User:           "alice",
+						RoleName:       "Viewer",
+						EntityID:       "*",
+						EntityTypeName: "APIs",
+						EntityRegion:   "us",
+					},
+				},
+			},
+			namespace: "default",
+		},
+		{
+			name: "system account assignment",
+			resource: &resources.ResourceSet{
+				Organization: &resources.OrganizationResource{
+					SystemAccounts: []resources.OrganizationSystemAccountResource{
+						{
+							Ref: "automation",
+							ID:  "system-account-123",
+						},
+					},
+				},
+				OrganizationSystemAccountRoles: []resources.OrganizationSystemAccountRoleResource{
+					{
+						Ref:            "automation-api-viewer",
+						SystemAccount:  "automation",
+						RoleName:       "Viewer",
+						EntityID:       "*",
+						EntityTypeName: "APIs",
+						EntityRegion:   "us",
+					},
+				},
+			},
+			namespace: "default",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var listTeamCalls int
+			client := state.NewClient(state.ClientConfig{
+				OrganizationTeamAPI: &organizationTeamAPIStub{
+					listOrganizationTeams: func(context.Context, kkOps.ListTeamsRequest) (*kkOps.ListTeamsResponse, error) {
+						listTeamCalls++
+						return nil, fmt.Errorf("team list called")
+					},
+				},
+			})
+			planner := NewPlanner(client, discardPlannerLogger())
+			planner.resources = tt.resource
+			teamPlanner := NewOrganizationTeamPlanner(NewBasePlanner(planner)).(*OrganizationTeamPlannerImpl)
+
+			err := teamPlanner.PlanChanges(t.Context(), NewConfig(tt.namespace), NewPlan("1.0", "test", PlanModeApply))
+
+			require.ErrorContains(t, err, "team list called")
+			require.Equal(t, 1, listTeamCalls)
+		})
+	}
+}
+
+func TestOrganizationTeamSyncStillListsOrganizationTeams(t *testing.T) {
+	var listTeamCalls int
+	client := state.NewClient(state.ClientConfig{
+		OrganizationTeamAPI: &organizationTeamAPIStub{
+			listOrganizationTeams: func(context.Context, kkOps.ListTeamsRequest) (*kkOps.ListTeamsResponse, error) {
+				listTeamCalls++
+				return nil, fmt.Errorf("team list called")
+			},
+		},
+	})
+	planner := NewPlanner(client, discardPlannerLogger())
+	planner.resources = &resources.ResourceSet{}
+	teamPlanner := NewOrganizationTeamPlanner(NewBasePlanner(planner)).(*OrganizationTeamPlannerImpl)
+
+	err := teamPlanner.PlanChanges(t.Context(), NewConfig("default"), NewPlan("1.0", "test", PlanModeSync))
+
+	require.ErrorContains(t, err, "team list called")
+	require.Equal(t, 1, listTeamCalls)
 }

--- a/test/e2e/scenarios/apis/eventual-consistency-polp/scenario.yaml
+++ b/test/e2e/scenarios/apis/eventual-consistency-polp/scenario.yaml
@@ -117,6 +117,8 @@ steps:
           - "{{ .workdir }}/catalog.yaml"
           - --mode
           - apply
+          - --log-level
+          - trace
         assertions:
           - select: summary
             expect:
@@ -135,6 +137,14 @@ steps:
             expect:
               fields:
                 "length(@)": 6
+          - source:
+              artifact:
+                path: kongctl.log
+            select: text
+            expect:
+              fields:
+                "contains(@, '/v3/teams')": false
+                "contains(@, 'workflow_component=organization_team')": false
       - name: 001-apply-catalog-limited-token
         timeout: 2m
         outputFormat: json


### PR DESCRIPTION
## Summary

- avoid organization team listing during non-sync API-only declarative planning
- keep organization user/system-account assignment and sync paths listing teams when needed
- add planner regression coverage plus PoLP e2e log assertions for the limited-token API-only plan path

## Validation

- `go test ./internal/declarative/planner -run 'TestAPIOnlyApplyDoesNotListOrganizationTeams|TestOrganizationAssignmentInputsStillListOrganizationTeams|TestOrganizationTeamSyncStillListsOrganizationTeams'`
- `KONGCTL_E2E_ARTIFACTS_DIR=.e2e_artifacts make test-e2e-scenarios SCENARIO=apis/eventual-consistency-polp STOP_AFTER=003-apply-catalog-with-limited-token/000-plan-catalog-limited-token`
- `KONGCTL_E2E_ARTIFACTS_DIR=.e2e_artifacts make test-e2e-scenarios SCENARIO=apis/eventual-consistency-polp`
- `go fix ./...`
- `make format`
- `make lint`
- `make test`
- `make build`
- `git diff --check`

Closes #1127