### PR TITLE
task(ci): debounce main e2e workflow runs

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+paths:
+  .github/workflows/**/*.{yml,yaml}:
+    ignore:
+      # actionlint v1.7.12 does not recognize GitHub's concurrency.queue key.
+      - 'unexpected key "queue" for "concurrency" section'

--- a/.github/workflows/e2e-main-debounce.yaml
+++ b/.github/workflows/e2e-main-debounce.yaml
@@ -1,0 +1,78 @@
+name: E2E Main Debounce
+run-name: E2E Main Debounce, sha:${{ github.sha }}
+
+on:
+  push:
+    branches: ['main']
+    paths:
+      - go.mod
+      - go.sum
+      - main.go
+      - '*.go'
+      - internal/**
+      - test/e2e/**
+      - Makefile
+      - .goreleaser.yml
+      - .github/workflows/e2e.yaml
+      - .github/workflows/e2e-main-debounce.yaml
+
+permissions:
+  actions: write
+  contents: read
+
+env:
+  DO_NOT_TRACK: "1"
+
+# Restart the timer on every matching main push. Only a quiet period dispatches
+# the real E2E workflow.
+concurrency:
+  group: kongctl-e2e-main-debounce
+  cancel-in-progress: true
+
+jobs:
+  dispatch:
+    name: Dispatch E2E After Quiet Period
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Wait for quiet period
+        run: sleep 900
+
+      - name: Dispatch E2E for latest main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          latest_main_sha="$(
+            gh api "/repos/${GITHUB_REPOSITORY}/git/ref/heads/${GITHUB_REF_NAME}" --jq '.object.sha'
+          )"
+          echo "Latest ${GITHUB_REF_NAME} SHA: ${latest_main_sha}"
+
+          gh api \
+            --method GET \
+            "/repos/${GITHUB_REPOSITORY}/actions/workflows/e2e.yaml/runs" \
+            -f event=workflow_dispatch \
+            -f status=queued \
+            -f branch="${GITHUB_REF_NAME}" \
+            -f per_page=100 \
+            --jq '.workflow_runs[] | select(.display_title | startswith("E2E main debounce ")) | .id' |
+            while IFS= read -r run_id; do
+              if [ -n "${run_id}" ]; then
+                echo "Canceling older queued debounced E2E run ${run_id}."
+                gh api \
+                  --method POST \
+                  "/repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/cancel" \
+                  >/dev/null
+              fi
+            done
+
+          gh workflow run e2e.yaml \
+            --ref "${GITHUB_REF_NAME}" \
+            -f dispatch_source=main-debounce \
+            -f main_sha="${latest_main_sha}"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,4 +1,10 @@
 name: E2E
+run-name: >-
+  E2E ${{
+    inputs.dispatch_source == 'main-debounce' &&
+    format('main debounce {0}', inputs.main_sha) ||
+    github.ref_name
+  }}
 permissions:
   contents: read
 
@@ -7,20 +13,16 @@ on:
     branches: ['**']
   merge_group:
     types: [checks_requested]
-  push:
-    branches: ['main']
-    paths:
-      - go.mod
-      - go.sum
-      - main.go
-      - '*.go'
-      - internal/**
-      - test/e2e/**
-      - Makefile
-      - .goreleaser.yml
-      - .github/workflows/e2e.yaml
   workflow_dispatch:
     inputs:
+      dispatch_source:
+        description: Internal dispatch source
+        type: string
+        default: ""
+      main_sha:
+        description: Main branch SHA selected by the debounce workflow
+        type: string
+        default: ""
       run_portal_applications:
         description: Run Gmail-backed portal applications scenario
         type: boolean
@@ -34,7 +36,7 @@ env:
   DO_NOT_TRACK: "1"
 
 # The E2E target orgs are shared stateful environments. Queue full workflow
-# runs so one run completes all shards before the next run starts.
+# runs so PR, merge queue, manual, and debounced main runs never overlap.
 concurrency:
   group: kongctl-e2e-global
   queue: max
@@ -62,10 +64,33 @@ jobs:
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           BASE_REF: ${{ github.base_ref || '' }}
+          DISPATCH_SOURCE: ${{ inputs.dispatch_source || '' }}
+          MAIN_SHA: ${{ inputs.main_sha || '' }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] || [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && [ "${DISPATCH_SOURCE}" = "main-debounce" ]; then
+            if [ -z "${MAIN_SHA}" ]; then
+              echo "::error::Debounced E2E dispatch is missing main_sha."
+              exit 1
+            fi
+
+            current_main_sha="$(
+              gh api "/repos/${GITHUB_REPOSITORY}/git/ref/heads/${DEFAULT_BRANCH}" --jq '.object.sha'
+            )"
+            if [ "${MAIN_SHA}" != "${current_main_sha}" ]; then
+              echo "required=false" >> "${GITHUB_OUTPUT}"
+              echo "Skipping stale debounced E2E for ${MAIN_SHA}; current ${DEFAULT_BRANCH} is ${current_main_sha}."
+              exit 0
+            fi
+
+            echo "required=true" >> "${GITHUB_OUTPUT}"
+            echo "E2E required for debounced ${DEFAULT_BRANCH} dispatch at ${MAIN_SHA}."
+            exit 0
+          fi
+
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
             echo "required=true" >> "${GITHUB_OUTPUT}"
             echo "E2E required for ${GITHUB_EVENT_NAME}."
             exit 0
@@ -94,9 +119,14 @@ jobs:
           changed_files="$(mktemp)"
           git diff --name-only "${merge_base}" HEAD | tee "${changed_files}"
 
-          if grep -Eq \
-            '^(go\.mod|go\.sum|main\.go|[^/]+\.go|internal/.*|test/e2e/.*|Makefile|\.goreleaser\.yml|\.github/workflows/e2e\.yaml)$' \
-            "${changed_files}"; then
+          e2e_pattern="$(
+            printf '%s' \
+              '^(go\.mod|go\.sum|main\.go|[^/]+\.go|internal/.*|test/e2e/.*' \
+              '|Makefile|\.goreleaser\.yml|\.github/workflows/e2e\.yaml' \
+              '|\.github/workflows/e2e-main-debounce\.yaml)$'
+          )"
+
+          if grep -Eq "${e2e_pattern}" "${changed_files}"; then
             echo "required=true" >> "${GITHUB_OUTPUT}"
             echo "E2E required for this change set."
             exit 0

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -65,8 +65,8 @@ jobs:
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           BASE_REF: ${{ github.base_ref || '' }}
-          DISPATCH_SOURCE: ${{ inputs.dispatch_source || '' }}
-          MAIN_SHA: ${{ inputs.main_sha || '' }}
+          DISPATCH_SOURCE: ${{ github.event_name == 'workflow_dispatch' && inputs.dispatch_source || '' }}
+          MAIN_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.main_sha || '' }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,6 +1,7 @@
 name: E2E
 run-name: >-
   E2E ${{
+    github.event_name == 'workflow_dispatch' &&
     inputs.dispatch_source == 'main-debounce' &&
     format('main debounce {0}', inputs.main_sha) ||
     github.ref_name


### PR DESCRIPTION
## Summary

- Move direct `main` E2E push handling into a debounce dispatcher workflow.
- Keep PR, merge queue, manual, and debounced main E2E runs globally serialized through the existing E2E workflow.
- Add a stale-main guard for debounced dispatches and a narrow actionlint compatibility ignore for `concurrency.queue`.

## Rationale

Multiple quick pushes to `main` currently enqueue full E2E workflow runs even when only the latest resulting state needs post-merge validation. The debounce workflow waits for a quiet period, dispatches E2E for the latest `main` SHA, and avoids running stale debounced dispatches before they touch shared Konnect E2E organizations.

PR and merge-queue runs still use the E2E workflow directly so each PR is verified individually, while the shared Konnect organization state remains protected by the global E2E concurrency group.

## Validation

- `actionlint .github/workflows/e2e.yaml .github/workflows/e2e-main-debounce.yaml`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f}: ok" }' .github/actionlint.yaml .github/workflows/e2e.yaml .github/workflows/e2e-main-debounce.yaml`
- `git diff --check --cached`