### PR TITLE
ci: schedule benchmark regression analysis

### DIFF
--- a/.github/workflows/benchmark-regression-analysis.lock.yml
+++ b/.github/workflows/benchmark-regression-analysis.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c806f4b7621565f6f3a4843c34afbd0abb589ab395d68fa5e4b4e1fec2492fbc","compiler_version":"v0.74.4","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"8b125cf7ee518a4437899f17a5ba34ba9143f4a3914a264ecf84bf3956d849d3","compiler_version":"v0.74.4","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"d3abfe96a194bce3a523ed2093ddedd5704cdf62","version":"v0.74.4"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.46","digest":"sha256:11c8c313d8ac37746223800ecf70962230feb12564692681e1dd57c234ee4ac1","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.46@sha256:11c8c313d8ac37746223800ecf70962230feb12564692681e1dd57c234ee4ac1"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.46","digest":"sha256:d62d7d60883f748bd2ec6349829c3662c2533eb896328962735ee7f87cce2175","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.46@sha256:d62d7d60883f748bd2ec6349829c3662c2533eb896328962735ee7f87cce2175"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.46","digest":"sha256:70c5b1ae3e73c0d689ca7bd4f4f8aee9e1b332206a5240629d21669824f93089","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.46@sha256:70c5b1ae3e73c0d689ca7bd4f4f8aee9e1b332206a5240629d21669824f93089"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -50,6 +50,8 @@
 
 name: "Benchmark Regression Analysis"
 on:
+  schedule:
+  - cron: 0 6 * * 0-4
   workflow_call:
     inputs:
       aw_context:
@@ -296,25 +298,24 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
-          GH_AW_INPUTS_ISSUE_NUMBER: ${{ inputs.issue_number }}
         # poutine:ignore untrusted_checkout_exec
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_27611a5162d0b0e4_EOF'
+          cat << 'GH_AW_PROMPT_86c7ebdbc479e08e_EOF'
           <system>
-          GH_AW_PROMPT_27611a5162d0b0e4_EOF
+          GH_AW_PROMPT_86c7ebdbc479e08e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_27611a5162d0b0e4_EOF'
+          cat << 'GH_AW_PROMPT_86c7ebdbc479e08e_EOF'
           <safe-output-tools>
           Tools: add_comment, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_27611a5162d0b0e4_EOF
