### PR TITLE
Fix: Support role entity refs by entity type

### DIFF
--- a/docs/examples/declarative/organization/README.md
+++ b/docs/examples/declarative/organization/README.md
@@ -6,9 +6,10 @@ These examples demonstrate how to manage Konnect organization resources with
 ## Files
 
 - `teams.yaml` - defines organization teams with namespaces.
-- `team-roles.yaml` - defines organization teams and assigns roles to an API.
-  The example shows both nested `organization.teams[].roles` declarations and
-  root-level `organization_team_roles` declarations.
+- `team-roles.yaml` - defines organization teams and assigns roles to API and
+  portal resources using `!ref` in `entity_id`. The example shows both nested
+  `organization.teams[].roles` declarations and root-level
+  `organization_team_roles` declarations.
 - `user-assignments.yaml` - assigns existing organization users to teams and
   direct roles. Users have a local `ref` and are selected by exactly one of
   `email` or `id`; team memberships and roles also have local refs. kongctl

--- a/docs/examples/declarative/organization/team-roles.yaml
+++ b/docs/examples/declarative/organization/team-roles.yaml
@@ -7,6 +7,15 @@ apis:
     name: products-api
     description: Product catalog API managed by the platform team.
 
+portals:
+  - ref: developer-portal
+    name: developer-portal
+    display_name: Developer Portal
+    description: Developer portal managed by the platform team.
+    authentication_enabled: false
+    default_api_visibility: public
+    default_page_visibility: private
+
 organization:
   teams:
     - ref: platform-team
@@ -20,6 +29,11 @@ organization:
           role_name: Viewer
           entity_id: !ref products-api#id
           entity_type_name: APIs
+          entity_region: us
+        - ref: platform-portal-viewer
+          role_name: Viewer
+          entity_id: !ref developer-portal#id
+          entity_type_name: Portals
           entity_region: us
 
     - ref: api-admins

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -1318,6 +1318,48 @@ func (e *Executor) resolveControlPlaneRef(ctx context.Context, refInfo planner.R
 	return cp.ID, nil
 }
 
+func (e *Executor) resolveRoleEntityRef(ctx context.Context, change *planner.PlannedChange) error {
+	if change == nil {
+		return nil
+	}
+
+	entityRef, ok := change.References[planner.FieldEntityID]
+	if !ok || !unresolvedReferenceID(entityRef.ID) {
+		return nil
+	}
+
+	entityTypeName, _ := change.Fields[planner.FieldEntityTypeName].(string)
+	entityResourceType, ok := resources.RoleEntityResourceType(entityTypeName)
+	if !ok {
+		return fmt.Errorf("failed to resolve entity reference: unsupported entity_type_name %q", entityTypeName)
+	}
+
+	var (
+		entityID string
+		err      error
+	)
+	switch entityResourceType { //nolint:exhaustive
+	case resources.ResourceTypeAPI:
+		entityID, err = e.resolveAPIRef(ctx, entityRef)
+	case resources.ResourceTypePortal:
+		entityID, err = e.resolvePortalRef(ctx, entityRef)
+	case resources.ResourceTypeControlPlane:
+		entityID, err = e.resolveControlPlaneRef(ctx, entityRef)
+	default:
+		return fmt.Errorf(
+			"failed to resolve entity reference: unsupported entity resource type %s",
+			entityResourceType,
+		)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to resolve entity reference: %w", err)
+	}
+
+	entityRef.ID = entityID
+	change.References[planner.FieldEntityID] = entityRef
+	return nil
+}
+
 func (e *Executor) syncControlPlaneGroupMembers(
 	ctx context.Context,
 	change *planner.PlannedChange,
@@ -2304,14 +2346,8 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 			change.References[planner.FieldTeamID] = teamRef
 		}
 
-		if entityRef, ok := change.References[planner.FieldEntityID]; ok &&
-			(entityRef.ID == "" || entityRef.ID == "[unknown]") {
-			apiID, err := e.resolveAPIRef(ctx, entityRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve entity reference: %w", err)
-			}
-			entityRef.ID = apiID
-			change.References[planner.FieldEntityID] = entityRef
+		if err := e.resolveRoleEntityRef(ctx, change); err != nil {
+			return "", err
 		}
 
 		return e.portalTeamRoleExecutor.Create(ctx, *change)
@@ -2408,14 +2444,8 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 			teamRef.ID = teamID
 			change.References[planner.FieldTeamID] = teamRef
 		}
-		if entityRef, ok := change.References[planner.FieldEntityID]; ok &&
-			(entityRef.ID == "" || entityRef.ID == "[unknown]") {
-			apiID, err := e.resolveAPIRef(ctx, entityRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve entity reference: %w", err)
-			}
-			entityRef.ID = apiID
-			change.References[planner.FieldEntityID] = entityRef
+		if err := e.resolveRoleEntityRef(ctx, change); err != nil {
+			return "", err
 		}
 		return e.organizationTeamRoleExecutor.Create(ctx, *change)
 	case planner.ResourceTypeOrganizationUserTeamMembership:
@@ -2429,13 +2459,8 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 		}
 		return e.organizationUserTeamMembershipExecutor.Create(ctx, *change)
 	case planner.ResourceTypeOrganizationUserRole:
-		if entityRef, ok := change.References[planner.FieldEntityID]; ok && unresolvedReferenceID(entityRef.ID) {
-			apiID, err := e.resolveAPIRef(ctx, entityRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve entity reference: %w", err)
-			}
-			entityRef.ID = apiID
-			change.References[planner.FieldEntityID] = entityRef
+		if err := e.resolveRoleEntityRef(ctx, change); err != nil {
+			return "", err
 		}
 		return e.organizationUserRoleExecutor.Create(ctx, *change)
 	case planner.ResourceTypeOrganizationSystemAccountTeamMembership:
@@ -2449,13 +2474,8 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 		}
 		return e.organizationSystemAccountTeamMembershipExecutor.Create(ctx, *change)
 	case planner.ResourceTypeOrganizationSystemAccountRole:
