### PR TITLE
Fix: Detect portal customization spec renderer drift

### DIFF
--- a/internal/declarative/executor/portal_customization_adapter.go
+++ b/internal/declarative/executor/portal_customization_adapter.go
@@ -218,6 +218,38 @@ func (p *PortalCustomizationAdapter) MapUpdateFields(_ context.Context, fields m
 		update.Menu = menu
 	}
 
+	if specRendererData, ok := fields[planner.FieldSpecRenderer].(map[string]any); ok {
+		specRenderer := &kkComps.SpecRenderer{}
+
+		if tryItUI, ok := specRendererData[planner.FieldTryItUI].(bool); ok {
+			specRenderer.TryItUI = &tryItUI
+		}
+		if tryItInsomnia, ok := specRendererData[planner.FieldTryItInsomnia].(bool); ok {
+			specRenderer.TryItInsomnia = &tryItInsomnia
+		}
+		if infiniteScroll, ok := specRendererData[planner.FieldInfiniteScroll].(bool); ok {
+			specRenderer.InfiniteScroll = &infiniteScroll
+		}
+		if showSchemas, ok := specRendererData[planner.FieldShowSchemas].(bool); ok {
+			specRenderer.ShowSchemas = &showSchemas
+		}
+		if hideInternal, ok := specRendererData[planner.FieldHideInternal].(bool); ok {
+			specRenderer.HideInternal = &hideInternal
+		}
+		if hideDeprecated, ok := specRendererData[planner.FieldHideDeprecated].(bool); ok {
+			specRenderer.HideDeprecated = &hideDeprecated
+		}
+		if allowCustomServerURLs, ok := specRendererData[planner.FieldAllowCustomServerURLs].(bool); ok {
+			specRenderer.AllowCustomServerUrls = &allowCustomServerURLs
+		}
+
+		update.SpecRenderer = specRenderer
+	}
+
+	if robots, ok := fields[planner.FieldRobots].(string); ok {
+		update.Robots = &robots
+	}
+
 	return nil
 }
 

--- a/internal/declarative/executor/portal_customization_adapter_test.go
+++ b/internal/declarative/executor/portal_customization_adapter_test.go
@@ -1,0 +1,49 @@
+package executor
+
+import (
+	"context"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPortalCustomizationAdapterMapUpdateFieldsSpecRendererAndRobots(t *testing.T) {
+	adapter := NewPortalCustomizationAdapter(nil)
+	fields := map[string]any{
+		planner.FieldSpecRenderer: map[string]any{
+			planner.FieldTryItUI:               false,
+			planner.FieldTryItInsomnia:         true,
+			planner.FieldInfiniteScroll:        false,
+			planner.FieldShowSchemas:           true,
+			planner.FieldHideInternal:          true,
+			planner.FieldHideDeprecated:        false,
+			planner.FieldAllowCustomServerURLs: true,
+		},
+		planner.FieldRobots: "User-agent: *",
+	}
+	var update kkComps.PortalCustomization
+
+	err := adapter.MapUpdateFields(context.Background(), fields, &update)
+
+	require.NoError(t, err)
+	require.NotNil(t, update.SpecRenderer)
+	require.NotNil(t, update.SpecRenderer.TryItUI)
+	assert.False(t, *update.SpecRenderer.TryItUI)
+	require.NotNil(t, update.SpecRenderer.TryItInsomnia)
+	assert.True(t, *update.SpecRenderer.TryItInsomnia)
+	require.NotNil(t, update.SpecRenderer.InfiniteScroll)
+	assert.False(t, *update.SpecRenderer.InfiniteScroll)
+	require.NotNil(t, update.SpecRenderer.ShowSchemas)
+	assert.True(t, *update.SpecRenderer.ShowSchemas)
+	require.NotNil(t, update.SpecRenderer.HideInternal)
+	assert.True(t, *update.SpecRenderer.HideInternal)
+	require.NotNil(t, update.SpecRenderer.HideDeprecated)
+	assert.False(t, *update.SpecRenderer.HideDeprecated)
+	require.NotNil(t, update.SpecRenderer.AllowCustomServerUrls)
+	assert.True(t, *update.SpecRenderer.AllowCustomServerUrls)
+	require.NotNil(t, update.Robots)
+	assert.Equal(t, "User-agent: *", *update.Robots)
+}

--- a/internal/declarative/loader/loader_test.go
+++ b/internal/declarative/loader/loader_test.go
@@ -76,6 +76,53 @@ portals:
 	assert.Contains(t, err.Error(), "unknown field 'team_group_mappings'")
 }
 
