### PR TITLE
Feat: Add dump action to view TUI

### DIFF
--- a/internal/cmd/output/tableview/tableview.go
+++ b/internal/cmd/output/tableview/tableview.go
@@ -17,6 +17,7 @@ import (
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/spinner"
 	"charm.land/bubbles/v2/table"
+	"charm.land/bubbles/v2/textinput"
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -47,6 +48,47 @@ type DetailContextProvider func(index int) any
 
 type RowLoader func(index int) (ChildView, error)
 
+// SelectionContext describes the currently highlighted row for selection actions.
+type SelectionContext struct {
+	ParentType string
+	Parent     any
+	Headers    []string
+	Row        table.Row
+	Label      string
+	Index      int
+}
+
+// SelectionActionResolver converts a highlighted row into an executable action.
+type SelectionActionResolver func(SelectionContext) (SelectionActionCommand, error)
+
+// SelectionActionRun executes a confirmed selection action.
+type SelectionActionRun func(SelectionActionValues) error
+
+// SelectionActionValues contains user-entered options collected by the action dialog.
+type SelectionActionValues struct {
+	OutputFile       string
+	DefaultNamespace string
+	IncludeChildren  bool
+}
+
+// SelectionActionCommand configures the modal prompt and execution callback for an action.
+type SelectionActionCommand struct {
+	Title               string
+	Label               string
+	DefaultOutputFile   string
+	DefaultNamespace    string
+	IncludeChildren     bool
+	IncludeChildrenText string
+	Run                 SelectionActionRun
+}
+
+// SelectionAction registers a keyboard action for the current row selection.
+type SelectionAction struct {
+	Key     string
+	Help    string
+	Resolve SelectionActionResolver
+}
+
 type config struct {
 	title         string
 	footer        string
@@ -73,6 +115,8 @@ type config struct {
 	childParentType string
 	detailContext   DetailContextProvider
 	childHelper     cmdpkg.Helper
+
+	selectionActions []SelectionAction
 }
 
 // PreviewRenderer allows injecting a synthetic preview above the table that
@@ -90,6 +134,7 @@ type requestKind int
 const (
 	requestKindRow requestKind = iota
 	requestKindDetail
+	requestKindAction
 )
 
 type pendingRequest struct {
@@ -117,6 +162,36 @@ type detailChildLoadedMsg struct {
 	child     ChildView
 	err       error
 	label     string
+}
+
+type selectionActionCompletedMsg struct {
+	requestID  string
+	label      string
+	outputFile string
+	err        error
+}
+
+type selectionActionFocus int
+
+const (
+	selectionActionFocusOutput selectionActionFocus = iota
+	selectionActionFocusNamespace
+	selectionActionFocusIncludeChildren
+)
+
+const (
+	selectionActionOutputLabel    = "Output file:"
+	selectionActionNamespaceLabel = "Default namespace:"
+)
+
+type selectionActionDialog struct {
+	action          SelectionAction
+	command         SelectionActionCommand
+	outputInput     textinput.Model
+	namespaceInput  textinput.Model
+	includeChildren bool
+	focus           selectionActionFocus
+	status          string
 }
 
 func newSpinnerModel(p theme.Palette) spinner.Model {
@@ -163,9 +238,14 @@ func (pr pendingRequest) inflightMessage() string {
 			label = "selection"
 		case requestKindDetail:
 			label = "detail"
+		case requestKindAction:
+			label = "action"
 		default:
 			label = "request"
 		}
+	}
+	if pr.kind == requestKindAction {
+		return fmt.Sprintf("Running %s...", label)
 	}
 	return fmt.Sprintf("Loading %s...", label)
 }
@@ -384,6 +464,16 @@ func WithTableStretch() Option {
 func WithProfileName(name string) Option {
 	return func(cfg *config) {
 		cfg.profileName = strings.TrimSpace(name)
+	}
+}
+
+// WithSelectionAction registers an action that can be invoked for the highlighted row.
+func WithSelectionAction(action SelectionAction) Option {
+	return func(cfg *config) {
+		if strings.TrimSpace(action.Key) == "" || action.Resolve == nil {
+			return
+		}
+		cfg.selectionActions = append(cfg.selectionActions, action)
 	}
 }
 
@@ -2382,47 +2472,49 @@ func (c *childViewState) labelForIndex(index int) string {
 }
 
 type bubbleModel struct {
-	table           table.Model
-	title           string
-	footer          string
-	detailFooter    string
-	showHelp        bool
-	toggleKey       string
-	quitKeys        []string
-	tableStyle      lipgloss.Style
-	detailStyle     lipgloss.Style
-	statusStyle     lipgloss.Style
-	selectedStyle   lipgloss.Style
-	profileName     string
-	useAltScreen    bool
-	hasDetail       bool
-	detail          *viewport.Model
-	detailRenderer  DetailRenderer
-	previewRenderer PreviewRenderer
-	palette         theme.Palette
-	windowWidth     int
-	windowHeight    int
-	detailStack     []detailView
-	rowCount        int
-	headers         []string
-	headerLookup    map[string]int
-	breadcrumbs     []string
-	parentType      string
-	detailContext   DetailContextProvider
-	helper          cmdpkg.Helper
-	statusMessage   string
-	rowLoader       RowLoader
-	searchActive    bool
-	searchBuffer    []rune
-	searchPrompt    string
-	searchDeadline  time.Time
-	spinner         spinner.Model
-	pendingRequest  pendingRequest
-	nextRequestID   int
-	nextDetailID    int
-	initCmd         tea.Cmd
-	availableThemes []string
-	themeIndex      int
+	table            table.Model
+	title            string
+	footer           string
+	detailFooter     string
+	showHelp         bool
+	toggleKey        string
+	quitKeys         []string
+	tableStyle       lipgloss.Style
+	detailStyle      lipgloss.Style
+	statusStyle      lipgloss.Style
+	selectedStyle    lipgloss.Style
+	profileName      string
+	useAltScreen     bool
+	hasDetail        bool
+	detail           *viewport.Model
+	detailRenderer   DetailRenderer
+	previewRenderer  PreviewRenderer
+	palette          theme.Palette
+	windowWidth      int
+	windowHeight     int
+	detailStack      []detailView
+	rowCount         int
+	headers          []string
+	headerLookup     map[string]int
+	breadcrumbs      []string
+	parentType       string
+	detailContext    DetailContextProvider
+	helper           cmdpkg.Helper
+	statusMessage    string
+	rowLoader        RowLoader
+	searchActive     bool
+	searchBuffer     []rune
+	searchPrompt     string
+	searchDeadline   time.Time
+	spinner          spinner.Model
+	pendingRequest   pendingRequest
+	nextRequestID    int
+	nextDetailID     int
+	initCmd          tea.Cmd
+	availableThemes  []string
+	themeIndex       int
+	selectionActions []SelectionAction
+	actionDialog     *selectionActionDialog
 }
 
 func newBubbleModel(
@@ -2453,37 +2545,38 @@ func newBubbleModel(
 	availableThemeNames := theme.Available()
 
 	m := &bubbleModel{
-		table:           tbl,
-		title:           cfg.title,
-		footer:          cfg.footer,
-		detailFooter:    "Press enter to select or copy · esc/backspace to go back · arrows/j/k navigate",
-		toggleKey:       cfg.toggleHelpKey,
-		quitKeys:        cfg.quitKeys,
-		tableStyle:      tableStyle,
-		detailStyle:     detailStyle,
-		statusStyle:     statusStyle,
-		selectedStyle:   selectedStyle,
-		profileName:     strings.TrimSpace(cfg.profileName),
-		useAltScreen:    true,
-		hasDetail:       cfg.hasDetail,
-		detailRenderer:  cfg.detailRenderer,
-		previewRenderer: previewRenderer,
-		palette:         palette,
-		windowWidth:     initialWidth,
-		windowHeight:    initialHeight,
-		rowCount:        rowCount,
-		headers:         append([]string(nil), headers...),
-		headerLookup:    buildHeaderLookup(headers),
-		breadcrumbs:     []string{rootLabel},
-		parentType:      parentType,
-		detailContext:   cfg.detailContext,
-		helper:          cfg.childHelper,
-		rowLoader:       cfg.rowLoader,
-		spinner:         newSpinnerModel(palette),
-		nextRequestID:   1,
-		nextDetailID:    1,
-		availableThemes: availableThemeNames,
-		themeIndex:      themeIndexOf(availableThemeNames, palette.Name),
+		table:            tbl,
+		title:            cfg.title,
+		footer:           cfg.footer,
+		detailFooter:     "Press enter to select or copy · esc/backspace to go back · arrows/j/k navigate",
+		toggleKey:        cfg.toggleHelpKey,
+		quitKeys:         cfg.quitKeys,
+		tableStyle:       tableStyle,
+		detailStyle:      detailStyle,
+		statusStyle:      statusStyle,
+		selectedStyle:    selectedStyle,
+		profileName:      strings.TrimSpace(cfg.profileName),
+		useAltScreen:     true,
+		hasDetail:        cfg.hasDetail,
+		detailRenderer:   cfg.detailRenderer,
+		previewRenderer:  previewRenderer,
+		palette:          palette,
+		windowWidth:      initialWidth,
+		windowHeight:     initialHeight,
+		rowCount:         rowCount,
+		headers:          append([]string(nil), headers...),
+		headerLookup:     buildHeaderLookup(headers),
+		breadcrumbs:      []string{rootLabel},
+		parentType:       parentType,
+		detailContext:    cfg.detailContext,
+		helper:           cfg.childHelper,
+		rowLoader:        cfg.rowLoader,
+		spinner:          newSpinnerModel(palette),
+		nextRequestID:    1,
+		nextDetailID:     1,
+		availableThemes:  availableThemeNames,
+		themeIndex:       themeIndexOf(availableThemeNames, palette.Name),
+		selectionActions: append([]SelectionAction(nil), cfg.selectionActions...),
 	}
 
 	if cfg.hasDetail && cfg.detailViewport != nil {
@@ -2680,6 +2773,248 @@ func (m *bubbleModel) previewDetailContent(index int) string {
 
 func (m *bubbleModel) inDetailMode() bool {
 	return len(m.detailStack) > 0
+}
+
+func (m *bubbleModel) currentSelection() (SelectionContext, bool) {
+	if m.inDetailMode() {
+		detail := &m.detailStack[len(m.detailStack)-1]
+		if detail.child != nil && detail.table != nil {
+			index := detail.table.Cursor()
+			if index < 0 || index >= len(detail.child.rows) {
+				return SelectionContext{}, false
+			}
+			parent := detail.parent
+			if detail.child.context != nil {
+				parent = detail.child.context(index)
+			}
+			return SelectionContext{
+				ParentType: detail.child.parentType,
+				Parent:     parent,
+				Headers:    append([]string(nil), detail.child.headers...),
+				Row:        append(table.Row(nil), detail.child.rows[index]...),
+				Label:      detail.child.labelForIndex(index),
+				Index:      index,
+			}, true
+		}
+
+		return SelectionContext{
+			ParentType: detail.parentType,
+			Parent:     detail.parent,
+			Label:      detail.label,
+			Index:      -1,
+		}, true
+	}
+
+	rows := m.table.Rows()
+	index := m.table.Cursor()
+	if index < 0 || index >= len(rows) {
+		return SelectionContext{}, false
+	}
+
+	var parent any
+	if m.detailContext != nil {
+		parent = m.detailContext(index)
+	}
+
+	return SelectionContext{
+		ParentType: m.parentType,
+		Parent:     parent,
+		Headers:    append([]string(nil), m.headers...),
+		Row:        append(table.Row(nil), rows[index]...),
+		Label:      m.labelForIndex(index),
+		Index:      index,
+	}, true
+}
+
+func (m *bubbleModel) openSelectionAction(action SelectionAction) {
+	if m.pendingRequest.active {
+		m.setStatus("Wait for the current request to finish.")
+		return
+	}
+
+	selection, ok := m.currentSelection()
+	if !ok {
+		m.setStatus("No selection available.")
+		return
+	}
+
+	command, err := action.Resolve(selection)
+	if err != nil {
+		m.setStatus(err.Error())
+		return
+	}
+	if command.Run == nil {
+		m.setStatus("Selection action is not available.")
+		return
+	}
+
+	outputInput := textinput.New()
+	outputInput.Prompt = ""
+	outputInput.Placeholder = "path/to/file.yaml"
+	outputInput.SetValue(strings.TrimSpace(command.DefaultOutputFile))
+	outputInput.SetWidth(m.selectionActionInputWidth())
+	_ = outputInput.Focus()
+
+	namespaceInput := textinput.New()
+	namespaceInput.Prompt = ""
+	namespaceInput.Placeholder = "optional namespace"
+	namespaceInput.SetValue(strings.TrimSpace(command.DefaultNamespace))
+	namespaceInput.SetWidth(m.selectionActionInputWidth())
+
+	m.actionDialog = &selectionActionDialog{
+		action:          action,
+		command:         command,
+		outputInput:     outputInput,
+		namespaceInput:  namespaceInput,
+		includeChildren: command.IncludeChildren,
+		focus:           selectionActionFocusOutput,
+	}
+	m.clearStatus()
+}
+
+func (m *bubbleModel) selectionActionInputWidth() int {
+	return max(m.selectionActionBoxWidth()-len(selectionActionNamespaceLabel)-1, 16)
+}
+
+func (m *bubbleModel) selectionActionBoxWidth() int {
+	width := m.windowWidth
+	if width <= 0 {
+		width = 80
+	}
+	return min(max(width-4, 40), 88)
+}
+
+func (m *bubbleModel) resizeActionDialogInput() {
+	if m.actionDialog == nil {
+		return
+	}
+	width := m.selectionActionInputWidth()
+	m.actionDialog.outputInput.SetWidth(width)
+	m.actionDialog.namespaceInput.SetWidth(width)
+}
+
+func (m *bubbleModel) handleSelectionActionDialogKey(key tea.KeyPressMsg) tea.Cmd {
+	if m.actionDialog == nil {
+		return nil
+	}
+
+	switch key.String() {
+	case "ctrl+c":
+		m.useAltScreen = false
+		return tea.Quit
+	case "esc":
+		m.actionDialog = nil
+		m.setStatus("Action canceled.")
+		return nil
+	case "shift+tab", "up":
+		m.moveSelectionActionFocus(-1)
+		return nil
+	case "tab", "down":
+		m.moveSelectionActionFocus(1)
+		return nil
+	case " ", "space":
+		if m.actionDialog.focus == selectionActionFocusIncludeChildren {
+			m.actionDialog.includeChildren = !m.actionDialog.includeChildren
+			return nil
+		}
+	case "enter":
+		return m.submitSelectionAction()
+	}
+
+	if m.actionDialog.focus != selectionActionFocusOutput {
+		if m.actionDialog.focus != selectionActionFocusNamespace {
+			return nil
+		}
+
+		var cmd tea.Cmd
+		m.actionDialog.namespaceInput, cmd = m.actionDialog.namespaceInput.Update(key)
+		return cmd
+	}
+
+	var cmd tea.Cmd
+	m.actionDialog.outputInput, cmd = m.actionDialog.outputInput.Update(key)
+	return cmd
+}
+
+func (m *bubbleModel) moveSelectionActionFocus(delta int) {
+	if m.actionDialog == nil {
+		return
+	}
+
+	const focusCount = int(selectionActionFocusIncludeChildren) + 1
+	next := (int(m.actionDialog.focus) + delta) % focusCount
+	if next < 0 {
+		next += focusCount
+	}
+	m.setSelectionActionFocus(selectionActionFocus(next))
+}
+
+func (m *bubbleModel) setSelectionActionFocus(focus selectionActionFocus) {
+	if m.actionDialog == nil {
+		return
+	}
+
+	m.actionDialog.focus = focus
+	m.actionDialog.outputInput.Blur()
+	m.actionDialog.namespaceInput.Blur()
+
+	switch focus {
+	case selectionActionFocusOutput:
+		_ = m.actionDialog.outputInput.Focus()
+	case selectionActionFocusNamespace:
+		_ = m.actionDialog.namespaceInput.Focus()
+	case selectionActionFocusIncludeChildren:
+	}
+}
+
+func (m *bubbleModel) submitSelectionAction() tea.Cmd {
+	if m.actionDialog == nil {
+		return nil
+	}
+
+	outputFile := strings.TrimSpace(m.actionDialog.outputInput.Value())
+	if outputFile == "" {
+		m.actionDialog.status = "Output file is required."
+		return nil
+	}
+	defaultNamespace := strings.TrimSpace(m.actionDialog.namespaceInput.Value())
+
+	command := m.actionDialog.command
+	label := strings.TrimSpace(command.Label)
+	if label == "" {
+		label = strings.TrimSpace(command.Title)
+	}
+	if label == "" {
+		label = "selection action"
+	}
+
+	requestID, tickCmd := m.beginRequest(requestKindAction, label, -1, 0, 0)
+	if requestID == "" {
+		return nil
+	}
+
+	includeChildren := m.actionDialog.includeChildren
+	run := command.Run
+	m.actionDialog = nil
+
+	runCmd := func() tea.Msg {
+		err := run(SelectionActionValues{
+			OutputFile:       outputFile,
+			DefaultNamespace: defaultNamespace,
+			IncludeChildren:  includeChildren,
+		})
+		return selectionActionCompletedMsg{
+			requestID:  requestID,
+			label:      label,
+			outputFile: outputFile,
+			err:        err,
+		}
+	}
+
+	if tickCmd != nil {
+		return tea.Batch(tickCmd, runCmd)
+	}
+	return runCmd
 }
 
 func (m *bubbleModel) presentRowChild(index int, childView ChildView) string {
@@ -3407,12 +3742,90 @@ func (m *bubbleModel) renderHelpContent(innerWidth int) string {
 		"?               : toggle this help",
 		"q               : quit",
 	}
+	for _, action := range m.selectionActions {
+		keyName := strings.TrimSpace(action.Key)
+		helpText := strings.TrimSpace(action.Help)
+		if keyName == "" || helpText == "" {
+			continue
+		}
+		helpLines = append(helpLines, fmt.Sprintf("%-15s : %s", keyName, helpText))
+	}
 	helpStyle := lipgloss.NewStyle().Faint(true)
 	rendered := make([]string, len(helpLines))
 	for i, line := range helpLines {
 		rendered[i] = padStatusLine(helpStyle.Render(line), innerWidth)
 	}
 	return strings.Join(rendered, "\n")
+}
+
+func (m *bubbleModel) renderSelectionActionDialog() string {
+	if m.actionDialog == nil {
+		return ""
+	}
+
+	dialog := m.actionDialog
+	title := strings.TrimSpace(dialog.command.Title)
+	if title == "" {
+		title = "Selection Action"
+	}
+
+	labelStyle := lipgloss.NewStyle().Faint(true)
+	activeStyle := m.palette.ForegroundStyle(theme.ColorAccent)
+	titleStyle := m.palette.ForegroundStyle(theme.ColorTextPrimary).Bold(true)
+	statusStyle := lipgloss.NewStyle().Faint(true)
+
+	includeLabel := strings.TrimSpace(dialog.command.IncludeChildrenText)
+	if includeLabel == "" {
+		includeLabel = "include child resources"
+	}
+	checkbox := "[ ]"
+	if dialog.includeChildren {
+		checkbox = "[x]"
+	}
+	includeLine := fmt.Sprintf("%s %s", checkbox, includeLabel)
+	if dialog.focus == selectionActionFocusIncludeChildren {
+		includeLine = activeStyle.Render(includeLine)
+	}
+
+	lines := []string{
+		titleStyle.Render(title),
+		renderSelectionActionInputRow(
+			selectionActionOutputLabel,
+			dialog.outputInput.View(),
+			dialog.focus == selectionActionFocusOutput,
+			labelStyle,
+			activeStyle,
+		),
+		renderSelectionActionInputRow(
+			selectionActionNamespaceLabel,
+			dialog.namespaceInput.View(),
+			dialog.focus == selectionActionFocusNamespace,
+			labelStyle,
+			activeStyle,
+		),
+		includeLine,
+	}
+
+	if status := strings.TrimSpace(dialog.status); status != "" {
+		lines = append(lines, statusStyle.Render(status))
+	}
+	lines = append(lines, statusStyle.Render("Enter confirms · Esc cancels · Tab switches fields"))
+
+	return m.detailStyle.Width(m.selectionActionBoxWidth()).Render(strings.Join(lines, "\n"))
+}
+
+func renderSelectionActionInputRow(
+	label, input string,
+	active bool,
+	labelStyle, activeStyle lipgloss.Style,
+) string {
+	paddedLabel := fmt.Sprintf("%-*s", len(selectionActionNamespaceLabel), label)
+	if active {
+		paddedLabel = activeStyle.Render(paddedLabel)
+	} else {
+		paddedLabel = labelStyle.Render(paddedLabel)
+	}
+	return fmt.Sprintf("%s %s", paddedLabel, input)
 }
 
 func renderStatusRow(left, right string, width int) string {
@@ -3802,6 +4215,13 @@ func (m *bubbleModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:iretur
 	skipKeyProcessing := false
 	searchConsumed := false
 
+	if keyMsg, ok := msg.(tea.KeyPressMsg); ok && m.actionDialog != nil {
+		if cmd := m.handleSelectionActionDialogKey(keyMsg); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+		return m, tea.Batch(cmds...)
+	}
+
 	if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
 		handled, propagate, searchCmd := m.handleSearchKey(keyMsg)
 		if handled {
@@ -3863,6 +4283,23 @@ func (m *bubbleModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:iretur
 			}
 		}
 		return m, tea.Batch(cmds...)
+	case selectionActionCompletedMsg:
+		if pr, duration, ok := m.completeRequest(key.requestID); ok {
+			label := formatRequestLabel(key.label)
+			if strings.TrimSpace(label) == "" {
+				label = formatRequestLabel(pr.label)
+			}
+			if key.err != nil {
+				message := fmt.Sprintf("Unable to run %s: %v", label, key.err)
+				if duration > 0 {
+					message = fmt.Sprintf("%s (after %s)", message, formatElapsed(duration))
+				}
+				m.setStatus(message)
+			} else {
+				m.setStatus(fmt.Sprintf("%s written to %s in %s", label, key.outputFile, formatElapsed(duration)))
+			}
+		}
+		return m, tea.Batch(cmds...)
 	case spinner.TickMsg:
 		if m.pendingRequest.active {
 			var tickCmd tea.Cmd
@@ -3894,6 +4331,18 @@ func (m *bubbleModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:iretur
 		if key.String() == m.toggleKey {
 			m.showHelp = !m.showHelp
 			return m, nil
+		}
+		if !m.searchActive {
+			for _, action := range m.selectionActions {
+				if key.String() == strings.TrimSpace(action.Key) {
+					m.openSelectionAction(action)
+					tableHandled = true
+					break
+				}
+			}
+			if tableHandled {
+				break
+			}
 		}
 		if (key.String() == "t" || key.String() == "T") && !m.searchActive && len(m.availableThemes) > 0 {
 			n := len(m.availableThemes)
@@ -3946,6 +4395,7 @@ func (m *bubbleModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) { //nolint:iretur
 	case tea.WindowSizeMsg:
 		m.windowWidth = key.Width
 		m.windowHeight = key.Height
+		m.resizeActionDialogInput()
 		m.resizeDetailViews()
 
 		newTable, cmd := m.table.Update(msg)
@@ -4102,6 +4552,10 @@ func (m *bubbleModel) View() tea.View {
 			main = lipgloss.JoinHorizontal(lipgloss.Top, tableBox, detailBox)
 		}
 		sections = append(sections, main)
+	}
+
+	if dialog := strings.TrimSpace(m.renderSelectionActionDialog()); dialog != "" {
+		sections = append(sections, dialog)
 	}
 
 	widthHint := 0

--- a/internal/cmd/output/tableview/tableview_test.go
+++ b/internal/cmd/output/tableview/tableview_test.go
@@ -557,6 +557,71 @@ func sendKey(t *testing.T, model *bubbleModel, key string) *bubbleModel {
 	return bm
 }
 
+func sendSpecialKey(t *testing.T, model *bubbleModel, code rune, text string) (*bubbleModel, tea.Cmd) {
+	t.Helper()
+	msg := tea.KeyPressMsg{Text: text, Code: code}
+	updated, cmd := model.Update(msg)
+	bm, ok := updated.(*bubbleModel)
+	require.True(t, ok)
+	return bm, cmd
+}
+
+func TestSelectionActionDialogRunsWithCollectedValues(t *testing.T) {
+	model := newMinimalBubbleModel(t)
+
+	var captured SelectionContext
+	var ranWith SelectionActionValues
+	model.selectionActions = []SelectionAction{
+		{
+			Key:  "d",
+			Help: "dump selected resource",
+			Resolve: func(selection SelectionContext) (SelectionActionCommand, error) {
+				captured = selection
+				return SelectionActionCommand{
+					Title:               "Dump alpha",
+					Label:               "Dump alpha",
+					DefaultOutputFile:   "alpha.yaml",
+					DefaultNamespace:    "team-alpha",
+					IncludeChildrenText: "include child resources",
+					Run: func(values SelectionActionValues) error {
+						ranWith = values
+						return nil
+					},
+				}, nil
+			},
+		},
+	}
+
+	model = sendKey(t, model, "d")
+	require.NotNil(t, model.actionDialog)
+	require.Equal(t, "alpha", captured.Label)
+	require.Equal(t, table.Row{"alpha"}, captured.Row)
+	dialogView := ansi.Strip(model.renderSelectionActionDialog())
+	require.Regexp(t, `Output file:[ \t]+alpha.yaml`, dialogView)
+	require.Regexp(t, `Default namespace:[ \t]+team-alpha`, dialogView)
+
+	model, _ = sendSpecialKey(t, model, tea.KeyTab, "")
+	require.Equal(t, selectionActionFocusNamespace, model.actionDialog.focus)
+
+	model, _ = sendSpecialKey(t, model, tea.KeyTab, "")
+	require.Equal(t, selectionActionFocusIncludeChildren, model.actionDialog.focus)
+
+	model, _ = sendSpecialKey(t, model, tea.KeySpace, " ")
+	require.True(t, model.actionDialog.includeChildren)
+
+	var cmd tea.Cmd
+	model, cmd = sendSpecialKey(t, model, tea.KeyEnter, "")
+	require.NotNil(t, cmd)
+	model = executeCmd(t, model, cmd)
+
+	require.Nil(t, model.actionDialog)
+	require.Equal(t, "alpha.yaml", ranWith.OutputFile)
+	require.Equal(t, "team-alpha", ranWith.DefaultNamespace)
+	require.True(t, ranWith.IncludeChildren)
+	require.Contains(t, model.statusMessage, "Dump alpha")
+	require.Contains(t, model.statusMessage, "alpha.yaml")
+}
+
 func TestThemeCycling_AdvancesPaletteAndSetsStatus(t *testing.T) {
 	model := newMinimalBubbleModel(t)
 

--- a/internal/cmd/root/products/konnect/navigator/dump_action.go
+++ b/internal/cmd/root/products/konnect/navigator/dump_action.go
@@ -1,0 +1,186 @@
+package navigator
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"unicode"
+
+	cmdpkg "github.com/kong/kongctl/internal/cmd"
+	"github.com/kong/kongctl/internal/cmd/output/tableview"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
+	"github.com/kong/kongctl/internal/cmd/root/verbs/dump"
+)
+
+var dumpResourceByViewParent = map[string]string{
+	common.ViewParentAPI:                "apis",
+	common.ViewParentAnalyticsDashboard: "analytics.dashboards",
+	common.ViewParentAuthStrategy:       "application_auth_strategies",
+	common.ViewParentControlPlane:       "control_planes",
+	common.ViewParentDCRProvider:        "dcr_providers",
+	common.ViewParentEventGateway:       "event_gateways",
+	common.ViewParentPortal:             "portals",
+	common.ViewParentTeam:               "organization.teams",
+}
+
+var dumpResourceByNavigatorLabel = map[string]string{
+	common.ViewResourceAPIs:           "apis",
+	common.ViewResourceAuthStrategies: "application_auth_strategies",
+	common.ViewResourceControlPlanes:  "control_planes",
+	common.ViewResourceDCRProviders:   "dcr_providers",
+	common.ViewResourceEventGateways:  "event_gateways",
+	common.ViewResourcePortals:        "portals",
+}
+
+func newDumpSelectionAction(helper cmdpkg.Helper) tableview.SelectionAction {
+	return tableview.SelectionAction{
+		Key:  "d",
+		Help: "dump selected resource",
+		Resolve: func(selection tableview.SelectionContext) (tableview.SelectionActionCommand, error) {
+			resource, err := dumpResourceForSelection(selection)
+			if err != nil {
+				return tableview.SelectionActionCommand{}, err
+			}
+
+			resourceID := stringField(selection.Parent, "ID", "Id")
+			if selection.Parent != nil && resourceID == "" {
+				return tableview.SelectionActionCommand{}, fmt.Errorf("selected resource has no resolvable id")
+			}
+
+			label := strings.TrimSpace(selection.Label)
+			if label == "" {
+				label = resource
+			}
+			title := fmt.Sprintf("Dump %s", label)
+			return tableview.SelectionActionCommand{
+				Title:               title,
+				Label:               title,
+				DefaultOutputFile:   defaultDumpOutputFile(resource, label, resourceID),
+				IncludeChildrenText: "include child resources",
+				Run: func(values tableview.SelectionActionValues) error {
+					return dump.RunDeclarativeDump(helper, dump.DeclarativeDumpOptions{
+						Resources:             []string{resource},
+						OutputFile:            values.OutputFile,
+						DefaultNamespace:      values.DefaultNamespace,
+						IncludeChildResources: values.IncludeChildren,
+						FilterID:              resourceID,
+					})
+				},
+			}, nil
+		},
+	}
+}
+
+func dumpResourceForSelection(selection tableview.SelectionContext) (string, error) {
+	parentType := strings.ToLower(strings.TrimSpace(selection.ParentType))
+	if resource, ok := dumpResourceByViewParent[parentType]; ok {
+		return resource, nil
+	}
+
+	for _, candidate := range selectionCandidates(selection) {
+		key := strings.ToLower(strings.TrimSpace(candidate))
+		if resource, ok := dumpResourceByNavigatorLabel[key]; ok {
+			return resource, nil
+		}
+	}
+
+	label := strings.TrimSpace(selection.Label)
+	if label == "" {
+		label = strings.TrimSpace(selection.ParentType)
+	}
+	if label == "" {
+		label = "selection"
+	}
+	return "", fmt.Errorf("dump is not available for %s", label)
+}
+
+func selectionCandidates(selection tableview.SelectionContext) []string {
+	candidates := []string{selection.Label}
+	candidates = append(candidates, selection.Row...)
+	return candidates
+}
+
+func defaultDumpOutputFile(resource, label, id string) string {
+	resourceSlug := filenameSlug(resource)
+	if resourceSlug == "" {
+		resourceSlug = "resource"
+	}
+
+	targetSlug := filenameSlug(label)
+	if strings.TrimSpace(id) == "" {
+		return resourceSlug + ".yaml"
+	}
+	if targetSlug == "" || targetSlug == resourceSlug {
+		targetSlug = filenameSlug(shortResourceID(id))
+	}
+	if targetSlug == "" {
+		return resourceSlug + ".yaml"
+	}
+	return resourceSlug + "-" + targetSlug + ".yaml"
+}
+
+func filenameSlug(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var b strings.Builder
+	lastDash := false
+	for _, r := range value {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			b.WriteRune(r)
+			lastDash = false
+		case r == '.', r == '-', r == '_':
+			if !lastDash && b.Len() > 0 {
+				b.WriteRune('-')
+				lastDash = true
+			}
+		default:
+			if !lastDash && b.Len() > 0 {
+				b.WriteRune('-')
+				lastDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func shortResourceID(id string) string {
+	id = strings.TrimSpace(id)
+	if len(id) <= 12 {
+		return id
+	}
+	return id[:12]
+}
+
+func stringField(source any, fieldNames ...string) string {
+	value := reflect.ValueOf(source)
+	for value.IsValid() && (value.Kind() == reflect.Pointer || value.Kind() == reflect.Interface) {
+		if value.IsNil() {
+			return ""
+		}
+		value = value.Elem()
+	}
+	if !value.IsValid() || value.Kind() != reflect.Struct {
+		return ""
+	}
+
+	for _, name := range fieldNames {
+		field := value.FieldByName(name)
+		if result := stringValue(field); result != "" {
+			return result
+		}
+	}
+	return ""
+}
+
+func stringValue(value reflect.Value) string {
+	for value.IsValid() && (value.Kind() == reflect.Pointer || value.Kind() == reflect.Interface) {
+		if value.IsNil() {
+			return ""
+		}
+		value = value.Elem()
+	}
+	if !value.IsValid() || value.Kind() != reflect.String {
+		return ""
+	}
+	return strings.TrimSpace(value.String())
+}

--- a/internal/cmd/root/products/konnect/navigator/dump_action_test.go
+++ b/internal/cmd/root/products/konnect/navigator/dump_action_test.go
@@ -1,0 +1,61 @@
+package navigator
+
+import (
+	"testing"
+
+	"charm.land/bubbles/v2/table"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kong/kongctl/internal/cmd/output/tableview"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
+)
+
+func TestDumpResourceForSelectionUsesParentType(t *testing.T) {
+	resource, err := dumpResourceForSelection(tableview.SelectionContext{
+		ParentType: common.ViewParentAPI,
+		Label:      "Orders API",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "apis", resource)
+}
+
+func TestDumpResourceForSelectionUsesNavigatorResourceRow(t *testing.T) {
+	resource, err := dumpResourceForSelection(tableview.SelectionContext{
+		Row: table.Row{common.ViewResourceControlPlanes},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "control_planes", resource)
+}
+
+func TestDumpResourceForSelectionRejectsUnsupportedResource(t *testing.T) {
+	_, err := dumpResourceForSelection(tableview.SelectionContext{
+		Label: common.ViewResourceCatalogServices,
+		Row:   table.Row{common.ViewResourceCatalogServices},
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "dump is not available")
+}
+
+func TestStringFieldExtractsStringAndStringPointerIDs(t *testing.T) {
+	id := "12345678-1234-1234-1234-123456789012"
+
+	require.Equal(t, id, stringField(struct {
+		ID string
+	}{ID: id}, "ID"))
+	require.Equal(t, id, stringField(&struct {
+		ID *string
+	}{ID: &id}, "ID"))
+}
+
+func TestDefaultDumpOutputFile(t *testing.T) {
+	require.Equal(t, "apis.yaml", defaultDumpOutputFile("apis", "apis", ""))
+	require.Equal(t,
+		"control-planes-prod.yaml",
+		defaultDumpOutputFile("control_planes", "Prod", "12345678-1234-1234-1234-123456789012"))
+	require.Equal(t,
+		"event-gateways-12345678-123.yaml",
+		defaultDumpOutputFile("event_gateways", "", "12345678-1234-1234-1234-123456789012"))
+}

--- a/internal/cmd/root/products/konnect/navigator/navigator.go
+++ b/internal/cmd/root/products/konnect/navigator/navigator.go
@@ -145,6 +145,7 @@ func Run(helper cmd.Helper, opts Options) error {
 		tableview.WithDetailHelper(helper),
 		tableview.WithTitle("Konnect Resources"),
 		tableview.WithTableStretch(),
+		tableview.WithSelectionAction(newDumpSelectionAction(helper)),
 	}
 	if initialIndex >= 0 {
 		options = append(options, tableview.WithInitialRowSelection(initialIndex, needle != ""))

--- a/internal/cmd/root/verbs/dump/common.go
+++ b/internal/cmd/root/verbs/dump/common.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -61,8 +62,14 @@ func Int64(v int64) *int64 {
 }
 
 func getDumpWriter(helper cmdpkg.Helper, outputFile string) (io.Writer, func() error, error) {
-	if strings.TrimSpace(outputFile) != "" {
-		file, err := os.Create(outputFile)
+	outputFile = strings.TrimSpace(outputFile)
+	if outputFile != "" {
+		outputPath, err := expandUserPath(outputFile)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		file, err := os.Create(outputPath)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create output file: %w", err)
 		}
@@ -70,6 +77,25 @@ func getDumpWriter(helper cmdpkg.Helper, outputFile string) (io.Writer, func() e
 	}
 
 	return helper.GetStreams().Out, func() error { return nil }, nil
+}
+
+func expandUserPath(path string) (string, error) {
+	switch {
+	case path == "~":
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve home directory: %w", err)
+		}
+		return home, nil
+	case strings.HasPrefix(path, "~/"):
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve home directory: %w", err)
+		}
+		return filepath.Join(home, strings.TrimPrefix(path, "~/")), nil
+	default:
+		return path, nil
+	}
 }
 
 func parseResourceList(resources string) []string {

--- a/internal/cmd/root/verbs/dump/common_test.go
+++ b/internal/cmd/root/verbs/dump/common_test.go
@@ -1,0 +1,25 @@
+package dump
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDumpWriterExpandsHomeDirectory(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	require.NoError(t, os.Mkdir(filepath.Join(home, "kongctl"), 0o755))
+
+	writer, cleanup, err := getDumpWriter(nil, "~/kongctl/api.yaml")
+	require.NoError(t, err)
+	_, err = writer.Write([]byte("apis: []\n"))
+	require.NoError(t, err)
+	require.NoError(t, cleanup())
+
+	content, err := os.ReadFile(filepath.Join(home, "kongctl", "api.yaml"))
+	require.NoError(t, err)
+	require.Equal(t, "apis: []\n", string(content))
+}

--- a/internal/cmd/root/verbs/dump/declarative.go
+++ b/internal/cmd/root/verbs/dump/declarative.go
@@ -33,6 +33,16 @@ type declarativeOptions struct {
 	filter                filterOptions
 }
 
+// DeclarativeDumpOptions configures a declarative resource dump outside Cobra flag parsing.
+type DeclarativeDumpOptions struct {
+	Resources             []string
+	OutputFile            string
+	DefaultNamespace      string
+	IncludeChildResources bool
+	FilterName            string
+	FilterID              string
+}
+
 var declarativeAllowedResources = map[string]struct{}{
 	"portals":                     {},
 	resourceAPIs:                  {},
@@ -149,6 +159,33 @@ Setting this value overrides tokens obtained from the login command.
 	}
 
 	return cmd
+}
+
+// RunDeclarativeDump exports Konnect resources as kongctl declarative configuration.
+func RunDeclarativeDump(helper cmdpkg.Helper, opts DeclarativeDumpOptions) error {
+	resources, err := normalizeResourceList(strings.Join(opts.Resources, ","), declarativeAllowedResources)
+	if err != nil {
+		return err
+	}
+
+	declarativeOpts := declarativeOptions{
+		resources:             resources,
+		outputFile:            strings.TrimSpace(opts.OutputFile),
+		defaultNamespace:      strings.TrimSpace(opts.DefaultNamespace),
+		includeChildResources: opts.IncludeChildResources,
+		filter: filterOptions{
+			name: strings.TrimSpace(opts.FilterName),
+			id:   strings.TrimSpace(opts.FilterID),
+		},
+	}
+	if err := validateFilterOptions(declarativeOpts.filter); err != nil {
+		return err
+	}
+	if err := ensureNonNegativePageSize(helper); err != nil {
+		return err
+	}
+
+	return runDeclarativeDump(helper, declarativeOpts)
 }
 
 func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
@@ -745,6 +782,7 @@ func mapPortalToDeclarativeResource(portal kkComps.ListPortalsResponsePortal) de
 	if userLabels := decllabels.GetUserLabels(portal.GetLabels()); len(userLabels) > 0 {
 		result.Labels = decllabels.DenormalizeLabels(userLabels)
 	}
+	result.Kongctl = kongctlMetaFromLabels(portal.GetLabels())
 
 	return result
 }
@@ -789,6 +827,7 @@ func mapAPIToDeclarativeResource(api kkComps.APIResponseSchema) declresources.AP
 	if labels := decllabels.GetUserLabels(api.Labels); len(labels) > 0 {
 		result.Labels = labels
 	}
+	result.Kongctl = kongctlMetaFromLabels(api.Labels)
 
 	normalizeAPIResource(&result)
 
@@ -809,6 +848,7 @@ func mapDashboardToDeclarativeResource(dashboard kkComps.DashboardResponse) decl
 	if labels := decllabels.GetUserLabels(dashboard.Labels); len(labels) > 0 {
 		result.Labels = labels
 	}
+	result.Kongctl = kongctlMetaFromLabels(dashboard.Labels)
 
 	return result
 }
@@ -825,6 +865,7 @@ func mapEventGatewayToDeclarativeResource(egw kkComps.EventGatewayInfo) declreso
 	if labels := decllabels.GetUserLabels(egw.Labels); len(labels) > 0 {
 		result.Labels = labels
 	}
+	result.Kongctl = kongctlMetaFromLabels(egw.Labels)
 
 	return result
 }
@@ -842,18 +883,27 @@ func mapOrganizationTeamToDeclarativeResource(team kkComps.Team) declresources.O
 		result.Labels = labels
 	}
 
-	if ns := strings.TrimSpace(team.Labels[decllabels.NamespaceKey]); ns != "" {
-		result.Kongctl = &declresources.KongctlMeta{Namespace: stringPointer(ns)}
-	}
-	if team.Labels[decllabels.ProtectedKey] == decllabels.TrueValue {
-		if result.Kongctl == nil {
-			result.Kongctl = &declresources.KongctlMeta{}
-		}
-		protected := true
-		result.Kongctl.Protected = &protected
-	}
+	result.Kongctl = kongctlMetaFromLabels(team.Labels)
 
 	return result
+}
+
+func kongctlMetaFromLabels(labels map[string]string) *declresources.KongctlMeta {
+	namespace := strings.TrimSpace(labels[decllabels.NamespaceKey])
+	protected := labels[decllabels.ProtectedKey] == decllabels.TrueValue
+	if namespace == "" && !protected {
+		return nil
+	}
+
+	meta := &declresources.KongctlMeta{}
+	if namespace != "" {
+		meta.Namespace = stringPointer(namespace)
+	}
+	if protected {
+		value := true
+		meta.Protected = &value
+	}
+	return meta
 }
 
 func normalizeAPIResource(api *declresources.APIResource) {
@@ -1011,7 +1061,10 @@ func mapKeyAuthStrategyToDeclarativeResource(
 	}
 
 	resource := declresources.ApplicationAuthStrategyResource{
-		BaseResource:                 declresources.BaseResource{Ref: buildAuthStrategyRef(resp.ID, resp.Name)},
+		BaseResource: declresources.BaseResource{
+			Ref:     buildAuthStrategyRef(resp.ID, resp.Name),
+			Kongctl: kongctlMetaFromLabels(resp.Labels),
+		},
 		CreateAppAuthStrategyRequest: kkComps.CreateCreateAppAuthStrategyRequestKeyAuth(req),
 	}
 
@@ -1044,7 +1097,10 @@ func mapOIDCStrategyToDeclarativeResource(
 	}
 
 	resource := declresources.ApplicationAuthStrategyResource{
-		BaseResource:                 declresources.BaseResource{Ref: buildAuthStrategyRef(resp.ID, resp.Name)},
+		BaseResource: declresources.BaseResource{
+			Ref:     buildAuthStrategyRef(resp.ID, resp.Name),
+			Kongctl: kongctlMetaFromLabels(resp.Labels),
+		},
 		CreateAppAuthStrategyRequest: kkComps.CreateCreateAppAuthStrategyRequestOpenidConnect(req),
 	}
 
@@ -1129,7 +1185,10 @@ func mapDCRProviderToDeclarativeResource(data any) (declresources.DCRProviderRes
 	}
 
 	resource := declresources.DCRProviderResource{
-		BaseResource: declresources.BaseResource{Ref: buildDCRProviderRef(provider.ID, provider.Name)},
+		BaseResource: declresources.BaseResource{
+			Ref:     buildDCRProviderRef(provider.ID, provider.Name),
+			Kongctl: kongctlMetaFromLabels(provider.Labels),
+		},
 		Name:         provider.Name,
 		ProviderType: provider.ProviderType,
 		Issuer:       provider.Issuer,
@@ -1261,16 +1320,7 @@ func mapControlPlaneToDeclarativeResource(
 		mapped.Labels = userLabels
 	}
 
-	if ns := strings.TrimSpace(cp.Labels[decllabels.NamespaceKey]); ns != "" {
-		mapped.Kongctl = &declresources.KongctlMeta{Namespace: stringPointer(ns)}
-	}
-	if cp.Labels[decllabels.ProtectedKey] == decllabels.TrueValue {
-		if mapped.Kongctl == nil {
-			mapped.Kongctl = &declresources.KongctlMeta{}
-		}
-		protected := true
-		mapped.Kongctl.Protected = &protected
-	}
+	mapped.Kongctl = kongctlMetaFromLabels(cp.Labels)
 
 	if len(memberIDs) > 0 && cp.Config.ClusterType == kkComps.ControlPlaneClusterTypeClusterTypeControlPlaneGroup {
 		mapped.Members = make([]declresources.ControlPlaneGroupMember, 0, len(memberIDs))

--- a/internal/cmd/root/verbs/dump/dump_declarative_test.go
+++ b/internal/cmd/root/verbs/dump/dump_declarative_test.go
@@ -13,6 +13,39 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+func requireKongctlMeta(
+	t *testing.T,
+	meta *declresources.KongctlMeta,
+	wantNamespace string,
+	wantProtected bool,
+) {
+	t.Helper()
+
+	if meta == nil {
+		t.Fatalf("expected kongctl metadata")
+	}
+
+	if wantNamespace == "" {
+		if meta.Namespace != nil {
+			t.Fatalf("expected namespace to be omitted, got %q", *meta.Namespace)
+		}
+	} else if meta.Namespace == nil || *meta.Namespace != wantNamespace {
+		got := "<nil>"
+		if meta.Namespace != nil {
+			got = *meta.Namespace
+		}
+		t.Fatalf("expected namespace %q, got %q", wantNamespace, got)
+	}
+
+	if wantProtected {
+		if meta.Protected == nil || !*meta.Protected {
+			t.Fatalf("expected protected metadata to be true")
+		}
+	} else if meta.Protected != nil && *meta.Protected {
+		t.Fatalf("expected protected metadata to be omitted or false")
+	}
+}
+
 func TestMapPortalToDeclarativeResource(t *testing.T) {
 	description := "Portal description"
 	authID := "auth-strategy"
@@ -56,16 +89,22 @@ func TestMapPortalToDeclarativeResource(t *testing.T) {
 		t.Fatalf("expected description pointer with %q", description)
 	}
 
-	if resource.Kongctl != nil {
-		t.Fatalf("expected kongctl metadata to be omitted when namespace flag not provided")
-	}
+	requireKongctlMeta(t, resource.Kongctl, "team-alpha", true)
 
 	if resource.Labels == nil {
 		t.Fatalf("expected user labels to be preserved")
 	}
 
+	if len(resource.Labels) != 1 {
+		t.Fatalf("expected only user labels to remain, got %v", resource.Labels)
+	}
+
 	if _, exists := resource.Labels[decllabels.NamespaceKey]; exists {
 		t.Fatalf("expected namespace label to be stripped from user labels")
+	}
+
+	if _, exists := resource.Labels[decllabels.ProtectedKey]; exists {
+		t.Fatalf("expected protected label to be stripped from user labels")
 	}
 
 	if val, exists := resource.Labels["custom"]; !exists || val == nil || *val != "value" {
@@ -202,9 +241,7 @@ func TestMapAPIToDeclarativeResource(t *testing.T) {
 		t.Fatalf("expected slug pointer with %q", slug)
 	}
 
-	if resource.Kongctl != nil {
-		t.Fatalf("expected kongctl metadata to be omitted when namespace flag not provided")
-	}
+	requireKongctlMeta(t, resource.Kongctl, "team-beta", true)
 
 	if len(resource.Labels) != 1 || resource.Labels["feature"] != "payments" {
 		t.Fatalf("expected only user labels to remain, got %v", resource.Labels)
@@ -239,6 +276,8 @@ func TestMapDashboardToDeclarativeResource(t *testing.T) {
 	if resource.Definition.Tiles == nil || len(resource.Definition.Tiles) != 0 {
 		t.Fatalf("expected definition tiles to be preserved, got %v", resource.Definition.Tiles)
 	}
+
+	requireKongctlMeta(t, resource.Kongctl, "team-alpha", true)
 
 	if len(resource.Labels) != 1 || resource.Labels["team"] != "platform" {
 		t.Fatalf("expected only user labels to remain, got %v", resource.Labels)
@@ -303,9 +342,7 @@ func TestMapAuthStrategyToDeclarativeResource_KeyAuth(t *testing.T) {
 		t.Fatalf("expected key names to be preserved, got %v", configs)
 	}
 
-	if resource.Kongctl != nil {
-		t.Fatalf("expected kongctl metadata to be omitted for key auth strategy")
-	}
+	requireKongctlMeta(t, resource.Kongctl, "default", false)
 
 	labels := resource.AppAuthStrategyKeyAuthRequest.Labels
 	if len(labels) != 1 || labels["tier"] != "gold" {
@@ -378,9 +415,7 @@ func TestMapAuthStrategyToDeclarativeResource_OIDC(t *testing.T) {
 		t.Fatalf("expected only user labels to remain, got %v", labels)
 	}
 
-	if resource.Kongctl != nil {
-		t.Fatalf("expected kongctl metadata to be omitted for oidc strategy")
-	}
+	requireKongctlMeta(t, resource.Kongctl, "default", false)
 
 	yamlBytes, err := yaml.Marshal(resource)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Add a reusable tableview selection action dialog for the Konnect view TUI.
- Wire the `d` shortcut to run `dump declarative` for the selected resource, including output file, default namespace, and child-resource options.
- Preserve existing `KONGCTL-namespace` / `KONGCTL-protected` labels as declarative `kongctl` metadata during dump, while keeping user labels clean.
- Expand `~/...` output paths before creating dump files.

## Validation

- `go test ./internal/cmd/root/verbs/dump ./internal/cmd/output/tableview ./internal/cmd/root/products/konnect/navigator`
- `golangci-lint run ./internal/cmd/root/verbs/dump ./internal/cmd/output/tableview ./internal/cmd/root/products/konnect/navigator`
- `make build`
- `make test`

Full `make lint` was also checked and currently reports unrelated existing findings in generated portal client code and mocks.

Closes #1104