### PR TITLE
Fix: omit resource content from text output

### DIFF
--- a/internal/cmd/root/products/konnect/api/content_text_output_test.go
+++ b/internal/cmd/root/products/konnect/api/content_text_output_test.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"testing"
+
+	cmdCommon "github.com/kong/kongctl/internal/cmd/common"
+	"github.com/kong/kongctl/internal/cmd/output/tableview"
+	"github.com/kong/kongctl/internal/iostreams"
+	"github.com/segmentio/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIDocumentDetailTextOutputOmitsContentField(t *testing.T) {
+	record := apiDocumentDetailRecord{
+		ID:               "b130...",
+		RawID:            "b130f7c0-0000-4000-8000-000000000000",
+		Title:            "Getting Started",
+		Slug:             "getting-started",
+		Status:           "published",
+		ParentDocumentID: valueNA,
+		LocalCreatedTime: "2025-08-27 14:42:18",
+		LocalUpdatedTime: "2025-08-27 14:42:18",
+		content:          normalizeAPIDocumentContent("# Getting Started\n\nDocument body content"),
+	}
+
+	output := renderAPIRecordAsText(t, record)
+
+	require.NotContains(t, output, "CONTENT")
+	require.NotContains(t, output, "# Getting Started")
+	require.NotContains(t, output, "Document body content")
+}
+
+func TestAPIVersionDetailTextOutputOmitsSpecContentField(t *testing.T) {
+	record := apiVersionDetailRecord{
+		ID:               "c130...",
+		RawID:            "c130f7c0-0000-4000-8000-000000000000",
+		Version:          "1.0.0",
+		SpecType:         "oas3",
+		LocalCreatedTime: "2025-08-27 14:42:18",
+		LocalUpdatedTime: "2025-08-27 14:42:18",
+		specContent:      normalizeAPIVersionContent("openapi: 3.0.0\ninfo:\n  title: Example API"),
+	}
+
+	output := renderAPIRecordAsText(t, record)
+
+	require.NotContains(t, output, "SPEC CONTENT")
+	require.NotContains(t, output, "openapi: 3.0.0")
+	require.NotContains(t, output, "title: Example API")
+}
+
+func renderAPIRecordAsText(t *testing.T, record any) string {
+	t.Helper()
+
+	streams, _, outBuf, _ := iostreams.NewTestIOStreams()
+	printer, err := cli.Format("text", streams.Out)
+	require.NoError(t, err)
+
+	err = tableview.RenderForFormat(
+		nil,
+		false,
+		cmdCommon.TEXT,
+		printer,
+		streams,
+		record,
+		nil,
+		"",
+	)
+	require.NoError(t, err)
+	printer.Flush()
+
+	return outBuf.String()
+}