+func TestLoaderFlattensPortalCustomizationSpecRendererAndRobots(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(`
+portals:
+  - ref: portal-1
+    name: Portal 1
+    customization:
+      ref: portal-customization
+      spec_renderer:
+        try_it_ui: false
+        try_it_insomnia: true
+        infinite_scroll: false
+        show_schemas: true
+        hide_internal: true
+        hide_deprecated: false
+        allow_custom_server_urls: true
+      robots: "User-agent: *"
+`), 0o600)
+	require.NoError(t, err)
+
+	rs, err := New().LoadFile(path)
+	require.NoError(t, err)
+	require.Len(t, rs.PortalCustomizations, 1)
+
+	customization := rs.PortalCustomizations[0]
+	assert.Equal(t, "portal-1", customization.Portal)
+	assert.Equal(t, "portal-customization", customization.Ref)
+	require.NotNil(t, customization.SpecRenderer)
+	require.NotNil(t, customization.SpecRenderer.TryItUI)
+	assert.False(t, *customization.SpecRenderer.TryItUI)
+	require.NotNil(t, customization.SpecRenderer.TryItInsomnia)
+	assert.True(t, *customization.SpecRenderer.TryItInsomnia)
+	require.NotNil(t, customization.SpecRenderer.InfiniteScroll)
+	assert.False(t, *customization.SpecRenderer.InfiniteScroll)
+	require.NotNil(t, customization.SpecRenderer.ShowSchemas)
+	assert.True(t, *customization.SpecRenderer.ShowSchemas)
+	require.NotNil(t, customization.SpecRenderer.HideInternal)
+	assert.True(t, *customization.SpecRenderer.HideInternal)
+	require.NotNil(t, customization.SpecRenderer.HideDeprecated)
+	assert.False(t, *customization.SpecRenderer.HideDeprecated)
+	require.NotNil(t, customization.SpecRenderer.AllowCustomServerUrls)
+	assert.True(t, *customization.SpecRenderer.AllowCustomServerUrls)
+	require.NotNil(t, customization.Robots)
+	assert.Equal(t, "User-agent: *", *customization.Robots)
+}
+
 func TestLoader_LoadFile_ValidConfigs(t *testing.T) {
 	tests := []struct {
 		name                  string

--- a/internal/declarative/planner/constants.go
+++ b/internal/declarative/planner/constants.go
@@ -143,10 +143,23 @@ const (
 	FieldReplyToEmail                 = "reply_to_email"
 	FieldRBACEnabled                  = "rbac_enabled"
 	FieldSSL                          = "ssl"
+	FieldRobots                       = "robots"
+	FieldSpecRenderer                 = "spec_renderer"
 	FieldTheme                        = "theme"
 	FieldVisibility                   = "visibility"
 	FieldCustomFields                 = "custom_fields"
 	FieldAuthenticationStrategyUpdate = "authentication_strategy_update"
+)
+
+// Common portal customization spec renderer plan field identifiers.
+const (
+	FieldAllowCustomServerURLs = "allow_custom_server_urls"
+	FieldHideDeprecated        = "hide_deprecated"
+	FieldHideInternal          = "hide_internal"
+	FieldInfiniteScroll        = "infinite_scroll"
+	FieldShowSchemas           = "show_schemas"
+	FieldTryItInsomnia         = "try_it_insomnia"
+	FieldTryItUI               = "try_it_ui"
 )
 
 // Common gateway and event-gateway plan field identifiers.

--- a/internal/declarative/planner/portal_child_planner.go
+++ b/internal/declarative/planner/portal_child_planner.go
@@ -1212,6 +1212,27 @@ func (p *Planner) shouldUpdatePortalCustomization(
 		}
 	}
 
+	if !p.compareSpecRenderer(current.SpecRenderer, desired.SpecRenderer) {
+		if desired.SpecRenderer != nil {
+			newSpecRenderer := p.buildSpecRendererFields(desired.SpecRenderer)
+			updates[FieldSpecRenderer] = newSpecRenderer
+			changedFields[FieldSpecRenderer] = FieldChange{
+				Old: current.SpecRenderer,
+				New: newSpecRenderer,
+			}
+		}
+	}
+
+	if !p.compareStringPtr(current.Robots, desired.Robots) {
+		if desired.Robots != nil {
+			updates[FieldRobots] = *desired.Robots
+			changedFields[FieldRobots] = FieldChange{
+				Old: current.Robots,
+				New: *desired.Robots,
+			}
+		}
+	}
+
 	return len(updates) > 0, updates, changedFields
 }
 
