### PR TITLE
docs: clarify system account assignment examples

### DIFF
--- a/docs/examples/declarative/organization/README.md
+++ b/docs/examples/declarative/organization/README.md
@@ -3,6 +3,13 @@
 These examples demonstrate how to manage Konnect organization resources with
 `kongctl` declarative configuration.
 
+## Important: system account selectors
+
+System accounts are selector-only for now. The Konnect API does not currently
+support labels on system accounts, so `kongctl` cannot manage them by namespace.
+Any system account referenced in these examples must already exist in the
+organization and must be selected by `name` or `id`.
+
 ## Files
 
 - `teams.yaml` - defines organization teams with namespaces.

--- a/docs/examples/declarative/organization/system-account-assignments.yaml
+++ b/docs/examples/declarative/organization/system-account-assignments.yaml
@@ -17,6 +17,8 @@ organization:
         focus: platform
 
   system-accounts:
+    # This system account must already exist in the Konnect organization. This
+    # example selects it by name and manages only its team and role assignments.
     - ref: ci-bot
       name: ci-bot
       teams:


### PR DESCRIPTION
## Summary

- Add an early note that organization system accounts are selector-only because Konnect does not currently support labels on them.
- Add a prerequisite comment to the system account assignment example that the referenced account must already exist.

## Validation

- `git diff --check`

Closes #1156