### PR TITLE
fix(declarative): Resolve nested event gateway policy refs

### DIFF
--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -858,7 +858,17 @@ func (e *Executor) executeChange(ctx context.Context, result *ExecutionResult, c
 // hydrateKnownReferenceIDs fills unresolved parent/reference IDs in-place using
 // IDs from already executed dependency CREATE changes.
 func (e *Executor) hydrateKnownReferenceIDs(change *planner.PlannedChange, plan *planner.Plan) {
-	if change == nil || plan == nil || len(change.DependsOn) == 0 {
+	if change == nil || plan == nil {
+		return
+	}
+
+	for field, refInfo := range change.References {
+		if change.Fields != nil && !unresolvedReferenceID(refInfo.ID) {
+			setResolvedFieldValue(change.Fields, field, refInfo.ID)
+		}
+	}
+
+	if len(change.DependsOn) == 0 {
 		return
 	}
 
@@ -895,9 +905,7 @@ func (e *Executor) hydrateKnownReferenceIDs(change *planner.PlannedChange, plan 
 				refInfo.ID = id
 				updated = true
 				if change.Fields != nil {
-					if _, exists := change.Fields[field]; exists {
-						change.Fields[field] = id
-					}
+					setResolvedFieldValue(change.Fields, field, id)
 				}
 			}
 		}
@@ -1141,9 +1149,121 @@ func (e *Executor) syncResolvedRef(
 		change.References[fieldName] = ref
 	}
 
-	change.Fields[fieldName] = ref.ID
+	if change.Fields != nil && !setResolvedFieldValue(change.Fields, fieldName, ref.ID) {
+		change.Fields[fieldName] = ref.ID
+	}
 
 	return nil
+}
+
+func (e *Executor) syncResolvedEventGatewayProducePolicyConfigRefs(
+	ctx context.Context,
+	change *planner.PlannedChange,
+) error {
+	if err := e.syncResolvedEventGatewaySchemaRegistryConfigRef(ctx, change); err != nil {
+		return err
+	}
+	if err := e.syncResolvedEventGatewayStaticKeyConfigRef(ctx, change); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (e *Executor) syncResolvedEventGatewaySchemaRegistryConfigRef(
+	ctx context.Context,
+	change *planner.PlannedChange,
+) error {
+	const fieldName = planner.FieldConfig + ".schema_registry." + planner.FieldID
+	ref, ok := change.References[fieldName]
+	if !ok {
+		return nil
+	}
+
+	if unresolvedReferenceID(ref.ID) {
+		if e.client == nil {
+			return fmt.Errorf("state client not configured")
+		}
+		gatewayID, err := eventGatewayIDFromChange(change)
+		if err != nil {
+			return err
+		}
+		name := referenceLookupName(ref)
+		registry, err := e.client.GetEventGatewaySchemaRegistryByName(ctx, gatewayID, name)
+		if err != nil {
+			return fmt.Errorf("failed to resolve event gateway schema registry reference: %w", err)
+		}
+		if registry == nil {
+			return fmt.Errorf("event gateway schema registry not found: ref=%s", ref.Ref)
+		}
+		ref.ID = registry.ID
+		change.References[fieldName] = ref
+	}
+
+	if change.Fields != nil {
+		setResolvedFieldValue(change.Fields, fieldName, ref.ID)
+	}
+	return nil
+}
+
+func (e *Executor) syncResolvedEventGatewayStaticKeyConfigRef(
+	ctx context.Context,
+	change *planner.PlannedChange,
+) error {
+	const fieldName = planner.FieldConfig + ".encryption_key.key." + planner.FieldID
+	ref, ok := change.References[fieldName]
+	if !ok {
+		return nil
+	}
+
+	if unresolvedReferenceID(ref.ID) {
+		if e.client == nil {
+			return fmt.Errorf("state client not configured")
+		}
+		gatewayID, err := eventGatewayIDFromChange(change)
+		if err != nil {
+			return err
+		}
+		name := referenceLookupName(ref)
+		keys, err := e.client.ListEventGatewayStaticKeys(ctx, gatewayID)
+		if err != nil {
+			return fmt.Errorf("failed to resolve event gateway static key reference: %w", err)
+		}
+		for _, key := range keys {
+			if key.Name == name {
+				ref.ID = key.ID
+				change.References[fieldName] = ref
+				break
+			}
+		}
+		if unresolvedReferenceID(ref.ID) {
+			return fmt.Errorf("event gateway static key not found: ref=%s", ref.Ref)
+		}
+	}
+
+	if change.Fields != nil {
+		setResolvedFieldValue(change.Fields, fieldName, ref.ID)
+	}
+	return nil
+}
+
+func eventGatewayIDFromChange(change *planner.PlannedChange) (string, error) {
+	if change == nil {
+		return "", fmt.Errorf("event gateway reference is required")
+	}
+	ref, ok := change.References[planner.FieldEventGatewayID]
+	if !ok || unresolvedReferenceID(ref.ID) {
+		return "", fmt.Errorf("event gateway reference is required")
+	}
+	return ref.ID, nil
+}
+
+func referenceLookupName(ref planner.ReferenceInfo) string {
+	if ref.LookupFields != nil {
+		if name := strings.TrimSpace(ref.LookupFields[planner.FieldName]); name != "" {
+			return name
+		}
+	}
+	return normalizedRefValue(ref.Ref)
 }
 
 func (e *Executor) syncResolvedDCRProviderID(
@@ -2644,6 +2764,9 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 			virtualClusterRef.ID = virtualClusterID
 			change.References[planner.FieldEventGatewayVirtualClusterID] = virtualClusterRef
 		}
+		if err := e.syncResolvedEventGatewayProducePolicyConfigRefs(ctx, change); err != nil {
+			return "", err
+		}
 		return e.eventGatewayProducePolicyExecutor.Create(ctx, *change)
 	case planner.ResourceTypeEventGatewayConsumePolicy:
 		// Resolve event gateway reference if needed
@@ -3105,6 +3228,9 @@ func (e *Executor) updateResource(ctx context.Context, change *planner.PlannedCh
 			}
 			virtualClusterRef.ID = virtualClusterID
 			change.References[planner.FieldEventGatewayVirtualClusterID] = virtualClusterRef
+		}
+		if err := e.syncResolvedEventGatewayProducePolicyConfigRefs(ctx, change); err != nil {
+			return "", err
 		}
 		return e.eventGatewayProducePolicyExecutor.Update(ctx, *change)
 	case planner.ResourceTypeEventGatewayConsumePolicy:

--- a/internal/declarative/executor/executor_test.go
+++ b/internal/declarative/executor/executor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/kong/kongctl/internal/declarative/resources"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -110,6 +111,84 @@ func TestValidateChangePreExecutionAllowsPortalTeamGroupMappingWithoutResourceID
 	err := exec.validateChangePreExecution(context.Background(), change)
 
 	require.NoError(t, err)
+}
+
+func TestHydrateKnownReferenceIDsUpdatesNestedField(t *testing.T) {
+	exec := New(nil, nil, false)
+	exec.createdResources["1-c-static-key"] = "static-key-id"
+
+	plan := planner.NewPlan("1.0", "test", planner.PlanModeApply)
+	plan.AddChange(planner.PlannedChange{
+		ID:           "1-c-static-key",
+		ResourceType: planner.ResourceTypeEventGatewayStaticKey,
+		ResourceRef:  "static-key",
+		Action:       planner.ActionCreate,
+	})
+
+	change := planner.PlannedChange{
+		ID:           "2-c-produce-policy",
+		ResourceType: planner.ResourceTypeEventGatewayProducePolicy,
+		ResourceRef:  "produce-policy",
+		Action:       planner.ActionCreate,
+		DependsOn:    []string{"1-c-static-key"},
+		Fields: map[string]any{
+			planner.FieldConfig: map[string]any{
+				"encryption_key": map[string]any{
+					"key": map[string]any{
+						planner.FieldID: "__REF__:static-key#id",
+					},
+				},
+			},
+		},
+		References: map[string]planner.ReferenceInfo{
+			"config.encryption_key.key.id": {
+				Ref: "__REF__:static-key#id",
+				ID:  resources.UnknownReferenceID,
+			},
+		},
+	}
+	plan.AddChange(change)
+
+	exec.hydrateKnownReferenceIDs(&change, plan)
+
+	ref := change.References["config.encryption_key.key.id"]
+	assert.Equal(t, "static-key-id", ref.ID)
+	config := change.Fields[planner.FieldConfig].(map[string]any)
+	encryptionKey := config["encryption_key"].(map[string]any)
+	key := encryptionKey["key"].(map[string]any)
+	assert.Equal(t, "static-key-id", key[planner.FieldID])
+	assert.NotContains(t, change.Fields, "config.encryption_key.key.id")
+}
+
+func TestHydrateKnownReferenceIDsAppliesResolvedNestedField(t *testing.T) {
+	exec := New(nil, nil, false)
+	plan := planner.NewPlan("1.0", "test", planner.PlanModeApply)
+	change := planner.PlannedChange{
+		ID:           "1-c-produce-policy",
+		ResourceType: planner.ResourceTypeEventGatewayProducePolicy,
+		ResourceRef:  "produce-policy",
+		Action:       planner.ActionCreate,
+		Fields: map[string]any{
+			planner.FieldConfig: map[string]any{
+				"schema_registry": map[string]any{
+					planner.FieldID: "__REF__:schema-registry#id",
+				},
+			},
+		},
+		References: map[string]planner.ReferenceInfo{
+			"config.schema_registry.id": {
+				Ref: "__REF__:schema-registry#id",
+				ID:  "schema-registry-id",
+			},
+		},
+	}
+
+	exec.hydrateKnownReferenceIDs(&change, plan)
+
+	config := change.Fields[planner.FieldConfig].(map[string]any)
+	schemaRegistry := config["schema_registry"].(map[string]any)
+	assert.Equal(t, "schema-registry-id", schemaRegistry[planner.FieldID])
+	assert.NotContains(t, change.Fields, "config.schema_registry.id")
 }
 
 func TestExecutor_Execute_EmptyPlan(t *testing.T) {

--- a/internal/declarative/executor/references.go
+++ b/internal/declarative/executor/references.go
@@ -1,0 +1,80 @@
+package executor
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/kong/kongctl/internal/declarative/planner"
+)
+
+func setResolvedFieldValue(fields map[string]any, fieldPath string, value any) bool {
+	if fields == nil || fieldPath == "" {
+		return false
+	}
+
+	if current, exists := fields[fieldPath]; exists {
+		fields[fieldPath] = resolvedFieldReplacement(current, value)
+		return true
+	}
+
+	_, ok := setResolvedFieldPathValue(fields, strings.Split(fieldPath, "."), value)
+	return ok
+}
+
+func resolvedFieldReplacement(current any, value any) any {
+	if fieldChange, ok := current.(planner.FieldChange); ok {
+		fieldChange.New = value
+		return fieldChange
+	}
+	return value
+}
+
+func setResolvedFieldPathValue(current any, segments []string, value any) (any, bool) {
+	if len(segments) == 0 {
+		return current, false
+	}
+
+	switch typed := current.(type) {
+	case planner.FieldChange:
+		updated, ok := setResolvedFieldPathValue(typed.New, segments, value)
+		if !ok {
+			return current, false
+		}
+		typed.New = updated
+		return typed, true
+	case map[string]any:
+		child, ok := typed[segments[0]]
+		if !ok {
+			return current, false
+		}
+		if len(segments) == 1 {
+			typed[segments[0]] = resolvedFieldReplacement(child, value)
+			return typed, true
+		}
+
+		updated, ok := setResolvedFieldPathValue(child, segments[1:], value)
+		if !ok {
+			return current, false
+		}
+		typed[segments[0]] = updated
+		return typed, true
+	case []any:
+		index, err := strconv.Atoi(segments[0])
+		if err != nil || index < 0 || index >= len(typed) {
+			return current, false
+		}
+		if len(segments) == 1 {
+			typed[index] = resolvedFieldReplacement(typed[index], value)
+			return typed, true
+		}
+
+		updated, ok := setResolvedFieldPathValue(typed[index], segments[1:], value)
+		if !ok {
+			return current, false
+		}
+		typed[index] = updated
+		return typed, true
+	default:
+		return current, false
+	}
+}