@@ -1239,6 +1260,14 @@ func (p *Planner) buildAllCustomizationFields(
 	// Add menu settings if present
 	if customization.Menu != nil {
 		fields[FieldMenu] = p.buildMenuFields(customization.Menu)
+	}
+
+	if customization.SpecRenderer != nil {
+		fields[FieldSpecRenderer] = p.buildSpecRendererFields(customization.SpecRenderer)
+	}
+
+	if customization.Robots != nil {
+		fields[FieldRobots] = *customization.Robots
 	}
 
 	return fields
@@ -1313,6 +1342,34 @@ func (p *Planner) buildMenuFields(menu *kkComps.Menu) map[string]any {
 	}
 
 	return menuFields
+}
+
+func (p *Planner) buildSpecRendererFields(specRenderer *kkComps.SpecRenderer) map[string]any {
+	specRendererFields := make(map[string]any)
+
+	if specRenderer.TryItUI != nil {
+		specRendererFields[FieldTryItUI] = *specRenderer.TryItUI
+	}
+	if specRenderer.TryItInsomnia != nil {
+		specRendererFields[FieldTryItInsomnia] = *specRenderer.TryItInsomnia
+	}
+	if specRenderer.InfiniteScroll != nil {
+		specRendererFields[FieldInfiniteScroll] = *specRenderer.InfiniteScroll
+	}
+	if specRenderer.ShowSchemas != nil {
+		specRendererFields[FieldShowSchemas] = *specRenderer.ShowSchemas
+	}
+	if specRenderer.HideInternal != nil {
+		specRendererFields[FieldHideInternal] = *specRenderer.HideInternal
+	}
+	if specRenderer.HideDeprecated != nil {
+		specRendererFields[FieldHideDeprecated] = *specRenderer.HideDeprecated
+	}
+	if specRenderer.AllowCustomServerUrls != nil {
+		specRendererFields[FieldAllowCustomServerURLs] = *specRenderer.AllowCustomServerUrls
+	}
+
+	return specRendererFields
 }
 
 // compareTheme does deep comparison of theme objects
@@ -1394,8 +1451,35 @@ func (p *Planner) compareMenu(current, desired *kkComps.Menu) bool {
 	return true
 }
 