+          GH_AW_PROMPT_86c7ebdbc479e08e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_27611a5162d0b0e4_EOF'
+          cat << 'GH_AW_PROMPT_86c7ebdbc479e08e_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -346,19 +347,18 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_27611a5162d0b0e4_EOF
+          GH_AW_PROMPT_86c7ebdbc479e08e_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_27611a5162d0b0e4_EOF'
+          cat << 'GH_AW_PROMPT_86c7ebdbc479e08e_EOF'
           </system>
           {{#runtime-import .github/workflows/benchmark-regression-analysis.md}}
-          GH_AW_PROMPT_27611a5162d0b0e4_EOF
+          GH_AW_PROMPT_86c7ebdbc479e08e_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_ENGINE_ID: "copilot"
-          GH_AW_INPUTS_ISSUE_NUMBER: ${{ inputs.issue_number }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -377,7 +377,6 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
-          GH_AW_INPUTS_ISSUE_NUMBER: ${{ inputs.issue_number }}
           GH_AW_MCP_CLI_SERVERS_LIST: '- `safeoutputs` — run `safeoutputs --help` to see available tools'
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
@@ -399,7 +398,6 @@ jobs:
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
-                GH_AW_INPUTS_ISSUE_NUMBER: process.env.GH_AW_INPUTS_ISSUE_NUMBER,
                 GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST,
                 GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
               }
@@ -438,6 +436,8 @@ jobs:
       actions: read
       contents: read
       issues: read
+    concurrency:
+      group: "gh-aw-copilot-${{ github.workflow }}"
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""
@@ -500,12 +500,13 @@ jobs:
           BENCHMARK_ARTIFACT_URL: ${{ inputs.artifact_url }}
           BENCHMARK_RUN_ID: ${{ inputs.run_id }}
           BENCHMARK_RUN_URL: ${{ inputs.run_url }}
+          GH_TOKEN: ${{ github.token }}
           HISTORY_REPORT_PATH: ${{ inputs.history_report_path }}
           ISSUE_NUMBER: ${{ inputs.issue_number }}
           REGRESSIONS_PATH: ${{ inputs.regressions_path }}
           RESULTS_PATH: ${{ inputs.results_path }}
         name: Prepare benchmark analysis data
-        run: "set -euo pipefail\n\ndata_dir=\"/tmp/gh-aw/benchmark-analysis\"\nmkdir -p \"${data_dir}\"\n\nif ! git fetch --depth=1 origin benchmark-results; then\n  echo \"Could not fetch benchmark-results branch\" >> \"${data_dir}/missing-files.txt\"\nfi\n\ncopy_from_history() {\n  source_path=\"$1\"\n  output_name=\"$2\"\n  if [ -z \"${source_path}\" ]; then\n    return 0\n  fi\n  if ! git show \"origin/benchmark-results:${source_path}\" > \"${data_dir}/${output_name}\"; then\n    echo \"Could not read benchmark-results:${source_path}\" >> \"${data_dir}/missing-files.txt\"\n  fi\n}\n\ncopy_from_history \"${RESULTS_PATH}\" \"results.json\"\ncopy_from_history \"${HISTORY_REPORT_PATH}\" \"history-report.json\"\ncopy_from_history \"${REGRESSIONS_PATH}\" \"regressions.md\"\ncopy_from_history \"${ANALYSIS_CONTEXT_PATH}\" \"analysis-context.json\"\n\nartifact_url=\"${BENCHMARK_ARTIFACT_URL}\"\nif [ -z \"${artifact_url}\" ]; then\n  artifact_url=\"${BENCHMARK_RUN_URL}#artifacts\"\nfi\n\nmake_blob_url() {\n  source_path=\"$1\"\n  if [ -z \"${source_path}\" ]; then\n    printf ''\n    return 0\n  fi\n  printf '%s/%s/blob/benchmark-results/%s' \"${GITHUB_SERVER_URL}\" \"${GITHUB_REPOSITORY}\" \"${source_path}\"\n}\n\njq -n \\\n  --arg repository \"${GITHUB_REPOSITORY}\" \\\n  --arg issue_number \"${ISSUE_NUMBER}\" \\\n  --arg run_id \"${BENCHMARK_RUN_ID}\" \\\n  --arg run_url \"${BENCHMARK_RUN_URL}\" \\\n  --arg artifact_url \"${artifact_url}\" \\\n  --arg results_path \"${RESULTS_PATH}\" \\\n  --arg history_report_path \"${HISTORY_REPORT_PATH}\" \\\n  --arg regressions_path \"${REGRESSIONS_PATH}\" \\\n  --arg analysis_context_path \"${ANALYSIS_CONTEXT_PATH}\" \\\n  --arg results_url \"$(make_blob_url \"${RESULTS_PATH}\")\" \\\n  --arg history_report_url \"$(make_blob_url \"${HISTORY_REPORT_PATH}\")\" \\\n  --arg regressions_url \"$(make_blob_url \"${REGRESSIONS_PATH}\")\" \\\n  --arg analysis_context_url \"$(make_blob_url \"${ANALYSIS_CONTEXT_PATH}\")\" \\\n  '{\n    repository: $repository,\n    issue_number: $issue_number,\n    run_id: $run_id,\n    run_url: $run_url,\n    artifact_url: $artifact_url,\n    branch: \"benchmark-results\",\n    paths: {\n      results: $results_path,\n      history_report: $history_report_path,\n      regressions: $regressions_path,\n      analysis_context: $analysis_context_path\n    },\n    links: {\n      workflow_run: $run_url,\n      artifacts: $artifact_url,\n      results_json: $results_url,\n      history_report_json: $history_report_url,\n      regressions_markdown: $regressions_url,\n      analysis_context_json: $analysis_context_url\n    }\n  }' > \"${data_dir}/run-context.json\"\n"
+        run: "set -euo pipefail\n\ndata_dir=\"/tmp/gh-aw/benchmark-analysis\"\nmkdir -p \"${data_dir}\"\n\nif ! git fetch --depth=1 origin benchmark-results; then\n  echo \"Could not fetch benchmark-results branch\" >> \"${data_dir}/missing-files.txt\"\nfi\n\nif [ -z \"${RESULTS_PATH}\" ]; then\n  RESULTS_PATH=\"latest/results.json\"\nfi\nif [ -z \"${HISTORY_REPORT_PATH}\" ]; then\n  HISTORY_REPORT_PATH=\"latest/history-report.json\"\nfi\nif [ -z \"${REGRESSIONS_PATH}\" ]; then\n  REGRESSIONS_PATH=\"latest/regressions.md\"\nfi\nif [ -z \"${ANALYSIS_CONTEXT_PATH}\" ]; then\n  ANALYSIS_CONTEXT_PATH=\"latest/analysis-context.json\"\nfi\n\nrun_records_dir=\"${RESULTS_PATH%/*}\"\nif [ \"${run_records_dir}\" = \"${RESULTS_PATH}\" ]; then\n  run_records_dir=\"latest\"\nfi\nMETADATA_PATH=\"${run_records_dir}/metadata.json\"\nREGRESSIONS_JSON_PATH=\"${run_records_dir}/regressions.json\"\n\ncopy_from_history() {\n  source_path=\"$1\"\n  output_name=\"$2\"\n  if [ -z \"${source_path}\" ]; then\n    return 0\n  fi\n  if ! git show \"origin/benchmark-results:${source_path}\" > \"${data_dir}/${output_name}\"; then\n    echo \"Could not read benchmark-results:${source_path}\" >> \"${data_dir}/missing-files.txt\"\n  fi\n}\n\ncopy_optional_from_history() {\n  source_path=\"$1\"\n  output_name=\"$2\"\n  if [ -z \"${source_path}\" ]; then\n    return 0\n  fi\n  git show \"origin/benchmark-results:${source_path}\" > \"${data_dir}/${output_name}\" 2>/dev/null || true\n}\n\ncopy_from_history \"${RESULTS_PATH}\" \"results.json\"\ncopy_from_history \"${HISTORY_REPORT_PATH}\" \"history-report.json\"\ncopy_from_history \"${REGRESSIONS_PATH}\" \"regressions.md\"\ncopy_from_history \"${ANALYSIS_CONTEXT_PATH}\" \"analysis-context.json\"\ncopy_optional_from_history \"${METADATA_PATH}\" \"metadata.json\"\ncopy_optional_from_history \"${REGRESSIONS_JSON_PATH}\" \"regressions.json\"\n\nif [ -f \"${data_dir}/metadata.json\" ]; then\n  if [ -z \"${BENCHMARK_RUN_ID}\" ]; then\n    BENCHMARK_RUN_ID=\"$(jq -r '.run_id // \"\"' \"${data_dir}/metadata.json\")\"\n  fi\n  if [ -z \"${BENCHMARK_RUN_URL}\" ]; then\n    BENCHMARK_RUN_URL=\"$(jq -r '.run_url // \"\"' \"${data_dir}/metadata.json\")\"\n  fi\nfi\n\nif [ -z \"${ISSUE_NUMBER}\" ]; then\n  title=\"[benchmark-regression] Declarative benchmark regressions\"\n  ISSUE_NUMBER=\"$(gh issue list \\\n    --state open \\\n    --search \"${title} in:title\" \\\n    --json number \\\n    --jq '.[0].number // empty' 2>/dev/null || true)\"\n  if [ -z \"${ISSUE_NUMBER}\" ]; then\n    echo \"Could not find an open benchmark regression issue\" >> \"${data_dir}/missing-files.txt\"\n  fi\nfi\n\nartifact_url=\"${BENCHMARK_ARTIFACT_URL}\"\nif [ -z \"${artifact_url}\" ] && [ -n \"${BENCHMARK_RUN_URL}\" ]; then\n  artifact_url=\"${BENCHMARK_RUN_URL}#artifacts\"\nfi\n\nmake_blob_url() {\n  source_path=\"$1\"\n  if [ -z \"${source_path}\" ]; then\n    printf ''\n    return 0\n  fi\n  printf '%s/%s/blob/benchmark-results/%s' \"${GITHUB_SERVER_URL}\" \"${GITHUB_REPOSITORY}\" \"${source_path}\"\n}\n\njq -n \\\n  --arg repository \"${GITHUB_REPOSITORY}\" \\\n  --arg issue_number \"${ISSUE_NUMBER}\" \\\n  --arg run_id \"${BENCHMARK_RUN_ID}\" \\\n  --arg run_url \"${BENCHMARK_RUN_URL}\" \\\n  --arg artifact_url \"${artifact_url}\" \\\n  --arg results_path \"${RESULTS_PATH}\" \\\n  --arg history_report_path \"${HISTORY_REPORT_PATH}\" \\\n  --arg regressions_path \"${REGRESSIONS_PATH}\" \\\n  --arg analysis_context_path \"${ANALYSIS_CONTEXT_PATH}\" \\\n  --arg metadata_path \"${METADATA_PATH}\" \\\n  --arg regressions_json_path \"${REGRESSIONS_JSON_PATH}\" \\\n  --arg results_url \"$(make_blob_url \"${RESULTS_PATH}\")\" \\\n  --arg history_report_url \"$(make_blob_url \"${HISTORY_REPORT_PATH}\")\" \\\n  --arg regressions_url \"$(make_blob_url \"${REGRESSIONS_PATH}\")\" \\\n  --arg analysis_context_url \"$(make_blob_url \"${ANALYSIS_CONTEXT_PATH}\")\" \\\n  --arg metadata_url \"$(make_blob_url \"${METADATA_PATH}\")\" \\\n  --arg regressions_json_url \"$(make_blob_url \"${REGRESSIONS_JSON_PATH}\")\" \\\n  '{\n    repository: $repository,\n    issue_number: $issue_number,\n    run_id: $run_id,\n    run_url: $run_url,\n    artifact_url: $artifact_url,\n    branch: \"benchmark-results\",\n    paths: {\n      results: $results_path,\n      history_report: $history_report_path,\n      regressions: $regressions_path,\n      analysis_context: $analysis_context_path,\n      metadata: $metadata_path,\n      regressions_json: $regressions_json_path\n    },\n    links: {\n      workflow_run: $run_url,\n      artifacts: $artifact_url,\n      results_json: $results_url,\n      history_report_json: $history_report_url,\n      regressions_markdown: $regressions_url,\n      analysis_context_json: $analysis_context_url,\n      metadata_json: $metadata_url,\n      regressions_json: $regressions_json_url\n    }\n  }' > \"${data_dir}/run-context.json\"\n"
 
       - name: Configure Git credentials
         env:
@@ -569,21 +570,19 @@ jobs:
       - name: Download container images
         run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" ghcr.io/github/gh-aw-firewall/agent:0.25.46@sha256:11c8c313d8ac37746223800ecf70962230feb12564692681e1dd57c234ee4ac1 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.46@sha256:d62d7d60883f748bd2ec6349829c3662c2533eb896328962735ee7f87cce2175 ghcr.io/github/gh-aw-firewall/squid:0.25.46@sha256:70c5b1ae3e73c0d689ca7bd4f4f8aee9e1b332206a5240629d21669824f93089 ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388 ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4 node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
       - name: Generate Safe Outputs Config
-        env:
-          GH_AW_INPUT_ISSUE_NUMBER: ${{ inputs.issue_number }}
         run: |
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_a0d1d678cc90e91b_EOF
-          {"add_comment":{"hide_older_comments":true,"max":1,"target":"${GH_AW_INPUT_ISSUE_NUMBER}"},"create_report_incomplete_issue":{},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_a0d1d678cc90e91b_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_d7efdec5fb17c723_EOF'
+          {"add_comment":{"hide_older_comments":true,"max":1},"create_report_incomplete_issue":{},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_d7efdec5fb17c723_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Target: ${{ inputs.issue_number }}. Supports reply_to_id for discussion threading."
+                "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Supports reply_to_id for discussion threading."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -771,7 +770,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_fb2dfc2d80084826_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_8d9c9db8ddb023a0_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -812,7 +811,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_fb2dfc2d80084826_EOF
+          GH_AW_MCP_CONFIG_8d9c9db8ddb023a0_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1507,7 +1506,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1,\"target\":\"${{ inputs.issue_number }}\"},\"create_report_incomplete_issue\":{},\"mentions\":{\"enabled\":false},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1},\"create_report_incomplete_issue\":{},\"mentions\":{\"enabled\":false},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/benchmark-regression-analysis.lock.yml
+++ b/.github/workflows/benchmark-regression-analysis.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"8b125cf7ee518a4437899f17a5ba34ba9143f4a3914a264ecf84bf3956d849d3","compiler_version":"v0.74.4","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"1d7c00f34efb973ba31d7387c1e6f6bb4b34e7220b795f5fb66d71481b4a6663","compiler_version":"v0.74.4","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"d3abfe96a194bce3a523ed2093ddedd5704cdf62","version":"v0.74.4"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.46","digest":"sha256:11c8c313d8ac37746223800ecf70962230feb12564692681e1dd57c234ee4ac1","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.46@sha256:11c8c313d8ac37746223800ecf70962230feb12564692681e1dd57c234ee4ac1"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.46","digest":"sha256:d62d7d60883f748bd2ec6349829c3662c2533eb896328962735ee7f87cce2175","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.46@sha256:d62d7d60883f748bd2ec6349829c3662c2533eb896328962735ee7f87cce2175"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.46","digest":"sha256:70c5b1ae3e73c0d689ca7bd4f4f8aee9e1b332206a5240629d21669824f93089","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.46@sha256:70c5b1ae3e73c0d689ca7bd4f4f8aee9e1b332206a5240629d21669824f93089"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4","digest":"sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.4@sha256:e3816a476a977cfb836e7d221510011436c654d11861db66ecfd826601aba6a4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -302,20 +302,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_86c7ebdbc479e08e_EOF'
+          cat << 'GH_AW_PROMPT_c83b098af0fa6a68_EOF'
           <system>
-          GH_AW_PROMPT_86c7ebdbc479e08e_EOF
+          GH_AW_PROMPT_c83b098af0fa6a68_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_86c7ebdbc479e08e_EOF'
+          cat << 'GH_AW_PROMPT_c83b098af0fa6a68_EOF'
           <safe-output-tools>
           Tools: add_comment, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_86c7ebdbc479e08e_EOF
+          GH_AW_PROMPT_c83b098af0fa6a68_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_86c7ebdbc479e08e_EOF'
+          cat << 'GH_AW_PROMPT_c83b098af0fa6a68_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -347,12 +347,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_86c7ebdbc479e08e_EOF
+          GH_AW_PROMPT_c83b098af0fa6a68_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_86c7ebdbc479e08e_EOF'
+          cat << 'GH_AW_PROMPT_c83b098af0fa6a68_EOF'
           </system>
           {{#runtime-import .github/workflows/benchmark-regression-analysis.md}}
-          GH_AW_PROMPT_86c7ebdbc479e08e_EOF
+          GH_AW_PROMPT_c83b098af0fa6a68_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -506,7 +506,7 @@ jobs:
           REGRESSIONS_PATH: ${{ inputs.regressions_path }}
           RESULTS_PATH: ${{ inputs.results_path }}
         name: Prepare benchmark analysis data
-        run: "set -euo pipefail\n\ndata_dir=\"/tmp/gh-aw/benchmark-analysis\"\nmkdir -p \"${data_dir}\"\n\nif ! git fetch --depth=1 origin benchmark-results; then\n  echo \"Could not fetch benchmark-results branch\" >> \"${data_dir}/missing-files.txt\"\nfi\n\nif [ -z \"${RESULTS_PATH}\" ]; then\n  RESULTS_PATH=\"latest/results.json\"\nfi\nif [ -z \"${HISTORY_REPORT_PATH}\" ]; then\n  HISTORY_REPORT_PATH=\"latest/history-report.json\"\nfi\nif [ -z \"${REGRESSIONS_PATH}\" ]; then\n  REGRESSIONS_PATH=\"latest/regressions.md\"\nfi\nif [ -z \"${ANALYSIS_CONTEXT_PATH}\" ]; then\n  ANALYSIS_CONTEXT_PATH=\"latest/analysis-context.json\"\nfi\n\nrun_records_dir=\"${RESULTS_PATH%/*}\"\nif [ \"${run_records_dir}\" = \"${RESULTS_PATH}\" ]; then\n  run_records_dir=\"latest\"\nfi\nMETADATA_PATH=\"${run_records_dir}/metadata.json\"\nREGRESSIONS_JSON_PATH=\"${run_records_dir}/regressions.json\"\n\ncopy_from_history() {\n  source_path=\"$1\"\n  output_name=\"$2\"\n  if [ -z \"${source_path}\" ]; then\n    return 0\n  fi\n  if ! git show \"origin/benchmark-results:${source_path}\" > \"${data_dir}/${output_name}\"; then\n    echo \"Could not read benchmark-results:${source_path}\" >> \"${data_dir}/missing-files.txt\"\n  fi\n}\n\ncopy_optional_from_history() {\n  source_path=\"$1\"\n  output_name=\"$2\"\n  if [ -z \"${source_path}\" ]; then\n    return 0\n  fi\n  git show \"origin/benchmark-results:${source_path}\" > \"${data_dir}/${output_name}\" 2>/dev/null || true\n}\n\ncopy_from_history \"${RESULTS_PATH}\" \"results.json\"\ncopy_from_history \"${HISTORY_REPORT_PATH}\" \"history-report.json\"\ncopy_from_history \"${REGRESSIONS_PATH}\" \"regressions.md\"\ncopy_from_history \"${ANALYSIS_CONTEXT_PATH}\" \"analysis-context.json\"\ncopy_optional_from_history \"${METADATA_PATH}\" \"metadata.json\"\ncopy_optional_from_history \"${REGRESSIONS_JSON_PATH}\" \"regressions.json\"\n\nif [ -f \"${data_dir}/metadata.json\" ]; then\n  if [ -z \"${BENCHMARK_RUN_ID}\" ]; then\n    BENCHMARK_RUN_ID=\"$(jq -r '.run_id // \"\"' \"${data_dir}/metadata.json\")\"\n  fi\n  if [ -z \"${BENCHMARK_RUN_URL}\" ]; then\n    BENCHMARK_RUN_URL=\"$(jq -r '.run_url // \"\"' \"${data_dir}/metadata.json\")\"\n  fi\nfi\n\nif [ -z \"${ISSUE_NUMBER}\" ]; then\n  title=\"[benchmark-regression] Declarative benchmark regressions\"\n  ISSUE_NUMBER=\"$(gh issue list \\\n    --state open \\\n    --search \"${title} in:title\" \\\n    --json number \\\n    --jq '.[0].number // empty' 2>/dev/null || true)\"\n  if [ -z \"${ISSUE_NUMBER}\" ]; then\n    echo \"Could not find an open benchmark regression issue\" >> \"${data_dir}/missing-files.txt\"\n  fi\nfi\n\nartifact_url=\"${BENCHMARK_ARTIFACT_URL}\"\nif [ -z \"${artifact_url}\" ] && [ -n \"${BENCHMARK_RUN_URL}\" ]; then\n  artifact_url=\"${BENCHMARK_RUN_URL}#artifacts\"\nfi\n\nmake_blob_url() {\n  source_path=\"$1\"\n  if [ -z \"${source_path}\" ]; then\n    printf ''\n    return 0\n  fi\n  printf '%s/%s/blob/benchmark-results/%s' \"${GITHUB_SERVER_URL}\" \"${GITHUB_REPOSITORY}\" \"${source_path}\"\n}\n\njq -n \\\n  --arg repository \"${GITHUB_REPOSITORY}\" \\\n  --arg issue_number \"${ISSUE_NUMBER}\" \\\n  --arg run_id \"${BENCHMARK_RUN_ID}\" \\\n  --arg run_url \"${BENCHMARK_RUN_URL}\" \\\n  --arg artifact_url \"${artifact_url}\" \\\n  --arg results_path \"${RESULTS_PATH}\" \\\n  --arg history_report_path \"${HISTORY_REPORT_PATH}\" \\\n  --arg regressions_path \"${REGRESSIONS_PATH}\" \\\n  --arg analysis_context_path \"${ANALYSIS_CONTEXT_PATH}\" \\\n  --arg metadata_path \"${METADATA_PATH}\" \\\n  --arg regressions_json_path \"${REGRESSIONS_JSON_PATH}\" \\\n  --arg results_url \"$(make_blob_url \"${RESULTS_PATH}\")\" \\\n  --arg history_report_url \"$(make_blob_url \"${HISTORY_REPORT_PATH}\")\" \\\n  --arg regressions_url \"$(make_blob_url \"${REGRESSIONS_PATH}\")\" \\\n  --arg analysis_context_url \"$(make_blob_url \"${ANALYSIS_CONTEXT_PATH}\")\" \\\n  --arg metadata_url \"$(make_blob_url \"${METADATA_PATH}\")\" \\\n  --arg regressions_json_url \"$(make_blob_url \"${REGRESSIONS_JSON_PATH}\")\" \\\n  '{\n    repository: $repository,\n    issue_number: $issue_number,\n    run_id: $run_id,\n    run_url: $run_url,\n    artifact_url: $artifact_url,\n    branch: \"benchmark-results\",\n    paths: {\n      results: $results_path,\n      history_report: $history_report_path,\n      regressions: $regressions_path,\n      analysis_context: $analysis_context_path,\n      metadata: $metadata_path,\n      regressions_json: $regressions_json_path\n    },\n    links: {\n      workflow_run: $run_url,\n      artifacts: $artifact_url,\n      results_json: $results_url,\n      history_report_json: $history_report_url,\n      regressions_markdown: $regressions_url,\n      analysis_context_json: $analysis_context_url,\n      metadata_json: $metadata_url,\n      regressions_json: $regressions_json_url\n    }\n  }' > \"${data_dir}/run-context.json\"\n"
+        run: "set -euo pipefail\n\ndata_dir=\"/tmp/gh-aw/benchmark-analysis\"\nmkdir -p \"${data_dir}\"\n\nif ! git fetch --depth=1 origin benchmark-results; then\n  echo \"Could not fetch benchmark-results branch\" >> \"${data_dir}/missing-files.txt\"\nfi\n\nif [ -z \"${RESULTS_PATH}\" ]; then\n  RESULTS_PATH=\"latest/results.json\"\nfi\nif [ -z \"${HISTORY_REPORT_PATH}\" ]; then\n  HISTORY_REPORT_PATH=\"latest/history-report.json\"\nfi\nif [ -z \"${REGRESSIONS_PATH}\" ]; then\n  REGRESSIONS_PATH=\"latest/regressions.md\"\nfi\nif [ -z \"${ANALYSIS_CONTEXT_PATH}\" ]; then\n  ANALYSIS_CONTEXT_PATH=\"latest/analysis-context.json\"\nfi\n\nrun_records_dir=\"${RESULTS_PATH%/*}\"\nif [ \"${run_records_dir}\" = \"${RESULTS_PATH}\" ]; then\n  run_records_dir=\"latest\"\nfi\nMETADATA_PATH=\"${run_records_dir}/metadata.json\"\nREGRESSIONS_JSON_PATH=\"${run_records_dir}/regressions.json\"\n\ncopy_from_history() {\n  source_path=\"$1\"\n  output_name=\"$2\"\n  if [ -z \"${source_path}\" ]; then\n    return 0\n  fi\n  if ! git show \"origin/benchmark-results:${source_path}\" > \"${data_dir}/${output_name}\"; then\n    echo \"Could not read benchmark-results:${source_path}\" >> \"${data_dir}/missing-files.txt\"\n  fi\n}\n\ncopy_optional_from_history() {\n  source_path=\"$1\"\n  output_name=\"$2\"\n  if [ -z \"${source_path}\" ]; then\n    return 0\n  fi\n  git show \"origin/benchmark-results:${source_path}\" > \"${data_dir}/${output_name}\" 2>/dev/null || true\n}\n\ncopy_from_history \"${RESULTS_PATH}\" \"results.json\"\ncopy_from_history \"${HISTORY_REPORT_PATH}\" \"history-report.json\"\ncopy_from_history \"${REGRESSIONS_PATH}\" \"regressions.md\"\ncopy_from_history \"${ANALYSIS_CONTEXT_PATH}\" \"analysis-context.json\"\ncopy_optional_from_history \"${METADATA_PATH}\" \"metadata.json\"\ncopy_optional_from_history \"${REGRESSIONS_JSON_PATH}\" \"regressions.json\"\n\nif [ -f \"${data_dir}/metadata.json\" ]; then\n  if [ -z \"${BENCHMARK_RUN_ID}\" ]; then\n    BENCHMARK_RUN_ID=\"$(jq -r '.run_id // \"\"' \"${data_dir}/metadata.json\")\"\n  fi\n  if [ -z \"${BENCHMARK_RUN_URL}\" ]; then\n    BENCHMARK_RUN_URL=\"$(jq -r '.run_url // \"\"' \"${data_dir}/metadata.json\")\"\n  fi\nfi\n\nif [ -z \"${ISSUE_NUMBER}\" ]; then\n  title=\"[benchmark-regression] Declarative benchmark regressions\"\n  ISSUE_NUMBER=\"$(gh issue list \\\n    --state open \\\n    --search \"${title} in:title\" \\\n    --json number \\\n    --jq '.[0].number // empty' 2>/dev/null || true)\"\n  if [ -z \"${ISSUE_NUMBER}\" ]; then\n    echo \"Could not find an open benchmark regression issue\" >> \"${data_dir}/missing-files.txt\"\n  fi\nfi\n\nartifact_url=\"${BENCHMARK_ARTIFACT_URL}\"\nif [ -z \"${artifact_url}\" ] && [ -n \"${BENCHMARK_RUN_URL}\" ]; then\n  artifact_url=\"${BENCHMARK_RUN_URL}#artifacts\"\nfi\n\nmake_blob_url() {\n  source_path=\"$1\"\n  if [ -z \"${source_path}\" ]; then\n    printf ''\n    return 0\n  fi\n  printf '%s/%s/blob/benchmark-results/%s' \"${GITHUB_SERVER_URL}\" \"${GITHUB_REPOSITORY}\" \"${source_path}\"\n}\n\njq -n \\\n  --arg repository \"${GITHUB_REPOSITORY}\" \\\n  --arg issue_number \"${ISSUE_NUMBER}\" \\\n  --arg run_id \"${BENCHMARK_RUN_ID}\" \\\n  --arg run_url \"${BENCHMARK_RUN_URL}\" \\\n  --arg artifact_url \"${artifact_url}\" \\\n  --arg results_path \"${RESULTS_PATH}\" \\\n  --arg history_report_path \"${HISTORY_REPORT_PATH}\" \\\n  --arg regressions_path \"${REGRESSIONS_PATH}\" \\\n  --arg analysis_context_path \"${ANALYSIS_CONTEXT_PATH}\" \\\n  --arg metadata_path \"${METADATA_PATH}\" \\\n  --arg regressions_json_path \"${REGRESSIONS_JSON_PATH}\" \\\n  --arg results_url \"$(make_blob_url \"${RESULTS_PATH}\")\" \\\n  --arg history_report_url \"$(make_blob_url \"${HISTORY_REPORT_PATH}\")\" \\\n  --arg regressions_url \"$(make_blob_url \"${REGRESSIONS_PATH}\")\" \\\n  --arg analysis_context_url \"$(make_blob_url \"${ANALYSIS_CONTEXT_PATH}\")\" \\\n  --arg metadata_url \"$(make_blob_url \"${METADATA_PATH}\")\" \\\n  --arg regressions_json_url \"$(make_blob_url \"${REGRESSIONS_JSON_PATH}\")\" \\\n  '{\n    repository: $repository,\n    issue_number: (if $issue_number == \"\" then null else $issue_number end),\n    run_id: $run_id,\n    run_url: $run_url,\n    artifact_url: $artifact_url,\n    branch: \"benchmark-results\",\n    paths: {\n      results: $results_path,\n      history_report: $history_report_path,\n      regressions: $regressions_path,\n      analysis_context: $analysis_context_path,\n      metadata: $metadata_path,\n      regressions_json: $regressions_json_path\n    },\n    links: {\n      workflow_run: $run_url,\n      artifacts: $artifact_url,\n      results_json: $results_url,\n      history_report_json: $history_report_url,\n      regressions_markdown: $regressions_url,\n      analysis_context_json: $analysis_context_url,\n      metadata_json: $metadata_url,\n      regressions_json: $regressions_json_url\n    }\n  }' > \"${data_dir}/run-context.json\"\n"
 
       - name: Configure Git credentials
         env:
@@ -574,15 +574,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_d7efdec5fb17c723_EOF'
-          {"add_comment":{"hide_older_comments":true,"max":1},"create_report_incomplete_issue":{},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_d7efdec5fb17c723_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a8f163a4c1cd0406_EOF'
+          {"add_comment":{"hide_older_comments":true,"max":1,"target":"*"},"create_report_incomplete_issue":{},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_a8f163a4c1cd0406_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Supports reply_to_id for discussion threading."
+                "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added. Target: *. Supports reply_to_id for discussion threading."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -770,7 +770,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_8d9c9db8ddb023a0_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_f026f0dda989388c_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -811,7 +811,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_8d9c9db8ddb023a0_EOF
+          GH_AW_MCP_CONFIG_f026f0dda989388c_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1011,6 +1011,10 @@ jobs:
           if [ ! -f /tmp/gh-aw/agent_output.json ]; then
             echo '{"items":[]}' > /tmp/gh-aw/agent_output.json
           fi
+      - if: always()
+        name: Validate benchmark analysis comment target
+        run: "set -euo pipefail\n\ndata_dir=\"/tmp/gh-aw/benchmark-analysis\"\nrun_context=\"${data_dir}/run-context.json\"\nagent_output=\"/tmp/gh-aw/agent_output.json\"\nsafe_outputs=\"${RUNNER_TEMP}/gh-aw/safeoutputs/outputs.jsonl\"\n\nif [ ! -f \"${safe_outputs}\" ] && [ ! -f \"${agent_output}\" ]; then\n  exit 0\nfi\n\nissue_number=\"\"\nif [ -f \"${run_context}\" ]; then\n  issue_number=\"$(jq -r '.issue_number // \"\"' \"${run_context}\")\"\nfi\n\nfiltered_outputs=\"${data_dir}/safeoutputs.validated.jsonl\"\ninvalid_comment_count=0\n\nif [ -f \"${safe_outputs}\" ]; then\n  invalid_comment_count=\"$(\n    jq -s --arg issue_number \"${issue_number}\" \\\n      '[.[] | select(.type == \"add_comment\" and ($issue_number == \"\" or ((.item_number // .issue_number // \"\") | tostring) != $issue_number))] | length' \\\n      \"${safe_outputs}\"\n  )\"\n\n  if [ \"${invalid_comment_count}\" -gt 0 ]; then\n    jq -c --arg issue_number \"${issue_number}\" \\\n      'select(.type != \"add_comment\" or ($issue_number != \"\" and ((.item_number // .issue_number // \"\") | tostring) == $issue_number))' \\\n      \"${safe_outputs}\" > \"${filtered_outputs}\"\n\n    if [ ! -s \"${filtered_outputs}\" ]; then\n      jq -cn --arg message \\\n        \"Skipped benchmark analysis comment because the requested target did not match the resolved benchmark regression issue.\" \\\n        '{type: \"noop\", message: $message}' >> \"${filtered_outputs}\"\n    fi\n\n    mv \"${filtered_outputs}\" \"${safe_outputs}\"\n  fi\nfi\n\nif [ -f \"${agent_output}\" ]; then\n  agent_invalid_comment_count=\"$(\n    jq --arg issue_number \"${issue_number}\" \\\n      '[.items[]? | select(.type == \"add_comment\" and ($issue_number == \"\" or ((.item_number // .issue_number // \"\") | tostring) != $issue_number))] | length' \\\n      \"${agent_output}\"\n  )\"\n  if [ \"${agent_invalid_comment_count}\" -eq 0 ]; then\n    exit 0\n  fi\n\n  filtered_agent_output=\"${data_dir}/agent_output.validated.json\"\n  jq --arg issue_number \"${issue_number}\" --arg message \\\n    \"Skipped benchmark analysis comment because the requested target did not match the resolved benchmark regression issue.\" \\\n    '\n    def valid_output:\n      .type != \"add_comment\" or\n      ($issue_number != \"\" and ((.item_number // .issue_number // \"\") | tostring) == $issue_number);\n\n    .items = ([.items[]? | select(valid_output)]) |\n    if (.items | length) == 0 then\n      .items = [{type: \"noop\", message: $message}]\n    else\n      .\n    end\n    ' \"${agent_output}\" > \"${filtered_agent_output}\"\n  mv \"${filtered_agent_output}\" \"${agent_output}\"\nfi\n"
+
       - name: Upload agent artifacts
         if: always()
         continue-on-error: true
@@ -1049,9 +1053,7 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      discussions: write
       issues: write
-      pull-requests: write
     concurrency:
       group: "gh-aw-conclusion-benchmark-regression-analysis"
       cancel-in-progress: false
@@ -1436,9 +1438,7 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      discussions: write
       issues: write
-      pull-requests: write
     timeout-minutes: 15
     env:
       GH_AW_CALLER_WORKFLOW_ID: "${{ github.repository }}/benchmark-regression-analysis"
@@ -1506,7 +1506,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1},\"create_report_incomplete_issue\":{},\"mentions\":{\"enabled\":false},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1,\"target\":\"*\"},\"create_report_incomplete_issue\":{},\"mentions\":{\"enabled\":false},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/benchmark-regression-analysis.md
+++ b/.github/workflows/benchmark-regression-analysis.md
@@ -4,6 +4,10 @@ description: |
   Analyzes declarative benchmark regression data and adds a human-readable
   explanation with action items to the rolling benchmark regression issue.
 on:
+  schedule:
+    # GitHub schedules are UTC-only. 06:00 UTC Sunday-Thursday maps to
+    # midnight US/Central during standard time and 1 AM during daylight time.
+    - cron: "0 6 * * 0-4"
   workflow_call:
     inputs:
       issue_number:
@@ -87,12 +91,12 @@ safe-outputs:
   noop:
     report-as-issue: false
   add-comment:
-    target: ${{ inputs.issue_number }}
     hide-older-comments: true
     max: 1
 steps:
   - name: Prepare benchmark analysis data
     env:
+      GH_TOKEN: ${{ github.token }}
       ISSUE_NUMBER: ${{ inputs.issue_number }}
       BENCHMARK_RUN_ID: ${{ inputs.run_id }}
       BENCHMARK_RUN_URL: ${{ inputs.run_url }}
@@ -111,6 +115,26 @@ steps:
         echo "Could not fetch benchmark-results branch" >> "${data_dir}/missing-files.txt"
       fi
 
+      if [ -z "${RESULTS_PATH}" ]; then
+        RESULTS_PATH="latest/results.json"
+      fi
+      if [ -z "${HISTORY_REPORT_PATH}" ]; then
+        HISTORY_REPORT_PATH="latest/history-report.json"
+      fi
+      if [ -z "${REGRESSIONS_PATH}" ]; then
+        REGRESSIONS_PATH="latest/regressions.md"
+      fi
+      if [ -z "${ANALYSIS_CONTEXT_PATH}" ]; then
+        ANALYSIS_CONTEXT_PATH="latest/analysis-context.json"
+      fi
+
+      run_records_dir="${RESULTS_PATH%/*}"
+      if [ "${run_records_dir}" = "${RESULTS_PATH}" ]; then
+        run_records_dir="latest"
+      fi
+      METADATA_PATH="${run_records_dir}/metadata.json"
+      REGRESSIONS_JSON_PATH="${run_records_dir}/regressions.json"
+
       copy_from_history() {
         source_path="$1"
         output_name="$2"
@@ -122,13 +146,45 @@ steps:
         fi
       }
 
+      copy_optional_from_history() {
+        source_path="$1"
+        output_name="$2"
+        if [ -z "${source_path}" ]; then
+          return 0
+        fi
+        git show "origin/benchmark-results:${source_path}" > "${data_dir}/${output_name}" 2>/dev/null || true
+      }
+
       copy_from_history "${RESULTS_PATH}" "results.json"
       copy_from_history "${HISTORY_REPORT_PATH}" "history-report.json"
       copy_from_history "${REGRESSIONS_PATH}" "regressions.md"
       copy_from_history "${ANALYSIS_CONTEXT_PATH}" "analysis-context.json"
+      copy_optional_from_history "${METADATA_PATH}" "metadata.json"
+      copy_optional_from_history "${REGRESSIONS_JSON_PATH}" "regressions.json"
+
+      if [ -f "${data_dir}/metadata.json" ]; then
+        if [ -z "${BENCHMARK_RUN_ID}" ]; then
+          BENCHMARK_RUN_ID="$(jq -r '.run_id // ""' "${data_dir}/metadata.json")"
+        fi
+        if [ -z "${BENCHMARK_RUN_URL}" ]; then
+          BENCHMARK_RUN_URL="$(jq -r '.run_url // ""' "${data_dir}/metadata.json")"
+        fi
+      fi
+
+      if [ -z "${ISSUE_NUMBER}" ]; then
+        title="[benchmark-regression] Declarative benchmark regressions"
+        ISSUE_NUMBER="$(gh issue list \
+          --state open \
+          --search "${title} in:title" \
+          --json number \
+          --jq '.[0].number // empty' 2>/dev/null || true)"
+        if [ -z "${ISSUE_NUMBER}" ]; then
+          echo "Could not find an open benchmark regression issue" >> "${data_dir}/missing-files.txt"
+        fi
+      fi
 
       artifact_url="${BENCHMARK_ARTIFACT_URL}"
-      if [ -z "${artifact_url}" ]; then
+      if [ -z "${artifact_url}" ] && [ -n "${BENCHMARK_RUN_URL}" ]; then
         artifact_url="${BENCHMARK_RUN_URL}#artifacts"
       fi
 
@@ -151,10 +207,14 @@ steps:
         --arg history_report_path "${HISTORY_REPORT_PATH}" \
         --arg regressions_path "${REGRESSIONS_PATH}" \
         --arg analysis_context_path "${ANALYSIS_CONTEXT_PATH}" \
+        --arg metadata_path "${METADATA_PATH}" \
+        --arg regressions_json_path "${REGRESSIONS_JSON_PATH}" \
         --arg results_url "$(make_blob_url "${RESULTS_PATH}")" \
         --arg history_report_url "$(make_blob_url "${HISTORY_REPORT_PATH}")" \
         --arg regressions_url "$(make_blob_url "${REGRESSIONS_PATH}")" \
         --arg analysis_context_url "$(make_blob_url "${ANALYSIS_CONTEXT_PATH}")" \
+        --arg metadata_url "$(make_blob_url "${METADATA_PATH}")" \
+        --arg regressions_json_url "$(make_blob_url "${REGRESSIONS_JSON_PATH}")" \
         '{
           repository: $repository,
           issue_number: $issue_number,
@@ -166,7 +226,9 @@ steps:
             results: $results_path,
             history_report: $history_report_path,
             regressions: $regressions_path,
-            analysis_context: $analysis_context_path
+            analysis_context: $analysis_context_path,
+            metadata: $metadata_path,
+            regressions_json: $regressions_json_path
           },
           links: {
             workflow_run: $run_url,
@@ -174,7 +236,9 @@ steps:
             results_json: $results_url,
             history_report_json: $history_report_url,
             regressions_markdown: $regressions_url,
-            analysis_context_json: $analysis_context_url
+            analysis_context_json: $analysis_context_url,
+            metadata_json: $metadata_url,
+            regressions_json: $regressions_json_url
           }
         }' > "${data_dir}/run-context.json"
 tracker-id: benchmark-regression-analysis
@@ -202,6 +266,8 @@ Prepared files are under `/tmp/gh-aw/benchmark-analysis`:
 - `history-report.json`: full current-vs-history comparison
 - `results.json`: full benchmark suite result
 - `regressions.md`: deterministic regression issue body
+- `regressions.json`: machine-readable deterministic regression status
+- `metadata.json`: benchmark-results metadata for the benchmark run
 - `missing-files.txt`: optional list of files that could not be fetched
 
 Use `analysis-context.json` first. Fall back to the other files only when you
@@ -211,10 +277,11 @@ need detail that the compact context does not include.
 
 Emit exactly one safe output:
 
-- Use `add_comment` with `item_number: ${{ inputs.issue_number }}` when there
+- Use `add_comment` with the `issue_number` from `run-context.json` when there
   is enough data to explain the regression.
 - Use `noop` if there are no regressions, if required files are missing, or if
-  the data is too incomplete to explain safely.
+  the data is too incomplete to explain safely. Also use `noop` if
+  `run-context.json` does not contain an `issue_number`.
 
 Do not use `gh` CLI commands for GitHub reads or writes. Use the prepared local
 files first and GitHub MCP tools only if you need repository context.

--- a/.github/workflows/benchmark-regression-analysis.md
+++ b/.github/workflows/benchmark-regression-analysis.md
@@ -91,6 +91,9 @@ safe-outputs:
   noop:
     report-as-issue: false
   add-comment:
+    target: "*"
+    discussions: false
+    pull-requests: false
     hide-older-comments: true
     max: 1
 steps:
@@ -217,7 +220,7 @@ steps:
         --arg regressions_json_url "$(make_blob_url "${REGRESSIONS_JSON_PATH}")" \
         '{
           repository: $repository,
-          issue_number: $issue_number,
+          issue_number: (if $issue_number == "" then null else $issue_number end),
           run_id: $run_id,
           run_url: $run_url,
           artifact_url: $artifact_url,
@@ -241,6 +244,78 @@ steps:
             regressions_json: $regressions_json_url
           }
         }' > "${data_dir}/run-context.json"
+post-steps:
+  - name: Validate benchmark analysis comment target
+    if: always()
+    run: |
+      set -euo pipefail
+
+      data_dir="/tmp/gh-aw/benchmark-analysis"
+      run_context="${data_dir}/run-context.json"
+      agent_output="/tmp/gh-aw/agent_output.json"
+      safe_outputs="${RUNNER_TEMP}/gh-aw/safeoutputs/outputs.jsonl"
+
+      if [ ! -f "${safe_outputs}" ] && [ ! -f "${agent_output}" ]; then
+        exit 0
+      fi
+
+      issue_number=""
+      if [ -f "${run_context}" ]; then
+        issue_number="$(jq -r '.issue_number // ""' "${run_context}")"
+      fi
+
+      filtered_outputs="${data_dir}/safeoutputs.validated.jsonl"
+      invalid_comment_count=0
+
+      if [ -f "${safe_outputs}" ]; then
+        invalid_comment_count="$(
+          jq -s --arg issue_number "${issue_number}" \
+            '[.[] | select(.type == "add_comment" and ($issue_number == "" or ((.item_number // .issue_number // "") | tostring) != $issue_number))] | length' \
+            "${safe_outputs}"
+        )"
+
+        if [ "${invalid_comment_count}" -gt 0 ]; then
+          jq -c --arg issue_number "${issue_number}" \
+            'select(.type != "add_comment" or ($issue_number != "" and ((.item_number // .issue_number // "") | tostring) == $issue_number))' \
+            "${safe_outputs}" > "${filtered_outputs}"
+
+          if [ ! -s "${filtered_outputs}" ]; then
+            jq -cn --arg message \
+              "Skipped benchmark analysis comment because the requested target did not match the resolved benchmark regression issue." \
+              '{type: "noop", message: $message}' >> "${filtered_outputs}"
+          fi
+
+          mv "${filtered_outputs}" "${safe_outputs}"
+        fi
+      fi
+
+      if [ -f "${agent_output}" ]; then
+        agent_invalid_comment_count="$(
+          jq --arg issue_number "${issue_number}" \
+            '[.items[]? | select(.type == "add_comment" and ($issue_number == "" or ((.item_number // .issue_number // "") | tostring) != $issue_number))] | length' \
+            "${agent_output}"
+        )"
+        if [ "${agent_invalid_comment_count}" -eq 0 ]; then
+          exit 0
+        fi
+
+        filtered_agent_output="${data_dir}/agent_output.validated.json"
+        jq --arg issue_number "${issue_number}" --arg message \
+          "Skipped benchmark analysis comment because the requested target did not match the resolved benchmark regression issue." \
+          '
+          def valid_output:
+            .type != "add_comment" or
+            ($issue_number != "" and ((.item_number // .issue_number // "") | tostring) == $issue_number);
+
+          .items = ([.items[]? | select(valid_output)]) |
+          if (.items | length) == 0 then
+            .items = [{type: "noop", message: $message}]
+          else
+            .
+          end
+          ' "${agent_output}" > "${filtered_agent_output}"
+        mv "${filtered_agent_output}" "${agent_output}"
+      fi
 tracker-id: benchmark-regression-analysis
 ---
 
@@ -277,11 +352,11 @@ need detail that the compact context does not include.
 
 Emit exactly one safe output:
 
-- Use `add_comment` with the `issue_number` from `run-context.json` when there
-  is enough data to explain the regression.
+- Use `add_comment` with `item_number` set to the `issue_number` from
+  `run-context.json` when there is enough data to explain the regression.
 - Use `noop` if there are no regressions, if required files are missing, or if
   the data is too incomplete to explain safely. Also use `noop` if
-  `run-context.json` does not contain an `issue_number`.
+  `run-context.json` has an empty, null, or missing `issue_number`.
 
 Do not use `gh` CLI commands for GitHub reads or writes. Use the prepared local
 files first and GitHub MCP tools only if you need repository context.


### PR DESCRIPTION
## Summary

- Schedule the benchmark regression analysis workflow Sunday through Thursday.
- Make scheduled runs self-contained by defaulting to the latest benchmark-results files and discovering the open rolling benchmark-regression issue.
- Regenerate the compiled agentic workflow lock file.

## Validation

- `gh aw compile benchmark-regression-analysis --no-check-update --actionlint`
- `gh aw validate benchmark-regression-analysis --no-check-update`

## Notes

GitHub Actions schedules are UTC-only. The configured `0 6 * * 0-4` cron maps to midnight US/Central during standard time and 1 AM US/Central during daylight time.