### PR TITLE
feat(declarative): add remote file URL support

### DIFF
--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -132,7 +132,8 @@ kongctl apply \
 
 Remote files are saved into the directory using the filename from each URL path.
 If multiple remote URLs would save to the same filename, the command fails
-before fetching them.
+before fetching them. Existing files are left intact by default. Use
+`--save-dir-overwrite` with `--save-dir` to replace existing saved files.
 
 When `--remote-file-auth=auto` is enabled, which is the default, `kongctl`
 sends the current profile's Konnect bearer token only to HTTPS remote sources

--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -121,19 +121,20 @@ kongctl apply -f https://get.konghq.com/example-kongctl.yaml
 ```
 
 To save remote files locally and run the command from the saved copies in one
-operation, use `--save-dir`:
+operation, use `--remote-file-save-dir` or its shorthand, `-s`:
 
 ```shell
 kongctl apply \
   -f https://get.konghq.com/portal.yaml \
   -f https://get.konghq.com/api.yaml \
-  --save-dir ./kongctl-example
+  --remote-file-save-dir ./kongctl-example
 ```
 
 Remote files are saved into the directory using the filename from each URL path.
 If multiple remote URLs would save to the same filename, the command fails
 before fetching them. Existing files are left intact by default. Use
-`--save-dir-overwrite` with `--save-dir` to replace existing saved files.
+`--remote-file-save-force` with `--remote-file-save-dir` to replace existing
+saved files.
 
 When `--remote-file-auth=auto` is enabled, which is the default, `kongctl`
 sends the current profile's Konnect bearer token only to HTTPS remote sources
@@ -577,8 +578,8 @@ current working directory. Set the base directory with `--base-dir` or
 `konnect.declarative.base-dir`
 (`KONGCTL_<PROFILE>_KONNECT_DECLARATIVE_BASE_DIR`, for example
 `KONGCTL_DEFAULT_KONNECT_DECLARATIVE_BASE_DIR`). When URL sources are loaded
-with `--save-dir`, subsequent relative paths are resolved like normal file
-sources from the save directory.
+with `--remote-file-save-dir`, subsequent relative paths are resolved like
+normal file sources from the save directory.
 
 ```yaml
 # ❌ These will fail with security errors

--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -120,14 +120,19 @@ You can also load a single configuration file from an HTTP or HTTPS URL:
 kongctl apply -f https://get.konghq.com/example-kongctl.yaml
 ```
 
-To save that remote file locally and run the command from the saved copy in one
-operation, use `--save-as`:
+To save remote files locally and run the command from the saved copies in one
+operation, use `--save-dir`:
 
 ```shell
 kongctl apply \
-  -f https://get.konghq.com/example-kongctl.yaml \
-  --save-as ./example-kongctl.yaml
+  -f https://get.konghq.com/portal.yaml \
+  -f https://get.konghq.com/api.yaml \
+  --save-dir ./kongctl-example
 ```
+
+Remote files are saved into the directory using the filename from each URL path.
+If multiple remote URLs would save to the same filename, the command fails
+before fetching them.
 
 When `--remote-file-auth=auto` is enabled, which is the default, `kongctl`
 sends the current profile's Konnect bearer token only to HTTPS remote sources
@@ -570,9 +575,9 @@ directory itself). For stdin and URL sources, the boundary defaults to the
 current working directory. Set the base directory with `--base-dir` or
 `konnect.declarative.base-dir`
 (`KONGCTL_<PROFILE>_KONNECT_DECLARATIVE_BASE_DIR`, for example
-`KONGCTL_DEFAULT_KONNECT_DECLARATIVE_BASE_DIR`). When a URL source is loaded
-with `--save-as`, subsequent relative paths are resolved like a normal file
-source from the saved file's directory.
+`KONGCTL_DEFAULT_KONNECT_DECLARATIVE_BASE_DIR`). When URL sources are loaded
+with `--save-dir`, subsequent relative paths are resolved like normal file
+sources from the save directory.
 
 ```yaml
 # ❌ These will fail with security errors

--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -133,8 +133,8 @@ kongctl apply \
 Remote files are saved into the directory using the filename from each URL path.
 If multiple remote URLs would save to the same filename, the command fails
 before fetching them. Existing files are left intact by default. Use
-`--remote-file-save-force` with `--remote-file-save-dir` to replace existing
-saved files.
+`--remote-file-save-force` or `-F` with `--remote-file-save-dir` to replace
+existing saved files.
 
 When `--remote-file-auth=auto` is enabled, which is the default, `kongctl`
 sends the current profile's Konnect bearer token only to HTTPS remote sources

--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -114,6 +114,31 @@ Apply configuration:
 kongctl apply -f portal.yaml
 ```
 
+You can also load a single configuration file from an HTTP or HTTPS URL:
+
+```shell
+kongctl apply -f https://get.konghq.com/example-kongctl.yaml
+```
+
+To save that remote file locally and run the command from the saved copy in one
+operation, use `--save-as`:
+
+```shell
+kongctl apply \
+  -f https://get.konghq.com/example-kongctl.yaml \
+  --save-as ./example-kongctl.yaml
+```
+
+When `--remote-file-auth=auto` is enabled, which is the default, `kongctl`
+sends the current profile's Konnect bearer token only to HTTPS remote sources
+on Konnect hosts, such as `*.cloud.konghq.com` or the configured Konnect API
+host. Authentication is never sent to arbitrary hosts. Use
+`--remote-file-auth=none` to fetch a remote file without adding Konnect
+authentication headers.
+
+Review remote configuration before running mutating commands in production.
+Prefer HTTPS URLs and pin examples to immutable versions when using them in CI.
+
 Verify resources with `kongctl get` commands:
 
 ```shell
@@ -540,10 +565,14 @@ Supported file types: Any text file (`.txt`, `.md`, `.yaml`, `.json`, etc.)
 
 **Path Traversal Prevention**: Absolute paths are blocked. Relative paths may include
 `..`, but the resolved path must stay within the base directory boundary. By default,
-the boundary is the root of each `-f` source (file: its parent dir, dir: the directory itself).
-For stdin, the boundary defaults to the current working directory. Set the base directory with
-`--base-dir` or `konnect.declarative.base-dir` (`KONGCTL_<PROFILE>_KONNECT_DECLARATIVE_BASE_DIR`,
-for example `KONGCTL_DEFAULT_KONNECT_DECLARATIVE_BASE_DIR`).
+the boundary is the root of each `-f` source (file: its parent dir, dir: the
+directory itself). For stdin and URL sources, the boundary defaults to the
+current working directory. Set the base directory with `--base-dir` or
+`konnect.declarative.base-dir`
+(`KONGCTL_<PROFILE>_KONNECT_DECLARATIVE_BASE_DIR`, for example
+`KONGCTL_DEFAULT_KONNECT_DECLARATIVE_BASE_DIR`). When a URL source is loaded
+with `--save-as`, subsequent relative paths are resolved like a normal file
+source from the saved file's directory.
 
 ```yaml
 # ❌ These will fail with security errors

--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	pathpkg "path"
 	"path/filepath"
 	"reflect"
 	"slices"
@@ -52,8 +53,8 @@ const (
 	requireNamespaceConfigPath = "konnect.declarative." + requireNamespaceFlagName
 	// baseDirFlagName is the CLI flag for the !file base directory boundary
 	baseDirFlagName = "base-dir"
-	// saveAsFlagName is the CLI flag for saving a remote declarative source locally before loading
-	saveAsFlagName = "save-as"
+	// saveDirFlagName is the CLI flag for saving remote declarative sources locally before loading
+	saveDirFlagName = "save-dir"
 	// remoteFileAuthFlagName is the CLI flag for remote URL source authentication
 	remoteFileAuthFlagName = "remote-file-auth"
 	// baseDirConfigPath is the config path backing the base-dir flag
@@ -88,13 +89,13 @@ func parseDeclarativeSources(filenames []string) ([]loader.Source, error) {
 }
 
 func validateSourcesForCommand(command *cobra.Command, planFile string, filenames []string) error {
-	_, saveAsSet, err := saveAsPathFromCommand(command)
+	saveDir, saveDirSet, err := saveDirPathFromCommand(command)
 	if err != nil {
 		return err
 	}
 	if planFile != "" {
-		if saveAsSet {
-			return fmt.Errorf("--%s cannot be used with --plan", saveAsFlagName)
+		if saveDirSet {
+			return fmt.Errorf("--%s cannot be used with --plan", saveDirFlagName)
 		}
 		return nil
 	}
@@ -103,8 +104,10 @@ func validateSourcesForCommand(command *cobra.Command, planFile string, filename
 	if err != nil {
 		return err
 	}
-	if saveAsSet && (len(sources) != 1 || sources[0].Type != loader.SourceTypeURL) {
-		return fmt.Errorf("--%s requires exactly one URL source from -f/--filename", saveAsFlagName)
+	if saveDirSet {
+		if _, err := remoteSourceSaveTargets(sources, saveDir); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -118,13 +121,13 @@ func sourcesForCommand(
 	cfg config.Hook,
 	logger *slog.Logger,
 ) ([]loader.Source, loader.URLFetchOptions, error) {
-	saveAsPath, saveAsSet, err := saveAsPathFromCommand(command)
+	saveDir, saveDirSet, err := saveDirPathFromCommand(command)
 	if err != nil {
 		return nil, loader.URLFetchOptions{}, err
 	}
 	if planFile != "" {
-		if saveAsSet {
-			return nil, loader.URLFetchOptions{}, fmt.Errorf("--%s cannot be used with --plan", saveAsFlagName)
+		if saveDirSet {
+			return nil, loader.URLFetchOptions{}, fmt.Errorf("--%s cannot be used with --plan", saveDirFlagName)
 		}
 		return nil, loader.URLFetchOptions{}, nil
 	}
@@ -136,56 +139,141 @@ func sourcesForCommand(
 	if err != nil {
 		return nil, loader.URLFetchOptions{}, err
 	}
-	sources, err = prepareRemoteDeclarativeSources(command, sources, saveAsPath, saveAsSet, fetchOptions)
+	sources, err = prepareSavedRemoteDeclarativeSources(command, sources, saveDir, saveDirSet, fetchOptions)
 	if err != nil {
 		return nil, loader.URLFetchOptions{}, err
 	}
 	return sources, fetchOptions, nil
 }
 
-func saveAsPathFromCommand(command *cobra.Command) (string, bool, error) {
-	if command == nil || command.Flags().Lookup(saveAsFlagName) == nil {
+func saveDirPathFromCommand(command *cobra.Command) (string, bool, error) {
+	if command == nil || command.Flags().Lookup(saveDirFlagName) == nil {
 		return "", false, nil
 	}
-	flag := command.Flags().Lookup(saveAsFlagName)
-	value, err := command.Flags().GetString(saveAsFlagName)
+	flag := command.Flags().Lookup(saveDirFlagName)
+	value, err := command.Flags().GetString(saveDirFlagName)
 	if err != nil {
-		return "", flag.Changed, fmt.Errorf("failed to parse --%s flag: %w", saveAsFlagName, err)
+		return "", flag.Changed, fmt.Errorf("failed to parse --%s flag: %w", saveDirFlagName, err)
 	}
 	if !flag.Changed {
 		return "", false, nil
 	}
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
-		return "", true, fmt.Errorf("--%s cannot be empty", saveAsFlagName)
+		return "", true, fmt.Errorf("--%s cannot be empty", saveDirFlagName)
 	}
 	return trimmed, true, nil
 }
 
-func prepareRemoteDeclarativeSources(
+type remoteSourceSaveTarget struct {
+	sourceIndex int
+	path        string
+}
+
+func prepareSavedRemoteDeclarativeSources(
 	command *cobra.Command,
 	sources []loader.Source,
-	saveAsPath string,
-	saveAsSet bool,
+	saveDir string,
+	saveDirSet bool,
 	fetchOptions loader.URLFetchOptions,
 ) ([]loader.Source, error) {
-	if !saveAsSet {
+	if !saveDirSet {
 		return sources, nil
 	}
-	if len(sources) != 1 || sources[0].Type != loader.SourceTypeURL {
-		return nil, fmt.Errorf("--%s requires exactly one URL source from -f/--filename", saveAsFlagName)
-	}
-
-	content, err := loader.FetchURLWithOptions(command.Context(), sources[0].Path, fetchOptions)
+	targets, err := remoteSourceSaveTargets(sources, saveDir)
 	if err != nil {
 		return nil, err
 	}
-	if err := writeRemoteSourceFile(saveAsPath, content); err != nil {
-		return nil, fmt.Errorf("failed to save remote source to %q: %w", saveAsPath, err)
+	if err := prepareSaveDir(saveDir, targets); err != nil {
+		return nil, err
 	}
 
-	fmt.Fprintf(command.ErrOrStderr(), "Saved remote source to: %s\n", saveAsPath)
-	return []loader.Source{{Path: saveAsPath, Type: loader.SourceTypeFile}}, nil
+	savedSources := slices.Clone(sources)
+	for _, target := range targets {
+		source := sources[target.sourceIndex]
+		content, err := loader.FetchURLWithOptions(command.Context(), source.Path, fetchOptions)
+		if err != nil {
+			return nil, err
+		}
+		if err := writeRemoteSourceFile(target.path, content); err != nil {
+			return nil, fmt.Errorf("failed to save remote source to %q: %w", target.path, err)
+		}
+
+		fmt.Fprintf(command.ErrOrStderr(), "Saved remote source to: %s\n", target.path)
+		savedSources[target.sourceIndex] = loader.Source{Path: target.path, Type: loader.SourceTypeFile}
+	}
+
+	return savedSources, nil
+}
+
+func remoteSourceSaveTargets(sources []loader.Source, saveDir string) ([]remoteSourceSaveTarget, error) {
+	targets := make([]remoteSourceSaveTarget, 0)
+	filenames := make(map[string]string)
+	for idx, source := range sources {
+		if source.Type != loader.SourceTypeURL {
+			continue
+		}
+		filename, err := remoteSourceFilename(source.Path)
+		if err != nil {
+			return nil, err
+		}
+		if previousURL, ok := filenames[filename]; ok {
+			return nil, fmt.Errorf(
+				"cannot save remote sources: both %s and %s would save as %q",
+				previousURL,
+				source.Path,
+				filename,
+			)
+		}
+		filenames[filename] = source.Path
+		targets = append(targets, remoteSourceSaveTarget{
+			sourceIndex: idx,
+			path:        filepath.Join(saveDir, filename),
+		})
+	}
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("--%s requires at least one URL source from -f/--filename", saveDirFlagName)
+	}
+	return targets, nil
+}
+
+func remoteSourceFilename(rawURL string) (string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid URL %q: %w", rawURL, err)
+	}
+	if parsed.Path == "" || strings.HasSuffix(parsed.Path, "/") {
+		return "", fmt.Errorf("cannot save remote source %s: URL path must include a filename", rawURL)
+	}
+	filename := pathpkg.Base(parsed.Path)
+	if filename == "." || filename == ".." || filename == "" ||
+		strings.ContainsAny(filename, `/\`) || filepath.Base(filename) != filename {
+		return "", fmt.Errorf("cannot save remote source %s: URL path must include a valid filename", rawURL)
+	}
+	return filename, nil
+}
+
+func prepareSaveDir(saveDir string, targets []remoteSourceSaveTarget) error {
+	info, err := os.Stat(saveDir)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("failed to inspect save dir %q: %w", saveDir, err)
+		}
+		if err := os.MkdirAll(saveDir, 0o755); err != nil {
+			return fmt.Errorf("failed to create save dir %q: %w", saveDir, err)
+		}
+	} else if !info.IsDir() {
+		return fmt.Errorf("save dir %q is not a directory", saveDir)
+	}
+
+	for _, target := range targets {
+		if _, err := os.Stat(target.path); err == nil {
+			return fmt.Errorf("cannot save remote source to %q: file already exists", target.path)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("failed to inspect save target %q: %w", target.path, err)
+		}
+	}
+	return nil
 }
 
 func writeRemoteSourceFile(path string, content []byte) error {
@@ -240,9 +328,9 @@ Defaults to each -f source root (file: its parent dir, dir: the directory itself
 - Config path: [ %s ]`, baseDirConfigPath))
 }
 
