### PR TITLE
Fix: control plane group member detach on delete

### DIFF
--- a/internal/declarative/executor/control_plane_operations_test.go
+++ b/internal/declarative/executor/control_plane_operations_test.go
@@ -2,6 +2,8 @@ package executor
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
@@ -168,5 +170,140 @@ func TestExecutorSyncControlPlaneGroupMembersOnCreate(t *testing.T) {
 	id, err := exec.createResource(ctx, change)
 	require.NoError(t, err)
 	assert.Equal(t, "group-id", id)
+	mockGroupsAPI.AssertExpectations(t)
+}
+
+func TestExecutorDetachControlPlaneGroupMembersBeforeDelete(t *testing.T) {
+	ctx := testContextWithLogger()
+	mockCPAPI := helpers.NewMockControlPlaneAPI(t)
+	mockGroupsAPI := &helpers.MockControlPlaneGroupsAPI{}
+
+	var detached atomic.Bool
+	var groupDeleted atomic.Bool
+
+	mockCPAPI.EXPECT().
+		GetControlPlane(mock.Anything, "group-id").
+		Return(&kkOps.GetControlPlaneResponse{
+			ControlPlane: &kkComps.ControlPlane{
+				ID:     "group-id",
+				Name:   "group-cp",
+				Labels: map[string]string{labels.NamespaceKey: "default"},
+			},
+		}, nil).
+		Once()
+
+	for _, member := range []struct {
+		id   string
+		name string
+	}{
+		{id: "member-a-id", name: "member-a"},
+		{id: "member-b-id", name: "member-b"},
+	} {
+		mockCPAPI.EXPECT().
+			GetControlPlane(mock.Anything, member.id).
+			Return(&kkOps.GetControlPlaneResponse{
+				ControlPlane: &kkComps.ControlPlane{
+					ID:     member.id,
+					Name:   member.name,
+					Labels: map[string]string{labels.NamespaceKey: "default"},
+				},
+			}, nil).
+			Maybe()
+	}
+
+	mockGroupsAPI.On(
+		"PostControlPlanesIDGroupMembershipsRemove",
+		mock.Anything,
+		"group-id",
+		mock.MatchedBy(func(req *kkComps.GroupMembership) bool {
+			require.NotNil(t, req)
+			require.Len(t, req.Members, 2)
+			assert.Equal(t, "member-a-id", req.Members[0].ID)
+			assert.Equal(t, "member-b-id", req.Members[1].ID)
+			return true
+		}),
+	).Run(func(_ mock.Arguments) {
+		detached.Store(true)
+	}).Return(&kkOps.PostControlPlanesIDGroupMembershipsRemoveResponse{}, nil).Once()
+
+	mockCPAPI.EXPECT().
+		DeleteControlPlane(mock.Anything, "group-id").
+		RunAndReturn(func(context.Context, string, ...kkOps.Option) (*kkOps.DeleteControlPlaneResponse, error) {
+			if !detached.Load() {
+				return nil, fmt.Errorf("control plane group deleted before members were detached")
+			}
+			groupDeleted.Store(true)
+			return &kkOps.DeleteControlPlaneResponse{}, nil
+		}).
+		Once()
+
+	for _, memberID := range []string{"member-a-id", "member-b-id"} {
+		mockCPAPI.EXPECT().
+			DeleteControlPlane(mock.Anything, memberID).
+			RunAndReturn(func(context.Context, string, ...kkOps.Option) (*kkOps.DeleteControlPlaneResponse, error) {
+				if !groupDeleted.Load() {
+					return nil, fmt.Errorf("member control plane deleted before group delete completed")
+				}
+				return &kkOps.DeleteControlPlaneResponse{}, nil
+			}).
+			Once()
+	}
+
+	client := state.NewClient(state.ClientConfig{
+		ControlPlaneAPI:       mockCPAPI,
+		ControlPlaneGroupsAPI: mockGroupsAPI,
+	})
+	exec := NewWithOptions(client, nil, false, Options{MaxConcurrency: 4})
+
+	groupChangeID := "1:d:control_plane:group-cp"
+	memberAChangeID := "2:d:control_plane:member-a"
+	memberBChangeID := "3:d:control_plane:member-b"
+
+	plan := planner.NewPlan("1.0", "test", planner.PlanModeDelete)
+	plan.AddChange(planner.PlannedChange{
+		ID:           groupChangeID,
+		ResourceType: planner.ResourceTypeControlPlane,
+		ResourceRef:  "group-cp",
+		ResourceID:   "group-id",
+		Action:       planner.ActionDelete,
+		Fields: map[string]any{
+			planner.FieldName: "group-cp",
+			planner.FieldMembers: []map[string]string{
+				{planner.FieldID: "member-a-id"},
+				{planner.FieldID: "member-b-id"},
+			},
+		},
+		References: map[string]planner.ReferenceInfo{
+			planner.FieldMembers: {
+				Refs:    []string{"member-a-id", "member-b-id"},
+				IsArray: true,
+			},
+		},
+	})
+	plan.AddChange(planner.PlannedChange{
+		ID:           memberAChangeID,
+		ResourceType: planner.ResourceTypeControlPlane,
+		ResourceRef:  "member-a",
+		ResourceID:   "member-a-id",
+		Action:       planner.ActionDelete,
+		Fields:       map[string]any{planner.FieldName: "member-a"},
+		DependsOn:    []string{groupChangeID},
+	})
+	plan.AddChange(planner.PlannedChange{
+		ID:           memberBChangeID,
+		ResourceType: planner.ResourceTypeControlPlane,
+		ResourceRef:  "member-b",
+		ResourceID:   "member-b-id",
+		Action:       planner.ActionDelete,
+		Fields:       map[string]any{planner.FieldName: "member-b"},
+		DependsOn:    []string{groupChangeID},
+	})
+	plan.SetExecutionOrder([]string{groupChangeID, memberAChangeID, memberBChangeID})
+	plan.SetExecutionGroups([][]string{{groupChangeID}, {memberAChangeID, memberBChangeID}})
+
+	result := exec.Execute(ctx, plan)
+
+	require.False(t, result.HasErrors(), "unexpected execution errors: %#v", result.Errors)
+	assert.Equal(t, 3, result.SuccessCount)
 	mockGroupsAPI.AssertExpectations(t)
 }