+func (p *Planner) compareSpecRenderer(current, desired *kkComps.SpecRenderer) bool {
+	if current == nil && desired == nil {
+		return true
+	}
+	if current == nil || desired == nil {
+		return false
+	}
+
+	return p.compareBoolPtr(current.TryItUI, desired.TryItUI) &&
+		p.compareBoolPtr(current.TryItInsomnia, desired.TryItInsomnia) &&
+		p.compareBoolPtr(current.InfiniteScroll, desired.InfiniteScroll) &&
+		p.compareBoolPtr(current.ShowSchemas, desired.ShowSchemas) &&
+		p.compareBoolPtr(current.HideInternal, desired.HideInternal) &&
+		p.compareBoolPtr(current.HideDeprecated, desired.HideDeprecated) &&
+		p.compareBoolPtr(current.AllowCustomServerUrls, desired.AllowCustomServerUrls)
+}
+
 // compareStringPtr compares two string pointers
 func (p *Planner) compareStringPtr(current, desired *string) bool {
+	if current == nil && desired == nil {
+		return true
+	}
+	if current == nil || desired == nil {
+		return false
+	}
+	return *current == *desired
+}
+
+func (p *Planner) compareBoolPtr(current, desired *bool) bool {
 	if current == nil && desired == nil {
 		return true
 	}

--- a/internal/declarative/planner/portal_child_test.go
+++ b/internal/declarative/planner/portal_child_test.go
@@ -258,6 +258,127 @@ func TestPlanPortalTeamGroupMappingUpdatePreservesEmptyGroups(t *testing.T) {
 	assert.Equal(t, []string{}, plan.Changes[0].ChangedFields[FieldGroups].New)
 }
 
+func TestShouldUpdatePortalCustomizationDetectsSpecRendererAndRobots(t *testing.T) {
+	planner := NewPlanner(nil, slog.Default())
+	boolPtr := func(v bool) *bool { return &v }
+	stringPtr := func(v string) *string { return &v }
+
+	current := &kkComps.PortalCustomization{
+		SpecRenderer: &kkComps.SpecRenderer{
+			TryItUI:               boolPtr(true),
+			TryItInsomnia:         boolPtr(true),
+			InfiniteScroll:        boolPtr(true),
+			ShowSchemas:           boolPtr(true),
+			HideInternal:          boolPtr(false),
+			HideDeprecated:        boolPtr(false),
+			AllowCustomServerUrls: boolPtr(true),
+		},
+		Robots: stringPtr("User-agent: *"),
+	}
+	desired := resources.PortalCustomizationResource{
+		PortalCustomization: kkComps.PortalCustomization{
+			SpecRenderer: &kkComps.SpecRenderer{
+				TryItUI:               boolPtr(false),
+				TryItInsomnia:         boolPtr(false),
+				InfiniteScroll:        boolPtr(false),
+				ShowSchemas:           boolPtr(false),
+				HideInternal:          boolPtr(true),
+				HideDeprecated:        boolPtr(true),
+				AllowCustomServerUrls: boolPtr(false),
+			},
+			Robots: stringPtr("User-agent: *\nDisallow: /internal"),
+		},
+	}
+
+	needsUpdate, updates, changedFields := planner.shouldUpdatePortalCustomization(current, desired)
+
+	require.True(t, needsUpdate)
+	require.Contains(t, updates, FieldSpecRenderer)
+	specRenderer, ok := updates[FieldSpecRenderer].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, false, specRenderer[FieldTryItUI])
+	assert.Equal(t, false, specRenderer[FieldTryItInsomnia])
+	assert.Equal(t, false, specRenderer[FieldInfiniteScroll])
+	assert.Equal(t, false, specRenderer[FieldShowSchemas])
+	assert.Equal(t, true, specRenderer[FieldHideInternal])
+	assert.Equal(t, true, specRenderer[FieldHideDeprecated])
+	assert.Equal(t, false, specRenderer[FieldAllowCustomServerURLs])
+	assert.Equal(t, "User-agent: *\nDisallow: /internal", updates[FieldRobots])
+	assert.Contains(t, changedFields, FieldSpecRenderer)
+	assert.Contains(t, changedFields, FieldRobots)
+}
+
+func TestShouldUpdatePortalCustomizationIgnoresMatchingSpecRendererAndRobots(t *testing.T) {
+	planner := NewPlanner(nil, slog.Default())
+	boolPtr := func(v bool) *bool { return &v }
+	stringPtr := func(v string) *string { return &v }
+
+	current := &kkComps.PortalCustomization{
+		SpecRenderer: &kkComps.SpecRenderer{
+			TryItUI:               boolPtr(true),
+			TryItInsomnia:         boolPtr(false),
+			InfiniteScroll:        boolPtr(true),
+			ShowSchemas:           boolPtr(false),
+			HideInternal:          boolPtr(true),
+			HideDeprecated:        boolPtr(false),
+			AllowCustomServerUrls: boolPtr(true),
+		},
+		Robots: stringPtr("User-agent: *"),
+	}
+	desired := resources.PortalCustomizationResource{
+		PortalCustomization: kkComps.PortalCustomization{
+			SpecRenderer: &kkComps.SpecRenderer{
+				TryItUI:               boolPtr(true),
+				TryItInsomnia:         boolPtr(false),
+				InfiniteScroll:        boolPtr(true),
+				ShowSchemas:           boolPtr(false),
+				HideInternal:          boolPtr(true),
+				HideDeprecated:        boolPtr(false),
+				AllowCustomServerUrls: boolPtr(true),
+			},
+			Robots: stringPtr("User-agent: *"),
+		},
+	}
+
+	needsUpdate, updates, changedFields := planner.shouldUpdatePortalCustomization(current, desired)
+
+	require.False(t, needsUpdate)
+	assert.Empty(t, updates)
+	assert.Empty(t, changedFields)
+}
+
+func TestBuildAllCustomizationFieldsIncludesSpecRendererAndRobots(t *testing.T) {
+	planner := NewPlanner(nil, slog.Default())
+	boolPtr := func(v bool) *bool { return &v }
+	stringPtr := func(v string) *string { return &v }
+
+	fields := planner.buildAllCustomizationFields(resources.PortalCustomizationResource{
+		PortalCustomization: kkComps.PortalCustomization{
+			SpecRenderer: &kkComps.SpecRenderer{
+				TryItUI:               boolPtr(false),
+				TryItInsomnia:         boolPtr(true),
+				InfiniteScroll:        boolPtr(false),
+				ShowSchemas:           boolPtr(true),
+				HideInternal:          boolPtr(false),
+				HideDeprecated:        boolPtr(true),
+				AllowCustomServerUrls: boolPtr(false),
+			},
+			Robots: stringPtr("User-agent: *"),
+		},
+	})
+
+	specRenderer, ok := fields[FieldSpecRenderer].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, false, specRenderer[FieldTryItUI])
+	assert.Equal(t, true, specRenderer[FieldTryItInsomnia])
+	assert.Equal(t, false, specRenderer[FieldInfiniteScroll])
+	assert.Equal(t, true, specRenderer[FieldShowSchemas])
+	assert.Equal(t, false, specRenderer[FieldHideInternal])
+	assert.Equal(t, true, specRenderer[FieldHideDeprecated])
+	assert.Equal(t, false, specRenderer[FieldAllowCustomServerURLs])
+	assert.Equal(t, "User-agent: *", fields[FieldRobots])
+}
+
 func TestPlanPortalTeamGroupMappingsSkipsUnconfiguredPortalAuthSettingsAPI(t *testing.T) {
 	client := state.NewClient(state.ClientConfig{})
 	planner := NewPlanner(client, slog.Default())

--- a/test/e2e/scenarios/portal/customization/overlays/003-update/config.yaml
+++ b/test/e2e/scenarios/portal/customization/overlays/003-update/config.yaml
@@ -16,6 +16,15 @@ portals:
         colors:
           primary: "#FF5733"
       layout: "sidebar"
+      spec_renderer:
+        try_it_ui: false
+        try_it_insomnia: false
+        infinite_scroll: false
+        show_schemas: false
+        hide_internal: true
+        hide_deprecated: true
+        allow_custom_server_urls: false
+      robots: "User-agent: *\nDisallow: /internal"
       menu:
         main:
           - path: "/home"

--- a/test/e2e/scenarios/portal/customization/scenario.yaml
+++ b/test/e2e/scenarios/portal/customization/scenario.yaml
@@ -54,6 +54,14 @@ steps:
                 "theme.mode": light
                 "theme.colors.primary": "#8250FF"
                 layout: topnav
+                "spec_renderer.try_it_ui": true
+                "spec_renderer.try_it_insomnia": true
+                "spec_renderer.infinite_scroll": true
+                "spec_renderer.show_schemas": true
+                "spec_renderer.hide_internal": false
+                "spec_renderer.hide_deprecated": false
+                "spec_renderer.allow_custom_server_urls": true
+                robots: "User-agent: *"
                 "length(menu.main)": 3
                 "length(menu.footer_sections)": 1
       - name: 001-apply-customization
@@ -114,6 +122,14 @@ steps:
                 "theme.mode": dark
                 "theme.colors.primary": "#FF5733"
                 layout: sidebar
+                "spec_renderer.try_it_ui": false
+                "spec_renderer.try_it_insomnia": false
+                "spec_renderer.infinite_scroll": false
+                "spec_renderer.show_schemas": false
+                "spec_renderer.hide_internal": true
+                "spec_renderer.hide_deprecated": true
+                "spec_renderer.allow_custom_server_urls": false
+                robots: "User-agent: *\nDisallow: /internal"
                 "length(menu.main)": 2
                 "length(menu.footer_sections)": 1
       - name: 001-apply-customization-update

--- a/test/e2e/scenarios/portal/customization/testdata/config.yaml
+++ b/test/e2e/scenarios/portal/customization/testdata/config.yaml
@@ -16,6 +16,15 @@ portals:
         colors:
           primary: "#8250FF"
       layout: "topnav"
+      spec_renderer:
+        try_it_ui: true
+        try_it_insomnia: true
+        infinite_scroll: true
+        show_schemas: true
+        hide_internal: false
+        hide_deprecated: false
+        allow_custom_server_urls: true
+      robots: "User-agent: *"
       menu:
         main:
           - path: "/getting-started"


### PR DESCRIPTION
## Summary

- detect portal customization drift for `spec_renderer` and `robots` in the planner
- map planned `spec_renderer` and `robots` fields through the portal customization executor adapter
- add loader, planner, executor, and portal customization E2E scenario coverage for these fields

Closes #1197

## Testing

- `go test -mod=mod ./internal/declarative/planner ./internal/declarative/executor ./internal/declarative/loader`
- `make test` (passed before rebasing onto the latest `origin/main`)
- `make build` (passed before rebasing onto the latest `origin/main`)
- `make lint` (passed before rebasing onto the latest `origin/main`)

Note: after rebasing onto the latest `origin/main`, plain `go test` is currently blocked by an upstream vendor metadata mismatch between `go.mod` and `vendor/modules.txt`; this patch does not modify `go.mod`, `go.sum`, or vendor files.