### PR TITLE
test(e2e): globally queue e2e workflow runs

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -33,6 +33,12 @@ on:
 env:
   DO_NOT_TRACK: "1"
 
+# The E2E target orgs are shared stateful environments. Queue full workflow
+# runs so one run completes all shards before the next run starts.
+concurrency:
+  group: kongctl-e2e-global
+  queue: max
+
 jobs:
   e2e-needed:
     name: E2E Needed
@@ -168,10 +174,11 @@ jobs:
     if: needs.e2e-needed.outputs.required == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    # Serialize Konnect-mutating runs per target org across refs without
-    # preventing the lightweight gate jobs from running and failing closed.
+    # Backstop serialization per target org if workflow-level serialization is
+    # relaxed in the future.
     concurrency:
       group: konnect-e2e-${{ matrix.org_name }}
+      queue: max
       cancel-in-progress: false
     environment: ${{ matrix.org_name }}
     strategy:


### PR DESCRIPTION
## Summary

- Add a workflow-level E2E concurrency group using `queue: max` so only one E2E workflow run enters scenario execution at a time.
- Keep the existing per-org matrix concurrency as a defensive backstop and add `queue: max` there too.

## Rationale

The E2E target orgs are shared, stateful environments. The previous job-level per-org concurrency protected individual orgs from simultaneous mutation, but GitHub Actions only allowed one pending job per concurrency group by default. When a newer E2E run queued for the same org, GitHub canceled the older pending shard job. That produced partial E2E runs where some shards ran and others were canceled before reaching a runner.

A workflow-level queued concurrency group matches the intended model: one E2E workflow run is admitted at a time, while shards within that run can still execute concurrently across separate org environments.

GitHub documentation for this behavior and fix:

- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency
- https://docs.github.com/en/actions/concepts/workflows-and-actions/concurrency
- https://github.blog/changelog/2026-05-07-github-actions-concurrency-groups-now-allow-larger-queues/

## Validation

- `git diff --check -- .github/workflows/e2e.yaml`
- YAML parse with Ruby: `YAML.load_file(".github/workflows/e2e.yaml")`