### PR TITLE
Fix: scope team memberships by team namespace

### DIFF
--- a/internal/declarative/loader/loader_test.go
+++ b/internal/declarative/loader/loader_test.go
@@ -738,6 +738,38 @@ organization:
 	require.Len(t, rs.GetOrganizationUserRolesByNamespace("org-users-test"), 1)
 }
 
+func TestLoader_LoadFileScopesOrganizationUserTeamMembershipsByTeamNamespace(t *testing.T) {
+	content := `
+organization:
+  teams:
+    - ref: platform-team
+      kongctl:
+        namespace: dumped-team-namespace
+      name: Platform Engineering
+  users:
+    - ref: alice
+      email: alice@example.com
+      teams:
+        - ref: alice-platform-team
+          team: platform-team
+`
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(file, []byte(content), 0o600))
+
+	loader := New()
+	rs, err := loader.LoadFile(file)
+	require.NoError(t, err)
+
+	require.NotNil(t, rs.Organization)
+	require.Len(t, rs.Organization.Users, 1)
+	memberships := rs.GetOrganizationUserTeamMembershipsByNamespace("dumped-team-namespace")
+	require.Len(t, memberships, 1)
+	assert.Equal(t, "alice-platform-team", memberships[0].Ref)
+	assert.Empty(t, rs.GetOrganizationUserTeamMembershipsByNamespace("default"))
+}
+
 func TestLoader_RejectsSingularPortalIntegrationKey(t *testing.T) {
 	content := `
 portals:

--- a/internal/declarative/planner/organization_system_account_assignments.go
+++ b/internal/declarative/planner/organization_system_account_assignments.go
@@ -46,7 +46,7 @@ func (t *OrganizationTeamPlannerImpl) planOrganizationSystemAccountTeamMembershi
 		membershipsByAccount[membership.SystemAccount] = append(membershipsByAccount[membership.SystemAccount], membership)
 	}
 	if plan.Metadata.Mode == PlanModeSync {
-		for _, account := range t.organizationSystemAccountsByNamespace(namespace) {
+		for _, account := range t.accountsForTeamMembershipSync() {
 			if _, ok := membershipsByAccount[account.Ref]; !ok {
 				membershipsByAccount[account.Ref] = []resources.OrganizationSystemAccountTeamMembershipResource{}
 			}
@@ -364,6 +364,13 @@ func (t *OrganizationTeamPlannerImpl) organizationSystemAccountsByNamespace(
 		}
 	}
 	return systemAccounts
+}
+
+func (t *OrganizationTeamPlannerImpl) accountsForTeamMembershipSync() []resources.OrganizationSystemAccountResource {
+	if t.planner.resources == nil || t.planner.resources.Organization == nil {
+		return nil
+	}
+	return t.planner.resources.Organization.SystemAccounts
 }
 
 func (t *OrganizationTeamPlannerImpl) organizationSystemAccountByRef(

--- a/internal/declarative/planner/organization_team_planner_test.go
+++ b/internal/declarative/planner/organization_team_planner_test.go
@@ -42,6 +42,22 @@ type systemAccountRolesAPIStub struct {
 	) (*kkOps.GetSystemAccountsAccountIDAssignedRolesResponse, error)
 }
 
+type organizationTeamMembershipAPIStub struct {
+	listUserTeams func(
+		context.Context,
+		kkOps.ListUserTeamsRequest,
+		...kkOps.Option,
+	) (*kkOps.ListUserTeamsResponse, error)
+}
+
+type systemAccountTeamMembershipAPIStub struct {
+	listSystemAccountTeams func(
+		context.Context,
+		kkOps.GetSystemAccountsAccountIDTeamsRequest,
+		...kkOps.Option,
+	) (*kkOps.GetSystemAccountsAccountIDTeamsResponse, error)
+}
+
 func (s *organizationTeamAPIStub) ListOrganizationTeams(
 	ctx context.Context,
 	req kkOps.ListTeamsRequest,
@@ -178,8 +194,89 @@ func (s *systemAccountRolesAPIStub) RemoveSystemAccountRole(
 	return nil, fmt.Errorf("RemoveSystemAccountRole not implemented")
 }
 
+func (s *organizationTeamMembershipAPIStub) ListTeamUsers(
+	_ context.Context,
+	_ kkOps.ListTeamUsersRequest,
+	_ ...kkOps.Option,
+) (*kkOps.ListTeamUsersResponse, error) {
+	return nil, fmt.Errorf("ListTeamUsers not implemented")
+}
+
+func (s *organizationTeamMembershipAPIStub) ListUserTeams(
+	ctx context.Context,
+	req kkOps.ListUserTeamsRequest,
+	opts ...kkOps.Option,
+) (*kkOps.ListUserTeamsResponse, error) {
+	if s.listUserTeams != nil {
+		return s.listUserTeams(ctx, req, opts...)
+	}
+	return &kkOps.ListUserTeamsResponse{TeamCollection: teamCollection()}, nil
+}
+
+func (s *organizationTeamMembershipAPIStub) AddUserToTeam(
+	_ context.Context,
+	_ string,
+	_ *kkComps.AddUserToTeam,
+	_ ...kkOps.Option,
+) (*kkOps.AddUserToTeamResponse, error) {
+	return nil, fmt.Errorf("AddUserToTeam not implemented")
+}
+
+func (s *organizationTeamMembershipAPIStub) RemoveUserFromTeam(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ ...kkOps.Option,
+) (*kkOps.RemoveUserFromTeamResponse, error) {
+	return nil, fmt.Errorf("RemoveUserFromTeam not implemented")
+}
+
+func (s *systemAccountTeamMembershipAPIStub) ListSystemAccountTeams(
+	ctx context.Context,
+	req kkOps.GetSystemAccountsAccountIDTeamsRequest,
+	opts ...kkOps.Option,
+) (*kkOps.GetSystemAccountsAccountIDTeamsResponse, error) {
+	if s.listSystemAccountTeams != nil {
+		return s.listSystemAccountTeams(ctx, req, opts...)
+	}
+	return &kkOps.GetSystemAccountsAccountIDTeamsResponse{TeamCollection: teamCollection()}, nil
+}
+
+func (s *systemAccountTeamMembershipAPIStub) AddSystemAccountToTeam(
+	_ context.Context,
+	_ string,
+	_ *kkComps.AddSystemAccountToTeam,
+	_ ...kkOps.Option,
+) (*kkOps.PostTeamsTeamIDSystemAccountsResponse, error) {
+	return nil, fmt.Errorf("AddSystemAccountToTeam not implemented")
+}
+
+func (s *systemAccountTeamMembershipAPIStub) RemoveSystemAccountFromTeam(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ ...kkOps.Option,
+) (*kkOps.DeleteTeamsTeamIDSystemAccountsAccountIDResponse, error) {
+	return nil, fmt.Errorf("RemoveSystemAccountFromTeam not implemented")
+}
+
 func discardPlannerLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func stringPtr(value string) *string {
+	return &value
+}
+
+func plannerNamespaceMeta(namespace string) *resources.KongctlMeta {
+	return &resources.KongctlMeta{Namespace: &namespace}
+}
+
+func teamCollection(teams ...kkComps.Team) *kkComps.TeamCollection {
+	return &kkComps.TeamCollection{
+		Data: teams,
+		Meta: &kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: float64(len(teams))}},
+	}
 }
 
 func assignedRoleCollection(roles ...kkComps.AssignedRole) *kkComps.AssignedRoleCollection {
@@ -304,6 +401,142 @@ func TestOrganizationUserAssignmentPlansCreateChanges(t *testing.T) {
 	require.Equal(t, ResourceTypeOrganizationUserRole, plan.Changes[1].ResourceType)
 	require.Equal(t, "alice-products-viewer", plan.Changes[1].ResourceRef)
 	require.Equal(t, "__REF__:products-api#id", plan.Changes[1].References[FieldEntityID].Ref)
+}
+
+func TestOrganizationUserTeamMembershipSyncDeletesScopedTeamForSelectorInDifferentNamespace(t *testing.T) {
+	const (
+		namespace = "team-namespace"
+		userID    = "user-123"
+		teamID    = "team-123"
+		teamName  = "Platform Engineering"
+	)
+
+	user := resources.OrganizationUserResource{Ref: "alice", Email: "alice@example.com"}
+	user.SetKonnectID(userID)
+
+	resourceSet := &resources.ResourceSet{
+		Organization: &resources.OrganizationResource{
+			Users: []resources.OrganizationUserResource{user},
+		},
+		OrganizationTeams: []resources.OrganizationTeamResource{
+			{
+				BaseResource: resources.BaseResource{
+					Ref:     "platform-team",
+					Kongctl: plannerNamespaceMeta(namespace),
+				},
+				CreateTeam: kkComps.CreateTeam{Name: teamName},
+			},
+		},
+	}
+
+	var queriedUserIDs []string
+	client := state.NewClient(state.ClientConfig{
+		OrganizationMembershipAPI: &organizationTeamMembershipAPIStub{
+			listUserTeams: func(
+				_ context.Context,
+				req kkOps.ListUserTeamsRequest,
+				_ ...kkOps.Option,
+			) (*kkOps.ListUserTeamsResponse, error) {
+				queriedUserIDs = append(queriedUserIDs, req.UserID)
+				return &kkOps.ListUserTeamsResponse{
+					TeamCollection: teamCollection(kkComps.Team{
+						ID:   stringPtr(teamID),
+						Name: stringPtr(teamName),
+					}),
+				}, nil
+			},
+		},
+	})
+	planner := NewPlanner(client, discardPlannerLogger())
+	planner.resources = resourceSet
+	teamPlanner := NewOrganizationTeamPlanner(NewBasePlanner(planner)).(*OrganizationTeamPlannerImpl)
+	plan := NewPlan("1.0", "test", PlanModeSync)
+
+	err := teamPlanner.planOrganizationUserTeamMembershipChanges(
+		t.Context(),
+		namespace,
+		nil,
+		map[string]state.OrganizationTeam{
+			teamName: {Team: kkComps.Team{ID: stringPtr(teamID), Name: stringPtr(teamName)}},
+		},
+		plan,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{userID}, queriedUserIDs)
+	require.Len(t, plan.Changes, 1)
+	require.Equal(t, ActionDelete, plan.Changes[0].Action)
+	require.Equal(t, ResourceTypeOrganizationUserTeamMembership, plan.Changes[0].ResourceType)
+	require.Equal(t, "alice|team-123", plan.Changes[0].ResourceRef)
+	require.Equal(t, namespace, plan.Changes[0].Namespace)
+}
+
+func TestOrganizationSystemAccountTeamMembershipSyncDeletesScopedTeamForSelectorInDifferentNamespace(t *testing.T) {
+	const (
+		namespace = "team-namespace"
+		accountID = "account-123"
+		teamID    = "team-123"
+		teamName  = "Platform Engineering"
+	)
+
+	account := resources.OrganizationSystemAccountResource{Ref: "ci-bot", Name: "CI Bot"}
+	account.SetKonnectID(accountID)
+
+	resourceSet := &resources.ResourceSet{
+		Organization: &resources.OrganizationResource{
+			SystemAccounts: []resources.OrganizationSystemAccountResource{account},
+		},
+		OrganizationTeams: []resources.OrganizationTeamResource{
+			{
+				BaseResource: resources.BaseResource{
+					Ref:     "platform-team",
+					Kongctl: plannerNamespaceMeta(namespace),
+				},
+				CreateTeam: kkComps.CreateTeam{Name: teamName},
+			},
+		},
+	}
+
+	var queriedAccountIDs []string
+	client := state.NewClient(state.ClientConfig{
+		SystemAccountMembershipAPI: &systemAccountTeamMembershipAPIStub{
+			listSystemAccountTeams: func(
+				_ context.Context,
+				req kkOps.GetSystemAccountsAccountIDTeamsRequest,
+				_ ...kkOps.Option,
+			) (*kkOps.GetSystemAccountsAccountIDTeamsResponse, error) {
+				queriedAccountIDs = append(queriedAccountIDs, req.AccountID)
+				return &kkOps.GetSystemAccountsAccountIDTeamsResponse{
+					TeamCollection: teamCollection(kkComps.Team{
+						ID:   stringPtr(teamID),
+						Name: stringPtr(teamName),
+					}),
+				}, nil
+			},
+		},
+	})
+	planner := NewPlanner(client, discardPlannerLogger())
+	planner.resources = resourceSet
+	teamPlanner := NewOrganizationTeamPlanner(NewBasePlanner(planner)).(*OrganizationTeamPlannerImpl)
+	plan := NewPlan("1.0", "test", PlanModeSync)
+
+	err := teamPlanner.planOrganizationSystemAccountTeamMembershipChanges(
+		t.Context(),
+		namespace,
+		nil,
+		map[string]state.OrganizationTeam{
+			teamName: {Team: kkComps.Team{ID: stringPtr(teamID), Name: stringPtr(teamName)}},
+		},
+		plan,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{accountID}, queriedAccountIDs)
+	require.Len(t, plan.Changes, 1)
+	require.Equal(t, ActionDelete, plan.Changes[0].Action)
+	require.Equal(t, ResourceTypeOrganizationSystemAccountTeamMembership, plan.Changes[0].ResourceType)
+	require.Equal(t, "ci-bot|team-123", plan.Changes[0].ResourceRef)
+	require.Equal(t, namespace, plan.Changes[0].Namespace)
 }
 
 func TestOrganizationTeamRolePortalEntityRefMatchesExistingRole(t *testing.T) {

--- a/internal/declarative/planner/organization_user_assignments.go
+++ b/internal/declarative/planner/organization_user_assignments.go
@@ -41,7 +41,7 @@ func (t *OrganizationTeamPlannerImpl) planOrganizationUserTeamMembershipChanges(
 	}
 
 	if plan.Metadata.Mode == PlanModeSync {
-		for _, user := range t.organizationUsersByNamespace(namespace) {
+		for _, user := range t.usersForTeamMembershipSync() {
 			if _, ok := membershipsByUser[user.Ref]; !ok {
 				membershipsByUser[user.Ref] = []resources.OrganizationUserTeamMembershipResource{}
 			}
@@ -347,6 +347,13 @@ func (t *OrganizationTeamPlannerImpl) organizationUsersByNamespace(
 		}
 	}
 	return users
+}
+
+func (t *OrganizationTeamPlannerImpl) usersForTeamMembershipSync() []resources.OrganizationUserResource {
+	if t.planner.resources == nil || t.planner.resources.Organization == nil {
+		return nil
+	}
+	return t.planner.resources.Organization.Users
 }
 
 func (t *OrganizationTeamPlannerImpl) organizationUserByRef(userRef string) *resources.OrganizationUserResource {

--- a/internal/declarative/resources/resources_test.go
+++ b/internal/declarative/resources/resources_test.go
@@ -6,6 +6,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func namespaceMeta(namespace string) *KongctlMeta {
+	return &KongctlMeta{Namespace: &namespace}
+}
+
 func TestGetPortalsByNamespaceIncludesExternalsWhenRequested(t *testing.T) {
 	team := "team-one"
 	rs := &ResourceSet{
@@ -46,4 +50,84 @@ func TestGetPortalsByNamespaceIncludesExternalsWhenRequested(t *testing.T) {
 	externalPages := rs.GetPortalPagesByNamespace(NamespaceExternal)
 	require.Len(t, externalPages, 1)
 	require.Equal(t, "page-2", externalPages[0].Ref)
+}
+
+func TestGetOrganizationUserTeamMembershipsByNamespaceUsesTeamNamespace(t *testing.T) {
+	teamNamespace := "team-namespace"
+	rs := &ResourceSet{
+		Organization: &OrganizationResource{
+			Users: []OrganizationUserResource{
+				{Ref: "existing-user", Email: "existing-user@example.com"},
+			},
+		},
+		OrganizationTeams: []OrganizationTeamResource{
+			{BaseResource: BaseResource{Ref: "managed-team", Kongctl: namespaceMeta(teamNamespace)}},
+		},
+		OrganizationUserTeamMemberships: []OrganizationUserTeamMembershipResource{
+			{Ref: "existing-user-managed-team", User: "existing-user", Team: "managed-team"},
+		},
+	}
+
+	memberships := rs.GetOrganizationUserTeamMembershipsByNamespace(teamNamespace)
+	require.Len(t, memberships, 1)
+	require.Equal(t, "existing-user-managed-team", memberships[0].Ref)
+
+	require.Empty(t, rs.GetOrganizationUserTeamMembershipsByNamespace("default"))
+}
+
+func TestGetOrganizationUserTeamMembershipsByNamespacePartitionsByTeamNamespace(t *testing.T) {
+	alphaNamespace := "alpha-namespace"
+	betaNamespace := "beta-namespace"
+	rs := &ResourceSet{
+		Organization: &OrganizationResource{
+			Users: []OrganizationUserResource{
+				{Ref: "existing-user", Email: "existing-user@example.com"},
+			},
+		},
+		OrganizationTeams: []OrganizationTeamResource{
+			{BaseResource: BaseResource{Ref: "alpha-team", Kongctl: namespaceMeta(alphaNamespace)}},
+			{BaseResource: BaseResource{Ref: "beta-team", Kongctl: namespaceMeta(betaNamespace)}},
+		},
+		OrganizationUserTeamMemberships: []OrganizationUserTeamMembershipResource{
+			{Ref: "existing-user-alpha-team", User: "existing-user", Team: "alpha-team"},
+			{Ref: "existing-user-beta-team", User: "existing-user", Team: "beta-team"},
+		},
+	}
+
+	alphaMemberships := rs.GetOrganizationUserTeamMembershipsByNamespace(alphaNamespace)
+	require.Len(t, alphaMemberships, 1)
+	require.Equal(t, "existing-user-alpha-team", alphaMemberships[0].Ref)
+
+	betaMemberships := rs.GetOrganizationUserTeamMembershipsByNamespace(betaNamespace)
+	require.Len(t, betaMemberships, 1)
+	require.Equal(t, "existing-user-beta-team", betaMemberships[0].Ref)
+
+	require.Empty(t, rs.GetOrganizationUserTeamMembershipsByNamespace("default"))
+}
+
+func TestGetOrganizationSystemAccountTeamMembershipsByNamespaceUsesTeamNamespace(t *testing.T) {
+	teamNamespace := "team-namespace"
+	rs := &ResourceSet{
+		Organization: &OrganizationResource{
+			SystemAccounts: []OrganizationSystemAccountResource{
+				{Ref: "existing-system-account", Name: "existing-system-account"},
+			},
+		},
+		OrganizationTeams: []OrganizationTeamResource{
+			{BaseResource: BaseResource{Ref: "managed-team", Kongctl: namespaceMeta(teamNamespace)}},
+		},
+		OrganizationSystemAccountTeamMemberships: []OrganizationSystemAccountTeamMembershipResource{
+			{
+				Ref:           "existing-system-account-managed-team",
+				SystemAccount: "existing-system-account",
+				Team:          "managed-team",
+			},
+		},
+	}
+
+	memberships := rs.GetOrganizationSystemAccountTeamMembershipsByNamespace(teamNamespace)
+	require.Len(t, memberships, 1)
+	require.Equal(t, "existing-system-account-managed-team", memberships[0].Ref)
+
+	require.Empty(t, rs.GetOrganizationSystemAccountTeamMembershipsByNamespace("default"))
 }

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -805,14 +805,14 @@ func (rs *ResourceSet) GetOrganizationTeamRolesByNamespace(namespace string) []O
 func (rs *ResourceSet) GetOrganizationUserTeamMembershipsByNamespace(
 	namespace string,
 ) []OrganizationUserTeamMembershipResource {
-	userByRef := make(map[string]OrganizationUserResource)
-	for _, user := range rs.organizationUsers() {
-		userByRef[user.Ref] = user
+	teamByRef := make(map[string]OrganizationTeamResource)
+	for _, team := range rs.GetOrganizationTeamsByNamespace(namespace) {
+		teamByRef[team.Ref] = team
 	}
 
 	var filtered []OrganizationUserTeamMembershipResource
 	for _, membership := range rs.OrganizationUserTeamMemberships {
-		if user, ok := userByRef[membership.User]; ok && GetNamespace(user.Kongctl) == namespace {
+		if _, ok := teamByRef[membership.Team]; ok {
 			filtered = append(filtered, membership)
 		}
 	}
@@ -839,15 +839,14 @@ func (rs *ResourceSet) GetOrganizationUserRolesByNamespace(namespace string) []O
 func (rs *ResourceSet) GetOrganizationSystemAccountTeamMembershipsByNamespace(
 	namespace string,
 ) []OrganizationSystemAccountTeamMembershipResource {
-	systemAccountByRef := make(map[string]OrganizationSystemAccountResource)
-	for _, systemAccount := range rs.organizationSystemAccounts() {
-		systemAccountByRef[systemAccount.Ref] = systemAccount
+	teamByRef := make(map[string]OrganizationTeamResource)
+	for _, team := range rs.GetOrganizationTeamsByNamespace(namespace) {
+		teamByRef[team.Ref] = team
 	}
 
 	var filtered []OrganizationSystemAccountTeamMembershipResource
 	for _, membership := range rs.OrganizationSystemAccountTeamMemberships {
-		if systemAccount, ok := systemAccountByRef[membership.SystemAccount]; ok &&
-			GetNamespace(systemAccount.Kongctl) == namespace {
+		if _, ok := teamByRef[membership.Team]; ok {
 			filtered = append(filtered, membership)
 		}
 	}


### PR DESCRIPTION
## Summary

Fix organization team-membership namespace filtering so membership relationship resources are scoped by the referenced organization team's namespace instead of the lookup selector's namespace.

This covers both affected relationship types:

- `organization_user_team_membership`
- `organization_system_account_team_membership`

## Root Cause

Dumped organization team configs can include synthetic `organization.users[]` selector entries for existing Konnect users. Those selector entries do not carry durable Konnect metadata, while the referenced organization team does. The planner was filtering desired user-team memberships by the selector namespace, causing dumped configs to miss the membership create unless users manually added `_defaults.kongctl.namespace`.

The system account path had the same selector-scoped pattern, so this PR updates it in parallel.

## Validation

- `go test ./internal/declarative/resources ./internal/declarative/loader ./internal/declarative/planner`
- `make build`
- `make lint`
- `make test`

## Related

Closes #1255.

Associated e2e coverage: #1236. That PR already contains the red `dump/organization-teams` scenario that should be rebased onto this fix and run manually with `KONGCTL_E2E_ORG_USER_EMAIL_1`.