### PR TITLE
Fix: [declarative] omit empty audit-logs group

### DIFF
--- a/internal/declarative/loader/audit_logs_test.go
+++ b/internal/declarative/loader/audit_logs_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func TestLoader_LoadsGroupedAuditLogWebhookDestinations(t *testing.T) {
@@ -23,6 +24,7 @@ audit-logs:
 
 	rs, err := New().LoadFromSources([]Source{{Path: path, Type: SourceTypeFile}}, false)
 	require.NoError(t, err)
+	require.NotNil(t, rs.AuditLogs)
 	require.Len(t, rs.AuditLogs.Destinations, 1)
 
 	destination := rs.AuditLogs.Destinations[0]
@@ -30,4 +32,22 @@ audit-logs:
 	require.NotNil(t, destination.External)
 	require.NotNil(t, destination.External.Selector)
 	require.Equal(t, "foo", destination.External.Selector.MatchFields["name"])
+}
+
+func TestLoader_OmitsAuditLogsWhenGroupAbsent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "portal.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+portals:
+  - ref: portal
+    name: Portal
+`), 0o600))
+
+	rs, err := New().LoadFromSources([]Source{{Path: path, Type: SourceTypeFile}}, false)
+	require.NoError(t, err)
+	require.Nil(t, rs.AuditLogs)
+
+	yamlBytes, err := yaml.Marshal(rs)
+	require.NoError(t, err)
+	require.NotContains(t, string(yamlBytes), "audit-logs:")
 }

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -50,8 +50,10 @@ func (l *Loader) validateResourceSet(rs *resources.ResourceSet) error {
 	}
 
 	// Validate audit-log webhook destinations
-	if err := l.validateAuditLogWebhookDestinations(rs.AuditLogs.Destinations, rs); err != nil {
-		return err
+	if rs.AuditLogs != nil {
+		if err := l.validateAuditLogWebhookDestinations(rs.AuditLogs.Destinations, rs); err != nil {
+			return err
+		}
 	}
 
 	// Validate control plane data plane certificates

--- a/internal/declarative/planner/audit_log_webhook_test.go
+++ b/internal/declarative/planner/audit_log_webhook_test.go
@@ -94,7 +94,7 @@ func TestPlanPortalAuditLogWebhookCreateUsesResolvedDestinationReference(t *test
 		Portals: []resources.PortalResource{
 			{BaseResource: resources.BaseResource{Ref: "portal"}},
 		},
-		AuditLogs: resources.AuditLogsResource{
+		AuditLogs: &resources.AuditLogsResource{
 			Destinations: []resources.AuditLogWebhookDestinationResource{destination},
 		},
 	}

--- a/internal/declarative/planner/planner.go
+++ b/internal/declarative/planner/planner.go
@@ -889,8 +889,10 @@ func (p *Planner) resolveResourceIdentities(ctx context.Context, rs *resources.R
 		return fmt.Errorf("failed to resolve gateway service identities: %w", err)
 	}
 
-	if err := p.resolveAuditLogWebhookDestinationIdentities(ctx, rs.AuditLogs.Destinations); err != nil {
-		return fmt.Errorf("failed to resolve audit log webhook destination identities: %w", err)
+	if rs.AuditLogs != nil {
+		if err := p.resolveAuditLogWebhookDestinationIdentities(ctx, rs.AuditLogs.Destinations); err != nil {
+			return fmt.Errorf("failed to resolve audit log webhook destination identities: %w", err)
+		}
 	}
 
 	if err := p.resolveAPIImplementationServiceReferences(rs); err != nil {

--- a/internal/declarative/resources/audit_log_webhook_destination.go
+++ b/internal/declarative/resources/audit_log_webhook_destination.go
@@ -3,16 +3,29 @@ package resources
 import "fmt"
 
 func init() {
-	registerResourceType(
+	registerResourceTypeWithSliceAccessors(
 		ResourceTypeAuditLogWebhookDestination,
-		func(rs *ResourceSet) *[]AuditLogWebhookDestinationResource {
-			return &rs.AuditLogs.Destinations
-		},
+		auditLogWebhookDestinationSlice,
+		ensureAuditLogWebhookDestinationSlice,
 		AutoExplain[AuditLogWebhookDestinationResource](
 			WithExplainAliases("audit-logs.destinations"),
 			WithExplainRecommendedFields("ref", "_external"),
 		),
 	)
+}
+
+func auditLogWebhookDestinationSlice(rs *ResourceSet) *[]AuditLogWebhookDestinationResource {
+	if rs == nil || rs.AuditLogs == nil {
+		return nil
+	}
+	return &rs.AuditLogs.Destinations
+}
+
+func ensureAuditLogWebhookDestinationSlice(rs *ResourceSet) *[]AuditLogWebhookDestinationResource {
+	if rs.AuditLogs == nil {
+		rs.AuditLogs = &AuditLogsResource{}
+	}
+	return &rs.AuditLogs.Destinations
 }
 
 // AuditLogsResource groups organization-scoped audit-log declarative resources.

--- a/internal/declarative/resources/registry.go
+++ b/internal/declarative/resources/registry.go
@@ -43,16 +43,39 @@ func registerResourceType[R any, RPtr interface {
 	getSlicePtr func(*ResourceSet) *[]R,
 	explain ExplainRegistration,
 ) {
+	registerResourceTypeWithSliceAccessors[R, RPtr](rt, getSlicePtr, getSlicePtr, explain)
+}
+
+func registerResourceTypeWithSliceAccessors[R any, RPtr interface {
+	*R
+	Resource
+}](rt ResourceType,
+	getSlicePtr func(*ResourceSet) *[]R,
+	ensureSlicePtr func(*ResourceSet) *[]R,
+	explain ExplainRegistration,
+) {
 	registry[rt] = resourceOps{
 		get: func(rs *ResourceSet) []Resource {
-			return sliceToResources[R, RPtr](*getSlicePtr(rs))
+			slicePtr := getSlicePtr(rs)
+			if slicePtr == nil {
+				return nil
+			}
+			return sliceToResources[R, RPtr](*slicePtr)
 		},
 		append: func(dest, src *ResourceSet) {
-			destPtr := getSlicePtr(dest)
-			*destPtr = append(*destPtr, *getSlicePtr(src)...)
+			srcPtr := getSlicePtr(src)
+			if srcPtr == nil || len(*srcPtr) == 0 {
+				return
+			}
+			destPtr := ensureSlicePtr(dest)
+			*destPtr = append(*destPtr, *srcPtr...)
 		},
 		forEach: func(rs *ResourceSet, fn func(Resource) bool) bool {
-			slice := *getSlicePtr(rs) // e.g., rs.Portals (the actual slice, not pointer)
+			slicePtr := getSlicePtr(rs)
+			if slicePtr == nil {
+				return true
+			}
+			slice := *slicePtr // e.g., rs.Portals (the actual slice, not pointer)
 			for i := range slice {
 				// Get pointer to element and convert to Resource interface
 				// This avoids allocating a new slice of Resource and allows direct iteration.
@@ -70,7 +93,11 @@ func registerResourceType[R any, RPtr interface {
 			return true
 		},
 		count: func(rs *ResourceSet) int {
-			return len(*getSlicePtr(rs))
+			slicePtr := getSlicePtr(rs)
+			if slicePtr == nil {
+				return 0
+			}
+			return len(*slicePtr)
 		},
 		explain: explain,
 	}

--- a/internal/declarative/resources/registry_test.go
+++ b/internal/declarative/resources/registry_test.go
@@ -216,6 +216,26 @@ func TestAppendAll(t *testing.T) {
 	})
 }
 
+func TestAppendAllInitializesAuditLogsOnlyWhenDestinationsExist(t *testing.T) {
+	dest := &ResourceSet{}
+	dest.AppendAll(&ResourceSet{})
+	require.Nil(t, dest.AuditLogs)
+
+	src := &ResourceSet{
+		AuditLogs: &AuditLogsResource{
+			Destinations: []AuditLogWebhookDestinationResource{
+				{BaseResource: BaseResource{Ref: "destination"}},
+			},
+		},
+	}
+
+	dest.AppendAll(src)
+
+	require.NotNil(t, dest.AuditLogs)
+	require.Len(t, dest.AuditLogs.Destinations, 1)
+	require.Equal(t, "destination", dest.AuditLogs.Destinations[0].Ref)
+}
+
 func TestIsRegistered(t *testing.T) {
 	t.Run("known types", func(t *testing.T) {
 		knownTypes := []ResourceType{

--- a/internal/declarative/resources/resources_test.go
+++ b/internal/declarative/resources/resources_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 )
 
 func namespaceMeta(namespace string) *KongctlMeta {
@@ -130,4 +131,17 @@ func TestGetOrganizationSystemAccountTeamMembershipsByNamespaceUsesTeamNamespace
 	require.Equal(t, "existing-system-account-managed-team", memberships[0].Ref)
 
 	require.Empty(t, rs.GetOrganizationSystemAccountTeamMembershipsByNamespace("default"))
+}
+
+func TestResourceSetMarshalOmitsEmptyAuditLogs(t *testing.T) {
+	rs := &ResourceSet{}
+
+	require.True(t, rs.IsEmpty())
+	require.Empty(t, rs.AllResourcesByType(ResourceTypeAuditLogWebhookDestination))
+	require.Nil(t, rs.AuditLogs)
+
+	yamlBytes, err := yaml.Marshal(rs)
+	require.NoError(t, err)
+	require.NotContains(t, string(yamlBytes), "audit-logs:")
+	require.Nil(t, rs.AuditLogs)
 }

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -82,7 +82,7 @@ type ResourceRef struct {
 type ResourceSet struct {
 	Portals []PortalResource `yaml:"portals,omitempty"                                        json:"portals,omitempty"`
 	// AuditLogs contains organization-scoped audit-log resources.
-	AuditLogs AuditLogsResource `yaml:"audit-logs,omitempty"                                     json:"audit-logs,omitempty"` //nolint:lll
+	AuditLogs *AuditLogsResource `yaml:"audit-logs,omitempty"                                    json:"audit-logs,omitempty"` //nolint:lll
 	// ApplicationAuthStrategies contains auth strategy configurations
 	ApplicationAuthStrategies []ApplicationAuthStrategyResource `yaml:"application_auth_strategies,omitempty"                    json:"application_auth_strategies,omitempty"` //nolint:lll
 	DCRProviders              []DCRProviderResource             `yaml:"dcr_providers,omitempty"                                  json:"dcr_providers,omitempty"`               //nolint:lll


### PR DESCRIPTION
## Summary

- make the declarative audit-log group nullable so empty dumps omit `audit-logs`
- keep audit-log destination registry access nil-safe while still initializing on append
- add regression coverage for marshaling and loader behavior when audit logs are absent

## Validation

- `go test ./internal/declarative/resources ./internal/declarative/loader ./internal/declarative/planner`
- `make test`
- `make build`
- `make lint`
- `git diff --check`

Closes #1254