-func addSaveAsFlag(cmd *cobra.Command) {
-	cmd.Flags().String(saveAsFlagName, "",
-		"Save a single remote -f URL source to this local file before loading")
+func addSaveDirFlag(cmd *cobra.Command) {
+	cmd.Flags().String(saveDirFlagName, "",
+		"Save remote -f URL sources into this local directory before loading")
 }
 
 func addRemoteFileAuthFlag(cmd *cobra.Command) {
@@ -663,8 +751,11 @@ func declarativeApplyExamples() string {
   # Apply using the explicit Konnect target form
   %[1]s apply konnect -f api.yaml
 
-  # Apply a remote example and save it locally for future edits
-  %[1]s apply -f https://get.konghq.com/example-kongctl.yaml --save-as ./example-kongctl.yaml
+  # Apply remote examples and save them locally for future edits
+  %[1]s apply \
+    -f https://get.konghq.com/portal.yaml \
+    -f https://get.konghq.com/api.yaml \
+    --save-dir ./kongctl-example
 
   # Apply from a pre-generated plan
   %[1]s apply --plan plan.json`, meta.CLIName))
@@ -701,7 +792,7 @@ Konnect is the default target for this command, so "kongctl plan" and
 		"File, directory, URL, or '-' to use to create the resource (can specify multiple)")
 	cmd.Flags().BoolP("recursive", "R", false,
 		"Process the directory used in -f, --filename recursively")
-	addSaveAsFlag(cmd)
+	addSaveDirFlag(cmd)
 	addRemoteFileAuthFlag(cmd)
 	addBaseDirFlag(cmd)
 	cmd.Flags().String("output-file", "", "Save plan artifact to file")
@@ -1612,7 +1703,7 @@ Konnect is the default target for this command, so "kongctl sync" and
 		"File, directory, URL, or '-' to use to create the resource (can specify multiple)")
 	cmd.Flags().BoolP("recursive", "R", false,
 		"Process the directory used in -f, --filename recursively")
-	addSaveAsFlag(cmd)
+	addSaveDirFlag(cmd)
 	addRemoteFileAuthFlag(cmd)
 	addBaseDirFlag(cmd)
 	cmd.Flags().String("plan", "", "Path to existing plan file")
@@ -1647,7 +1738,7 @@ Konnect is the default target for this command, so "kongctl diff" and
 		"File, directory, URL, or '-' to use to create the resource (can specify multiple)")
 	cmd.Flags().BoolP("recursive", "R", false,
 		"Process the directory used in -f, --filename recursively")
-	addSaveAsFlag(cmd)
+	addSaveDirFlag(cmd)
 	addRemoteFileAuthFlag(cmd)
 	addBaseDirFlag(cmd)
 	cmd.Flags().String("plan", "", "Path to existing plan file to display")
@@ -2128,7 +2219,7 @@ Konnect is the default target for this command, so "kongctl apply" and
 		"File, directory, URL, or '-' to use to create the resource (can specify multiple)")
 	cmd.Flags().BoolP("recursive", "R", false,
 		"Process the directory used in -f, --filename recursively")
-	addSaveAsFlag(cmd)
+	addSaveDirFlag(cmd)
 	addRemoteFileAuthFlag(cmd)
 	addBaseDirFlag(cmd)
 	cmd.Flags().String("plan", "", "Path to existing plan file")
@@ -2164,7 +2255,7 @@ This is equivalent to running:
 		"File, directory, URL, or '-' to use to create the resource (can specify multiple)")
 	cmd.Flags().BoolP("recursive", "R", false,
 		"Process the directory used in -f, --filename recursively")
-	addSaveAsFlag(cmd)
+	addSaveDirFlag(cmd)
 	addRemoteFileAuthFlag(cmd)
 	addBaseDirFlag(cmd)
 	cmd.Flags().String("plan", "", "Path to existing delete plan file")

--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -51,8 +52,16 @@ const (
 	requireNamespaceConfigPath = "konnect.declarative." + requireNamespaceFlagName
 	// baseDirFlagName is the CLI flag for the !file base directory boundary
 	baseDirFlagName = "base-dir"
+	// saveAsFlagName is the CLI flag for saving a remote declarative source locally before loading
+	saveAsFlagName = "save-as"
+	// remoteFileAuthFlagName is the CLI flag for remote URL source authentication
+	remoteFileAuthFlagName = "remote-file-auth"
 	// baseDirConfigPath is the config path backing the base-dir flag
 	baseDirConfigPath = "konnect.declarative." + baseDirFlagName
+	// remoteFileAuthConfigPath is the config path backing the remote-file-auth flag
+	remoteFileAuthConfigPath = "konnect.declarative." + remoteFileAuthFlagName
+	// remoteFileAuthHostsConfigPath is the config path for extra remote URL authentication hosts
+	remoteFileAuthHostsConfigPath = "konnect.declarative.remote-file-auth-hosts"
 	// requireAnyNamespaceFlagName is the CLI flag for requiring any namespace
 	requireAnyNamespaceFlagName = "require-any-namespace"
 	// requireAnyNamespaceConfigPath is the config path backing the any namespace flag
@@ -61,6 +70,8 @@ const (
 	maxConcurrencyFlagName = "max-concurrency"
 	// maxConcurrencyConfigPath is the config path backing the max concurrency flag
 	maxConcurrencyConfigPath = "konnect.declarative." + maxConcurrencyFlagName
+
+	defaultRemoteFileAuthHost = "cloud.konghq.com"
 )
 
 const diffFieldRedactedValue = "[REDACTED]"
@@ -76,13 +87,124 @@ func parseDeclarativeSources(filenames []string) ([]loader.Source, error) {
 	return sources, nil
 }
 
+func validateSourcesForCommand(command *cobra.Command, planFile string, filenames []string) error {
+	_, saveAsSet, err := saveAsPathFromCommand(command)
+	if err != nil {
+		return err
+	}
+	if planFile != "" {
+		if saveAsSet {
+			return fmt.Errorf("--%s cannot be used with --plan", saveAsFlagName)
+		}
+		return nil
+	}
+
+	sources, err := parseDeclarativeSources(filenames)
+	if err != nil {
+		return err
+	}
+	if saveAsSet && (len(sources) != 1 || sources[0].Type != loader.SourceTypeURL) {
+		return fmt.Errorf("--%s requires exactly one URL source from -f/--filename", saveAsFlagName)
+	}
+	return nil
+}
+
 // sourcesForCommand returns parsed sources when no plan file is provided.
 // When planFile is non-empty (run from a saved plan) sources are not needed.
-func sourcesForCommand(planFile string, filenames []string) ([]loader.Source, error) {
-	if planFile != "" {
-		return nil, nil
+func sourcesForCommand(
+	command *cobra.Command,
+	planFile string,
+	filenames []string,
+	cfg config.Hook,
+	logger *slog.Logger,
+) ([]loader.Source, loader.URLFetchOptions, error) {
+	saveAsPath, saveAsSet, err := saveAsPathFromCommand(command)
+	if err != nil {
+		return nil, loader.URLFetchOptions{}, err
 	}
-	return parseDeclarativeSources(filenames)
+	if planFile != "" {
+		if saveAsSet {
+			return nil, loader.URLFetchOptions{}, fmt.Errorf("--%s cannot be used with --plan", saveAsFlagName)
+		}
+		return nil, loader.URLFetchOptions{}, nil
+	}
+	sources, err := parseDeclarativeSources(filenames)
+	if err != nil {
+		return nil, loader.URLFetchOptions{}, err
+	}
+	fetchOptions, err := remoteFileFetchOptionsForSources(command, cfg, logger, sources)
+	if err != nil {
+		return nil, loader.URLFetchOptions{}, err
+	}
+	sources, err = prepareRemoteDeclarativeSources(command, sources, saveAsPath, saveAsSet, fetchOptions)
+	if err != nil {
+		return nil, loader.URLFetchOptions{}, err
+	}
+	return sources, fetchOptions, nil
+}
+
+func saveAsPathFromCommand(command *cobra.Command) (string, bool, error) {
+	if command == nil || command.Flags().Lookup(saveAsFlagName) == nil {
+		return "", false, nil
+	}
+	flag := command.Flags().Lookup(saveAsFlagName)
+	value, err := command.Flags().GetString(saveAsFlagName)
+	if err != nil {
+		return "", flag.Changed, fmt.Errorf("failed to parse --%s flag: %w", saveAsFlagName, err)
+	}
+	if !flag.Changed {
+		return "", false, nil
+	}
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", true, fmt.Errorf("--%s cannot be empty", saveAsFlagName)
+	}
+	return trimmed, true, nil
+}
+
+func prepareRemoteDeclarativeSources(
+	command *cobra.Command,
+	sources []loader.Source,
+	saveAsPath string,
+	saveAsSet bool,
+	fetchOptions loader.URLFetchOptions,
+) ([]loader.Source, error) {
+	if !saveAsSet {
+		return sources, nil
+	}
+	if len(sources) != 1 || sources[0].Type != loader.SourceTypeURL {
+		return nil, fmt.Errorf("--%s requires exactly one URL source from -f/--filename", saveAsFlagName)
+	}
+
+	content, err := loader.FetchURLWithOptions(command.Context(), sources[0].Path, fetchOptions)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeRemoteSourceFile(saveAsPath, content); err != nil {
+		return nil, fmt.Errorf("failed to save remote source to %q: %w", saveAsPath, err)
+	}
+
+	fmt.Fprintf(command.ErrOrStderr(), "Saved remote source to: %s\n", saveAsPath)
+	return []loader.Source{{Path: saveAsPath, Type: loader.SourceTypeFile}}, nil
+}
+
+func writeRemoteSourceFile(path string, content []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := tmp.Write(content); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
 }
 
 var diffSensitiveExactFieldKeys = map[string]struct{}{
@@ -114,8 +236,20 @@ var diffNonSensitiveTokenFieldKeys = map[string]struct{}{
 func addBaseDirFlag(cmd *cobra.Command) {
 	cmd.Flags().String(baseDirFlagName, "",
 		fmt.Sprintf(`Base directory boundary for !file resolution.
-Defaults to each -f source root (file: its parent dir, dir: the directory itself). For stdin, defaults to CWD.
+Defaults to each -f source root (file: its parent dir, dir: the directory itself). For stdin and URLs, defaults to CWD.
 - Config path: [ %s ]`, baseDirConfigPath))
+}
+
+func addSaveAsFlag(cmd *cobra.Command) {
+	cmd.Flags().String(saveAsFlagName, "",
+		"Save a single remote -f URL source to this local file before loading")
+}
+
+func addRemoteFileAuthFlag(cmd *cobra.Command) {
+	cmd.Flags().String(remoteFileAuthFlagName, string(loader.URLFetchAuthAuto),
+		fmt.Sprintf(`Authentication mode for remote -f URL sources (auto|none).
+In auto mode, kongctl sends the current Konnect bearer token only to HTTPS Konnect hosts.
+- Config path: [ %s ]`, remoteFileAuthConfigPath))
 }
 
 func addMaxConcurrencyFlag(cmd *cobra.Command) {
@@ -200,19 +334,143 @@ func normalizeBaseDir(baseDir string) (string, error) {
 	return baseDir, nil
 }
 
-func newDeclarativeLoader(command *cobra.Command, cfg config.Hook) (*loader.Loader, error) {
+func newDeclarativeLoader(
+	command *cobra.Command,
+	cfg config.Hook,
+	fetchOptions loader.URLFetchOptions,
+) (*loader.Loader, error) {
 	baseDir, err := resolveBaseDir(command, cfg)
 	if err != nil {
 		return nil, err
 	}
 	if baseDir == "" {
-		return loader.New(), nil
+		return loader.New().WithURLFetchOptions(fetchOptions), nil
 	}
 	baseDir, err = normalizeBaseDir(baseDir)
 	if err != nil {
 		return nil, err
 	}
-	return loader.NewWithBaseDir(baseDir), nil
+	return loader.NewWithBaseDir(baseDir).WithURLFetchOptions(fetchOptions), nil
+}
+
+func remoteFileFetchOptionsForSources(
+	command *cobra.Command,
+	cfg config.Hook,
+	logger *slog.Logger,
+	sources []loader.Source,
+) (loader.URLFetchOptions, error) {
+	policy, err := resolveRemoteFileAuthPolicy(command, cfg)
+	if err != nil {
+		return loader.URLFetchOptions{}, err
+	}
+
+	hosts, err := remoteFileAuthAllowedHosts(cfg)
+	if err != nil {
+		return loader.URLFetchOptions{}, err
+	}
+
+	options := loader.URLFetchOptions{
+		AuthPolicy:       policy,
+		AuthAllowedHosts: hosts,
+	}
+	if policy != loader.URLFetchAuthAuto || !remoteSourcesAllowAuthentication(sources, options) || cfg == nil {
+		return options, nil
+	}
+
+	tokenSource, err := konnectcommon.GetAccessTokenSource(cfg, logger)
+	if err != nil {
+		return loader.URLFetchOptions{}, err
+	}
+	options.TokenSource = tokenSource
+	return options, nil
+}
+
+func resolveRemoteFileAuthPolicy(command *cobra.Command, cfg config.Hook) (loader.URLFetchAuthPolicy, error) {
+	value := ""
+	if command != nil && command.Flags().Lookup(remoteFileAuthFlagName) != nil &&
+		command.Flags().Changed(remoteFileAuthFlagName) {
+		flagValue, err := command.Flags().GetString(remoteFileAuthFlagName)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse --%s flag: %w", remoteFileAuthFlagName, err)
+		}
+		value = flagValue
+	} else if cfg != nil {
+		value = cfg.GetString(remoteFileAuthConfigPath)
+	}
+
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		if command != nil && command.Flags().Lookup(remoteFileAuthFlagName) != nil &&
+			command.Flags().Changed(remoteFileAuthFlagName) {
+			return "", fmt.Errorf("--%s cannot be empty", remoteFileAuthFlagName)
+		}
+		return loader.URLFetchAuthAuto, nil
+	}
+
+	switch loader.URLFetchAuthPolicy(value) {
+	case loader.URLFetchAuthAuto, loader.URLFetchAuthNone:
+		return loader.URLFetchAuthPolicy(value), nil
+	default:
+		return "", fmt.Errorf("--%s must be one of: auto, none", remoteFileAuthFlagName)
+	}
+}
+
+func remoteFileAuthAllowedHosts(cfg config.Hook) ([]string, error) {
+	hosts := []string{defaultRemoteFileAuthHost}
+	if cfg == nil {
+		return hosts, nil
+	}
+
+	baseURL, err := konnectcommon.ResolveBaseURL(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if host := hostnameFromURL(baseURL); host != "" {
+		hosts = append(hosts, host)
+	}
+	hosts = append(hosts, cfg.GetStringSlice(remoteFileAuthHostsConfigPath)...)
+	return compactUniqueStrings(hosts), nil
+}
+
+func hostnameFromURL(rawURL string) string {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return ""
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Hostname() == "" {
+		parsed, err = url.Parse("https://" + rawURL)
+	}
+	if err != nil {
+		return ""
+	}
+	return parsed.Hostname()
+}
+
+func compactUniqueStrings(values []string) []string {
+	result := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+func remoteSourcesAllowAuthentication(sources []loader.Source, options loader.URLFetchOptions) bool {
+	for _, source := range sources {
+		if source.Type == loader.SourceTypeURL && options.AllowsAuthenticationForURL(source.Path) {
+			return true
+		}
+	}
+	return false
 }
 
 func parseNamespaceRequirement(
@@ -405,6 +663,9 @@ func declarativeApplyExamples() string {
   # Apply using the explicit Konnect target form
   %[1]s apply konnect -f api.yaml
 
+  # Apply a remote example and save it locally for future edits
+  %[1]s apply -f https://get.konghq.com/example-kongctl.yaml --save-as ./example-kongctl.yaml
+
   # Apply from a pre-generated plan
   %[1]s apply --plan plan.json`, meta.CLIName))
 }
@@ -437,9 +698,11 @@ Konnect is the default target for this command, so "kongctl plan" and
 
 	// Add declarative config flags
 	cmd.Flags().StringSliceP("filename", "f", []string{},
-		"Filename or directory to files to use to create the resource (can specify multiple)")
+		"File, directory, URL, or '-' to use to create the resource (can specify multiple)")
 	cmd.Flags().BoolP("recursive", "R", false,
 		"Process the directory used in -f, --filename recursively")
+	addSaveAsFlag(cmd)
+	addRemoteFileAuthFlag(cmd)
 	addBaseDirFlag(cmd)
 	cmd.Flags().String("output-file", "", "Save plan artifact to file")
 	cmd.Flags().String("mode", "sync", "Plan generation mode (sync|apply|delete)")
