### PR TITLE
feat(install): add shell installer

### DIFF
--- a/.github/workflows/sync-get-konghq-installer.yml
+++ b/.github/workflows/sync-get-konghq-installer.yml
@@ -1,0 +1,87 @@
+name: Sync get.konghq.com installer
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - scripts/install.sh
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout kongctl
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: kongctl
+          persist-credentials: false
+
+      - name: Checkout get.konghq.com
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: Kong/get.konghq.com
+          path: get-konghq-com
+          token: ${{ secrets.GET_KONGHQ_COM_TOKEN }}
+
+      - name: Stage installer
+        id: stage
+        run: |
+          set -euo pipefail
+
+          cp kongctl/scripts/install.sh get-konghq-com/kongctl
+          chmod 0755 get-konghq-com/kongctl
+
+          if [ -n "$(git -C get-konghq-com status --porcelain -- kongctl)" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Write PR body
+        if: steps.stage.outputs.changed == 'true'
+        id: summary
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+          SOURCE_REPOSITORY: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          body_path="${RUNNER_TEMP}/get-konghq-installer-pr.md"
+          {
+            echo "## kongctl installer sync"
+            echo
+            echo "- Source repository: \`${SOURCE_REPOSITORY}\`"
+            echo "- Source path: \`scripts/install.sh\`"
+            echo "- Source commit: \`${SOURCE_SHA}\`"
+            echo "- Hosted destination: \`kongctl\`"
+            echo "- Workflow run: ${RUN_URL}"
+            echo
+            echo "This PR updates the hosted copy of the reviewed kongctl installer."
+          } > "$body_path"
+
+          echo "body_path=$body_path" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update PR
+        if: steps.stage.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          path: get-konghq-com
+          token: ${{ secrets.GET_KONGHQ_COM_TOKEN }}
+          base: main
+          branch: kongctl/update-installer
+          delete-branch: true
+          add-paths: kongctl
+          commit-message: 'task(kongctl): update installer script'
+          title: 'task(kongctl): update installer script'
+          body-path: ${{ steps.summary.outputs.body_path }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,12 +37,19 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+      - name: Install installer test tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck zip unzip libarchive-tools
       - name: Clear Go build cache before lint
         run: go clean -cache
       - name: Setup golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           version: v2.12.2
+      - name: test installer
+        run: |
+          make test-installer
       - name: test
         run: |
           go test -race -count=1 ./...

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: test-all
-test-all: lint test test-integration
+test-all: lint test-installer test test-integration
 
 VERSION ?= $(shell (git describe --tags --exact-match 2>/dev/null || echo dev) | sed 's/^v//')
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
@@ -12,6 +12,18 @@ LATEST_BENCHMARK_LINK ?= .latest-benchmark
 .PHONY: lint
 lint:
 	golangci-lint run -v
+
+.PHONY: test-installer
+test-installer:
+	@if command -v shellcheck >/dev/null 2>&1; then \
+		shellcheck scripts/install.sh test/installer/install_test.sh; \
+	elif [ "$$CI" = "true" ]; then \
+		echo "shellcheck is required to run installer linting in CI" >&2; \
+		exit 1; \
+	else \
+		echo "shellcheck not found; skipping installer shell lint" >&2; \
+	fi
+	bash test/installer/install_test.sh
 
 .PHONY: format fmt
 format:

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ The CLI ships with:
 
 - [Documentation](#documentation)
 - [Installation](#installation)
-  - [macOS](#macos)
-  - [Linux](#linux)
+  - [Shell installer](#shell-installer)
+  - [macOS Homebrew](#macos-homebrew)
+  - [Manual download](#manual-download)
   - [Verify](#verify)
 - [Getting Started](#getting-started)
   - [1. Create a Kong Konnect Account](#1-create-a-kong-konnect-account)
@@ -41,7 +42,37 @@ For complete documentation and guides, see the documentation on the Kong Develop
 
 ## Installation
 
-### macOS
+### Shell installer
+
+Install the latest stable release on Linux or macOS with:
+
+```shell
+curl -fsSL https://get.konghq.com/kongctl | sh
+```
+
+The installer downloads the matching release archive, verifies it with the
+published SHA256 checksum, and installs `kongctl` into `$HOME/.local/bin` by
+default. It runs without prompting, and it does not use `sudo` or edit shell
+profile files.
+
+Inspect the installer before running it:
+
+```shell
+curl -fsSL https://get.konghq.com/kongctl -o kongctl-install.sh
+sh kongctl-install.sh --help
+sh kongctl-install.sh
+```
+
+Pin a specific version or install directory:
+
+```shell
+sh kongctl-install.sh --version v1.3.0 --install-dir "$HOME/bin"
+```
+
+Windows is not supported by the shell installer. Download Windows binaries from
+the [release page](https://github.com/kong/kongctl/releases).
+
+### macOS Homebrew
 
 Install using Homebrew (distributed as a cask):
 
@@ -51,7 +82,7 @@ brew install --cask kong/kongctl/kongctl
 
 *Note: If you previously installed the old formula, you may have to remove it first with `brew uninstall kongctl`.*
 
-### Linux
+### Manual download
 
 Download from the [release page](https://github.com/kong/kongctl/releases):
 
@@ -203,6 +234,8 @@ backend.
 - **[Declarative Configuration Guide](docs/declarative.md)** - Complete guide
   covering quick start, concepts, YAML tags, CI/CD integration, and best
   practices
+- **[Installer Contributor Notes](docs/contributor/installer.md)** - Maintainer
+  notes for the shell installer and hosted-script sync workflow
 - **[AI Agent Skills](skills/README.md)** - Agent skills for declarative
   configuration and extension development
 - **[Troubleshooting Guide](docs/troubleshooting.md)** - Common issues and solutions

--- a/docs/contributor/installer.md
+++ b/docs/contributor/installer.md
@@ -1,0 +1,28 @@
+# kongctl Installer
+
+`scripts/install.sh` is the canonical source for the shell installer published
+at:
+
+```shell
+https://get.konghq.com/kongctl
+```
+
+The hosted file in `Kong/get.konghq.com` is a reviewed copy, not the source of
+truth. Update `scripts/install.sh` in this repository first. After changes land
+on `main`, the `Sync get.konghq.com installer` workflow opens or updates a pull
+request in `Kong/get.konghq.com` that copies the script to the root-level
+`kongctl` path.
+
+The sync workflow requires a `GET_KONGHQ_COM_TOKEN` secret with permission to
+push branches and open pull requests in `Kong/get.konghq.com`. It must not
+auto-merge the hosted-script pull request.
+
+Before merging installer changes, run:
+
+```shell
+make test-installer
+```
+
+The installer verifies GitHub release archive checksums by default. Stronger
+release provenance, such as signed checksums or artifact attestations, should be
+added as a future hardening step without weakening checksum verification.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -807,7 +807,7 @@ print_completion() {
 
   if ! install_dir_on_path; then
     printf '  Tip: Add %s to PATH:\n' "$INSTALL_DIR_ABS"
-    printf '       export PATH="%s:$PATH"\n' "$INSTALL_DIR_ABS"
+    printf "       export PATH=\"%s:\$PATH\"\n" "$INSTALL_DIR_ABS"
     printf '\n'
   fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,871 @@
+#!/bin/sh
+# shellcheck shell=sh
+set -eu
+
+PROGRAM="kongctl"
+REPO="Kong/kongctl"
+
+VERSION="${KONGCTL_VERSION:-}"
+INSTALL_DIR="${KONGCTL_INSTALL_DIR:-}"
+INSTALL_OS="${KONGCTL_INSTALL_OS:-}"
+INSTALL_ARCH="${KONGCTL_INSTALL_ARCH:-}"
+RELEASE_BASE_URL="${KONGCTL_RELEASE_BASE_URL:-}"
+RELEASE_METADATA_URL="${KONGCTL_RELEASE_METADATA_URL:-}"
+ALLOW_FILE_URLS="${KONGCTL_ALLOW_FILE_URLS:-}"
+
+TMP_DIR=""
+DOWNLOADER=""
+CHECKSUM_TOOL=""
+EXTRACTOR=""
+INSTALL_TARGET=""
+INSTALL_DIR_ABS=""
+INSTALLED_VERSION=""
+CURRENT_VERSION=""
+RESOLVED_VERSION="latest stable"
+RELEASE_METADATA_FILE=""
+LOCK_DIR=""
+LOCK_ACQUIRED="0"
+LOCK_STALE_AFTER_SECS=600
+USE_COLOR="0"
+
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  USE_COLOR="1"
+fi
+
+log() {
+  printf '%s\n' "$*"
+}
+
+warn() {
+  if [ "$USE_COLOR" = "1" ]; then
+    printf '\033[33m!\033[0m %s\n' "$*" >&2
+  else
+    printf 'warning: %s\n' "$*" >&2
+  fi
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+cleanup() {
+  release_install_lock
+  if [ -n "$TMP_DIR" ] && [ -d "$TMP_DIR" ]; then
+    rm -rf "$TMP_DIR"
+  fi
+}
+
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' HUP TERM
+
+usage() {
+  cat <<'EOF'
+Install kongctl from GitHub Releases.
+
+Usage:
+  sh install.sh [flags]
+
+Flags:
+  --version VERSION      Install a specific release tag, such as v1.3.0
+  --install-dir PATH    Install directory (default: $HOME/.local/bin)
+  --os OS               Override OS detection: linux or darwin
+  --arch ARCH           Override architecture detection: amd64 or arm64
+  --yes                 Accepted for compatibility; install does not prompt
+  --help                Show this help
+
+Environment:
+  KONGCTL_VERSION
+  KONGCTL_INSTALL_DIR
+  KONGCTL_INSTALL_OS
+  KONGCTL_INSTALL_ARCH
+
+The installer verifies checksums before extraction and does not use sudo or
+modify shell profile files.
+EOF
+}
+
+color_text() {
+  color_code="$1"
+  text="$2"
+
+  if [ "$USE_COLOR" = "1" ]; then
+    printf '\033[%sm%s\033[0m' "$color_code" "$text"
+  else
+    printf '%s' "$text"
+  fi
+}
+
+status() {
+  marker="$(color_text 34 "==>")"
+  printf '%s %s\n' "$marker" "$*"
+}
+
+success() {
+  marker="$(color_text 32 "OK")"
+  printf '%s %s\n' "$marker" "$*"
+}
+
+is_truthy() {
+  case "$1" in
+    1 | true | TRUE | yes | YES | y | Y)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+require_arg() {
+  if [ $# -lt 2 ] || [ -z "$2" ]; then
+    die "$1 requires a value"
+  fi
+}
+
+parse_args() {
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --version)
+        require_arg "$1" "${2:-}"
+        VERSION="$2"
+        shift 2
+        ;;
+      --version=*)
+        VERSION="${1#--version=}"
+        [ -n "$VERSION" ] || die "--version requires a value"
+        shift
+        ;;
+      --install-dir)
+        require_arg "$1" "${2:-}"
+        INSTALL_DIR="$2"
+        shift 2
+        ;;
+      --install-dir=*)
+        INSTALL_DIR="${1#--install-dir=}"
+        [ -n "$INSTALL_DIR" ] || die "--install-dir requires a value"
+        shift
+        ;;
+      --os)
+        require_arg "$1" "${2:-}"
+        INSTALL_OS="$2"
+        shift 2
+        ;;
+      --os=*)
+        INSTALL_OS="${1#--os=}"
+        [ -n "$INSTALL_OS" ] || die "--os requires a value"
+        shift
+        ;;
+      --arch)
+        require_arg "$1" "${2:-}"
+        INSTALL_ARCH="$2"
+        shift 2
+        ;;
+      --arch=*)
+        INSTALL_ARCH="${1#--arch=}"
+        [ -n "$INSTALL_ARCH" ] || die "--arch requires a value"
+        shift
+        ;;
+      --yes)
+        shift
+        ;;
+      --help | -h)
+        usage
+        exit 0
+        ;;
+      --)
+        shift
+        break
+        ;;
+      *)
+        die "unknown argument: $1"
+        ;;
+    esac
+  done
+}
+
+normalize_version() {
+  if [ -z "$VERSION" ]; then
+    return
+  fi
+
+  case "$VERSION" in
+    v* | V*)
+      VERSION="v${VERSION#?}"
+      ;;
+    [0-9]*)
+      VERSION="v$VERSION"
+      ;;
+  esac
+}
+
+detect_os() {
+  if [ -n "$INSTALL_OS" ]; then
+    case "$INSTALL_OS" in
+      linux | darwin)
+        printf '%s\n' "$INSTALL_OS"
+        return
+        ;;
+      windows)
+        die "Windows is not supported by this shell installer; download a Windows release asset instead"
+        ;;
+      *)
+        die "unsupported OS: $INSTALL_OS"
+        ;;
+    esac
+  fi
+
+  case "$(uname -s 2>/dev/null || true)" in
+    Linux)
+      printf '%s\n' "linux"
+      ;;
+    Darwin)
+      printf '%s\n' "darwin"
+      ;;
+    MINGW* | MSYS* | CYGWIN*)
+      die "Windows is not supported by this shell installer; download a Windows release asset instead"
+      ;;
+    *)
+      die "unsupported OS: $(uname -s 2>/dev/null || printf '%s' unknown)"
+      ;;
+  esac
+}
+
+detect_arch() {
+  if [ -n "$INSTALL_ARCH" ]; then
+    case "$INSTALL_ARCH" in
+      amd64 | arm64)
+        printf '%s\n' "$INSTALL_ARCH"
+        return
+        ;;
+      *)
+        die "unsupported architecture: $INSTALL_ARCH"
+        ;;
+    esac
+  fi
+
+  case "$(uname -m 2>/dev/null || true)" in
+    x86_64 | amd64)
+      printf '%s\n' "amd64"
+      ;;
+    arm64 | aarch64)
+      printf '%s\n' "arm64"
+      ;;
+    *)
+      die "unsupported architecture: $(uname -m 2>/dev/null || printf '%s' unknown)"
+      ;;
+  esac
+}
+
+set_default_install_dir() {
+  if [ -n "$INSTALL_DIR" ]; then
+    return
+  fi
+
+  if [ -z "${HOME:-}" ]; then
+    die "HOME is not set; pass --install-dir"
+  fi
+
+  INSTALL_DIR="$HOME/.local/bin"
+}
+
+find_downloader() {
+  if command -v curl >/dev/null 2>&1; then
+    DOWNLOADER="curl"
+    return
+  fi
+
+  if command -v wget >/dev/null 2>&1; then
+    DOWNLOADER="wget"
+    return
+  fi
+
+  die "curl or wget is required to download release artifacts"
+}
+
+find_checksum_tool() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    CHECKSUM_TOOL="sha256sum"
+    return
+  fi
+
+  if command -v shasum >/dev/null 2>&1; then
+    CHECKSUM_TOOL="shasum"
+    return
+  fi
+
+  if command -v openssl >/dev/null 2>&1; then
+    CHECKSUM_TOOL="openssl"
+    return
+  fi
+
+  die "sha256sum, shasum, or openssl is required to verify release checksums"
+}
+
+find_extractor() {
+  if command -v unzip >/dev/null 2>&1; then
+    EXTRACTOR="unzip"
+    return
+  fi
+
+  if command -v bsdtar >/dev/null 2>&1; then
+    EXTRACTOR="bsdtar"
+    return
+  fi
+
+  die "unzip or bsdtar is required to extract kongctl release archives"
+}
+
+prepare_install_dir() {
+  mkdir -p "$INSTALL_DIR" || die "could not create install directory: $INSTALL_DIR"
+
+  INSTALL_DIR_ABS="$(cd "$INSTALL_DIR" && pwd -P)" ||
+    die "could not resolve install directory: $INSTALL_DIR"
+  INSTALL_TARGET="$INSTALL_DIR_ABS/$PROGRAM"
+  LOCK_DIR="$INSTALL_DIR_ABS/.${PROGRAM}-install.lock.d"
+}
+
+lock_is_stale() {
+  [ -d "$LOCK_DIR" ] || return 1
+
+  pid="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
+  started_at="$(cat "$LOCK_DIR/started_at" 2>/dev/null || true)"
+  now="$(date +%s 2>/dev/null || printf '%s' 0)"
+
+  case "$started_at" in
+    "" | *[!0-9]*)
+      started_at=0
+      ;;
+  esac
+
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    return 1
+  fi
+
+  if [ "$started_at" -eq 0 ] || [ "$now" -eq 0 ]; then
+    return 0
+  fi
+
+  [ $((now - started_at)) -ge "$LOCK_STALE_AFTER_SECS" ]
+}
+
+acquire_install_lock() {
+  while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+    if lock_is_stale; then
+      warn "removing stale installer lock at $LOCK_DIR"
+      rm -rf "$LOCK_DIR"
+      continue
+    fi
+
+    die "another $PROGRAM install is already running for $INSTALL_DIR_ABS"
+  done
+
+  LOCK_ACQUIRED="1"
+  printf '%s\n' "$$" > "$LOCK_DIR/pid"
+  date +%s > "$LOCK_DIR/started_at" 2>/dev/null || true
+}
+
+release_install_lock() {
+  if [ "$LOCK_ACQUIRED" = "1" ] && [ -n "$LOCK_DIR" ]; then
+    rm -rf "$LOCK_DIR" 2>/dev/null || true
+  fi
+  LOCK_ACQUIRED="0"
+}
+
+ensure_https_url() {
+  case "$1" in
+    https://*)
+      ;;
+    file://*)
+      if ! is_truthy "$ALLOW_FILE_URLS"; then
+        die "refusing file URL outside installer tests: $1"
+      fi
+      ;;
+    *)
+      die "refusing non-HTTPS download URL: $1"
+      ;;
+  esac
+}
+
+download_file() {
+  url="$1"
+  dest="$2"
+
+  ensure_https_url "$url"
+
+  case "$DOWNLOADER" in
+    curl)
+      curl -fsSL "$url" -o "$dest"
+      ;;
+    wget)
+      wget -q -O "$dest" "$url"
+      ;;
+    *)
+      die "no downloader selected"
+      ;;
+  esac
+}
+
+download_text() {
+  url="$1"
+
+  ensure_https_url "$url"
+
+  case "$DOWNLOADER" in
+    curl)
+      curl -fsSL "$url"
+      ;;
+    wget)
+      wget -q -O - "$url"
+      ;;
+    *)
+      die "no downloader selected"
+      ;;
+  esac
+}
+
+compute_sha256() {
+  file="$1"
+
+  case "$CHECKSUM_TOOL" in
+    sha256sum)
+      sha256sum "$file" | awk '{print $1}'
+      ;;
+    shasum)
+      shasum -a 256 "$file" | awk '{print $1}'
+      ;;
+    openssl)
+      openssl dgst -sha256 "$file" | awk '{print $NF}'
+      ;;
+    *)
+      die "no checksum tool selected"
+      ;;
+  esac
+}
+
+release_metadata_url() {
+  if [ -n "$RELEASE_METADATA_URL" ]; then
+    printf '%s\n' "$RELEASE_METADATA_URL"
+    return
+  fi
+
+  if [ -n "$VERSION" ]; then
+    printf 'https://api.github.com/repos/%s/releases/tags/%s\n' "$REPO" "$VERSION"
+    return
+  fi
+
+  printf 'https://api.github.com/repos/%s/releases/latest\n' "$REPO"
+}
+
+fetch_release_metadata() {
+  metadata_url="$(release_metadata_url)"
+  metadata_file="$TMP_DIR/release.json"
+
+  if download_text "$metadata_url" > "$metadata_file"; then
+    RELEASE_METADATA_FILE="$metadata_file"
+    return
+  fi
+
+  if [ -n "$RELEASE_METADATA_URL" ]; then
+    die "could not download release metadata from $metadata_url"
+  fi
+
+  warn "could not fetch GitHub release metadata; checksum file digest verification will be skipped"
+}
+
+release_tag_from_metadata() {
+  [ -n "$RELEASE_METADATA_FILE" ] || return 1
+
+  sed -n 's/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p' "$RELEASE_METADATA_FILE" | head -n 1
+}
+
+release_asset_digest_from_metadata() {
+  metadata_asset="$1"
+  [ -n "$RELEASE_METADATA_FILE" ] || return 1
+
+  awk -v asset="$metadata_asset" '
+    /"name":[[:space:]]*"[^"]+"/ {
+      name = $0
+      sub(/^.*"name":[[:space:]]*"/, "", name)
+      sub(/".*$/, "", name)
+      in_asset = (name == asset)
+    }
+
+    in_asset && /"digest":[[:space:]]*"sha256:[^"]+"/ {
+      digest = $0
+      sub(/^.*"digest":[[:space:]]*"sha256:/, "", digest)
+      sub(/".*$/, "", digest)
+      print tolower(digest)
+      found = 1
+      exit
+    }
+
+    END {
+      if (!found) {
+        exit 1
+      }
+    }
+  ' "$RELEASE_METADATA_FILE"
+}
+
+verify_file_digest_from_metadata() {
+  digest_file="$1"
+  digest_asset="$2"
+
+  [ -n "$RELEASE_METADATA_FILE" ] || return
+
+  expected="$(release_asset_digest_from_metadata "$digest_asset")" ||
+    die "release metadata does not contain SHA256 digest for $digest_asset"
+  actual="$(compute_sha256 "$digest_file")"
+
+  if [ "$expected" != "$actual" ]; then
+    die "checksum mismatch for $digest_asset"
+  fi
+
+  success "Verified release digest for $digest_asset"
+}
+
+expected_checksum() {
+  checksums_file="$1"
+  checksum_asset="$2"
+
+  awk -v asset="$checksum_asset" '
+    $2 == asset {
+      print $1
+      found = 1
+      exit
+    }
+    END {
+      if (!found) {
+        exit 1
+      }
+    }
+  ' "$checksums_file"
+}
+
+verify_checksum() {
+  checksums_file="$1"
+  archive="$2"
+  checksum_asset="$3"
+
+  expected="$(expected_checksum "$checksums_file" "$checksum_asset")" ||
+    die "checksums.txt does not contain $checksum_asset"
+  actual="$(compute_sha256 "$archive")"
+
+  if [ "$expected" != "$actual" ]; then
+    die "checksum mismatch for $checksum_asset"
+  fi
+
+  success "Verified checksum for $checksum_asset"
+}
+
+list_archive() {
+  archive="$1"
+
+  case "$EXTRACTOR" in
+    unzip)
+      unzip -Z -1 "$archive"
+      ;;
+    bsdtar)
+      bsdtar -tf "$archive"
+      ;;
+    *)
+      die "no extractor selected"
+      ;;
+  esac
+}
+
+validate_archive_entries() {
+  archive="$1"
+  binary_name="$2"
+  entries_file="$TMP_DIR/archive-entries.txt"
+  found_binary="0"
+
+  list_archive "$archive" > "$entries_file" || die "could not inspect archive"
+
+  while IFS= read -r entry; do
+    case "$entry" in
+      "" | /* | ../* | */../* | */.. | *//*)
+        die "archive contains unsafe path: $entry"
+        ;;
+    esac
+
+    case "$entry" in
+      "$binary_name")
+        found_binary="1"
+        ;;
+      LICENSE | README.md)
+        ;;
+      *)
+        die "archive contains unexpected path: $entry"
+        ;;
+    esac
+  done < "$entries_file"
+
+  if [ "$found_binary" != "1" ]; then
+    die "archive does not contain expected $binary_name binary"
+  fi
+}
+
+extract_binary() {
+  archive="$1"
+  binary_name="$2"
+  dest="$3"
+
+  case "$EXTRACTOR" in
+    unzip)
+      unzip -p "$archive" "$binary_name" > "$dest" || die "could not extract $binary_name"
+      ;;
+    bsdtar)
+      bsdtar -xOf "$archive" "$binary_name" > "$dest" || die "could not extract $binary_name"
+      ;;
+    *)
+      die "no extractor selected"
+      ;;
+  esac
+
+  chmod 755 "$dest"
+}
+
+install_binary() {
+  source_binary="$1"
+  binary_name="$2"
+
+  target="$INSTALL_TARGET"
+  tmp_target="$INSTALL_DIR_ABS/.${binary_name}.tmp.$$"
+
+  if [ -d "$target" ]; then
+    die "refusing to replace directory: $target"
+  fi
+
+  if [ ! -w "$INSTALL_DIR_ABS" ]; then
+    die "install directory is not writable: $INSTALL_DIR_ABS"
+  fi
+
+  if [ -e "$target" ] || [ -L "$target" ]; then
+    warn "replacing existing file: $target"
+  fi
+
+  if [ -e "$tmp_target" ] || [ -L "$tmp_target" ]; then
+    die "temporary install path already exists: $tmp_target"
+  fi
+
+  mv "$source_binary" "$tmp_target" || die "could not stage binary in install directory"
+  chmod 755 "$tmp_target"
+  mv -f "$tmp_target" "$target" || die "could not install binary to $target"
+
+  INSTALL_TARGET="$target"
+}
+
+version_from_binary() {
+  binary_path="$1"
+  [ -x "$binary_path" ] || return 0
+
+  version_home="$TMP_DIR/version-home"
+  version_config_home="$TMP_DIR/version-config"
+  mkdir -p "$version_home" "$version_config_home" ||
+    die "could not create version check directories"
+
+  output="$(HOME="$version_home" XDG_CONFIG_HOME="$version_config_home" DO_NOT_TRACK=1 "$binary_path" version --full 2>/dev/null || true)"
+  printf '%s\n' "$output" | awk '
+    {
+      for (i = 1; i <= NF; i++) {
+        value = $i
+        sub(/^[^0-9vV]*/, "", value)
+        sub(/[),].*$/, "", value)
+        if (value ~ /^[vV]?[0-9][0-9A-Za-z.+-]*$/) {
+          sub(/^[vV]/, "", value)
+          print value
+          exit
+        }
+      }
+    }
+  '
+}
+
+current_installed_version() {
+  version_from_binary "$INSTALL_TARGET"
+}
+
+classify_existing_kongctl() {
+  existing_path="$1"
+
+  case "$existing_path" in
+    /opt/homebrew/* | /usr/local/* | /home/linuxbrew/.linuxbrew/*)
+      printf '%s\n' "Homebrew-managed"
+      ;;
+    *)
+      printf '%s\n' "other"
+      ;;
+  esac
+}
+
+warn_path_shadowing() {
+  binary_name="$1"
+  existing="$(command -v "$binary_name" 2>/dev/null || true)"
+
+  if [ -n "$existing" ] && [ "$existing" != "$INSTALL_TARGET" ]; then
+    manager="$(classify_existing_kongctl "$existing")"
+    if [ "$manager" = "Homebrew-managed" ]; then
+      warn "existing Homebrew-managed $binary_name found at $existing; PATH order may prefer it over $INSTALL_TARGET"
+    else
+      warn "another $binary_name found at $existing; it may shadow $INSTALL_TARGET"
+    fi
+  fi
+}
+
+verify_installed_binary() {
+  verify_home="$TMP_DIR/verify-home"
+  verify_config_home="$TMP_DIR/verify-config"
+  output=""
+
+  mkdir -p "$verify_home" "$verify_config_home" ||
+    die "could not create verification directories"
+
+  if ! output="$(HOME="$verify_home" XDG_CONFIG_HOME="$verify_config_home" DO_NOT_TRACK=1 "$INSTALL_TARGET" version --full 2>&1)"; then
+    printf '%s\n' "$output" >&2
+    die "installed binary did not run successfully: $INSTALL_TARGET"
+  fi
+
+  INSTALLED_VERSION="$output"
+}
+
+make_temp_dir() {
+  TMP_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t kongctl-install)" ||
+    die "could not create temporary directory"
+}
+
+release_base_url() {
+  if [ -n "$RELEASE_BASE_URL" ]; then
+    printf '%s\n' "${RELEASE_BASE_URL%/}"
+    return
+  fi
+
+  if [ -n "$VERSION" ]; then
+    printf 'https://github.com/%s/releases/download/%s\n' "$REPO" "$VERSION"
+    return
+  fi
+
+  printf 'https://github.com/%s/releases/latest/download\n' "$REPO"
+}
+
+resolve_display_version() {
+  tag="$(release_tag_from_metadata || true)"
+  if [ -n "$tag" ]; then
+    printf '%s\n' "${tag#v}"
+    return
+  fi
+
+  if [ -n "$VERSION" ]; then
+    printf '%s\n' "${VERSION#v}"
+    return
+  fi
+
+  printf '%s\n' "latest stable"
+}
+
+platform_label() {
+  case "$os/$arch" in
+    linux/amd64)
+      printf '%s\n' "Linux (x64)"
+      ;;
+    linux/arm64)
+      printf '%s\n' "Linux (ARM64)"
+      ;;
+    darwin/amd64)
+      printf '%s\n' "macOS (Intel)"
+      ;;
+    darwin/arm64)
+      printf '%s\n' "macOS (Apple Silicon)"
+      ;;
+    *)
+      printf '%s\n' "$os/$arch"
+      ;;
+  esac
+}
+
+install_dir_on_path() {
+  case ":${PATH:-}:" in
+    *":$INSTALL_DIR_ABS:"*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+print_completion() {
+  printf '\n'
+  success "$PROGRAM successfully installed!"
+  printf '\n'
+  printf '  Version: %s\n' "$INSTALLED_VERSION"
+  printf '\n'
+  printf '  Location: %s\n' "$INSTALL_TARGET"
+  printf '\n'
+
+  if ! install_dir_on_path; then
+    printf '  Tip: Add %s to PATH:\n' "$INSTALL_DIR_ABS"
+    printf '       export PATH="$PATH:%s"\n' "$INSTALL_DIR_ABS"
+    printf '\n'
+  fi
+
+  printf '  Next: Run %s --help to get started\n' "$PROGRAM"
+  printf '\n'
+  success "Installation complete!"
+}
+
+main() {
+  parse_args "$@"
+  normalize_version
+  set_default_install_dir
+
+  os="$(detect_os)"
+  arch="$(detect_arch)"
+  archive_asset="${PROGRAM}_${os}_${arch}.zip"
+  binary_name="$PROGRAM"
+  base_url="$(release_base_url)"
+
+  find_downloader
+  find_checksum_tool
+  find_extractor
+  make_temp_dir
+  prepare_install_dir
+  acquire_install_lock
+  fetch_release_metadata
+  RESOLVED_VERSION="$(resolve_display_version)"
+  CURRENT_VERSION="$(current_installed_version)"
+
+  archive="$TMP_DIR/$archive_asset"
+  checksums="$TMP_DIR/checksums.txt"
+  extracted="$TMP_DIR/$binary_name"
+
+  if [ -n "$CURRENT_VERSION" ] && [ "$RESOLVED_VERSION" != "latest stable" ] &&
+    [ "$CURRENT_VERSION" != "$RESOLVED_VERSION" ]; then
+    status "Updating $PROGRAM from $CURRENT_VERSION to $RESOLVED_VERSION"
+  elif [ -n "$CURRENT_VERSION" ]; then
+    status "Updating $PROGRAM"
+  else
+    status "Installing $PROGRAM"
+  fi
+  status "Detected platform: $(platform_label)"
+  status "Resolved version: $RESOLVED_VERSION"
+  log "  Location: $INSTALL_DIR"
+  log ""
+
+  status "Downloading $PROGRAM"
+  download_file "$base_url/$archive_asset" "$archive"
+  download_file "$base_url/checksums.txt" "$checksums"
+  verify_file_digest_from_metadata "$checksums" "checksums.txt"
+  verify_checksum "$checksums" "$archive" "$archive_asset"
+  validate_archive_entries "$archive" "$binary_name"
+  extract_binary "$archive" "$binary_name" "$extracted"
+  status "Installing $PROGRAM to $INSTALL_TARGET"
+  install_binary "$extracted" "$binary_name"
+  warn_path_shadowing "$binary_name"
+  verify_installed_binary
+  print_completion
+}
+
+main "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -807,7 +807,7 @@ print_completion() {
 
   if ! install_dir_on_path; then
     printf '  Tip: Add %s to PATH:\n' "$INSTALL_DIR_ABS"
-    printf '       export PATH="$PATH:%s"\n' "$INSTALL_DIR_ABS"
+    printf '       export PATH="%s:$PATH"\n' "$INSTALL_DIR_ABS"
     printf '\n'
   fi
 

--- a/test/installer/install_test.sh
+++ b/test/installer/install_test.sh
@@ -1,0 +1,430 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INSTALLER="${ROOT}/scripts/install.sh"
+
+tmp_base="${KONGCTL_INSTALLER_TEST_TMPDIR:-}"
+if [[ -z "${tmp_base}" ]]; then
+  tmp_base="$(go env GOCACHE 2>/dev/null || true)"
+fi
+if [[ -z "${tmp_base}" ]]; then
+  tmp_base="${TMPDIR:-/tmp}"
+fi
+
+mkdir -p "${tmp_base}"
+TMP_ROOT="$(mktemp -d "${tmp_base%/}/kongctl-installer-tests.XXXXXX")"
+trap 'rm -rf "${TMP_ROOT}"' EXIT
+
+LAST_OUTPUT=""
+LAST_STATUS=0
+LAST_INSTALL_DIR=""
+
+fail() {
+  echo "not ok - $1" >&2
+  if [[ -n "${2:-}" && -f "$2" ]]; then
+    echo "--- output ---" >&2
+    cat "$2" >&2
+    echo "--------------" >&2
+  fi
+  exit 1
+}
+
+pass() {
+  echo "ok - $1"
+}
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  local name="$3"
+
+  if ! grep -Fq "$pattern" "$file"; then
+    fail "$name" "$file"
+  fi
+}
+
+assert_executable() {
+  local file="$1"
+  local name="$2"
+
+  if [[ ! -x "$file" ]]; then
+    fail "$name"
+  fi
+}
+
+write_fake_binary() {
+  local path="$1"
+  local version="$2"
+  local os="$3"
+  local arch="$4"
+
+  cat > "$path" <<EOF
+#!/bin/sh
+if [ "\${1:-}" = "version" ] && [ "\${2:-}" = "--full" ]; then
+  printf '%s\n' "kongctl fake ${version} ${os}/${arch}"
+  exit 0
+fi
+printf '%s\n' "kongctl fake"
+EOF
+  chmod 755 "$path"
+}
+
+append_checksum() {
+  local release_dir="$1"
+  local asset="$2"
+  local checksum
+
+  checksum="$(sha256sum "${release_dir}/${asset}" | awk '{print $1}')"
+  printf '%s  %s\n' "$checksum" "$asset" >> "${release_dir}/checksums.txt"
+}
+
+write_release_metadata() {
+  local release_dir="$1"
+  local version="$2"
+  local checksum_digest
+
+  checksum_digest="$(sha256sum "${release_dir}/checksums.txt" | awk '{print $1}')"
+  cat > "${release_dir}/release.json" <<EOF
+{
+  "tag_name": "${version}",
+  "assets": [
+    {
+      "name": "checksums.txt",
+      "digest": "sha256:${checksum_digest}"
+    }
+  ]
+}
+EOF
+}
+
+make_release() {
+  local release_dir="$1"
+  local version="${2:-v9.9.9}"
+  local os
+  local arch
+  local asset
+  local payload
+
+  mkdir -p "$release_dir"
+  : > "${release_dir}/checksums.txt"
+
+  for os in linux darwin; do
+    for arch in amd64 arm64; do
+      asset="kongctl_${os}_${arch}.zip"
+      payload="${release_dir}/payload-${os}-${arch}"
+      mkdir -p "$payload"
+      write_fake_binary "${payload}/kongctl" "$version" "$os" "$arch"
+      printf 'fake license\n' > "${payload}/LICENSE"
+      printf 'fake readme\n' > "${payload}/README.md"
+      (cd "$payload" && zip -q "${release_dir}/${asset}" LICENSE README.md kongctl)
+      append_checksum "$release_dir" "$asset"
+    done
+  done
+
+  write_release_metadata "$release_dir" "$version"
+}
+
+make_unsafe_release() {
+  local release_dir="$1"
+  local payload="${release_dir}/payload"
+  local asset="kongctl_linux_amd64.zip"
+
+  mkdir -p "${payload}/bin"
+  write_fake_binary "${payload}/bin/kongctl" "v9.9.9" "linux" "amd64"
+  : > "${release_dir}/checksums.txt"
+  (cd "$payload" && zip -q "${release_dir}/${asset}" bin/kongctl)
+  append_checksum "$release_dir" "$asset"
+  write_release_metadata "$release_dir" "v9.9.9"
+}
+
+make_bad_checksum_release() {
+  local release_dir="$1"
+
+  make_release "$release_dir"
+  printf '%064d  kongctl_linux_amd64.zip\n' 0 > "${release_dir}/checksums.txt"
+  write_release_metadata "$release_dir" "v9.9.9"
+}
+
+make_bad_metadata_release() {
+  local release_dir="$1"
+
+  make_release "$release_dir"
+  cat > "${release_dir}/release.json" <<'EOF'
+{
+  "tag_name": "v9.9.9",
+  "assets": [
+    {
+      "name": "checksums.txt",
+      "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  ]
+}
+EOF
+}
+
+run_installer() {
+  local name="$1"
+  local release_dir="$2"
+  shift 2
+
+  local case_dir="${TMP_ROOT}/${name}"
+  local metadata_env=()
+  mkdir -p "$case_dir"
+  LAST_OUTPUT="${case_dir}/output.log"
+  LAST_INSTALL_DIR="${case_dir}/bin"
+  if [[ -f "${release_dir}/release.json" ]]; then
+    metadata_env=(KONGCTL_RELEASE_METADATA_URL="file://${release_dir}/release.json")
+  fi
+
+  set +e
+  env \
+    HOME="${case_dir}/home" \
+    KONGCTL_ALLOW_FILE_URLS=1 \
+    KONGCTL_RELEASE_BASE_URL="file://${release_dir}" \
+    PATH="${PATH}" \
+    "${metadata_env[@]}" \
+    /bin/sh "$INSTALLER" --install-dir "$LAST_INSTALL_DIR" "$@" > "$LAST_OUTPUT" 2>&1
+  LAST_STATUS=$?
+  set -e
+}
+
+expect_success() {
+  local name="$1"
+  local release_dir="$2"
+  shift 2
+
+  run_installer "$name" "$release_dir" "$@"
+  if [[ "$LAST_STATUS" -ne 0 ]]; then
+    fail "$name" "$LAST_OUTPUT"
+  fi
+  pass "$name"
+}
+
+expect_failure() {
+  local name="$1"
+  local release_dir="$2"
+  local expected="$3"
+  shift 3
+
+  run_installer "$name" "$release_dir" "$@"
+  if [[ "$LAST_STATUS" -eq 0 ]]; then
+    fail "$name should have failed" "$LAST_OUTPUT"
+  fi
+  assert_contains "$LAST_OUTPUT" "$expected" "$name"
+  pass "$name"
+}
+
+test_success_matrix() {
+  local release_dir="${TMP_ROOT}/release"
+  local os
+  local arch
+  local bin
+
+  make_release "$release_dir"
+
+  for os in linux darwin; do
+    for arch in amd64 arm64; do
+      expect_success "installs ${os}/${arch}" "$release_dir" --os "$os" --arch "$arch"
+      bin="${LAST_INSTALL_DIR}/kongctl"
+      assert_executable "$bin" "installed binary is executable for ${os}/${arch}"
+      "$bin" version --full | grep -Fq "kongctl fake v9.9.9 ${os}/${arch}" ||
+        fail "installed binary reports version for ${os}/${arch}"
+    done
+  done
+}
+
+test_version_pin_and_install_dir() {
+  local release_dir="${TMP_ROOT}/release-version"
+
+  make_release "$release_dir" "v1.2.3"
+  expect_success "supports version pinning" "$release_dir" --version "1.2.3" --os linux --arch amd64
+  assert_contains "$LAST_OUTPUT" "Resolved version: 1.2.3" "version pin is normalized"
+  assert_executable "${LAST_INSTALL_DIR}/kongctl" "install-dir override is honored"
+}
+
+test_completion_output() {
+  local release_dir="${TMP_ROOT}/release-completion"
+
+  make_release "$release_dir" "v2.0.0"
+  expect_success "prints completion output" "$release_dir" --os linux --arch amd64
+  assert_contains "$LAST_OUTPUT" "OK kongctl successfully installed!" "completion success line"
+  assert_contains "$LAST_OUTPUT" "Version: kongctl fake v2.0.0 linux/amd64" "completion version line"
+  assert_contains "$LAST_OUTPUT" "Location: ${LAST_INSTALL_DIR}/kongctl" "completion location line"
+  assert_contains "$LAST_OUTPUT" "Next: Run kongctl --help to get started" "completion next step"
+}
+
+test_update_status() {
+  local release_dir="${TMP_ROOT}/release-update"
+  local case_dir="${TMP_ROOT}/update-status"
+  local install_dir="${case_dir}/bin"
+
+  make_release "$release_dir" "v2.0.0"
+  mkdir -p "$install_dir"
+  write_fake_binary "${install_dir}/kongctl" "v1.0.0" "linux" "amd64"
+
+  set +e
+  env \
+    HOME="${case_dir}/home" \
+    KONGCTL_ALLOW_FILE_URLS=1 \
+    KONGCTL_RELEASE_BASE_URL="file://${release_dir}" \
+    KONGCTL_RELEASE_METADATA_URL="file://${release_dir}/release.json" \
+    PATH="${PATH}" \
+    /bin/sh "$INSTALLER" --install-dir "$install_dir" \
+      --os linux --arch amd64 > "${case_dir}.log" 2>&1
+  LAST_STATUS=$?
+  set -e
+  if [[ "$LAST_STATUS" -ne 0 ]]; then
+    fail "update status install should succeed" "${case_dir}.log"
+  fi
+  assert_contains "${case_dir}.log" "Updating kongctl from 1.0.0 to 2.0.0" "update status"
+  pass "prints update status"
+}
+
+test_release_metadata_digest_failure() {
+  local release_dir="${TMP_ROOT}/release-bad-metadata"
+
+  make_bad_metadata_release "$release_dir"
+  expect_failure "fails on checksum manifest digest mismatch" "$release_dir" \
+    "checksum mismatch for checksums.txt" --os linux --arch amd64
+}
+
+test_yes_flag_compatibility() {
+  local release_dir="${TMP_ROOT}/release-yes"
+
+  make_release "$release_dir"
+  expect_success "accepts yes flag" "$release_dir" --yes --os linux --arch amd64
+}
+
+test_checksum_failure() {
+  local release_dir="${TMP_ROOT}/release-bad-checksum"
+
+  make_bad_checksum_release "$release_dir"
+  expect_failure "fails on checksum mismatch" "$release_dir" "checksum mismatch" --os linux --arch amd64
+}
+
+test_unsupported_platforms() {
+  local release_dir="${TMP_ROOT}/release-unsupported"
+
+  make_release "$release_dir"
+  expect_failure "fails on unsupported os" "$release_dir" "unsupported OS" --os solaris --arch amd64
+  expect_failure "fails on unsupported arch" "$release_dir" "unsupported architecture" --os linux --arch riscv64
+}
+
+test_missing_dependencies() {
+  local release_dir="${TMP_ROOT}/release-deps"
+  local empty_path="${TMP_ROOT}/empty-path"
+  local tool_path="${TMP_ROOT}/tool-path"
+
+  make_release "$release_dir"
+  mkdir -p "$empty_path" "$tool_path"
+
+  set +e
+  env \
+    HOME="${TMP_ROOT}/missing-downloader-home" \
+    KONGCTL_ALLOW_FILE_URLS=1 \
+    KONGCTL_RELEASE_BASE_URL="file://${release_dir}" \
+    PATH="$empty_path" \
+    /bin/sh "$INSTALLER" --yes --install-dir "${TMP_ROOT}/missing-downloader-bin" \
+      --os linux --arch amd64 > "${TMP_ROOT}/missing-downloader.log" 2>&1
+  LAST_STATUS=$?
+  set -e
+  if [[ "$LAST_STATUS" -eq 0 ]]; then
+    fail "missing downloader should fail" "${TMP_ROOT}/missing-downloader.log"
+  fi
+  assert_contains "${TMP_ROOT}/missing-downloader.log" "curl or wget is required" "missing downloader"
+  pass "fails when downloader is missing"
+
+  ln -s "$(command -v curl)" "${tool_path}/curl"
+  ln -s "$(command -v sha256sum)" "${tool_path}/sha256sum"
+  set +e
+  env \
+    HOME="${TMP_ROOT}/missing-extractor-home" \
+    KONGCTL_ALLOW_FILE_URLS=1 \
+    KONGCTL_RELEASE_BASE_URL="file://${release_dir}" \
+    KONGCTL_RELEASE_METADATA_URL="file://${release_dir}/release.json" \
+    PATH="$tool_path" \
+    /bin/sh "$INSTALLER" --yes --install-dir "${TMP_ROOT}/missing-extractor-bin" \
+      --os linux --arch amd64 > "${TMP_ROOT}/missing-extractor.log" 2>&1
+  LAST_STATUS=$?
+  set -e
+  if [[ "$LAST_STATUS" -eq 0 ]]; then
+    fail "missing extractor should fail" "${TMP_ROOT}/missing-extractor.log"
+  fi
+  assert_contains "${TMP_ROOT}/missing-extractor.log" "unzip or bsdtar is required" "missing extractor"
+  pass "fails when extractor is missing"
+}
+
+test_unsafe_archive() {
+  local release_dir="${TMP_ROOT}/release-unsafe"
+
+  make_unsafe_release "$release_dir"
+  expect_failure "refuses unexpected archive paths" "$release_dir" "unexpected path" --os linux --arch amd64
+}
+
+test_existing_directory_refusal() {
+  local release_dir="${TMP_ROOT}/release-existing-dir"
+  local case_dir="${TMP_ROOT}/existing-dir"
+  local install_dir="${case_dir}/bin"
+
+  make_release "$release_dir"
+  mkdir -p "${install_dir}/kongctl"
+
+  set +e
+  env \
+    HOME="${case_dir}/home" \
+    KONGCTL_ALLOW_FILE_URLS=1 \
+    KONGCTL_RELEASE_BASE_URL="file://${release_dir}" \
+    KONGCTL_RELEASE_METADATA_URL="file://${release_dir}/release.json" \
+    PATH="${PATH}" \
+    /bin/sh "$INSTALLER" --yes --install-dir "$install_dir" \
+      --os linux --arch amd64 > "${case_dir}.log" 2>&1
+  LAST_STATUS=$?
+  set -e
+  if [[ "$LAST_STATUS" -eq 0 ]]; then
+    fail "existing directory should fail" "${case_dir}.log"
+  fi
+  assert_contains "${case_dir}.log" "refusing to replace directory" "existing directory refusal"
+  pass "refuses to replace existing directory"
+}
+
+test_path_shadow_warning() {
+  local release_dir="${TMP_ROOT}/release-shadow"
+  local case_dir="${TMP_ROOT}/path-shadow"
+  local shadow_dir="${case_dir}/shadow"
+  local install_dir="${case_dir}/bin"
+
+  make_release "$release_dir"
+  mkdir -p "$shadow_dir"
+  write_fake_binary "${shadow_dir}/kongctl" "v0.0.1" "linux" "amd64"
+
+  set +e
+  env \
+    HOME="${case_dir}/home" \
+    KONGCTL_ALLOW_FILE_URLS=1 \
+    KONGCTL_RELEASE_BASE_URL="file://${release_dir}" \
+    KONGCTL_RELEASE_METADATA_URL="file://${release_dir}/release.json" \
+    PATH="${shadow_dir}:${PATH}" \
+    /bin/sh "$INSTALLER" --yes --install-dir "$install_dir" \
+      --os linux --arch amd64 > "${case_dir}.log" 2>&1
+  LAST_STATUS=$?
+  set -e
+  if [[ "$LAST_STATUS" -ne 0 ]]; then
+    fail "path shadow install should succeed" "${case_dir}.log"
+  fi
+  assert_contains "${case_dir}.log" "may shadow" "path shadow warning"
+  pass "warns about PATH shadowing"
+}
+
+test_success_matrix
+test_version_pin_and_install_dir
+test_completion_output
+test_yes_flag_compatibility
+test_update_status
+test_release_metadata_digest_failure
+test_checksum_failure
+test_unsupported_platforms
+test_missing_dependencies
+test_unsafe_archive
+test_existing_directory_refusal
+test_path_shadow_warning

--- a/test/installer/install_test.sh
+++ b/test/installer/install_test.sh
@@ -70,12 +70,52 @@ EOF
   chmod 755 "$path"
 }
 
+fixture_sha256() {
+  local file="$1"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+    return
+  fi
+
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | awk '{print $1}'
+    return
+  fi
+
+  if command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 "$file" | awk '{print $NF}'
+    return
+  fi
+
+  fail "sha256sum, shasum, or openssl is required for installer tests"
+}
+
+available_checksum_tool() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s\n' "sha256sum"
+    return
+  fi
+
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s\n' "shasum"
+    return
+  fi
+
+  if command -v openssl >/dev/null 2>&1; then
+    printf '%s\n' "openssl"
+    return
+  fi
+
+  fail "sha256sum, shasum, or openssl is required for installer tests"
+}
+
 append_checksum() {
   local release_dir="$1"
   local asset="$2"
   local checksum
 
-  checksum="$(sha256sum "${release_dir}/${asset}" | awk '{print $1}')"
+  checksum="$(fixture_sha256 "${release_dir}/${asset}")"
   printf '%s  %s\n' "$checksum" "$asset" >> "${release_dir}/checksums.txt"
 }
 
@@ -84,7 +124,7 @@ write_release_metadata() {
   local version="$2"
   local checksum_digest
 
-  checksum_digest="$(sha256sum "${release_dir}/checksums.txt" | awk '{print $1}')"
+  checksum_digest="$(fixture_sha256 "${release_dir}/checksums.txt")"
   cat > "${release_dir}/release.json" <<EOF
 {
   "tag_name": "${version}",
@@ -315,6 +355,7 @@ test_missing_dependencies() {
   local release_dir="${TMP_ROOT}/release-deps"
   local empty_path="${TMP_ROOT}/empty-path"
   local tool_path="${TMP_ROOT}/tool-path"
+  local checksum_tool
 
   make_release "$release_dir"
   mkdir -p "$empty_path" "$tool_path"
@@ -336,7 +377,8 @@ test_missing_dependencies() {
   pass "fails when downloader is missing"
 
   ln -s "$(command -v curl)" "${tool_path}/curl"
-  ln -s "$(command -v sha256sum)" "${tool_path}/sha256sum"
+  checksum_tool="$(available_checksum_tool)"
+  ln -s "$(command -v "$checksum_tool")" "${tool_path}/${checksum_tool}"
   set +e
   env \
     HOME="${TMP_ROOT}/missing-extractor-home" \


### PR DESCRIPTION
## Summary

- Add a POSIX shell installer for Linux/macOS amd64 and arm64 release assets.
- Verify GitHub release metadata digest for `checksums.txt`, then verify the selected archive checksum before extraction.
- Add fixture-based installer tests, CI wiring, README installation docs, and contributor notes.
- Add a PR-based sync workflow that copies canonical `scripts/install.sh` to `Kong/get.konghq.com` as root-level `kongctl`.

Closes #1281

## Validation

- `git diff --check`
- `sh -n scripts/install.sh`
- `bash -n test/installer/install_test.sh`
- `make test-installer`
- live install from current GitHub release into a temp directory
- `make build-ci`
- `make test`
- `make lint`

Note: local `shellcheck` is not installed in this environment, so `make test-installer` skipped shell lint locally. CI installs ShellCheck and enforces it.