### PR TITLE
fix(cmd): reject output flag for dump

### DIFF
--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -94,6 +94,30 @@ func TestOutputFlagHelpVisibility(t *testing.T) {
 			},
 		},
 		{
+			name: "dump hides unsupported inherited output flag",
+			args: []string{"dump", "--help"},
+			forbidOut: []string{
+				"-o, --output string",
+				"Allowed    : [ json|yaml|text ]",
+			},
+		},
+		{
+			name: "dump declarative hides unsupported inherited output flag",
+			args: []string{"dump", "declarative", "--help"},
+			forbidOut: []string{
+				"-o, --output string",
+				"Allowed    : [ json|yaml|text ]",
+			},
+		},
+		{
+			name: "dump tf-import hides unsupported inherited output flag",
+			args: []string{"dump", "tf-import", "--help"},
+			forbidOut: []string{
+				"-o, --output string",
+				"Allowed    : [ json|yaml|text ]",
+			},
+		},
+		{
 			name: "explain keeps supported output flag",
 			args: []string{"explain", "--help"},
 			wantOut: []string{
@@ -123,6 +147,85 @@ func TestOutputFlagHelpVisibility(t *testing.T) {
 		})
 	}
 }
+
+func TestDumpRejectsOutputFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "long output flag on declarative dump",
+			args: []string{"dump", "declarative", "--resources=apis", "--output", "json"},
+		},
+		{
+			name: "missing long output flag value on declarative dump",
+			args: []string{"dump", "declarative", "--resources=apis", "--output"},
+		},
+		{
+			name: "short output flag on declarative dump",
+			args: []string{"dump", "declarative", "--resources=apis", "-o", "json"},
+		},
+		{
+			name: "long output flag on terraform import dump",
+			args: []string{"dump", "tf-import", "--resources=portal", "--output", "json"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := executeRootForTest(t, tt.args...)
+			if result.exitCode == 0 {
+				t.Fatalf("expected command to fail\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+			}
+			want := "flags -o/--output are not supported for the dump command; " +
+				"use --output-file to save dump output to a file"
+			if !strings.Contains(result.stderr, want) {
+				t.Fatalf("expected stderr to contain %q\nstderr:\n%s", want, result.stderr)
+			}
+		})
+	}
+}
+
+func TestDumpPreservesNonOutputFlagParseErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "declarative output-file missing value",
+			args: []string{"dump", "declarative", "--resources=apis", "--output-file"},
+			want: "flag needs an argument: --output-file",
+		},
+		{
+			name: "tf-import output-file missing value",
+			args: []string{"dump", "tf-import", "--resources=portal", "--output-file"},
+			want: "flag needs an argument: --output-file",
+		},
+		{
+			name: "unknown output-prefixed flag",
+			args: []string{"dump", "declarative", "--resources=apis", "--output-format=json"},
+			want: "unknown flag: --output-format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := executeRootForTest(t, tt.args...)
+			if result.exitCode == 0 {
+				t.Fatalf("expected command to fail\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+			}
+			if !strings.Contains(result.stderr, tt.want) {
+				t.Fatalf("expected stderr to contain %q\nstderr:\n%s", tt.want, result.stderr)
+			}
+			if strings.Contains(result.stderr, outputFlagUnsupportedMsgForTest) {
+				t.Fatalf("expected stderr not to contain output flag unsupported message\nstderr:\n%s", result.stderr)
+			}
+		})
+	}
+}
+
+const outputFlagUnsupportedMsgForTest = "flags -o/--output are not supported for the dump command"
 
 func TestKonnectFirstHelpExamplesMatchExplicitTarget(t *testing.T) {
 	tests := []struct {

--- a/internal/cmd/root/verbs/dump/dump.go
+++ b/internal/cmd/root/verbs/dump/dump.go
@@ -2,11 +2,14 @@ package dump
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"regexp"
 
 	"github.com/spf13/cobra"
 
 	cmdpkg "github.com/kong/kongctl/internal/cmd"
+	cmdcommon "github.com/kong/kongctl/internal/cmd/common"
 	konnectCommon "github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	"github.com/kong/kongctl/internal/konnect/helpers"
@@ -16,13 +19,18 @@ import (
 )
 
 const (
-	Verb              = verbs.Dump
-	formatTFImport    = "tf-import"
-	formatDeclarative = "declarative"
+	Verb                     = verbs.Dump
+	formatTFImport           = "tf-import"
+	formatDeclarative        = "declarative"
+	outputFlagUnsupportedMsg = "flags -o/--" + cmdcommon.OutputFlagName +
+		" are not supported for the dump command; use --output-file to save dump output to a file"
 )
 
 var (
 	dumpUse = Verb.String()
+
+	outputFlagParseErrorPattern = regexp.MustCompile(`(^|[\s"',:])(?:--` +
+		cmdcommon.OutputFlagName + `|-` + cmdcommon.OutputFlagShort + `)($|[\s"',:=])`)
 
 	dumpShort = i18n.T("root.verbs.dump.dumpShort", "Dump existing resources into local declarative configuration")
 
@@ -73,14 +81,35 @@ func NewDumpCmd() (*cobra.Command, error) {
 	}
 	cmdpkg.ConfigureRequiresSubcommand(dumpCommand)
 
-	dumpCommand.PersistentPreRun = func(cmd *cobra.Command, _ []string) {
+	dumpCommand.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
+		if isOutputFlagParseError(err) {
+			return &cmdpkg.UsageError{Err: errors.New(outputFlagUnsupportedMsg)}
+		}
+		return err
+	})
+
+	cmdcommon.SkipOutputFormatValidation(dumpCommand)
+
+	dumpCommand.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
+		if outputFlag := cmd.Flag(cmdcommon.OutputFlagName); outputFlag != nil && outputFlag.Changed {
+			return &cmdpkg.UsageError{Err: errors.New(outputFlagUnsupportedMsg)}
+		}
+
 		cmd.SetContext(context.WithValue(cmd.Context(), verbs.Verb, Verb))
 		cmd.SetContext(context.WithValue(cmd.Context(),
 			helpers.SDKAPIFactoryKey, helpers.SDKAPIFactory(konnectCommon.KonnectSDKFactory)))
+		return nil
 	}
 
 	dumpCommand.AddCommand(newTFImportCmd())
 	dumpCommand.AddCommand(newDeclarativeCmd())
 
 	return dumpCommand, nil
+}
+
+func isOutputFlagParseError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return outputFlagParseErrorPattern.MatchString(err.Error())
 }