--- a/internal/declarative/planner/event_gateway_produce_policy_planner.go
+++ b/internal/declarative/planner/event_gateway_produce_policy_planner.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/kong/kongctl/internal/declarative/resources"
 	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/declarative/tags"
 )
 
 // planEventGatewayVirtualClusterProducePolicyChanges plans changes for Event Gateway Produce Policies
@@ -211,6 +213,7 @@ func (p *Planner) planProducePolicyCreate(
 			},
 		},
 	}
+	p.addProducePolicyConfigReferences(&change)
 
 	p.logger.Debug("Enqueuing produce policy CREATE",
 		"policy_ref", policy.Ref,
@@ -259,6 +262,7 @@ func (p *Planner) planProducePolicyUpdate(
 			},
 		},
 	}
+	p.addProducePolicyConfigReferences(&change)
 
 	p.logger.Debug("Enqueuing produce policy UPDATE",
 		"policy_ref", policy.Ref,
@@ -266,6 +270,75 @@ func (p *Planner) planProducePolicyUpdate(
 		"policy_id", policyID,
 	)
 	plan.AddChange(change)
+}
+
+func (p *Planner) addProducePolicyConfigReferences(change *PlannedChange) {
+	if change == nil {
+		return
+	}
+	p.addProducePolicyConfigReference(
+		change,
+		FieldConfig+".schema_registry."+FieldID,
+		ResourceTypeEventGatewaySchemaRegistry,
+	)
+	p.addProducePolicyConfigReference(
+		change,
+		FieldConfig+".encryption_key.key."+FieldID,
+		ResourceTypeEventGatewayStaticKey,
+	)
+}
+
+func (p *Planner) addProducePolicyConfigReference(
+	change *PlannedChange,
+	fieldPath string,
+	resourceType string,
+) {
+	ref, ok := stringValueAtFieldPath(change.Fields, fieldPath)
+	if !ok || !tags.IsRefPlaceholder(ref) {
+		return
+	}
+
+	refInfo := ReferenceInfo{
+		Ref: ref,
+		ID:  resources.UnknownReferenceID,
+	}
+	targetRef := referenceTargetRef(ref)
+	if p.resolver != nil {
+		if resource, exists := p.resolver.getResourceByTypeAndRef(resourceType, targetRef); exists {
+			if moniker := resource.GetMoniker(); moniker != "" {
+				refInfo.LookupFields = map[string]string{FieldName: moniker}
+			}
+		}
+	}
+
+	if change.References == nil {
+		change.References = make(map[string]ReferenceInfo)
+	}
+	change.References[fieldPath] = refInfo
+}
+
+func stringValueAtFieldPath(fields map[string]any, fieldPath string) (string, bool) {
+	if fields == nil || fieldPath == "" {
+		return "", false
+	}
+	if value, ok := fields[fieldPath].(string); ok {
+		return value, true
+	}
+
+	var current any = fields
+	for _, segment := range strings.Split(fieldPath, ".") {
+		currentMap, ok := current.(map[string]any)
+		if !ok {
+			return "", false
+		}
+		current, ok = currentMap[segment]
+		if !ok {
+			return "", false
+		}
+	}
+
+	value, ok := current.(string)
+	return value, ok
 }
 
 func (p *Planner) planProducePolicyDelete(

--- a/internal/declarative/planner/planner.go
+++ b/internal/declarative/planner/planner.go
@@ -422,10 +422,10 @@ func (p *Planner) GeneratePlan(ctx context.Context, rs *resources.ResourceSet, o
 					basePlan.Changes[i].References = make(map[string]ReferenceInfo)
 				}
 				for field, ref := range refs {
-					basePlan.Changes[i].References[field] = ReferenceInfo{
-						Ref: ref.Ref,
-						ID:  ref.ID,
-					}
+					refInfo := basePlan.Changes[i].References[field]
+					refInfo.Ref = ref.Ref
+					refInfo.ID = ref.ID
+					basePlan.Changes[i].References[field] = refInfo
 				}
 				break
 			}