--- a/internal/declarative/executor/control_plane_operations_test.go
+++ b/internal/declarative/executor/control_plane_operations_test.go
@@ -307,3 +307,32 @@ func TestExecutorDetachControlPlaneGroupMembersBeforeDelete(t *testing.T) {
 	assert.Equal(t, 3, result.SuccessCount)
 	mockGroupsAPI.AssertExpectations(t)
 }
+
+func TestExecutorDoesNotDetachControlPlaneGroupMembersInDryRun(t *testing.T) {
+	ctx := testContextWithLogger()
+	mockGroupsAPI := &helpers.MockControlPlaneGroupsAPI{}
+	client := state.NewClient(state.ClientConfig{ControlPlaneGroupsAPI: mockGroupsAPI})
+	exec := New(client, nil, true)
+
+	change := &planner.PlannedChange{
+		ResourceType: planner.ResourceTypeControlPlane,
+		ResourceRef:  "group-cp",
+		ResourceID:   "group-id",
+		Action:       planner.ActionDelete,
+		Fields: map[string]any{
+			planner.FieldName: "group-cp",
+			planner.FieldMembers: []map[string]string{
+				{planner.FieldID: "member-a-id"},
+			},
+		},
+	}
+
+	require.NoError(t, exec.detachControlPlaneGroupMembers(ctx, change))
+	mockGroupsAPI.AssertNotCalled(
+		t,
+		"PostControlPlanesIDGroupMembershipsRemove",
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+	)
+}

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -1427,6 +1427,9 @@ func (e *Executor) detachControlPlaneGroupMembers(ctx context.Context, change *p
 	if len(normalized) == 0 {
 		return nil
 	}
+	if e.dryRun {
+		return nil
+	}
 
 	return e.client.RemoveControlPlaneGroupMemberships(ctx, change.ResourceID, normalized)
 }

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -1412,6 +1412,25 @@ func (e *Executor) syncControlPlaneGroupMembers(
 	return e.client.UpsertControlPlaneGroupMemberships(ctx, controlPlaneID, normalized)
 }
 
