### PR TITLE
Feat: add imperative Konnect token commands

### DIFF
--- a/internal/cmd/common/common.go
+++ b/internal/cmd/common/common.go
@@ -14,6 +14,8 @@ const (
 	YAML
 	TEXT
 	HELM
+	TOKEN
+	ENV
 )
 
 // ExtraOutputFormatsAnnotation is the cobra command-annotation key listing
@@ -98,7 +100,7 @@ const (
 )
 
 func (of OutputFormat) String() string {
-	return [...]string{"json", "yaml", "text", "helm"}[of]
+	return [...]string{"json", "yaml", "text", "helm", "token", "env"}[of]
 }
 
 func OutputFormatStringToIota(format string) (OutputFormat, error) {
@@ -111,6 +113,10 @@ func OutputFormatStringToIota(format string) (OutputFormat, error) {
 		return TEXT, nil
 	case "helm":
 		return HELM, nil
+	case "token":
+		return TOKEN, nil
+	case "env":
+		return ENV, nil
 	default:
 		allowed := []string{"json", "yaml", "text"}
 		return TEXT, fmt.Errorf("invalid output format %q, must be one of %v", format, allowed)

--- a/internal/cmd/root/products/konnect/konnect.go
+++ b/internal/cmd/root/products/konnect/konnect.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/organization"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/portal"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/regions"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/token"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/meta"
@@ -220,6 +221,14 @@ func NewKonnectCmd(verb verbs.VerbValue) (*cobra.Command, error) {
 		return newLogoutKonnectCmd(verb, cmd, addFlags, preRunE).Command, nil
 	}
 
+	if verb == verbs.Create {
+		if err := addTokenCommands(cmd, verb, addFlags, preRunE); err != nil {
+			return nil, err
+		}
+		addFlags(verb, cmd)
+		return cmd, nil
+	}
+
 	// Do not expose audit-logs under `create`, which is reserved for
 	// resource creation flows.
 	if verb == verbs.Listen {
@@ -313,6 +322,12 @@ func NewKonnectCmd(verb verbs.VerbValue) (*cobra.Command, error) {
 	}
 	cmd.AddCommand(c)
 
+	if verb == verbs.Get {
+		if err := addDirectTokenCommands(cmd, verb, addFlags, preRunE); err != nil {
+			return nil, err
+		}
+	}
+
 	// Add portal command
 	pc, e := portal.NewPortalCmd(verb, addFlags, preRunE)
 	if e != nil {
@@ -395,4 +410,44 @@ func NewKonnectCmd(verb verbs.VerbValue) (*cobra.Command, error) {
 	}
 
 	return cmd, e
+}
+
+func addTokenCommands(
+	cmd *cobra.Command,
+	verb verbs.VerbValue,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) error {
+	if err := addDirectTokenCommands(cmd, verb, addParentFlags, parentPreRun); err != nil {
+		return err
+	}
+
+	orgCmd, err := organization.NewOrganizationCmd(verb, addParentFlags, parentPreRun)
+	if err != nil {
+		return err
+	}
+	cmd.AddCommand(orgCmd)
+
+	return nil
+}
+
+func addDirectTokenCommands(
+	cmd *cobra.Command,
+	verb verbs.VerbValue,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) error {
+	patCmd, err := token.NewPATCmd(verb, addParentFlags, parentPreRun)
+	if err != nil {
+		return err
+	}
+	cmd.AddCommand(patCmd)
+
+	spatCmd, err := token.NewSPATCmd(verb, addParentFlags, parentPreRun)
+	if err != nil {
+		return err
+	}
+	cmd.AddCommand(spatCmd)
+
+	return nil
 }

--- a/internal/cmd/root/products/konnect/organization/organization.go
+++ b/internal/cmd/root/products/konnect/organization/organization.go
@@ -3,6 +3,7 @@ package organization
 import (
 	"fmt"
 
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/organization/systemaccount"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	"github.com/kong/kongctl/internal/meta"
 	"github.com/kong/kongctl/internal/util/i18n"
@@ -51,6 +52,21 @@ func NewOrganizationCmd(verb verbs.VerbValue,
 	}
 	if verb == verbs.Adopt {
 		return newAdoptOrganizationCmd(verb, &baseCmd, addParentFlags, parentPreRun).Command, nil
+	}
+	if verb == verbs.Create || verb == verbs.Delete {
+		if parentPreRun != nil {
+			baseCmd.PreRunE = parentPreRun
+		}
+		if addParentFlags != nil {
+			addParentFlags(verb, &baseCmd)
+		}
+
+		systemAccountCmd, err := systemaccount.NewSystemAccountCmd(verb, addParentFlags, parentPreRun)
+		if err != nil {
+			return nil, err
+		}
+		baseCmd.AddCommand(systemAccountCmd)
+		return &baseCmd, nil
 	}
 
 	// Return base command for unsupported verbs

--- a/internal/cmd/root/products/konnect/organization/systemaccount/systemaccount.go
+++ b/internal/cmd/root/products/konnect/organization/systemaccount/systemaccount.go
@@ -3,6 +3,7 @@ package systemaccount
 import (
 	"fmt"
 
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/token"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	"github.com/kong/kongctl/internal/meta"
 	"github.com/kong/kongctl/internal/util/i18n"
@@ -50,7 +51,24 @@ func NewSystemAccountCmd(
 		cmd := newGetSystemAccountCmd(verb, &baseCmd, addParentFlags, parentPreRun)
 		cmd.AddCommand(newGetSystemAccountRolesCmd(verb, addParentFlags, parentPreRun))
 		cmd.AddCommand(newGetSystemAccountTeamsCmd(verb, addParentFlags, parentPreRun))
+		if spatCmd, err := token.NewSPATCmd(verb, addParentFlags, parentPreRun); err == nil && spatCmd != nil {
+			cmd.AddCommand(spatCmd)
+		}
 		return cmd.Command, nil
+	}
+	if verb == verbs.Create || verb == verbs.Delete {
+		if parentPreRun != nil {
+			baseCmd.PreRunE = parentPreRun
+		}
+		if addParentFlags != nil {
+			addParentFlags(verb, &baseCmd)
+		}
+		spatCmd, err := token.NewSPATCmd(verb, addParentFlags, parentPreRun)
+		if err != nil {
+			return nil, err
+		}
+		baseCmd.AddCommand(spatCmd)
+		return &baseCmd, nil
 	}
 
 	// Return base command for unsupported verbs

--- a/internal/cmd/root/products/konnect/organization/systemaccount/systemaccount.go
+++ b/internal/cmd/root/products/konnect/organization/systemaccount/systemaccount.go
@@ -51,7 +51,11 @@ func NewSystemAccountCmd(
 		cmd := newGetSystemAccountCmd(verb, &baseCmd, addParentFlags, parentPreRun)
 		cmd.AddCommand(newGetSystemAccountRolesCmd(verb, addParentFlags, parentPreRun))
 		cmd.AddCommand(newGetSystemAccountTeamsCmd(verb, addParentFlags, parentPreRun))
-		if spatCmd, err := token.NewSPATCmd(verb, addParentFlags, parentPreRun); err == nil && spatCmd != nil {
+		spatCmd, err := token.NewSPATCmd(verb, addParentFlags, parentPreRun)
+		if err != nil {
+			return nil, err
+		}
+		if spatCmd != nil {
 			cmd.AddCommand(spatCmd)
 		}
 		return cmd.Command, nil

--- a/internal/cmd/root/products/konnect/token/token.go
+++ b/internal/cmd/root/products/konnect/token/token.go
@@ -1,0 +1,1099 @@
+package token
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	cmdpkg "github.com/kong/kongctl/internal/cmd"
+	cmdcommon "github.com/kong/kongctl/internal/cmd/common"
+	"github.com/kong/kongctl/internal/cmd/output/jq"
+	konnectcommon "github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
+	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/kong/kongctl/internal/config"
+	"github.com/kong/kongctl/internal/konnect/helpers"
+	"github.com/kong/kongctl/internal/meta"
+	"github.com/kong/kongctl/internal/util"
+	utilviper "github.com/kong/kongctl/internal/util/viper"
+	"github.com/segmentio/cli"
+	"github.com/spf13/cobra"
+)
+
+const (
+	PATCommandName  = "pat"
+	SPATCommandName = "spat"
+
+	flagName              = "name"
+	flagUserID            = "user-id"
+	flagExpiresIn         = "expires-in"
+	flagExpiresAt         = "expires-at"
+	flagSystemAccountID   = "system-account-id"
+	flagSystemAccountName = "system-account-name"
+
+	expiresInHelp = "Token lifetime. Accepts Go durations with ns, us, ms, s, m, h, " +
+		"plus numeric days with d. Examples: 90m, 12h, 30d."
+	expiresAtHelp        = "Token expiration timestamp in RFC3339 format, for example 2026-06-24T12:00:00Z."
+	expiresInExpectation = "use a positive duration like 90m, 12h, or 30d " +
+		"(supported units: ns, us, ms, s, m, h, d)"
+)
+
+type expiration struct {
+	ExpiresAt  *time.Time
+	TTLSeconds *int64
+}
+
+type createTokenRecord struct {
+	Type              string `json:"type"                          yaml:"type"`
+	ID                string `json:"id,omitempty"                  yaml:"id,omitempty"`
+	Name              string `json:"name,omitempty"                yaml:"name,omitempty"`
+	Token             string `json:"token"                         yaml:"token"`
+	UserID            string `json:"user_id,omitempty"             yaml:"user_id,omitempty"`
+	SystemAccountID   string `json:"system_account_id,omitempty"   yaml:"system_account_id,omitempty"`
+	SystemAccountName string `json:"system_account_name,omitempty" yaml:"system_account_name,omitempty"`
+	State             string `json:"state,omitempty"               yaml:"state,omitempty"`
+	CreatedAt         string `json:"created_at,omitempty"          yaml:"created_at,omitempty"`
+	UpdatedAt         string `json:"updated_at,omitempty"          yaml:"updated_at,omitempty"`
+	LastUsedAt        string `json:"last_used_at,omitempty"        yaml:"last_used_at,omitempty"`
+	ExpiresAt         string `json:"expires_at,omitempty"          yaml:"expires_at,omitempty"`
+}
+
+type getTokenRecord struct {
+	Type              string `json:"type"                          yaml:"type"`
+	ID                string `json:"id,omitempty"                  yaml:"id,omitempty"`
+	Name              string `json:"name,omitempty"                yaml:"name,omitempty"`
+	UserID            string `json:"user_id,omitempty"             yaml:"user_id,omitempty"`
+	SystemAccountID   string `json:"system_account_id,omitempty"   yaml:"system_account_id,omitempty"`
+	SystemAccountName string `json:"system_account_name,omitempty" yaml:"system_account_name,omitempty"`
+	State             string `json:"state,omitempty"               yaml:"state,omitempty"`
+	CreatedAt         string `json:"created_at,omitempty"          yaml:"created_at,omitempty"`
+	UpdatedAt         string `json:"updated_at,omitempty"          yaml:"updated_at,omitempty"`
+	LastUsedAt        string `json:"last_used_at,omitempty"        yaml:"last_used_at,omitempty"`
+	ExpiresAt         string `json:"expires_at,omitempty"          yaml:"expires_at,omitempty"`
+}
+
+type deleteTokenRecord struct {
+	Type   string `json:"type"           yaml:"type"`
+	ID     string `json:"id,omitempty"   yaml:"id,omitempty"`
+	Name   string `json:"name,omitempty" yaml:"name,omitempty"`
+	Status string `json:"status"         yaml:"status"`
+}
+
+type patOptions struct {
+	name      string
+	userID    string
+	expiresIn string
+	expiresAt string
+}
+
+type spatOptions struct {
+	name              string
+	systemAccountID   string
+	systemAccountName string
+	expiresIn         string
+	expiresAt         string
+}
+
+func NewPATCmd(
+	verb verbs.VerbValue,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:     PATCommandName + " [id|name]",
+		Short:   "Manage Konnect personal access tokens",
+		Aliases: []string{"pats"},
+	}
+
+	if addParentFlags != nil {
+		addParentFlags(verb, cmd)
+	}
+	if parentPreRun != nil {
+		cmd.PreRunE = parentPreRun
+	}
+
+	opts := &patOptions{}
+	if verb == verbs.Create {
+		cmd.Use = PATCommandName
+		cmd.Short = "Create a Konnect personal access token"
+		cmd.Example = fmt.Sprintf(`  %[1]s create pat --name ci --expires-in 30d -o token
+  %[1]s create pat --name ci --expires-in 12h --jq -r '.token'`, meta.CLIName)
+		cmd.Args = createTokenArgs
+		addPATCreateFlags(cmd, opts)
+		cmdcommon.AllowExtraOutputFormats(cmd, cmdcommon.TOKEN.String(), cmdcommon.ENV.String())
+		cmd.RunE = func(c *cobra.Command, args []string) error {
+			return runCreatePAT(c, args, opts)
+		}
+		return cmd, nil
+	}
+	if verb == verbs.Get {
+		cmd.Short = "List or get Konnect personal access tokens"
+		cmd.Example = fmt.Sprintf(`  %[1]s get pat
+  %[1]s get pat <id|name>
+  %[1]s get pat --jq '.[] | {id,name,expires_at}'`, meta.CLIName)
+		cmd.Args = cobra.MaximumNArgs(1)
+		cmd.Flags().StringVar(&opts.userID, flagUserID, "", "Konnect user ID. Defaults to the authenticated user.")
+		cmd.RunE = func(c *cobra.Command, args []string) error {
+			return runGetPAT(c, args, opts)
+		}
+		return cmd, nil
+	}
+	if verb == verbs.Delete {
+		cmd.Short = "Delete a Konnect personal access token"
+		cmd.Example = fmt.Sprintf(`  %[1]s delete pat <id|name> --auto-approve`, meta.CLIName)
+		cmd.Args = cobra.ExactArgs(1)
+		cmd.Flags().StringVar(&opts.userID, flagUserID, "", "Konnect user ID. Defaults to the authenticated user.")
+		cmd.RunE = func(c *cobra.Command, args []string) error {
+			return runDeletePAT(c, args, opts)
+		}
+		return cmd, nil
+	}
+
+	return cmd, nil
+}
+
+func NewSPATCmd(
+	verb verbs.VerbValue,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:     SPATCommandName + " [id|name]",
+		Short:   "Manage Konnect system account access tokens",
+		Aliases: []string{"spats"},
+	}
+
+	if addParentFlags != nil {
+		addParentFlags(verb, cmd)
+	}
+	if parentPreRun != nil {
+		cmd.PreRunE = parentPreRun
+	}
+
+	opts := &spatOptions{}
+	if verb == verbs.Create {
+		cmd.Use = SPATCommandName
+		cmd.Short = "Create a Konnect system account access token"
+		cmd.Example = fmt.Sprintf(
+			`  %[1]s create spat --system-account-name ci-bot --name ci --expires-at 2026-06-24T12:00:00Z -o env`,
+			meta.CLIName,
+		)
+		cmd.Args = createTokenArgs
+		addSPATCreateFlags(cmd, opts)
+		addSystemAccountFlags(cmd, opts)
+		cmdcommon.AllowExtraOutputFormats(cmd, cmdcommon.TOKEN.String(), cmdcommon.ENV.String())
+		cmd.RunE = func(c *cobra.Command, args []string) error {
+			return runCreateSPAT(c, args, opts)
+		}
+		return cmd, nil
+	}
+	if verb == verbs.Get {
+		cmd.Short = "List or get Konnect system account access tokens"
+		cmd.Example = fmt.Sprintf(`  %[1]s get spat --system-account-id <system-account-id>
+  %[1]s get spat --system-account-name ci-bot <id|name>`, meta.CLIName)
+		cmd.Args = cobra.MaximumNArgs(1)
+		addSystemAccountFlags(cmd, opts)
+		cmd.RunE = func(c *cobra.Command, args []string) error {
+			return runGetSPAT(c, args, opts)
+		}
+		return cmd, nil
+	}
+	if verb == verbs.Delete {
+		cmd.Short = "Delete a Konnect system account access token"
+		cmd.Example = fmt.Sprintf(`  %[1]s delete spat ci --system-account-name ci-bot --auto-approve`, meta.CLIName)
+		cmd.Args = cobra.ExactArgs(1)
+		addSystemAccountFlags(cmd, opts)
+		cmd.RunE = func(c *cobra.Command, args []string) error {
+			return runDeleteSPAT(c, args, opts)
+		}
+		return cmd, nil
+	}
+
+	return cmd, nil
+}
+
+func addPATCreateFlags(cmd *cobra.Command, opts *patOptions) {
+	cmd.Flags().StringVar(&opts.name, flagName, "", "Token name")
+	cmd.Flags().StringVar(&opts.userID, flagUserID, "", "Konnect user ID. Defaults to the authenticated user.")
+	cmd.Flags().StringVar(&opts.expiresIn, flagExpiresIn, "", expiresInHelp)
+	cmd.Flags().StringVar(&opts.expiresAt, flagExpiresAt, "", expiresAtHelp)
+}
+
+func addSPATCreateFlags(cmd *cobra.Command, opts *spatOptions) {
+	cmd.Flags().StringVar(&opts.name, flagName, "", "Token name")
+	cmd.Flags().StringVar(&opts.expiresIn, flagExpiresIn, "", expiresInHelp)
+	cmd.Flags().StringVar(&opts.expiresAt, flagExpiresAt, "", expiresAtHelp)
+}
+
+func addSystemAccountFlags(cmd *cobra.Command, opts *spatOptions) {
+	cmd.Flags().StringVar(&opts.systemAccountID, flagSystemAccountID, "", "Konnect system account ID")
+	cmd.Flags().StringVar(&opts.systemAccountName, flagSystemAccountName, "", "Konnect system account name")
+}
+
+func createTokenArgs(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return nil
+	}
+	if len(args) == 1 {
+		if flag := cmd.Flags().Lookup(jq.FlagName); flag != nil && flag.Changed && flag.Value.String() == "-r" {
+			return nil
+		}
+	}
+	return cobra.NoArgs(cmd, args)
+}
+
+func applyCreateJQExpressionArg(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return nil
+	}
+	flag := cmd.Flags().Lookup(jq.FlagName)
+	if flag == nil || !flag.Changed || flag.Value.String() != "-r" {
+		return nil
+	}
+	if err := cmd.Flags().Set(jq.FlagName, args[0]); err != nil {
+		return err
+	}
+	return cmd.Flags().Set(jq.RawOutputFlagName, "true")
+}
+
+func runCreatePAT(c *cobra.Command, args []string, opts *patOptions) error {
+	helper := cmdpkg.BuildHelper(c, args)
+	if err := applyCreateJQExpressionArg(c, args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(opts.name) == "" {
+		return &cmdpkg.ConfigurationError{Err: fmt.Errorf("--%s is required", flagName)}
+	}
+
+	exp, err := parseExpiration(opts.expiresIn, opts.expiresAt)
+	if err != nil {
+		return err
+	}
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return err
+	}
+
+	userID, err := resolveUserID(opts.userID, sdk.GetMeAPI(), helper)
+	if err != nil {
+		return err
+	}
+
+	api := sdk.GetPersonalAccessTokenAPI()
+	if api == nil {
+		return cmdpkg.PrepareExecutionErrorMsg(helper, "personal access token API is unavailable")
+	}
+
+	request := patCreateRequest(strings.TrimSpace(opts.name), exp)
+	res, err := api.CreatePersonalAccessToken(helper.GetContext(), userID, &request)
+	if err != nil {
+		attrs := cmdpkg.TryConvertErrorToAttrs(err)
+		return cmdpkg.PrepareExecutionError("Failed to create personal access token", err, helper.GetCmd(), attrs...)
+	}
+	record := createPATRecord(res.GetPersonalAccessTokenCreateResponse())
+	return renderCreateRecord(helper, record)
+}
+
+func runGetPAT(c *cobra.Command, args []string, opts *patOptions) error {
+	helper := cmdpkg.BuildHelper(c, args)
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return err
+	}
+
+	userID, err := resolveUserID(opts.userID, sdk.GetMeAPI(), helper)
+	if err != nil {
+		return err
+	}
+	api := sdk.GetPersonalAccessTokenAPI()
+	if api == nil {
+		return cmdpkg.PrepareExecutionErrorMsg(helper, "personal access token API is unavailable")
+	}
+
+	if len(args) == 0 {
+		tokens, err := listPATs(api, helper, userID)
+		if err != nil {
+			return err
+		}
+		records := make([]getTokenRecord, 0, len(tokens))
+		for i := range tokens {
+			records = append(records, patRecord(&tokens[i]))
+		}
+		return renderGetRecords(helper, records)
+	}
+
+	token, err := resolvePAT(args[0], api, helper, userID)
+	if err != nil {
+		return err
+	}
+	return renderGetRecords(helper, patRecord(token))
+}
+
+func runDeletePAT(c *cobra.Command, args []string, opts *patOptions) error {
+	helper := cmdpkg.BuildHelper(c, args)
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return err
+	}
+
+	userID, err := resolveUserID(opts.userID, sdk.GetMeAPI(), helper)
+	if err != nil {
+		return err
+	}
+	api := sdk.GetPersonalAccessTokenAPI()
+	if api == nil {
+		return cmdpkg.PrepareExecutionErrorMsg(helper, "personal access token API is unavailable")
+	}
+
+	token, err := resolvePAT(args[0], api, helper, userID)
+	if err != nil {
+		return err
+	}
+	record := patDeleteRecord(token)
+	if err := cmdpkg.ConfirmDelete(helper, fmt.Sprintf("personal access token %q", record.Name)); err != nil {
+		return err
+	}
+	if _, err := api.DeletePersonalAccessToken(helper.GetContext(), userID, token.ID); err != nil {
+		attrs := cmdpkg.TryConvertErrorToAttrs(err)
+		return cmdpkg.PrepareExecutionError("Failed to delete personal access token", err, helper.GetCmd(), attrs...)
+	}
+	record.Status = "deleted"
+	return renderDeleteRecord(helper, record)
+}
+
+func runCreateSPAT(c *cobra.Command, args []string, opts *spatOptions) error {
+	helper := cmdpkg.BuildHelper(c, args)
+	if err := applyCreateJQExpressionArg(c, args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(opts.name) == "" {
+		return &cmdpkg.ConfigurationError{Err: fmt.Errorf("--%s is required", flagName)}
+	}
+	if err := validateSystemAccountSelector(opts.systemAccountID, opts.systemAccountName); err != nil {
+		return err
+	}
+
+	exp, err := parseExpiration(opts.expiresIn, opts.expiresAt)
+	if err != nil {
+		return err
+	}
+	expiresAt := expirationToTime(exp)
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return err
+	}
+
+	accountID, accountName, err := resolveSystemAccount(opts.systemAccountID, opts.systemAccountName, sdk, helper, cfg)
+	if err != nil {
+		return err
+	}
+	api := sdk.GetSystemAccountAccessTokenAPI()
+	if api == nil {
+		return cmdpkg.PrepareExecutionErrorMsg(helper, "system account access token API is unavailable")
+	}
+
+	request := &kkComps.CreateSystemAccountAccessToken{
+		Name:      strings.TrimSpace(opts.name),
+		ExpiresAt: expiresAt,
+	}
+	res, err := api.PostSystemAccountsIDAccessTokens(helper.GetContext(), accountID, request)
+	if err != nil {
+		attrs := cmdpkg.TryConvertErrorToAttrs(err)
+		return cmdpkg.PrepareExecutionError("Failed to create system account access token", err, helper.GetCmd(), attrs...)
+	}
+	record := createSPATRecord(res.GetSystemAccountAccessTokenCreated(), accountID, accountName)
+	return renderCreateRecord(helper, record)
+}
+
+func runGetSPAT(c *cobra.Command, args []string, opts *spatOptions) error {
+	helper := cmdpkg.BuildHelper(c, args)
+	if err := validateSystemAccountSelector(opts.systemAccountID, opts.systemAccountName); err != nil {
+		return err
+	}
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return err
+	}
+
+	accountID, accountName, err := resolveSystemAccount(opts.systemAccountID, opts.systemAccountName, sdk, helper, cfg)
+	if err != nil {
+		return err
+	}
+	api := sdk.GetSystemAccountAccessTokenAPI()
+	if api == nil {
+		return cmdpkg.PrepareExecutionErrorMsg(helper, "system account access token API is unavailable")
+	}
+
+	if len(args) == 0 {
+		tokens, err := listSPATs(api, helper, cfg, accountID, "")
+		if err != nil {
+			return err
+		}
+		records := make([]getTokenRecord, 0, len(tokens))
+		for i := range tokens {
+			records = append(records, spatRecord(&tokens[i], accountID, accountName))
+		}
+		return renderGetRecords(helper, records)
+	}
+
+	token, err := resolveSPAT(args[0], api, helper, cfg, accountID)
+	if err != nil {
+		return err
+	}
+	return renderGetRecords(helper, spatRecord(token, accountID, accountName))
+}
+
+func runDeleteSPAT(c *cobra.Command, args []string, opts *spatOptions) error {
+	helper := cmdpkg.BuildHelper(c, args)
+	if err := validateSystemAccountSelector(opts.systemAccountID, opts.systemAccountName); err != nil {
+		return err
+	}
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return err
+	}
+
+	accountID, accountName, err := resolveSystemAccount(opts.systemAccountID, opts.systemAccountName, sdk, helper, cfg)
+	if err != nil {
+		return err
+	}
+	api := sdk.GetSystemAccountAccessTokenAPI()
+	if api == nil {
+		return cmdpkg.PrepareExecutionErrorMsg(helper, "system account access token API is unavailable")
+	}
+
+	token, err := resolveSPAT(args[0], api, helper, cfg, accountID)
+	if err != nil {
+		return err
+	}
+	record := spatDeleteRecord(token)
+	if err := cmdpkg.ConfirmDelete(helper, fmt.Sprintf("system account access token %q", record.Name)); err != nil {
+		return err
+	}
+	tokenID := pointerValue(token.ID)
+	if _, err := api.DeleteSystemAccountsIDAccessTokensID(helper.GetContext(), accountID, tokenID); err != nil {
+		attrs := cmdpkg.TryConvertErrorToAttrs(err)
+		return cmdpkg.PrepareExecutionError("Failed to delete system account access token", err, helper.GetCmd(), attrs...)
+	}
+	record.Status = "deleted"
+	if record.Name == "" {
+		record.Name = accountName
+	}
+	return renderDeleteRecord(helper, record)
+}
+
+func resolveUserID(userID string, meAPI helpers.MeAPI, helper cmdpkg.Helper) (string, error) {
+	if value := strings.TrimSpace(userID); value != "" {
+		return value, nil
+	}
+	if meAPI == nil {
+		return "", cmdpkg.PrepareExecutionErrorMsg(helper, "current user lookup API is unavailable")
+	}
+
+	res, err := meAPI.GetUsersMe(helper.GetContext())
+	if err != nil {
+		attrs := cmdpkg.TryConvertErrorToAttrs(err)
+		return "", cmdpkg.PrepareExecutionError("Failed to get current user", err, helper.GetCmd(), attrs...)
+	}
+	user := res.GetUser()
+	if user == nil || user.GetID() == nil || strings.TrimSpace(*user.GetID()) == "" {
+		return "", cmdpkg.PrepareExecutionErrorMsg(helper, "current user response did not include an id")
+	}
+	return strings.TrimSpace(*user.GetID()), nil
+}
+
+//nolint:staticcheck
+func patCreateRequest(name string, exp expiration) kkComps.PersonalAccessTokenCreateRequest {
+	if exp.TTLSeconds != nil {
+		return kkComps.CreatePersonalAccessTokenCreateRequestPersonalAccessTokenCreateRequestWithTTL(
+			kkComps.PersonalAccessTokenCreateRequestWithTTL{
+				Name:       name,
+				TTLSeconds: *exp.TTLSeconds,
+			},
+		)
+	}
+	return kkComps.CreatePersonalAccessTokenCreateRequestPersonalAccessTokenCreateRequestWithExpiresAt(
+		kkComps.PersonalAccessTokenCreateRequestWithExpiresAt{
+			Name:      name,
+			ExpiresAt: *exp.ExpiresAt,
+		},
+	)
+}
+
+func listPATs(
+	api helpers.PersonalAccessTokenAPI,
+	helper cmdpkg.Helper,
+	userID string,
+) ([]kkComps.PersonalAccessToken, error) {
+	res, err := api.ListUsersPersonalAccessTokens(helper.GetContext(), userID)
+	if err != nil {
+		attrs := cmdpkg.TryConvertErrorToAttrs(err)
+		return nil, cmdpkg.PrepareExecutionError("Failed to list personal access tokens", err, helper.GetCmd(), attrs...)
+	}
+	list := res.GetPersonalAccessTokenListResponse()
+	if list == nil {
+		return nil, nil
+	}
+	return list.GetData(), nil
+}
+
+func resolvePAT(
+	identifier string,
+	api helpers.PersonalAccessTokenAPI,
+	helper cmdpkg.Helper,
+	userID string,
+) (*kkComps.PersonalAccessToken, error) {
+	identifier = strings.TrimSpace(identifier)
+	if util.IsValidUUID(identifier) {
+		res, err := api.GetPersonalAccessTokenDetails(helper.GetContext(), userID, identifier)
+		if err != nil {
+			attrs := cmdpkg.TryConvertErrorToAttrs(err)
+			return nil, cmdpkg.PrepareExecutionError("Failed to get personal access token", err, helper.GetCmd(), attrs...)
+		}
+		return res.GetPersonalAccessToken(), nil
+	}
+
+	tokens, err := listPATs(api, helper, userID)
+	if err != nil {
+		return nil, err
+	}
+	matches := make([]kkComps.PersonalAccessToken, 0, 1)
+	for i := range tokens {
+		if tokens[i].Name == identifier {
+			matches = append(matches, tokens[i])
+		}
+	}
+	if len(matches) == 0 {
+		return nil, cmdpkg.PrepareExecutionErrorMsg(helper,
+			fmt.Sprintf("personal access token %q not found", identifier))
+	}
+	if len(matches) > 1 {
+		return nil, cmdpkg.PrepareExecutionErrorMsg(helper,
+			fmt.Sprintf("multiple personal access tokens found with name %q; use an id", identifier))
+	}
+	return &matches[0], nil
+}
+
+func validateSystemAccountSelector(id, name string) error {
+	hasID := strings.TrimSpace(id) != ""
+	hasName := strings.TrimSpace(name) != ""
+	if hasID == hasName {
+		return &cmdpkg.ConfigurationError{
+			Err: fmt.Errorf("exactly one of --%s or --%s is required", flagSystemAccountID, flagSystemAccountName),
+		}
+	}
+	return nil
+}
+
+func resolveSystemAccount(
+	id string,
+	name string,
+	sdk helpers.SDKAPI,
+	helper cmdpkg.Helper,
+	cfg config.Hook,
+) (string, string, error) {
+	id = strings.TrimSpace(id)
+	name = strings.TrimSpace(name)
+	if id != "" {
+		return id, name, nil
+	}
+
+	api := sdk.GetSystemAccountAPI()
+	if api == nil {
+		return "", "", cmdpkg.PrepareExecutionErrorMsg(helper, "system account API is unavailable")
+	}
+	accounts, err := listSystemAccountsByName(name, api, helper, cfg)
+	if err != nil {
+		return "", "", err
+	}
+	if len(accounts) == 0 {
+		return "", "", cmdpkg.PrepareExecutionErrorMsg(helper, fmt.Sprintf("system account %q not found", name))
+	}
+	if len(accounts) > 1 {
+		return "", "", cmdpkg.PrepareExecutionErrorMsg(helper,
+			fmt.Sprintf("multiple system accounts found with name %q; use --%s", name, flagSystemAccountID))
+	}
+	accountID := pointerValue(accounts[0].ID)
+	if accountID == "" {
+		return "", "", cmdpkg.PrepareExecutionErrorMsg(helper,
+			fmt.Sprintf("system account %q did not include an id", name))
+	}
+	return accountID, pointerValue(accounts[0].Name), nil
+}
+
+func listSystemAccountsByName(
+	name string,
+	api helpers.SystemAccountAPI,
+	helper cmdpkg.Helper,
+	cfg config.Hook,
+) ([]kkComps.SystemAccount, error) {
+	pageSize := requestPageSize(cfg)
+	pageNumber := int64(1)
+	var allData []kkComps.SystemAccount
+
+	for {
+		req := kkOps.GetSystemAccountsRequest{
+			PageSize:   &pageSize,
+			PageNumber: &pageNumber,
+			Filter: &kkOps.GetSystemAccountsQueryParamFilter{
+				Name: &kkComps.LegacyStringFieldFilter{Eq: &name},
+			},
+		}
+		res, err := api.ListSystemAccounts(helper.GetContext(), req)
+		if err != nil {
+			attrs := cmdpkg.TryConvertErrorToAttrs(err)
+			return nil, cmdpkg.PrepareExecutionError("Failed to list system accounts", err, helper.GetCmd(), attrs...)
+		}
+		collection := res.GetSystemAccountCollection()
+		if collection == nil {
+			return allData, nil
+		}
+		allData = append(allData, collection.Data...)
+		if collection.Meta == nil || len(allData) >= int(collection.Meta.Page.Total) {
+			return allData, nil
+		}
+		pageNumber++
+	}
+}
+
+func listSPATs(
+	api helpers.SystemAccountAccessTokenAPI,
+	helper cmdpkg.Helper,
+	cfg config.Hook,
+	accountID string,
+	name string,
+) ([]kkComps.SystemAccountAccessToken, error) {
+	pageSize := requestPageSize(cfg)
+	pageNumber := int64(1)
+	var allData []kkComps.SystemAccountAccessToken
+
+	for {
+		req := kkOps.GetSystemAccountIDAccessTokensRequest{
+			AccountID:  accountID,
+			PageSize:   &pageSize,
+			PageNumber: &pageNumber,
+			Filter:     nil,
+		}
+		if name != "" {
+			req.Filter = &kkOps.GetSystemAccountIDAccessTokensQueryParamFilter{
+				Name: &kkComps.LegacyStringFieldFilter{Eq: &name},
+			}
+		}
+		res, err := api.GetSystemAccountIDAccessTokens(helper.GetContext(), req)
+		if err != nil {
+			attrs := cmdpkg.TryConvertErrorToAttrs(err)
+			return nil, cmdpkg.PrepareExecutionError(
+				"Failed to list system account access tokens", err, helper.GetCmd(), attrs...)
+		}
+		collection := res.GetSystemAccountAccessTokenCollection()
+		if collection == nil {
+			return allData, nil
+		}
+		allData = append(allData, collection.Data...)
+		if collection.Meta == nil || len(allData) >= int(collection.Meta.Page.Total) {
+			return allData, nil
+		}
+		pageNumber++
+	}
+}
+
+func resolveSPAT(
+	identifier string,
+	api helpers.SystemAccountAccessTokenAPI,
+	helper cmdpkg.Helper,
+	cfg config.Hook,
+	accountID string,
+) (*kkComps.SystemAccountAccessToken, error) {
+	identifier = strings.TrimSpace(identifier)
+	if util.IsValidUUID(identifier) {
+		res, err := api.GetSystemAccountsIDAccessTokensID(helper.GetContext(), accountID, identifier)
+		if err != nil {
+			attrs := cmdpkg.TryConvertErrorToAttrs(err)
+			return nil, cmdpkg.PrepareExecutionError("Failed to get system account access token", err, helper.GetCmd(), attrs...)
+		}
+		return res.GetSystemAccountAccessToken(), nil
+	}
+
+	matches, err := listSPATs(api, helper, cfg, accountID, identifier)
+	if err != nil {
+		return nil, err
+	}
+	if len(matches) == 0 {
+		return nil, cmdpkg.PrepareExecutionErrorMsg(helper,
+			fmt.Sprintf("system account access token %q not found", identifier))
+	}
+	if len(matches) > 1 {
+		return nil, cmdpkg.PrepareExecutionErrorMsg(helper,
+			fmt.Sprintf("multiple system account access tokens found with name %q; use an id", identifier))
+	}
+	return &matches[0], nil
+}
+
+func requestPageSize(cfg config.Hook) int64 {
+	pageSize := int64(konnectcommon.DefaultRequestPageSize)
+	if cfg != nil {
+		value := int64(cfg.GetInt(konnectcommon.RequestPageSizeConfigPath))
+		if value > 0 {
+			pageSize = value
+		}
+	}
+	return pageSize
+}
+
+func parseExpiration(expiresIn, expiresAt string) (expiration, error) {
+	expiresIn = strings.TrimSpace(expiresIn)
+	expiresAt = strings.TrimSpace(expiresAt)
+	if (expiresIn == "") == (expiresAt == "") {
+		return expiration{}, &cmdpkg.ConfigurationError{
+			Err: fmt.Errorf("exactly one of --%s or --%s is required", flagExpiresIn, flagExpiresAt),
+		}
+	}
+	if expiresAt != "" {
+		parsed, err := time.Parse(time.RFC3339, expiresAt)
+		if err != nil {
+			return expiration{}, &cmdpkg.ConfigurationError{
+				Err: fmt.Errorf("invalid --%s value %q: %w", flagExpiresAt, expiresAt, err),
+			}
+		}
+		return expiration{ExpiresAt: &parsed}, nil
+	}
+
+	duration, err := parseDurationWithDays(expiresIn)
+	if err != nil {
+		return expiration{}, &cmdpkg.ConfigurationError{
+			Err: fmt.Errorf("invalid --%s value %q: %s", flagExpiresIn, expiresIn, expiresInExpectation),
+		}
+	}
+	ttl := int64(duration.Seconds())
+	if ttl <= 0 {
+		return expiration{}, &cmdpkg.ConfigurationError{
+			Err: fmt.Errorf("--%s must be greater than zero; %s", flagExpiresIn, expiresInExpectation),
+		}
+	}
+	return expiration{TTLSeconds: &ttl}, nil
+}
+
+func parseDurationWithDays(raw string) (time.Duration, error) {
+	if before, ok := strings.CutSuffix(raw, "d"); ok {
+		days, err := strconv.ParseFloat(before, 64)
+		if err != nil {
+			return 0, err
+		}
+		return time.Duration(days * float64(24*time.Hour)), nil
+	}
+	return time.ParseDuration(raw)
+}
+
+func expirationToTime(exp expiration) time.Time {
+	if exp.ExpiresAt != nil {
+		return *exp.ExpiresAt
+	}
+	return time.Now().UTC().Add(time.Duration(*exp.TTLSeconds) * time.Second)
+}
+
+func createPATRecord(token *kkComps.PersonalAccessTokenCreateResponse) createTokenRecord {
+	if token == nil {
+		return createTokenRecord{Type: PATCommandName}
+	}
+	return createTokenRecord{
+		Type:       PATCommandName,
+		ID:         token.ID,
+		Name:       token.Name,
+		Token:      token.KonnectToken,
+		UserID:     token.UserID,
+		State:      string(token.State),
+		CreatedAt:  formatTime(token.CreatedAt),
+		UpdatedAt:  formatTimePtr(token.UpdatedAt),
+		LastUsedAt: formatTimePtr(token.LastUsedAt),
+		ExpiresAt:  formatTimePtr(token.ExpiresAt),
+	}
+}
+
+func createSPATRecord(
+	token *kkComps.SystemAccountAccessTokenCreated,
+	accountID string,
+	accountName string,
+) createTokenRecord {
+	record := createTokenRecord{
+		Type:              SPATCommandName,
+		SystemAccountID:   accountID,
+		SystemAccountName: accountName,
+	}
+	if token == nil {
+		return record
+	}
+	record.ID = pointerValue(token.ID)
+	record.Name = pointerValue(token.Name)
+	record.Token = pointerValue(token.Token)
+	record.CreatedAt = formatTimePtr(token.CreatedAt)
+	record.UpdatedAt = formatTimePtr(token.UpdatedAt)
+	record.LastUsedAt = formatTimePtr(token.LastUsedAt)
+	record.ExpiresAt = formatTimePtr(token.ExpiresAt)
+	return record
+}
+
+func patRecord(token *kkComps.PersonalAccessToken) getTokenRecord {
+	if token == nil {
+		return getTokenRecord{Type: PATCommandName}
+	}
+	return getTokenRecord{
+		Type:       PATCommandName,
+		ID:         token.ID,
+		Name:       token.Name,
+		UserID:     token.UserID,
+		State:      string(token.State),
+		CreatedAt:  formatTime(token.CreatedAt),
+		UpdatedAt:  formatTime(token.UpdatedAt),
+		LastUsedAt: formatTimePtr(token.LastUsedAt),
+		ExpiresAt:  formatTimePtr(token.ExpiresAt),
+	}
+}
+
+func spatRecord(token *kkComps.SystemAccountAccessToken, accountID, accountName string) getTokenRecord {
+	record := getTokenRecord{
+		Type:              SPATCommandName,
+		SystemAccountID:   accountID,
+		SystemAccountName: accountName,
+	}
+	if token == nil {
+		return record
+	}
+	record.ID = pointerValue(token.ID)
+	record.Name = pointerValue(token.Name)
+	record.CreatedAt = formatTimePtr(token.CreatedAt)
+	record.UpdatedAt = formatTimePtr(token.UpdatedAt)
+	record.LastUsedAt = formatTimePtr(token.LastUsedAt)
+	record.ExpiresAt = formatTimePtr(token.ExpiresAt)
+	return record
+}
+
+func patDeleteRecord(token *kkComps.PersonalAccessToken) deleteTokenRecord {
+	record := deleteTokenRecord{Type: PATCommandName, Status: "pending"}
+	if token == nil {
+		return record
+	}
+	record.ID = token.ID
+	record.Name = token.Name
+	return record
+}
+
+func spatDeleteRecord(token *kkComps.SystemAccountAccessToken) deleteTokenRecord {
+	record := deleteTokenRecord{Type: SPATCommandName, Status: "pending"}
+	if token == nil {
+		return record
+	}
+	record.ID = pointerValue(token.ID)
+	record.Name = pointerValue(token.Name)
+	return record
+}
+
+func renderCreateRecord(helper cmdpkg.Helper, record createTokenRecord) error {
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+	outType, err := helper.GetOutputFormat()
+	if err != nil {
+		return err
+	}
+
+	settings, err := jq.ResolveSettings(helper.GetCmd(), cfg)
+	if err != nil {
+		return err
+	}
+	if jq.HasFilter(settings) {
+		if outType == cmdcommon.TOKEN || outType == cmdcommon.ENV {
+			return &cmdpkg.ConfigurationError{
+				Err: fmt.Errorf("--%s is not supported with --output %s", jq.FlagName, outType.String()),
+			}
+		}
+		if !outputFlagChanged(helper.GetCmd()) {
+			outType = cmdcommon.JSON
+		}
+		filtered, handled, err := jq.ApplyToRaw(record, outType, settings, helper.GetStreams().Out)
+		if err != nil {
+			return cmdpkg.PrepareExecutionErrorWithHelper(helper, "jq filter failed", err)
+		}
+		if handled {
+			return nil
+		}
+		return printStructured(helper, outType, filtered)
+	}
+
+	switch outType {
+	case cmdcommon.TOKEN:
+		_, err = fmt.Fprintln(helper.GetStreams().Out, record.Token)
+		return err
+	case cmdcommon.ENV:
+		envName := utilviper.ProfileEnvPrefix(cfg.GetProfile()) + "_KONNECT_PAT"
+		_, err = fmt.Fprintf(helper.GetStreams().Out, "export %s=%s\n", envName, shellQuote(record.Token))
+		return err
+	case cmdcommon.TEXT:
+		_, err = fmt.Fprintf(helper.GetStreams().Out, "Created %s %q (%s)\ntoken: %s\n",
+			record.Type, record.Name, record.ID, record.Token)
+		return err
+	case cmdcommon.JSON, cmdcommon.YAML:
+		return printStructured(helper, outType, record)
+	case cmdcommon.HELM:
+		return fmt.Errorf("unsupported output format %s", outType.String())
+	default:
+		return fmt.Errorf("unsupported output format %s", outType.String())
+	}
+}
+
+func renderGetRecords(helper cmdpkg.Helper, data any) error {
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+	outType, err := helper.GetOutputFormat()
+	if err != nil {
+		return err
+	}
+	settings, err := jq.ResolveSettings(helper.GetCmd(), cfg)
+	if err != nil {
+		return err
+	}
+	if jq.HasFilter(settings) {
+		if !outputFlagChanged(helper.GetCmd()) {
+			outType = cmdcommon.JSON
+		}
+		filtered, handled, err := jq.ApplyToRaw(data, outType, settings, helper.GetStreams().Out)
+		if err != nil {
+			return cmdpkg.PrepareExecutionErrorWithHelper(helper, "jq filter failed", err)
+		}
+		if handled {
+			return nil
+		}
+		data = filtered
+	}
+	if outType == cmdcommon.TEXT && isEmptyCollection(data) {
+		_, err = fmt.Fprintln(helper.GetStreams().Out, "No resources found.")
+		return err
+	}
+	return printStructured(helper, outType, data)
+}
+
+func renderDeleteRecord(helper cmdpkg.Helper, record deleteTokenRecord) error {
+	outType, err := helper.GetOutputFormat()
+	if err != nil {
+		return err
+	}
+	if outType == cmdcommon.TEXT {
+		_, err = fmt.Fprintf(helper.GetStreams().Out, "Deleted %s %q\n", record.Type, record.Name)
+		return err
+	}
+	return printStructured(helper, outType, record)
+}
+
+func printStructured(helper cmdpkg.Helper, outType cmdcommon.OutputFormat, data any) error {
+	printer, err := cli.Format(outType.String(), helper.GetStreams().Out)
+	if err != nil {
+		return err
+	}
+	defer printer.Flush()
+	printer.Print(data)
+	return nil
+}
+
+func isEmptyCollection(data any) bool {
+	value := reflect.ValueOf(data)
+	if !value.IsValid() {
+		return false
+	}
+	kind := value.Kind()
+	return (kind == reflect.Array || kind == reflect.Chan || kind == reflect.Map || kind == reflect.Slice) &&
+		value.Len() == 0
+}
+
+func outputFlagChanged(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		if f := c.Flags().Lookup(cmdcommon.OutputFlagName); f != nil && f.Changed {
+			return true
+		}
+		if f := c.PersistentFlags().Lookup(cmdcommon.OutputFlagName); f != nil && f.Changed {
+			return true
+		}
+	}
+	return false
+}
+
+func formatTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
+func formatTimePtr(value *time.Time) string {
+	if value == nil {
+		return ""
+	}
+	return formatTime(*value)
+}
+
+func pointerValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
+}

