### PR TITLE
Task: telemetry - exclude meta commands

### DIFF
--- a/internal/telemetry/recorder_test.go
+++ b/internal/telemetry/recorder_test.go
@@ -427,6 +427,36 @@ func TestRecorder_BareKongctl_SkipsEvent(t *testing.T) {
 	}
 }
 
+func TestRecorder_SkippedCommands_DoNotEmit(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "version", path: "kongctl version"},
+		{name: "completion", path: "kongctl completion bash"},
+		{name: "__complete", path: "kongctl __complete get apis"},
+		{name: "__completeNoDesc", path: "kongctl __completeNoDesc get apis"},
+		{name: "help", path: "kongctl help plan"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sink := &capturingSink{}
+			rec := newTestRecorder(sink)
+
+			rec.SetCommand(CommandInfo{Path: tt.path})
+			rec.Finalize(time.Now())
+			if err := rec.Close(t.Context()); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+
+			if got := sink.Events(); len(got) != 0 {
+				t.Errorf("%s emitted %d events, want 0", tt.path, len(got))
+			}
+		})
+	}
+}
+
 func TestRecorder_FinalizeWithoutSetCommand_Skips(t *testing.T) {
 	sink := &capturingSink{}
 	rec := newTestRecorder(sink)

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -206,6 +206,14 @@ type CommandInfo struct {
 	Path string
 }
 
+var skippedCommandPrefixes = map[string]struct{}{
+	"version":          {},
+	"completion":       {},
+	"__complete":       {},
+	"__completeNoDesc": {},
+	"help":             {},
+}
+
 // Recorder buffers a single event for the duration of one command execution
 // and flushes it to a Sink on Close. A Recorder is single-use: Begin → (one
 // SetCommand) → Finalize → Close. When telemetry is disabled, NewRecorder
@@ -321,13 +329,19 @@ func (r *Recorder) SetCommand(info CommandInfo) {
 		return
 	}
 	info.Path = trimBinaryPrefix(info.Path)
-	if info.Path == "" {
+	if info.Path == "" || shouldSkipCommand(info.Path) {
 		return
 	}
 	r.mu.Lock()
 	r.cmdInfo = info
 	r.cmdSet = true
 	r.mu.Unlock()
+}
+
+func shouldSkipCommand(path string) bool {
+	firstSegment, _, _ := strings.Cut(path, " ")
+	_, skip := skippedCommandPrefixes[firstSegment]
+	return skip
 }
 
 // trimBinaryPrefix strips the leading "kongctl" / "kongctl " from a cobra

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -206,7 +206,7 @@ type CommandInfo struct {
 	Path string
 }
 
-var skippedCommandPrefixes = map[string]struct{}{
+var skippedCommands = map[string]struct{}{
 	"version":          {},
 	"completion":       {},
 	"__complete":       {},
@@ -340,7 +340,7 @@ func (r *Recorder) SetCommand(info CommandInfo) {
 
 func shouldSkipCommand(path string) bool {
 	firstSegment, _, _ := strings.Cut(path, " ")
-	_, skip := skippedCommandPrefixes[firstSegment]
+	_, skip := skippedCommands[firstSegment]
 	return skip
 }
 


### PR DESCRIPTION
## Summary

- Exclude low-signal meta commands from telemetry collection: `version`, `completion`, `__complete`, `__completeNoDesc`, and `help`.
- Keep the filtering centralized in the telemetry recorder so skipped commands behave like a bare `kongctl` invocation and emit no event.
- Add focused recorder tests covering each skipped command path.

Fixes #1245

## Validation

- `go test ./internal/telemetry`
- `make test`
