### PR TITLE
task(agents): add PR title conventions

### DIFF
--- a/.github/agents/agentic-workflows.agent.md
+++ b/.github/agents/agentic-workflows.agent.md
@@ -188,7 +188,11 @@ When a user interacts with you:
 1. **Identify the task type** from the user's request
 2. **Load the appropriate prompt** from the GitHub repository URLs listed above
 3. **Follow the loaded prompt's instructions** exactly
-4. **If uncertain**, ask clarifying questions to determine the right prompt
+4. **Apply repository PR title conventions** when creating or updating
+   workflows that can open pull requests. Prompt the workflow or configure its
+   PR creation step to use the `type(category): title` format documented in
+   `AGENTS.md`, without agent prefixes.
+5. **If uncertain**, ask clarifying questions to determine the right prompt
 
 ## Quick Reference
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,8 +23,10 @@ The `AGENTS.md` file contains detailed information about:
 5. **Follow verb-noun command pattern**: `kongctl <verb> <resource>`
 6. **Respect line length**: Max 120 characters (golines enforces)
 7. **Document markdown at 80 chars**: When writing docs, wrap at 80 chars
+8. **Use standard PR titles**: When opening or updating a pull request, use
+   `type(category): title` from [AGENTS.md](/AGENTS.md), and do not add agent
+   prefixes such as `[copilot]:` or `[codex]:`
 
 ## Quick Reference
 
 See [AGENTS.md](/AGENTS.md) for detailed commands and examples.
-

--- a/.github/workflows/sdk-prerelease-preview.yml
+++ b/.github/workflows/sdk-prerelease-preview.yml
@@ -193,8 +193,8 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           branch: sdk-konnect-go/${{ steps.release.outputs.tag }}
-          commit-message: 'pre-release: sdk-konnect-go ${{ steps.release.outputs.tag }}'
-          title: 'pre-release: sdk-konnect-go: ${{ steps.release.outputs.tag }}'
+          commit-message: 'task(sdk): update sdk-konnect-go prerelease to ${{ steps.release.outputs.tag }}'
+          title: 'task(sdk): update sdk-konnect-go prerelease to ${{ steps.release.outputs.tag }}'
           body-path: ${{ steps.summary.outputs.body_path }}
           delete-branch: false
           token: ${{ secrets.PAT }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,6 +342,44 @@ after making changes to catch regressions.
 
 ## Commit & Pull Request Guidelines
 
+### Pull Request Titles
+
+All pull requests, including AI-agent-authored and automation-authored PRs,
+must use this title format:
+
+```text
+type(category): title
+```
+
+`type` must be one of:
+
+- `feat`: Adds or expands user-visible behavior.
+- `fix`: Corrects broken, incomplete, or misleading behavior.
+- `task`: Handles maintenance, docs, CI, dependencies, releases, or other work
+  that is neither a feature nor a bug fix.
+- `refactor`: Restructures code without changing behavior.
+- `test`: Adds or changes tests without changing product behavior.
+
+`category` is a short, lowercase area of the codebase or workflow. Prefer the
+smallest useful area, such as `declarative`, `tui`, `logging`, `cmd`,
+`konnect`, `auth`, `config`, `e2e`, `integration`, `docs`, `ci`, `deps`,
+`sdk`, `release`, `skills`, or `simplify`. Use a subjective but recognizable
+area; do not invent agent names as categories.
+
+`title` should be a concise, present-tense summary with no trailing period.
+Do not prefix PR titles with agent or tool labels such as `[codex]:`,
+`[copilot]:`, `Copilot:`, or `[agent]`.
+
+Examples:
+
+- `fix(declarative): add force flag for remote file save`
+- `test(e2e): expand dump coverage for event gateways`
+- `refactor(simplify): reduce kongctl view command boilerplate`
+- `task(ci): redact UUIDs in feature-user artifacts`
+- `task(deps): update sdk-konnect-go prerelease`
+
+When creating PRs programmatically, set the PR title explicitly to this format.
+
 - Commits: concise subject, imperative mood; prefix scope when helpful
   - Scopes: `cmd:`, `declarative:`, `konnect:`, `docs:`, `test:`, `ci:`
   - Examples: `cmd: add support for API product filtering`, `docs: update getting started guide`


### PR DESCRIPTION
## Summary

- Document the repository PR title format as `type(category): title` in `AGENTS.md`
- Point Copilot and agentic workflow guidance at the same PR title convention
- Update the SDK prerelease automation PR title and commit message to match the convention

## Validation

- `git diff --check`
- `yamllint .github/workflows/sdk-prerelease-preview.yml` was not run because `yamllint` is not installed in this worktree