### PR TITLE
Fix: release Docker username env

### DIFF
--- a/.github/workflows/release.lock.yml
+++ b/.github/workflows/release.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6cdb5e813fea975b28147d79141b0893988d20dc2cf12afc0289d654a0f22cf8","compiler_version":"v0.74.4","agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"1c0a3808cba0e260e07c8e691451d4cfef8600a422d3cb710733aef5d691bfb2","compiler_version":"v0.74.4","agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","DOCKER_TOKEN","DOCKER_USERNAME","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_TOKEN_PRIVATE_READ","GITHUB_TOKEN","TAP_GITHUB_TOKEN"],"actions":[{"repo":"Homebrew/actions/setup-homebrew","sha":"cced187498280712e078aaba62dc13a3e9cd80bf","version":"cced187498280712e078aaba62dc13a3e9cd80bf"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"ed597411d8f924073f98dfc5c65a23a2325f34cd","version":"v8"},{"repo":"actions/setup-go","sha":"4a3601121dd01d1626a1e23e37211e3254c1c06c","version":"v6.4.0 (source v6)"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"docker/login-action","sha":"c94ce9fb468520275223c153574b00df6fe4bcc9","version":"c94ce9fb468520275223c153574b00df6fe4bcc9"},{"repo":"docker/setup-buildx-action","sha":"8d2750c68a42422c14e847fe6c8ac0403b4cbd6f","version":"8d2750c68a42422c14e847fe6c8ac0403b4cbd6f"},{"repo":"docker/setup-qemu-action","sha":"c7c53464625b32c7a7e944ae62b3e17d2b600130","version":"c7c53464625b32c7a7e944ae62b3e17d2b600130"},{"repo":"github/gh-aw-actions/setup","sha":"d3abfe96a194bce3a523ed2093ddedd5704cdf62","version":"v0.74.4"},{"repo":"goreleaser/goreleaser-action","sha":"e435ccd777264be153ace6237001ef4d979d3a7a","version":"e435ccd777264be153ace6237001ef4d979d3a7a"},{"repo":"step-security/harden-runner","sha":"6c3c2f2c1c457b00c10c4848d6f5491db3b629df","version":"6c3c2f2c1c457b00c10c4848d6f5491db3b629df"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.46","digest":"sha256:11c8c313d8ac37746223800ecf70962230feb12564692681e1dd57c234ee4ac1","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.46@sha256:11c8c313d8ac37746223800ecf70962230feb12564692681e1dd57c234ee4ac1"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.46","digest":"sha256:d62d7d60883f748bd2ec6349829c3662c2533eb896328962735ee7f87cce2175","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.46@sha256:d62d7d60883f748bd2ec6349829c3662c2533eb896328962735ee7f87cce2175"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.46","digest":"sha256:70c5b1ae3e73c0d689ca7bd4f4f8aee9e1b332206a5240629d21669824f93089","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.46@sha256:70c5b1ae3e73c0d689ca7bd4f4f8aee9e1b332206a5240629d21669824f93089"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -220,20 +220,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_c61e59275b3ec197_EOF'
+          cat << 'GH_AW_PROMPT_06745ae7565c06f3_EOF'
           <system>
-          GH_AW_PROMPT_c61e59275b3ec197_EOF
+          GH_AW_PROMPT_06745ae7565c06f3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_c61e59275b3ec197_EOF'
+          cat << 'GH_AW_PROMPT_06745ae7565c06f3_EOF'
           <safe-output-tools>
           Tools: update_release, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_c61e59275b3ec197_EOF
+          GH_AW_PROMPT_06745ae7565c06f3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_c61e59275b3ec197_EOF'
+          cat << 'GH_AW_PROMPT_06745ae7565c06f3_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -262,12 +262,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_c61e59275b3ec197_EOF
+          GH_AW_PROMPT_06745ae7565c06f3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_c61e59275b3ec197_EOF'
+          cat << 'GH_AW_PROMPT_06745ae7565c06f3_EOF'
           </system>
           {{#runtime-import .github/workflows/release.md}}
-          GH_AW_PROMPT_c61e59275b3ec197_EOF
+          GH_AW_PROMPT_06745ae7565c06f3_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -484,9 +484,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_e2b48c9cf1db5c00_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_8cf712f574ffca87_EOF'
           {"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_release":{"max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_e2b48c9cf1db5c00_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_8cf712f574ffca87_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -683,7 +683,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_c01d53753e143b1c_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_1fa9988dbbe755b3_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -724,7 +724,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_c01d53753e143b1c_EOF
+          GH_AW_MCP_CONFIG_1fa9988dbbe755b3_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1490,6 +1490,7 @@ jobs:
       packages: write
 
     env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       RELEASE_TAG: ${{ needs.config.outputs.release_tag }}
       RELEASE_VERSION: ${{ needs.config.outputs.release_version }}
     outputs:
@@ -1518,7 +1519,6 @@ jobs:
           set -euo pipefail
           echo "RELEASE_TAG=$GH_AW_NEEDS_CONFIG_OUTPUTS_RELEASE_TAG" >> "$GITHUB_ENV"
           echo "RELEASE_VERSION=$GH_AW_NEEDS_CONFIG_OUTPUTS_RELEASE_VERSION" >> "$GITHUB_ENV"
-          echo "DOCKER_USERNAME=${DOCKER_USERNAME}" >> "$GITHUB_ENV"
         env:
           GH_AW_NEEDS_CONFIG_OUTPUTS_RELEASE_TAG: ${{ needs.config.outputs.release_tag }}
           GH_AW_NEEDS_CONFIG_OUTPUTS_RELEASE_VERSION: ${{ needs.config.outputs.release_version }}

--- a/.github/workflows/release.lock.yml
+++ b/.github/workflows/release.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"1c0a3808cba0e260e07c8e691451d4cfef8600a422d3cb710733aef5d691bfb2","compiler_version":"v0.74.4","agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"56c501e3abdd0e68601ae21070e479a4c165f746fdfca034f8799d4b2d9f0572","compiler_version":"v0.74.4","agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","DOCKER_TOKEN","DOCKER_USERNAME","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_TOKEN_PRIVATE_READ","GITHUB_TOKEN","TAP_GITHUB_TOKEN"],"actions":[{"repo":"Homebrew/actions/setup-homebrew","sha":"cced187498280712e078aaba62dc13a3e9cd80bf","version":"cced187498280712e078aaba62dc13a3e9cd80bf"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"ed597411d8f924073f98dfc5c65a23a2325f34cd","version":"v8"},{"repo":"actions/setup-go","sha":"4a3601121dd01d1626a1e23e37211e3254c1c06c","version":"v6.4.0 (source v6)"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"docker/login-action","sha":"c94ce9fb468520275223c153574b00df6fe4bcc9","version":"c94ce9fb468520275223c153574b00df6fe4bcc9"},{"repo":"docker/setup-buildx-action","sha":"8d2750c68a42422c14e847fe6c8ac0403b4cbd6f","version":"8d2750c68a42422c14e847fe6c8ac0403b4cbd6f"},{"repo":"docker/setup-qemu-action","sha":"c7c53464625b32c7a7e944ae62b3e17d2b600130","version":"c7c53464625b32c7a7e944ae62b3e17d2b600130"},{"repo":"github/gh-aw-actions/setup","sha":"d3abfe96a194bce3a523ed2093ddedd5704cdf62","version":"v0.74.4"},{"repo":"goreleaser/goreleaser-action","sha":"e435ccd777264be153ace6237001ef4d979d3a7a","version":"e435ccd777264be153ace6237001ef4d979d3a7a"},{"repo":"step-security/harden-runner","sha":"6c3c2f2c1c457b00c10c4848d6f5491db3b629df","version":"6c3c2f2c1c457b00c10c4848d6f5491db3b629df"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.46","digest":"sha256:11c8c313d8ac37746223800ecf70962230feb12564692681e1dd57c234ee4ac1","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.46@sha256:11c8c313d8ac37746223800ecf70962230feb12564692681e1dd57c234ee4ac1"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.46","digest":"sha256:d62d7d60883f748bd2ec6349829c3662c2533eb896328962735ee7f87cce2175","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.46@sha256:d62d7d60883f748bd2ec6349829c3662c2533eb896328962735ee7f87cce2175"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.46","digest":"sha256:70c5b1ae3e73c0d689ca7bd4f4f8aee9e1b332206a5240629d21669824f93089","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.46@sha256:70c5b1ae3e73c0d689ca7bd4f4f8aee9e1b332206a5240629d21669824f93089"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -220,20 +220,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_06745ae7565c06f3_EOF'
+          cat << 'GH_AW_PROMPT_75d972cf267d61c3_EOF'
           <system>
-          GH_AW_PROMPT_06745ae7565c06f3_EOF
+          GH_AW_PROMPT_75d972cf267d61c3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_06745ae7565c06f3_EOF'
+          cat << 'GH_AW_PROMPT_75d972cf267d61c3_EOF'
           <safe-output-tools>
           Tools: update_release, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_06745ae7565c06f3_EOF
+          GH_AW_PROMPT_75d972cf267d61c3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_06745ae7565c06f3_EOF'
+          cat << 'GH_AW_PROMPT_75d972cf267d61c3_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -262,12 +262,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_06745ae7565c06f3_EOF
+          GH_AW_PROMPT_75d972cf267d61c3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_06745ae7565c06f3_EOF'
+          cat << 'GH_AW_PROMPT_75d972cf267d61c3_EOF'
           </system>
           {{#runtime-import .github/workflows/release.md}}
-          GH_AW_PROMPT_06745ae7565c06f3_EOF
+          GH_AW_PROMPT_75d972cf267d61c3_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -484,9 +484,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_8cf712f574ffca87_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_8a64ba031e65b208_EOF'
           {"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_release":{"max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_8cf712f574ffca87_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_8a64ba031e65b208_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -683,7 +683,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_1fa9988dbbe755b3_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_b48b6de44806e7a0_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -724,7 +724,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_1fa9988dbbe755b3_EOF
+          GH_AW_MCP_CONFIG_b48b6de44806e7a0_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1514,14 +1514,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: true
-      - name: Export release variables
-        run: |
-          set -euo pipefail
-          echo "RELEASE_TAG=$GH_AW_NEEDS_CONFIG_OUTPUTS_RELEASE_TAG" >> "$GITHUB_ENV"
-          echo "RELEASE_VERSION=$GH_AW_NEEDS_CONFIG_OUTPUTS_RELEASE_VERSION" >> "$GITHUB_ENV"
-        env:
-          GH_AW_NEEDS_CONFIG_OUTPUTS_RELEASE_TAG: ${{ needs.config.outputs.release_tag }}
-          GH_AW_NEEDS_CONFIG_OUTPUTS_RELEASE_VERSION: ${{ needs.config.outputs.release_version }}
       - name: Determine build mode
         run: |
           set -euo pipefail

--- a/.github/workflows/release.md
+++ b/.github/workflows/release.md
@@ -205,12 +205,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
-      - name: Export release variables
-        run: |
-          set -euo pipefail
-          echo "RELEASE_TAG=${{ needs.config.outputs.release_tag }}" >> "$GITHUB_ENV"
-          echo "RELEASE_VERSION=${{ needs.config.outputs.release_version }}" >> "$GITHUB_ENV"
-
       - name: Determine build mode
         env:
           REQUESTED_BUILD_MODE: ${{ github.event.inputs.build_mode || 'full' }}

--- a/.github/workflows/release.md
+++ b/.github/workflows/release.md
@@ -193,6 +193,7 @@ jobs:
     env:
       RELEASE_TAG: ${{ needs.config.outputs.release_tag }}
       RELEASE_VERSION: ${{ needs.config.outputs.release_version }}
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
@@ -205,13 +206,10 @@ jobs:
           persist-credentials: true
 
       - name: Export release variables
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         run: |
           set -euo pipefail
           echo "RELEASE_TAG=${{ needs.config.outputs.release_tag }}" >> "$GITHUB_ENV"
           echo "RELEASE_VERSION=${{ needs.config.outputs.release_version }}" >> "$GITHUB_ENV"
-          echo "DOCKER_USERNAME=${DOCKER_USERNAME}" >> "$GITHUB_ENV"
 
       - name: Determine build mode
         env:


### PR DESCRIPTION
## Summary

Fix the generated release workflow so `DOCKER_USERNAME` is available at the `release` job level instead of being read from an unmerged step env.

## Root cause

After the `gh aw` upgrade in #1126, the compiled `release.lock.yml` rewrote the `Export release variables` step env to include generated `GH_AW_NEEDS_CONFIG_OUTPUTS_*` values but dropped `DOCKER_USERNAME`. The step still referenced `${DOCKER_USERNAME}` under `set -u`, so workflow dispatch run 32 failed before any release work started.

## Changes

- Move `DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}` to the `release` job env in `release.md`.
- Stop echoing `DOCKER_USERNAME` through `$GITHUB_ENV` in the shell step.
- Recompile `release.lock.yml` with `gh aw compile release`.

## Validation

- `gh aw compile release` completed with 0 errors and 0 warnings.
- `git diff --check -- .github/workflows/release.md .github/workflows/release.lock.yml` passed.