--- a/internal/declarative/planner/resolver.go
+++ b/internal/declarative/planner/resolver.go
@@ -40,6 +40,11 @@ type ResolveResult struct {
 	Errors []error
 }
 
+type extractedReference struct {
+	Field string
+	Ref   string
+}
+
 // ResolveReferences resolves all references in planned changes
 func (r *ReferenceResolver) ResolveReferences(ctx context.Context, changes []PlannedChange) (*ResolveResult, error) {
 	result := &ResolveResult{
@@ -63,32 +68,30 @@ func (r *ReferenceResolver) ResolveReferences(ctx context.Context, changes []Pla
 		changeRefs := make(map[string]ResolvedReference)
 
 		// Check fields that might contain references
-		for fieldName, fieldValue := range change.Fields {
-			if ref, isRef := r.extractReference(fieldName, fieldValue); isRef {
-				// Determine resource type from field name and role entity metadata.
-				resourceType := r.getResourceTypeForChangeField(change, fieldName)
-				targetRef := referenceTargetRef(ref)
+		for _, fieldRef := range r.extractReferencesFromFields(change.Fields) {
+			// Determine resource type from field name and role entity metadata.
+			resourceType := r.getResourceTypeForChangeField(change, fieldRef.Field)
+			targetRef := referenceTargetRef(fieldRef.Ref)
 
-				// Check if this references something being created
-				if _, inPlan := createdResources[resourceType][targetRef]; inPlan {
-					changeRefs[fieldName] = ResolvedReference{
-						Ref: ref,
-						ID:  resources.UnknownReferenceID, // Will be resolved at execution
-					}
-				} else {
-					// Resolve from existing resources
-					id, err := r.resolveReference(ctx, resourceType, ref)
-					if err != nil {
-						result.Errors = append(result.Errors, fmt.Errorf(
-							"change %s: failed to resolve %s reference %q: %w",
-							change.ID, resourceType, ref, err,
-						))
-						continue
-					}
-					changeRefs[fieldName] = ResolvedReference{
-						Ref: ref,
-						ID:  id,
-					}
+			// Check if this references something being created
+			if referenceCreatedInPlan(createdResources, resourceType, targetRef) {
+				changeRefs[fieldRef.Field] = ResolvedReference{
+					Ref: fieldRef.Ref,
+					ID:  resources.UnknownReferenceID, // Will be resolved at execution
+				}
+			} else {
+				// Resolve from existing resources
+				id, err := r.resolveReference(ctx, resourceType, fieldRef.Ref)
+				if err != nil {
+					result.Errors = append(result.Errors, fmt.Errorf(
+						"change %s: failed to resolve %s reference %q: %w",
+						change.ID, resourceType, fieldRef.Ref, err,
+					))
+					continue
+				}
+				changeRefs[fieldRef.Field] = ResolvedReference{
+					Ref: fieldRef.Ref,
+					ID:  id,
 				}
 			}
 		}
@@ -99,6 +102,55 @@ func (r *ReferenceResolver) ResolveReferences(ctx context.Context, changes []Pla
 	}
 
 	return result, nil
+}
+
+func referenceCreatedInPlan(createdResources map[string]map[string]string, resourceType, targetRef string) bool {
+	if targetRef == "" {
+		return false
+	}
+	if resourceType != "" {
+		_, ok := createdResources[resourceType][targetRef]
+		return ok
+	}
+	for _, refs := range createdResources {
+		if _, ok := refs[targetRef]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *ReferenceResolver) extractReferencesFromFields(fields map[string]any) []extractedReference {
+	references := []extractedReference{}
+	for fieldName, fieldValue := range fields {
+		references = append(references, r.extractReferences(fieldName, fieldValue)...)
+	}
+	return references
+}
+
+func (r *ReferenceResolver) extractReferences(fieldName string, value any) []extractedReference {
+	if ref, isRef := r.extractReference(fieldName, value); isRef {
+		return []extractedReference{{Field: fieldName, Ref: ref}}
+	}
+
+	switch v := value.(type) {
+	case FieldChange:
+		return r.extractReferences(fieldName, v.New)
+	case map[string]any:
+		references := []extractedReference{}
+		for childField, childValue := range v {
+			references = append(references, r.extractReferences(fieldName+"."+childField, childValue)...)
+		}
+		return references
+	case []any:
+		references := []extractedReference{}
+		for i, childValue := range v {
+			references = append(references, r.extractReferences(fmt.Sprintf("%s.%d", fieldName, i), childValue)...)
+		}
+		return references
+	default:
+		return nil
+	}
 }
 
 // extractReference checks if a field value is a reference
@@ -169,6 +221,12 @@ func (r *ReferenceResolver) getResourceTypeForField(fieldName string) string {
 	case FieldEntityID:
 		return ResourceTypeAPI
 	default:
+		if strings.HasSuffix(fieldName, ".schema_registry.id") {
+			return ResourceTypeEventGatewaySchemaRegistry
+		}
+		if strings.HasSuffix(fieldName, ".encryption_key.key.id") {
+			return ResourceTypeEventGatewayStaticKey
+		}
 		return ""
 	}
 }
@@ -216,6 +274,11 @@ func (r *ReferenceResolver) resolveReference(ctx context.Context, resourceType, 
 			if fieldName == FieldID || fieldName == "ID" {
 				konnectID := resource.GetKonnectID()
 				if konnectID == "" {
+					if id, resolved, err := r.resolveEventGatewayChildResource(ctx, resource); err != nil {
+						return "", err
+					} else if resolved {
+						return id, nil
+					}
 					// Resource exists but no Konnect ID (will be created)
 					return resources.UnknownReferenceID, nil // Trigger forward reference
 				}
@@ -254,7 +317,102 @@ func (r *ReferenceResolver) getResourceByTypeAndRef(resourceType string, ref str
 			return resource, true
 		}
 	}
+	if resource, exists := r.getEventGatewayChildResourceByTypeAndRef(resourceType, ref); exists {
+		return resource, true
+	}
+	if resource, exists := r.resources.GetResourceByRef(ref); exists && string(resource.GetType()) == resourceType {
+		return resource, true
+	}
 	return nil, false
+}
+
+func (r *ReferenceResolver) getEventGatewayChildResourceByTypeAndRef(
+	resourceType string,
+	ref string,
+) (resources.Resource, bool) {
+	for _, gateway := range r.resources.EventGatewayControlPlanes {
+		switch resourceType {
+		case ResourceTypeEventGatewaySchemaRegistry:
+			for _, registry := range gateway.SchemaRegistries {
+				if registry.Ref == ref {
+					registryCopy := registry
+					registryCopy.EventGateway = gateway.Ref
+					return &registryCopy, true
+				}
+			}
+		case ResourceTypeEventGatewayStaticKey:
+			for _, staticKey := range gateway.StaticKeys {
+				if staticKey.Ref == ref {
+					staticKeyCopy := staticKey
+					staticKeyCopy.EventGateway = gateway.Ref
+					return &staticKeyCopy, true
+				}
+			}
+		}
+	}
+	return nil, false
+}
+
+func (r *ReferenceResolver) resolveEventGatewayChildResource(
+	ctx context.Context,
+	resource resources.Resource,
+) (string, bool, error) {
+	switch typed := resource.(type) {
+	case *resources.EventGatewaySchemaRegistryResource:
+		if r.client == nil || typed == nil {
+			return "", false, nil
+		}
+		gatewayID, err := r.resolveEventGatewayParentRef(ctx, typed.EventGateway)
+		if err != nil {
+			return "", true, err
+		}
+		registry, err := r.client.GetEventGatewaySchemaRegistryByName(ctx, gatewayID, typed.GetMoniker())
+		if err != nil {
+			return "", true, fmt.Errorf("failed to resolve event gateway schema registry ref %q: %w", typed.Ref, err)
+		}
+		if registry == nil {
+			return "", true, fmt.Errorf("event gateway schema registry not found: ref=%s", typed.Ref)
+		}
+		return registry.ID, true, nil
+	case *resources.EventGatewayStaticKeyResource:
+		if r.client == nil || typed == nil {
+			return "", false, nil
+		}
+		gatewayID, err := r.resolveEventGatewayParentRef(ctx, typed.EventGateway)
+		if err != nil {
+			return "", true, err
+		}
+		keys, err := r.client.ListEventGatewayStaticKeys(ctx, gatewayID)
+		if err != nil {
+			return "", true, fmt.Errorf("failed to resolve event gateway static key ref %q: %w", typed.Ref, err)
+		}
+		for _, key := range keys {
+			if key.Name == typed.GetMoniker() {
+				return key.ID, true, nil
+			}
+		}
+		return "", true, fmt.Errorf("event gateway static key not found: ref=%s", typed.Ref)
+	default:
+		return "", false, nil
+	}
+}
+
+func (r *ReferenceResolver) resolveEventGatewayParentRef(ctx context.Context, eventGatewayRef string) (string, error) {
+	if eventGatewayRef == "" {
+		return "", fmt.Errorf("event gateway parent reference is required")
+	}
+	if util.IsValidUUID(eventGatewayRef) {
+		return eventGatewayRef, nil
+	}
+	if resource, exists := r.getResourceByTypeAndRef(ResourceTypeEventGatewayControlPlane, eventGatewayRef); exists {
+		if id := resource.GetKonnectID(); id != "" {
+			return id, nil
+		}
+		if moniker := resource.GetMoniker(); moniker != "" {
+			return r.resolveControlPlaneRef(ctx, moniker)
+		}
+	}
+	return r.resolveControlPlaneRef(ctx, eventGatewayRef)
 }
 
 func (r *ReferenceResolver) resolveDCRProviderRef(ctx context.Context, ref string) (string, error) {

--- a/internal/declarative/planner/resolver.go
+++ b/internal/declarative/planner/resolver.go
@@ -105,19 +105,11 @@ func (r *ReferenceResolver) ResolveReferences(ctx context.Context, changes []Pla
 }
 
 func referenceCreatedInPlan(createdResources map[string]map[string]string, resourceType, targetRef string) bool {
-	if targetRef == "" {
+	if resourceType == "" || targetRef == "" {
 		return false
 	}
-	if resourceType != "" {
-		_, ok := createdResources[resourceType][targetRef]
-		return ok
-	}
-	for _, refs := range createdResources {
-		if _, ok := refs[targetRef]; ok {
-			return true
-		}
-	}
-	return false
+	_, ok := createdResources[resourceType][targetRef]
+	return ok
 }
 
 func (r *ReferenceResolver) extractReferencesFromFields(fields map[string]any) []extractedReference {
@@ -306,11 +298,8 @@ func (r *ReferenceResolver) resolveReference(ctx context.Context, resourceType, 
 }
 
 func (r *ReferenceResolver) getResourceByTypeAndRef(resourceType string, ref string) (resources.Resource, bool) {
-	if r.resources == nil {
+	if r.resources == nil || resourceType == "" {
 		return nil, false
-	}
-	if resourceType == "" {
-		return r.resources.GetResourceByRef(ref)
 	}
 	for _, resource := range r.resources.AllResourcesByType(resources.ResourceType(resourceType)) {
 		if resource.GetRef() == ref {

--- a/internal/declarative/planner/resolver_test.go
+++ b/internal/declarative/planner/resolver_test.go
@@ -573,6 +573,69 @@ func TestResolveReferences_RoleEntityPortalReferenceUsesEntityTypeName(t *testin
 	assert.Equal(t, "portal-id", entityRef.ID)
 }
 
+func TestResolveReferences_UnknownTypePlaceholderDoesNotMatchCreatedRefInPlan(t *testing.T) {
+	ctx := context.Background()
+	client := state.NewClient(state.ClientConfig{})
+	resolver := NewReferenceResolver(client, nil)
+
+	changes := []PlannedChange{
+		{
+			ID:           "1-c-portal",
+			ResourceType: ResourceTypePortal,
+			ResourceRef:  "shared-ref",
+			Action:       ActionCreate,
+			Fields: map[string]any{
+				FieldName: "Dev Portal",
+			},
+		},
+		{
+			ID:           "2-c-resource",
+			ResourceType: ResourceTypeAPI,
+			ResourceRef:  "api-ref",
+			Action:       ActionCreate,
+			Fields: map[string]any{
+				FieldConfig: "__REF__:shared-ref#id",
+			},
+		},
+	}
+
+	result, err := resolver.ResolveReferences(ctx, changes)
+	require.NoError(t, err)
+	require.Len(t, result.Errors, 1)
+	assert.Contains(t, result.Errors[0].Error(), `unknown resource type`)
+	assert.Empty(t, result.ChangeReferences)
+}
+
+func TestResolveReferences_UnknownTypePlaceholderDoesNotUseGlobalResourceSetLookup(t *testing.T) {
+	ctx := context.Background()
+	client := state.NewClient(state.ClientConfig{})
+
+	api := declresources.APIResource{BaseResource: declresources.BaseResource{Ref: "shared-ref"}}
+	api.SetKonnectID("api-id")
+	resourceSet := &declresources.ResourceSet{
+		APIs: []declresources.APIResource{api},
+	}
+	resolver := NewReferenceResolver(client, resourceSet)
+
+	changes := []PlannedChange{
+		{
+			ID:           "1-c-resource",
+			ResourceType: ResourceTypeEventGatewayProducePolicy,
+			ResourceRef:  "produce-policy",
+			Action:       ActionCreate,
+			Fields: map[string]any{
+				FieldConfig: "__REF__:shared-ref#id",
+			},
+		},
+	}
+
+	result, err := resolver.ResolveReferences(ctx, changes)
+	require.NoError(t, err)
+	require.Len(t, result.Errors, 1)
+	assert.Contains(t, result.Errors[0].Error(), `unknown resource type`)
+	assert.Empty(t, result.ChangeReferences)
+}
+
 func TestResolveReferences_EventGatewayProducePolicyNestedReferencesCreatedInPlan(t *testing.T) {
 	ctx := context.Background()
 	client := state.NewClient(state.ClientConfig{})

--- a/internal/declarative/planner/resolver_test.go
+++ b/internal/declarative/planner/resolver_test.go
@@ -23,6 +23,63 @@ type MockPortalAPI struct {
 	mock.Mock
 }
 
+type schemaRegistryAPIForResolver struct {
+	gatewayID  string
+	registries []kkComps.SchemaRegistry
+}
+
+func (m schemaRegistryAPIForResolver) ListEventGatewaySchemaRegistries(
+	_ context.Context,
+	req kkOps.ListEventGatewaySchemaRegistriesRequest,
+	_ ...kkOps.Option,
+) (*kkOps.ListEventGatewaySchemaRegistriesResponse, error) {
+	if req.GatewayID != m.gatewayID {
+		return nil, errors.New("unexpected gateway ID")
+	}
+	return &kkOps.ListEventGatewaySchemaRegistriesResponse{
+		ListSchemaRegistriesResponse: &kkComps.ListSchemaRegistriesResponse{
+			Data: m.registries,
+		},
+	}, nil
+}
+
+func (m schemaRegistryAPIForResolver) GetEventGatewaySchemaRegistry(
+	context.Context,
+	string,
+	string,
+	...kkOps.Option,
+) (*kkOps.GetEventGatewaySchemaRegistryResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m schemaRegistryAPIForResolver) CreateEventGatewaySchemaRegistry(
+	context.Context,
+	string,
+	kkComps.SchemaRegistryCreate,
+	...kkOps.Option,
+) (*kkOps.CreateEventGatewaySchemaRegistryResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m schemaRegistryAPIForResolver) UpdateEventGatewaySchemaRegistry(
+	context.Context,
+	string,
+	string,
+	kkComps.SchemaRegistryUpdate,
+	...kkOps.Option,
+) (*kkOps.UpdateEventGatewaySchemaRegistryResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m schemaRegistryAPIForResolver) DeleteEventGatewaySchemaRegistry(
+	context.Context,
+	string,
+	string,
+	...kkOps.Option,
+) (*kkOps.DeleteEventGatewaySchemaRegistryResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m *MockPortalAPI) ListPortals(
 	ctx context.Context,
 	req kkOps.ListPortalsRequest,
@@ -514,6 +571,153 @@ func TestResolveReferences_RoleEntityPortalReferenceUsesEntityTypeName(t *testin
 	require.True(t, ok, "expected entity_id reference")
 	assert.Equal(t, "__REF__:shared-ref#id", entityRef.Ref)
 	assert.Equal(t, "portal-id", entityRef.ID)
+}
+
+func TestResolveReferences_EventGatewayProducePolicyNestedReferencesCreatedInPlan(t *testing.T) {
+	ctx := context.Background()
+	client := state.NewClient(state.ClientConfig{})
+	resolver := NewReferenceResolver(client, nil)
+
+	changes := []PlannedChange{
+		{
+			ID:           "1-c-schema-registry",
+			ResourceType: ResourceTypeEventGatewaySchemaRegistry,
+			ResourceRef:  "schema-registry",
+			Action:       ActionCreate,
+			Fields: map[string]any{
+				FieldName: "Schema Registry",
+			},
+		},
+		{
+			ID:           "2-c-static-key",
+			ResourceType: ResourceTypeEventGatewayStaticKey,
+			ResourceRef:  "static-key",
+			Action:       ActionCreate,
+			Fields: map[string]any{
+				FieldName: "Static Key",
+			},
+		},
+		{
+			ID:           "3-c-produce-policy",
+			ResourceType: ResourceTypeEventGatewayProducePolicy,
+			ResourceRef:  "produce-policy",
+			Action:       ActionCreate,
+			Fields: map[string]any{
+				FieldConfig: map[string]any{
+					"schema_registry": map[string]any{
+						FieldID: "__REF__:schema-registry#id",
+					},
+					"encryption_key": map[string]any{
+						"key": map[string]any{
+							FieldID: "__REF__:static-key#id",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := resolver.ResolveReferences(ctx, changes)
+	require.NoError(t, err)
+	require.Empty(t, result.Errors)
+
+	policyRefs, ok := result.ChangeReferences["3-c-produce-policy"]
+	require.True(t, ok, "expected produce policy references")
+
+	schemaRegistryRef, ok := policyRefs["config.schema_registry.id"]
+	require.True(t, ok, "expected schema registry reference")
+	assert.Equal(t, "__REF__:schema-registry#id", schemaRegistryRef.Ref)
+	assert.Equal(t, "[unknown]", schemaRegistryRef.ID)
+
+	staticKeyRef, ok := policyRefs["config.encryption_key.key.id"]
+	require.True(t, ok, "expected static key reference")
+	assert.Equal(t, "__REF__:static-key#id", staticKeyRef.Ref)
+	assert.Equal(t, "[unknown]", staticKeyRef.ID)
+}
+
+func TestResolveReferences_EventGatewayProducePolicyNestedSchemaRegistryReferenceExistingNestedResource(t *testing.T) {
+	ctx := context.Background()
+	mockCPAPI := helpers.NewMockControlPlaneAPI(t)
+	mockCPAPI.EXPECT().
+		ListControlPlanes(mock.Anything, mock.Anything).
+		Return(&kkOps.ListControlPlanesResponse{
+			ListControlPlanesResponse: &kkComps.ListControlPlanesResponse{
+				Data: []kkComps.ControlPlane{
+					{
+						ID:   "gateway-id",
+						Name: "gateway-name",
+						Labels: map[string]string{
+							labels.NamespaceKey: "default",
+						},
+					},
+				},
+				Meta: kkComps.PaginatedMeta{
+					Page: kkComps.PageMeta{Total: 1},
+				},
+			},
+		}, nil).
+		Once()
+
+	client := state.NewClient(state.ClientConfig{
+		ControlPlaneAPI: mockCPAPI,
+		EventGatewaySchemaRegistryAPI: &schemaRegistryAPIForResolver{
+			gatewayID: "gateway-id",
+			registries: []kkComps.SchemaRegistry{
+				{
+					ID:   "schema-registry-id",
+					Name: "schema-registry-name",
+				},
+			},
+		},
+	})
+	resourceSet := &declresources.ResourceSet{
+		EventGatewayControlPlanes: []declresources.EventGatewayControlPlaneResource{
+			{
+				BaseResource: declresources.BaseResource{Ref: "gateway-ref"},
+				CreateGatewayRequest: kkComps.CreateGatewayRequest{
+					Name: "gateway-name",
+				},
+				SchemaRegistries: []declresources.EventGatewaySchemaRegistryResource{
+					{
+						Ref: "schema-registry-ref",
+						SchemaRegistryCreate: kkComps.CreateSchemaRegistryCreateConfluent(
+							kkComps.SchemaRegistryConfluent{
+								Name: "schema-registry-name",
+							},
+						),
+					},
+				},
+			},
+		},
+	}
+	resolver := NewReferenceResolver(client, resourceSet)
+
+	changes := []PlannedChange{
+		{
+			ID:           "1-u-produce-policy",
+			ResourceType: ResourceTypeEventGatewayProducePolicy,
+			ResourceRef:  "produce-policy",
+			Action:       ActionUpdate,
+			Fields: map[string]any{
+				FieldConfig: map[string]any{
+					"schema_registry": map[string]any{
+						FieldID: "__REF__:schema-registry-ref#id",
+					},
+				},
+			},
+		},
+	}
+
+	result, err := resolver.ResolveReferences(ctx, changes)
+	require.NoError(t, err)
+	require.Empty(t, result.Errors)
+
+	policyRefs, ok := result.ChangeReferences["1-u-produce-policy"]
+	require.True(t, ok, "expected produce policy references")
+	schemaRegistryRef, ok := policyRefs["config.schema_registry.id"]
+	require.True(t, ok, "expected schema registry reference")
+	assert.Equal(t, "__REF__:schema-registry-ref#id", schemaRegistryRef.Ref)
+	assert.Equal(t, "schema-registry-id", schemaRegistryRef.ID)
 }
 
 func TestResolveReferences_ExistingPortal(t *testing.T) {

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/003-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/003-root-level-declaration/config.yaml
@@ -32,6 +32,11 @@ event_gateways:
         acl_mode: enforce_on_gateway
         dns_label: vc-default
         # produce_policies declared at root level
+    static_keys:
+      - ref: static-key-for-produce-policy
+        name: static-key-for-produce-policy-name
+        description: "Static Key for Produce Policy Test"
+        value: "YXNkZmdoamthc2RmZ2hqa2FzZGZnaGprYXNkZmdoams="
 
 event_gateway_virtual_cluster_produce_policies:
   - ref: root-level-produce-policy
@@ -49,5 +54,6 @@ event_gateway_virtual_cluster_produce_policies:
       part_of_record:
       - value
       encryption_key:
-        type: aws
-        arn: arn:aws:kms:us-east-1:123456789012:key/abcd-1234-efgh-5678
+        type: static
+        key:
+          id: !ref static-key-for-produce-policy#id

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -33,3 +33,4 @@ event_gateways:
         acl_mode: enforce_on_gateway
         dns_label: vc-default
         produce_policies: []
+    static_keys: []

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/005-schema-validation-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/005-schema-validation-policy/config.yaml
@@ -44,3 +44,18 @@ event_gateways:
               key_validation_action: mark
               value_validation_action: reject
               type: json
+              schema_registry:
+                id: !ref schema-registry-for-produce-policy#id
+    schema_registries:
+      - ref: schema-registry-for-produce-policy
+        name: schema-registry-for-produce-policy-name
+        description: "Schema Registry for Produce Policy Test"
+        type: confluent
+        config:
+          schema_type: json
+          endpoint: https://schema-registry.example.com
+          timeout_seconds: 30
+          authentication:
+            type: basic
+            username: testuser
+            password: testpassword

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/005-schema-validation-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/005-schema-validation-policy/config.yaml
@@ -43,7 +43,7 @@ event_gateways:
             config:
               key_validation_action: mark
               value_validation_action: reject
-              type: json
+              type: confluent_schema_registry
               schema_registry:
                 id: !ref schema-registry-for-produce-policy#id
     schema_registries:

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/006-update-schema-validation/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/006-update-schema-validation/config.yaml
@@ -44,3 +44,18 @@ event_gateways:
               key_validation_action: mark
               value_validation_action: mark
               type: json
+              schema_registry:
+                id: !ref schema-registry-for-produce-policy#id
+    schema_registries:
+      - ref: schema-registry-for-produce-policy
+        name: schema-registry-for-produce-policy-name
+        description: "Schema Registry for Produce Policy Test"
+        type: confluent
+        config:
+          schema_type: json
+          endpoint: https://schema-registry.example.com
+          timeout_seconds: 30
+          authentication:
+            type: basic
+            username: testuser
+            password: testpassword

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/006-update-schema-validation/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/006-update-schema-validation/config.yaml
@@ -43,7 +43,7 @@ event_gateways:
             config:
               key_validation_action: mark
               value_validation_action: mark
-              type: json
+              type: confluent_schema_registry
               schema_registry:
                 id: !ref schema-registry-for-produce-policy#id
     schema_registries:

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/007-sync-delete-schema-validation/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/007-sync-delete-schema-validation/config.yaml
@@ -32,3 +32,4 @@ event_gateways:
         acl_mode: enforce_on_gateway
         dns_label: vc-default
         produce_policies: []
+    schema_registries: []

--- a/test/e2e/scenarios/event-gateway/produce-policy/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/scenario.yaml
@@ -16,6 +16,10 @@ vars:
   producePolicyDescription: Default Produce Policy description
   svPolicyRef: schema-validation-produce-policy
   svPolicyName: schema-validation-produce-policy-name-for-test
+  staticKeyRef: static-key-for-produce-policy
+  staticKeyName: static-key-for-produce-policy-name
+  schemaRegistryRef: schema-registry-for-produce-policy
+  schemaRegistryName: schema-registry-for-produce-policy-name
 
 defaults:
   mask:
@@ -271,8 +275,14 @@ steps:
           - select: summary
             expect:
               fields:
-                total_changes: 1
-                by_action.CREATE: 1
+                total_changes: 2
+                by_action.CREATE: 2
+          - select: >-
+              changes[?resource_type=='event_gateway_static_key' && resource_ref=='{{ .vars.staticKeyRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.staticKeyRef }}"
           - select: >-
               changes[?resource_type=='event_gateway_virtual_cluster_produce_policy' && resource_ref=='root-level-produce-policy'] | [0]
             expect:
@@ -290,7 +300,7 @@ steps:
           - select: summary
             expect:
               fields:
-                applied: 1
+                applied: 2
                 failed: 0
       - name: 003-verify-root-level-create
         run:
@@ -319,13 +329,10 @@ steps:
                 labels:
                   env: production
                   team: platform
-                config:
-                  failure_mode: passthrough
-                  part_of_record:
+                config.failure_mode: passthrough
+                config.part_of_record:
                   - value
-                  encryption_key:
-                    type: aws
-                    arn: arn:aws:kms:us-east-1:123456789012:key/abcd-1234-efgh-5678
+                config.encryption_key.type: static
 
   - name: 005-root-level-sync-delete
     inputOverlayDirs:
@@ -348,14 +355,20 @@ steps:
           - select: summary
             expect:
               fields:
-                total_changes: 1
-                by_action.DELETE: 1
+                total_changes: 2
+                by_action.DELETE: 2
           - select: >-
               changes[?resource_type=='event_gateway_virtual_cluster_produce_policy' && resource_ref=='root-level-produce-policy-name'] | [0]
             expect:
               fields:
                 action: DELETE
                 resource_ref: "root-level-produce-policy-name"
+          - select: >-
+              changes[?resource_type=='event_gateway_static_key' && resource_ref=='{{ .vars.staticKeyName }}'] | [0]
+            expect:
+              fields:
+                action: DELETE
+                resource_ref: "{{ .vars.staticKeyName }}"
       - name: 002-sync-delete
         outputFormat: json
         run:
@@ -367,7 +380,7 @@ steps:
           - select: summary
             expect:
               fields:
-                applied: 1
+                applied: 2
                 failed: 0
       - name: 003-verify-root-level-sync-delete
         run:
@@ -408,8 +421,14 @@ steps:
           - select: summary
             expect:
               fields:
-                total_changes: 1
-                by_action.CREATE: 1
+                total_changes: 2
+                by_action.CREATE: 2
+          - select: >-
+              changes[?resource_type=='event_gateway_schema_registry' && resource_ref=='{{ .vars.schemaRegistryRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.schemaRegistryRef }}"
           - select: >-
               changes[?resource_type=='event_gateway_virtual_cluster_produce_policy' && resource_ref=='{{ .vars.svPolicyRef }}'] | [0]
             expect:
@@ -427,7 +446,7 @@ steps:
           - select: summary
             expect:
               fields:
-                applied: 1
+                applied: 2
                 failed: 0
       - name: 003-verify-schema-validation-create
         run:
@@ -456,10 +475,9 @@ steps:
                 labels:
                   env: staging
                   team: payments
-                config:
-                  key_validation_action: mark
-                  value_validation_action: reject
-                  type: json
+                config.key_validation_action: mark
+                config.value_validation_action: reject
+                config.type: json
 
   - name: 007-schema-validation-update
     inputOverlayDirs:
@@ -530,10 +548,9 @@ steps:
                 labels:
                   env: production
                   version: v2
-                config:
-                  key_validation_action: mark
-                  value_validation_action: mark
-                  type: json
+                config.key_validation_action: mark
+                config.value_validation_action: mark
+                config.type: json
 
   - name: 008-schema-validation-sync-delete
     inputOverlayDirs:
@@ -556,14 +573,20 @@ steps:
           - select: summary
             expect:
               fields:
-                total_changes: 1
-                by_action.DELETE: 1
+                total_changes: 2
+                by_action.DELETE: 2
           - select: >-
               changes[?resource_type=='event_gateway_virtual_cluster_produce_policy' && resource_ref=='{{ .vars.svPolicyName }}'] | [0]
             expect:
               fields:
                 action: DELETE
                 resource_ref: "{{ .vars.svPolicyName }}"
+          - select: >-
+              changes[?resource_type=='event_gateway_schema_registry' && resource_ref=='{{ .vars.schemaRegistryName }}'] | [0]
+            expect:
+              fields:
+                action: DELETE
+                resource_ref: "{{ .vars.schemaRegistryName }}"
       - name: 002-sync-delete-schema-validation
         outputFormat: json
         run:
@@ -575,7 +598,7 @@ steps:
           - select: summary
             expect:
               fields:
-                applied: 1
+                applied: 2
                 failed: 0
       - name: 003-verify-schema-validation-sync-delete
         run:

--- a/test/e2e/scenarios/event-gateway/produce-policy/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/scenario.yaml
@@ -477,7 +477,7 @@ steps:
                   team: payments
                 config.key_validation_action: mark
                 config.value_validation_action: reject
-                config.type: json
+                config.type: confluent_schema_registry
 
   - name: 007-schema-validation-update
     inputOverlayDirs:
@@ -550,7 +550,7 @@ steps:
                   version: v2
                 config.key_validation_action: mark
                 config.value_validation_action: mark
-                config.type: json
+                config.type: confluent_schema_registry
 
   - name: 008-schema-validation-sync-delete
     inputOverlayDirs:


### PR DESCRIPTION
## Summary

- Resolve nested `!ref` placeholders inside Event Gateway produce policy config fields.
- Hydrate resolved IDs back into nested plan fields before executor SDK mapping.
- Cover schema registry and static key references in the produce policy e2e scenario.

## Root Cause

Reference resolution only discovered and hydrated top-level plan fields. Nested values such as `config.schema_registry.id` and `config.encryption_key.key.id` could remain as `__REF__:` placeholders and be sent to Konnect, which rejected them as invalid UUIDs.

## Validation

- `go test ./internal/declarative/planner ./internal/declarative/executor`
- `make test`
- `make build`
- `make test-e2e-scenarios SCENARIO=event-gateway/produce-policy`

Known existing issue: `make lint` fails on unrelated generated/mock files outside this change (`test/e2e/harness/portalclient/portal_api.gen.go`, mock selector findings).

Closes #1271