--- a/test/e2e/harness/cli.go
+++ b/test/e2e/harness/cli.go
@@ -699,7 +699,12 @@ func supportsHarnessOutputArg(args []string) bool {
 	if len(args) == 0 {
 		return true
 	}
-	return args[0] != "plan"
+	switch args[0] {
+	case "dump", "plan", "scaffold":
+		return false
+	default:
+		return true
+	}
 }
 
 func hasLogFileArg(args []string) bool {

--- a/test/e2e/harness/cli_test.go
+++ b/test/e2e/harness/cli_test.go
@@ -87,9 +87,17 @@ func TestWithEnvReplacesExistingKeys(t *testing.T) {
 	}
 }
 
-func TestSupportsHarnessOutputArgSkipsPlan(t *testing.T) {
-	if supportsHarnessOutputArg([]string{"plan", "-f", "config.yaml"}) {
-		t.Fatalf("plan command must not receive harness-managed output flags")
+func TestSupportsHarnessOutputArgSkipsFixedOutputCommands(t *testing.T) {
+	tests := [][]string{
+		{"dump", "declarative", "--resources=apis"},
+		{"plan", "-f", "config.yaml"},
+		{"scaffold", "api"},
+	}
+
+	for _, args := range tests {
+		if supportsHarnessOutputArg(args) {
+			t.Fatalf("%s command must not receive harness-managed output flags", args[0])
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Hide the inherited global `--output` flag from `kongctl dump`, `kongctl dump declarative`, and `kongctl dump tf-import` help.
- Reject explicit `-o/--output` on dump commands with a usage error that points users to `--output-file`.
- Add root command coverage for help visibility and explicit flag rejection.
- Prevent the e2e harness from auto-injecting `-o` into fixed-output commands (`dump`, `plan`, `scaffold`).

Fixes #1284.

## Rationale

`dump declarative` emits kongctl declarative YAML only, so accepting the global output-format flag is misleading. The command now follows the same fixed-output pattern as other commands that use `--output-file` for destination rather than `--output` for serialization format.

## Verification

- `go test ./internal/cmd/root/...`
- `go test -tags=e2e ./test/e2e/harness`
- `make test-e2e-scenarios SCENARIO=org/users/assignments`
- `make test`
- `make build`
- `git diff --check`

## Notes

- `make lint` was run locally and failed on existing generated/mocked files outside this change:
  - `test/e2e/harness/portalclient/portal_api.gen.go` long-line and misspelling findings
  - `internal/cmd/helper_mock.go` and `internal/konnect/helpers/controlplaneapi_mock.go` staticcheck QF1008 findings
  - local `golangci-lint` also reported a permission warning while inspecting a sibling worktree path, not this worktree