--- a/internal/cmd/root/products/konnect/api/documents.go
+++ b/internal/cmd/root/products/konnect/api/documents.go
@@ -47,9 +47,9 @@ type apiDocumentDetailRecord struct {
 	Slug             string
 	Status           string
 	ParentDocumentID string
-	Content          string
 	LocalCreatedTime string
 	LocalUpdatedTime string
+	content          string
 }
 
 type apiDocumentContentContext struct {
@@ -480,7 +480,7 @@ func documentSummaryDetailView(doc *kkComps.APIDocumentSummaryWithChildren, deta
 
 	fmt.Fprintf(&b, "content: %s (press enter to view)", apiDocumentContentIndicator)
 	if detail != nil {
-		if preview := previewAPIDocumentContent(detail.Content, apiDocumentContentPreviewLimit); preview != "" {
+		if preview := previewAPIDocumentContent(detail.content, apiDocumentContentPreviewLimit); preview != "" {
 			fmt.Fprintf(&b, " %s", preview)
 		}
 	}
@@ -519,7 +519,7 @@ func apiDocumentDetailView(record apiDocumentDetailRecord) string {
 	}
 
 	fmt.Fprintf(&b, "content: %s (press enter to view)", apiDocumentContentIndicator)
-	if preview := previewAPIDocumentContent(record.Content, apiDocumentContentPreviewLimit); preview != "" {
+	if preview := previewAPIDocumentContent(record.content, apiDocumentContentPreviewLimit); preview != "" {
 		fmt.Fprintf(&b, " %s", preview)
 	}
 	fmt.Fprintln(&b)
@@ -551,9 +551,9 @@ func apiDocumentDetailToRecord(doc *kkComps.APIDocumentResponse) apiDocumentDeta
 			return valueNA
 		}(),
 		ParentDocumentID: parentID,
-		Content:          content,
 		LocalCreatedTime: doc.GetCreatedAt().In(time.Local).Format("2006-01-02 15:04:05"),
 		LocalUpdatedTime: doc.GetUpdatedAt().In(time.Local).Format("2006-01-02 15:04:05"),
+		content:          content,
 	}
 }
 
@@ -628,7 +628,7 @@ func loadAPIDocumentContent(_ context.Context, helper cmd.Helper, parent any) (t
 		record = detail
 	}
 
-	raw := normalizeAPIDocumentContent(record.Content)
+	raw := normalizeAPIDocumentContent(record.content)
 	if strings.TrimSpace(raw) == "" {
 		raw = "(content is empty)"
 	}

--- a/internal/cmd/root/products/konnect/api/versions.go
+++ b/internal/cmd/root/products/konnect/api/versions.go
@@ -45,9 +45,9 @@ type apiVersionDetailRecord struct {
 	RawID            string
 	Version          string
 	SpecType         string
-	SpecContent      string
 	LocalCreatedTime string
 	LocalUpdatedTime string
+	specContent      string
 }
 
 type apiVersionContentContext struct {
@@ -443,7 +443,7 @@ func versionDetailToRecord(version *kkComps.APIVersionResponse) apiVersionDetail
 		RawID:    strings.TrimSpace(version.GetID()),
 		Version:  version.GetVersion(),
 		SpecType: specType,
-		SpecContent: func() string {
+		specContent: func() string {
 			if version.GetSpec() != nil && version.GetSpec().GetContent() != nil {
 				return normalizeAPIVersionContent(*version.GetSpec().GetContent())
 			}
@@ -488,7 +488,7 @@ func versionSummaryDetailView(
 
 	fmt.Fprintf(&b, "spec: %s (press enter to view)", apiVersionSpecIndicator)
 	if detail != nil {
-		if preview := previewAPIVersionContent(detail.SpecContent, apiVersionSpecPreviewLimit); preview != "" {
+		if preview := previewAPIVersionContent(detail.specContent, apiVersionSpecPreviewLimit); preview != "" {
 			fmt.Fprintf(&b, " %s", preview)
 		}
 	}
@@ -518,7 +518,7 @@ func apiVersionDetailView(record apiVersionDetailRecord) string {
 	}
 
 	fmt.Fprintf(&b, "spec: %s (press enter to view)", apiVersionSpecIndicator)
-	if preview := previewAPIVersionContent(record.SpecContent, apiVersionSpecPreviewLimit); preview != "" {
+	if preview := previewAPIVersionContent(record.specContent, apiVersionSpecPreviewLimit); preview != "" {
 		fmt.Fprintf(&b, " %s", preview)
 	}
 	fmt.Fprintln(&b)
@@ -648,7 +648,7 @@ func loadAPIVersionSpec(_ context.Context, helper cmd.Helper, parent any) (table
 }
 
 func renderAPIVersionSpecMarkdown(record apiVersionDetailRecord) string {
-	content, language := formatAPIVersionSpecContent(record.SpecContent)
+	content, language := formatAPIVersionSpecContent(record.specContent)
 	specType := strings.TrimSpace(record.SpecType)
 	if specType == "" {
 		specType = valueNA

--- a/internal/cmd/root/products/konnect/portal/pages.go
+++ b/internal/cmd/root/products/konnect/portal/pages.go
@@ -49,9 +49,9 @@ type portalPageDetailRecord struct {
 	Visibility       string
 	Status           string
 	ParentPageID     string
-	Content          string
 	LocalCreatedTime string
 	LocalUpdatedTime string
+	content          string
 	rawID            string
 }
 
@@ -511,7 +511,7 @@ func portalPageInfoDetail(page kkComps.PortalPageInfo, detail *portalPageDetailR
 
 	fmt.Fprintf(&b, "content: %s (press enter to view)", portalPageContentIndicator)
 	if detail != nil {
-		if preview := previewPortalPageContent(detail.Content); preview != "" {
+		if preview := previewPortalPageContent(detail.content); preview != "" {
 			fmt.Fprintf(&b, " %s", preview)
 		}
 	}
@@ -556,7 +556,7 @@ func portalPageDetailView(record portalPageDetailRecord) string {
 	}
 
 	fmt.Fprintf(&b, "content: %s", portalPageContentIndicator)
-	if preview := previewPortalPageContent(record.Content); preview != "" {
+	if preview := previewPortalPageContent(record.content); preview != "" {
 		fmt.Fprintf(&b, " %s", preview)
 	}
 	fmt.Fprintln(&b)
@@ -596,9 +596,9 @@ func portalPageDetailToRecord(page *kkComps.PortalPageResponse) portalPageDetail
 		Visibility:       string(page.GetVisibility()),
 		Status:           string(page.GetStatus()),
 		ParentPageID:     parentID,
-		Content:          normalizePortalPageContent(page.GetContent()),
 		LocalCreatedTime: formatTime(page.GetCreatedAt()),
 		LocalUpdatedTime: formatTime(page.GetUpdatedAt()),
+		content:          normalizePortalPageContent(page.GetContent()),
 	}
 	record.rawID = strings.TrimSpace(page.GetID())
 	return record
@@ -694,7 +694,7 @@ func loadPortalPageContent(ctx context.Context, helper cmd.Helper, parent any) (
 		record = detail
 	}
 
-	raw := normalizePortalPageContent(record.Content)
+	raw := normalizePortalPageContent(record.content)
 	if strings.TrimSpace(raw) == "" {
 		raw = "(content is empty)"
 	}

--- a/internal/cmd/root/products/konnect/portal/pages_test.go
+++ b/internal/cmd/root/products/konnect/portal/pages_test.go
@@ -4,6 +4,10 @@ import (
 	"testing"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	cmdCommon "github.com/kong/kongctl/internal/cmd/common"
+	"github.com/kong/kongctl/internal/cmd/output/tableview"
+	"github.com/kong/kongctl/internal/iostreams"
+	"github.com/segmentio/cli"
 	"github.com/stretchr/testify/require"
 )
 
@@ -75,4 +79,78 @@ func TestFindPageBySlugOrTitle(t *testing.T) {
 		require.NotNil(t, match)
 		require.Equal(t, "page-1", match.ID)
 	})
+}
+
+func TestPortalPageDetailTextOutputOmitsContentField(t *testing.T) {
+	content := `---
+title: "APIs"
+description: "Explore a wide range of API products in our Developer Portal designed for fast, flexible development."
+---
+
+::apis-list
+---
+persist-page-number: true
+cta-text: "View APIs"
+---
+::`
+	record := portalPageDetailRecord{
+		ID:               "b9f7...",
+		Title:            "APIs",
+		Slug:             "apis",
+		Visibility:       "private",
+		Status:           "published",
+		ParentPageID:     valueNA,
+		LocalCreatedTime: "2025-08-27 14:42:18",
+		LocalUpdatedTime: "2025-08-27 14:42:18",
+		content:          normalizePortalPageContent(content),
+	}
+
+	output := renderPortalRecordAsText(t, record)
+
+	require.NotContains(t, output, "CONTENT")
+	require.NotContains(t, output, `title: "APIs"`)
+	require.NotContains(t, output, "persist-page-number")
+}
+
+func TestPortalSnippetDetailTextOutputOmitsContentField(t *testing.T) {
+	record := portalSnippetDetailRecord{
+		ID:               "a130...",
+		Name:             "hero-snippet",
+		Title:            "Hero Snippet",
+		Visibility:       "public",
+		Status:           "published",
+		Description:      "Reusable page hero",
+		LocalCreatedTime: "2025-08-27 14:42:18",
+		LocalUpdatedTime: "2025-08-27 14:42:18",
+		content:          "snippet-frontmatter: true\n\n::hero\nSnippet content\n::",
+	}
+
+	output := renderPortalRecordAsText(t, record)
+
+	require.NotContains(t, output, "CONTENT")
+	require.NotContains(t, output, "snippet-frontmatter")
+	require.NotContains(t, output, "Snippet content")
+}
+
+func renderPortalRecordAsText(t *testing.T, record any) string {
+	t.Helper()
+
+	streams, _, outBuf, _ := iostreams.NewTestIOStreams()
+	printer, err := cli.Format("text", streams.Out)
+	require.NoError(t, err)
+
+	err = tableview.RenderForFormat(
+		nil,
+		false,
+		cmdCommon.TEXT,
+		printer,
+		streams,
+		record,
+		nil,
+		"",
+	)
+	require.NoError(t, err)
+	printer.Flush()
+
+	return outBuf.String()
 }

--- a/internal/cmd/root/products/konnect/portal/snippets.go
+++ b/internal/cmd/root/products/konnect/portal/snippets.go
@@ -47,9 +47,9 @@ type portalSnippetDetailRecord struct {
 	Visibility       string
 	Status           string
 	Description      string
-	Content          string
 	LocalCreatedTime string
 	LocalUpdatedTime string
+	content          string
 	rawID            string
 }
 
@@ -433,9 +433,9 @@ func portalSnippetDetailToRecord(snippet *kkComps.PortalSnippetResponse) portalS
 		Visibility:       string(snippet.GetVisibility()),
 		Status:           string(snippet.GetStatus()),
 		Description:      formatOptionalString(snippet.GetDescription()),
-		Content:          content,
 		LocalCreatedTime: formatTime(snippet.GetCreatedAt()),
 		LocalUpdatedTime: formatTime(snippet.GetUpdatedAt()),
+		content:          content,
 		rawID:            strings.TrimSpace(snippet.GetID()),
 	}
 	return record
@@ -505,7 +505,7 @@ func portalSnippetInfoDetail(snippet kkComps.PortalSnippetInfo, detail *portalSn
 
 	fmt.Fprintf(&b, "content: %s", portalPageContentIndicator)
 	if detail != nil {
-		if preview := previewPortalPageContent(detail.Content); preview != "" {
+		if preview := previewPortalPageContent(detail.content); preview != "" {
 			fmt.Fprintf(&b, " %s", preview)
 		}
 	}
@@ -552,7 +552,7 @@ func portalSnippetDetailView(record portalSnippetDetailRecord) string {
 	}
 
 	fmt.Fprintf(&b, "content: %s", portalPageContentIndicator)
-	if preview := previewPortalPageContent(record.Content); preview != "" {
+	if preview := previewPortalPageContent(record.content); preview != "" {
 		fmt.Fprintf(&b, " %s", preview)
 	}
 	fmt.Fprintln(&b)
@@ -580,7 +580,7 @@ func loadPortalSnippetContent(ctx context.Context, helper cmd.Helper, parent any
 		record = detail
 	}
 
-	raw := normalizePortalPageContent(record.Content)
+	raw := normalizePortalPageContent(record.content)
 	if strings.TrimSpace(raw) == "" {
 		raw = "(content is empty)"
 	}


### PR DESCRIPTION
## Summary

- Omit raw content/spec fields from default text table output for portal pages, portal snippets, API documents, and API versions.
- Keep content available internally for previews and interactive detail views.
- Add regression coverage for text output so multiline content is not rendered inline.

## Tests

- `go test ./internal/cmd/root/products/konnect/portal ./internal/cmd/root/products/konnect/api -run 'Test(Portal(Page|Snippet)DetailTextOutputOmitsContentField|API(DocumentDetailTextOutputOmitsContentField|VersionDetailTextOutputOmitsSpecContentField))' -count=1`
- `make test`

Closes #1211