+func (e *Executor) detachControlPlaneGroupMembers(ctx context.Context, change *planner.PlannedChange) error {
+	field, ok := change.Fields[planner.FieldMembers]
+	if !ok {
+		return nil
+	}
+
+	memberIDs, err := extractMemberIDsFromField(field)
+	if err != nil {
+		return fmt.Errorf("failed to extract control plane group members: %w", err)
+	}
+
+	normalized := normalizers.NormalizeMemberIDs(memberIDs)
+	if len(normalized) == 0 {
+		return nil
+	}
+
+	return e.client.RemoveControlPlaneGroupMemberships(ctx, change.ResourceID, normalized)
+}
+
 func (e *Executor) resolveMemberReference(
 	ctx context.Context,
 	placeholder string,
@@ -3107,6 +3126,9 @@ func (e *Executor) deleteResource(ctx context.Context, change *planner.PlannedCh
 		// No references to resolve for portal
 		return e.portalExecutor.Delete(ctx, *change)
 	case planner.ResourceTypeControlPlane:
+		if err := e.detachControlPlaneGroupMembers(ctx, change); err != nil {
+			return fmt.Errorf("failed to detach control plane group members: %w", err)
+		}
 		return e.controlPlaneExecutor.Delete(ctx, *change)
 	case planner.ResourceTypeControlPlaneDataPlaneCertificate:
 		return e.controlPlaneDataPlaneCertificateExecutor.Delete(ctx, *change)

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -836,6 +836,38 @@ func (c *Client) UpsertControlPlaneGroupMemberships(ctx context.Context, groupID
 	return nil
 }
 
+// RemoveControlPlaneGroupMemberships removes members from a control plane group.
+func (c *Client) RemoveControlPlaneGroupMemberships(ctx context.Context, groupID string, memberIDs []string) error {
+	if err := ValidateAPIClient(c.controlPlaneGroupsAPI, "Control Plane Groups API"); err != nil {
+		return err
+	}
+
+	members := make([]kkComps.Members, 0, len(memberIDs))
+	for _, id := range memberIDs {
+		if strings.TrimSpace(id) == "" {
+			continue
+		}
+		members = append(members, kkComps.Members{ID: id})
+	}
+	if len(members) == 0 {
+		return nil
+	}
+
+	req := kkComps.GroupMembership{
+		Members: members,
+	}
+
+	if _, err := c.controlPlaneGroupsAPI.PostControlPlanesIDGroupMembershipsRemove(ctx, groupID, &req); err != nil {
+		return WrapAPIError(err, "remove control plane group memberships", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeControlPlaneGroup),
+			ResourceName: groupID,
+			UseEnhanced:  true,
+		})
+	}
+
+	return nil
+}
+
 // ListGatewayServices returns all gateway services for the provided control plane.
 func (c *Client) ListGatewayServices(ctx context.Context, controlPlaneID string) ([]GatewayService, error) {
 	if err := ValidateAPIClient(c.gatewayServiceAPI, "Gateway Service API"); err != nil {

--- a/internal/declarative/state/client_control_plane_test.go
+++ b/internal/declarative/state/client_control_plane_test.go
@@ -265,3 +265,29 @@ func TestUpsertControlPlaneGroupMemberships(t *testing.T) {
 	require.NoError(t, err)
 	mockGroups.AssertExpectations(t)
 }
+
+func TestRemoveControlPlaneGroupMemberships(t *testing.T) {
+	ctx := testContextWithLogger()
+	mockGroups := &helpers.MockControlPlaneGroupsAPI{}
+
+	mockGroups.On(
+		"PostControlPlanesIDGroupMembershipsRemove",
+		mock.Anything,
+		"group-1",
+		mock.MatchedBy(func(req *kkComps.GroupMembership) bool {
+			require.NotNil(t, req)
+			require.Len(t, req.Members, 2)
+			assert.Equal(t, "cp-1", req.Members[0].ID)
+			assert.Equal(t, "cp-2", req.Members[1].ID)
+			return true
+		}),
+	).Return(&kkOps.PostControlPlanesIDGroupMembershipsRemoveResponse{}, nil).Once()
+
+	client := NewClient(ClientConfig{
+		ControlPlaneGroupsAPI: mockGroups,
+	})
+
+	err := client.RemoveControlPlaneGroupMemberships(ctx, "group-1", []string{"cp-1", "", "cp-2"})
+	require.NoError(t, err)
+	mockGroups.AssertExpectations(t)
+}

--- a/internal/konnect/helpers/control_plane_groups.go
+++ b/internal/konnect/helpers/control_plane_groups.go
@@ -21,4 +21,11 @@ type ControlPlaneGroupsAPI interface {
 		groupMembership *kkCOM.GroupMembership,
 		opts ...kkOPS.Option,
 	) (*kkOPS.PutControlPlanesIDGroupMembershipsResponse, error)
+
+	PostControlPlanesIDGroupMembershipsRemove(
+		ctx context.Context,
+		id string,
+		groupMembership *kkCOM.GroupMembership,
+		opts ...kkOPS.Option,
+	) (*kkOPS.PostControlPlanesIDGroupMembershipsRemoveResponse, error)
 }

--- a/internal/konnect/helpers/controlplanegroupsapi_mock.go
+++ b/internal/konnect/helpers/controlplanegroupsapi_mock.go
@@ -75,3 +75,32 @@ func (m *MockControlPlaneGroupsAPI) PutControlPlanesIDGroupMemberships(
 
 	return resp, err
 }
+
+// PostControlPlanesIDGroupMembershipsRemove mocks the remove API call.
+func (m *MockControlPlaneGroupsAPI) PostControlPlanesIDGroupMembershipsRemove(
+	ctx context.Context,
+	id string,
+	groupMembership *kkComps.GroupMembership,
+	opts ...kkOps.Option,
+) (*kkOps.PostControlPlanesIDGroupMembershipsRemoveResponse, error) {
+	args := []any{ctx, id, groupMembership}
+	for _, opt := range opts {
+		args = append(args, opt)
+	}
+
+	ret := m.Called(args...)
+
+	var resp *kkOps.PostControlPlanesIDGroupMembershipsRemoveResponse
+	if len(ret) > 0 && ret.Get(0) != nil {
+		resp = ret.Get(0).(*kkOps.PostControlPlanesIDGroupMembershipsRemoveResponse)
+	}
+
+	var err error
+	if len(ret) > 1 {
+		if e, ok := ret.Get(1).(error); ok {
+			err = e
+		}
+	}
+
+	return resp, err
+}

--- a/test/e2e/scenarios/control-plane/delete-groups/scenario.yaml
+++ b/test/e2e/scenarios/control-plane/delete-groups/scenario.yaml
@@ -1,0 +1,92 @@
+baseInputsPath: testdata
+
+env:
+  KONGCTL_LOG_LEVEL: info
+
+vars:
+  runtimeAName: "delete-groups-runtime-a"
+  runtimeBName: "delete-groups-runtime-b"
+  groupName: "delete-groups-shared-group"
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - resource_id
+      - change_id
+      - created_at
+      - updated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-apply-group-members
+    commands:
+      - name: 000-apply
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/control-plane.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: apply
+          - select: "summary"
+            expect:
+              fields:
+                failed: 0
+                status: success
+          - select: >-
+              plan.changes[?resource_type=='control_plane' &&
+                            resource_ref=='delete-groups-shared-group'] | [0]
+            expect:
+              fields:
+                action: CREATE
+
+  - name: 002-delete-group-members
+    commands:
+      - name: 000-delete
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/control-plane.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: delete
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 3
+                by_action.DELETE: 3
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success
+
+  - name: 003-verify-deleted
+    skipInputs: true
+    commands:
+      - name: 000-get-control-planes
+        run: ["get", "gateway", "control-planes", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.runtimeAName }}']"
+            expect:
+              fields:
+                "length(@)": 0
+          - select: "[?name=='{{ .vars.runtimeBName }}']"
+            expect:
+              fields:
+                "length(@)": 0
+          - select: "[?name=='{{ .vars.groupName }}']"
+            expect:
+              fields:
+                "length(@)": 0