--- a/internal/cmd/root/products/konnect/token/token.go
+++ b/internal/cmd/root/products/konnect/token/token.go
@@ -508,7 +508,7 @@ func runDeleteSPAT(c *cobra.Command, args []string, opts *spatOptions) error {
 		return err
 	}
 
-	accountID, accountName, err := resolveSystemAccount(opts.systemAccountID, opts.systemAccountName, sdk, helper, cfg)
+	accountID, _, err := resolveSystemAccount(opts.systemAccountID, opts.systemAccountName, sdk, helper, cfg)
 	if err != nil {
 		return err
 	}
@@ -522,7 +522,8 @@ func runDeleteSPAT(c *cobra.Command, args []string, opts *spatOptions) error {
 		return err
 	}
 	record := spatDeleteRecord(token)
-	if err := cmdpkg.ConfirmDelete(helper, fmt.Sprintf("system account access token %q", record.Name)); err != nil {
+	deleteLabel := deleteRecordLabel(record)
+	if err := cmdpkg.ConfirmDelete(helper, fmt.Sprintf("system account access token %q", deleteLabel)); err != nil {
 		return err
 	}
 	tokenID := pointerValue(token.ID)
@@ -531,9 +532,6 @@ func runDeleteSPAT(c *cobra.Command, args []string, opts *spatOptions) error {
 		return cmdpkg.PrepareExecutionError("Failed to delete system account access token", err, helper.GetCmd(), attrs...)
 	}
 	record.Status = "deleted"
-	if record.Name == "" {
-		record.Name = accountName
-	}
 	return renderDeleteRecord(helper, record)
 }
 
