### PR TITLE
Fix: validate token expiration bounds

### DIFF
--- a/internal/cmd/root/products/konnect/token/token.go
+++ b/internal/cmd/root/products/konnect/token/token.go
@@ -34,11 +34,22 @@ const (
 	flagSystemAccountID   = "system-account-id"
 	flagSystemAccountName = "system-account-name"
 
-	expiresInHelp = "Token lifetime. Accepts Go durations with ns, us, ms, s, m, h, " +
-		"plus numeric days with d. Examples: 90m, 12h, 30d."
-	expiresAtHelp        = "Token expiration timestamp in RFC3339 format, for example 2026-06-24T12:00:00Z."
-	expiresInExpectation = "use a positive duration like 90m, 12h, or 30d " +
-		"(supported units: ns, us, ms, s, m, h, d)"
+	secondsPerDay = int64(24 * 60 * 60)
+
+	minTokenTTLDays = int64(1)
+	maxTokenTTLDays = int64(365)
+
+	minTokenTTLSeconds = minTokenTTLDays * secondsPerDay
+	maxTokenTTLSeconds = maxTokenTTLDays * secondsPerDay
+
+	expiresInHelp = "Token lifetime. Use a duration between 1 day and 365 days (12 months). " +
+		"Supported units are ns, us, ms, s, m, h, and d (days). Examples: 24h, 36h, 1d, 30d."
+	expiresAtHelp = "Token expiration timestamp in RFC3339 format, for example 2026-06-24T12:00:00Z " +
+		"or 2026-06-24T12:00:00+02:00. Fractional seconds are accepted. " +
+		"Must be between 1 day and 365 days (12 months) from now."
+	expiresInExpectation       = "use a valid duration with a unit suffix"
+	createExpiresInExpectation = "use a duration between 1 day and 365 days (12 months) " +
+		"with units ns, us, ms, s, m, h, or d (days)"
 )
 
 type expiration struct {
@@ -120,7 +131,7 @@ func NewPATCmd(
 		cmd.Use = PATCommandName
 		cmd.Short = "Create a Konnect personal access token"
 		cmd.Example = fmt.Sprintf(`  %[1]s create pat --name ci --expires-in 30d -o token
-  %[1]s create pat --name ci --expires-in 12h --jq -r '.token'`, meta.CLIName)
+  %[1]s create pat --name ci --expires-in 7d --jq -r '.token'`, meta.CLIName)
 		cmd.Args = createTokenArgs
 		addPATCreateFlags(cmd, opts)
 		cmdcommon.AllowExtraOutputFormats(cmd, cmdcommon.TOKEN.String(), cmdcommon.ENV.String())
@@ -178,7 +189,7 @@ func NewSPATCmd(
 		cmd.Use = SPATCommandName
 		cmd.Short = "Create a Konnect system account access token"
 		cmd.Example = fmt.Sprintf(
-			`  %[1]s create spat --system-account-name ci-bot --name ci --expires-at 2026-06-24T12:00:00Z -o env`,
+			`  %[1]s create spat --system-account-name ci-bot --name ci --expires-in 30d -o env`,
 			meta.CLIName,
 		)
 		cmd.Args = createTokenArgs
@@ -268,7 +279,7 @@ func runCreatePAT(c *cobra.Command, args []string, opts *patOptions) error {
 		return &cmdpkg.ConfigurationError{Err: fmt.Errorf("--%s is required", flagName)}
 	}
 
-	exp, err := parseExpiration(opts.expiresIn, opts.expiresAt)
+	exp, err := parseCreateTokenExpiration(opts.expiresIn, opts.expiresAt)
 	if err != nil {
 		return err
 	}
@@ -401,7 +412,7 @@ func runCreateSPAT(c *cobra.Command, args []string, opts *spatOptions) error {
 		return err
 	}
 
-	exp, err := parseExpiration(opts.expiresIn, opts.expiresAt)
+	exp, err := parseCreateTokenExpiration(opts.expiresIn, opts.expiresAt)
 	if err != nil {
 		return err
 	}
@@ -794,6 +805,10 @@ func requestPageSize(cfg config.Hook) int64 {
 }
 
 func parseExpiration(expiresIn, expiresAt string) (expiration, error) {
+	return parseExpirationWithExpectation(expiresIn, expiresAt, expiresInExpectation)
+}
+
+func parseExpirationWithExpectation(expiresIn, expiresAt string, expectation string) (expiration, error) {
 	expiresIn = strings.TrimSpace(expiresIn)
 	expiresAt = strings.TrimSpace(expiresAt)
 	if (expiresIn == "") == (expiresAt == "") {
@@ -814,16 +829,83 @@ func parseExpiration(expiresIn, expiresAt string) (expiration, error) {
 	duration, err := parseDurationWithDays(expiresIn)
 	if err != nil {
 		return expiration{}, &cmdpkg.ConfigurationError{
-			Err: fmt.Errorf("invalid --%s value %q: %s", flagExpiresIn, expiresIn, expiresInExpectation),
+			Err: fmt.Errorf("invalid --%s value %q: %s", flagExpiresIn, expiresIn, expectation),
 		}
 	}
 	ttl := int64(duration.Seconds())
 	if ttl <= 0 {
 		return expiration{}, &cmdpkg.ConfigurationError{
-			Err: fmt.Errorf("--%s must be greater than zero; %s", flagExpiresIn, expiresInExpectation),
+			Err: fmt.Errorf("--%s must be greater than zero; %s", flagExpiresIn, expectation),
 		}
 	}
 	return expiration{TTLSeconds: &ttl}, nil
+}
+
+func parseCreateTokenExpiration(expiresIn, expiresAt string) (expiration, error) {
+	return parseCreateTokenExpirationAt(expiresIn, expiresAt, time.Now().UTC())
+}
+
+func parseCreateTokenExpirationAt(expiresIn, expiresAt string, now time.Time) (expiration, error) {
+	expiresIn = strings.TrimSpace(expiresIn)
+	expiresAt = strings.TrimSpace(expiresAt)
+	if (expiresIn == "") == (expiresAt == "") {
+		return expiration{}, &cmdpkg.ConfigurationError{
+			Err: fmt.Errorf("exactly one of --%s or --%s is required", flagExpiresIn, flagExpiresAt),
+		}
+	}
+
+	if expiresAt != "" {
+		return parseCreateTokenExpiresAt(expiresAt, now)
+	}
+
+	duration, err := parseDurationWithDays(expiresIn)
+	if err != nil {
+		return expiration{}, &cmdpkg.ConfigurationError{
+			Err: fmt.Errorf("invalid --%s value %q: %s", flagExpiresIn, expiresIn, createExpiresInExpectation),
+		}
+	}
+	if duration < time.Duration(minTokenTTLSeconds)*time.Second {
+		return expiration{}, &cmdpkg.ConfigurationError{
+			Err: fmt.Errorf("minimum token lifetime is 1 day (--%s must be at least 1d)", flagExpiresIn),
+		}
+	}
+	if duration > time.Duration(maxTokenTTLSeconds)*time.Second {
+		return expiration{}, &cmdpkg.ConfigurationError{
+			Err: fmt.Errorf(
+				"maximum token lifetime is 365 days (12 months) (--%s must be at most 365d)",
+				flagExpiresIn,
+			),
+		}
+	}
+	ttl := int64(duration / time.Second)
+	return expiration{TTLSeconds: &ttl}, nil
+}
+
+func parseCreateTokenExpiresAt(expiresAt string, now time.Time) (expiration, error) {
+	parsed, err := time.Parse(time.RFC3339, expiresAt)
+	if err != nil {
+		return expiration{}, &cmdpkg.ConfigurationError{
+			Err: fmt.Errorf("invalid --%s value %q: %w", flagExpiresAt, expiresAt, err),
+		}
+	}
+	ttlSeconds := parsed.Unix() - now.Unix()
+	if ttlSeconds < minTokenTTLSeconds {
+		return expiration{}, &cmdpkg.ConfigurationError{
+			Err: fmt.Errorf(
+				"minimum token lifetime is 1 day (--%s must be at least 1 day from now)",
+				flagExpiresAt,
+			),
+		}
+	}
+	if ttlSeconds > maxTokenTTLSeconds {
+		return expiration{}, &cmdpkg.ConfigurationError{
+			Err: fmt.Errorf(
+				"maximum token lifetime is 365 days (12 months) (--%s must be at most 365 days from now)",
+				flagExpiresAt,
+			),
+		}
+	}
+	return expiration{ExpiresAt: &parsed}, nil
 }
 
 func parseDurationWithDays(raw string) (time.Duration, error) {

--- a/internal/cmd/root/products/konnect/token/token_test.go
+++ b/internal/cmd/root/products/konnect/token/token_test.go
@@ -9,7 +9,7 @@ import (
 	cmdpkg "github.com/kong/kongctl/internal/cmd"
 )
 
-func TestParseExpirationSupportsGoDurationsAndDays(t *testing.T) {
+func TestParseExpirationSupportsDurationsAndDays(t *testing.T) {
 	tests := []struct {
 		name      string
 		expiresIn string
@@ -27,6 +27,176 @@ func TestParseExpirationSupportsGoDurationsAndDays(t *testing.T) {
 			}
 			if got.TTLSeconds == nil || *got.TTLSeconds != tt.wantTTL {
 				t.Fatalf("expected ttl %d, got %#v", tt.wantTTL, got.TTLSeconds)
+			}
+		})
+	}
+}
+
+func TestParseCreateTokenExpirationAcceptsDurationUnitsWithinBounds(t *testing.T) {
+	tests := []struct {
+		name      string
+		expiresIn string
+		wantTTL   int64
+	}{
+		{name: "hours at minimum", expiresIn: "24h", wantTTL: minTokenTTLSeconds},
+		{name: "hours above minimum", expiresIn: "36h", wantTTL: 36 * 60 * 60},
+		{name: "minutes at minimum", expiresIn: "1440m", wantTTL: minTokenTTLSeconds},
+		{name: "days", expiresIn: "30d", wantTTL: 30 * secondsPerDay},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCreateTokenExpiration(tt.expiresIn, "")
+			if err != nil {
+				t.Fatalf("parseCreateTokenExpiration returned error: %v", err)
+			}
+			if got.TTLSeconds == nil || *got.TTLSeconds != tt.wantTTL {
+				t.Fatalf("expected ttl %d, got %#v", tt.wantTTL, got.TTLSeconds)
+			}
+		})
+	}
+}
+
+func TestParseCreateTokenExpirationRejectsBelowMinDuration(t *testing.T) {
+	_, err := parseCreateTokenExpiration("12h", "")
+	var cfgErr *cmdpkg.ConfigurationError
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("expected ConfigurationError, got %T: %v", err, err)
+	}
+	for _, want := range []string{
+		"minimum token lifetime is 1 day",
+		"--expires-in must be at least 1d",
+	} {
+		if !strings.Contains(cfgErr.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %q", want, cfgErr.Error())
+		}
+	}
+}
+
+func TestParseCreateTokenExpirationRejectsOverMaxDuration(t *testing.T) {
+	_, err := parseCreateTokenExpiration("366d", "")
+	var cfgErr *cmdpkg.ConfigurationError
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("expected ConfigurationError, got %T: %v", err, err)
+	}
+	for _, want := range []string{
+		"maximum token lifetime is 365 days (12 months)",
+		"--expires-in must be at most 365d",
+	} {
+		if !strings.Contains(cfgErr.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %q", want, cfgErr.Error())
+		}
+	}
+}
+
+func TestParseCreateTokenExpirationRejectsExpiresAtOutsideBounds(t *testing.T) {
+	now := time.Date(2026, time.May, 27, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		expiresAt string
+		want      []string
+	}{
+		{
+			name:      "too soon",
+			expiresAt: now.Add(12 * time.Hour).Format(time.RFC3339),
+			want: []string{
+				"minimum token lifetime is 1 day",
+				"--expires-at must be at least 1 day from now",
+			},
+		},
+		{
+			name:      "too far",
+			expiresAt: now.Add(366 * 24 * time.Hour).Format(time.RFC3339),
+			want: []string{
+				"maximum token lifetime is 365 days (12 months)",
+				"--expires-at must be at most 365 days from now",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseCreateTokenExpirationAt("", tt.expiresAt, now)
+			var cfgErr *cmdpkg.ConfigurationError
+			if !errors.As(err, &cfgErr) {
+				t.Fatalf("expected ConfigurationError, got %T: %v", err, err)
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(cfgErr.Error(), want) {
+					t.Fatalf("expected error to contain %q, got %q", want, cfgErr.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestParseCreateTokenExpirationAcceptsBoundaryDurations(t *testing.T) {
+	tests := []struct {
+		name      string
+		expiresIn string
+		wantTTL   int64
+	}{
+		{name: "minimum", expiresIn: "1d", wantTTL: minTokenTTLSeconds},
+		{name: "maximum", expiresIn: "365d", wantTTL: maxTokenTTLSeconds},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCreateTokenExpiration(tt.expiresIn, "")
+			if err != nil {
+				t.Fatalf("parseCreateTokenExpiration returned error: %v", err)
+			}
+			if got.TTLSeconds == nil || *got.TTLSeconds != tt.wantTTL {
+				t.Fatalf("expected ttl %d, got %#v", tt.wantTTL, got.TTLSeconds)
+			}
+		})
+	}
+}
+
+func TestParseCreateTokenExpirationAcceptsExpiresAtAtMinBoundaryWithSubsecondNow(t *testing.T) {
+	now := time.Date(2026, time.May, 27, 12, 0, 0, 900_000_000, time.UTC)
+	expiresAt := now.Truncate(time.Second).Add(24 * time.Hour).Format(time.RFC3339)
+	got, err := parseCreateTokenExpirationAt("", expiresAt, now)
+	if err != nil {
+		t.Fatalf("parseCreateTokenExpiration returned error: %v", err)
+	}
+	if got.ExpiresAt == nil || got.ExpiresAt.Format(time.RFC3339) != expiresAt {
+		t.Fatalf("expected expires_at %s, got %#v", expiresAt, got.ExpiresAt)
+	}
+}
+
+func TestParseCreateTokenExpirationSupportsRFC3339(t *testing.T) {
+	now := time.Date(2026, time.May, 27, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		expiresAt string
+		want      time.Time
+	}{
+		{
+			name:      "utc",
+			expiresAt: "2026-06-24T12:00:00Z",
+			want:      time.Date(2026, time.June, 24, 12, 0, 0, 0, time.UTC),
+		},
+		{
+			name:      "offset",
+			expiresAt: "2026-06-24T14:00:00+02:00",
+			want:      time.Date(2026, time.June, 24, 12, 0, 0, 0, time.UTC),
+		},
+		{
+			name:      "fractional seconds",
+			expiresAt: "2026-06-24T12:00:00.123Z",
+			want:      time.Date(2026, time.June, 24, 12, 0, 0, 123_000_000, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCreateTokenExpirationAt("", tt.expiresAt, now)
+			if err != nil {
+				t.Fatalf("parseCreateTokenExpiration returned error: %v", err)
+			}
+			if got.ExpiresAt == nil || !got.ExpiresAt.Equal(tt.want) {
+				t.Fatalf("expected expires_at %s, got %#v", tt.want.Format(time.RFC3339Nano), got.ExpiresAt)
 			}
 		})
 	}
@@ -72,8 +242,7 @@ func TestParseExpirationInvalidDurationExplainsAcceptedUnits(t *testing.T) {
 	}
 	for _, want := range []string{
 		`invalid --expires-in value "30days"`,
-		"supported units: ns, us, ms, s, m, h, d",
-		"90m, 12h, or 30d",
+		"use a valid duration with a unit suffix",
 	} {
 		if !strings.Contains(cfgErr.Error(), want) {
 			t.Fatalf("expected error to contain %q, got %q", want, cfgErr.Error())

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -221,14 +221,87 @@ func TestCreatePATHelpIncludesTokenExamplesAndFormats(t *testing.T) {
 	}
 	for _, want := range []string{
 		"kongctl create pat --name ci --expires-in 30d -o token",
-		"kongctl create pat --name ci --expires-in 12h --jq -r '.token'",
-		"Accepts Go durations with ns, us, ms, s, m, h, plus numeric days with d.",
-		"Token expiration timestamp in RFC3339 format, for example 2026-06-24T12:00:00Z.",
+		"kongctl create pat --name ci --expires-in 7d --jq -r '.token'",
+		"Use a duration between 1 day and 365 days (12 months).",
+		"Supported units are ns, us, ms, s, m, h, and d (days).",
+		"Examples: 24h, 36h, 1d, 30d.",
+		"Token expiration timestamp in RFC3339 format, for example 2026-06-24T12:00:00Z",
+		"or 2026-06-24T12:00:00+02:00. Fractional seconds are accepted.",
+		"Must be between 1 day and 365 days (12 months) from now.",
 		"Allowed    : [ json|yaml|text|token|env ]",
 	} {
 		if !strings.Contains(result.stdout, want) {
 			t.Fatalf("expected help to contain %q\nstdout:\n%s", want, result.stdout)
 		}
+	}
+}
+
+func TestCreatePATRejectsBelowMinDuration(t *testing.T) {
+	result := executeRootForTest(t, "create", "pat", "--name", "ci", "--expires-in", "12h")
+	if result.exitCode == 0 {
+		t.Fatalf("expected create pat with below-min duration to fail\nstdout:\n%s", result.stdout)
+	}
+	for _, want := range []string{
+		"minimum token lifetime is 1 day",
+		"--expires-in must be at least 1d",
+	} {
+		if !strings.Contains(result.stderr, want) {
+			t.Fatalf("expected stderr to contain %q\nstderr:\n%s", want, result.stderr)
+		}
+	}
+}
+
+func TestCreatePATRejectsOverMaxDuration(t *testing.T) {
+	result := executeRootForTest(t, "create", "pat", "--name", "ci", "--expires-in", "366d")
+	if result.exitCode == 0 {
+		t.Fatalf("expected create pat with over-max duration to fail\nstdout:\n%s", result.stdout)
+	}
+	for _, want := range []string{
+		"maximum token lifetime is 365 days (12 months)",
+		"--expires-in must be at most 365d",
+	} {
+		if !strings.Contains(result.stderr, want) {
+			t.Fatalf("expected stderr to contain %q\nstderr:\n%s", want, result.stderr)
+		}
+	}
+}
+
+func TestCreatePATRejectsExpiresAtOutsideBounds(t *testing.T) {
+	tests := []struct {
+		name      string
+		expiresAt string
+		want      []string
+	}{
+		{
+			name:      "too soon",
+			expiresAt: time.Now().UTC().Add(12 * time.Hour).Format(time.RFC3339),
+			want: []string{
+				"minimum token lifetime is 1 day",
+				"--expires-at must be at least 1 day from now",
+			},
+		},
+		{
+			name:      "too far",
+			expiresAt: time.Now().UTC().Add(366 * 24 * time.Hour).Format(time.RFC3339),
+			want: []string{
+				"maximum token lifetime is 365 days (12 months)",
+				"--expires-at must be at most 365 days from now",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := executeRootForTest(t, "create", "pat", "--name", "ci", "--expires-at", tt.expiresAt)
+			if result.exitCode == 0 {
+				t.Fatalf("expected create pat with %s expires-at to fail\nstdout:\n%s", tt.name, result.stdout)
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(result.stderr, want) {
+					t.Fatalf("expected stderr to contain %q\nstderr:\n%s", want, result.stderr)
+				}
+			}
+		})
 	}
 }
 
@@ -246,7 +319,7 @@ func TestCreatePATTokenOutputAndJQ(t *testing.T) {
 	result := executeRootForTest(t,
 		"create", "pat",
 		"--name", "ci",
-		"--expires-in", "12h",
+		"--expires-in", "24h",
 		"-o", "token",
 	)
 	if result.exitCode != 0 {
@@ -258,14 +331,14 @@ func TestCreatePATTokenOutputAndJQ(t *testing.T) {
 	if patAPI.createdUserID != "user-1" {
 		t.Fatalf("expected current user id to be used, got %q", patAPI.createdUserID)
 	}
-	if got := patAPI.createdRequest.PersonalAccessTokenCreateRequestWithTTL.GetTTLSeconds(); got != 43200 {
-		t.Fatalf("expected 12h ttl to be 43200 seconds, got %d", got)
+	if got := patAPI.createdRequest.PersonalAccessTokenCreateRequestWithTTL.GetTTLSeconds(); got != 86400 {
+		t.Fatalf("expected 24h ttl to be 86400 seconds, got %d", got)
 	}
 
 	result = executeRootForTest(t,
 		"create", "pat",
 		"--name", "ci",
-		"--expires-in", "12h",
+		"--expires-in", "7d",
 		"--user-id", "user-2",
 		"--jq", "-r", ".token",
 	)
@@ -297,7 +370,7 @@ func TestCreateSPATEnvOutputResolvesSystemAccountName(t *testing.T) {
 		"create", "spat",
 		"--system-account-name", "ci-bot",
 		"--name", "ci",
-		"--expires-at", "2026-06-24T12:00:00Z",
+		"--expires-in", "30d",
 		"-o", "env",
 	)
 	if result.exitCode != 0 {
@@ -305,6 +378,90 @@ func TestCreateSPATEnvOutputResolvesSystemAccountName(t *testing.T) {
 	}
 	if result.stdout != "export KONGCTL_TEAM_A_KONNECT_PAT='spat_123'\n" {
 		t.Fatalf("unexpected env output: %q", result.stdout)
+	}
+}
+
+func TestCreateSPATRejectsBelowMinDuration(t *testing.T) {
+	result := executeRootForTest(t,
+		"create", "spat",
+		"--system-account-id", "system-account-id",
+		"--name", "ci",
+		"--expires-in", "12h",
+	)
+	if result.exitCode == 0 {
+		t.Fatalf("expected create spat with below-min duration to fail\nstdout:\n%s", result.stdout)
+	}
+	for _, want := range []string{
+		"minimum token lifetime is 1 day",
+		"--expires-in must be at least 1d",
+	} {
+		if !strings.Contains(result.stderr, want) {
+			t.Fatalf("expected stderr to contain %q\nstderr:\n%s", want, result.stderr)
+		}
+	}
+}
+
+func TestCreateSPATRejectsOverMaxDuration(t *testing.T) {
+	result := executeRootForTest(t,
+		"create", "spat",
+		"--system-account-id", "system-account-id",
+		"--name", "ci",
+		"--expires-in", "366d",
+	)
+	if result.exitCode == 0 {
+		t.Fatalf("expected create spat with over-max duration to fail\nstdout:\n%s", result.stdout)
+	}
+	for _, want := range []string{
+		"maximum token lifetime is 365 days (12 months)",
+		"--expires-in must be at most 365d",
+	} {
+		if !strings.Contains(result.stderr, want) {
+			t.Fatalf("expected stderr to contain %q\nstderr:\n%s", want, result.stderr)
+		}
+	}
+}
+
+func TestCreateSPATRejectsExpiresAtOutsideBounds(t *testing.T) {
+	tests := []struct {
+		name      string
+		expiresAt string
+		want      []string
+	}{
+		{
+			name:      "too soon",
+			expiresAt: time.Now().UTC().Add(12 * time.Hour).Format(time.RFC3339),
+			want: []string{
+				"minimum token lifetime is 1 day",
+				"--expires-at must be at least 1 day from now",
+			},
+		},
+		{
+			name:      "too far",
+			expiresAt: time.Now().UTC().Add(366 * 24 * time.Hour).Format(time.RFC3339),
+			want: []string{
+				"maximum token lifetime is 365 days (12 months)",
+				"--expires-at must be at most 365 days from now",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := executeRootForTest(t,
+				"create", "spat",
+				"--system-account-id", "system-account-id",
+				"--name", "ci",
+				"--expires-at", tt.expiresAt,
+			)
+			if result.exitCode == 0 {
+				t.Fatalf("expected create spat with %s expires-at to fail\nstdout:\n%s", tt.name, result.stdout)
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(result.stderr, want) {
+					t.Fatalf("expected stderr to contain %q\nstderr:\n%s", want, result.stderr)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/cmd/root/verbs/create/create.go
+++ b/internal/cmd/root/verbs/create/create.go
@@ -40,9 +40,9 @@ Output can be formatted in multiple ways to aid in further processing.`))
 		# Create a Konnect personal access token and print only the token value
 		%[1]s create pat --name ci --expires-in 30d -o token
 		# Create a Konnect personal access token and extract the token with jq
-		%[1]s create pat --name ci --expires-in 12h --jq -r '.token'
+		%[1]s create pat --name ci --expires-in 7d --jq -r '.token'
 		# Create a Konnect system account access token as an environment export
-		%[1]s create spat --system-account-name ci-bot --name ci --expires-at 2026-06-24T12:00:00Z -o env
+		%[1]s create spat --system-account-name ci-bot --name ci --expires-in 30d -o env
 		`, meta.CLIName)))
 )
 


### PR DESCRIPTION
## Summary
- validate PAT and SPAT `--expires-in` values to the supported 1d through 365d window
- validate `--expires-at` timestamps against the same token lifetime window
- update token creation help/examples to avoid invalid sub-day durations and stale fixed timestamps

## Tests
- `go test ./internal/cmd/root/products/konnect/token`
- `go test ./internal/cmd/root`
- `make format`
- `make build`
- `make test`
- `make lint`
- `git diff --check`

Closes #1172