### PR TITLE
Task: Fix Renovate config JSON

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,7 +30,6 @@
         "docs/examples/extensions/go/go.mod"
       ],
       "matchPackageNames": [
-      "matchPackageNames": [
         "github.com/kong/kongctl"
       ],
       "minimumReleaseAge": "0 days"


### PR DESCRIPTION
## Summary

- Remove the duplicated `matchPackageNames` key that made `renovate.json` invalid JSON.
- Preserve the package rule from #1246 that allows the example Go extension SDK dependency to update immediately.

## Root Cause

#1246 added a Renovate package rule for `docs/examples/extensions/go/go.mod`, but the `matchPackageNames` line was duplicated during insertion. That left the JSON malformed, causing Renovate to open #1253 and stop PRs until the configuration parses again.

## Validation

- `jq empty renovate.json`
- `npx --yes --package renovate renovate-config-validator renovate.json`
- `git diff --check`

Closes #1253.