-		if entityRef, ok := change.References[planner.FieldEntityID]; ok && unresolvedReferenceID(entityRef.ID) {
-			apiID, err := e.resolveAPIRef(ctx, entityRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve entity reference: %w", err)
-			}
-			entityRef.ID = apiID
-			change.References[planner.FieldEntityID] = entityRef
+		if err := e.resolveRoleEntityRef(ctx, change); err != nil {
+			return "", err
 		}
 		return e.organizationSystemAccountRoleExecutor.Create(ctx, *change)
 

--- a/internal/declarative/loader/loader_test.go
+++ b/internal/declarative/loader/loader_test.go
@@ -386,6 +386,37 @@ organization_team_roles:
 	}, rolesByRef)
 }
 
+func TestLoader_LoadFileAllowsOrganizationTeamRolePortalRef(t *testing.T) {
+	content := `
+organization:
+  teams:
+    - ref: repro-team
+      name: repro-team
+      roles:
+        - ref: repro-team-role
+          role_name: viewer
+          entity_id: !ref repro-portal
+          entity_type_name: Portals
+          entity_region: us
+
+portals:
+  - ref: repro-portal
+    name: repro-portal
+`
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(file, []byte(content), 0o600))
+
+	loader := New()
+	rs, err := loader.LoadFile(file)
+	require.NoError(t, err)
+
+	require.Len(t, rs.OrganizationTeamRoles, 1)
+	assert.Equal(t, "__REF__:repro-portal#id", rs.OrganizationTeamRoles[0].EntityID)
+	assert.Equal(t, "Portals", rs.OrganizationTeamRoles[0].EntityTypeName)
+}
+
 func TestLoader_FlattensOrganizationUserAssignments(t *testing.T) {
 	content := `
 apis:

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -161,25 +161,13 @@ func (l *Loader) validateUserRoleEntityReference(
 	role *resources.OrganizationUserRoleResource,
 	rs *resources.ResourceSet,
 ) error {
-	if !tags.IsRefPlaceholder(role.EntityID) {
-		return nil
-	}
-
-	apiRef, _, ok := tags.ParseRefPlaceholder(role.EntityID)
-	if !ok || apiRef == "" {
-		return fmt.Errorf("organization_user_role %q has invalid entity_id reference: %s",
-			role.GetRef(), role.EntityID)
-	}
-
-	if resource, found := rs.GetResourceByRef(apiRef); !found {
-		return fmt.Errorf("organization_user_role %q references unknown api: %s (field: entity_id)",
-			role.GetRef(), apiRef)
-	} else if resource.GetType() != resources.ResourceTypeAPI {
-		return fmt.Errorf("organization_user_role %q references %s but expected api: %s (field: entity_id)",
-			role.GetRef(), resource.GetType(), apiRef)
-	}
-
-	return nil
+	return validateRoleEntityReference(
+		resources.ResourceTypeOrganizationUserRole,
+		role.GetRef(),
+		role.EntityID,
+		role.EntityTypeName,
+		rs,
+	)
 }
 
 func (l *Loader) validateOrganizationSystemAccounts(rs *resources.ResourceSet) error {
@@ -260,25 +248,13 @@ func (l *Loader) validateSystemAccountRoleEntityReference(
 	role *resources.OrganizationSystemAccountRoleResource,
 	rs *resources.ResourceSet,
 ) error {
-	if !tags.IsRefPlaceholder(role.EntityID) {
-		return nil
-	}
-
-	apiRef, _, ok := tags.ParseRefPlaceholder(role.EntityID)
-	if !ok || apiRef == "" {
-		return fmt.Errorf("organization_system_account_role %q has invalid entity_id reference: %s",
-			role.GetRef(), role.EntityID)
-	}
-
-	if resource, found := rs.GetResourceByRef(apiRef); !found {
-		return fmt.Errorf("organization_system_account_role %q references unknown api: %s (field: entity_id)",
-			role.GetRef(), apiRef)
-	} else if resource.GetType() != resources.ResourceTypeAPI {
-		return fmt.Errorf("organization_system_account_role %q references %s but expected api: %s (field: entity_id)",
-			role.GetRef(), resource.GetType(), apiRef)
-	}
-
-	return nil
+	return validateRoleEntityReference(
+		resources.ResourceTypeOrganizationSystemAccountRole,
+		role.GetRef(),
+		role.EntityID,
+		role.EntityTypeName,
+		rs,
+	)
 }
 
 func (l *Loader) validateOrganizationTeamRoles(roles []resources.OrganizationTeamRoleResource,
@@ -328,18 +304,47 @@ func (l *Loader) validateOrganizationTeamRoleReferences(
 		return nil
 	}
 
-	apiRef, _, ok := tags.ParseRefPlaceholder(role.EntityID)
-	if !ok || apiRef == "" {
-		return fmt.Errorf("organization_team_role %q has invalid entity_id reference: %s",
-			role.GetRef(), role.EntityID)
+	return validateRoleEntityReference(
+		resources.ResourceTypeOrganizationTeamRole,
+		role.GetRef(),
+		role.EntityID,
+		role.EntityTypeName,
+		rs,
+	)
+}
+
+func validateRoleEntityReference(
+	roleType resources.ResourceType,
+	roleRef string,
+	entityID string,
+	entityTypeName string,
+	rs *resources.ResourceSet,
+) error {
+	if !tags.IsRefPlaceholder(entityID) {
+		return nil
 	}
 
-	if resource, found := rs.GetResourceByRef(apiRef); !found {
-		return fmt.Errorf("organization_team_role %q references unknown api: %s (field: entity_id)",
-			role.GetRef(), apiRef)
-	} else if resource.GetType() != resources.ResourceTypeAPI {
-		return fmt.Errorf("organization_team_role %q references %s but expected api: %s (field: entity_id)",
-			role.GetRef(), resource.GetType(), apiRef)
+	entityRef, _, ok := tags.ParseRefPlaceholder(entityID)
+	if !ok || entityRef == "" {
+		return fmt.Errorf("%s %q has invalid entity_id reference: %s", roleType, roleRef, entityID)
+	}
+
+	expectedType, ok := resources.RoleEntityResourceType(entityTypeName)
+	if !ok {
+		return fmt.Errorf(
+			"%s %q has unsupported entity_type_name for entity_id reference: %s",
+			roleType,
+			roleRef,
+			entityTypeName,
+		)
+	}
+
+	if resource, found := rs.GetResourceByRef(entityRef); !found {
+		return fmt.Errorf("%s %q references unknown %s: %s (field: entity_id)",
+			roleType, roleRef, expectedType, entityRef)
+	} else if resource.GetType() != expectedType {
+		return fmt.Errorf("%s %q references %s but expected %s: %s (field: entity_id)",
+			roleType, roleRef, resource.GetType(), expectedType, entityRef)
 	}
 
 	return nil

--- a/internal/declarative/loader/validator_test.go
+++ b/internal/declarative/loader/validator_test.go
@@ -629,6 +629,33 @@ func TestLoader_validateOrganizationTeamRoles_ValidatesReferences(t *testing.T) 
 			},
 		},
 		{
+			name: "valid team and portal refs",
+			rs: &resources.ResourceSet{
+				OrganizationTeams: []resources.OrganizationTeamResource{
+					{
+						BaseResource: resources.BaseResource{Ref: "platform-team"},
+						CreateTeam:   kkComps.CreateTeam{Name: "Platform"},
+					},
+				},
+				Portals: []resources.PortalResource{
+					{
+						BaseResource: resources.BaseResource{Ref: "developer-portal"},
+						CreatePortal: kkComps.CreatePortal{Name: "Developer Portal"},
+					},
+				},
+				OrganizationTeamRoles: []resources.OrganizationTeamRoleResource{
+					{
+						Ref:            "platform-portal-viewer",
+						Team:           "platform-team",
+						RoleName:       "Viewer",
+						EntityID:       tags.RefPlaceholderPrefix + "developer-portal#id",
+						EntityTypeName: "Portals",
+						EntityRegion:   "us",
+					},
+				},
+			},
+		},
+		{
 			name: "unknown team ref",
 			rs: &resources.ResourceSet{
 				OrganizationTeamRoles: []resources.OrganizationTeamRoleResource{
@@ -666,6 +693,32 @@ func TestLoader_validateOrganizationTeamRoles_ValidatesReferences(t *testing.T) 
 			},
 			expectError: `organization_team_role "platform-admin" references unknown api: missing-api (field: entity_id)`,
 		},
+		{
+			name: "entity type mismatch",
+			rs: &resources.ResourceSet{
+				OrganizationTeams: []resources.OrganizationTeamResource{
+					{
+						BaseResource: resources.BaseResource{Ref: "platform-team"},
+						CreateTeam:   kkComps.CreateTeam{Name: "Platform"},
+					},
+				},
+				APIs: []resources.APIResource{
+					{BaseResource: resources.BaseResource{Ref: "products-api"}},
+				},
+				OrganizationTeamRoles: []resources.OrganizationTeamRoleResource{
+					{
+						Ref:            "platform-admin",
+						Team:           "platform-team",
+						RoleName:       "Admin",
+						EntityID:       tags.RefPlaceholderPrefix + "products-api#id",
+						EntityTypeName: "Portals",
+						EntityRegion:   "us",
+					},
+				},
+			},
+			expectError: `organization_team_role "platform-admin" references api but expected portal: ` +
+				`products-api (field: entity_id)`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -680,6 +733,50 @@ func TestLoader_validateOrganizationTeamRoles_ValidatesReferences(t *testing.T) 
 			assert.Contains(t, err.Error(), tt.expectError)
 		})
 	}
+}
+
+func TestLoader_validateOrganizationUserRole_AllowsPortalEntityRef(t *testing.T) {
+	loader := New()
+	rs := &resources.ResourceSet{
+		Portals: []resources.PortalResource{
+			{
+				BaseResource: resources.BaseResource{Ref: "developer-portal"},
+				CreatePortal: kkComps.CreatePortal{Name: "Developer Portal"},
+			},
+		},
+	}
+	role := &resources.OrganizationUserRoleResource{
+		Ref:            "alice-portal-viewer",
+		User:           "alice",
+		RoleName:       "Viewer",
+		EntityID:       tags.RefPlaceholderPrefix + "developer-portal#id",
+		EntityTypeName: "Portals",
+		EntityRegion:   "us",
+	}
+
+	require.NoError(t, loader.validateUserRoleEntityReference(role, rs))
+}
+
+func TestLoader_validateOrganizationSystemAccountRole_AllowsPortalEntityRef(t *testing.T) {
+	loader := New()
+	rs := &resources.ResourceSet{
+		Portals: []resources.PortalResource{
+			{
+				BaseResource: resources.BaseResource{Ref: "developer-portal"},
+				CreatePortal: kkComps.CreatePortal{Name: "Developer Portal"},
+			},
+		},
+	}
+	role := &resources.OrganizationSystemAccountRoleResource{
+		Ref:            "ci-bot-portal-viewer",
+		SystemAccount:  "ci-bot",
+		RoleName:       "Viewer",
+		EntityID:       tags.RefPlaceholderPrefix + "developer-portal#id",
+		EntityTypeName: "Portals",
+		EntityRegion:   "us",
+	}
+
+	require.NoError(t, loader.validateSystemAccountRoleEntityReference(role, rs))
 }
 
 func TestLoader_getFieldValue(t *testing.T) {

--- a/internal/declarative/planner/organization_system_account_assignments.go
+++ b/internal/declarative/planner/organization_system_account_assignments.go
@@ -293,11 +293,7 @@ func (t *OrganizationTeamPlannerImpl) planOrganizationSystemAccountRoleCreate(
 ) {
 	dependencies := []string{}
 	if tags.IsRefPlaceholder(role.EntityID) {
-		if apiRef, _, ok := tags.ParseRefPlaceholder(role.EntityID); ok {
-			if apiChangeID := findChangeID(plan, string(resources.ResourceTypeAPI), apiRef); apiChangeID != "" {
-				dependencies = append(dependencies, apiChangeID)
-			}
-		}
+		dependencies = appendRoleEntityDependency(dependencies, plan, role.EntityID, role.EntityTypeName)
 	}
 
 	refs := map[string]ReferenceInfo{

--- a/internal/declarative/planner/organization_team_planner.go
+++ b/internal/declarative/planner/organization_team_planner.go
@@ -457,11 +457,7 @@ func (t *OrganizationTeamPlannerImpl) planOrganizationTeamRoleCreate(
 		dependencies = append(dependencies, teamChangeID)
 	}
 	if tags.IsRefPlaceholder(role.EntityID) {
-		if apiRef, _, ok := tags.ParseRefPlaceholder(role.EntityID); ok {
-			if apiChangeID := findChangeID(plan, string(resources.ResourceTypeAPI), apiRef); apiChangeID != "" {
-				dependencies = append(dependencies, apiChangeID)
-			}
-		}
+		dependencies = appendRoleEntityDependency(dependencies, plan, role.EntityID, role.EntityTypeName)
 	}
 
 	refs := map[string]ReferenceInfo{

--- a/internal/declarative/planner/organization_user_assignments.go
+++ b/internal/declarative/planner/organization_user_assignments.go
@@ -276,11 +276,7 @@ func (t *OrganizationTeamPlannerImpl) planOrganizationUserRoleCreate(
 ) {
 	dependencies := []string{}
 	if tags.IsRefPlaceholder(role.EntityID) {
-		if apiRef, _, ok := tags.ParseRefPlaceholder(role.EntityID); ok {
-			if apiChangeID := findChangeID(plan, string(resources.ResourceTypeAPI), apiRef); apiChangeID != "" {
-				dependencies = append(dependencies, apiChangeID)
-			}
-		}
+		dependencies = appendRoleEntityDependency(dependencies, plan, role.EntityID, role.EntityTypeName)
 	}
 
 	refs := map[string]ReferenceInfo{

--- a/internal/declarative/planner/planner.go
+++ b/internal/declarative/planner/planner.go
@@ -432,7 +432,7 @@ func (p *Planner) GeneratePlan(ctx context.Context, rs *resources.ResourceSet, o
 		}
 	}
 
-	// Ensure team roles depend on referenced APIs created in the same plan
+	// Ensure team roles depend on referenced entities created in the same plan.
 	adjustTeamRoleDependencies(basePlan)
 
 	// Resolve dependencies and calculate execution order.

--- a/internal/declarative/planner/portal_child_planner.go
+++ b/internal/declarative/planner/portal_child_planner.go
@@ -4881,11 +4881,7 @@ func (p *Planner) planPortalTeamRoleCreate(
 	}
 
 	if tags.IsRefPlaceholder(role.EntityID) {
-		if apiRef, _, ok := tags.ParseRefPlaceholder(role.EntityID); ok {
-			if apiChangeID := findChangeID(plan, string(resources.ResourceTypeAPI), apiRef); apiChangeID != "" {
-				dependencies = append(dependencies, apiChangeID)
-			}
-		}
+		dependencies = appendRoleEntityDependency(dependencies, plan, role.EntityID, role.EntityTypeName)
 	}
 
 	refs := map[string]ReferenceInfo{

--- a/internal/declarative/planner/resolver.go
+++ b/internal/declarative/planner/resolver.go
@@ -65,11 +65,12 @@ func (r *ReferenceResolver) ResolveReferences(ctx context.Context, changes []Pla
 		// Check fields that might contain references
 		for fieldName, fieldValue := range change.Fields {
 			if ref, isRef := r.extractReference(fieldName, fieldValue); isRef {
-				// Determine resource type from field name
-				resourceType := r.getResourceTypeForField(fieldName)
+				// Determine resource type from field name and role entity metadata.
+				resourceType := r.getResourceTypeForChangeField(change, fieldName)
+				targetRef := referenceTargetRef(ref)
 
 				// Check if this references something being created
-				if _, inPlan := createdResources[resourceType][ref]; inPlan {
+				if _, inPlan := createdResources[resourceType][targetRef]; inPlan {
 					changeRefs[fieldName] = ResolvedReference{
 						Ref: ref,
 						ID:  "[unknown]", // Will be resolved at execution
@@ -171,6 +172,24 @@ func (r *ReferenceResolver) getResourceTypeForField(fieldName string) string {
 	}
 }
 
+func (r *ReferenceResolver) getResourceTypeForChangeField(change PlannedChange, fieldName string) string {
+	if fieldName == FieldEntityID {
+		entityTypeName, _ := change.Fields[FieldEntityTypeName].(string)
+		if resourceType, ok := resources.RoleEntityResourceType(entityTypeName); ok {
+			return string(resourceType)
+		}
+	}
+	return r.getResourceTypeForField(fieldName)
+}
+
+func referenceTargetRef(ref string) string {
+	targetRef, _, ok := tags.ParseRefPlaceholder(ref)
+	if ok {
+		return targetRef
+	}
+	return ref
+}
+
 // resolveReference looks up a reference in existing resources
 func (r *ReferenceResolver) resolveReference(ctx context.Context, resourceType, ref string) (string, error) {
 	var targetRef string
@@ -191,8 +210,7 @@ func (r *ReferenceResolver) resolveReference(ctx context.Context, resourceType, 
 
 	// Find resource in ResourceSet by ref
 	if r.resources != nil {
-		resource, exists := r.resources.GetResourceByRef(targetRef)
-		if exists {
+		if resource, exists := r.getResourceByTypeAndRef(resourceType, targetRef); exists {
 			// Special handling for "id" field - return konnectID
 			if fieldName == FieldID || fieldName == "ID" {
 				konnectID := resource.GetKonnectID()
@@ -221,6 +239,21 @@ func (r *ReferenceResolver) resolveReference(ctx context.Context, resourceType, 
 	default:
 		return "", fmt.Errorf("unknown resource type: %s", resourceType)
 	}
+}
+
+func (r *ReferenceResolver) getResourceByTypeAndRef(resourceType string, ref string) (resources.Resource, bool) {
+	if r.resources == nil {
+		return nil, false
+	}
+	if resourceType == "" {
+		return r.resources.GetResourceByRef(ref)
+	}
+	for _, resource := range r.resources.AllResourcesByType(resources.ResourceType(resourceType)) {
+		if resource.GetRef() == ref {
+			return resource, true
+		}
+	}
+	return nil, false
 }
 
 func (r *ReferenceResolver) resolveDCRProviderRef(ctx context.Context, ref string) (string, error) {

--- a/internal/declarative/planner/resolver_test.go
+++ b/internal/declarative/planner/resolver_test.go
@@ -9,6 +9,7 @@ import (
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
 	"github.com/kong/kongctl/internal/declarative/labels"
+	declresources "github.com/kong/kongctl/internal/declarative/resources"
 	"github.com/kong/kongctl/internal/declarative/state"
 	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/util"
@@ -431,6 +432,88 @@ func TestResolveReferences_PortalReference(t *testing.T) {
 	}
 
 	mockAPI.AssertExpectations(t)
+}
+
+func TestResolveReferences_RoleEntityPortalReferenceCreatedInPlan(t *testing.T) {
+	ctx := context.Background()
+	client := state.NewClient(state.ClientConfig{})
+	resolver := NewReferenceResolver(client, nil)
+
+	changes := []PlannedChange{
+		{
+			ID:           "1-c-portal",
+			ResourceType: ResourceTypePortal,
+			ResourceRef:  "dev-portal",
+			Action:       ActionCreate,
+			Fields: map[string]any{
+				FieldName: "Dev Portal",
+			},
+		},
+		{
+			ID:           "2-c-role",
+			ResourceType: ResourceTypeOrganizationTeamRole,
+			ResourceRef:  "portal-viewer",
+			Action:       ActionCreate,
+			Fields: map[string]any{
+				FieldRoleName:       "Viewer",
+				FieldEntityID:       "__REF__:dev-portal#id",
+				FieldEntityTypeName: "Portals",
+				FieldEntityRegion:   "us",
+			},
+		},
+	}
+
+	result, err := resolver.ResolveReferences(ctx, changes)
+	require.NoError(t, err)
+	require.Empty(t, result.Errors)
+
+	roleRefs, ok := result.ChangeReferences["2-c-role"]
+	require.True(t, ok, "expected role references")
+	entityRef, ok := roleRefs[FieldEntityID]
+	require.True(t, ok, "expected entity_id reference")
+	assert.Equal(t, "__REF__:dev-portal#id", entityRef.Ref)
+	assert.Equal(t, "[unknown]", entityRef.ID)
+}
+
+func TestResolveReferences_RoleEntityPortalReferenceUsesEntityTypeName(t *testing.T) {
+	ctx := context.Background()
+	client := state.NewClient(state.ClientConfig{})
+
+	api := declresources.APIResource{BaseResource: declresources.BaseResource{Ref: "shared-ref"}}
+	api.SetKonnectID("api-id")
+	portal := declresources.PortalResource{BaseResource: declresources.BaseResource{Ref: "shared-ref"}}
+	portal.SetKonnectID("portal-id")
+	resourceSet := &declresources.ResourceSet{
+		APIs:    []declresources.APIResource{api},
+		Portals: []declresources.PortalResource{portal},
+	}
+	resolver := NewReferenceResolver(client, resourceSet)
+
+	changes := []PlannedChange{
+		{
+			ID:           "1-c-role",
+			ResourceType: ResourceTypeOrganizationTeamRole,
+			ResourceRef:  "portal-viewer",
+			Action:       ActionCreate,
+			Fields: map[string]any{
+				FieldRoleName:       "Viewer",
+				FieldEntityID:       "__REF__:shared-ref#id",
+				FieldEntityTypeName: "Portals",
+				FieldEntityRegion:   "us",
+			},
+		},
+	}
+
+	result, err := resolver.ResolveReferences(ctx, changes)
+	require.NoError(t, err)
+	require.Empty(t, result.Errors)
+
+	roleRefs, ok := result.ChangeReferences["1-c-role"]
+	require.True(t, ok, "expected role references")
+	entityRef, ok := roleRefs[FieldEntityID]
+	require.True(t, ok, "expected entity_id reference")
+	assert.Equal(t, "__REF__:shared-ref#id", entityRef.Ref)
+	assert.Equal(t, "portal-id", entityRef.ID)
 }
 
 func TestResolveReferences_ExistingPortal(t *testing.T) {

--- a/internal/declarative/planner/team_role_dependencies.go
+++ b/internal/declarative/planner/team_role_dependencies.go
@@ -5,8 +5,8 @@ import (
 	"github.com/kong/kongctl/internal/declarative/tags"
 )
 
-// adjustTeamRoleDependencies wires team role changes to depend on API creations when
-// entity_id is a reference placeholder pointing to an API being created in the same plan.
+// adjustTeamRoleDependencies wires team role changes to depend on entity creations when
+// entity_id is a reference placeholder pointing to a resource being created in the same plan.
 func adjustTeamRoleDependencies(plan *Plan) {
 	if plan == nil {
 		return
@@ -16,8 +16,8 @@ func adjustTeamRoleDependencies(plan *Plan) {
 	adjustTeamRoleDeleteDependencies(plan)
 }
 
-// adjustTeamRoleCreateDependencies wires team role changes to depend on API creations when
-// entity_id is a reference placeholder pointing to an API being created in the same plan.
+// adjustTeamRoleCreateDependencies wires team role changes to depend on entity creations when
+// entity_id is a reference placeholder pointing to a resource being created in the same plan.
 func adjustTeamRoleCreateDependencies(plan *Plan) {
 	changeByKey := make(map[string]string) // resource_type|ref -> changeID
 	for _, change := range plan.Changes {
@@ -49,10 +49,16 @@ func adjustTeamRoleCreateDependencies(plan *Plan) {
 			continue
 		}
 
-		apiKey := string(resources.ResourceTypeAPI) + "|" + parsedRef
-		if apiChangeID, exists := changeByKey[apiKey]; exists {
-			if !containsString(change.DependsOn, apiChangeID) {
-				change.DependsOn = append(change.DependsOn, apiChangeID)
+		entityTypeName, _ := change.Fields[FieldEntityTypeName].(string)
+		entityResourceType, ok := resources.RoleEntityResourceType(entityTypeName)
+		if !ok {
+			continue
+		}
+
+		entityKey := string(entityResourceType) + "|" + parsedRef
+		if entityChangeID, exists := changeByKey[entityKey]; exists {
+			if !containsString(change.DependsOn, entityChangeID) {
+				change.DependsOn = append(change.DependsOn, entityChangeID)
 			}
 		}
 	}
@@ -96,14 +102,50 @@ func adjustTeamRoleDeleteDependencies(plan *Plan) {
 					change.DependsOn = appendDependsOn(change.DependsOn, roleDelete.ID)
 				}
 			}
-		case ResourceTypeAPI:
+		case ResourceTypeAPI, ResourceTypePortal, ResourceTypeControlPlane:
 			for _, roleDelete := range roleDeletes {
-				if teamRoleReferencesEntity(roleDelete, change.ResourceID) {
+				if teamRoleEntityResourceType(roleDelete) == change.ResourceType &&
+					teamRoleReferencesEntity(roleDelete, change.ResourceID) {
 					change.DependsOn = appendDependsOn(change.DependsOn, roleDelete.ID)
 				}
 			}
 		}
 	}
+}
+
+func appendRoleEntityDependency(dependencies []string, plan *Plan, entityID, entityTypeName string) []string {
+	entityRef, _, ok := tags.ParseRefPlaceholder(entityID)
+	if !ok || entityRef == "" {
+		return dependencies
+	}
+
+	entityResourceType, ok := resources.RoleEntityResourceType(entityTypeName)
+	if !ok {
+		return dependencies
+	}
+
+	entityChangeID := findChangeID(plan, string(entityResourceType), entityRef)
+	if entityChangeID == "" || containsString(dependencies, entityChangeID) {
+		return dependencies
+	}
+	return append(dependencies, entityChangeID)
+}
+
+func teamRoleEntityResourceType(roleDelete *PlannedChange) string {
+	if roleDelete == nil {
+		return ""
+	}
+
+	entityTypeName, _ := roleDelete.Fields[FieldEntityTypeName].(string)
+	if entityTypeName == "" {
+		return ResourceTypeAPI
+	}
+
+	resourceType, ok := resources.RoleEntityResourceType(entityTypeName)
+	if !ok {
+		return ""
+	}
+	return string(resourceType)
 }
 
 func teamMembershipBelongsToTeam(change *PlannedChange, teamID string) bool {

--- a/internal/declarative/resources/organization_system_account.go
+++ b/internal/declarative/resources/organization_system_account.go
@@ -2,8 +2,6 @@ package resources
 
 import (
 	"fmt"
-
-	"github.com/kong/kongctl/internal/declarative/tags"
 )
 
 func init() {
@@ -149,13 +147,7 @@ func (r OrganizationSystemAccountRoleResource) GetMoniker() string {
 }
 
 func (r OrganizationSystemAccountRoleResource) GetDependencies() []ResourceRef {
-	deps := []ResourceRef{}
-	if tags.IsRefPlaceholder(r.EntityID) {
-		if ref, _, ok := tags.ParseRefPlaceholder(r.EntityID); ok && ref != "" {
-			deps = append(deps, ResourceRef{Kind: ResourceTypeAPI, Ref: ref})
-		}
-	}
-	return deps
+	return roleEntityDependency(r.EntityID, r.EntityTypeName)
 }
 
 func (r OrganizationSystemAccountRoleResource) Validate() error {

--- a/internal/declarative/resources/organization_team_role.go
+++ b/internal/declarative/resources/organization_team_role.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-
-	"github.com/kong/kongctl/internal/declarative/tags"
 )
 
 func init() {
@@ -96,14 +94,7 @@ func (r OrganizationTeamRoleResource) GetDependencies() []ResourceRef {
 		})
 	}
 
-	if tags.IsRefPlaceholder(r.EntityID) {
-		if ref, _, ok := tags.ParseRefPlaceholder(r.EntityID); ok && ref != "" {
-			deps = append(deps, ResourceRef{
-				Kind: ResourceTypeAPI,
-				Ref:  ref,
-			})
-		}
-	}
+	deps = append(deps, roleEntityDependency(r.EntityID, r.EntityTypeName)...)
 
 	return deps
 }

--- a/internal/declarative/resources/organization_user.go
+++ b/internal/declarative/resources/organization_user.go
@@ -2,8 +2,6 @@ package resources
 
 import (
 	"fmt"
-
-	"github.com/kong/kongctl/internal/declarative/tags"
 )
 
 func init() {
@@ -149,13 +147,7 @@ func (r OrganizationUserRoleResource) GetMoniker() string {
 }
 
 func (r OrganizationUserRoleResource) GetDependencies() []ResourceRef {
-	deps := []ResourceRef{}
-	if tags.IsRefPlaceholder(r.EntityID) {
-		if ref, _, ok := tags.ParseRefPlaceholder(r.EntityID); ok && ref != "" {
-			deps = append(deps, ResourceRef{Kind: ResourceTypeAPI, Ref: ref})
-		}
-	}
-	return deps
+	return roleEntityDependency(r.EntityID, r.EntityTypeName)
 }
 
 func (r OrganizationUserRoleResource) Validate() error {

--- a/internal/declarative/resources/portal_team_role.go
+++ b/internal/declarative/resources/portal_team_role.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-
-	"github.com/kong/kongctl/internal/declarative/tags"
 )
 
 func init() {
@@ -114,17 +112,8 @@ func (r PortalTeamRoleResource) GetDependencies() []ResourceRef {
 		})
 	}
 
-	if tags.IsRefPlaceholder(r.EntityID) {
-		if ref, _, ok := tags.ParseRefPlaceholder(r.EntityID); ok && ref != "" {
-			deps = append(deps, ResourceRef{
-				Kind: ResourceTypeAPI,
-				Ref:  ref,
-			})
-		}
-	}
+	deps = append(deps, roleEntityDependency(r.EntityID, r.EntityTypeName)...)
 
-	// EntityID may be a !ref to another resource; we rely on loader reference
-	// resolution to inject reference metadata rather than explicit dependency here.
 	return deps
 }
 

--- a/internal/declarative/resources/role_entity.go
+++ b/internal/declarative/resources/role_entity.go
@@ -1,0 +1,48 @@
+package resources
+
+import (
+	"strings"
+
+	"github.com/kong/kongctl/internal/declarative/tags"
+)
+
+// RoleEntityResourceType maps Konnect role entity_type_name values to the
+// declarative resource type that can supply the referenced entity_id.
+func RoleEntityResourceType(entityTypeName string) (ResourceType, bool) {
+	switch normalizeRoleEntityTypeName(entityTypeName) {
+	case "api", "apis", "apiproduct", "apiproducts", "service", "services":
+		return ResourceTypeAPI, true
+	case "portal", "portals":
+		return ResourceTypePortal, true
+	case "controlplane", "controlplanes":
+		return ResourceTypeControlPlane, true
+	default:
+		return "", false
+	}
+}
+
+func normalizeRoleEntityTypeName(entityTypeName string) string {
+	normalized := strings.ToLower(strings.TrimSpace(entityTypeName))
+	normalized = strings.ReplaceAll(normalized, " ", "")
+	normalized = strings.ReplaceAll(normalized, "_", "")
+	normalized = strings.ReplaceAll(normalized, "-", "")
+	return normalized
+}
+
+func roleEntityDependency(entityID, entityTypeName string) []ResourceRef {
+	if !tags.IsRefPlaceholder(entityID) {
+		return nil
+	}
+
+	ref, _, ok := tags.ParseRefPlaceholder(entityID)
+	if !ok || ref == "" {
+		return nil
+	}
+
+	resourceType, ok := RoleEntityResourceType(entityTypeName)
+	if !ok {
+		return nil
+	}
+
+	return []ResourceRef{{Kind: resourceType, Ref: ref}}
+}

--- a/internal/declarative/resources/role_entity_test.go
+++ b/internal/declarative/resources/role_entity_test.go
@@ -1,0 +1,83 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/kong/kongctl/internal/declarative/tags"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRoleEntityResourceType(t *testing.T) {
+	tests := []struct {
+		name           string
+		entityTypeName string
+		expected       ResourceType
+		expectedOK     bool
+	}{
+		{
+			name:           "apis",
+			entityTypeName: "APIs",
+			expected:       ResourceTypeAPI,
+			expectedOK:     true,
+		},
+		{
+			name:           "services",
+			entityTypeName: "Services",
+			expected:       ResourceTypeAPI,
+			expectedOK:     true,
+		},
+		{
+			name:           "portals",
+			entityTypeName: "Portals",
+			expected:       ResourceTypePortal,
+			expectedOK:     true,
+		},
+		{
+			name:           "control planes",
+			entityTypeName: "Control Planes",
+			expected:       ResourceTypeControlPlane,
+			expectedOK:     true,
+		},
+		{
+			name:           "unsupported",
+			entityTypeName: "Networks",
+			expectedOK:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, ok := RoleEntityResourceType(tt.entityTypeName)
+			assert.Equal(t, tt.expectedOK, ok)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestOrganizationRoleDependenciesUseEntityTypeName(t *testing.T) {
+	portalEntityID := tags.RefPlaceholderPrefix + "developer-portal#id"
+	controlPlaneEntityID := tags.RefPlaceholderPrefix + "runtime-cp#id"
+
+	assert.Equal(t, []ResourceRef{
+		{Kind: ResourceTypeOrganizationTeam, Ref: "platform-team"},
+		{Kind: ResourceTypePortal, Ref: "developer-portal"},
+	}, OrganizationTeamRoleResource{
+		Team:           "platform-team",
+		EntityID:       portalEntityID,
+		EntityTypeName: "Portals",
+	}.GetDependencies())
+
+	assert.Equal(t, []ResourceRef{
+		{Kind: ResourceTypePortal, Ref: "developer-portal"},
+	}, OrganizationUserRoleResource{
+		EntityID:       portalEntityID,
+		EntityTypeName: "Portals",
+	}.GetDependencies())
+
+	assert.Equal(t, []ResourceRef{
+		{Kind: ResourceTypeControlPlane, Ref: "runtime-cp"},
+	}, OrganizationSystemAccountRoleResource{
+		EntityID:       controlPlaneEntityID,
+		EntityTypeName: "Control Planes",
+	}.GetDependencies())
+}

--- a/test/e2e/harness/builder.go
+++ b/test/e2e/harness/builder.go
@@ -4,6 +4,7 @@ package harness
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -57,19 +58,24 @@ func BinPath() (string, error) {
 		Debugf("Module root located at: %s", modRoot)
 		out := filepath.Join(rd, "bin", exeName("kongctl"))
 		_ = os.MkdirAll(filepath.Dir(out), 0o755)
-		cmd := exec.Command("go", "build", "-trimpath", "-o", out)
+		cmd := exec.Command("go", "build", "-trimpath", "-buildvcs=false", "-o", out)
 		cmd.Dir = modRoot
 		cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 		// Optional ldflags via env for reproducibility if desired.
 		if ld := os.Getenv("KONGCTL_E2E_LDFLAGS"); ld != "" {
 			Debugf("Building with ldflags: %s", ld)
-			cmd = exec.Command("go", "build", "-trimpath", "-ldflags", ld, "-o", out)
+			cmd = exec.Command("go", "build", "-trimpath", "-buildvcs=false", "-ldflags", ld, "-o", out)
 			cmd.Dir = modRoot
 			cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 		}
 		Debugf("Executing: %s (dir=%s)", strings.Join(cmd.Args, " "), cmd.Dir)
-		if err := cmd.Run(); err != nil {
-			buildErr = err
+		if output, err := cmd.CombinedOutput(); err != nil {
+			outputText := strings.TrimSpace(string(output))
+			if outputText != "" {
+				buildErr = fmt.Errorf("%w: %s", err, outputText)
+			} else {
+				buildErr = err
+			}
 			return
 		}
 		Infof("Built kongctl binary: %s", out)

--- a/test/e2e/harness/builder_test.go
+++ b/test/e2e/harness/builder_test.go
@@ -13,6 +13,9 @@ func TestCopyFilePreservesExecutablePermissions(t *testing.T) {
 	if err := os.WriteFile(src, []byte("binary"), 0o755); err != nil {
 		t.Fatalf("write source file: %v", err)
 	}
+	if err := os.Chmod(src, 0o755); err != nil {
+		t.Fatalf("chmod source file: %v", err)
+	}
 
 	dst := filepath.Join(t.TempDir(), "dst")
 	if err := copyFile(src, dst); err != nil {

--- a/test/e2e/scenarios/org/teams/roles/overlays/004-portal-entity-ref/config.yaml
+++ b/test/e2e/scenarios/org/teams/roles/overlays/004-portal-entity-ref/config.yaml
@@ -1,0 +1,29 @@
+_defaults:
+  kongctl:
+    namespace: "{{ .vars.portalRoleNamespace }}"
+
+apis: []
+
+portals:
+  - ref: "{{ .vars.portalRef }}"
+    name: "{{ .vars.portalName }}"
+    display_name: "{{ .vars.portalName }}"
+    description: Portal used by the organization team role entity ref E2E scenario
+    authentication_enabled: false
+    rbac_enabled: false
+    auto_approve_developers: false
+    auto_approve_applications: false
+    default_api_visibility: public
+    default_page_visibility: private
+
+organization:
+  teams:
+    - ref: "{{ .vars.portalRoleTeamRef }}"
+      name: "{{ .vars.portalRoleTeamName }}"
+      description: Team used by the organization team role portal ref E2E scenario
+      roles:
+        - ref: "{{ .vars.portalViewerRoleRef }}"
+          role_name: Viewer
+          entity_id: !ref {{ .vars.portalRef }}#id
+          entity_type_name: Portals
+          entity_region: us

--- a/test/e2e/scenarios/org/teams/roles/scenario.yaml
+++ b/test/e2e/scenarios/org/teams/roles/scenario.yaml
@@ -11,6 +11,12 @@ vars:
   teamName: Platform Role Team
   viewerRoleRef: platform-api-viewer
   adminRoleRef: platform-api-admin
+  portalRoleNamespace: org-team-roles-portal-ref-e2e
+  portalRef: org-team-roles-portal-ref
+  portalName: org-team-roles-portal-ref
+  portalRoleTeamRef: portal-role-team
+  portalRoleTeamName: Portal Role Team
+  portalViewerRoleRef: portal-viewer
 
 defaults:
   mask:
@@ -485,3 +491,56 @@ steps:
               fields:
                 failed: 0
                 status: success
+
+  - name: 008-plan-portal-entity-ref
+    inputOverlayDirs:
+      - overlays/004-portal-entity-ref
+    commands:
+      - name: 000-plan-portal-entity-ref
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 3
+                by_action.CREATE: 3
+          - select: >-
+              changes[?resource_type=='portal' &&
+                      resource_ref=='{{ .vars.portalRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                namespace: "{{ .vars.portalRoleNamespace }}"
+                fields.name: "{{ .vars.portalName }}"
+          - select: >-
+              changes[?resource_type=='organization_team' &&
+                      resource_ref=='{{ .vars.portalRoleTeamRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                namespace: "{{ .vars.portalRoleNamespace }}"
+                fields.name: "{{ .vars.portalRoleTeamName }}"
+          - select: >-
+              changes[?resource_type=='organization_team_role' &&
+                      resource_ref=='{{ .vars.portalViewerRoleRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                namespace: "{{ .vars.portalRoleNamespace }}"
+                fields.role_name: Viewer
+                fields.entity_id: "__REF__:{{ .vars.portalRef }}#id"
+                fields.entity_type_name: Portals
+                fields.entity_region: us
+                references.entity_id.ref: "__REF__:{{ .vars.portalRef }}#id"
+                "contains(depends_on, '1:c:portal:org-team-roles-portal-ref')": true
+                "contains(depends_on, '2:c:organization_team:portal-role-team')": true


### PR DESCRIPTION
## Summary

Fixes #1135 by resolving `entity_id` refs for role assignments according to the API-level `entity_type_name` field instead of assuming every role entity ref points at an API.

## What Changed

- Added shared role entity type mapping for `APIs`, `Portals`, and control planes.
- Updated loader validation, resource dependencies, planner dependencies, reference resolution, and executor ref resolution to use that mapping.
- Added unit coverage for portal role entity refs and mismatched role entity refs.
- Added an e2e org team roles scenario covering `entity_id: !ref <portal>#id` with `entity_type_name: Portals`.
- Updated the organization declarative examples to show `!ref` usage in role `entity_id` for API and portal resources.
- Made the e2e binary builder use `-buildvcs=false` and report build output so local worktree VCS stamping failures are actionable.

## Validation

- `go test ./internal/declarative/planner`
- `go test ./internal/declarative/...`
- `go test ./internal/declarative/loader`
- `go test ./internal/declarative/resources`
- `go test -tags=e2e ./test/e2e/harness/...`
- `make test-e2e-scenarios SCENARIO=org/teams/roles`
- `make lint`
- `make test`
- `git diff --check`

`make build` was also verified via `GOFLAGS=-buildvcs=false make build` because this local worktree triggers Go VCS stamping from `/home/rspurgeon` outside the git root.