### PR TITLE
Fix: normalize frontmatter content and api body metadata

### DIFF
--- a/internal/cmd/root/verbs/dump/declarative.go
+++ b/internal/cmd/root/verbs/dump/declarative.go
@@ -407,7 +407,18 @@ func collectDeclarativePortals(
 		}
 
 		for _, portal := range resp.ListPortalsResponse.Data {
-			results = append(results, mapPortalToDeclarativeResource(portal))
+			resource := mapPortalToDeclarativeResource(portal)
+			if portalID := strings.TrimSpace(portal.GetID()); portalID != "" {
+				detail, err := portalAPI.GetPortal(ctx, portalID)
+				if err != nil {
+					return false, fmt.Errorf("failed to get portal %q: %w", portalID, err)
+				}
+				if detailedPortal := detail.GetPortalResponse(); detailedPortal != nil {
+					resource = mapPortalResponseToDeclarativeResource(*detailedPortal)
+				}
+			}
+
+			results = append(results, resource)
 		}
 
 		return true, nil
@@ -732,6 +743,31 @@ func mapPortalToDeclarativeResource(portal kkComps.ListPortalsResponsePortal) de
 	}
 
 	return result
+}
+
+func mapPortalResponseToDeclarativeResource(portal kkComps.PortalResponse) declresources.PortalResource {
+	listPortal := kkComps.ListPortalsResponsePortal{
+		ID:                               portal.GetID(),
+		Name:                             portal.GetName(),
+		DisplayName:                      portal.GetDisplayName(),
+		Description:                      portal.GetDescription(),
+		AuthenticationEnabled:            portal.GetAuthenticationEnabled(),
+		RbacEnabled:                      portal.GetRbacEnabled(),
+		DefaultApplicationAuthStrategyID: portal.GetDefaultApplicationAuthStrategyID(),
+		AutoApproveDevelopers:            portal.GetAutoApproveDevelopers(),
+		AutoApproveApplications:          portal.GetAutoApproveApplications(),
+		Labels:                           portal.GetLabels(),
+	}
+
+	if visibility := portal.GetDefaultAPIVisibility(); visibility != "" {
+		listPortal.DefaultAPIVisibility = kkComps.ListPortalsResponseDefaultAPIVisibility(visibility)
+	}
+
+	if visibility := portal.GetDefaultPageVisibility(); visibility != "" {
+		listPortal.DefaultPageVisibility = kkComps.ListPortalsResponseDefaultPageVisibility(visibility)
+	}
+
+	return mapPortalToDeclarativeResource(listPortal)
 }
 
 func mapAPIToDeclarativeResource(api kkComps.APIResponseSchema) declresources.APIResource {

--- a/internal/cmd/root/verbs/dump/declarative_children.go
+++ b/internal/cmd/root/verbs/dump/declarative_children.go
@@ -522,13 +522,14 @@ func mapPortalPageToResource(page *declstate.PortalPage) (declresources.PortalPa
 		Ref: page.ID,
 	}
 
-	if strings.TrimSpace(page.Title) != "" &&
-		!contentFrontmatterHasField(page.Content, frontmatter.PortalPageFields, frontmatter.FieldTitle) {
+	contentMetadata := contentFrontmatterFields(page.Content, frontmatter.PortalPageFields)
+
+	if strings.TrimSpace(page.Title) != "" && !contentMetadataHasField(contentMetadata, frontmatter.FieldTitle) {
 		title := page.Title
 		res.Title = &title
 	}
 	if strings.TrimSpace(page.Description) != "" &&
-		!contentFrontmatterHasField(page.Content, frontmatter.PortalPageFields, frontmatter.FieldDescription) {
+		!contentMetadataHasField(contentMetadata, frontmatter.FieldDescription) {
 		desc := page.Description
 		res.Description = &desc
 	}
@@ -607,13 +608,14 @@ func mapPortalSnippetToResource(snippet *declstate.PortalSnippet) declresources.
 		Content: snippet.Content,
 	}
 
-	if strings.TrimSpace(snippet.Title) != "" &&
-		!contentFrontmatterHasField(snippet.Content, frontmatter.PortalSnippetFields, frontmatter.FieldTitle) {
+	contentMetadata := contentFrontmatterFields(snippet.Content, frontmatter.PortalSnippetFields)
+
+	if strings.TrimSpace(snippet.Title) != "" && !contentMetadataHasField(contentMetadata, frontmatter.FieldTitle) {
 		title := snippet.Title
 		res.Title = &title
 	}
 	if strings.TrimSpace(snippet.Description) != "" &&
-		!contentFrontmatterHasField(snippet.Content, frontmatter.PortalSnippetFields, frontmatter.FieldDescription) {
+		!contentMetadataHasField(contentMetadata, frontmatter.FieldDescription) {
 		desc := snippet.Description
 		res.Description = &desc
 	}
@@ -1347,18 +1349,17 @@ func mapAPIDocumentToResource(doc *declstate.APIDocument) declresources.APIDocum
 		Ref: doc.ID,
 	}
 
-	if strings.TrimSpace(doc.Title) != "" &&
-		!contentFrontmatterHasField(doc.Content, frontmatter.APIDocumentFields, frontmatter.FieldTitle) {
+	contentMetadata := contentFrontmatterFields(doc.Content, frontmatter.APIDocumentFields)
+
+	if strings.TrimSpace(doc.Title) != "" && !contentMetadataHasField(contentMetadata, frontmatter.FieldTitle) {
 		title := doc.Title
 		res.Title = &title
 	}
-	if strings.TrimSpace(doc.Slug) != "" &&
-		!contentFrontmatterHasField(doc.Content, frontmatter.APIDocumentFields, frontmatter.FieldSlug) {
+	if strings.TrimSpace(doc.Slug) != "" && !contentMetadataHasField(contentMetadata, frontmatter.FieldSlug) {
 		slug := doc.Slug
 		res.Slug = &slug
 	}
-	if strings.TrimSpace(doc.Status) != "" &&
-		!contentFrontmatterHasField(doc.Content, frontmatter.APIDocumentFields, frontmatter.FieldStatus) {
+	if strings.TrimSpace(doc.Status) != "" && !contentMetadataHasField(contentMetadata, frontmatter.FieldStatus) {
 		status := kkComps.APIDocumentStatus(doc.Status)
 		res.Status = &status
 	}
@@ -1366,11 +1367,15 @@ func mapAPIDocumentToResource(doc *declstate.APIDocument) declresources.APIDocum
 	return res
 }
 
-func contentFrontmatterHasField(content string, recognized []string, field string) bool {
+func contentFrontmatterFields(content string, recognized []string) map[string]string {
 	metadata, err := frontmatter.Parse(content, recognized)
 	if err != nil {
-		return false
+		return nil
 	}
+	return metadata
+}
+
+func contentMetadataHasField(metadata map[string]string, field string) bool {
 	_, ok := metadata[field]
 	return ok
 }

--- a/internal/cmd/root/verbs/dump/declarative_children.go
+++ b/internal/cmd/root/verbs/dump/declarative_children.go
@@ -15,6 +15,7 @@ import (
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 	kkErrors "github.com/Kong/sdk-konnect-go/models/sdkerrors"
 
+	"github.com/kong/kongctl/internal/declarative/frontmatter"
 	declresources "github.com/kong/kongctl/internal/declarative/resources"
 	declstate "github.com/kong/kongctl/internal/declarative/state"
 )
@@ -521,11 +522,13 @@ func mapPortalPageToResource(page *declstate.PortalPage) (declresources.PortalPa
 		Ref: page.ID,
 	}
 
-	if strings.TrimSpace(page.Title) != "" {
+	if strings.TrimSpace(page.Title) != "" &&
+		!contentFrontmatterHasField(page.Content, frontmatter.PortalPageFields, frontmatter.FieldTitle) {
 		title := page.Title
 		res.Title = &title
 	}
-	if strings.TrimSpace(page.Description) != "" {
+	if strings.TrimSpace(page.Description) != "" &&
+		!contentFrontmatterHasField(page.Content, frontmatter.PortalPageFields, frontmatter.FieldDescription) {
 		desc := page.Description
 		res.Description = &desc
 	}
@@ -604,11 +607,13 @@ func mapPortalSnippetToResource(snippet *declstate.PortalSnippet) declresources.
 		Content: snippet.Content,
 	}
 
-	if strings.TrimSpace(snippet.Title) != "" {
+	if strings.TrimSpace(snippet.Title) != "" &&
+		!contentFrontmatterHasField(snippet.Content, frontmatter.PortalSnippetFields, frontmatter.FieldTitle) {
 		title := snippet.Title
 		res.Title = &title
 	}
-	if strings.TrimSpace(snippet.Description) != "" {
+	if strings.TrimSpace(snippet.Description) != "" &&
+		!contentFrontmatterHasField(snippet.Content, frontmatter.PortalSnippetFields, frontmatter.FieldDescription) {
 		desc := snippet.Description
 		res.Description = &desc
 	}
@@ -1342,20 +1347,32 @@ func mapAPIDocumentToResource(doc *declstate.APIDocument) declresources.APIDocum
 		Ref: doc.ID,
 	}
 
-	if strings.TrimSpace(doc.Title) != "" {
+	if strings.TrimSpace(doc.Title) != "" &&
+		!contentFrontmatterHasField(doc.Content, frontmatter.APIDocumentFields, frontmatter.FieldTitle) {
 		title := doc.Title
 		res.Title = &title
 	}
-	if strings.TrimSpace(doc.Slug) != "" {
+	if strings.TrimSpace(doc.Slug) != "" &&
+		!contentFrontmatterHasField(doc.Content, frontmatter.APIDocumentFields, frontmatter.FieldSlug) {
 		slug := doc.Slug
 		res.Slug = &slug
 	}
-	if strings.TrimSpace(doc.Status) != "" {
+	if strings.TrimSpace(doc.Status) != "" &&
+		!contentFrontmatterHasField(doc.Content, frontmatter.APIDocumentFields, frontmatter.FieldStatus) {
 		status := kkComps.APIDocumentStatus(doc.Status)
 		res.Status = &status
 	}
 
 	return res
+}
+
+func contentFrontmatterHasField(content string, recognized []string, field string) bool {
+	metadata, err := frontmatter.Parse(content, recognized)
+	if err != nil {
+		return false
+	}
+	_, ok := metadata[field]
+	return ok
 }
 
 func buildGatewayServices(

--- a/internal/cmd/root/verbs/dump/declarative_children_test.go
+++ b/internal/cmd/root/verbs/dump/declarative_children_test.go
@@ -86,6 +86,104 @@ func TestNormalizePortalPageSlug(t *testing.T) {
 	}
 }
 
+func TestMapPortalPageToResourceOmitsMetadataPresentInFrontmatter(t *testing.T) {
+	t.Parallel()
+
+	resource, err := mapPortalPageToResource(&declstate.PortalPage{
+		ID:          "page-1",
+		Slug:        "/getting-started",
+		Title:       "API title",
+		Description: "API description",
+		Content: `---
+title: Frontmatter title
+description: Frontmatter description
+---
+
+# Body
+`,
+		Visibility: "public",
+		Status:     "published",
+	})
+	require.NoError(t, err)
+
+	require.Nil(t, resource.Title)
+	require.Nil(t, resource.Description)
+	require.Equal(t, "getting-started", resource.Slug)
+	require.Contains(t, resource.Content, "title: Frontmatter title")
+}
+
+func TestMapPortalSnippetToResourceOmitsMetadataPresentInFrontmatter(t *testing.T) {
+	t.Parallel()
+
+	resource := mapPortalSnippetToResource(&declstate.PortalSnippet{
+		ID:          "snippet-1",
+		Name:        "welcome",
+		Title:       "API title",
+		Description: "API description",
+		Content: `---
+title: Frontmatter title
+description: Frontmatter description
+---
+
+<div>Welcome</div>
+`,
+		Visibility: "public",
+		Status:     "published",
+	})
+
+	require.Nil(t, resource.Title)
+	require.Nil(t, resource.Description)
+	require.Equal(t, "welcome", resource.Name)
+	require.Contains(t, resource.Content, "description: Frontmatter description")
+}
+
+func TestMapAPIDocumentToResourceOmitsMetadataPresentInFrontmatter(t *testing.T) {
+	t.Parallel()
+
+	resource := mapAPIDocumentToResource(&declstate.APIDocument{
+		ID:     "doc-1",
+		Title:  "API title",
+		Slug:   "api-slug",
+		Status: "published",
+		Content: `---
+title: Frontmatter title
+slug: frontmatter-slug
+status: unpublished
+---
+
+# Body
+`,
+	})
+
+	require.Nil(t, resource.Title)
+	require.Nil(t, resource.Slug)
+	require.Nil(t, resource.Status)
+	require.Contains(t, resource.Content, "status: unpublished")
+}
+
+func TestMapAPIDocumentToResourceKeepsMetadataAbsentFromFrontmatter(t *testing.T) {
+	t.Parallel()
+
+	resource := mapAPIDocumentToResource(&declstate.APIDocument{
+		ID:     "doc-1",
+		Title:  "API title",
+		Slug:   "api-slug",
+		Status: "published",
+		Content: `---
+title: Frontmatter title
+---
+
+# Body
+`,
+	})
+
+	require.Nil(t, resource.Title)
+	require.NotNil(t, resource.Slug)
+	require.Equal(t, "api-slug", *resource.Slug)
+	require.NotNil(t, resource.Status)
+	require.Equal(t, "published", string(*resource.Status))
+}
+
 func TestResolveAPIPublicationRef(t *testing.T) {
 	apiID := "api-123"
 	portalID := "portal-456"

--- a/internal/cmd/root/verbs/dump/dump_declarative_test.go
+++ b/internal/cmd/root/verbs/dump/dump_declarative_test.go
@@ -1,10 +1,12 @@
 package dump
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
 
 	decllabels "github.com/kong/kongctl/internal/declarative/labels"
 	declresources "github.com/kong/kongctl/internal/declarative/resources"
@@ -88,6 +90,75 @@ func TestMapPortalToDeclarativeResource(t *testing.T) {
 
 	if *resource.AutoApproveApplications != *portal.AutoApproveApplications {
 		t.Fatalf("expected auto approve applications to match input")
+	}
+}
+
+func TestCollectDeclarativePortalsUsesPortalDetails(t *testing.T) {
+	listAuthEnabled := false
+	detailAuthEnabled := true
+	var getPortalIDs []string
+
+	api := &portalPaginationStub{
+		t: t,
+		listPortalsFunc: func(
+			_ context.Context,
+			req kkOps.ListPortalsRequest,
+		) (*kkOps.ListPortalsResponse, error) {
+			pageNumber := int64(1)
+			if req.PageNumber != nil {
+				pageNumber = *req.PageNumber
+			}
+
+			switch pageNumber {
+			case 1:
+				return &kkOps.ListPortalsResponse{
+					ListPortalsResponse: &kkComps.ListPortalsResponse{
+						Data: []kkComps.ListPortalsResponsePortal{
+							{
+								ID:                    "portal-id",
+								Name:                  "portal-name",
+								AuthenticationEnabled: &listAuthEnabled,
+							},
+						},
+					},
+				}, nil
+			case 2:
+				return &kkOps.ListPortalsResponse{
+					ListPortalsResponse: &kkComps.ListPortalsResponse{},
+				}, nil
+			default:
+				t.Fatalf("unexpected page request: %d", pageNumber)
+				return nil, nil
+			}
+		},
+		getPortalFunc: func(_ context.Context, id string) (*kkOps.GetPortalResponse, error) {
+			getPortalIDs = append(getPortalIDs, id)
+			return &kkOps.GetPortalResponse{
+				PortalResponse: &kkComps.PortalResponse{
+					ID:                    id,
+					Name:                  "portal-name",
+					AuthenticationEnabled: &detailAuthEnabled,
+				},
+			}, nil
+		},
+	}
+
+	resources, err := collectDeclarativePortals(t.Context(), api, 100, filterOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error collecting portals: %v", err)
+	}
+
+	if len(resources) != 1 {
+		t.Fatalf("expected one portal resource, got %d", len(resources))
+	}
+
+	if resources[0].AuthenticationEnabled == nil || !*resources[0].AuthenticationEnabled {
+		t.Fatalf("expected authentication_enabled to come from portal detail, got %+v",
+			resources[0].AuthenticationEnabled)
+	}
+
+	if len(getPortalIDs) != 1 || getPortalIDs[0] != "portal-id" {
+		t.Fatalf("expected GetPortal to be called once for portal-id, got %v", getPortalIDs)
 	}
 }
 

--- a/internal/cmd/root/verbs/dump/pagination_test.go
+++ b/internal/cmd/root/verbs/dump/pagination_test.go
@@ -15,6 +15,7 @@ import (
 type portalPaginationStub struct {
 	t               *testing.T
 	listPortalsFunc func(context.Context, kkOps.ListPortalsRequest) (*kkOps.ListPortalsResponse, error)
+	getPortalFunc   func(context.Context, string) (*kkOps.GetPortalResponse, error)
 }
 
 func (p *portalPaginationStub) ListPortals(
@@ -28,7 +29,10 @@ func (p *portalPaginationStub) ListPortals(
 	return nil, nil
 }
 
-func (p *portalPaginationStub) GetPortal(context.Context, string) (*kkOps.GetPortalResponse, error) {
+func (p *portalPaginationStub) GetPortal(ctx context.Context, id string) (*kkOps.GetPortalResponse, error) {
+	if p.getPortalFunc != nil {
+		return p.getPortalFunc(ctx, id)
+	}
 	p.t.Fatalf("unexpected GetPortal call")
 	return nil, nil
 }

--- a/internal/declarative/frontmatter/frontmatter.go
+++ b/internal/declarative/frontmatter/frontmatter.go
@@ -1,0 +1,121 @@
+package frontmatter
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	FieldTitle       = "title"
+	FieldDescription = "description"
+	FieldSlug        = "slug"
+	FieldStatus      = "status"
+)
+
+var (
+	PortalPageFields    = []string{FieldTitle, FieldDescription}
+	PortalSnippetFields = []string{FieldTitle, FieldDescription}
+	APIDocumentFields   = []string{FieldTitle, FieldSlug, FieldStatus}
+)
+
+// Metadata contains recognized scalar fields from a YAML frontmatter block.
+type Metadata map[string]string
+
+// Parse returns recognized scalar metadata from a leading YAML frontmatter block.
+func Parse(content string, recognized []string) (Metadata, error) {
+	block, ok, err := extractBlock(content)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return Metadata{}, nil
+	}
+
+	var doc any
+	if err := yaml.Unmarshal([]byte(block), &doc); err != nil {
+		return nil, fmt.Errorf("invalid YAML frontmatter: %w", err)
+	}
+
+	mapping, ok := doc.(map[string]any)
+	if !ok {
+		return Metadata{}, nil
+	}
+
+	recognizedSet := make(map[string]struct{}, len(recognized))
+	for _, field := range recognized {
+		recognizedSet[field] = struct{}{}
+	}
+
+	fields := Metadata{}
+	for field, value := range mapping {
+		if _, ok := recognizedSet[field]; !ok {
+			continue
+		}
+		scalar, ok := scalarString(value)
+		if !ok {
+			continue
+		}
+		fields[field] = scalar
+	}
+
+	return fields, nil
+}
+
+func scalarString(value any) (string, bool) {
+	switch v := value.(type) {
+	case string:
+		return v, true
+	case bool:
+		return strconv.FormatBool(v), true
+	case int:
+		return strconv.Itoa(v), true
+	case int64:
+		return strconv.FormatInt(v, 10), true
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64), true
+	case nil:
+		return "", false
+	default:
+		return "", false
+	}
+}
+
+func extractBlock(content string) (string, bool, error) {
+	rest, ok := trimOpeningDelimiter(content)
+	if !ok {
+		return "", false, nil
+	}
+
+	start := 0
+	for {
+		lineEnd := strings.IndexByte(rest[start:], '\n')
+		if lineEnd < 0 {
+			line := strings.TrimSuffix(rest[start:], "\r")
+			if line == "---" {
+				return rest[:start], true, nil
+			}
+			return "", false, fmt.Errorf("unclosed YAML frontmatter block")
+		}
+
+		lineEnd += start
+		line := strings.TrimSuffix(rest[start:lineEnd], "\r")
+		if line == "---" {
+			return rest[:start], true, nil
+		}
+		start = lineEnd + 1
+	}
+}
+
+func trimOpeningDelimiter(content string) (string, bool) {
+	switch {
+	case strings.HasPrefix(content, "---\n"):
+		return content[len("---\n"):], true
+	case strings.HasPrefix(content, "---\r\n"):
+		return content[len("---\r\n"):], true
+	default:
+		return "", false
+	}
+}

--- a/internal/declarative/frontmatter/frontmatter_test.go
+++ b/internal/declarative/frontmatter/frontmatter_test.go
@@ -1,0 +1,89 @@
+package frontmatter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRecognizedScalarFields(t *testing.T) {
+	t.Parallel()
+
+	content := "---\ntitle: Frontmatter Title\ndescription: Frontmatter Description\nimage: hero.png\n---\n# Body\n"
+
+	metadata, err := Parse(content, PortalPageFields)
+	require.NoError(t, err)
+
+	assert.Equal(t, Metadata{
+		FieldTitle:       "Frontmatter Title",
+		FieldDescription: "Frontmatter Description",
+	}, metadata)
+}
+
+func TestParseSupportsCRLF(t *testing.T) {
+	t.Parallel()
+
+	content := "---\r\ntitle: Frontmatter Title\r\n---\r\n# Body\r\n"
+
+	metadata, err := Parse(content, PortalPageFields)
+	require.NoError(t, err)
+
+	assert.Equal(t, "Frontmatter Title", metadata[FieldTitle])
+}
+
+func TestParseIgnoresContentWithoutOpeningDelimiter(t *testing.T) {
+	t.Parallel()
+
+	content := "title: Not Frontmatter\n---\n# Body\n"
+
+	metadata, err := Parse(content, PortalPageFields)
+	require.NoError(t, err)
+
+	assert.Empty(t, metadata)
+}
+
+func TestParseIgnoresUnknownAndNonScalarFields(t *testing.T) {
+	t.Parallel()
+
+	content := `---
+title: Frontmatter Title
+description:
+  text: nested
+image: hero.png
+tags:
+  - one
+---
+# Body
+`
+
+	metadata, err := Parse(content, PortalPageFields)
+	require.NoError(t, err)
+
+	assert.Equal(t, Metadata{FieldTitle: "Frontmatter Title"}, metadata)
+}
+
+func TestParseRejectsInvalidFrontmatter(t *testing.T) {
+	t.Parallel()
+
+	_, err := Parse("---\ntitle: [broken\n---\n# Body\n", PortalPageFields)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid YAML frontmatter")
+}
+
+func TestParseRejectsUnclosedFrontmatter(t *testing.T) {
+	t.Parallel()
+
+	_, err := Parse("---\ntitle: Frontmatter Title\n# Body\n", PortalPageFields)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unclosed YAML frontmatter block")
+}
+
+func TestParseIgnoresNonMapFrontmatter(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := Parse("---\n- title\n- description\n---\n# Body\n", PortalPageFields)
+	require.NoError(t, err)
+
+	assert.Empty(t, metadata)
+}

--- a/internal/declarative/loader/content_metadata.go
+++ b/internal/declarative/loader/content_metadata.go
@@ -1,0 +1,161 @@
+package loader
+
+import (
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/frontmatter"
+	"github.com/kong/kongctl/internal/declarative/resources"
+)
+
+func (l *Loader) normalizeContentMetadata(rs *resources.ResourceSet) error {
+	for i := range rs.PortalPages {
+		if err := normalizePortalPageContentMetadata(&rs.PortalPages[i]); err != nil {
+			return err
+		}
+	}
+
+	for i := range rs.PortalSnippets {
+		if err := normalizePortalSnippetContentMetadata(&rs.PortalSnippets[i]); err != nil {
+			return err
+		}
+	}
+
+	for i := range rs.APIDocuments {
+		if err := normalizeAPIDocumentContentMetadata(&rs.APIDocuments[i]); err != nil {
+			return err
+		}
+	}
+
+	for i := range rs.APIs {
+		for j := range rs.APIs[i].Documents {
+			if err := normalizeAPIDocumentContentMetadata(&rs.APIs[i].Documents[j]); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func normalizePortalPageContentMetadata(page *resources.PortalPageResource) error {
+	metadata, err := frontmatter.Parse(page.Content, frontmatter.PortalPageFields)
+	if err != nil {
+		return metadataParseError(resources.ResourceTypePortalPage, page.Ref, err)
+	}
+
+	if value, ok := metadata[frontmatter.FieldTitle]; ok {
+		if err := deriveStringPtrMetadata(
+			resources.ResourceTypePortalPage, page.Ref, frontmatter.FieldTitle, &page.Title, value,
+		); err != nil {
+			return err
+		}
+	}
+
+	if value, ok := metadata[frontmatter.FieldDescription]; ok {
+		if err := deriveStringPtrMetadata(
+			resources.ResourceTypePortalPage, page.Ref, frontmatter.FieldDescription, &page.Description, value,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func normalizePortalSnippetContentMetadata(snippet *resources.PortalSnippetResource) error {
+	metadata, err := frontmatter.Parse(snippet.Content, frontmatter.PortalSnippetFields)
+	if err != nil {
+		return metadataParseError(resources.ResourceTypePortalSnippet, snippet.Ref, err)
+	}
+
+	if value, ok := metadata[frontmatter.FieldTitle]; ok {
+		if err := deriveStringPtrMetadata(
+			resources.ResourceTypePortalSnippet, snippet.Ref, frontmatter.FieldTitle, &snippet.Title, value,
+		); err != nil {
+			return err
+		}
+	}
+
+	if value, ok := metadata[frontmatter.FieldDescription]; ok {
+		if err := deriveStringPtrMetadata(
+			resources.ResourceTypePortalSnippet, snippet.Ref, frontmatter.FieldDescription, &snippet.Description, value,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func normalizeAPIDocumentContentMetadata(document *resources.APIDocumentResource) error {
+	metadata, err := frontmatter.Parse(document.Content, frontmatter.APIDocumentFields)
+	if err != nil {
+		return metadataParseError(resources.ResourceTypeAPIDocument, document.Ref, err)
+	}
+
+	if value, ok := metadata[frontmatter.FieldTitle]; ok {
+		if err := deriveStringPtrMetadata(
+			resources.ResourceTypeAPIDocument, document.Ref, frontmatter.FieldTitle, &document.Title, value,
+		); err != nil {
+			return err
+		}
+	}
+
+	if value, ok := metadata[frontmatter.FieldSlug]; ok {
+		if err := deriveStringPtrMetadata(
+			resources.ResourceTypeAPIDocument, document.Ref, frontmatter.FieldSlug, &document.Slug, value,
+		); err != nil {
+			return err
+		}
+	}
+
+	if value, ok := metadata[frontmatter.FieldStatus]; ok {
+		if document.Status == nil || string(*document.Status) == "" {
+			status := kkComps.APIDocumentStatus(value)
+			document.Status = &status
+		} else if string(*document.Status) != value {
+			return metadataConflictError(
+				resources.ResourceTypeAPIDocument, document.Ref, frontmatter.FieldStatus, string(*document.Status), value,
+			)
+		}
+	}
+
+	return nil
+}
+
+func deriveStringPtrMetadata(
+	resourceType resources.ResourceType,
+	ref string,
+	field string,
+	target **string,
+	value string,
+) error {
+	if *target == nil || **target == "" {
+		derived := value
+		*target = &derived
+		return nil
+	}
+	if **target != value {
+		return metadataConflictError(resourceType, ref, field, **target, value)
+	}
+	return nil
+}
+
+func metadataParseError(resourceType resources.ResourceType, ref string, err error) error {
+	return fmt.Errorf("configuration error for %s %q: failed to parse content frontmatter: %w", resourceType, ref, err)
+}
+
+func metadataConflictError(
+	resourceType resources.ResourceType,
+	ref string,
+	field string,
+	topLevel string,
+	front string,
+) error {
+	return fmt.Errorf(
+		"configuration error for %s %q: field %q is defined in both the top-level resource and content "+
+			"frontmatter with different values (top-level: %q, frontmatter: %q)",
+		resourceType, ref, field, topLevel, front,
+	)
+}

--- a/internal/declarative/loader/content_metadata_test.go
+++ b/internal/declarative/loader/content_metadata_test.go
@@ -1,0 +1,473 @@
+package loader
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoaderDerivesContentMetadataFromFrontmatter(t *testing.T) {
+	t.Parallel()
+
+	rs := loadContentMetadataConfig(t, `
+portals:
+  - ref: portal-1
+    name: Portal 1
+    pages:
+      - ref: page-1
+        slug: getting-started
+        content: |
+          ---
+          title: Getting Started
+          description: Page description
+          ---
+
+          # Getting Started
+    snippets:
+      - ref: snippet-1
+        name: getting-started-banner
+        content: |
+          ---
+          title: Getting Started Banner
+          description: Snippet description
+          ---
+
+          <div>Welcome</div>
+apis:
+  - ref: api-1
+    name: API 1
+    documents:
+      - ref: doc-1
+        content: |
+          ---
+          title: API Guide
+          slug: api-guide
+          status: unpublished
+          ---
+
+          # API Guide
+`)
+
+	require.Len(t, rs.PortalPages, 1)
+	require.NotNil(t, rs.PortalPages[0].Title)
+	assert.Equal(t, "Getting Started", *rs.PortalPages[0].Title)
+	require.NotNil(t, rs.PortalPages[0].Description)
+	assert.Equal(t, "Page description", *rs.PortalPages[0].Description)
+
+	require.Len(t, rs.PortalSnippets, 1)
+	require.NotNil(t, rs.PortalSnippets[0].Title)
+	assert.Equal(t, "Getting Started Banner", *rs.PortalSnippets[0].Title)
+	require.NotNil(t, rs.PortalSnippets[0].Description)
+	assert.Equal(t, "Snippet description", *rs.PortalSnippets[0].Description)
+
+	require.Len(t, rs.APIs, 1)
+	require.Len(t, rs.APIs[0].Documents, 1)
+	doc := rs.APIs[0].Documents[0]
+	require.NotNil(t, doc.Title)
+	assert.Equal(t, "API Guide", *doc.Title)
+	require.NotNil(t, doc.Slug)
+	assert.Equal(t, "api-guide", *doc.Slug)
+	require.NotNil(t, doc.Status)
+	assert.Equal(t, "unpublished", string(*doc.Status))
+}
+
+func TestLoaderAllowsMatchingContentMetadata(t *testing.T) {
+	t.Parallel()
+
+	rs := loadContentMetadataConfig(t, `
+portals:
+  - ref: portal-1
+    name: Portal 1
+    pages:
+      - ref: page-1
+        slug: getting-started
+        title: Getting Started
+        description: Page description
+        content: |
+          ---
+          title: Getting Started
+          description: Page description
+          ---
+
+          # Getting Started
+`)
+
+	require.Len(t, rs.PortalPages, 1)
+	require.NotNil(t, rs.PortalPages[0].Title)
+	assert.Equal(t, "Getting Started", *rs.PortalPages[0].Title)
+	require.NotNil(t, rs.PortalPages[0].Description)
+	assert.Equal(t, "Page description", *rs.PortalPages[0].Description)
+}
+
+func TestLoaderDefaultsAPIDocumentSlugAfterFrontmatterTitleDerivation(t *testing.T) {
+	t.Parallel()
+
+	rs := loadContentMetadataConfig(t, `
+apis:
+  - ref: api-1
+    name: API 1
+    documents:
+      - ref: doc-1
+        content: |
+          ---
+          title: API Guide
+          ---
+
+          # API Guide
+`)
+
+	require.Len(t, rs.APIs, 1)
+	require.Len(t, rs.APIs[0].Documents, 1)
+	doc := rs.APIs[0].Documents[0]
+	require.NotNil(t, doc.Title)
+	assert.Equal(t, "API Guide", *doc.Title)
+	require.NotNil(t, doc.Slug)
+	assert.Equal(t, "api-guide", *doc.Slug)
+}
+
+func TestLoaderDoesNotDerivePortalPageSlugFromFrontmatterTitle(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadContentMetadataConfigErr(t, `
+portals:
+  - ref: portal-1
+    name: Portal 1
+    pages:
+      - ref: page-1
+        content: |
+          ---
+          title: Getting Started
+          ---
+
+          # Getting Started
+`)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "page slug is required")
+}
+
+func TestLoaderDoesNotDerivePortalSnippetNameFromFrontmatterTitle(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadContentMetadataConfigErr(t, `
+portals:
+  - ref: portal-1
+    name: Portal 1
+    snippets:
+      - ref: snippet-1
+        content: |
+          ---
+          title: Getting Started
+          ---
+
+          body
+`)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "snippet name is required")
+}
+
+func TestLoaderRejectsConflictingContentMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		resourceType string
+		ref          string
+		field        string
+		topLevel     string
+		frontmatter  string
+		config       string
+	}{
+		{
+			name:         "portal page title",
+			resourceType: "portal_page",
+			ref:          "page-1",
+			field:        "title",
+			topLevel:     "Top Page",
+			frontmatter:  "Front Page",
+			config: `
+portals:
+  - ref: portal-1
+    name: Portal 1
+    pages:
+      - ref: page-1
+        slug: page
+        title: Top Page
+        content: |
+          ---
+          title: Front Page
+          ---
+
+          # Body
+`,
+		},
+		{
+			name:         "portal page description",
+			resourceType: "portal_page",
+			ref:          "page-1",
+			field:        "description",
+			topLevel:     "Top description",
+			frontmatter:  "Front description",
+			config: `
+portals:
+  - ref: portal-1
+    name: Portal 1
+    pages:
+      - ref: page-1
+        slug: page
+        description: Top description
+        content: |
+          ---
+          description: Front description
+          ---
+
+          # Body
+`,
+		},
+		{
+			name:         "portal snippet title",
+			resourceType: "portal_snippet",
+			ref:          "snippet-1",
+			field:        "title",
+			topLevel:     "Top Snippet",
+			frontmatter:  "Front Snippet",
+			config: `
+portals:
+  - ref: portal-1
+    name: Portal 1
+    snippets:
+      - ref: snippet-1
+        name: snippet
+        title: Top Snippet
+        content: |
+          ---
+          title: Front Snippet
+          ---
+
+          body
+`,
+		},
+		{
+			name:         "portal snippet description",
+			resourceType: "portal_snippet",
+			ref:          "snippet-1",
+			field:        "description",
+			topLevel:     "Top description",
+			frontmatter:  "Front description",
+			config: `
+portals:
+  - ref: portal-1
+    name: Portal 1
+    snippets:
+      - ref: snippet-1
+        name: snippet
+        description: Top description
+        content: |
+          ---
+          description: Front description
+          ---
+
+          body
+`,
+		},
+		{
+			name:         "api document title",
+			resourceType: "api_document",
+			ref:          "doc-1",
+			field:        "title",
+			topLevel:     "Top Doc",
+			frontmatter:  "Front Doc",
+			config: `
+apis:
+  - ref: api-1
+    name: API 1
+    documents:
+      - ref: doc-1
+        title: Top Doc
+        content: |
+          ---
+          title: Front Doc
+          ---
+
+          # Body
+`,
+		},
+		{
+			name:         "api document slug",
+			resourceType: "api_document",
+			ref:          "doc-1",
+			field:        "slug",
+			topLevel:     "top-doc",
+			frontmatter:  "front-doc",
+			config: `
+apis:
+  - ref: api-1
+    name: API 1
+    documents:
+      - ref: doc-1
+        title: Doc
+        slug: top-doc
+        content: |
+          ---
+          slug: front-doc
+          ---
+
+          # Body
+`,
+		},
+		{
+			name:         "api document status",
+			resourceType: "api_document",
+			ref:          "doc-1",
+			field:        "status",
+			topLevel:     "published",
+			frontmatter:  "unpublished",
+			config: `
+apis:
+  - ref: api-1
+    name: API 1
+    documents:
+      - ref: doc-1
+        title: Doc
+        status: published
+        content: |
+          ---
+          status: unpublished
+          ---
+
+          # Body
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := loadContentMetadataConfigErr(t, tt.config)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), fmt.Sprintf(`configuration error for %s %q`, tt.resourceType, tt.ref))
+			assert.Contains(t, err.Error(), fmt.Sprintf(`field %q`, tt.field))
+			assert.Contains(t, err.Error(), fmt.Sprintf(`top-level: %q`, tt.topLevel))
+			assert.Contains(t, err.Error(), fmt.Sprintf(`frontmatter: %q`, tt.frontmatter))
+		})
+	}
+}
+
+func TestLoaderIgnoresUnknownContentMetadata(t *testing.T) {
+	t.Parallel()
+
+	rs := loadContentMetadataConfig(t, `
+portals:
+  - ref: portal-1
+    name: Portal 1
+    pages:
+      - ref: page-1
+        slug: getting-started
+        content: |
+          ---
+          image: hero.png
+          page-layout: landing
+          ---
+
+          # Getting Started
+`)
+
+	require.Len(t, rs.PortalPages, 1)
+	require.NotNil(t, rs.PortalPages[0].Title)
+	assert.Equal(t, "getting-started", *rs.PortalPages[0].Title)
+	assert.Contains(t, rs.PortalPages[0].Content, "image: hero.png")
+}
+
+func TestLoaderRejectsInvalidContentFrontmatter(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadContentMetadataConfigErr(t, `
+portals:
+  - ref: portal-1
+    name: Portal 1
+    pages:
+      - ref: page-1
+        slug: page
+        content: |
+          ---
+          title: [broken
+          ---
+
+          # Body
+`)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `configuration error for portal_page "page-1"`)
+	assert.Contains(t, err.Error(), "invalid YAML frontmatter")
+}
+
+func TestLoaderRejectsUnclosedContentFrontmatter(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadContentMetadataConfigErr(t, `
+portals:
+  - ref: portal-1
+    name: Portal 1
+    pages:
+      - ref: page-1
+        slug: page
+        content: |
+          ---
+          title: Frontmatter Title
+
+          # Body
+`)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `configuration error for portal_page "page-1"`)
+	assert.Contains(t, err.Error(), "unclosed YAML frontmatter block")
+}
+
+func TestLoaderIgnoresNonMapContentFrontmatter(t *testing.T) {
+	t.Parallel()
+
+	rs := loadContentMetadataConfig(t, `
+portals:
+  - ref: portal-1
+    name: Portal 1
+    pages:
+      - ref: page-1
+        slug: page
+        content: |
+          ---
+          - title
+          - description
+          ---
+
+          # Body
+`)
+
+	require.Len(t, rs.PortalPages, 1)
+	require.NotNil(t, rs.PortalPages[0].Title)
+	assert.Equal(t, "page", *rs.PortalPages[0].Title)
+}
+
+func loadContentMetadataConfig(t *testing.T, content string) *resources.ResourceSet {
+	t.Helper()
+
+	rs, err := loadContentMetadataConfigErr(t, content)
+	require.NoError(t, err)
+	return rs
+}
+
+func loadContentMetadataConfigErr(t *testing.T, content string) (*resources.ResourceSet, error) {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return New().LoadFromSources([]Source{{Path: path, Type: SourceTypeFile}}, false)
+}

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -120,8 +120,12 @@ func (l *Loader) LoadFromSourcesWithContext(ctx context.Context, sources []Sourc
 		}
 	}
 
-	// Apply SDK defaults to merged resources
-	// Note: Only namespace defaults are applied per-file in parseYAML
+	if err := l.normalizeContentMetadata(&allResources); err != nil {
+		return nil, err
+	}
+
+	// Apply SDK defaults to merged resources.
+	// Note: Only namespace defaults are applied per-file in parseYAML.
 	l.applyDefaults(&allResources)
 
 	// Reference resolution must happen after all files are loaded but before validation.
@@ -149,6 +153,10 @@ func (l *Loader) LoadFile(path string) (*resources.ResourceSet, error) {
 	var rs resources.ResourceSet
 	refIndex := make(map[string]resources.ResourceType)
 	if err := l.loadSingleFile(path, filepath.Dir(path), &rs, refIndex); err != nil {
+		return nil, err
+	}
+
+	if err := l.normalizeContentMetadata(&rs); err != nil {
 		return nil, err
 	}
 

--- a/internal/declarative/planner/portal_child_test.go
+++ b/internal/declarative/planner/portal_child_test.go
@@ -20,6 +20,70 @@ type stubPortalCustomDomainAPI struct {
 	getFn func(ctx context.Context, portalID string, opts ...kkOps.Option) (*kkOps.GetPortalCustomDomainResponse, error)
 }
 
+type stubPortalPageAPI struct {
+	listData []kkComps.PortalPageInfo
+	getData  map[string]kkComps.PortalPageResponse
+}
+
+func (s *stubPortalPageAPI) CreatePortalPage(
+	_ context.Context,
+	_ string,
+	_ kkComps.CreatePortalPageRequest,
+	_ ...kkOps.Option,
+) (*kkOps.CreatePortalPageResponse, error) {
+	return nil, nil
+}
+
+func (s *stubPortalPageAPI) UpdatePortalPage(
+	_ context.Context,
+	_ kkOps.UpdatePortalPageRequest,
+	_ ...kkOps.Option,
+) (*kkOps.UpdatePortalPageResponse, error) {
+	return nil, nil
+}
+
+func (s *stubPortalPageAPI) DeletePortalPage(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ ...kkOps.Option,
+) (*kkOps.DeletePortalPageResponse, error) {
+	return nil, nil
+}
+
+func (s *stubPortalPageAPI) ListPortalPages(
+	_ context.Context,
+	_ kkOps.ListPortalPagesRequest,
+	_ ...kkOps.Option,
+) (*kkOps.ListPortalPagesResponse, error) {
+	data := s.listData
+	if data == nil {
+		data = []kkComps.PortalPageInfo{}
+	}
+	return &kkOps.ListPortalPagesResponse{
+		StatusCode: 200,
+		ListPortalPagesResponse: &kkComps.ListPortalPagesResponse{
+			Data: data,
+		},
+	}, nil
+}
+
+func (s *stubPortalPageAPI) GetPortalPage(
+	_ context.Context,
+	_ string,
+	pageID string,
+	_ ...kkOps.Option,
+) (*kkOps.GetPortalPageResponse, error) {
+	page, ok := s.getData[pageID]
+	if !ok {
+		return &kkOps.GetPortalPageResponse{StatusCode: 404}, nil
+	}
+	return &kkOps.GetPortalPageResponse{
+		StatusCode:         200,
+		PortalPageResponse: &page,
+	}, nil
+}
+
 func (s *stubPortalCustomDomainAPI) CreatePortalCustomDomain(
 	_ context.Context,
 	_ string,
@@ -256,6 +320,102 @@ func TestPlanPortalTeamGroupMappingUpdatePreservesEmptyGroups(t *testing.T) {
 	assert.Empty(t, plan.Changes[0].Fields[FieldGroups])
 	assert.NotNil(t, plan.Changes[0].Fields[FieldGroups])
 	assert.Equal(t, []string{}, plan.Changes[0].ChangedFields[FieldGroups].New)
+}
+
+func TestPlanPortalPagesChanges_PlansContentOnlyUpdate(t *testing.T) {
+	t.Parallel()
+
+	title := "Getting Started"
+	description := "A quick-start guide for new users"
+	currentContent := "# Getting Started\n\nFollow this guide to get up and running quickly with our platform."
+	desiredContent := `---
+title: "Getting Started"
+description: "A quick-start guide for new users"
+---
+
+# Getting Started
+
+This body changed without changing page metadata.
+Issue 1210 content-only update.
+`
+	desiredVisibility := kkComps.PageVisibilityStatusPublic
+	desiredStatus := kkComps.PublishedStatusPublished
+
+	pageAPI := &stubPortalPageAPI{
+		listData: []kkComps.PortalPageInfo{
+			{
+				ID:          "page-getting-started",
+				Slug:        "getting-started",
+				Title:       title,
+				Description: &description,
+				Visibility:  kkComps.VisibilityStatusPublic,
+				Status:      kkComps.PublishedStatusPublished,
+			},
+		},
+		getData: map[string]kkComps.PortalPageResponse{
+			"page-getting-started": {
+				ID:          "page-getting-started",
+				Slug:        "getting-started",
+				Title:       title,
+				Content:     currentContent,
+				Description: &description,
+				Visibility:  kkComps.VisibilityStatusPublic,
+				Status:      kkComps.PublishedStatusPublished,
+			},
+		},
+	}
+
+	planner := &Planner{
+		client: state.NewClient(state.ClientConfig{PortalPageAPI: pageAPI}),
+		logger: slog.Default(),
+		desiredPortals: []resources.PortalResource{
+			{
+				CreatePortal: kkComps.CreatePortal{Name: "pages-portal"},
+				BaseResource: resources.BaseResource{
+					Ref: "pages-portal",
+				},
+			},
+		},
+	}
+	plan := NewPlan("1.0", "test", PlanModeApply)
+	desired := []resources.PortalPageResource{
+		{
+			Ref:    "getting-started-page",
+			Portal: "pages-portal",
+			CreatePortalPageRequest: kkComps.CreatePortalPageRequest{
+				Slug:        "getting-started",
+				Title:       &title,
+				Description: &description,
+				Content:     desiredContent,
+				Visibility:  &desiredVisibility,
+				Status:      &desiredStatus,
+			},
+		},
+	}
+
+	err := planner.planPortalPagesChanges(
+		context.Background(),
+		DefaultNamespace,
+		"portal-id",
+		"pages-portal",
+		desired,
+		plan,
+	)
+	require.NoError(t, err)
+
+	require.Len(t, plan.Changes, 1)
+	change := plan.Changes[0]
+	assert.Equal(t, ActionUpdate, change.Action)
+	assert.Equal(t, ResourceTypePortalPage, change.ResourceType)
+	assert.Equal(t, "getting-started-page", change.ResourceRef)
+	assert.Equal(t, "page-getting-started", change.ResourceID)
+	assert.Equal(t, "getting-started", change.Fields[FieldSlug])
+	assert.Equal(t, desiredContent, change.Fields[FieldContent])
+	assert.NotContains(t, change.Fields, FieldTitle)
+	assert.NotContains(t, change.Fields, FieldVisibility)
+	assert.NotContains(t, change.Fields, FieldStatus)
+	assert.Equal(t, currentContent, change.ChangedFields[FieldContent].Old)
+	assert.Equal(t, desiredContent, change.ChangedFields[FieldContent].New)
 }
 
 func TestShouldUpdatePortalCustomizationDetectsSpecRendererAndRobots(t *testing.T) {

--- a/test/e2e/scenarios/portal/page-frontmatter-conflict/overlays/002-top-level-only/portal.yaml
+++ b/test/e2e/scenarios/portal/page-frontmatter-conflict/overlays/002-top-level-only/portal.yaml
@@ -1,0 +1,27 @@
+_defaults:
+  kongctl:
+    namespace: portal-page-frontmatter-conflict
+
+portals:
+  - ref: frontmatter-conflict-portal
+    name: "frontmatter-conflict-portal"
+    display_name: "Frontmatter Conflict Portal"
+    description: "Portal for testing page metadata conflicts with markdown frontmatter"
+    authentication_enabled: false
+    rbac_enabled: false
+    auto_approve_developers: false
+    auto_approve_applications: false
+    default_page_visibility: "public"
+    kongctl:
+      namespace: portal-page-frontmatter-conflict
+    pages:
+      - ref: frontmatter-conflict-page
+        slug: "frontmatter-conflict"
+        title: "Frontmatter Page Title"
+        description: "Frontmatter page description"
+        visibility: "public"
+        status: "published"
+        content: |
+          # Top Level Only
+
+          Top-level-only body.

--- a/test/e2e/scenarios/portal/page-frontmatter-conflict/overlays/003-matching-both/portal.yaml
+++ b/test/e2e/scenarios/portal/page-frontmatter-conflict/overlays/003-matching-both/portal.yaml
@@ -1,0 +1,32 @@
+_defaults:
+  kongctl:
+    namespace: portal-page-frontmatter-conflict
+
+portals:
+  - ref: frontmatter-conflict-portal
+    name: "frontmatter-conflict-portal"
+    display_name: "Frontmatter Conflict Portal"
+    description: "Portal for testing page metadata conflicts with markdown frontmatter"
+    authentication_enabled: false
+    rbac_enabled: false
+    auto_approve_developers: false
+    auto_approve_applications: false
+    default_page_visibility: "public"
+    kongctl:
+      namespace: portal-page-frontmatter-conflict
+    pages:
+      - ref: frontmatter-conflict-page
+        slug: "frontmatter-conflict"
+        title: "Frontmatter Page Title"
+        description: "Frontmatter page description"
+        visibility: "public"
+        status: "published"
+        content: |
+          ---
+          title: "Frontmatter Page Title"
+          description: "Frontmatter page description"
+          ---
+
+          # Matching Both
+
+          Matching both body.

--- a/test/e2e/scenarios/portal/page-frontmatter-conflict/overlays/004-conflicting-both/portal.yaml
+++ b/test/e2e/scenarios/portal/page-frontmatter-conflict/overlays/004-conflicting-both/portal.yaml
@@ -1,0 +1,32 @@
+_defaults:
+  kongctl:
+    namespace: portal-page-frontmatter-conflict
+
+portals:
+  - ref: frontmatter-conflict-portal
+    name: "frontmatter-conflict-portal"
+    display_name: "Frontmatter Conflict Portal"
+    description: "Portal for testing page metadata conflicts with markdown frontmatter"
+    authentication_enabled: false
+    rbac_enabled: false
+    auto_approve_developers: false
+    auto_approve_applications: false
+    default_page_visibility: "public"
+    kongctl:
+      namespace: portal-page-frontmatter-conflict
+    pages:
+      - ref: frontmatter-conflict-page
+        slug: "frontmatter-conflict"
+        title: "Configured Page Title"
+        description: "Configured page description"
+        visibility: "public"
+        status: "published"
+        content: |
+          ---
+          title: "Frontmatter Page Title"
+          description: "Frontmatter page description"
+          ---
+
+          # Conflicting Both
+
+          This page intentionally declares conflicting metadata in both places.

--- a/test/e2e/scenarios/portal/page-frontmatter-conflict/scenario.yaml
+++ b/test/e2e/scenarios/portal/page-frontmatter-conflict/scenario.yaml
@@ -1,0 +1,215 @@
+baseInputsPath: ./testdata
+
+env:
+  KONGCTL_LOG_LEVEL: info
+
+vars:
+  namespace: portal-page-frontmatter-conflict
+  portalRef: frontmatter-conflict-portal
+  portalName: frontmatter-conflict-portal
+  pageRef: frontmatter-conflict-page
+  pageTitle: "Frontmatter Page Title"
+  pageDescription: "Frontmatter page description"
+  conflictingTitle: "Configured Page Title"
+  conflictingDescription: "Configured page description"
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - change_id
+      - resource_id
+      - generated_at
+      - created_at
+      - updated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-frontmatter-only-applies-and-converges
+    commands:
+      - name: 000-plan-frontmatter-only
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-frontmatter-only.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 2
+                by_action.CREATE: 2
+                by_resource.portal: 1
+                by_resource.portal_page: 1
+          - select: >-
+              changes[?resource_type=='portal_page' && resource_ref=='{{ .vars.pageRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                "fields.title": "{{ .vars.pageTitle }}"
+                "fields.description": "{{ .vars.pageDescription }}"
+                "contains(fields.content, '{{ .vars.pageTitle }}')": true
+                "contains(fields.content, '{{ .vars.pageDescription }}')": true
+      - name: 001-apply-frontmatter-only
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-frontmatter-only.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 2
+                failed: 0
+      - name: 002-plan-after-frontmatter-only-is-no-op
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+
+  - name: 002-top-level-only-applies-and-converges
+    inputOverlayDirs:
+      - overlays/002-top-level-only
+    commands:
+      - name: 000-plan-top-level-only
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-top-level-only.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+                by_resource.portal_page: 1
+          - select: >-
+              changes[?resource_type=='portal_page' && resource_ref=='{{ .vars.pageRef }}'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                "contains(fields.content, 'Top-level-only body')": true
+      - name: 001-apply-top-level-only
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-top-level-only.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 002-plan-after-top-level-only-is-no-op
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+
+  - name: 003-matching-both-applies-and-converges
+    inputOverlayDirs:
+      - overlays/003-matching-both
+    commands:
+      - name: 000-plan-matching-both
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-matching-both.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+                by_resource.portal_page: 1
+          - select: >-
+              changes[?resource_type=='portal_page' && resource_ref=='{{ .vars.pageRef }}'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                "contains(fields.content, 'Matching both body')": true
+      - name: 001-apply-matching-both
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-matching-both.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 002-plan-after-matching-both-is-no-op
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+
+  - name: 004-conflicting-both-fails-during-load
+    inputOverlayDirs:
+      - overlays/004-conflicting-both
+    commands:
+      - name: 000-plan-conflicting-both
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - --mode
+          - apply
+        expectFailure:
+          exitCode: 1
+          contains: "configuration error for portal_page \"{{ .vars.pageRef }}\": field \"title\""
+      - name: 001-apply-conflicting-both
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - --auto-approve
+        expectFailure:
+          exitCode: 1
+          contains: "top-level: \"{{ .vars.conflictingTitle }}\", frontmatter: \"{{ .vars.pageTitle }}\""

--- a/test/e2e/scenarios/portal/page-frontmatter-conflict/scenario.yaml
+++ b/test/e2e/scenarios/portal/page-frontmatter-conflict/scenario.yaml
@@ -203,7 +203,7 @@ steps:
           - apply
         expectFailure:
           exitCode: 1
-          contains: "configuration error for portal_page \"{{ .vars.pageRef }}\": field \"title\""
+          contains: "configuration error for portal_page \"frontmatter-conflict-page\": field \"title\""
       - name: 001-apply-conflicting-both
         run:
           - apply
@@ -212,4 +212,4 @@ steps:
           - --auto-approve
         expectFailure:
           exitCode: 1
-          contains: "top-level: \"{{ .vars.conflictingTitle }}\", frontmatter: \"{{ .vars.pageTitle }}\""
+          contains: "top-level: \"Configured Page Title\", frontmatter: \"Frontmatter Page Title\""

--- a/test/e2e/scenarios/portal/page-frontmatter-conflict/testdata/portal.yaml
+++ b/test/e2e/scenarios/portal/page-frontmatter-conflict/testdata/portal.yaml
@@ -1,0 +1,30 @@
+_defaults:
+  kongctl:
+    namespace: portal-page-frontmatter-conflict
+
+portals:
+  - ref: frontmatter-conflict-portal
+    name: "frontmatter-conflict-portal"
+    display_name: "Frontmatter Conflict Portal"
+    description: "Portal for testing page metadata conflicts with markdown frontmatter"
+    authentication_enabled: false
+    rbac_enabled: false
+    auto_approve_developers: false
+    auto_approve_applications: false
+    default_page_visibility: "public"
+    kongctl:
+      namespace: portal-page-frontmatter-conflict
+    pages:
+      - ref: frontmatter-conflict-page
+        slug: "frontmatter-conflict"
+        visibility: "public"
+        status: "published"
+        content: |
+          ---
+          title: "Frontmatter Page Title"
+          description: "Frontmatter page description"
+          ---
+
+          # Frontmatter Only
+
+          This page declares recognized metadata only in markdown frontmatter.

--- a/test/e2e/scenarios/portal/pages/overlays/003-update-page-content/portal.yaml
+++ b/test/e2e/scenarios/portal/pages/overlays/003-update-page-content/portal.yaml
@@ -1,0 +1,41 @@
+_defaults:
+  kongctl:
+    namespace: portal-pages-lifecycle
+
+portals:
+  - ref: pages-portal
+    name: "pages-portal"
+    display_name: "Pages Lifecycle Portal"
+    description: "Portal for testing page create, update, and sync-delete lifecycle"
+    authentication_enabled: false
+    rbac_enabled: false
+    auto_approve_developers: false
+    auto_approve_applications: false
+    default_page_visibility: "public"
+    kongctl:
+      namespace: portal-pages-lifecycle
+    pages:
+      - ref: guides-page
+        slug: "guides"
+        title: "Guides"
+        description: "Step-by-step guides for our platform"
+        visibility: "public"
+        status: "published"
+        content: !file ./pages/guides.md
+        children:
+          - ref: getting-started-page
+            slug: "getting-started"
+            title: "Getting Started (Updated)"
+            description: "An updated quick-start guide for new users"
+            visibility: "private"
+            status: "unpublished"
+            content: |
+              ---
+              title: "Getting Started (Updated)"
+              description: "An updated quick-start guide for new users"
+              ---
+
+              # Getting Started
+
+              This body changed without changing page metadata.
+              Issue 1210 content-only update.

--- a/test/e2e/scenarios/portal/pages/overlays/004-update-page-content-missing-frontmatter-start/portal.yaml
+++ b/test/e2e/scenarios/portal/pages/overlays/004-update-page-content-missing-frontmatter-start/portal.yaml
@@ -1,0 +1,40 @@
+_defaults:
+  kongctl:
+    namespace: portal-pages-lifecycle
+
+portals:
+  - ref: pages-portal
+    name: "pages-portal"
+    display_name: "Pages Lifecycle Portal"
+    description: "Portal for testing page create, update, and sync-delete lifecycle"
+    authentication_enabled: false
+    rbac_enabled: false
+    auto_approve_developers: false
+    auto_approve_applications: false
+    default_page_visibility: "public"
+    kongctl:
+      namespace: portal-pages-lifecycle
+    pages:
+      - ref: guides-page
+        slug: "guides"
+        title: "Guides"
+        description: "Step-by-step guides for our platform"
+        visibility: "public"
+        status: "published"
+        content: !file ./pages/guides.md
+        children:
+          - ref: getting-started-page
+            slug: "getting-started"
+            title: "Getting Started (Updated)"
+            description: "An updated quick-start guide for new users"
+            visibility: "private"
+            status: "unpublished"
+            content: |
+              title: "Getting Started (Updated)"
+              description: "An updated quick-start guide for new users"
+              ---
+
+              # Getting Started
+
+              This body changed without changing page metadata.
+              Issue 1210 content-only update.

--- a/test/e2e/scenarios/portal/pages/scenario.yaml
+++ b/test/e2e/scenarios/portal/pages/scenario.yaml
@@ -172,7 +172,94 @@ steps:
                 visibility: "public"
                 status: "published"
 
-  - name: 003-sync-delete-leaf-page
+  - name: 003-plan-apply-update-page-content
+    inputOverlayDirs:
+      - overlays/003-update-page-content
+    commands:
+      - name: 000-plan-update-page-content
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-update-page-content.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+                by_resource.portal_page: 1
+          - select: >-
+              changes[?resource_type=='portal_page' && resource_ref=='{{ .vars.gettingStartedPageRef }}'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                "fields.slug": "/getting-started"
+                "contains(fields.content, 'Issue 1210 content-only update')": true
+                "contains(changed_fields.content.new, 'Issue 1210 content-only update')": true
+      - name: 001-apply-update-page-content
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-update-page-content.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 002-plan-after-page-content-update-is-no-op
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+          - select: changes
+            expect:
+              fields:
+                "length(@)": 0
+
+  - name: 004-plan-update-page-content-missing-frontmatter-start
+    inputOverlayDirs:
+      - overlays/004-update-page-content-missing-frontmatter-start
+    commands:
+      - name: 000-plan-update-page-content
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-update-page-content-missing-frontmatter-start.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/portal.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+                by_resource.portal_page: 1
+          - select: >-
+              changes[?resource_type=='portal_page' && resource_ref=='{{ .vars.gettingStartedPageRef }}'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                "contains(fields.content, 'Issue 1210 content-only update')": true
+                "starts_with(fields.content, 'title:')": true
+
+  - name: 005-sync-delete-leaf-page
     inputOverlayDirs:
       - overlays/003-delete-leaf-page
     commands:


### PR DESCRIPTION
## Summary
- add frontmatter parsing and loader normalization for recognized content metadata fields
- make dump declarative prefer frontmatter-only output for portal pages, snippets, and API documents
- hydrate portal parent resources from detail responses during dump to avoid stale list-field drift
- add loader, dump, planner, and e2e coverage for frontmatter-only, top-level-only, matching, and conflict cases

## Verification
- `go test ./internal/declarative/frontmatter`
- `go test ./internal/declarative/loader`
- `go test ./internal/cmd/root/verbs/dump`
- `go test ./internal/declarative/...`
- `go test ./internal/cmd/root/products/konnect/declarative`
- `go test ./internal/cmd/root/verbs/dump ./internal/cmd/root/verbs/plan ./internal/cmd/root/verbs/apply ./internal/cmd/root/verbs/sync`
- `go test ./test/e2e/...`
- `make build`
- `make test`
- `GOLANGCI_LINT_CACHE=/home/rspurgeon/go/cache/golangci-lint make lint`
- `git diff --check`


Closes #1210 