@@ -487,8 +750,7 @@ func runPlan(command *cobra.Command, args []string) error {
 	ctx = withDeclarativeHTTPLogContext(ctx, command, verbs.Plan, planMode)
 	command.SetContext(ctx)
 
-	sources, err := parseDeclarativeSources(filenames)
-	if err != nil {
+	if err := validateSourcesForCommand(command, "", filenames); err != nil {
 		return err
 	}
 
@@ -507,6 +769,11 @@ func runPlan(command *cobra.Command, args []string) error {
 		return err
 	}
 
+	sources, fetchOptions, err := sourcesForCommand(command, "", filenames, cfg, logger)
+	if err != nil {
+		return err
+	}
+
 	// Get Konnect SDK
 	kkClient, err := helper.GetKonnectSDK(cfg, logger)
 	if err != nil {
@@ -519,11 +786,11 @@ func runPlan(command *cobra.Command, args []string) error {
 	}
 
 	// Load configuration
-	ldr, err := newDeclarativeLoader(command, cfg)
+	ldr, err := newDeclarativeLoader(command, cfg, fetchOptions)
 	if err != nil {
 		return err
 	}
-	resourceSet, err := ldr.LoadFromSources(sources, recursive)
+	resourceSet, err := ldr.LoadFromSourcesWithContext(command.Context(), sources, recursive)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
@@ -799,13 +1066,21 @@ func runDiff(command *cobra.Command, args []string) error {
 	}
 
 	filenames, _ := command.Flags().GetStringSlice("filename")
-	sources, err := sourcesForCommand(planFile, filenames)
-	if err != nil {
+	if err := validateSourcesForCommand(command, planFile, filenames); err != nil {
 		return err
 	}
 
 	helper := cmd.BuildHelper(command, args)
 	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+
+	sources, fetchOptions, err := sourcesForCommand(command, planFile, filenames, cfg, logger)
 	if err != nil {
 		return err
 	}
@@ -833,21 +1108,16 @@ func runDiff(command *cobra.Command, args []string) error {
 		recursive, _ := command.Flags().GetBool("recursive")
 		generator := planGenerator(helper)
 
-		logger, err := helper.GetLogger()
-		if err != nil {
-			return err
-		}
-
 		kkClient, err := helper.GetKonnectSDK(cfg, logger)
 		if err != nil {
 			return fmt.Errorf("failed to initialize Konnect client: %w", err)
 		}
 
-		ldr, err := newDeclarativeLoader(command, cfg)
+		ldr, err := newDeclarativeLoader(command, cfg, fetchOptions)
 		if err != nil {
 			return err
 		}
-		resourceSet, err := ldr.LoadFromSources(sources, recursive)
+		resourceSet, err := ldr.LoadFromSourcesWithContext(command.Context(), sources, recursive)
 		if err != nil {
 			return fmt.Errorf("failed to load configuration: %w", err)
 		}
@@ -1339,9 +1609,11 @@ Konnect is the default target for this command, so "kongctl sync" and
 
 	// Add declarative config flags (matching apply command pattern)
 	cmd.Flags().StringSliceP("filename", "f", []string{},
-		"Filename or directory to files to use to create the resource (can specify multiple)")
+		"File, directory, URL, or '-' to use to create the resource (can specify multiple)")
 	cmd.Flags().BoolP("recursive", "R", false,
 		"Process the directory used in -f, --filename recursively")
+	addSaveAsFlag(cmd)
+	addRemoteFileAuthFlag(cmd)
 	addBaseDirFlag(cmd)
 	cmd.Flags().String("plan", "", "Path to existing plan file")
 	cmd.Flags().Bool("dry-run", false, "Preview changes without applying them")
@@ -1372,9 +1644,11 @@ Konnect is the default target for this command, so "kongctl diff" and
 
 	// Add declarative config flags
 	cmd.Flags().StringSliceP("filename", "f", []string{},
-		"Filename or directory to files to use to create the resource (can specify multiple)")
+		"File, directory, URL, or '-' to use to create the resource (can specify multiple)")
 	cmd.Flags().BoolP("recursive", "R", false,
 		"Process the directory used in -f, --filename recursively")
+	addSaveAsFlag(cmd)
+	addRemoteFileAuthFlag(cmd)
 	addBaseDirFlag(cmd)
 	cmd.Flags().String("plan", "", "Path to existing plan file to display")
 	cmd.Flags().String("mode", "sync", "Diff mode (sync|apply|delete)")
@@ -1438,8 +1712,7 @@ func runApply(command *cobra.Command, args []string) error {
 		usingStdinForInput = planFile == "-" || (planFile == "" && slices.Contains(filenames, "-"))
 	}
 
-	sources, err := sourcesForCommand(planFile, filenames)
-	if err != nil {
+	if err := validateSourcesForCommand(command, planFile, filenames); err != nil {
 		return err
 	}
 
@@ -1458,6 +1731,11 @@ func runApply(command *cobra.Command, args []string) error {
 	}
 	// Get logger
 	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+
+	sources, fetchOptions, err := sourcesForCommand(command, planFile, filenames, cfg, logger)
 	if err != nil {
 		return err
 	}
@@ -1502,11 +1780,11 @@ func runApply(command *cobra.Command, args []string) error {
 		recursive, _ := command.Flags().GetBool("recursive")
 
 		// Load configuration
-		ldr, err := newDeclarativeLoader(command, cfg)
+		ldr, err := newDeclarativeLoader(command, cfg, fetchOptions)
 		if err != nil {
 			return err
 		}
-		resourceSet, err := ldr.LoadFromSources(sources, recursive)
+		resourceSet, err := ldr.LoadFromSourcesWithContext(command.Context(), sources, recursive)
 		if err != nil {
 			return fmt.Errorf("failed to load configuration: %w", err)
 		}
@@ -1847,9 +2125,11 @@ Konnect is the default target for this command, so "kongctl apply" and
 
 	// Add declarative config flags
 	cmd.Flags().StringSliceP("filename", "f", []string{},
-		"Filename or directory to files to use to create the resource (can specify multiple)")
+		"File, directory, URL, or '-' to use to create the resource (can specify multiple)")
 	cmd.Flags().BoolP("recursive", "R", false,
 		"Process the directory used in -f, --filename recursively")
+	addSaveAsFlag(cmd)
+	addRemoteFileAuthFlag(cmd)
 	addBaseDirFlag(cmd)
 	cmd.Flags().String("plan", "", "Path to existing plan file")
 	cmd.Flags().Bool("dry-run", false, "Preview changes without applying")
@@ -1881,9 +2161,11 @@ This is equivalent to running:
 
 	// Add declarative config flags
 	cmd.Flags().StringSliceP("filename", "f", []string{},
-		"Filename or directory to files to use to create the resource (can specify multiple)")
+		"File, directory, URL, or '-' to use to create the resource (can specify multiple)")
 	cmd.Flags().BoolP("recursive", "R", false,
 		"Process the directory used in -f, --filename recursively")
+	addSaveAsFlag(cmd)
+	addRemoteFileAuthFlag(cmd)
 	addBaseDirFlag(cmd)
 	cmd.Flags().String("plan", "", "Path to existing delete plan file")
 	cmd.Flags().Bool("dry-run", false, "Preview deletions without executing them")
@@ -1921,8 +2203,7 @@ func runDelete(command *cobra.Command, args []string) error {
 		usingStdinForInput = planFile == "-" || (planFile == "" && slices.Contains(filenames, "-"))
 	}
 
-	sources, err := sourcesForCommand(planFile, filenames)
-	if err != nil {
+	if err := validateSourcesForCommand(command, planFile, filenames); err != nil {
 		return err
 	}
 
@@ -1942,6 +2223,11 @@ func runDelete(command *cobra.Command, args []string) error {
 
 	// Get logger
 	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+
+	sources, fetchOptions, err := sourcesForCommand(command, planFile, filenames, cfg, logger)
 	if err != nil {
 		return err
 	}
@@ -1983,11 +2269,11 @@ func runDelete(command *cobra.Command, args []string) error {
 		// Generate plan from configuration files
 		recursive, _ := command.Flags().GetBool("recursive")
 
-		ldr, err := newDeclarativeLoader(command, cfg)
+		ldr, err := newDeclarativeLoader(command, cfg, fetchOptions)
 		if err != nil {
 			return err
 		}
-		resourceSet, err := ldr.LoadFromSources(sources, recursive)
+		resourceSet, err := ldr.LoadFromSourcesWithContext(command.Context(), sources, recursive)
 		if err != nil {
 			return fmt.Errorf("failed to load configuration: %w", err)
 		}
@@ -2146,8 +2432,7 @@ func runSync(command *cobra.Command, args []string) error {
 		usingStdinForInput = planFile == "-" || (planFile == "" && slices.Contains(filenames, "-"))
 	}
 
-	sources, err := sourcesForCommand(planFile, filenames)
-	if err != nil {
+	if err := validateSourcesForCommand(command, planFile, filenames); err != nil {
 		return err
 	}
 
@@ -2167,6 +2452,11 @@ func runSync(command *cobra.Command, args []string) error {
 
 	// Get logger
 	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+
+	sources, fetchOptions, err := sourcesForCommand(command, planFile, filenames, cfg, logger)
 	if err != nil {
 		return err
 	}
@@ -2211,11 +2501,11 @@ func runSync(command *cobra.Command, args []string) error {
 		recursive, _ := command.Flags().GetBool("recursive")
 
 		// Load configuration
-		ldr, err := newDeclarativeLoader(command, cfg)
+		ldr, err := newDeclarativeLoader(command, cfg, fetchOptions)
 		if err != nil {
 			return err
 		}
-		resourceSet, err := ldr.LoadFromSources(sources, recursive)
+		resourceSet, err := ldr.LoadFromSourcesWithContext(command.Context(), sources, recursive)
 		if err != nil {
 			return fmt.Errorf("failed to load configuration: %w", err)
 		}

--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -53,10 +53,12 @@ const (
 	requireNamespaceConfigPath = "konnect.declarative." + requireNamespaceFlagName
 	// baseDirFlagName is the CLI flag for the !file base directory boundary
 	baseDirFlagName = "base-dir"
-	// saveDirFlagName is the CLI flag for saving remote declarative sources locally before loading
-	saveDirFlagName = "save-dir"
-	// saveDirOverwriteFlagName is the CLI flag for overwriting existing files in save-dir
-	saveDirOverwriteFlagName = "save-dir-overwrite"
+	// remoteFileSaveDirFlagName is the CLI flag for saving remote declarative sources locally before loading
+	remoteFileSaveDirFlagName = "remote-file-save-dir"
+	// remoteFileSaveDirFlagShort is the CLI shorthand flag for saving remote declarative sources locally
+	remoteFileSaveDirFlagShort = "s"
+	// remoteFileSaveForceFlagName is the CLI flag for overwriting existing files in remote-file-save-dir
+	remoteFileSaveForceFlagName = "remote-file-save-force"
 	// remoteFileAuthFlagName is the CLI flag for remote URL source authentication
 	remoteFileAuthFlagName = "remote-file-auth"
 	// baseDirConfigPath is the config path backing the base-dir flag
@@ -97,7 +99,7 @@ func validateSourcesForCommand(command *cobra.Command, planFile string, filename
 	}
 	if planFile != "" {
 		if saveDirSet {
-			return fmt.Errorf("--%s cannot be used with --plan", saveDirFlagName)
+			return fmt.Errorf("--%s cannot be used with --plan", remoteFileSaveDirFlagName)
 		}
 		return nil
 	}
@@ -123,13 +125,16 @@ func sourcesForCommand(
 	cfg config.Hook,
 	logger *slog.Logger,
 ) ([]loader.Source, loader.URLFetchOptions, error) {
-	saveDir, saveDirSet, saveDirOverwrite, err := saveDirOptionsFromCommand(command)
+	saveDir, saveDirSet, saveForce, err := saveDirOptionsFromCommand(command)
 	if err != nil {
 		return nil, loader.URLFetchOptions{}, err
 	}
 	if planFile != "" {
 		if saveDirSet {
-			return nil, loader.URLFetchOptions{}, fmt.Errorf("--%s cannot be used with --plan", saveDirFlagName)
+			return nil, loader.URLFetchOptions{}, fmt.Errorf(
+				"--%s cannot be used with --plan",
+				remoteFileSaveDirFlagName,
+			)
 		}
 		return nil, loader.URLFetchOptions{}, nil
 	}
@@ -146,7 +151,7 @@ func sourcesForCommand(
 		sources,
 		saveDir,
 		saveDirSet,
-		saveDirOverwrite,
+		saveForce,
 		fetchOptions,
 	)
 	if err != nil {
@@ -160,43 +165,47 @@ func saveDirOptionsFromCommand(command *cobra.Command) (string, bool, bool, erro
 	if err != nil {
 		return "", saveDirSet, false, err
 	}
-	overwrite, _, err := saveDirOverwriteFromCommand(command)
+	force, _, err := remoteFileSaveForceFromCommand(command)
 	if err != nil {
 		return "", saveDirSet, false, err
 	}
-	if overwrite && !saveDirSet {
-		return "", saveDirSet, overwrite, fmt.Errorf("--%s requires --%s", saveDirOverwriteFlagName, saveDirFlagName)
+	if force && !saveDirSet {
+		return "", saveDirSet, force, fmt.Errorf(
+			"--%s requires --%s",
+			remoteFileSaveForceFlagName,
+			remoteFileSaveDirFlagName,
+		)
 	}
-	return saveDir, saveDirSet, overwrite, nil
+	return saveDir, saveDirSet, force, nil
 }
 
 func saveDirPathFromCommand(command *cobra.Command) (string, bool, error) {
-	if command == nil || command.Flags().Lookup(saveDirFlagName) == nil {
+	if command == nil || command.Flags().Lookup(remoteFileSaveDirFlagName) == nil {
 		return "", false, nil
 	}
-	flag := command.Flags().Lookup(saveDirFlagName)
-	value, err := command.Flags().GetString(saveDirFlagName)
+	flag := command.Flags().Lookup(remoteFileSaveDirFlagName)
+	value, err := command.Flags().GetString(remoteFileSaveDirFlagName)
 	if err != nil {
-		return "", flag.Changed, fmt.Errorf("failed to parse --%s flag: %w", saveDirFlagName, err)
+		return "", flag.Changed, fmt.Errorf("failed to parse --%s flag: %w", remoteFileSaveDirFlagName, err)
 	}
 	if !flag.Changed {
 		return "", false, nil
 	}
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
-		return "", true, fmt.Errorf("--%s cannot be empty", saveDirFlagName)
+		return "", true, fmt.Errorf("--%s cannot be empty", remoteFileSaveDirFlagName)
 	}
 	return trimmed, true, nil
 }
 
-func saveDirOverwriteFromCommand(command *cobra.Command) (bool, bool, error) {
-	if command == nil || command.Flags().Lookup(saveDirOverwriteFlagName) == nil {
+func remoteFileSaveForceFromCommand(command *cobra.Command) (bool, bool, error) {
+	if command == nil || command.Flags().Lookup(remoteFileSaveForceFlagName) == nil {
 		return false, false, nil
 	}
-	flag := command.Flags().Lookup(saveDirOverwriteFlagName)
-	value, err := command.Flags().GetBool(saveDirOverwriteFlagName)
+	flag := command.Flags().Lookup(remoteFileSaveForceFlagName)
+	value, err := command.Flags().GetBool(remoteFileSaveForceFlagName)
 	if err != nil {
-		return false, flag.Changed, fmt.Errorf("failed to parse --%s flag: %w", saveDirOverwriteFlagName, err)
+		return false, flag.Changed, fmt.Errorf("failed to parse --%s flag: %w", remoteFileSaveForceFlagName, err)
 	}
 	return value, flag.Changed, nil
 }
@@ -211,7 +220,7 @@ func prepareSavedRemoteDeclarativeSources(
 	sources []loader.Source,
 	saveDir string,
 	saveDirSet bool,
-	saveDirOverwrite bool,
+	saveForce bool,
 	fetchOptions loader.URLFetchOptions,
 ) ([]loader.Source, error) {
 	if !saveDirSet {
@@ -221,7 +230,7 @@ func prepareSavedRemoteDeclarativeSources(
 	if err != nil {
 		return nil, err
 	}
-	if err := prepareSaveDir(saveDir, targets, saveDirOverwrite); err != nil {
+	if err := prepareSaveDir(saveDir, targets, saveForce); err != nil {
 		return nil, err
 	}
 
@@ -269,7 +278,7 @@ func remoteSourceSaveTargets(sources []loader.Source, saveDir string) ([]remoteS
 		})
 	}
 	if len(targets) == 0 {
-		return nil, fmt.Errorf("--%s requires at least one URL source from -f/--filename", saveDirFlagName)
+		return nil, fmt.Errorf("--%s requires at least one URL source from -f/--filename", remoteFileSaveDirFlagName)
 	}
 	return targets, nil
 }
@@ -372,10 +381,10 @@ Defaults to each -f source root (file: its parent dir, dir: the directory itself
 }
 
 func addSaveDirFlag(cmd *cobra.Command) {
-	cmd.Flags().String(saveDirFlagName, "",
+	cmd.Flags().StringP(remoteFileSaveDirFlagName, remoteFileSaveDirFlagShort, "",
 		"Save remote -f URL sources into this local directory before loading")
-	cmd.Flags().Bool(saveDirOverwriteFlagName, false,
-		"Overwrite existing files when saving remote -f URL sources with --save-dir")
+	cmd.Flags().Bool(remoteFileSaveForceFlagName, false,
+		"Overwrite existing files when saving remote -f URL sources with --remote-file-save-dir")
 }
 
 func addRemoteFileAuthFlag(cmd *cobra.Command) {
@@ -800,7 +809,7 @@ func declarativeApplyExamples() string {
   %[1]s apply \
     -f https://get.konghq.com/portal.yaml \
     -f https://get.konghq.com/api.yaml \
-    --save-dir ./kongctl-example
+    -s ./kongctl-example
 
   # Apply from a pre-generated plan
   %[1]s apply --plan plan.json`, meta.CLIName))

--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -59,6 +59,8 @@ const (
 	remoteFileSaveDirFlagShort = "s"
 	// remoteFileSaveForceFlagName is the CLI flag for overwriting existing files in remote-file-save-dir
 	remoteFileSaveForceFlagName = "remote-file-save-force"
+	// remoteFileSaveForceFlagShort is the CLI shorthand flag for overwriting saved remote files
+	remoteFileSaveForceFlagShort = "F"
 	// remoteFileAuthFlagName is the CLI flag for remote URL source authentication
 	remoteFileAuthFlagName = "remote-file-auth"
 	// baseDirConfigPath is the config path backing the base-dir flag
@@ -383,7 +385,7 @@ Defaults to each -f source root (file: its parent dir, dir: the directory itself
 func addSaveDirFlag(cmd *cobra.Command) {
 	cmd.Flags().StringP(remoteFileSaveDirFlagName, remoteFileSaveDirFlagShort, "",
 		"Save remote -f URL sources into this local directory before loading")
-	cmd.Flags().Bool(remoteFileSaveForceFlagName, false,
+	cmd.Flags().BoolP(remoteFileSaveForceFlagName, remoteFileSaveForceFlagShort, false,
 		"Overwrite existing files when saving remote -f URL sources with --remote-file-save-dir")
 }
 

--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -55,6 +55,8 @@ const (
 	baseDirFlagName = "base-dir"
 	// saveDirFlagName is the CLI flag for saving remote declarative sources locally before loading
 	saveDirFlagName = "save-dir"
+	// saveDirOverwriteFlagName is the CLI flag for overwriting existing files in save-dir
+	saveDirOverwriteFlagName = "save-dir-overwrite"
 	// remoteFileAuthFlagName is the CLI flag for remote URL source authentication
 	remoteFileAuthFlagName = "remote-file-auth"
 	// baseDirConfigPath is the config path backing the base-dir flag
@@ -89,7 +91,7 @@ func parseDeclarativeSources(filenames []string) ([]loader.Source, error) {
 }
 
 func validateSourcesForCommand(command *cobra.Command, planFile string, filenames []string) error {
-	saveDir, saveDirSet, err := saveDirPathFromCommand(command)
+	saveDir, saveDirSet, _, err := saveDirOptionsFromCommand(command)
 	if err != nil {
 		return err
 	}
@@ -121,7 +123,7 @@ func sourcesForCommand(
 	cfg config.Hook,
 	logger *slog.Logger,
 ) ([]loader.Source, loader.URLFetchOptions, error) {
-	saveDir, saveDirSet, err := saveDirPathFromCommand(command)
+	saveDir, saveDirSet, saveDirOverwrite, err := saveDirOptionsFromCommand(command)
 	if err != nil {
 		return nil, loader.URLFetchOptions{}, err
 	}
@@ -139,11 +141,33 @@ func sourcesForCommand(
 	if err != nil {
 		return nil, loader.URLFetchOptions{}, err
 	}
-	sources, err = prepareSavedRemoteDeclarativeSources(command, sources, saveDir, saveDirSet, fetchOptions)
+	sources, err = prepareSavedRemoteDeclarativeSources(
+		command,
+		sources,
+		saveDir,
+		saveDirSet,
+		saveDirOverwrite,
+		fetchOptions,
+	)
 	if err != nil {
 		return nil, loader.URLFetchOptions{}, err
 	}
 	return sources, fetchOptions, nil
+}
+
+func saveDirOptionsFromCommand(command *cobra.Command) (string, bool, bool, error) {
+	saveDir, saveDirSet, err := saveDirPathFromCommand(command)
+	if err != nil {
+		return "", saveDirSet, false, err
+	}
+	overwrite, _, err := saveDirOverwriteFromCommand(command)
+	if err != nil {
+		return "", saveDirSet, false, err
+	}
+	if overwrite && !saveDirSet {
+		return "", saveDirSet, overwrite, fmt.Errorf("--%s requires --%s", saveDirOverwriteFlagName, saveDirFlagName)
+	}
+	return saveDir, saveDirSet, overwrite, nil
 }
 
 func saveDirPathFromCommand(command *cobra.Command) (string, bool, error) {
@@ -165,6 +189,18 @@ func saveDirPathFromCommand(command *cobra.Command) (string, bool, error) {
 	return trimmed, true, nil
 }
 
+func saveDirOverwriteFromCommand(command *cobra.Command) (bool, bool, error) {
+	if command == nil || command.Flags().Lookup(saveDirOverwriteFlagName) == nil {
+		return false, false, nil
+	}
+	flag := command.Flags().Lookup(saveDirOverwriteFlagName)
+	value, err := command.Flags().GetBool(saveDirOverwriteFlagName)
+	if err != nil {
+		return false, flag.Changed, fmt.Errorf("failed to parse --%s flag: %w", saveDirOverwriteFlagName, err)
+	}
+	return value, flag.Changed, nil
+}
+
 type remoteSourceSaveTarget struct {
 	sourceIndex int
 	path        string
@@ -175,6 +211,7 @@ func prepareSavedRemoteDeclarativeSources(
 	sources []loader.Source,
 	saveDir string,
 	saveDirSet bool,
+	saveDirOverwrite bool,
 	fetchOptions loader.URLFetchOptions,
 ) ([]loader.Source, error) {
 	if !saveDirSet {
@@ -184,7 +221,7 @@ func prepareSavedRemoteDeclarativeSources(
 	if err != nil {
 		return nil, err
 	}
-	if err := prepareSaveDir(saveDir, targets); err != nil {
+	if err := prepareSaveDir(saveDir, targets, saveDirOverwrite); err != nil {
 		return nil, err
 	}
 
@@ -253,7 +290,7 @@ func remoteSourceFilename(rawURL string) (string, error) {
 	return filename, nil
 }
 
-func prepareSaveDir(saveDir string, targets []remoteSourceSaveTarget) error {
+func prepareSaveDir(saveDir string, targets []remoteSourceSaveTarget, overwrite bool) error {
 	info, err := os.Stat(saveDir)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
@@ -267,8 +304,14 @@ func prepareSaveDir(saveDir string, targets []remoteSourceSaveTarget) error {
 	}
 
 	for _, target := range targets {
-		if _, err := os.Stat(target.path); err == nil {
-			return fmt.Errorf("cannot save remote source to %q: file already exists", target.path)
+		info, err := os.Lstat(target.path)
+		if err == nil {
+			if !info.Mode().IsRegular() {
+				return fmt.Errorf("cannot save remote source to %q: target is not a regular file", target.path)
+			}
+			if !overwrite {
+				return fmt.Errorf("cannot save remote source to %q: file already exists", target.path)
+			}
 		} else if !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("failed to inspect save target %q: %w", target.path, err)
 		}
@@ -331,6 +374,8 @@ Defaults to each -f source root (file: its parent dir, dir: the directory itself
 func addSaveDirFlag(cmd *cobra.Command) {
 	cmd.Flags().String(saveDirFlagName, "",
 		"Save remote -f URL sources into this local directory before loading")
+	cmd.Flags().Bool(saveDirOverwriteFlagName, false,
+		"Overwrite existing files when saving remote -f URL sources with --save-dir")
 }
 
 func addRemoteFileAuthFlag(cmd *cobra.Command) {

--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -155,6 +155,7 @@ func sourcesForCommand(
 		saveDirSet,
 		saveForce,
 		fetchOptions,
+		logger,
 	)
 	if err != nil {
 		return nil, loader.URLFetchOptions{}, err
@@ -224,6 +225,7 @@ func prepareSavedRemoteDeclarativeSources(
 	saveDirSet bool,
 	saveForce bool,
 	fetchOptions loader.URLFetchOptions,
+	logger *slog.Logger,
 ) ([]loader.Source, error) {
 	if !saveDirSet {
 		return sources, nil
@@ -247,7 +249,9 @@ func prepareSavedRemoteDeclarativeSources(
 			return nil, fmt.Errorf("failed to save remote source to %q: %w", target.path, err)
 		}
 
-		fmt.Fprintf(command.ErrOrStderr(), "Saved remote source to: %s\n", target.path)
+		if logger != nil {
+			logger.Info("saved remote source", "path", target.path)
+		}
 		savedSources[target.sourceIndex] = loader.Source{Path: target.path, Type: loader.SourceTypeFile}
 	}
 

--- a/internal/cmd/root/products/konnect/declarative/declarative_test.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative_test.go
@@ -264,6 +264,10 @@ func TestDeclarativeCommandsExposeRemoteSourceFlags(t *testing.T) {
 			require.NotNil(t, saveDirFlag)
 			assert.Contains(t, saveDirFlag.Usage, "remote")
 
+			saveDirOverwriteFlag := tt.cmd.Flags().Lookup(saveDirOverwriteFlagName)
+			require.NotNil(t, saveDirOverwriteFlag)
+			assert.Contains(t, saveDirOverwriteFlag.Usage, "Overwrite")
+
 			remoteAuthFlag := tt.cmd.Flags().Lookup(remoteFileAuthFlagName)
 			require.NotNil(t, remoteAuthFlag)
 			assert.Contains(t, remoteAuthFlag.Usage, "auto|none")
@@ -463,6 +467,78 @@ func TestSourcesForCommand_SaveDir(t *testing.T) {
 		)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "file already exists")
+	})
+
+	t.Run("overwrites existing save target when requested", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, err := w.Write([]byte("portals: []\n"))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		saveDir := t.TempDir()
+		savePath := filepath.Join(saveDir, "config.yaml")
+		require.NoError(t, os.WriteFile(savePath, []byte("old content"), 0o600))
+		cmd := newDeclarativeApplyCmd()
+		require.NoError(t, cmd.Flags().Set(saveDirFlagName, saveDir))
+		require.NoError(t, cmd.Flags().Set(saveDirOverwriteFlagName, "true"))
+
+		sources, _, err := sourcesForCommand(
+			cmd,
+			"",
+			[]string{server.URL + "/config.yaml"},
+			testDeclarativeConfig(),
+			testDeclarativeLogger(),
+		)
+		require.NoError(t, err)
+		require.Len(t, sources, 1)
+		assert.Equal(t, loader.Source{Path: savePath, Type: loader.SourceTypeFile}, sources[0])
+
+		content, err := os.ReadFile(savePath)
+		require.NoError(t, err)
+		assert.Equal(t, "portals: []\n", string(content))
+	})
+
+	t.Run("rejects overwrite without save dir", func(t *testing.T) {
+		cmd := newDeclarativeApplyCmd()
+		require.NoError(t, cmd.Flags().Set(saveDirOverwriteFlagName, "true"))
+
+		_, _, err := sourcesForCommand(
+			cmd,
+			"",
+			[]string{"https://example.com/config.yaml"},
+			testDeclarativeConfig(),
+			testDeclarativeLogger(),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--save-dir-overwrite requires --save-dir")
+	})
+
+	t.Run("rejects non regular save target before fetching", func(t *testing.T) {
+		var requests atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			requests.Add(1)
+			_, err := w.Write([]byte("portals: []\n"))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		saveDir := t.TempDir()
+		require.NoError(t, os.Mkdir(filepath.Join(saveDir, "config.yaml"), 0o755))
+		cmd := newDeclarativeApplyCmd()
+		require.NoError(t, cmd.Flags().Set(saveDirFlagName, saveDir))
+		require.NoError(t, cmd.Flags().Set(saveDirOverwriteFlagName, "true"))
+
+		_, _, err := sourcesForCommand(
+			cmd,
+			"",
+			[]string{server.URL + "/config.yaml"},
+			testDeclarativeConfig(),
+			testDeclarativeLogger(),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "target is not a regular file")
+		assert.Zero(t, requests.Load())
 	})
 
 	t.Run("rejects empty save dir", func(t *testing.T) {

--- a/internal/cmd/root/products/konnect/declarative/declarative_test.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative_test.go
@@ -268,6 +268,7 @@ func TestDeclarativeCommandsExposeRemoteSourceFlags(t *testing.T) {
 			saveForceFlag := tt.cmd.Flags().Lookup(remoteFileSaveForceFlagName)
 			require.NotNil(t, saveForceFlag)
 			assert.Contains(t, saveForceFlag.Usage, "Overwrite")
+			assert.Equal(t, remoteFileSaveForceFlagShort, saveForceFlag.Shorthand)
 
 			remoteAuthFlag := tt.cmd.Flags().Lookup(remoteFileAuthFlagName)
 			require.NotNil(t, remoteAuthFlag)

--- a/internal/cmd/root/products/konnect/declarative/declarative_test.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	cmdpkg "github.com/kong/kongctl/internal/cmd"
@@ -259,9 +260,9 @@ func TestDeclarativeCommandsExposeRemoteSourceFlags(t *testing.T) {
 			require.NotNil(t, filenameFlag)
 			assert.Contains(t, filenameFlag.Usage, "URL")
 
-			saveAsFlag := tt.cmd.Flags().Lookup(saveAsFlagName)
-			require.NotNil(t, saveAsFlag)
-			assert.Contains(t, saveAsFlag.Usage, "remote")
+			saveDirFlag := tt.cmd.Flags().Lookup(saveDirFlagName)
+			require.NotNil(t, saveDirFlag)
+			assert.Contains(t, saveDirFlag.Usage, "remote")
 
 			remoteAuthFlag := tt.cmd.Flags().Lookup(remoteFileAuthFlagName)
 			require.NotNil(t, remoteAuthFlag)
@@ -270,7 +271,7 @@ func TestDeclarativeCommandsExposeRemoteSourceFlags(t *testing.T) {
 	}
 }
 
-func TestSourcesForCommand_SaveAs(t *testing.T) {
+func TestSourcesForCommand_SaveDir(t *testing.T) {
 	t.Run("saves URL source and returns saved file source", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			_, err := w.Write([]byte("portals: []\n"))
@@ -282,8 +283,9 @@ func TestSourcesForCommand_SaveAs(t *testing.T) {
 		var stderr bytes.Buffer
 		cmd.SetErr(&stderr)
 
-		savePath := filepath.Join(t.TempDir(), "remote.yaml")
-		require.NoError(t, cmd.Flags().Set(saveAsFlagName, savePath))
+		saveDir := t.TempDir()
+		savePath := filepath.Join(saveDir, "config.yaml")
+		require.NoError(t, cmd.Flags().Set(saveDirFlagName, saveDir))
 
 		sources, _, err := sourcesForCommand(
 			cmd,
@@ -303,31 +305,55 @@ func TestSourcesForCommand_SaveAs(t *testing.T) {
 		assert.Contains(t, stderr.String(), "Saved remote source to: "+savePath)
 	})
 
-	t.Run("rejects plan input", func(t *testing.T) {
-		cmd := newDeclarativeApplyCmd()
-		require.NoError(t, cmd.Flags().Set(saveAsFlagName, filepath.Join(t.TempDir(), "remote.yaml")))
+	t.Run("saves multiple URL sources and returns saved file sources", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/portal.yaml":
+				_, err := w.Write([]byte("portals: []\n"))
+				require.NoError(t, err)
+			case "/api.yaml":
+				_, err := w.Write([]byte("apis: []\n"))
+				require.NoError(t, err)
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer server.Close()
 
-		_, _, err := sourcesForCommand(cmd, "plan.json", nil, testDeclarativeConfig(), testDeclarativeLogger())
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "--save-as cannot be used with --plan")
+		cmd := newDeclarativeApplyCmd()
+		var stderr bytes.Buffer
+		cmd.SetErr(&stderr)
+
+		saveDir := t.TempDir()
+		portalPath := filepath.Join(saveDir, "portal.yaml")
+		apiPath := filepath.Join(saveDir, "api.yaml")
+		require.NoError(t, cmd.Flags().Set(saveDirFlagName, saveDir))
+
+		sources, _, err := sourcesForCommand(
+			cmd,
+			"",
+			[]string{server.URL + "/portal.yaml", server.URL + "/api.yaml"},
+			testDeclarativeConfig(),
+			testDeclarativeLogger(),
+		)
+		require.NoError(t, err)
+		require.Len(t, sources, 2)
+		assert.Equal(t, loader.Source{Path: portalPath, Type: loader.SourceTypeFile}, sources[0])
+		assert.Equal(t, loader.Source{Path: apiPath, Type: loader.SourceTypeFile}, sources[1])
+
+		content, err := os.ReadFile(portalPath)
+		require.NoError(t, err)
+		assert.Equal(t, "portals: []\n", string(content))
+		content, err = os.ReadFile(apiPath)
+		require.NoError(t, err)
+		assert.Equal(t, "apis: []\n", string(content))
+		assert.Contains(t, stderr.String(), "Saved remote source to: "+portalPath)
+		assert.Contains(t, stderr.String(), "Saved remote source to: "+apiPath)
 	})
 
-	t.Run("rejects non URL input", func(t *testing.T) {
-		dir := t.TempDir()
-		configPath := filepath.Join(dir, "config.yaml")
-		require.NoError(t, os.WriteFile(configPath, []byte("portals: []\n"), 0o600))
-
-		cmd := newDeclarativeApplyCmd()
-		require.NoError(t, cmd.Flags().Set(saveAsFlagName, filepath.Join(dir, "remote.yaml")))
-
-		_, _, err := sourcesForCommand(cmd, "", []string{configPath}, testDeclarativeConfig(), testDeclarativeLogger())
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "--save-as requires exactly one URL source")
-	})
-
-	t.Run("rejects multiple sources", func(t *testing.T) {
+	t.Run("saves URL sources and preserves local sources", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			_, err := w.Write([]byte("portals: []\n"))
+			_, err := w.Write([]byte("apis: []\n"))
 			require.NoError(t, err)
 		}))
 		defer server.Close()
@@ -335,24 +361,113 @@ func TestSourcesForCommand_SaveAs(t *testing.T) {
 		dir := t.TempDir()
 		configPath := filepath.Join(dir, "config.yaml")
 		require.NoError(t, os.WriteFile(configPath, []byte("portals: []\n"), 0o600))
+		saveDir := filepath.Join(dir, "saved")
+		savePath := filepath.Join(saveDir, "api.yaml")
 
 		cmd := newDeclarativeApplyCmd()
-		require.NoError(t, cmd.Flags().Set(saveAsFlagName, filepath.Join(dir, "remote.yaml")))
+		require.NoError(t, cmd.Flags().Set(saveDirFlagName, saveDir))
+
+		sources, _, err := sourcesForCommand(
+			cmd,
+			"",
+			[]string{configPath, server.URL + "/api.yaml"},
+			testDeclarativeConfig(),
+			testDeclarativeLogger(),
+		)
+		require.NoError(t, err)
+		require.Len(t, sources, 2)
+		assert.Equal(t, loader.Source{Path: configPath, Type: loader.SourceTypeFile}, sources[0])
+		assert.Equal(t, loader.Source{Path: savePath, Type: loader.SourceTypeFile}, sources[1])
+	})
+
+	t.Run("rejects plan input", func(t *testing.T) {
+		cmd := newDeclarativeApplyCmd()
+		require.NoError(t, cmd.Flags().Set(saveDirFlagName, t.TempDir()))
+
+		_, _, err := sourcesForCommand(cmd, "plan.json", nil, testDeclarativeConfig(), testDeclarativeLogger())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--save-dir cannot be used with --plan")
+	})
+
+	t.Run("rejects input without URL sources", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "config.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte("portals: []\n"), 0o600))
+
+		cmd := newDeclarativeApplyCmd()
+		require.NoError(t, cmd.Flags().Set(saveDirFlagName, filepath.Join(dir, "saved")))
+
+		_, _, err := sourcesForCommand(cmd, "", []string{configPath}, testDeclarativeConfig(), testDeclarativeLogger())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--save-dir requires at least one URL source")
+	})
+
+	t.Run("rejects duplicate remote filenames before fetching", func(t *testing.T) {
+		var requests atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			requests.Add(1)
+			_, err := w.Write([]byte("portals: []\n"))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		dir := t.TempDir()
+		cmd := newDeclarativeApplyCmd()
+		require.NoError(t, cmd.Flags().Set(saveDirFlagName, dir))
 
 		_, _, err := sourcesForCommand(
 			cmd,
 			"",
-			[]string{server.URL, configPath},
+			[]string{server.URL + "/one/config.yaml", server.URL + "/two/config.yaml"},
 			testDeclarativeConfig(),
 			testDeclarativeLogger(),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "--save-as requires exactly one URL source")
+		assert.Contains(t, err.Error(), `would save as "config.yaml"`)
+		assert.Zero(t, requests.Load())
 	})
 
-	t.Run("rejects empty save path", func(t *testing.T) {
+	t.Run("rejects URL without filename", func(t *testing.T) {
 		cmd := newDeclarativeApplyCmd()
-		require.NoError(t, cmd.Flags().Set(saveAsFlagName, ""))
+		require.NoError(t, cmd.Flags().Set(saveDirFlagName, t.TempDir()))
+
+		_, _, err := sourcesForCommand(
+			cmd,
+			"",
+			[]string{"https://example.com/config/"},
+			testDeclarativeConfig(),
+			testDeclarativeLogger(),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "URL path must include a filename")
+	})
+
+	t.Run("rejects existing save target", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, err := w.Write([]byte("portals: []\n"))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		saveDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(saveDir, "config.yaml"), []byte("existing"), 0o600))
+		cmd := newDeclarativeApplyCmd()
+		require.NoError(t, cmd.Flags().Set(saveDirFlagName, saveDir))
+
+		_, _, err := sourcesForCommand(
+			cmd,
+			"",
+			[]string{server.URL + "/config.yaml"},
+			testDeclarativeConfig(),
+			testDeclarativeLogger(),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "file already exists")
+	})
+
+	t.Run("rejects empty save dir", func(t *testing.T) {
+		cmd := newDeclarativeApplyCmd()
+		require.NoError(t, cmd.Flags().Set(saveDirFlagName, ""))
 
 		_, _, err := sourcesForCommand(
 			cmd,
@@ -362,7 +477,7 @@ func TestSourcesForCommand_SaveAs(t *testing.T) {
 			testDeclarativeLogger(),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "--save-as cannot be empty")
+		assert.Contains(t, err.Error(), "--save-dir cannot be empty")
 	})
 }
 

--- a/internal/cmd/root/products/konnect/declarative/declarative_test.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative_test.go
@@ -2,11 +2,19 @@ package declarative
 
 import (
 	"bytes"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	cmdpkg "github.com/kong/kongctl/internal/cmd"
+	konnectcommon "github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
 	"github.com/kong/kongctl/internal/config"
 	"github.com/kong/kongctl/internal/declarative/executor"
+	"github.com/kong/kongctl/internal/declarative/loader"
 	"github.com/kong/kongctl/internal/declarative/planner"
 	"github.com/kong/kongctl/internal/declarative/resources"
 	utilviper "github.com/kong/kongctl/internal/util/viper"
@@ -14,6 +22,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func testDeclarativeConfig() *config.ProfiledConfig {
+	return config.BuildProfiledConfig("default", "nonexistent.yaml", utilviper.NewViper("nonexistent.yaml"))
+}
+
+func testDeclarativeLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
 
 func TestMaxConcurrencyFromCmd(t *testing.T) {
 	t.Run("uses default value when flag is not set", func(t *testing.T) {
@@ -216,9 +232,242 @@ func TestDeclarativeCommandsRequireExplicitFilename(t *testing.T) {
 			err := tt.cmd.RunE(tt.cmd, nil)
 			require.Error(t, err)
 			assert.True(t, cmdpkg.IsUsageError(err))
-			assert.Equal(t, "no configuration sources specified; use -f to specify files or directories", err.Error())
+			assert.Equal(
+				t,
+				"no configuration sources specified; use -f to specify files, directories, or URLs",
+				err.Error(),
+			)
 		})
 	}
+}
+
+func TestDeclarativeCommandsExposeRemoteSourceFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  *cobra.Command
+	}{
+		{name: "plan", cmd: newDeclarativePlanCmd()},
+		{name: "apply", cmd: newDeclarativeApplyCmd()},
+		{name: "sync", cmd: newDeclarativeSyncCmd()},
+		{name: "diff", cmd: newDeclarativeDiffCmd()},
+		{name: "delete", cmd: newDeclarativeDeleteCmd()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filenameFlag := tt.cmd.Flags().Lookup("filename")
+			require.NotNil(t, filenameFlag)
+			assert.Contains(t, filenameFlag.Usage, "URL")
+
+			saveAsFlag := tt.cmd.Flags().Lookup(saveAsFlagName)
+			require.NotNil(t, saveAsFlag)
+			assert.Contains(t, saveAsFlag.Usage, "remote")
+
+			remoteAuthFlag := tt.cmd.Flags().Lookup(remoteFileAuthFlagName)
+			require.NotNil(t, remoteAuthFlag)
+			assert.Contains(t, remoteAuthFlag.Usage, "auto|none")
+		})
+	}
+}
+
+func TestSourcesForCommand_SaveAs(t *testing.T) {
+	t.Run("saves URL source and returns saved file source", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, err := w.Write([]byte("portals: []\n"))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		cmd := newDeclarativeApplyCmd()
+		var stderr bytes.Buffer
+		cmd.SetErr(&stderr)
+
+		savePath := filepath.Join(t.TempDir(), "remote.yaml")
+		require.NoError(t, cmd.Flags().Set(saveAsFlagName, savePath))
+
+		sources, _, err := sourcesForCommand(
+			cmd,
+			"",
+			[]string{server.URL + "/config.yaml"},
+			testDeclarativeConfig(),
+			testDeclarativeLogger(),
+		)
+		require.NoError(t, err)
+		require.Len(t, sources, 1)
+		assert.Equal(t, savePath, sources[0].Path)
+		assert.Equal(t, loader.SourceTypeFile, sources[0].Type)
+
+		content, err := os.ReadFile(savePath)
+		require.NoError(t, err)
+		assert.Equal(t, "portals: []\n", string(content))
+		assert.Contains(t, stderr.String(), "Saved remote source to: "+savePath)
+	})
+
+	t.Run("rejects plan input", func(t *testing.T) {
+		cmd := newDeclarativeApplyCmd()
+		require.NoError(t, cmd.Flags().Set(saveAsFlagName, filepath.Join(t.TempDir(), "remote.yaml")))
+
+		_, _, err := sourcesForCommand(cmd, "plan.json", nil, testDeclarativeConfig(), testDeclarativeLogger())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--save-as cannot be used with --plan")
+	})
+
+	t.Run("rejects non URL input", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "config.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte("portals: []\n"), 0o600))
+
+		cmd := newDeclarativeApplyCmd()
+		require.NoError(t, cmd.Flags().Set(saveAsFlagName, filepath.Join(dir, "remote.yaml")))
+
+		_, _, err := sourcesForCommand(cmd, "", []string{configPath}, testDeclarativeConfig(), testDeclarativeLogger())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--save-as requires exactly one URL source")
+	})
+
+	t.Run("rejects multiple sources", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, err := w.Write([]byte("portals: []\n"))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "config.yaml")
+		require.NoError(t, os.WriteFile(configPath, []byte("portals: []\n"), 0o600))
+
+		cmd := newDeclarativeApplyCmd()
+		require.NoError(t, cmd.Flags().Set(saveAsFlagName, filepath.Join(dir, "remote.yaml")))
+
+		_, _, err := sourcesForCommand(
+			cmd,
+			"",
+			[]string{server.URL, configPath},
+			testDeclarativeConfig(),
+			testDeclarativeLogger(),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--save-as requires exactly one URL source")
+	})
+
+	t.Run("rejects empty save path", func(t *testing.T) {
+		cmd := newDeclarativeApplyCmd()
+		require.NoError(t, cmd.Flags().Set(saveAsFlagName, ""))
+
+		_, _, err := sourcesForCommand(
+			cmd,
+			"",
+			[]string{"https://example.com/config.yaml"},
+			testDeclarativeConfig(),
+			testDeclarativeLogger(),
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--save-as cannot be empty")
+	})
+}
+
+func TestResolveRemoteFileAuthPolicy(t *testing.T) {
+	t.Run("defaults to auto", func(t *testing.T) {
+		got, err := resolveRemoteFileAuthPolicy(newDeclarativeApplyCmd(), testDeclarativeConfig())
+		require.NoError(t, err)
+		assert.Equal(t, loader.URLFetchAuthAuto, got)
+	})
+
+	t.Run("uses config value", func(t *testing.T) {
+		cfg := testDeclarativeConfig()
+		cfg.Set(remoteFileAuthConfigPath, "none")
+
+		got, err := resolveRemoteFileAuthPolicy(newDeclarativeApplyCmd(), cfg)
+		require.NoError(t, err)
+		assert.Equal(t, loader.URLFetchAuthNone, got)
+	})
+
+	t.Run("flag overrides config value", func(t *testing.T) {
+		cfg := testDeclarativeConfig()
+		cfg.Set(remoteFileAuthConfigPath, "none")
+		cmd := newDeclarativeApplyCmd()
+		require.NoError(t, cmd.Flags().Set(remoteFileAuthFlagName, "auto"))
+
+		got, err := resolveRemoteFileAuthPolicy(cmd, cfg)
+		require.NoError(t, err)
+		assert.Equal(t, loader.URLFetchAuthAuto, got)
+	})
+
+	t.Run("rejects invalid value", func(t *testing.T) {
+		cmd := newDeclarativeApplyCmd()
+		require.NoError(t, cmd.Flags().Set(remoteFileAuthFlagName, "always"))
+
+		_, err := resolveRemoteFileAuthPolicy(cmd, testDeclarativeConfig())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--remote-file-auth must be one of")
+	})
+}
+
+func TestRemoteFileFetchOptionsForSources(t *testing.T) {
+	t.Run("enables token source for default Konnect cloud host", func(t *testing.T) {
+		cfg := testDeclarativeConfig()
+		cfg.Set(konnectcommon.PATConfigPath, "test-token")
+
+		options, err := remoteFileFetchOptionsForSources(
+			newDeclarativeApplyCmd(),
+			cfg,
+			testDeclarativeLogger(),
+			[]loader.Source{{Path: "https://us.cloud.konghq.com/remote-file.yaml", Type: loader.SourceTypeURL}},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, loader.URLFetchAuthAuto, options.AuthPolicy)
+		assert.True(t, options.AllowsAuthenticationForURL("https://us.cloud.konghq.com/remote-file.yaml"))
+		assert.NotNil(t, options.TokenSource)
+	})
+
+	t.Run("does not enable token source for arbitrary host", func(t *testing.T) {
+		cfg := testDeclarativeConfig()
+		cfg.Set(konnectcommon.PATConfigPath, "test-token")
+
+		options, err := remoteFileFetchOptionsForSources(
+			newDeclarativeApplyCmd(),
+			cfg,
+			testDeclarativeLogger(),
+			[]loader.Source{{Path: "https://example.com/config.yaml", Type: loader.SourceTypeURL}},
+		)
+		require.NoError(t, err)
+		assert.False(t, options.AllowsAuthenticationForURL("https://example.com/config.yaml"))
+		assert.Nil(t, options.TokenSource)
+	})
+
+	t.Run("honors remote-file-auth none", func(t *testing.T) {
+		cfg := testDeclarativeConfig()
+		cfg.Set(konnectcommon.PATConfigPath, "test-token")
+		cmd := newDeclarativeApplyCmd()
+		require.NoError(t, cmd.Flags().Set(remoteFileAuthFlagName, "none"))
+
+		options, err := remoteFileFetchOptionsForSources(
+			cmd,
+			cfg,
+			testDeclarativeLogger(),
+			[]loader.Source{{Path: "https://us.cloud.konghq.com/remote-file.yaml", Type: loader.SourceTypeURL}},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, loader.URLFetchAuthNone, options.AuthPolicy)
+		assert.False(t, options.AllowsAuthenticationForURL("https://us.cloud.konghq.com/remote-file.yaml"))
+		assert.Nil(t, options.TokenSource)
+	})
+
+	t.Run("supports additional configured hosts", func(t *testing.T) {
+		cfg := testDeclarativeConfig()
+		cfg.Set(konnectcommon.PATConfigPath, "test-token")
+		cfg.Set(remoteFileAuthHostsConfigPath, []string{"example.com"})
+
+		options, err := remoteFileFetchOptionsForSources(
+			newDeclarativeApplyCmd(),
+			cfg,
+			testDeclarativeLogger(),
+			[]loader.Source{{Path: "https://example.com/config.yaml", Type: loader.SourceTypeURL}},
+		)
+		require.NoError(t, err)
+		assert.True(t, options.AllowsAuthenticationForURL("https://example.com/config.yaml"))
+		assert.NotNil(t, options.TokenSource)
+	})
 }
 
 func TestDisplayTextDiff_UsesChangedFieldsForUpdateOutput(t *testing.T) {

--- a/internal/cmd/root/products/konnect/declarative/declarative_test.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative_test.go
@@ -32,6 +32,10 @@ func testDeclarativeLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
+func testDeclarativeLoggerTo(w io.Writer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(w, &slog.HandlerOptions{Level: slog.LevelInfo}))
+}
+
 func TestMaxConcurrencyFromCmd(t *testing.T) {
 	t.Run("uses default value when flag is not set", func(t *testing.T) {
 		cmd := &cobra.Command{}
@@ -288,6 +292,7 @@ func TestSourcesForCommand_SaveDir(t *testing.T) {
 		cmd := newDeclarativeApplyCmd()
 		var stderr bytes.Buffer
 		cmd.SetErr(&stderr)
+		var logs bytes.Buffer
 
 		saveDir := t.TempDir()
 		savePath := filepath.Join(saveDir, "config.yaml")
@@ -298,7 +303,7 @@ func TestSourcesForCommand_SaveDir(t *testing.T) {
 			"",
 			[]string{server.URL + "/config.yaml"},
 			testDeclarativeConfig(),
-			testDeclarativeLogger(),
+			testDeclarativeLoggerTo(&logs),
 		)
 		require.NoError(t, err)
 		require.Len(t, sources, 1)
@@ -308,7 +313,9 @@ func TestSourcesForCommand_SaveDir(t *testing.T) {
 		content, err := os.ReadFile(savePath)
 		require.NoError(t, err)
 		assert.Equal(t, "portals: []\n", string(content))
-		assert.Contains(t, stderr.String(), "Saved remote source to: "+savePath)
+		assert.Empty(t, stderr.String())
+		assert.Contains(t, logs.String(), "saved remote source")
+		assert.Contains(t, logs.String(), "path="+savePath)
 	})
 
 	t.Run("saves multiple URL sources and returns saved file sources", func(t *testing.T) {
@@ -353,8 +360,7 @@ func TestSourcesForCommand_SaveDir(t *testing.T) {
 		content, err = os.ReadFile(apiPath)
 		require.NoError(t, err)
 		assert.Equal(t, "apis: []\n", string(content))
-		assert.Contains(t, stderr.String(), "Saved remote source to: "+portalPath)
-		assert.Contains(t, stderr.String(), "Saved remote source to: "+apiPath)
+		assert.Empty(t, stderr.String())
 	})
 
 	t.Run("saves URL sources and preserves local sources", func(t *testing.T) {

--- a/internal/cmd/root/products/konnect/declarative/declarative_test.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative_test.go
@@ -260,13 +260,14 @@ func TestDeclarativeCommandsExposeRemoteSourceFlags(t *testing.T) {
 			require.NotNil(t, filenameFlag)
 			assert.Contains(t, filenameFlag.Usage, "URL")
 
-			saveDirFlag := tt.cmd.Flags().Lookup(saveDirFlagName)
+			saveDirFlag := tt.cmd.Flags().Lookup(remoteFileSaveDirFlagName)
 			require.NotNil(t, saveDirFlag)
 			assert.Contains(t, saveDirFlag.Usage, "remote")
+			assert.Equal(t, remoteFileSaveDirFlagShort, saveDirFlag.Shorthand)
 
-			saveDirOverwriteFlag := tt.cmd.Flags().Lookup(saveDirOverwriteFlagName)
-			require.NotNil(t, saveDirOverwriteFlag)
-			assert.Contains(t, saveDirOverwriteFlag.Usage, "Overwrite")
+			saveForceFlag := tt.cmd.Flags().Lookup(remoteFileSaveForceFlagName)
+			require.NotNil(t, saveForceFlag)
+			assert.Contains(t, saveForceFlag.Usage, "Overwrite")
 
 			remoteAuthFlag := tt.cmd.Flags().Lookup(remoteFileAuthFlagName)
 			require.NotNil(t, remoteAuthFlag)
@@ -289,7 +290,7 @@ func TestSourcesForCommand_SaveDir(t *testing.T) {
 
 		saveDir := t.TempDir()
 		savePath := filepath.Join(saveDir, "config.yaml")
-		require.NoError(t, cmd.Flags().Set(saveDirFlagName, saveDir))
+		require.NoError(t, cmd.Flags().Set(remoteFileSaveDirFlagName, saveDir))
 
 		sources, _, err := sourcesForCommand(
 			cmd,
@@ -331,7 +332,7 @@ func TestSourcesForCommand_SaveDir(t *testing.T) {
 		saveDir := t.TempDir()
 		portalPath := filepath.Join(saveDir, "portal.yaml")
 		apiPath := filepath.Join(saveDir, "api.yaml")
-		require.NoError(t, cmd.Flags().Set(saveDirFlagName, saveDir))
+		require.NoError(t, cmd.Flags().Set(remoteFileSaveDirFlagName, saveDir))
 
 		sources, _, err := sourcesForCommand(
 			cmd,
@@ -369,7 +370,7 @@ func TestSourcesForCommand_SaveDir(t *testing.T) {
 		savePath := filepath.Join(saveDir, "api.yaml")
 
 		cmd := newDeclarativeApplyCmd()
-		require.NoError(t, cmd.Flags().Set(saveDirFlagName, saveDir))
+		require.NoError(t, cmd.Flags().Set(remoteFileSaveDirFlagName, saveDir))
 
 		sources, _, err := sourcesForCommand(
 			cmd,
@@ -386,11 +387,11 @@ func TestSourcesForCommand_SaveDir(t *testing.T) {
 
 	t.Run("rejects plan input", func(t *testing.T) {
 		cmd := newDeclarativeApplyCmd()
-		require.NoError(t, cmd.Flags().Set(saveDirFlagName, t.TempDir()))
+		require.NoError(t, cmd.Flags().Set(remoteFileSaveDirFlagName, t.TempDir()))
 
 		_, _, err := sourcesForCommand(cmd, "plan.json", nil, testDeclarativeConfig(), testDeclarativeLogger())
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "--save-dir cannot be used with --plan")
+		assert.Contains(t, err.Error(), "--remote-file-save-dir cannot be used with --plan")
 	})
 
 	t.Run("rejects input without URL sources", func(t *testing.T) {
@@ -399,11 +400,11 @@ func TestSourcesForCommand_SaveDir(t *testing.T) {
 		require.NoError(t, os.WriteFile(configPath, []byte("portals: []\n"), 0o600))
 
 		cmd := newDeclarativeApplyCmd()
-		require.NoError(t, cmd.Flags().Set(saveDirFlagName, filepath.Join(dir, "saved")))
+		require.NoError(t, cmd.Flags().Set(remoteFileSaveDirFlagName, filepath.Join(dir, "saved")))
 
 		_, _, err := sourcesForCommand(cmd, "", []string{configPath}, testDeclarativeConfig(), testDeclarativeLogger())
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "--save-dir requires at least one URL source")
+		assert.Contains(t, err.Error(), "--remote-file-save-dir requires at least one URL source")
 	})
 
 	t.Run("rejects duplicate remote filenames before fetching", func(t *testing.T) {
@@ -417,7 +418,7 @@ func TestSourcesForCommand_SaveDir(t *testing.T) {
 
 		dir := t.TempDir()
 		cmd := newDeclarativeApplyCmd()
-		require.NoError(t, cmd.Flags().Set(saveDirFlagName, dir))
+		require.NoError(t, cmd.Flags().Set(remoteFileSaveDirFlagName, dir))
 
 		_, _, err := sourcesForCommand(
 			cmd,
@@ -433,7 +434,7 @@ func TestSourcesForCommand_SaveDir(t *testing.T) {
 
 	t.Run("rejects URL without filename", func(t *testing.T) {
 		cmd := newDeclarativeApplyCmd()
-		require.NoError(t, cmd.Flags().Set(saveDirFlagName, t.TempDir()))
+		require.NoError(t, cmd.Flags().Set(remoteFileSaveDirFlagName, t.TempDir()))
 
 		_, _, err := sourcesForCommand(
 			cmd,
@@ -456,7 +457,7 @@ func TestSourcesForCommand_SaveDir(t *testing.T) {
 		saveDir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(saveDir, "config.yaml"), []byte("existing"), 0o600))
 		cmd := newDeclarativeApplyCmd()
-		require.NoError(t, cmd.Flags().Set(saveDirFlagName, saveDir))
+		require.NoError(t, cmd.Flags().Set(remoteFileSaveDirFlagName, saveDir))
 
 		_, _, err := sourcesForCommand(
 			cmd,
@@ -480,8 +481,8 @@ func TestSourcesForCommand_SaveDir(t *testing.T) {
 		savePath := filepath.Join(saveDir, "config.yaml")
 		require.NoError(t, os.WriteFile(savePath, []byte("old content"), 0o600))
 		cmd := newDeclarativeApplyCmd()
-		require.NoError(t, cmd.Flags().Set(saveDirFlagName, saveDir))
-		require.NoError(t, cmd.Flags().Set(saveDirOverwriteFlagName, "true"))
+		require.NoError(t, cmd.Flags().Set(remoteFileSaveDirFlagName, saveDir))
+		require.NoError(t, cmd.Flags().Set(remoteFileSaveForceFlagName, "true"))
 
 		sources, _, err := sourcesForCommand(
 			cmd,
@@ -501,7 +502,7 @@ func TestSourcesForCommand_SaveDir(t *testing.T) {
 
 	t.Run("rejects overwrite without save dir", func(t *testing.T) {
 		cmd := newDeclarativeApplyCmd()
-		require.NoError(t, cmd.Flags().Set(saveDirOverwriteFlagName, "true"))
+		require.NoError(t, cmd.Flags().Set(remoteFileSaveForceFlagName, "true"))
 
 		_, _, err := sourcesForCommand(
 			cmd,
@@ -511,7 +512,7 @@ func TestSourcesForCommand_SaveDir(t *testing.T) {
 			testDeclarativeLogger(),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "--save-dir-overwrite requires --save-dir")
+		assert.Contains(t, err.Error(), "--remote-file-save-force requires --remote-file-save-dir")
 	})
 
 	t.Run("rejects non regular save target before fetching", func(t *testing.T) {
@@ -526,8 +527,8 @@ func TestSourcesForCommand_SaveDir(t *testing.T) {
 		saveDir := t.TempDir()
 		require.NoError(t, os.Mkdir(filepath.Join(saveDir, "config.yaml"), 0o755))
 		cmd := newDeclarativeApplyCmd()
-		require.NoError(t, cmd.Flags().Set(saveDirFlagName, saveDir))
-		require.NoError(t, cmd.Flags().Set(saveDirOverwriteFlagName, "true"))
+		require.NoError(t, cmd.Flags().Set(remoteFileSaveDirFlagName, saveDir))
+		require.NoError(t, cmd.Flags().Set(remoteFileSaveForceFlagName, "true"))
 
 		_, _, err := sourcesForCommand(
 			cmd,
@@ -543,7 +544,7 @@ func TestSourcesForCommand_SaveDir(t *testing.T) {
 
 	t.Run("rejects empty save dir", func(t *testing.T) {
 		cmd := newDeclarativeApplyCmd()
-		require.NoError(t, cmd.Flags().Set(saveDirFlagName, ""))
+		require.NoError(t, cmd.Flags().Set(remoteFileSaveDirFlagName, ""))
 
 		_, _, err := sourcesForCommand(
 			cmd,
@@ -553,7 +554,7 @@ func TestSourcesForCommand_SaveDir(t *testing.T) {
 			testDeclarativeLogger(),
 		)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "--save-dir cannot be empty")
+		assert.Contains(t, err.Error(), "--remote-file-save-dir cannot be empty")
 	})
 }
 

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -938,7 +938,7 @@ func TestRootErrorUX(t *testing.T) {
 				`Error: unknown shorthand flag: 'g' in -g`,
 				"Did you mean one of these flags?",
 				"-f, --filename",
-				"Filename or directory to files to use to create the resource",
+				"File, directory, URL, or '-' to use to create the resource",
 				"-R, --recursive",
 				"Process the directory used in -f, --filename recursively",
 				`Run 'kongctl diff --help' for usage`,
@@ -973,8 +973,8 @@ func TestRootErrorUX(t *testing.T) {
 			name: "bare declarative plan requires filename with concise help hint",
 			args: []string{"plan"},
 			wantErr: []string{
-				`Error: no configuration sources specified; use -f to specify files or directories`,
-				"Error: no configuration sources specified; use -f to specify files or directories\n\n" +
+				`Error: no configuration sources specified; use -f to specify files, directories, or URLs`,
+				"Error: no configuration sources specified; use -f to specify files, directories, or URLs\n\n" +
 					`Run 'kongctl plan --help' for usage`,
 			},
 			wantExit:     1,

--- a/internal/cmd/root/verbs/help/templates/apply.md
+++ b/internal/cmd/root/verbs/help/templates/apply.md
@@ -17,6 +17,7 @@ kongctl apply [flags]
 - `-f, --filename` (string): File, directory, URL, or `-` for stdin
   - Can be specified multiple times
 - `--save-dir` (string): Save remote URL sources into a local directory before loading
+- `--save-dir-overwrite`: Overwrite existing files when saving with `--save-dir`
 - `--remote-file-auth` (string): Remote URL authentication mode: `auto` or `none`
 - `--plan` (string): Path to a pre-generated plan file
 - `-r, --recursive`: Process directories recursively

--- a/internal/cmd/root/verbs/help/templates/apply.md
+++ b/internal/cmd/root/verbs/help/templates/apply.md
@@ -16,7 +16,7 @@ kongctl apply [flags]
 
 - `-f, --filename` (string): File, directory, URL, or `-` for stdin
   - Can be specified multiple times
-- `--save-as` (string): Save a single remote URL source locally before loading
+- `--save-dir` (string): Save remote URL sources into a local directory before loading
 - `--remote-file-auth` (string): Remote URL authentication mode: `auto` or `none`
 - `--plan` (string): Path to a pre-generated plan file
 - `-r, --recursive`: Process directories recursively
@@ -61,10 +61,11 @@ kongctl apply -f portals.yaml -f apis.yaml
 # Apply from directory
 kongctl apply -f ./configs/
 
-# Apply from a remote URL and save the file for later edits
+# Apply from remote URLs and save the files for later edits
 kongctl apply \
-  -f https://get.konghq.com/example-kongctl.yaml \
-  --save-as ./example-kongctl.yaml
+  -f https://get.konghq.com/portal.yaml \
+  -f https://get.konghq.com/api.yaml \
+  --save-dir ./kongctl-example
 
 # Apply with auto-approval (no prompts)
 kongctl apply -f config.yaml --auto-approve

--- a/internal/cmd/root/verbs/help/templates/apply.md
+++ b/internal/cmd/root/verbs/help/templates/apply.md
@@ -17,7 +17,7 @@ kongctl apply [flags]
 - `-f, --filename` (string): File, directory, URL, or `-` for stdin
   - Can be specified multiple times
 - `-s, --remote-file-save-dir` (string): Save remote URL sources into a local directory before loading
-- `--remote-file-save-force`: Overwrite existing files when saving with `--remote-file-save-dir`
+- `-F, --remote-file-save-force`: Overwrite existing files when saving with `--remote-file-save-dir`
 - `--remote-file-auth` (string): Remote URL authentication mode: `auto` or `none`
 - `--plan` (string): Path to a pre-generated plan file
 - `-r, --recursive`: Process directories recursively

--- a/internal/cmd/root/verbs/help/templates/apply.md
+++ b/internal/cmd/root/verbs/help/templates/apply.md
@@ -16,8 +16,8 @@ kongctl apply [flags]
 
 - `-f, --filename` (string): File, directory, URL, or `-` for stdin
   - Can be specified multiple times
-- `--save-dir` (string): Save remote URL sources into a local directory before loading
-- `--save-dir-overwrite`: Overwrite existing files when saving with `--save-dir`
+- `-s, --remote-file-save-dir` (string): Save remote URL sources into a local directory before loading
+- `--remote-file-save-force`: Overwrite existing files when saving with `--remote-file-save-dir`
 - `--remote-file-auth` (string): Remote URL authentication mode: `auto` or `none`
 - `--plan` (string): Path to a pre-generated plan file
 - `-r, --recursive`: Process directories recursively
@@ -66,7 +66,7 @@ kongctl apply -f ./configs/
 kongctl apply \
   -f https://get.konghq.com/portal.yaml \
   -f https://get.konghq.com/api.yaml \
-  --save-dir ./kongctl-example
+  -s ./kongctl-example
 
 # Apply with auto-approval (no prompts)
 kongctl apply -f config.yaml --auto-approve

--- a/internal/cmd/root/verbs/help/templates/apply.md
+++ b/internal/cmd/root/verbs/help/templates/apply.md
@@ -14,9 +14,10 @@ kongctl apply [flags]
 
 ### Input Flags
 
-- `-f, --file` (string): Path to configuration file or directory
+- `-f, --filename` (string): File, directory, URL, or `-` for stdin
   - Can be specified multiple times
-  - Use `-` to read from stdin
+- `--save-as` (string): Save a single remote URL source locally before loading
+- `--remote-file-auth` (string): Remote URL authentication mode: `auto` or `none`
 - `--plan` (string): Path to a pre-generated plan file
 - `-r, --recursive`: Process directories recursively
 
@@ -59,6 +60,11 @@ kongctl apply -f portals.yaml -f apis.yaml
 
 # Apply from directory
 kongctl apply -f ./configs/
+
+# Apply from a remote URL and save the file for later edits
+kongctl apply \
+  -f https://get.konghq.com/example-kongctl.yaml \
+  --save-as ./example-kongctl.yaml
 
 # Apply with auto-approval (no prompts)
 kongctl apply -f config.yaml --auto-approve

--- a/internal/cmd/root/verbs/help/templates/diff.md
+++ b/internal/cmd/root/verbs/help/templates/diff.md
@@ -17,7 +17,7 @@ kongctl diff [flags]
 - `-f, --filename` (string): File, directory, URL, or `-` for stdin
   - Can be specified multiple times
 - `-s, --remote-file-save-dir` (string): Save remote URL sources into a local directory before loading
-- `--remote-file-save-force`: Overwrite existing files when saving with `--remote-file-save-dir`
+- `-F, --remote-file-save-force`: Overwrite existing files when saving with `--remote-file-save-dir`
 - `--remote-file-auth` (string): Remote URL authentication mode: `auto` or `none`
 - `--plan` (string): Use a pre-generated plan file
 - `--mode` (string): Diff mode: `sync`, `apply`, or `delete` (default: `sync`)

--- a/internal/cmd/root/verbs/help/templates/diff.md
+++ b/internal/cmd/root/verbs/help/templates/diff.md
@@ -17,6 +17,7 @@ kongctl diff [flags]
 - `-f, --filename` (string): File, directory, URL, or `-` for stdin
   - Can be specified multiple times
 - `--save-dir` (string): Save remote URL sources into a local directory before loading
+- `--save-dir-overwrite`: Overwrite existing files when saving with `--save-dir`
 - `--remote-file-auth` (string): Remote URL authentication mode: `auto` or `none`
 - `--plan` (string): Use a pre-generated plan file
 - `--mode` (string): Diff mode: `sync`, `apply`, or `delete` (default: `sync`)

--- a/internal/cmd/root/verbs/help/templates/diff.md
+++ b/internal/cmd/root/verbs/help/templates/diff.md
@@ -14,9 +14,10 @@ kongctl diff [flags]
 
 ### Input Flags
 
-- `-f, --filename` (string): Path to configuration file or directory
+- `-f, --filename` (string): File, directory, URL, or `-` for stdin
   - Can be specified multiple times
-  - Use `-` to read from stdin
+- `--save-as` (string): Save a single remote URL source locally before loading
+- `--remote-file-auth` (string): Remote URL authentication mode: `auto` or `none`
 - `--plan` (string): Use a pre-generated plan file
 - `--mode` (string): Diff mode: `sync`, `apply`, or `delete` (default: `sync`)
 - `-R, --recursive`: Process directories recursively

--- a/internal/cmd/root/verbs/help/templates/diff.md
+++ b/internal/cmd/root/verbs/help/templates/diff.md
@@ -16,8 +16,8 @@ kongctl diff [flags]
 
 - `-f, --filename` (string): File, directory, URL, or `-` for stdin
   - Can be specified multiple times
-- `--save-dir` (string): Save remote URL sources into a local directory before loading
-- `--save-dir-overwrite`: Overwrite existing files when saving with `--save-dir`
+- `-s, --remote-file-save-dir` (string): Save remote URL sources into a local directory before loading
+- `--remote-file-save-force`: Overwrite existing files when saving with `--remote-file-save-dir`
 - `--remote-file-auth` (string): Remote URL authentication mode: `auto` or `none`
 - `--plan` (string): Use a pre-generated plan file
 - `--mode` (string): Diff mode: `sync`, `apply`, or `delete` (default: `sync`)

--- a/internal/cmd/root/verbs/help/templates/diff.md
+++ b/internal/cmd/root/verbs/help/templates/diff.md
@@ -16,7 +16,7 @@ kongctl diff [flags]
 
 - `-f, --filename` (string): File, directory, URL, or `-` for stdin
   - Can be specified multiple times
-- `--save-as` (string): Save a single remote URL source locally before loading
+- `--save-dir` (string): Save remote URL sources into a local directory before loading
 - `--remote-file-auth` (string): Remote URL authentication mode: `auto` or `none`
 - `--plan` (string): Use a pre-generated plan file
 - `--mode` (string): Diff mode: `sync`, `apply`, or `delete` (default: `sync`)

--- a/internal/cmd/root/verbs/help/templates/plan.md
+++ b/internal/cmd/root/verbs/help/templates/plan.md
@@ -17,7 +17,7 @@ kongctl plan [flags]
 - `-f, --filename` (string): File, directory, URL, or `-` for stdin
   - Can be specified multiple times to load multiple files
   - Directories are processed non-recursively by default
-- `--save-as` (string): Save a single remote URL source locally before loading
+- `--save-dir` (string): Save remote URL sources into a local directory before loading
 - `--remote-file-auth` (string): Remote URL authentication mode: `auto` or `none`
 
 ### Optional Flags

--- a/internal/cmd/root/verbs/help/templates/plan.md
+++ b/internal/cmd/root/verbs/help/templates/plan.md
@@ -17,8 +17,8 @@ kongctl plan [flags]
 - `-f, --filename` (string): File, directory, URL, or `-` for stdin
   - Can be specified multiple times to load multiple files
   - Directories are processed non-recursively by default
-- `--save-dir` (string): Save remote URL sources into a local directory before loading
-- `--save-dir-overwrite`: Overwrite existing files when saving with `--save-dir`
+- `-s, --remote-file-save-dir` (string): Save remote URL sources into a local directory before loading
+- `--remote-file-save-force`: Overwrite existing files when saving with `--remote-file-save-dir`
 - `--remote-file-auth` (string): Remote URL authentication mode: `auto` or `none`
 
 ### Optional Flags

--- a/internal/cmd/root/verbs/help/templates/plan.md
+++ b/internal/cmd/root/verbs/help/templates/plan.md
@@ -18,7 +18,7 @@ kongctl plan [flags]
   - Can be specified multiple times to load multiple files
   - Directories are processed non-recursively by default
 - `-s, --remote-file-save-dir` (string): Save remote URL sources into a local directory before loading
-- `--remote-file-save-force`: Overwrite existing files when saving with `--remote-file-save-dir`
+- `-F, --remote-file-save-force`: Overwrite existing files when saving with `--remote-file-save-dir`
 - `--remote-file-auth` (string): Remote URL authentication mode: `auto` or `none`
 
 ### Optional Flags

--- a/internal/cmd/root/verbs/help/templates/plan.md
+++ b/internal/cmd/root/verbs/help/templates/plan.md
@@ -18,6 +18,7 @@ kongctl plan [flags]
   - Can be specified multiple times to load multiple files
   - Directories are processed non-recursively by default
 - `--save-dir` (string): Save remote URL sources into a local directory before loading
+- `--save-dir-overwrite`: Overwrite existing files when saving with `--save-dir`
 - `--remote-file-auth` (string): Remote URL authentication mode: `auto` or `none`
 
 ### Optional Flags

--- a/internal/cmd/root/verbs/help/templates/plan.md
+++ b/internal/cmd/root/verbs/help/templates/plan.md
@@ -14,9 +14,11 @@ kongctl plan [flags]
 
 ### Required Flags
 
-- `-f, --file` (string): Path to configuration file or directory containing YAML configurations
+- `-f, --filename` (string): File, directory, URL, or `-` for stdin
   - Can be specified multiple times to load multiple files
   - Directories are processed non-recursively by default
+- `--save-as` (string): Save a single remote URL source locally before loading
+- `--remote-file-auth` (string): Remote URL authentication mode: `auto` or `none`
 
 ### Optional Flags
 

--- a/internal/cmd/root/verbs/help/templates/sync.md
+++ b/internal/cmd/root/verbs/help/templates/sync.md
@@ -21,6 +21,7 @@ kongctl sync [flags]
 - `-f, --filename` (string): File, directory, URL, or `-` for stdin
   - Can be specified multiple times
 - `--save-dir` (string): Save remote URL sources into a local directory before loading
+- `--save-dir-overwrite`: Overwrite existing files when saving with `--save-dir`
 - `--remote-file-auth` (string): Remote URL authentication mode: `auto` or `none`
 - `--plan` (string): Path to a pre-generated plan file
 - `-r, --recursive`: Process directories recursively

--- a/internal/cmd/root/verbs/help/templates/sync.md
+++ b/internal/cmd/root/verbs/help/templates/sync.md
@@ -20,7 +20,7 @@ kongctl sync [flags]
 
 - `-f, --filename` (string): File, directory, URL, or `-` for stdin
   - Can be specified multiple times
-- `--save-as` (string): Save a single remote URL source locally before loading
+- `--save-dir` (string): Save remote URL sources into a local directory before loading
 - `--remote-file-auth` (string): Remote URL authentication mode: `auto` or `none`
 - `--plan` (string): Path to a pre-generated plan file
 - `-r, --recursive`: Process directories recursively

--- a/internal/cmd/root/verbs/help/templates/sync.md
+++ b/internal/cmd/root/verbs/help/templates/sync.md
@@ -21,7 +21,7 @@ kongctl sync [flags]
 - `-f, --filename` (string): File, directory, URL, or `-` for stdin
   - Can be specified multiple times
 - `-s, --remote-file-save-dir` (string): Save remote URL sources into a local directory before loading
-- `--remote-file-save-force`: Overwrite existing files when saving with `--remote-file-save-dir`
+- `-F, --remote-file-save-force`: Overwrite existing files when saving with `--remote-file-save-dir`
 - `--remote-file-auth` (string): Remote URL authentication mode: `auto` or `none`
 - `--plan` (string): Path to a pre-generated plan file
 - `-r, --recursive`: Process directories recursively

--- a/internal/cmd/root/verbs/help/templates/sync.md
+++ b/internal/cmd/root/verbs/help/templates/sync.md
@@ -18,9 +18,10 @@ kongctl sync [flags]
 
 ### Input Flags
 
-- `-f, --file` (string): Path to configuration file or directory
+- `-f, --filename` (string): File, directory, URL, or `-` for stdin
   - Can be specified multiple times
-  - Use `-` to read from stdin
+- `--save-as` (string): Save a single remote URL source locally before loading
+- `--remote-file-auth` (string): Remote URL authentication mode: `auto` or `none`
 - `--plan` (string): Path to a pre-generated plan file
 - `-r, --recursive`: Process directories recursively
 

--- a/internal/cmd/root/verbs/help/templates/sync.md
+++ b/internal/cmd/root/verbs/help/templates/sync.md
@@ -20,8 +20,8 @@ kongctl sync [flags]
 
 - `-f, --filename` (string): File, directory, URL, or `-` for stdin
   - Can be specified multiple times
-- `--save-dir` (string): Save remote URL sources into a local directory before loading
-- `--save-dir-overwrite`: Overwrite existing files when saving with `--save-dir`
+- `-s, --remote-file-save-dir` (string): Save remote URL sources into a local directory before loading
+- `--remote-file-save-force`: Overwrite existing files when saving with `--remote-file-save-dir`
 - `--remote-file-auth` (string): Remote URL authentication mode: `auto` or `none`
 - `--plan` (string): Path to a pre-generated plan file
 - `-r, --recursive`: Process directories recursively

--- a/internal/cmd/root/verbs/sync/sync_test.go
+++ b/internal/cmd/root/verbs/sync/sync_test.go
@@ -77,7 +77,7 @@ func TestSyncCmd_Flags(t *testing.T) {
 	fileFlag := konnectCmd.Flags().Lookup("filename")
 	assert.NotNil(t, fileFlag, "Should have --filename flag")
 	assert.Equal(t, "f", fileFlag.Shorthand, "Should have -f shorthand")
-	assert.Contains(t, fileFlag.Usage, "Filename", "Usage should mention filename")
+	assert.Contains(t, fileFlag.Usage, "URL", "Usage should mention URL sources")
 
 	autoApproveFlag := konnectCmd.Flags().Lookup("auto-approve")
 	assert.NotNil(t, autoApproveFlag, "Should have --auto-approve flag")

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -1,6 +1,7 @@
 package loader
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -31,6 +32,8 @@ type Loader struct {
 	baseDir string
 	// tagRootDir is the boundary directory for !file tag resolution
 	tagRootDir string
+	// urlFetchOptions controls remote URL source fetching
+	urlFetchOptions URLFetchOptions
 	// tagRegistry is the registry of tag resolvers (created on demand)
 	tagRegistry *tags.ResolverRegistry
 }
@@ -58,6 +61,15 @@ func NewWithBaseDir(baseDir string) *Loader {
 	}
 }
 
+// WithURLFetchOptions configures remote URL source fetching.
+func (l *Loader) WithURLFetchOptions(options URLFetchOptions) *Loader {
+	if l == nil {
+		return nil
+	}
+	l.urlFetchOptions = options
+	return l
+}
+
 // getTagRegistry returns the tag registry, creating it if needed
 func (l *Loader) getTagRegistry() *tags.ResolverRegistry {
 	if l.tagRegistry == nil {
@@ -77,6 +89,8 @@ func (l *Loader) resolveSourceRoot(source Source) string {
 	case SourceTypeDirectory:
 		return source.Path
 	case SourceTypeSTDIN:
+		return l.baseDir
+	case SourceTypeURL:
 		return l.baseDir
 	default:
 		return ""
@@ -107,6 +121,8 @@ func (l *Loader) LoadFromSourcesWithContext(ctx context.Context, sources []Sourc
 			err = l.loadDirectorySourceWithContext(ctx, source.Path, rootDir, recursive, &allResources, refIndex)
 		case SourceTypeSTDIN:
 			err = l.loadSTDINWithContext(ctx, rootDir, &allResources, refIndex)
+		case SourceTypeURL:
+			err = l.loadURLWithContext(ctx, source.Path, rootDir, &allResources, refIndex)
 		default:
 			return nil, decerrors.FormatConfigurationError(
 				source.Path,
@@ -198,6 +214,26 @@ func (l *Loader) loadSingleFile(
 	return l.appendResourcesWithDuplicateCheck(accumulated, rs, path, refIndex)
 }
 
+func (l *Loader) loadURLWithContext(
+	ctx context.Context,
+	rawURL string,
+	rootDir string,
+	accumulated *resources.ResourceSet,
+	refIndex map[string]resources.ResourceType,
+) error {
+	content, err := FetchURLWithOptions(ctx, rawURL, l.urlFetchOptions)
+	if err != nil {
+		return err
+	}
+
+	rs, err := l.parseYAML(bytes.NewReader(content), rawURL, rootDir)
+	if err != nil {
+		return err
+	}
+
+	return l.appendResourcesWithDuplicateCheck(accumulated, rs, rawURL, refIndex)
+}
+
 // parseYAML parses YAML content into ResourceSet
 func (l *Loader) parseYAML(r io.Reader, sourcePath string, rootDir string) (*resources.ResourceSet, error) {
 	var temp temporaryParseResult
@@ -221,7 +257,13 @@ func (l *Loader) parseYAML(r io.Reader, sourcePath string, rootDir string) (*res
 	// Update base directory based on source file location
 	baseDir := l.baseDir
 	if sourcePath != "stdin" && sourcePath != "" {
-		baseDir = filepath.Dir(sourcePath)
+		if isURLSourcePath(sourcePath) {
+			if strings.TrimSpace(rootDir) != "" {
+				baseDir = rootDir
+			}
+		} else {
+			baseDir = filepath.Dir(sourcePath)
+		}
 	}
 
 	tagRootDir := strings.TrimSpace(l.tagRootDir)

--- a/internal/declarative/loader/loader_test.go
+++ b/internal/declarative/loader/loader_test.go
@@ -1087,6 +1087,20 @@ func TestLoader_ParseSources(t *testing.T) {
 			},
 		},
 		{
+			name:  "https url",
+			input: []string{"https://example.com/config.yaml"},
+			expected: []Source{
+				{Path: "https://example.com/config.yaml", Type: SourceTypeURL},
+			},
+		},
+		{
+			name:  "http url",
+			input: []string{"http://example.com/config"},
+			expected: []Source{
+				{Path: "http://example.com/config", Type: SourceTypeURL},
+			},
+		},
+		{
 			name:  "empty rejects missing configuration source",
 			input: []string{},
 			err:   ErrNoSources,
@@ -1096,6 +1110,11 @@ func TestLoader_ParseSources(t *testing.T) {
 			input: []string{","},
 			err:   ErrNoSources,
 		},
+		{
+			name:  "unsupported url scheme",
+			input: []string{"ftp://example.com/config.yaml"},
+			err:   errors.New("unsupported URL scheme"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -1103,11 +1122,15 @@ func TestLoader_ParseSources(t *testing.T) {
 			// For testing, we need to mock file existence checks
 			// Since ParseSources checks if files exist, we'll test with stdin
 			// which doesn't require file existence
-			if tt.name == "stdin" || tt.err != nil {
+			if tt.name == "stdin" || strings.Contains(tt.name, "url") || tt.err != nil {
 				sources, err := ParseSources(tt.input)
 				if tt.err != nil {
 					require.Error(t, err)
-					assert.True(t, errors.Is(err, tt.err))
+					if errors.Is(tt.err, ErrNoSources) {
+						assert.True(t, errors.Is(err, tt.err))
+					} else {
+						assert.Contains(t, err.Error(), tt.err.Error())
+					}
 					assert.Nil(t, sources)
 					return
 				}

--- a/internal/declarative/loader/sources.go
+++ b/internal/declarative/loader/sources.go
@@ -3,12 +3,13 @@ package loader
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 )
 
 // ErrNoSources is returned when no configuration sources are provided.
-var ErrNoSources = errors.New("no configuration sources specified; use -f to specify files or directories")
+var ErrNoSources = errors.New("no configuration sources specified; use -f to specify files, directories, or URLs")
 
 // SourceType represents the type of configuration source
 type SourceType int
@@ -20,6 +21,8 @@ const (
 	SourceTypeDirectory
 	// SourceTypeSTDIN represents stdin source
 	SourceTypeSTDIN
+	// SourceTypeURL represents an HTTP(S) URL source
+	SourceTypeURL
 )
 
 // Source represents a configuration source with its type
@@ -67,6 +70,10 @@ func detectSourceType(source string) (SourceType, error) {
 		return SourceTypeSTDIN, nil
 	}
 
+	if sourceType, ok, err := detectURLSourceType(source); ok || err != nil {
+		return sourceType, err
+	}
+
 	// Check if file/directory exists
 	info, err := os.Stat(source)
 	if err != nil {
@@ -81,6 +88,32 @@ func detectSourceType(source string) (SourceType, error) {
 	}
 
 	return SourceTypeFile, nil
+}
+
+func detectURLSourceType(source string) (SourceType, bool, error) {
+	if !strings.Contains(source, "://") {
+		return 0, false, nil
+	}
+
+	parsed, err := url.Parse(source)
+	if err != nil {
+		return 0, true, fmt.Errorf("invalid URL: %w", err)
+	}
+
+	switch parsed.Scheme {
+	case "http", "https":
+		if parsed.Host == "" {
+			return 0, true, fmt.Errorf("URL must include a host")
+		}
+		return SourceTypeURL, true, nil
+	default:
+		return 0, true, fmt.Errorf("unsupported URL scheme %q", parsed.Scheme)
+	}
+}
+
+func isURLSourcePath(source string) bool {
+	sourceType, ok, err := detectURLSourceType(source)
+	return err == nil && ok && sourceType == SourceTypeURL
 }
 
 // ValidateYAMLFile checks if a file has a valid YAML extension

--- a/internal/declarative/loader/url_fetcher.go
+++ b/internal/declarative/loader/url_fetcher.go
@@ -96,7 +96,7 @@ func fetchURL(ctx context.Context, rawURL string, cfg urlFetchConfig) ([]byte, e
 			return nil, err
 		}
 		if err := waitBeforeURLFetchRetry(ctx, backoff, attempt); err != nil {
-			return nil, fmt.Errorf("failed to fetch URL %s: %w", rawURL, err)
+			return nil, fmt.Errorf("failed to fetch URL %s: %w", safeURLForLog(rawURL), err)
 		}
 	}
 
@@ -106,7 +106,7 @@ func fetchURL(ctx context.Context, rawURL string, cfg urlFetchConfig) ([]byte, e
 func parseFetchURL(rawURL string) (*url.URL, error) {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid URL %q: %w", rawURL, err)
+		return nil, fmt.Errorf("invalid URL %q: %s", safeURLForLog(rawURL), safeURLErrorMessage(rawURL, err))
 	}
 	if parsed.Scheme != "http" && parsed.Scheme != "https" {
 		return nil, fmt.Errorf("unsupported URL scheme %q", parsed.Scheme)
@@ -165,9 +165,10 @@ func fetchURLOnce(
 	options URLFetchOptions,
 	attempt int,
 ) ([]byte, bool, error) {
+	safeURL := safeURLForLog(rawURL)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to create request for URL %s: %w", rawURL, err)
+		return nil, false, fmt.Errorf("failed to create request for URL %s: %w", safeURL, err)
 	}
 	httpheaders.SetUserAgent(req, meta.UserAgent())
 	httpheaders.SetAccept(req, "application/yaml, text/yaml, text/plain, */*")
@@ -184,7 +185,7 @@ func fetchURLOnce(
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, isRetryableURLFetchError(ctx, err), fmt.Errorf("failed to fetch URL %s: %w", rawURL, err)
+		return nil, isRetryableURLFetchError(ctx, err), fmt.Errorf("failed to fetch URL %s: %w", safeURL, err)
 	}
 	defer resp.Body.Close()
 
@@ -196,7 +197,7 @@ func fetchURLOnce(
 	if resp.ContentLength > maxBytes {
 		return nil, false, fmt.Errorf(
 			"failed to fetch URL %s: response is too large (%d bytes, limit %d bytes)",
-			rawURL, resp.ContentLength, maxBytes,
+			safeURL, resp.ContentLength, maxBytes,
 		)
 	}
 
@@ -211,12 +212,12 @@ func fetchURLOnce(
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
 	if err != nil {
-		return nil, isRetryableURLFetchError(ctx, err), fmt.Errorf("failed to read URL %s: %w", rawURL, err)
+		return nil, isRetryableURLFetchError(ctx, err), fmt.Errorf("failed to read URL %s: %w", safeURL, err)
 	}
 	if int64(len(body)) > maxBytes {
 		return nil, false, fmt.Errorf(
 			"failed to fetch URL %s: response is too large (limit %d bytes)",
-			rawURL, maxBytes,
+			safeURL, maxBytes,
 		)
 	}
 
@@ -264,11 +265,14 @@ func configureURLFetchAuth(req *http.Request, options URLFetchOptions) error {
 
 	token, err := options.TokenSource.Token(req.Context())
 	if err != nil {
-		return fmt.Errorf("failed to resolve authentication token for URL %s: %w", req.URL.String(), err)
+		return fmt.Errorf("failed to resolve authentication token for URL %s: %w", safeURLForLog(req.URL.String()), err)
 	}
 	token = strings.TrimSpace(token)
 	if token == "" {
-		return fmt.Errorf("failed to resolve authentication token for URL %s: token is empty", req.URL.String())
+		return fmt.Errorf(
+			"failed to resolve authentication token for URL %s: token is empty",
+			safeURLForLog(req.URL.String()),
+		)
 	}
 	httpheaders.SetBearerAuthorization(req, token)
 	return nil
@@ -306,12 +310,13 @@ func normalizeURLFetchAuthHost(host string) string {
 }
 
 func unexpectedURLFetchStatusError(rawURL string, resp *http.Response) error {
+	safeURL := safeURLForLog(rawURL)
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 	snippet := strings.TrimSpace(string(body))
 	if snippet == "" {
-		return fmt.Errorf("failed to fetch URL %s: unexpected HTTP status %s", rawURL, resp.Status)
+		return fmt.Errorf("failed to fetch URL %s: unexpected HTTP status %s", safeURL, resp.Status)
 	}
-	return fmt.Errorf("failed to fetch URL %s: unexpected HTTP status %s: %s", rawURL, resp.Status, snippet)
+	return fmt.Errorf("failed to fetch URL %s: unexpected HTTP status %s: %s", safeURL, resp.Status, snippet)
 }
 
 func isRetryableURLFetchStatus(statusCode int) bool {
@@ -364,10 +369,45 @@ func loggerFromContext(ctx context.Context) *slog.Logger {
 func safeURLForLog(rawURL string) string {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
-		return rawURL
+		return redactMalformedURL(rawURL)
 	}
 	parsed.User = nil
 	parsed.RawQuery = ""
 	parsed.Fragment = ""
 	return parsed.String()
+}
+
+func redactMalformedURL(rawURL string) string {
+	redacted := rawURL
+	if idx := strings.IndexAny(redacted, "?#"); idx >= 0 {
+		redacted = redacted[:idx]
+	}
+	scheme, rest, ok := strings.Cut(redacted, "://")
+	if !ok {
+		return redacted
+	}
+
+	authority := rest
+	suffix := ""
+	if idx := strings.Index(authority, "/"); idx >= 0 {
+		suffix = authority[idx:]
+		authority = authority[:idx]
+	}
+	if idx := strings.LastIndex(authority, "@"); idx >= 0 {
+		authority = authority[idx+1:]
+	}
+	return scheme + "://" + authority + suffix
+}
+
+func safeURLErrorMessage(rawURL string, err error) string {
+	if err == nil {
+		return ""
+	}
+	message := err.Error()
+	redactedURL := safeURLForLog(rawURL)
+	message = strings.ReplaceAll(message, rawURL, redactedURL)
+	if rawWithoutFragment, _, ok := strings.Cut(rawURL, "#"); ok {
+		message = strings.ReplaceAll(message, rawWithoutFragment, redactedURL)
+	}
+	return message
 }

--- a/internal/declarative/loader/url_fetcher.go
+++ b/internal/declarative/loader/url_fetcher.go
@@ -1,0 +1,373 @@
+package loader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/kong/kongctl/internal/konnect/httpclient"
+	applog "github.com/kong/kongctl/internal/log"
+	"github.com/kong/kongctl/internal/meta"
+	"github.com/kong/kongctl/internal/util/httpheaders"
+)
+
+const (
+	defaultURLFetchTimeout     = 30 * time.Second
+	defaultURLFetchMaxBytes    = 50 * 1024 * 1024
+	defaultURLFetchMaxAttempts = 3
+	defaultURLFetchMaxRedirect = 10
+	defaultURLFetchBackoff     = 100 * time.Millisecond
+)
+
+// URLFetchAuthPolicy controls when remote declarative URL fetches may include authentication.
+type URLFetchAuthPolicy string
+
+const (
+	// URLFetchAuthAuto sends the configured bearer token only to HTTPS URLs whose host is explicitly allowed.
+	URLFetchAuthAuto URLFetchAuthPolicy = "auto"
+	// URLFetchAuthNone disables authentication for remote declarative URL fetches.
+	URLFetchAuthNone URLFetchAuthPolicy = "none"
+)
+
+// URLFetchTokenSource provides bearer tokens for authenticated remote declarative URL fetches.
+type URLFetchTokenSource interface {
+	Token(context.Context) (string, error)
+}
+
+// URLFetchOptions controls remote declarative URL fetch behavior that should be selected by the command layer.
+type URLFetchOptions struct {
+	AuthPolicy       URLFetchAuthPolicy
+	AuthAllowedHosts []string
+	TokenSource      URLFetchTokenSource
+}
+
+type urlFetchConfig struct {
+	client       *http.Client
+	maxBytes     int64
+	maxAttempts  int
+	maxRedirects int
+	backoff      time.Duration
+	options      URLFetchOptions
+}
+
+// FetchURL retrieves a declarative configuration source from an HTTP(S) URL.
+func FetchURL(ctx context.Context, rawURL string) ([]byte, error) {
+	return fetchURL(ctx, rawURL, urlFetchConfig{})
+}
+
+// FetchURLWithOptions retrieves a declarative configuration source from an HTTP(S) URL using the provided options.
+func FetchURLWithOptions(ctx context.Context, rawURL string, options URLFetchOptions) ([]byte, error) {
+	return fetchURL(ctx, rawURL, urlFetchConfig{options: options})
+}
+
+func fetchURL(ctx context.Context, rawURL string, cfg urlFetchConfig) ([]byte, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, err := parseFetchURL(rawURL); err != nil {
+		return nil, err
+	}
+
+	client := configuredFetchClient(cfg)
+	maxAttempts := cfg.maxAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = defaultURLFetchMaxAttempts
+	}
+	backoff := cfg.backoff
+	if backoff <= 0 {
+		backoff = defaultURLFetchBackoff
+	}
+
+	var lastErr error
+	for attempt := range maxAttempts {
+		body, retryable, err := fetchURLOnce(ctx, client, rawURL, maxResponseBytes(cfg), cfg.options, attempt+1)
+		if err == nil {
+			return body, nil
+		}
+		lastErr = err
+		if !retryable || attempt == maxAttempts-1 {
+			return nil, err
+		}
+		if err := waitBeforeURLFetchRetry(ctx, backoff, attempt); err != nil {
+			return nil, fmt.Errorf("failed to fetch URL %s: %w", rawURL, err)
+		}
+	}
+
+	return nil, lastErr
+}
+
+func parseFetchURL(rawURL string) (*url.URL, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL %q: %w", rawURL, err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("unsupported URL scheme %q", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return nil, fmt.Errorf("URL must include a host")
+	}
+	return parsed, nil
+}
+
+func configuredFetchClient(cfg urlFetchConfig) *http.Client {
+	var client http.Client
+	if cfg.client != nil {
+		client = *cfg.client
+	} else {
+		client = *httpclient.NewHTTPClient(defaultURLFetchTimeout)
+	}
+	client.CheckRedirect = checkURLFetchRedirect(maxRedirects(cfg), cfg.options)
+	return &client
+}
+
+func maxResponseBytes(cfg urlFetchConfig) int64 {
+	if cfg.maxBytes > 0 {
+		return cfg.maxBytes
+	}
+	return defaultURLFetchMaxBytes
+}
+
+func maxRedirects(cfg urlFetchConfig) int {
+	if cfg.maxRedirects > 0 {
+		return cfg.maxRedirects
+	}
+	return defaultURLFetchMaxRedirect
+}
+
+func checkURLFetchRedirect(maxRedirects int, options URLFetchOptions) func(*http.Request, []*http.Request) error {
+	return func(req *http.Request, via []*http.Request) error {
+		if len(via) >= maxRedirects {
+			return fmt.Errorf("stopped after %d redirects", maxRedirects)
+		}
+		if len(via) > 0 && via[len(via)-1].URL.Scheme == "https" && req.URL.Scheme == "http" {
+			return fmt.Errorf("refusing to follow HTTPS to HTTP redirect")
+		}
+		if req.URL.Scheme != "http" && req.URL.Scheme != "https" {
+			return fmt.Errorf("unsupported redirect URL scheme %q", req.URL.Scheme)
+		}
+		return configureURLFetchAuth(req, options)
+	}
+}
+
+func fetchURLOnce(
+	ctx context.Context,
+	client *http.Client,
+	rawURL string,
+	maxBytes int64,
+	options URLFetchOptions,
+	attempt int,
+) ([]byte, bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to create request for URL %s: %w", rawURL, err)
+	}
+	httpheaders.SetUserAgent(req, meta.UserAgent())
+	httpheaders.SetAccept(req, "application/yaml, text/yaml, text/plain, */*")
+	if err := configureURLFetchAuth(req, options); err != nil {
+		return nil, false, err
+	}
+
+	if logger := loggerFromContext(ctx); logger != nil {
+		logger.Debug("fetching remote declarative configuration",
+			slog.String("url", safeURLForLog(rawURL)),
+			slog.Int("attempt", attempt),
+			slog.Bool("authenticated", req.Header.Get(httpheaders.HeaderAuthorization) != ""))
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, isRetryableURLFetchError(ctx, err), fmt.Errorf("failed to fetch URL %s: %w", rawURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		statusErr := unexpectedURLFetchStatusError(rawURL, resp)
+		return nil, isRetryableURLFetchStatus(resp.StatusCode), statusErr
+	}
+
+	if resp.ContentLength > maxBytes {
+		return nil, false, fmt.Errorf(
+			"failed to fetch URL %s: response is too large (%d bytes, limit %d bytes)",
+			rawURL, resp.ContentLength, maxBytes,
+		)
+	}
+
+	if logger := loggerFromContext(ctx); logger != nil {
+		contentType := resp.Header.Get(httpheaders.HeaderContentType)
+		if contentType != "" && !isExpectedURLFetchContentType(contentType) {
+			logger.Debug("remote declarative configuration has unexpected content type",
+				slog.String("url", safeURLForLog(rawURL)),
+				slog.String("content_type", contentType))
+		}
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
+	if err != nil {
+		return nil, isRetryableURLFetchError(ctx, err), fmt.Errorf("failed to read URL %s: %w", rawURL, err)
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, false, fmt.Errorf(
+			"failed to fetch URL %s: response is too large (limit %d bytes)",
+			rawURL, maxBytes,
+		)
+	}
+
+	return body, false, nil
+}
+
+// AllowsAuthenticationForURL reports whether the URL is within the configured authentication boundary.
+func (o URLFetchOptions) AllowsAuthenticationForURL(rawURL string) bool {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	return o.allowsAuthenticationForParsedURL(parsed)
+}
+
+func (o URLFetchOptions) shouldAuthenticateURL(u *url.URL) bool {
+	return o.TokenSource != nil && o.allowsAuthenticationForParsedURL(u)
+}
+
+func (o URLFetchOptions) allowsAuthenticationForParsedURL(u *url.URL) bool {
+	if remoteURLFetchAuthPolicyOrDefault(o.AuthPolicy) != URLFetchAuthAuto {
+		return false
+	}
+	if u == nil || u.Scheme != "https" {
+		return false
+	}
+	return urlFetchAuthHostAllowed(u.Hostname(), o.AuthAllowedHosts)
+}
+
+func remoteURLFetchAuthPolicyOrDefault(policy URLFetchAuthPolicy) URLFetchAuthPolicy {
+	if policy == "" {
+		return URLFetchAuthAuto
+	}
+	return policy
+}
+
+func configureURLFetchAuth(req *http.Request, options URLFetchOptions) error {
+	if req == nil {
+		return nil
+	}
+	if !options.shouldAuthenticateURL(req.URL) {
+		req.Header.Del(httpheaders.HeaderAuthorization)
+		return nil
+	}
+
+	token, err := options.TokenSource.Token(req.Context())
+	if err != nil {
+		return fmt.Errorf("failed to resolve authentication token for URL %s: %w", req.URL.String(), err)
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return fmt.Errorf("failed to resolve authentication token for URL %s: token is empty", req.URL.String())
+	}
+	httpheaders.SetBearerAuthorization(req, token)
+	return nil
+}
+
+func urlFetchAuthHostAllowed(host string, allowedHosts []string) bool {
+	host = normalizeURLFetchAuthHost(host)
+	if host == "" {
+		return false
+	}
+	for _, allowedHost := range allowedHosts {
+		allowedHost = normalizeURLFetchAuthHost(allowedHost)
+		if allowedHost == "" {
+			continue
+		}
+		if host == allowedHost || strings.HasSuffix(host, "."+allowedHost) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeURLFetchAuthHost(host string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" {
+		return ""
+	}
+	if parsed, err := url.Parse(host); err == nil && parsed.Hostname() != "" {
+		host = parsed.Hostname()
+	} else if splitHost, _, err := net.SplitHostPort(host); err == nil {
+		host = splitHost
+	}
+	host = strings.Trim(host, "[]")
+	return strings.TrimSuffix(host, ".")
+}
+
+func unexpectedURLFetchStatusError(rawURL string, resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+	snippet := strings.TrimSpace(string(body))
+	if snippet == "" {
+		return fmt.Errorf("failed to fetch URL %s: unexpected HTTP status %s", rawURL, resp.Status)
+	}
+	return fmt.Errorf("failed to fetch URL %s: unexpected HTTP status %s: %s", rawURL, resp.Status, snippet)
+}
+
+func isRetryableURLFetchStatus(statusCode int) bool {
+	return statusCode == http.StatusTooManyRequests || statusCode >= http.StatusInternalServerError
+}
+
+func isRetryableURLFetchError(ctx context.Context, err error) bool {
+	if err == nil || ctx.Err() != nil {
+		return false
+	}
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
+func waitBeforeURLFetchRetry(ctx context.Context, base time.Duration, attempt int) error {
+	delay := min(base<<attempt, time.Second)
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func isExpectedURLFetchContentType(contentType string) bool {
+	mediaType, _, _ := strings.Cut(strings.ToLower(strings.TrimSpace(contentType)), ";")
+	switch mediaType {
+	case "", "application/yaml", "application/x-yaml", "text/yaml", "text/x-yaml", "text/plain",
+		"application/octet-stream":
+		return true
+	default:
+		return strings.HasSuffix(mediaType, "+yaml")
+	}
+}
+
+func loggerFromContext(ctx context.Context) *slog.Logger {
+	if ctx == nil {
+		return nil
+	}
+	logger, _ := ctx.Value(applog.LoggerKey).(*slog.Logger)
+	return logger
+}
+
+func safeURLForLog(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	parsed.User = nil
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String()
+}

--- a/internal/declarative/loader/url_fetcher_test.go
+++ b/internal/declarative/loader/url_fetcher_test.go
@@ -1,0 +1,294 @@
+package loader
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kong/kongctl/internal/util/httpheaders"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchURL(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.NotEmpty(t, r.Header.Get(httpheaders.HeaderUserAgent))
+			assert.Empty(t, r.Header.Get(httpheaders.HeaderAuthorization))
+			w.Header().Set(httpheaders.HeaderContentType, "application/yaml")
+			_, err := w.Write([]byte("portals: []\n"))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		body, err := FetchURL(t.Context(), server.URL+"/config.yaml")
+		require.NoError(t, err)
+		assert.Equal(t, "portals: []\n", string(body))
+	})
+
+	t.Run("retries retryable status", func(t *testing.T) {
+		var attempts atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			attempt := attempts.Add(1)
+			if attempt < 3 {
+				http.Error(w, "try again", http.StatusInternalServerError)
+				return
+			}
+			_, err := w.Write([]byte("portals: []\n"))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		body, err := fetchURL(t.Context(), server.URL, urlFetchConfig{backoff: time.Millisecond})
+		require.NoError(t, err)
+		assert.Equal(t, "portals: []\n", string(body))
+		assert.Equal(t, int32(3), attempts.Load())
+	})
+
+	t.Run("does not retry non-retryable status", func(t *testing.T) {
+		var attempts atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			attempts.Add(1)
+			http.NotFound(w, nil)
+		}))
+		defer server.Close()
+
+		_, err := fetchURL(t.Context(), server.URL, urlFetchConfig{backoff: time.Millisecond})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "404")
+		assert.Equal(t, int32(1), attempts.Load())
+	})
+
+	t.Run("rejects response over content length limit", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Length", "4")
+			_, err := w.Write([]byte("data"))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		_, err := fetchURL(t.Context(), server.URL, urlFetchConfig{maxBytes: 3})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "response is too large")
+	})
+
+	t.Run("rejects response over streaming limit", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+			_, err := w.Write([]byte("data"))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		_, err := fetchURL(t.Context(), server.URL, urlFetchConfig{maxBytes: 3})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "response is too large")
+	})
+
+	t.Run("rejects redirect loops", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/loop", http.StatusFound)
+		}))
+		defer server.Close()
+
+		_, err := fetchURL(t.Context(), server.URL+"/loop", urlFetchConfig{maxRedirects: 2})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "stopped after 2 redirects")
+	})
+
+	t.Run("rejects https to http redirects", func(t *testing.T) {
+		target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, err := w.Write([]byte("portals: []\n"))
+			require.NoError(t, err)
+		}))
+		defer target.Close()
+
+		source := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, target.URL, http.StatusFound)
+		}))
+		defer source.Close()
+
+		_, err := fetchURL(t.Context(), source.URL, urlFetchConfig{client: source.Client()})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "refusing to follow HTTPS to HTTP redirect")
+	})
+
+	t.Run("honors canceled context", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, err := w.Write([]byte("portals: []\n"))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		_, err := FetchURL(ctx, server.URL)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), context.Canceled.Error())
+	})
+}
+
+func TestFetchURLAuth(t *testing.T) {
+	t.Run("sends bearer token to allowed HTTPS host", func(t *testing.T) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "Bearer test-token", r.Header.Get(httpheaders.HeaderAuthorization))
+			_, err := w.Write([]byte("portals: []\n"))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		body, err := fetchURL(t.Context(), server.URL, urlFetchConfig{
+			client: server.Client(),
+			options: URLFetchOptions{
+				AuthPolicy:       URLFetchAuthAuto,
+				AuthAllowedHosts: []string{mustURLHostname(t, server.URL)},
+				TokenSource:      staticURLFetchTokenSource{token: "test-token"},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "portals: []\n", string(body))
+	})
+
+	t.Run("does not send bearer token to non-allowed HTTPS host", func(t *testing.T) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Empty(t, r.Header.Get(httpheaders.HeaderAuthorization))
+			_, err := w.Write([]byte("portals: []\n"))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		_, err := fetchURL(t.Context(), server.URL, urlFetchConfig{
+			client: server.Client(),
+			options: URLFetchOptions{
+				AuthPolicy:       URLFetchAuthAuto,
+				AuthAllowedHosts: []string{"example.com"},
+				TokenSource:      staticURLFetchTokenSource{token: "test-token"},
+			},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("does not send bearer token over HTTP", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Empty(t, r.Header.Get(httpheaders.HeaderAuthorization))
+			_, err := w.Write([]byte("portals: []\n"))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		_, err := fetchURL(t.Context(), server.URL, urlFetchConfig{
+			options: URLFetchOptions{
+				AuthPolicy:       URLFetchAuthAuto,
+				AuthAllowedHosts: []string{mustURLHostname(t, server.URL)},
+				TokenSource:      staticURLFetchTokenSource{token: "test-token"},
+			},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("strips bearer token on redirect outside allowed hosts", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://example.com/config.yaml", nil)
+		require.NoError(t, err)
+		req.Header.Set(httpheaders.HeaderAuthorization, "Bearer test-token")
+
+		via, err := http.NewRequestWithContext(
+			t.Context(),
+			http.MethodGet,
+			"https://us.cloud.konghq.com/config.yaml",
+			nil,
+		)
+		require.NoError(t, err)
+
+		err = checkURLFetchRedirect(10, URLFetchOptions{
+			AuthPolicy:       URLFetchAuthAuto,
+			AuthAllowedHosts: []string{"cloud.konghq.com"},
+			TokenSource:      staticURLFetchTokenSource{token: "test-token"},
+		})(req, []*http.Request{via})
+		require.NoError(t, err)
+		assert.Empty(t, req.Header.Get(httpheaders.HeaderAuthorization))
+	})
+}
+
+func TestLoader_LoadFromSources_URL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(`
+portals:
+  - ref: remote-portal
+    name: Remote Portal
+`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	rs, err := New().LoadFromSourcesWithContext(t.Context(), []Source{
+		{Path: server.URL + "/config", Type: SourceTypeURL},
+	}, false)
+	require.NoError(t, err)
+	require.Len(t, rs.Portals, 1)
+	assert.Equal(t, "remote-portal", rs.Portals[0].Ref)
+}
+
+type staticURLFetchTokenSource struct {
+	token string
+}
+
+func (s staticURLFetchTokenSource) Token(context.Context) (string, error) {
+	return s.token, nil
+}
+
+func mustURLHostname(t *testing.T, rawURL string) string {
+	t.Helper()
+	parsed, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	return parsed.Hostname()
+}
+
+func TestLoader_LoadFromSources_URLUsesBaseDirForFileTags(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "description.txt"), []byte("loaded from base dir"), 0o600))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(`
+apis:
+  - ref: remote-api
+    name: Remote API
+    description: !file description.txt
+`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	rs, err := NewWithBaseDir(dir).LoadFromSourcesWithContext(t.Context(), []Source{
+		{Path: server.URL + "/config.yaml", Type: SourceTypeURL},
+	}, false)
+	require.NoError(t, err)
+	require.Len(t, rs.APIs, 1)
+	require.NotNil(t, rs.APIs[0].Description)
+	assert.Equal(t, "loaded from base dir", *rs.APIs[0].Description)
+}
+
+func TestFetchURLRejectsInvalidURL(t *testing.T) {
+	tests := []string{
+		"file:///tmp/config.yaml",
+		"https://",
+		"://bad",
+	}
+
+	for _, rawURL := range tests {
+		t.Run(strings.ReplaceAll(rawURL, "/", "_"), func(t *testing.T) {
+			_, err := FetchURL(t.Context(), rawURL)
+			require.Error(t, err)
+			assert.Contains(t, fmt.Sprint(err), "URL")
+		})
+	}
+}

--- a/internal/declarative/loader/url_fetcher_test.go
+++ b/internal/declarative/loader/url_fetcher_test.go
@@ -2,6 +2,7 @@ package loader
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -77,6 +78,34 @@ func TestFetchURL(t *testing.T) {
 
 		_, err := fetchURL(t.Context(), server.URL, urlFetchConfig{maxBytes: 3})
 		require.Error(t, err)
+		assert.Contains(t, err.Error(), "response is too large")
+	})
+
+	t.Run("sanitizes URL in status errors", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "not found", http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		_, err := fetchURL(t.Context(), sensitiveURLForTest(t, server.URL+"/config.yaml"), urlFetchConfig{})
+		require.Error(t, err)
+		assertURLFetchErrorSanitized(t, err)
+		assert.Contains(t, err.Error(), "/config.yaml")
+	})
+
+	t.Run("sanitizes URL in response size errors", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Length", "4")
+			_, err := w.Write([]byte("data"))
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		_, err := fetchURL(t.Context(), sensitiveURLForTest(t, server.URL+"/config.yaml"), urlFetchConfig{
+			maxBytes: 3,
+		})
+		require.Error(t, err)
+		assertURLFetchErrorSanitized(t, err)
 		assert.Contains(t, err.Error(), "response is too large")
 	})
 
@@ -217,6 +246,25 @@ func TestFetchURLAuth(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, req.Header.Get(httpheaders.HeaderAuthorization))
 	})
+
+	t.Run("sanitizes URL in token source errors", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(
+			t.Context(),
+			http.MethodGet,
+			sensitiveURLForTest(t, "https://example.com/config.yaml"),
+			nil,
+		)
+		require.NoError(t, err)
+
+		err = configureURLFetchAuth(req, URLFetchOptions{
+			AuthPolicy:       URLFetchAuthAuto,
+			AuthAllowedHosts: []string{"example.com"},
+			TokenSource:      staticURLFetchTokenSource{err: errors.New("token unavailable")},
+		})
+		require.Error(t, err)
+		assertURLFetchErrorSanitized(t, err)
+		assert.Contains(t, err.Error(), "token unavailable")
+	})
 }
 
 func TestLoader_LoadFromSources_URL(t *testing.T) {
@@ -240,10 +288,32 @@ portals:
 
 type staticURLFetchTokenSource struct {
 	token string
+	err   error
 }
 
 func (s staticURLFetchTokenSource) Token(context.Context) (string, error) {
+	if s.err != nil {
+		return "", s.err
+	}
 	return s.token, nil
+}
+
+func sensitiveURLForTest(t *testing.T, rawURL string) string {
+	t.Helper()
+	parsed, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	parsed.User = url.UserPassword("user", "pass")
+	parsed.RawQuery = "token=secret"
+	parsed.Fragment = "fragment"
+	return parsed.String()
+}
+
+func assertURLFetchErrorSanitized(t *testing.T, err error) {
+	t.Helper()
+	errText := err.Error()
+	assert.NotContains(t, errText, "user:pass")
+	assert.NotContains(t, errText, "token=secret")
+	assert.NotContains(t, errText, "fragment")
 }
 
 func mustURLHostname(t *testing.T, rawURL string) string {
@@ -291,4 +361,11 @@ func TestFetchURLRejectsInvalidURL(t *testing.T) {
 			assert.Contains(t, fmt.Sprint(err), "URL")
 		})
 	}
+}
+
+func TestFetchURLRejectsMalformedURLWithoutLeakingSecrets(t *testing.T) {
+	_, err := FetchURL(t.Context(), "https://user:pass@example.com/%zz?token=secret#fragment")
+	require.Error(t, err)
+	assertURLFetchErrorSanitized(t, err)
+	assert.Contains(t, err.Error(), "https://example.com/%zz")
 }


### PR DESCRIPTION
## Summary

Closes #1262.

Adds support for using HTTP(S) URLs as declarative `-f/--filename` sources across plan, diff, apply, sync, and delete workflows.

## What changed

- Added remote URL source detection and loading in the declarative loader.
- Added bounded remote fetching with retries, response-size limits, redirect limits, HTTPS downgrade protection, and sanitized logging.
- Added `-s, --remote-file-save-dir` so one or more remote URL sources can be saved by URL filename into a local directory and then loaded from the saved files. Duplicate filenames fail before fetching.
- Added `-F, --remote-file-save-force` to explicitly replace existing regular files in `--remote-file-save-dir`; existing files remain protected by default.
- Added `--remote-file-auth=auto|none`, defaulting to scoped Konnect auth for HTTPS Konnect hosts only.
- Moved remote-save notifications to INFO logs so structured stdout stays clean.
- Updated command help, documentation, and tests for remote file inputs.

## Validation

- `go test ./internal/declarative/loader`
- `go test ./internal/cmd/root/products/konnect/declarative`
- `golangci-lint run ./internal/cmd/root/products/konnect/declarative`
- `git diff --check`
- `make build`
- `make test`
- `./kongctl apply --help | rg "remote-file-save| -s,| -F,"`
- redirected `kongctl plan ... -s ... --log-level info --log-file ...`: stdout parsed as JSON, stderr was empty, log contained `saved remote source`
