### PR TITLE
Task: add theme-aware logo to release highlights heading

### DIFF
--- a/.github/workflows/release.md
+++ b/.github/workflows/release.md
@@ -576,12 +576,12 @@ You MUST call the `safeoutputs/update_release` MCP tool exactly once:
 The body should begin with:
 
 ```markdown
-## kongctl Release Highlights
+## <img src="https://raw.githubusercontent.com/Kong/kongctl/main/brand/logo/dark/Kong-Logomark.svg" alt="Kong logo" width="20" /> kongctl Release Highlights
 ```
 
-Do not emit raw HTML in the release body. The `safeoutputs/update_release`
-safe-output tool sanitizes the `body` field before publishing, so tags like
-`<img>` will be escaped or stripped instead of rendered.
+The `<img>` tag in the opening heading is intentional and must be preserved so
+the Kong logo renders in the GitHub release body. Avoid other raw HTML unless it
+is required for GitHub-flavored Markdown rendering.
 
 When commits are available, include this section near the end:
 

--- a/.github/workflows/release.md
+++ b/.github/workflows/release.md
@@ -576,12 +576,12 @@ You MUST call the `safeoutputs/update_release` MCP tool exactly once:
 The body should begin with:
 
 ```markdown
-## <img src="https://raw.githubusercontent.com/Kong/kongctl/main/brand/logo/dark/Kong-Logomark.svg" alt="Kong logo" width="20" /> kongctl Release Highlights
+## <img src="https://raw.githubusercontent.com/Kong/kongctl/main/brand/logo/light/Kong-Logomark.svg#gh-light-mode-only" alt="Kong logo" width="20" /> <img src="https://raw.githubusercontent.com/Kong/kongctl/main/brand/logo/dark/Kong-Logomark.svg#gh-dark-mode-only" alt="Kong logo" width="20" /> kongctl Release Highlights
 ```
 
-The `<img>` tag in the opening heading is intentional and must be preserved so
-the Kong logo renders in the GitHub release body. Avoid other raw HTML unless it
-is required for GitHub-flavored Markdown rendering.
+The `<img>` tags in the opening heading are intentional and must be preserved so
+the theme-aware Kong logo renders in the GitHub release body. Avoid other raw
+HTML unless it is required for GitHub-flavored Markdown rendering.
 
 When commits are available, include this section near the end:
 


### PR DESCRIPTION
## Summary
- Update the release workflow prompt so generated release notes begin with theme-aware Kong logo images in the `kongctl Release Highlights` heading.
- Use two plain `<img>` tags with `#gh-light-mode-only` and `#gh-dark-mode-only` fragments for light/dark GitHub themes.
- Replace the old raw-HTML warning with explicit guidance to preserve the heading image tags.

## Validation
- `make test`
- `git diff --check`

Note: `.github/workflows/release.lock.yml` runtime-imports `.github/workflows/release.md`, so this prompt-body change does not require recompiling the lock file.