@@ -1035,10 +1033,17 @@ func renderDeleteRecord(helper cmdpkg.Helper, record deleteTokenRecord) error {
 		return err
 	}
 	if outType == cmdcommon.TEXT {
-		_, err = fmt.Fprintf(helper.GetStreams().Out, "Deleted %s %q\n", record.Type, record.Name)
+		_, err = fmt.Fprintf(helper.GetStreams().Out, "Deleted %s %q\n", record.Type, deleteRecordLabel(record))
 		return err
 	}
 	return printStructured(helper, outType, record)
+}
+
+func deleteRecordLabel(record deleteTokenRecord) string {
+	if record.Name != "" {
+		return record.Name
+	}
+	return record.ID
 }
 
 func printStructured(helper cmdpkg.Helper, outType cmdcommon.OutputFormat, data any) error {

--- a/internal/cmd/root/products/konnect/token/token_test.go
+++ b/internal/cmd/root/products/konnect/token/token_test.go
@@ -1,0 +1,108 @@
+package token
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	cmdpkg "github.com/kong/kongctl/internal/cmd"
+)
+
+func TestParseExpirationSupportsGoDurationsAndDays(t *testing.T) {
+	tests := []struct {
+		name      string
+		expiresIn string
+		wantTTL   int64
+	}{
+		{name: "hours", expiresIn: "12h", wantTTL: 43200},
+		{name: "days", expiresIn: "30d", wantTTL: 2592000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseExpiration(tt.expiresIn, "")
+			if err != nil {
+				t.Fatalf("parseExpiration returned error: %v", err)
+			}
+			if got.TTLSeconds == nil || *got.TTLSeconds != tt.wantTTL {
+				t.Fatalf("expected ttl %d, got %#v", tt.wantTTL, got.TTLSeconds)
+			}
+		})
+	}
+}
+
+func TestParseExpirationSupportsRFC3339(t *testing.T) {
+	got, err := parseExpiration("", "2026-06-24T12:00:00Z")
+	if err != nil {
+		t.Fatalf("parseExpiration returned error: %v", err)
+	}
+	want := time.Date(2026, time.June, 24, 12, 0, 0, 0, time.UTC)
+	if got.ExpiresAt == nil || !got.ExpiresAt.Equal(want) {
+		t.Fatalf("expected expires_at %s, got %#v", want.Format(time.RFC3339), got.ExpiresAt)
+	}
+}
+
+func TestParseExpirationRequiresExactlyOneExpirationFlag(t *testing.T) {
+	tests := []struct {
+		name      string
+		expiresIn string
+		expiresAt string
+	}{
+		{name: "neither"},
+		{name: "both", expiresIn: "12h", expiresAt: "2026-06-24T12:00:00Z"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseExpiration(tt.expiresIn, tt.expiresAt)
+			var cfgErr *cmdpkg.ConfigurationError
+			if !errors.As(err, &cfgErr) {
+				t.Fatalf("expected ConfigurationError, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+func TestParseExpirationInvalidDurationExplainsAcceptedUnits(t *testing.T) {
+	_, err := parseExpiration("30days", "")
+	var cfgErr *cmdpkg.ConfigurationError
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("expected ConfigurationError, got %T: %v", err, err)
+	}
+	for _, want := range []string{
+		`invalid --expires-in value "30days"`,
+		"supported units: ns, us, ms, s, m, h, d",
+		"90m, 12h, or 30d",
+	} {
+		if !strings.Contains(cfgErr.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %q", want, cfgErr.Error())
+		}
+	}
+}
+
+func TestValidateSystemAccountSelectorRequiresExactlyOneSelector(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		sa   string
+		err  bool
+	}{
+		{name: "id", id: "sa-id"},
+		{name: "name", sa: "ci-bot"},
+		{name: "neither", err: true},
+		{name: "both", id: "sa-id", sa: "ci-bot", err: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSystemAccountSelector(tt.id, tt.sa)
+			if tt.err && err == nil {
+				t.Fatal("expected error")
+			}
+			if !tt.err && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kong/kongctl/internal/cmd/root/verbs/adopt"
 	"github.com/kong/kongctl/internal/cmd/root/verbs/api"
 	"github.com/kong/kongctl/internal/cmd/root/verbs/apply"
+	"github.com/kong/kongctl/internal/cmd/root/verbs/create"
 	"github.com/kong/kongctl/internal/cmd/root/verbs/del"
 	"github.com/kong/kongctl/internal/cmd/root/verbs/diff"
 	"github.com/kong/kongctl/internal/cmd/root/verbs/dump"
@@ -304,6 +305,12 @@ func addCommands() error {
 	rootCmd.AddCommand(command)
 
 	command, err = get.NewGetCmd()
+	if err != nil {
+		return err
+	}
+	rootCmd.AddCommand(command)
+
+	command, err = create.NewCreateCmd()
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -9,11 +9,15 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
 	cmdpkg "github.com/kong/kongctl/internal/cmd"
 	"github.com/kong/kongctl/internal/cmd/common"
 	configpkg "github.com/kong/kongctl/internal/config"
 	"github.com/kong/kongctl/internal/iostreams"
+	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/log"
 	"github.com/kong/kongctl/internal/profile"
 	"github.com/spf13/cobra"
@@ -188,6 +192,330 @@ func TestDeleteHelpUsesDeclarativeExamples(t *testing.T) {
 	}
 	if strings.Contains(examples, "kongctl delete -f ./configs/ --recursive") {
 		t.Fatalf("expected delete examples not to contain stale recursive example\nexamples:\n%s", examples)
+	}
+}
+
+func TestCreateCommandIsTokenOnly(t *testing.T) {
+	result := executeRootForTest(t, "create", "gateway", "control-plane", "cp")
+	if result.exitCode == 0 {
+		t.Fatalf("expected create gateway control-plane to fail\nstdout:\n%s", result.stdout)
+	}
+	if !strings.Contains(result.stderr, `unknown command "gateway"`) {
+		t.Fatalf("expected unknown gateway command\nstderr:\n%s", result.stderr)
+	}
+
+	result = executeRootForTest(t, "create", "konnect", "gateway", "control-plane", "cp")
+	if result.exitCode == 0 {
+		t.Fatalf("expected create konnect gateway control-plane to fail\nstdout:\n%s", result.stdout)
+	}
+	if !strings.Contains(result.stderr, `unknown command "gateway"`) {
+		t.Fatalf("expected unknown gateway command under konnect\nstderr:\n%s", result.stderr)
+	}
+}
+
+func TestCreatePATHelpIncludesTokenExamplesAndFormats(t *testing.T) {
+	result := executeRootForTest(t, "create", "pat", "--help")
+	if result.exitCode != 0 {
+		t.Fatalf("expected create pat help to succeed, got %d\nstdout:\n%s\nstderr:\n%s",
+			result.exitCode, result.stdout, result.stderr)
+	}
+	for _, want := range []string{
+		"kongctl create pat --name ci --expires-in 30d -o token",
+		"kongctl create pat --name ci --expires-in 12h --jq -r '.token'",
+		"Accepts Go durations with ns, us, ms, s, m, h, plus numeric days with d.",
+		"Token expiration timestamp in RFC3339 format, for example 2026-06-24T12:00:00Z.",
+		"Allowed    : [ json|yaml|text|token|env ]",
+	} {
+		if !strings.Contains(result.stdout, want) {
+			t.Fatalf("expected help to contain %q\nstdout:\n%s", want, result.stdout)
+		}
+	}
+}
+
+func TestCreatePATTokenOutputAndJQ(t *testing.T) {
+	patAPI := &rootTestPATAPI{token: "kpat_123", id: "pat-id"}
+	installRootTokenSDK(t, &helpers.MockKonnectSDK{
+		MeFactory: func() helpers.MeAPI {
+			return rootTestMeAPI{userID: "user-1"}
+		},
+		PersonalAccessTokenFactory: func() helpers.PersonalAccessTokenAPI {
+			return patAPI
+		},
+	})
+
+	result := executeRootForTest(t,
+		"create", "pat",
+		"--name", "ci",
+		"--expires-in", "12h",
+		"-o", "token",
+	)
+	if result.exitCode != 0 {
+		t.Fatalf("expected token output to succeed\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+	if result.stdout != "kpat_123\n" {
+		t.Fatalf("expected token-only stdout, got %q", result.stdout)
+	}
+	if patAPI.createdUserID != "user-1" {
+		t.Fatalf("expected current user id to be used, got %q", patAPI.createdUserID)
+	}
+	if got := patAPI.createdRequest.PersonalAccessTokenCreateRequestWithTTL.GetTTLSeconds(); got != 43200 {
+		t.Fatalf("expected 12h ttl to be 43200 seconds, got %d", got)
+	}
+
+	result = executeRootForTest(t,
+		"create", "pat",
+		"--name", "ci",
+		"--expires-in", "12h",
+		"--user-id", "user-2",
+		"--jq", "-r", ".token",
+	)
+	if result.exitCode != 0 {
+		t.Fatalf("expected jq output to succeed\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+	if result.stdout != "kpat_123\n" {
+		t.Fatalf("expected jq raw token stdout, got %q", result.stdout)
+	}
+	if patAPI.createdUserID != "user-2" {
+		t.Fatalf("expected explicit user id to be used, got %q", patAPI.createdUserID)
+	}
+}
+
+func TestCreateSPATEnvOutputResolvesSystemAccountName(t *testing.T) {
+	spatToken := "spat_123"
+	accountID := "9d0462e0-6a6b-4811-9b37-0ad7dd48d9f1"
+	installRootTokenSDK(t, &helpers.MockKonnectSDK{
+		SystemAccountFactory: func() helpers.SystemAccountAPI {
+			return rootTestSystemAccountAPI{id: accountID, name: "ci-bot"}
+		},
+		SystemAccountAccessTokenFactory: func() helpers.SystemAccountAccessTokenAPI {
+			return &rootTestSPATAPI{token: spatToken}
+		},
+	})
+
+	result := executeRootForTest(t,
+		"--profile", "team-a",
+		"create", "spat",
+		"--system-account-name", "ci-bot",
+		"--name", "ci",
+		"--expires-at", "2026-06-24T12:00:00Z",
+		"-o", "env",
+	)
+	if result.exitCode != 0 {
+		t.Fatalf("expected env output to succeed\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+	if result.stdout != "export KONGCTL_TEAM_A_KONNECT_PAT='spat_123'\n" {
+		t.Fatalf("unexpected env output: %q", result.stdout)
+	}
+}
+
+func TestPATGetAndDeleteCommands(t *testing.T) {
+	patID := "11111111-1111-1111-1111-111111111111"
+	patAPI := &rootTestPATAPI{
+		tokens: []kkComps.PersonalAccessToken{rootTestPAT(patID, "ci")},
+	}
+	installRootTokenSDK(t, &helpers.MockKonnectSDK{
+		MeFactory: func() helpers.MeAPI {
+			return rootTestMeAPI{userID: "user-1"}
+		},
+		PersonalAccessTokenFactory: func() helpers.PersonalAccessTokenAPI {
+			return patAPI
+		},
+	})
+
+	result := executeRootForTest(t, "get", "pat", "--user-id", "user-1", "-o", "json")
+	if result.exitCode != 0 {
+		t.Fatalf("expected get pat list to succeed\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+	if !strings.Contains(result.stdout, patID) || !strings.Contains(result.stdout, `"name": "ci"`) {
+		t.Fatalf("expected PAT list output to include token metadata\nstdout:\n%s", result.stdout)
+	}
+	if strings.Contains(result.stdout, `"token"`) {
+		t.Fatalf("expected PAT list output not to include token values\nstdout:\n%s", result.stdout)
+	}
+
+	result = executeRootForTest(t, "get", "pat", "--user-id", "user-1", "--jq", ".[] | {id,name,expires_at}")
+	if result.exitCode != 0 {
+		t.Fatalf("expected get pat jq to succeed\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+	if !strings.Contains(result.stdout, `"expires_at"`) || !strings.Contains(result.stdout, patID) {
+		t.Fatalf("expected jq output to include selected PAT fields\nstdout:\n%s", result.stdout)
+	}
+
+	result = executeRootForTest(t, "get", "pat", patID, "--user-id", "user-1", "-o", "json")
+	if result.exitCode != 0 {
+		t.Fatalf("expected get pat by id to succeed\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+	if patAPI.gotTokenID != patID {
+		t.Fatalf("expected get by id to call detail API with %q, got %q", patID, patAPI.gotTokenID)
+	}
+
+	result = executeRootForTest(t, "get", "pat", "ci", "--user-id", "user-1", "-o", "json")
+	if result.exitCode != 0 {
+		t.Fatalf("expected get pat by name to succeed\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+
+	result = executeRootForTest(t, "delete", "pat", patID, "--user-id", "user-1", "--auto-approve", "-o", "json")
+	if result.exitCode != 0 {
+		t.Fatalf("expected delete pat by id to succeed\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+	if patAPI.deletedTokenID != patID {
+		t.Fatalf("expected delete by id to delete %q, got %q", patID, patAPI.deletedTokenID)
+	}
+	if !strings.Contains(result.stdout, `"status": "deleted"`) {
+		t.Fatalf("expected delete output to include deleted status\nstdout:\n%s", result.stdout)
+	}
+
+	patAPI.deletedTokenID = ""
+	result = executeRootForTest(t, "delete", "pat", "ci", "--user-id", "user-1", "--auto-approve", "-o", "json")
+	if result.exitCode != 0 {
+		t.Fatalf("expected delete pat by name to succeed\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+	if patAPI.deletedTokenID != patID {
+		t.Fatalf("expected delete by name to delete %q, got %q", patID, patAPI.deletedTokenID)
+	}
+}
+
+func TestSPATGetAndDeleteCommands(t *testing.T) {
+	accountID := "9d0462e0-6a6b-4811-9b37-0ad7dd48d9f1"
+	spatID := "22222222-2222-2222-2222-222222222222"
+	spatAPI := &rootTestSPATAPI{
+		tokens: []kkComps.SystemAccountAccessToken{rootTestSPAT(spatID, "ci")},
+	}
+	installRootTokenSDK(t, &helpers.MockKonnectSDK{
+		SystemAccountFactory: func() helpers.SystemAccountAPI {
+			return rootTestSystemAccountAPI{id: accountID, name: "ci-bot"}
+		},
+		SystemAccountAccessTokenFactory: func() helpers.SystemAccountAccessTokenAPI {
+			return spatAPI
+		},
+	})
+
+	result := executeRootForTest(t, "get", "spat", "--system-account-id", accountID, "-o", "json")
+	if result.exitCode != 0 {
+		t.Fatalf("expected get spat list to succeed\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+	if !strings.Contains(result.stdout, spatID) || !strings.Contains(result.stdout, `"system_account_id":`) {
+		t.Fatalf("expected SPAT list output to include token metadata\nstdout:\n%s", result.stdout)
+	}
+	if strings.Contains(result.stdout, `"token"`) {
+		t.Fatalf("expected SPAT list output not to include token values\nstdout:\n%s", result.stdout)
+	}
+
+	result = executeRootForTest(t, "get", "spat", spatID, "--system-account-id", accountID, "-o", "json")
+	if result.exitCode != 0 {
+		t.Fatalf("expected get spat by id to succeed\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+	if spatAPI.gotTokenID != spatID {
+		t.Fatalf("expected get by id to call detail API with %q, got %q", spatID, spatAPI.gotTokenID)
+	}
+
+	result = executeRootForTest(t, "get", "spat", "ci", "--system-account-name", "ci-bot", "-o", "json")
+	if result.exitCode != 0 {
+		t.Fatalf("expected get spat by name to succeed\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+	if !strings.Contains(result.stdout, `"system_account_name": "ci-bot"`) {
+		t.Fatalf("expected SPAT by name output to include resolved system account name\nstdout:\n%s", result.stdout)
+	}
+
+	result = executeRootForTest(t,
+		"delete", "spat", "ci",
+		"--system-account-name", "ci-bot",
+		"--auto-approve",
+		"-o", "json",
+	)
+	if result.exitCode != 0 {
+		t.Fatalf("expected delete spat by name to succeed\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+	if spatAPI.deletedAccountID != accountID || spatAPI.deletedTokenID != spatID {
+		t.Fatalf("expected delete spat to delete %s/%s, got %s/%s",
+			accountID, spatID, spatAPI.deletedAccountID, spatAPI.deletedTokenID)
+	}
+	if !strings.Contains(result.stdout, `"status": "deleted"`) {
+		t.Fatalf("expected delete output to include deleted status\nstdout:\n%s", result.stdout)
+	}
+}
+
+func TestTokenGetEmptyTextOutput(t *testing.T) {
+	accountID := "9d0462e0-6a6b-4811-9b37-0ad7dd48d9f1"
+	installRootTokenSDK(t, &helpers.MockKonnectSDK{
+		MeFactory: func() helpers.MeAPI {
+			return rootTestMeAPI{userID: "user-1"}
+		},
+		PersonalAccessTokenFactory: func() helpers.PersonalAccessTokenAPI {
+			return &rootTestPATAPI{}
+		},
+		SystemAccountFactory: func() helpers.SystemAccountAPI {
+			return rootTestSystemAccountAPI{id: accountID, name: "ci-bot"}
+		},
+		SystemAccountAccessTokenFactory: func() helpers.SystemAccountAccessTokenAPI {
+			return &rootTestSPATAPI{}
+		},
+	})
+
+	result := executeRootForTest(t, "get", "pat", "--user-id", "user-1", "-o", "text")
+	if result.exitCode != 0 {
+		t.Fatalf("expected empty get pat to succeed\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+	if result.stdout != "No resources found.\n" {
+		t.Fatalf("expected no resources message for empty PAT list, got %q", result.stdout)
+	}
+
+	result = executeRootForTest(t, "get", "spats", "--system-account-name", "ci-bot", "-o", "text")
+	if result.exitCode != 0 {
+		t.Fatalf("expected empty get spats to succeed\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+	if result.stdout != "No resources found.\n" {
+		t.Fatalf("expected no resources message for empty SPAT list, got %q", result.stdout)
+	}
+}
+
+func TestTokenNameResolutionErrors(t *testing.T) {
+	accountID := "9d0462e0-6a6b-4811-9b37-0ad7dd48d9f1"
+	patAPI := &rootTestPATAPI{
+		tokens: []kkComps.PersonalAccessToken{
+			rootTestPAT("11111111-1111-1111-1111-111111111111", "dupe"),
+			rootTestPAT("33333333-3333-3333-3333-333333333333", "dupe"),
+		},
+	}
+	spatAPI := &rootTestSPATAPI{
+		tokens: []kkComps.SystemAccountAccessToken{
+			rootTestSPAT("22222222-2222-2222-2222-222222222222", "dupe"),
+			rootTestSPAT("44444444-4444-4444-4444-444444444444", "dupe"),
+		},
+	}
+	installRootTokenSDK(t, &helpers.MockKonnectSDK{
+		MeFactory: func() helpers.MeAPI {
+			return rootTestMeAPI{userID: "user-1"}
+		},
+		PersonalAccessTokenFactory: func() helpers.PersonalAccessTokenAPI {
+			return patAPI
+		},
+		SystemAccountFactory: func() helpers.SystemAccountAPI {
+			return rootTestSystemAccountAPI{id: accountID, name: "ci-bot"}
+		},
+		SystemAccountAccessTokenFactory: func() helpers.SystemAccountAccessTokenAPI {
+			return spatAPI
+		},
+	})
+
+	result := executeRootForTest(t, "get", "pat", "missing", "--user-id", "user-1")
+	if result.exitCode == 0 || !strings.Contains(result.stderr, `personal access token "missing" not found`) {
+		t.Fatalf("expected PAT not found error\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+
+	result = executeRootForTest(t, "delete", "pat", "dupe", "--user-id", "user-1", "--auto-approve")
+	if result.exitCode == 0 || !strings.Contains(result.stderr, `multiple personal access tokens found`) {
+		t.Fatalf("expected duplicate PAT name error\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+
+	result = executeRootForTest(t, "get", "spat", "missing", "--system-account-id", accountID)
+	if result.exitCode == 0 || !strings.Contains(result.stderr, `system account access token "missing" not found`) {
+		t.Fatalf("expected SPAT not found error\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+
+	result = executeRootForTest(t, "delete", "spat", "dupe", "--system-account-id", accountID, "--auto-approve")
+	if result.exitCode == 0 || !strings.Contains(result.stderr, `multiple system account access tokens found`) {
+		t.Fatalf("expected duplicate SPAT name error\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
 	}
 }
 
@@ -760,6 +1088,243 @@ func addCommandsWithRootForTest(command *cobra.Command) error {
 		rootCmd = oldRootCmd
 	}()
 	return addCommands()
+}
+
+func installRootTokenSDK(t *testing.T, sdk helpers.SDKAPI) {
+	t.Helper()
+
+	original := helpers.DefaultSDKFactory
+	t.Cleanup(func() {
+		helpers.DefaultSDKFactory = original
+	})
+	helpers.DefaultSDKFactory = func(configpkg.Hook, *slog.Logger) (helpers.SDKAPI, error) {
+		return sdk, nil
+	}
+}
+
+type rootTestMeAPI struct {
+	userID string
+}
+
+func (m rootTestMeAPI) GetUsersMe(context.Context, ...kkOps.Option) (*kkOps.GetUsersMeResponse, error) {
+	return &kkOps.GetUsersMeResponse{
+		User: &kkComps.User{ID: &m.userID},
+	}, nil
+}
+
+func (m rootTestMeAPI) GetOrganizationsMe(
+	context.Context,
+	...kkOps.Option,
+) (*kkOps.GetOrganizationsMeResponse, error) {
+	return &kkOps.GetOrganizationsMeResponse{}, nil
+}
+
+func rootTestPAT(id, name string) kkComps.PersonalAccessToken {
+	createdAt := time.Date(2026, time.May, 25, 12, 0, 0, 0, time.UTC)
+	expiresAt := createdAt.Add(30 * 24 * time.Hour)
+	return kkComps.PersonalAccessToken{
+		ID:        id,
+		UserID:    "user-1",
+		Name:      name,
+		State:     kkComps.PersonalAccessTokenStateActive,
+		CreatedAt: createdAt,
+		UpdatedAt: createdAt,
+		ExpiresAt: &expiresAt,
+	}
+}
+
+func rootTestSPAT(id, name string) kkComps.SystemAccountAccessToken {
+	createdAt := time.Date(2026, time.May, 25, 12, 0, 0, 0, time.UTC)
+	expiresAt := createdAt.Add(30 * 24 * time.Hour)
+	return kkComps.SystemAccountAccessToken{
+		ID:        &id,
+		Name:      &name,
+		CreatedAt: &createdAt,
+		UpdatedAt: &createdAt,
+		ExpiresAt: &expiresAt,
+	}
+}
+
+type rootTestPATAPI struct {
+	token          string
+	id             string
+	tokens         []kkComps.PersonalAccessToken
+	createdUserID  string
+	createdRequest *kkComps.PersonalAccessTokenCreateRequest
+	gotTokenID     string
+	deletedTokenID string
+}
+
+func (a *rootTestPATAPI) ListUsersPersonalAccessTokens(
+	context.Context,
+	string,
+	...kkOps.Option,
+) (*kkOps.ListUsersPersonalAccessTokensResponse, error) {
+	return &kkOps.ListUsersPersonalAccessTokensResponse{
+		PersonalAccessTokenListResponse: &kkComps.PersonalAccessTokenListResponse{
+			Data: a.tokens,
+		},
+	}, nil
+}
+
+func (a *rootTestPATAPI) CreatePersonalAccessToken(
+	_ context.Context,
+	userID string,
+	request *kkComps.PersonalAccessTokenCreateRequest,
+	_ ...kkOps.Option,
+) (*kkOps.CreatePersonalAccessTokenResponse, error) {
+	a.createdUserID = userID
+	a.createdRequest = request
+	createdAt := time.Date(2026, time.May, 25, 12, 0, 0, 0, time.UTC)
+	return &kkOps.CreatePersonalAccessTokenResponse{
+		PersonalAccessTokenCreateResponse: &kkComps.PersonalAccessTokenCreateResponse{
+			ID:           a.id,
+			UserID:       userID,
+			Name:         "ci",
+			State:        kkComps.PersonalAccessTokenCreateResponseStateActive,
+			KonnectToken: a.token,
+			CreatedAt:    createdAt,
+		},
+	}, nil
+}
+
+func (a *rootTestPATAPI) GetPersonalAccessTokenDetails(
+	_ context.Context,
+	_ string,
+	tokenID string,
+	_ ...kkOps.Option,
+) (*kkOps.GetPersonalAccessTokenDetailsResponse, error) {
+	a.gotTokenID = tokenID
+	for i := range a.tokens {
+		if a.tokens[i].ID == tokenID {
+			return &kkOps.GetPersonalAccessTokenDetailsResponse{
+				PersonalAccessToken: &a.tokens[i],
+			}, nil
+		}
+	}
+	return &kkOps.GetPersonalAccessTokenDetailsResponse{
+		PersonalAccessToken: &kkComps.PersonalAccessToken{
+			ID:   tokenID,
+			Name: "ci",
+		},
+	}, nil
+}
+
+func (a *rootTestPATAPI) DeletePersonalAccessToken(
+	_ context.Context,
+	_ string,
+	tokenID string,
+	_ ...kkOps.Option,
+) (*kkOps.DeletePersonalAccessTokenResponse, error) {
+	a.deletedTokenID = tokenID
+	return &kkOps.DeletePersonalAccessTokenResponse{}, nil
+}
+
+type rootTestSystemAccountAPI struct {
+	id   string
+	name string
+}
+
+func (a rootTestSystemAccountAPI) ListSystemAccounts(
+	context.Context,
+	kkOps.GetSystemAccountsRequest,
+) (*kkOps.GetSystemAccountsResponse, error) {
+	return &kkOps.GetSystemAccountsResponse{
+		SystemAccountCollection: &kkComps.SystemAccountCollection{
+			Meta: &kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: 1}},
+			Data: []kkComps.SystemAccount{
+				{ID: &a.id, Name: &a.name},
+			},
+		},
+	}, nil
+}
+
+func (a rootTestSystemAccountAPI) GetSystemAccount(
+	context.Context,
+	string,
+) (*kkOps.GetSystemAccountsIDResponse, error) {
+	return &kkOps.GetSystemAccountsIDResponse{}, nil
+}
+
+type rootTestSPATAPI struct {
+	token            string
+	tokens           []kkComps.SystemAccountAccessToken
+	gotTokenID       string
+	deletedAccountID string
+	deletedTokenID   string
+}
+
+func (a rootTestSPATAPI) GetSystemAccountIDAccessTokens(
+	_ context.Context,
+	request kkOps.GetSystemAccountIDAccessTokensRequest,
+	_ ...kkOps.Option,
+) (*kkOps.GetSystemAccountIDAccessTokensResponse, error) {
+	tokens := a.tokens
+	if request.Filter != nil && request.Filter.Name != nil && request.Filter.Name.Eq != nil {
+		name := *request.Filter.Name.Eq
+		tokens = []kkComps.SystemAccountAccessToken{}
+		for i := range a.tokens {
+			if a.tokens[i].Name != nil && *a.tokens[i].Name == name {
+				tokens = append(tokens, a.tokens[i])
+			}
+		}
+	}
+	return &kkOps.GetSystemAccountIDAccessTokensResponse{
+		SystemAccountAccessTokenCollection: &kkComps.SystemAccountAccessTokenCollection{
+			Meta: &kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: float64(len(tokens))}},
+			Data: tokens,
+		},
+	}, nil
+}
+
+func (a rootTestSPATAPI) PostSystemAccountsIDAccessTokens(
+	context.Context,
+	string,
+	*kkComps.CreateSystemAccountAccessToken,
+	...kkOps.Option,
+) (*kkOps.PostSystemAccountsIDAccessTokensResponse, error) {
+	id := "spat-id"
+	name := "ci"
+	return &kkOps.PostSystemAccountsIDAccessTokensResponse{
+		SystemAccountAccessTokenCreated: &kkComps.SystemAccountAccessTokenCreated{
+			ID:    &id,
+			Name:  &name,
+			Token: &a.token,
+		},
+	}, nil
+}
+
+func (a *rootTestSPATAPI) GetSystemAccountsIDAccessTokensID(
+	_ context.Context,
+	_ string,
+	tokenID string,
+	_ ...kkOps.Option,
+) (*kkOps.GetSystemAccountsIDAccessTokensIDResponse, error) {
+	a.gotTokenID = tokenID
+	for i := range a.tokens {
+		if a.tokens[i].ID != nil && *a.tokens[i].ID == tokenID {
+			return &kkOps.GetSystemAccountsIDAccessTokensIDResponse{
+				SystemAccountAccessToken: &a.tokens[i],
+			}, nil
+		}
+	}
+	return &kkOps.GetSystemAccountsIDAccessTokensIDResponse{
+		SystemAccountAccessToken: &kkComps.SystemAccountAccessToken{
+			ID:   &tokenID,
+			Name: &tokenID,
+		},
+	}, nil
+}
+
+func (a *rootTestSPATAPI) DeleteSystemAccountsIDAccessTokensID(
+	_ context.Context,
+	accountID string,
+	tokenID string,
+	_ ...kkOps.Option,
+) (*kkOps.DeleteSystemAccountsIDAccessTokensIDResponse, error) {
+	a.deletedAccountID = accountID
+	a.deletedTokenID = tokenID
+	return &kkOps.DeleteSystemAccountsIDAccessTokensIDResponse{}, nil
 }
 
 func walkCommandsForTest(command *cobra.Command, path []string, visit func(*cobra.Command, []string)) {

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -433,6 +433,21 @@ func TestSPATGetAndDeleteCommands(t *testing.T) {
 	if !strings.Contains(result.stdout, `"status": "deleted"`) {
 		t.Fatalf("expected delete output to include deleted status\nstdout:\n%s", result.stdout)
 	}
+
+	unnamedID := "55555555-5555-5555-5555-555555555555"
+	spatAPI.tokens = append(spatAPI.tokens, kkComps.SystemAccountAccessToken{ID: &unnamedID})
+	result = executeRootForTest(t,
+		"delete", "spat", unnamedID,
+		"--system-account-id", accountID,
+		"--auto-approve",
+		"-o", "text",
+	)
+	if result.exitCode != 0 {
+		t.Fatalf("expected delete unnamed spat by id to succeed\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+	if result.stdout != fmt.Sprintf("Deleted spat %q\n", unnamedID) {
+		t.Fatalf("expected unnamed SPAT delete text to use token id, got %q", result.stdout)
+	}
 }
 
 func TestTokenGetEmptyTextOutput(t *testing.T) {

--- a/internal/cmd/root/verbs/create/create.go
+++ b/internal/cmd/root/verbs/create/create.go
@@ -5,9 +5,14 @@ import (
 	"fmt"
 
 	cmdpkg "github.com/kong/kongctl/internal/cmd"
+	"github.com/kong/kongctl/internal/cmd/output/jq"
+	"github.com/kong/kongctl/internal/cmd/root/products"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/organization"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/token"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/meta"
 	"github.com/kong/kongctl/internal/util/i18n"
 	"github.com/kong/kongctl/internal/util/normalizers"
@@ -24,18 +29,20 @@ var (
 	createShort = i18n.T("root.verbs.create.createShort", "Create objects")
 
 	createLong = normalizers.LongDesc(i18n.T("root.verbs.create.createLong",
-		`Use create to create a new object.
+		`Use create to create Konnect access tokens.
 
 Further sub-commands are required to determine which remote system is contacted (if necessary).
-The command will create an object and report a result depending on further arguments.
+The command will create a token and report a result depending on further arguments.
 Output can be formatted in multiple ways to aid in further processing.`))
 
 	createExamples = normalizers.Examples(i18n.T("root.verbs.create.createExamples",
 		fmt.Sprintf(`
-		# Create a new Konnect Kong Gateway control plane (Konnect-first)
-		%[1]s create gateway control-plane <name>
-		# Create a new Konnect Kong Gateway control plane (explicit)
-		%[1]s create konnect gateway control-plane <name>
+		# Create a Konnect personal access token and print only the token value
+		%[1]s create pat --name ci --expires-in 30d -o token
+		# Create a Konnect personal access token and extract the token with jq
+		%[1]s create pat --name ci --expires-in 12h --jq -r '.token'
+		# Create a Konnect system account access token as an environment export
+		%[1]s create spat --system-account-name ci-bot --name ci --expires-at 2026-06-24T12:00:00Z -o env
 		`, meta.CLIName)))
 )
 
@@ -47,7 +54,14 @@ func NewCreateCmd() (*cobra.Command, error) {
 		Example: createExamples,
 		Aliases: []string{"c", "C"},
 		PersistentPreRunE: func(c *cobra.Command, args []string) error {
-			c.SetContext(context.WithValue(c.Context(), verbs.Verb, Verb))
+			ctx := c.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			ctx = context.WithValue(ctx, verbs.Verb, Verb)
+			ctx = context.WithValue(ctx, products.Product, konnect.Product)
+			ctx = context.WithValue(ctx, helpers.SDKAPIFactoryKey, common.GetSDKFactoryForVerb(Verb))
+			c.SetContext(ctx)
 			return bindKonnectFlags(c, args)
 		},
 	}
@@ -71,8 +85,17 @@ Setting this value overrides tokens obtained from the login command.
 - Config path: [ %s ]`,
 			common.PATConfigPath))
 
-	// TODO: Determine if creating profiles for the command make sense and how to implement
-	// cmd.AddCommand(profileCmd.NewProfileCmd())
+	jq.AddFlags(cmd.PersistentFlags())
+
+	cmd.RunE = func(c *cobra.Command, args []string) error {
+		helper := cmdpkg.BuildHelper(c, args)
+		if _, err := helper.GetOutputFormat(); err != nil {
+			return err
+		}
+		return cmdpkg.RequireSubcommand(c, args)
+	}
+	cmdpkg.MarkRequiresSubcommand(cmd)
+
 	c, e := konnect.NewKonnectCmd(Verb)
 	if e != nil {
 		return nil, e
@@ -80,12 +103,23 @@ Setting this value overrides tokens obtained from the login command.
 
 	cmd.AddCommand(c)
 
-	// Add gateway command directly for Konnect-first pattern
-	gatewayCmd, err := NewDirectGatewayCmd()
+	patCmd, err := token.NewPATCmd(Verb, nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	cmd.AddCommand(gatewayCmd)
+	cmd.AddCommand(patCmd)
+
+	spatCmd, err := token.NewSPATCmd(Verb, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	cmd.AddCommand(spatCmd)
+
+	orgCmd, err := organization.NewOrganizationCmd(Verb, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	cmd.AddCommand(orgCmd)
 
 	return cmd, nil
 }
@@ -114,6 +148,10 @@ func bindKonnectFlags(c *cobra.Command, args []string) error {
 		if err := cfg.BindFlag(common.PATConfigPath, f); err != nil {
 			return err
 		}
+	}
+
+	if err := jq.BindFlags(cfg, c.Flags()); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/cmd/root/verbs/del/del.go
+++ b/internal/cmd/root/verbs/del/del.go
@@ -10,6 +10,8 @@ import (
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/declarative"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/organization"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/token"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/util/i18n"
@@ -123,7 +125,55 @@ Setting this value overrides tokens obtained from the login command.
 		fmt.Sprintf(`Retry selected retryable connection-level errors.
 - Config path: [ %s ]`, common.HTTPRetryOnConnectionErrorsConfigPath))
 
+	if err := addDeleteTokenCommands(cmd); err != nil {
+		return nil, err
+	}
+
 	return cmd, nil
+}
+
+func addDeleteTokenCommands(cmd *cobra.Command) error {
+	patCmd, err := token.NewPATCmd(Verb, nil, nil)
+	if err != nil {
+		return err
+	}
+	cmd.AddCommand(patCmd)
+
+	spatCmd, err := token.NewSPATCmd(Verb, nil, nil)
+	if err != nil {
+		return err
+	}
+	cmd.AddCommand(spatCmd)
+
+	orgCmd, err := organization.NewOrganizationCmd(Verb, nil, nil)
+	if err != nil {
+		return err
+	}
+	cmd.AddCommand(orgCmd)
+
+	konnectCmd := &cobra.Command{
+		Use:     konnect.Product.String(),
+		Short:   "Delete Konnect tokens",
+		Aliases: []string{"k", "K"},
+	}
+	konnectPATCmd, err := token.NewPATCmd(Verb, nil, nil)
+	if err != nil {
+		return err
+	}
+	konnectCmd.AddCommand(konnectPATCmd)
+	konnectSPATCmd, err := token.NewSPATCmd(Verb, nil, nil)
+	if err != nil {
+		return err
+	}
+	konnectCmd.AddCommand(konnectSPATCmd)
+	konnectOrgCmd, err := organization.NewOrganizationCmd(Verb, nil, nil)
+	if err != nil {
+		return err
+	}
+	konnectCmd.AddCommand(konnectOrgCmd)
+	cmd.AddCommand(konnectCmd)
+
+	return nil
 }
 
 // bindKonnectFlags binds Konnect-specific flags to configuration

--- a/internal/cmd/root/verbs/get/get.go
+++ b/internal/cmd/root/verbs/get/get.go
@@ -6,11 +6,14 @@ import (
 
 	cmdpkg "github.com/kong/kongctl/internal/cmd"
 	"github.com/kong/kongctl/internal/cmd/output/jq"
+	"github.com/kong/kongctl/internal/cmd/root/products"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/token"
 	profileCmd "github.com/kong/kongctl/internal/cmd/root/profile"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	extensioncmd "github.com/kong/kongctl/internal/cmd/root/verbs/extensions"
+	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/meta"
 	"github.com/kong/kongctl/internal/util/i18n"
 	"github.com/kong/kongctl/internal/util/normalizers"
@@ -62,7 +65,14 @@ func NewGetCmd() (*cobra.Command, error) {
 		Example: getExamples,
 		Aliases: []string{"g", "G"},
 		PersistentPreRunE: func(c *cobra.Command, args []string) error {
-			c.SetContext(context.WithValue(c.Context(), verbs.Verb, Verb))
+			ctx := c.Context()
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			ctx = context.WithValue(ctx, verbs.Verb, Verb)
+			ctx = context.WithValue(ctx, products.Product, konnect.Product)
+			ctx = context.WithValue(ctx, helpers.SDKAPIFactoryKey, common.GetSDKFactoryForVerb(Verb))
+			c.SetContext(ctx)
 			return bindKonnectFlags(c, args)
 		},
 	}
@@ -109,6 +119,18 @@ Setting this value overrides tokens obtained from the login command.
 		return nil, e
 	}
 	cmd.AddCommand(c)
+
+	patCmd, err := token.NewPATCmd(Verb, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	cmd.AddCommand(patCmd)
+
+	spatCmd, err := token.NewSPATCmd(Verb, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	cmd.AddCommand(spatCmd)
 
 	cmd.AddCommand(profileCmd.NewProfileCmd())
 	cmd.AddCommand(extensioncmd.NewGetExtensionCmd())

--- a/internal/konnect/helpers/access_tokens.go
+++ b/internal/konnect/helpers/access_tokens.go
@@ -1,0 +1,139 @@
+package helpers
+
+import (
+	"context"
+
+	kkSDK "github.com/Kong/sdk-konnect-go"
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+)
+
+type PersonalAccessTokenAPI interface {
+	ListUsersPersonalAccessTokens(
+		ctx context.Context,
+		userID string,
+		opts ...kkOps.Option,
+	) (*kkOps.ListUsersPersonalAccessTokensResponse, error)
+	CreatePersonalAccessToken(
+		ctx context.Context,
+		userID string,
+		request *kkComps.PersonalAccessTokenCreateRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.CreatePersonalAccessTokenResponse, error)
+	GetPersonalAccessTokenDetails(
+		ctx context.Context,
+		userID string,
+		tokenID string,
+		opts ...kkOps.Option,
+	) (*kkOps.GetPersonalAccessTokenDetailsResponse, error)
+	DeletePersonalAccessToken(
+		ctx context.Context,
+		userID string,
+		tokenID string,
+		opts ...kkOps.Option,
+	) (*kkOps.DeletePersonalAccessTokenResponse, error)
+}
+
+type SystemAccountAccessTokenAPI interface {
+	GetSystemAccountIDAccessTokens(
+		ctx context.Context,
+		request kkOps.GetSystemAccountIDAccessTokensRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.GetSystemAccountIDAccessTokensResponse, error)
+	PostSystemAccountsIDAccessTokens(
+		ctx context.Context,
+		accountID string,
+		request *kkComps.CreateSystemAccountAccessToken,
+		opts ...kkOps.Option,
+	) (*kkOps.PostSystemAccountsIDAccessTokensResponse, error)
+	GetSystemAccountsIDAccessTokensID(
+		ctx context.Context,
+		accountID string,
+		tokenID string,
+		opts ...kkOps.Option,
+	) (*kkOps.GetSystemAccountsIDAccessTokensIDResponse, error)
+	DeleteSystemAccountsIDAccessTokensID(
+		ctx context.Context,
+		accountID string,
+		tokenID string,
+		opts ...kkOps.Option,
+	) (*kkOps.DeleteSystemAccountsIDAccessTokensIDResponse, error)
+}
+
+type PersonalAccessTokenAPIImpl struct {
+	SDK *kkSDK.SDK
+}
+
+func (p *PersonalAccessTokenAPIImpl) ListUsersPersonalAccessTokens(
+	ctx context.Context,
+	userID string,
+	opts ...kkOps.Option,
+) (*kkOps.ListUsersPersonalAccessTokensResponse, error) {
+	return p.SDK.PersonalAccessTokens.ListUsersPersonalAccessTokens(ctx, userID, opts...)
+}
+
+func (p *PersonalAccessTokenAPIImpl) CreatePersonalAccessToken(
+	ctx context.Context,
+	userID string,
+	request *kkComps.PersonalAccessTokenCreateRequest,
+	opts ...kkOps.Option,
+) (*kkOps.CreatePersonalAccessTokenResponse, error) {
+	return p.SDK.PersonalAccessTokens.CreatePersonalAccessToken(ctx, userID, request, opts...)
+}
+
+func (p *PersonalAccessTokenAPIImpl) GetPersonalAccessTokenDetails(
+	ctx context.Context,
+	userID string,
+	tokenID string,
+	opts ...kkOps.Option,
+) (*kkOps.GetPersonalAccessTokenDetailsResponse, error) {
+	return p.SDK.PersonalAccessTokens.GetPersonalAccessTokenDetails(ctx, userID, tokenID, opts...)
+}
+
+func (p *PersonalAccessTokenAPIImpl) DeletePersonalAccessToken(
+	ctx context.Context,
+	userID string,
+	tokenID string,
+	opts ...kkOps.Option,
+) (*kkOps.DeletePersonalAccessTokenResponse, error) {
+	return p.SDK.PersonalAccessTokens.DeletePersonalAccessToken(ctx, userID, tokenID, opts...)
+}
+
+type SystemAccountAccessTokenAPIImpl struct {
+	SDK *kkSDK.SDK
+}
+
+func (s *SystemAccountAccessTokenAPIImpl) GetSystemAccountIDAccessTokens(
+	ctx context.Context,
+	request kkOps.GetSystemAccountIDAccessTokensRequest,
+	opts ...kkOps.Option,
+) (*kkOps.GetSystemAccountIDAccessTokensResponse, error) {
+	return s.SDK.SystemAccountsAccessTokens.GetSystemAccountIDAccessTokens(ctx, request, opts...)
+}
+
+func (s *SystemAccountAccessTokenAPIImpl) PostSystemAccountsIDAccessTokens(
+	ctx context.Context,
+	accountID string,
+	request *kkComps.CreateSystemAccountAccessToken,
+	opts ...kkOps.Option,
+) (*kkOps.PostSystemAccountsIDAccessTokensResponse, error) {
+	return s.SDK.SystemAccountsAccessTokens.PostSystemAccountsIDAccessTokens(ctx, accountID, request, opts...)
+}
+
+func (s *SystemAccountAccessTokenAPIImpl) GetSystemAccountsIDAccessTokensID(
+	ctx context.Context,
+	accountID string,
+	tokenID string,
+	opts ...kkOps.Option,
+) (*kkOps.GetSystemAccountsIDAccessTokensIDResponse, error) {
+	return s.SDK.SystemAccountsAccessTokens.GetSystemAccountsIDAccessTokensID(ctx, accountID, tokenID, opts...)
+}
+
+func (s *SystemAccountAccessTokenAPIImpl) DeleteSystemAccountsIDAccessTokensID(
+	ctx context.Context,
+	accountID string,
+	tokenID string,
+	opts ...kkOps.Option,
+) (*kkOps.DeleteSystemAccountsIDAccessTokensIDResponse, error) {
+	return s.SDK.SystemAccountsAccessTokens.DeleteSystemAccountsIDAccessTokensID(ctx, accountID, tokenID, opts...)
+}

--- a/internal/konnect/helpers/sdk.go
+++ b/internal/konnect/helpers/sdk.go
@@ -31,6 +31,8 @@ type SDKAPI interface {
 	GetAppAuthStrategiesAPI() AppAuthStrategiesAPI
 	GetDCRProvidersAPI() DCRProvidersAPI
 	GetMeAPI() MeAPI
+	GetPersonalAccessTokenAPI() PersonalAccessTokenAPI
+	GetSystemAccountAccessTokenAPI() SystemAccountAccessTokenAPI
 	GetGatewayServiceAPI() GatewayServiceAPI
 	GetDataPlaneCertificateAPI() DataPlaneCertificateAPI
 	GetSystemAccountAPI() SystemAccountAPI
@@ -385,6 +387,22 @@ func (k *KonnectSDK) GetMeAPI() MeAPI {
 	}
 
 	return k.SDK.Me
+}
+
+func (k *KonnectSDK) GetPersonalAccessTokenAPI() PersonalAccessTokenAPI {
+	if k.SDK == nil || k.SDK.PersonalAccessTokens == nil {
+		return nil
+	}
+
+	return &PersonalAccessTokenAPIImpl{SDK: k.SDK}
+}
+
+func (k *KonnectSDK) GetSystemAccountAccessTokenAPI() SystemAccountAccessTokenAPI {
+	if k.SDK == nil || k.SDK.SystemAccountsAccessTokens == nil {
+		return nil
+	}
+
+	return &SystemAccountAccessTokenAPIImpl{SDK: k.SDK}
 }
 
 // Returns the implementation of the AssetsAPI interface

--- a/internal/konnect/helpers/sdk_mock.go
+++ b/internal/konnect/helpers/sdk_mock.go
@@ -19,6 +19,8 @@ type MockKonnectSDK struct {
 	AppAuthStrategiesFactory           func() AppAuthStrategiesAPI
 	DCRProvidersFactory                func() DCRProvidersAPI
 	MeFactory                          func() MeAPI
+	PersonalAccessTokenFactory         func() PersonalAccessTokenAPI
+	SystemAccountAccessTokenFactory    func() SystemAccountAccessTokenAPI
 	GatewayServiceFactory              func() GatewayServiceAPI
 	DataPlaneCertificateFactory        func() DataPlaneCertificateAPI
 	SystemAccountFactory               func() SystemAccountAPI
@@ -287,6 +289,20 @@ func (m *MockKonnectSDK) GetPortalTeamMembershipAPI() PortalTeamMembershipAPI {
 func (m *MockKonnectSDK) GetMeAPI() MeAPI {
 	if m.MeFactory != nil {
 		return m.MeFactory()
+	}
+	return nil
+}
+
+func (m *MockKonnectSDK) GetPersonalAccessTokenAPI() PersonalAccessTokenAPI {
+	if m.PersonalAccessTokenFactory != nil {
+		return m.PersonalAccessTokenFactory()
+	}
+	return nil
+}
+
+func (m *MockKonnectSDK) GetSystemAccountAccessTokenAPI() SystemAccountAccessTokenAPI {
+	if m.SystemAccountAccessTokenFactory != nil {
+		return m.SystemAccountAccessTokenFactory()
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Adds imperative Konnect token commands for personal access tokens and system account access tokens:

- `create|get|delete pat` and `create|get|delete spat`
- explicit `konnect` command forms and SPAT organization/system-account aliases
- PAT/SPAT creation with `--expires-in` and `--expires-at`
- token-specific create output formats: `token`, `env`, JSON/YAML/text, and `--jq`
- empty text list output matching other resources with `No resources found.`

## User impact

Users can manage Konnect PATs and SPATs directly from kongctl with short, token-focused commands. Help and validation now explain accepted duration values for expiration, and get/list output avoids exposing one-time token values.

## Testing

- `make format`
- `go test ./...`
- `make lint`
- `make build`
- `git diff --check`

No new live Konnect E2E scenario files are included in this PR.

Closed #1148 