--- a/test/e2e/scenarios/control-plane/delete-groups/testdata/control-plane.yaml
+++ b/test/e2e/scenarios/control-plane/delete-groups/testdata/control-plane.yaml
@@ -1,0 +1,30 @@
+_defaults:
+  kongctl:
+    namespace: delete-groups
+
+control_planes:
+  - ref: delete-groups-runtime-a
+    name: "delete-groups-runtime-a"
+    description: "First runtime for control plane group delete coverage"
+    cluster_type: "CLUSTER_TYPE_CONTROL_PLANE"
+    proxy_urls:
+      - host: delete-groups-runtime-a.example.com
+        port: 443
+        protocol: https
+
+  - ref: delete-groups-runtime-b
+    name: "delete-groups-runtime-b"
+    description: "Second runtime for control plane group delete coverage"
+    cluster_type: "CLUSTER_TYPE_CONTROL_PLANE"
+    proxy_urls:
+      - host: delete-groups-runtime-b.example.com
+        port: 8443
+        protocol: https
+
+  - ref: delete-groups-shared-group
+    name: "delete-groups-shared-group"
+    description: "Shared group for delete membership detach coverage"
+    cluster_type: "CLUSTER_TYPE_CONTROL_PLANE_GROUP"
+    members:
+      - id: !ref delete-groups-runtime-a#id
+      - id: !ref delete-groups-runtime-b#id


### PR DESCRIPTION
## Summary

- Add coverage for deleting control plane groups that still have members.
- Add a state client wrapper for the Konnect control plane group membership remove endpoint.
- Detach recorded group members before deleting the control plane group so member deletes cannot race ahead while the group still contains them.

## Validation

- `go test ./internal/declarative/executor -run TestExecutorDetachControlPlaneGroupMembersBeforeDelete -count=1`
- `go test ./internal/declarative/state -run 'Test(Remove|Upsert|List)ControlPlaneGroupMemberships' -count=1`
- `go test ./internal/declarative/planner -run TestControlPlanePlanner_PlanDeleteMembersDependOnGroupDelete -count=1`
- `go fix ./...`
- `make format`
- `make build`
- `make test`
- `make lint`
- `make scenario SCENARIO=control-plane/delete-groups`
- `make scenario SCENARIO=all`

Closes #1138