### PR TITLE
feat(konnect): support tech environment targeting

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,6 +24,13 @@ on:
         description: Main branch SHA selected by the debounce workflow
         type: string
         default: ""
+      konnect_environment:
+        description: Konnect environment to target
+        type: choice
+        options:
+          - production
+          - tech
+        default: production
       run_portal_applications:
         description: Run Gmail-backed portal applications scenario
         type: boolean
@@ -222,7 +229,10 @@ jobs:
       KONGCTL_E2E_TEST_BIN: ${{ github.workspace }}/e2e.test
       KONGCTL_E2E_TEST_TIMEOUT: ${{ vars.KONGCTL_E2E_TEST_TIMEOUT || '55m' }}
       KONGCTL_E2E_KONNECT_PAT: ${{ secrets.KONGCTL_E2E_KONNECT_PAT }}
-      KONGCTL_E2E_KONNECT_BASE_URL: ${{ vars.KONGCTL_E2E_KONNECT_BASE_URL || 'https://us.api.konghq.com' }}
+      KONGCTL_E2E_KONNECT_ENV: ${{ github.event_name == 'workflow_dispatch' && inputs.konnect_environment || vars.KONGCTL_E2E_KONNECT_ENV || 'production' }}
+      KONGCTL_E2E_KONNECT_BASE_URL: ${{ vars.KONGCTL_E2E_KONNECT_BASE_URL || '' }}
+      KONGCTL_E2E_KONNECT_BASE_AUTH_URL: ${{ vars.KONGCTL_E2E_KONNECT_BASE_AUTH_URL || '' }}
+      KONGCTL_E2E_KONNECT_MACHINE_CLIENT_ID: ${{ vars.KONGCTL_E2E_KONNECT_MACHINE_CLIENT_ID || '' }}
       # Reset is enabled by default in the harness; set explicitly for clarity
       KONGCTL_E2E_RESET: "1"
       # Set HTTP timeout vars to 0s/default/off to disable kongctl/harness application-level timeouts
@@ -313,20 +323,44 @@ jobs:
           CAP_DIR="${KONGCTL_E2E_ARTIFACTS_DIR}/tcpdump"
           mkdir -p "${CAP_DIR}"
 
-          regional_host="${KONGCTL_E2E_KONNECT_BASE_URL#http://}"
+          regional_url="${KONGCTL_E2E_KONNECT_BASE_URL:-}"
+          global_url="${KONGCTL_E2E_KONNECT_BASE_AUTH_URL:-}"
+          konnect_env="${KONGCTL_E2E_KONNECT_ENV:-production}"
+
+          if [ -z "${regional_url}" ]; then
+            if [ "${konnect_env}" = "tech" ]; then
+              regional_url="https://us.api.konghq.tech"
+            else
+              regional_url="https://us.api.konghq.com"
+            fi
+          fi
+          if [ -z "${global_url}" ]; then
+            if [ "${konnect_env}" = "tech" ]; then
+              global_url="https://global.api.konghq.tech"
+            else
+              global_url="https://global.api.konghq.com"
+            fi
+          fi
+
+          regional_host="${regional_url#http://}"
           regional_host="${regional_host#https://}"
           regional_host="${regional_host%%/*}"
-          filter="(tcp port 443) and (host ${regional_host} or host global.api.konghq.com)"
+          global_host="${global_url#http://}"
+          global_host="${global_host#https://}"
+          global_host="${global_host%%/*}"
+          filter="(tcp port 443) and (host ${regional_host} or host ${global_host})"
 
           {
             printf 'started_at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            printf 'konnect_env=%s\n' "${konnect_env}"
             printf 'regional_host=%s\n' "${regional_host}"
+            printf 'global_host=%s\n' "${global_host}"
             printf 'filter=%s\n' "${filter}"
             echo
             uname -a
             echo
             getent hosts "${regional_host}" || true
-            getent hosts global.api.konghq.com || true
+            getent hosts "${global_host}" || true
             echo
             ip addr || true
             echo

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -55,6 +55,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       required: ${{ steps.detect.outputs.required }}
+      konnect_environment: ${{ steps.target.outputs.konnect_environment }}
+      orgs_json: ${{ steps.target.outputs.orgs_json }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -65,6 +67,62 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+
+      - name: Resolve Konnect target
+        id: target
+        shell: bash
+        env:
+          DISPATCH_KONNECT_ENVIRONMENT: ${{ github.event_name == 'workflow_dispatch' && inputs.konnect_environment || '' }}
+          CONFIGURED_KONNECT_ENVIRONMENT: ${{ vars.KONGCTL_E2E_KONNECT_ENV || '' }}
+          DEFAULT_ORGS_JSON: ${{ vars.KONGCTL_E2E_ORGS_JSON || '' }}
+          PRODUCTION_ORGS_JSON: ${{ vars.KONGCTL_E2E_PRODUCTION_ORGS_JSON || '' }}
+          TECH_ORGS_JSON: ${{ vars.KONGCTL_E2E_TECH_ORGS_JSON || '' }}
+        run: |
+          set -euo pipefail
+
+          konnect_environment="${DISPATCH_KONNECT_ENVIRONMENT:-}"
+          if [ -z "${konnect_environment}" ]; then
+            konnect_environment="${CONFIGURED_KONNECT_ENVIRONMENT:-production}"
+          fi
+
+          case "${konnect_environment}" in
+            production|tech)
+              ;;
+            *)
+              echo "::error::Unsupported Konnect environment: ${konnect_environment}"
+              exit 1
+              ;;
+          esac
+
+          orgs_json=""
+          if [ "${konnect_environment}" = "tech" ]; then
+            orgs_json="${TECH_ORGS_JSON:-}"
+          else
+            orgs_json="${PRODUCTION_ORGS_JSON:-}"
+          fi
+          if [ -z "${orgs_json}" ]; then
+            orgs_json="${DEFAULT_ORGS_JSON:-}"
+          fi
+          if [ -z "${orgs_json}" ]; then
+            orgs_json='[{"org_name":"default"}]'
+          fi
+
+          orgs_json="$(ORGS_JSON="${orgs_json}" python3 - <<'PY'
+          import json
+          import os
+
+          orgs = json.loads(os.environ["ORGS_JSON"])
+          if not isinstance(orgs, list):
+              raise SystemExit("org matrix must be a JSON array")
+          for index, org in enumerate(orgs):
+              if not isinstance(org, dict) or not org.get("org_name"):
+                  raise SystemExit(f"org matrix entry {index} must include org_name")
+          print(json.dumps(orgs, separators=(",", ":")))
+          PY
+          )"
+
+          echo "konnect_environment=${konnect_environment}" >> "${GITHUB_OUTPUT}"
+          echo "orgs_json=${orgs_json}" >> "${GITHUB_OUTPUT}"
 
       - name: Detect whether E2E is required
         id: detect
@@ -222,14 +280,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(vars.KONGCTL_E2E_ORGS_JSON || '[{"org_name":"default"}]') }}
+        include: ${{ fromJSON(needs.e2e-needed.outputs.orgs_json) }}
     env:
       KONGCTL_E2E_MATRIX_ORG: ${{ matrix.org_name }}
       KONGCTL_E2E_BIN: ${{ github.workspace }}/kongctl
       KONGCTL_E2E_TEST_BIN: ${{ github.workspace }}/e2e.test
       KONGCTL_E2E_TEST_TIMEOUT: ${{ vars.KONGCTL_E2E_TEST_TIMEOUT || '55m' }}
       KONGCTL_E2E_KONNECT_PAT: ${{ secrets.KONGCTL_E2E_KONNECT_PAT }}
-      KONGCTL_E2E_KONNECT_ENV: ${{ github.event_name == 'workflow_dispatch' && inputs.konnect_environment || vars.KONGCTL_E2E_KONNECT_ENV || 'production' }}
+      KONGCTL_E2E_KONNECT_ENV: ${{ needs.e2e-needed.outputs.konnect_environment }}
       KONGCTL_E2E_KONNECT_BASE_URL: ${{ vars.KONGCTL_E2E_KONNECT_BASE_URL || '' }}
       KONGCTL_E2E_KONNECT_BASE_AUTH_URL: ${{ vars.KONGCTL_E2E_KONNECT_BASE_AUTH_URL || '' }}
       KONGCTL_E2E_KONNECT_MACHINE_CLIENT_ID: ${{ vars.KONGCTL_E2E_KONNECT_MACHINE_CLIENT_ID || '' }}
@@ -260,7 +318,7 @@ jobs:
       KONGCTL_E2E_ARTIFACTS_DIR: ${{ github.workspace }}/.e2e-artifacts/${{ github.run_id }}-${{ matrix.org_name }}
       KONGCTL_E2E_SHARD_INDEX: ${{ strategy.job-index }}
       KONGCTL_E2E_SHARD_TOTAL: ${{ strategy.job-total }}
-      KONGCTL_E2E_ORGS_JSON: ${{ vars.KONGCTL_E2E_ORGS_JSON || '[{"org_name":"default"}]' }}
+      KONGCTL_E2E_ORGS_JSON: ${{ needs.e2e-needed.outputs.orgs_json }}
       KONGCTL_E2E_RUN_PORTAL_APPLICATIONS: ${{ github.event_name == 'workflow_dispatch' && inputs.run_portal_applications && '1' || '' }}
       KONGCTL_E2E_RUN_PORTAL_IDENTITY_PROVIDERS: ${{ vars.KONGCTL_E2E_RUN_PORTAL_IDENTITY_PROVIDERS || '' }}
       KONGCTL_E2E_CAPTURE_TCPDUMP: ${{ github.event_name == 'workflow_dispatch' && inputs.capture_tcpdump && '1' || vars.KONGCTL_E2E_CAPTURE_TCPDUMP || '' }}

--- a/Makefile
+++ b/Makefile
@@ -219,5 +219,5 @@ diagnose-e2e-ci:
 
 .PHONY: reset-org
 reset-org:
-	@echo "Resetting Konnect org (requires KONGCTL_E2E_KONNECT_PAT, optional KONGCTL_E2E_KONNECT_BASE_URL, KONGCTL_E2E_RESET)"
+	@echo "Resetting Konnect org (requires KONGCTL_E2E_KONNECT_PAT, optional KONGCTL_E2E_KONNECT_ENV, KONGCTL_E2E_KONNECT_BASE_URL, KONGCTL_E2E_RESET)"
 	go run -tags e2e ./test/e2e/harness/cmd/reset-org --stage make-reset

--- a/internal/cmd/common/flags.go
+++ b/internal/cmd/common/flags.go
@@ -1,0 +1,81 @@
+package common
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// SetCommandTreeFlagValue updates every unchanged flag with the given name in a
+// command tree.
+func SetCommandTreeFlagValue(command *cobra.Command, name, value string) error {
+	if command == nil {
+		return nil
+	}
+	for _, flags := range []*pflag.FlagSet{
+		command.Flags(),
+		command.PersistentFlags(),
+		command.LocalNonPersistentFlags(),
+		command.InheritedFlags(),
+	} {
+		if flags == nil {
+			continue
+		}
+		if flag := flags.Lookup(name); flag != nil && !flag.Changed {
+			if err := flag.Value.Set(value); err != nil {
+				return fmt.Errorf("set --%s default: %w", name, err)
+			}
+			flag.DefValue = value
+		}
+	}
+	for _, child := range command.Commands() {
+		if err := SetCommandTreeFlagValue(child, name, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CommandTreeFlagChanged reports whether any flag with the given name changed
+// in a command tree.
+func CommandTreeFlagChanged(command *cobra.Command, name string) bool {
+	return CommandTreeChangedFlag(command, name) != nil
+}
+
+// CommandTreeChangedFlagString returns the changed value for a flag with the
+// given name in a command tree.
+func CommandTreeChangedFlagString(command *cobra.Command, name string) (string, bool) {
+	flag := CommandTreeChangedFlag(command, name)
+	if flag == nil {
+		return "", false
+	}
+	return flag.Value.String(), true
+}
+
+// CommandTreeChangedFlag returns the changed flag with the given name in a
+// command tree.
+func CommandTreeChangedFlag(command *cobra.Command, name string) *pflag.Flag {
+	if command == nil {
+		return nil
+	}
+	for _, flags := range []*pflag.FlagSet{
+		command.Flags(),
+		command.PersistentFlags(),
+		command.LocalNonPersistentFlags(),
+		command.InheritedFlags(),
+	} {
+		if flags == nil {
+			continue
+		}
+		if flag := flags.Lookup(name); flag != nil && flag.Changed {
+			return flag
+		}
+	}
+	for _, child := range command.Commands() {
+		if flag := CommandTreeChangedFlag(child, name); flag != nil {
+			return flag
+		}
+	}
+	return nil
+}

--- a/internal/cmd/helper.go
+++ b/internal/cmd/helper.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kong/kongctl/internal/build"
 	"github.com/kong/kongctl/internal/cmd/common"
 	"github.com/kong/kongctl/internal/cmd/root/products"
+	konnectcommon "github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	"github.com/kong/kongctl/internal/config"
 	"github.com/kong/kongctl/internal/iostreams"
@@ -134,6 +135,9 @@ func (r *CommandHelper) GetContext() context.Context {
 }
 
 func (r *CommandHelper) GetKonnectSDK(cfg config.Hook, logger *slog.Logger) (helpers.SDKAPI, error) {
+	if err := konnectcommon.ApplyEnvironmentDefaults(r.Cmd.Root(), cfg); err != nil {
+		return nil, PrepareExecutionErrorFromErr(r, &ConfigurationError{Err: err})
+	}
 	factory := r.Cmd.Context().Value(helpers.SDKAPIFactoryKey).(helpers.SDKAPIFactory)
 	sdk, err := factory(cfg, logger)
 	if err != nil {

--- a/internal/cmd/root/products/konnect/common/common.go
+++ b/internal/cmd/root/products/konnect/common/common.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"net/url"
 	"os"
 	"regexp"
 	"strconv"
@@ -20,7 +21,6 @@ import (
 	"github.com/kong/kongctl/internal/konnect/httpclient"
 	"github.com/kong/kongctl/internal/meta"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 const (
@@ -135,9 +135,9 @@ func ApplyEnvironmentDefaults(command *cobra.Command, cfg config.Hook) error {
 		return err
 	}
 
-	if !commandTreeFlagChanged(command, BaseURLFlagName) {
+	if !cmdcommon.CommandTreeFlagChanged(command, BaseURLFlagName) {
 		baseURL := defaults.BaseURL
-		if region, ok := commandTreeChangedFlagString(command, RegionFlagName); ok {
+		if region, ok := cmdcommon.CommandTreeChangedFlagString(command, RegionFlagName); ok {
 			resolved, err := BuildBaseURLFromRegionForEnvironment(region, defaults.Name)
 			if err != nil {
 				return err
@@ -151,19 +151,19 @@ func ApplyEnvironmentDefaults(command *cobra.Command, cfg config.Hook) error {
 			baseURL = resolved
 		}
 		cfg.SetString(BaseURLConfigPath, baseURL)
-		if err := setCommandTreeFlagValue(command, BaseURLFlagName, baseURL); err != nil {
+		if err := cmdcommon.SetCommandTreeFlagValue(command, BaseURLFlagName, baseURL); err != nil {
 			return err
 		}
 	}
-	if !commandTreeFlagChanged(command, AuthBaseURLFlagName) {
+	if !cmdcommon.CommandTreeFlagChanged(command, AuthBaseURLFlagName) {
 		cfg.SetString(AuthBaseURLConfigPath, defaults.AuthBaseURL)
-		if err := setCommandTreeFlagValue(command, AuthBaseURLFlagName, defaults.AuthBaseURL); err != nil {
+		if err := cmdcommon.SetCommandTreeFlagValue(command, AuthBaseURLFlagName, defaults.AuthBaseURL); err != nil {
 			return err
 		}
 	}
-	if !commandTreeFlagChanged(command, MachineClientIDFlagName) {
+	if !cmdcommon.CommandTreeFlagChanged(command, MachineClientIDFlagName) {
 		cfg.SetString(MachineClientIDConfigPath, defaults.MachineClientID)
-		if err := setCommandTreeFlagValue(command, MachineClientIDFlagName, defaults.MachineClientID); err != nil {
+		if err := cmdcommon.SetCommandTreeFlagValue(command, MachineClientIDFlagName, defaults.MachineClientID); err != nil {
 			return err
 		}
 	}
@@ -171,7 +171,7 @@ func ApplyEnvironmentDefaults(command *cobra.Command, cfg config.Hook) error {
 }
 
 func SelectedEnvironmentDefaults(command *cobra.Command) (EnvironmentDefaults, bool, error) {
-	if value, ok := commandTreeChangedFlagString(command, KonnectEnvFlagName); ok {
+	if value, ok := cmdcommon.CommandTreeChangedFlagString(command, KonnectEnvFlagName); ok {
 		defaults, err := environmentDefaultsForSelector(value)
 		return defaults, true, err
 	}
@@ -227,77 +227,16 @@ func environmentDefaultsForSelector(value string) (EnvironmentDefaults, error) {
 	}
 }
 
-func setCommandTreeFlagValue(command *cobra.Command, name, value string) error {
-	if command == nil {
-		return nil
-	}
-	for _, flags := range []*pflag.FlagSet{
-		command.Flags(),
-		command.PersistentFlags(),
-		command.LocalNonPersistentFlags(),
-		command.InheritedFlags(),
-	} {
-		if flags == nil {
-			continue
-		}
-		if flag := flags.Lookup(name); flag != nil && !flag.Changed {
-			if err := flag.Value.Set(value); err != nil {
-				return fmt.Errorf("set --%s default: %w", name, err)
-			}
-			flag.DefValue = value
-		}
-	}
-	for _, child := range command.Commands() {
-		if err := setCommandTreeFlagValue(child, name, value); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func commandTreeFlagChanged(command *cobra.Command, name string) bool {
-	return commandTreeChangedFlag(command, name) != nil
-}
-
-func commandTreeChangedFlagString(command *cobra.Command, name string) (string, bool) {
-	flag := commandTreeChangedFlag(command, name)
-	if flag == nil {
-		return "", false
-	}
-	return flag.Value.String(), true
-}
-
-func commandTreeChangedFlag(command *cobra.Command, name string) *pflag.Flag {
-	if command == nil {
-		return nil
-	}
-	for _, flags := range []*pflag.FlagSet{
-		command.Flags(),
-		command.PersistentFlags(),
-		command.LocalNonPersistentFlags(),
-		command.InheritedFlags(),
-	} {
-		if flags == nil {
-			continue
-		}
-		if flag := flags.Lookup(name); flag != nil && flag.Changed {
-			return flag
-		}
-	}
-	for _, child := range command.Commands() {
-		if flag := commandTreeChangedFlag(child, name); flag != nil {
-			return flag
-		}
-	}
-	return nil
-}
-
 func InferEnvironmentDefaultsFromURL(rawURL string) (EnvironmentDefaults, bool) {
-	value := strings.ToLower(strings.TrimSpace(rawURL))
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return EnvironmentDefaults{}, false
+	}
+	host := strings.ToLower(parsed.Hostname())
 	switch {
-	case strings.Contains(value, konnectTechDomain):
+	case host == konnectTechDomain || strings.HasSuffix(host, "."+konnectTechDomain):
 		return TechEnvironmentDefaults(), true
-	case strings.Contains(value, konnectProductionDomain):
+	case host == konnectProductionDomain || strings.HasSuffix(host, "."+konnectProductionDomain):
 		return ProductionEnvironmentDefaults(), true
 	default:
 		return EnvironmentDefaults{}, false

--- a/internal/cmd/root/products/konnect/common/common.go
+++ b/internal/cmd/root/products/konnect/common/common.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -18,6 +19,8 @@ import (
 	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/konnect/httpclient"
 	"github.com/kong/kongctl/internal/meta"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 const (
@@ -44,13 +47,15 @@ const (
 
 	RegionFlagName = "region"
 
+	EnvironmentCom        = "com"
 	EnvironmentProduction = "production"
 	EnvironmentTech       = "tech"
 
 	TechGlobalBaseURL       = "https://global.api.konghq.tech"
 	TechBaseURLDefault      = "https://us.api.konghq.tech"
 	TechMachineClientID     = "35b065db-8eaf-4584-9cb6-05b1daea0750"
-	KongTechFlagName        = "kong-tech"
+	KonnectEnvFlagName      = "konnect-env"
+	KonnectEnvEnvName       = "KONGCTL_KONNECT_ENV"
 	konnectProductionDomain = "konghq.com"
 	konnectTechDomain       = "konghq.tech"
 
@@ -111,13 +116,180 @@ func TechEnvironmentDefaults() EnvironmentDefaults {
 
 func EnvironmentDefaultsFor(name string) (EnvironmentDefaults, error) {
 	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "", EnvironmentProduction, "prod", "com":
+	case "", EnvironmentCom, EnvironmentProduction, "prod":
 		return ProductionEnvironmentDefaults(), nil
 	case EnvironmentTech:
 		return TechEnvironmentDefaults(), nil
 	default:
 		return EnvironmentDefaults{}, fmt.Errorf("unsupported konnect environment %q", name)
 	}
+}
+
+func ApplyEnvironmentDefaults(command *cobra.Command, cfg config.Hook) error {
+	if command == nil || cfg == nil {
+		return nil
+	}
+
+	defaults, selected, err := SelectedEnvironmentDefaults(command)
+	if err != nil || !selected {
+		return err
+	}
+
+	if !commandTreeFlagChanged(command, BaseURLFlagName) {
+		baseURL := defaults.BaseURL
+		if region, ok := commandTreeChangedFlagString(command, RegionFlagName); ok {
+			resolved, err := BuildBaseURLFromRegionForEnvironment(region, defaults.Name)
+			if err != nil {
+				return err
+			}
+			baseURL = resolved
+		} else if region := strings.TrimSpace(cfg.GetString(RegionConfigPath)); region != "" {
+			resolved, err := BuildBaseURLFromRegionForEnvironment(region, defaults.Name)
+			if err != nil {
+				return err
+			}
+			baseURL = resolved
+		}
+		cfg.SetString(BaseURLConfigPath, baseURL)
+		if err := setCommandTreeFlagValue(command, BaseURLFlagName, baseURL); err != nil {
+			return err
+		}
+	}
+	if !commandTreeFlagChanged(command, AuthBaseURLFlagName) {
+		cfg.SetString(AuthBaseURLConfigPath, defaults.AuthBaseURL)
+		if err := setCommandTreeFlagValue(command, AuthBaseURLFlagName, defaults.AuthBaseURL); err != nil {
+			return err
+		}
+	}
+	if !commandTreeFlagChanged(command, MachineClientIDFlagName) {
+		cfg.SetString(MachineClientIDConfigPath, defaults.MachineClientID)
+		if err := setCommandTreeFlagValue(command, MachineClientIDFlagName, defaults.MachineClientID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func SelectedEnvironmentDefaults(command *cobra.Command) (EnvironmentDefaults, bool, error) {
+	if value, ok := commandTreeChangedFlagString(command, KonnectEnvFlagName); ok {
+		defaults, err := environmentDefaultsForSelector(value)
+		return defaults, true, err
+	}
+
+	if value, ok := selectedEnvironmentFromArgs(os.Args[1:]); ok {
+		defaults, err := environmentDefaultsForSelector(value)
+		return defaults, true, err
+	}
+
+	value, ok := os.LookupEnv(KonnectEnvEnvName)
+	if !ok || strings.TrimSpace(value) == "" {
+		return EnvironmentDefaults{}, false, nil
+	}
+
+	defaults, err := environmentDefaultsForSelector(value)
+	return defaults, true, err
+}
+
+func selectedEnvironmentFromArgs(args []string) (string, bool) {
+	value := ""
+	selected := false
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			break
+		}
+		if arg == "--"+KonnectEnvFlagName {
+			selected = true
+			value = ""
+			if i+1 < len(args) {
+				value = args[i+1]
+				i++
+			}
+			continue
+		}
+		if stripped, ok := strings.CutPrefix(arg, "--"+KonnectEnvFlagName+"="); ok {
+			selected = true
+			value = stripped
+		}
+	}
+	return value, selected
+}
+
+func environmentDefaultsForSelector(value string) (EnvironmentDefaults, error) {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	switch normalized {
+	case EnvironmentCom, EnvironmentTech:
+		return EnvironmentDefaultsFor(normalized)
+	default:
+		return EnvironmentDefaults{},
+			fmt.Errorf("unsupported konnect environment %q (allowed: %s, %s)",
+				value, EnvironmentCom, EnvironmentTech)
+	}
+}
+
+func setCommandTreeFlagValue(command *cobra.Command, name, value string) error {
+	if command == nil {
+		return nil
+	}
+	for _, flags := range []*pflag.FlagSet{
+		command.Flags(),
+		command.PersistentFlags(),
+		command.LocalNonPersistentFlags(),
+		command.InheritedFlags(),
+	} {
+		if flags == nil {
+			continue
+		}
+		if flag := flags.Lookup(name); flag != nil && !flag.Changed {
+			if err := flag.Value.Set(value); err != nil {
+				return fmt.Errorf("set --%s default: %w", name, err)
+			}
+			flag.DefValue = value
+		}
+	}
+	for _, child := range command.Commands() {
+		if err := setCommandTreeFlagValue(child, name, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func commandTreeFlagChanged(command *cobra.Command, name string) bool {
+	return commandTreeChangedFlag(command, name) != nil
+}
+
+func commandTreeChangedFlagString(command *cobra.Command, name string) (string, bool) {
+	flag := commandTreeChangedFlag(command, name)
+	if flag == nil {
+		return "", false
+	}
+	return flag.Value.String(), true
+}
+
+func commandTreeChangedFlag(command *cobra.Command, name string) *pflag.Flag {
+	if command == nil {
+		return nil
+	}
+	for _, flags := range []*pflag.FlagSet{
+		command.Flags(),
+		command.PersistentFlags(),
+		command.LocalNonPersistentFlags(),
+		command.InheritedFlags(),
+	} {
+		if flags == nil {
+			continue
+		}
+		if flag := flags.Lookup(name); flag != nil && flag.Changed {
+			return flag
+		}
+	}
+	for _, child := range command.Commands() {
+		if flag := commandTreeChangedFlag(child, name); flag != nil {
+			return flag
+		}
+	}
+	return nil
 }
 
 func InferEnvironmentDefaultsFromURL(rawURL string) (EnvironmentDefaults, bool) {
@@ -240,7 +412,8 @@ func ResolveRetryConfig(cfg config.Hook) (httpclient.RetryConfig, error) {
 	if maxAttempts > httpclient.MaxRetryMaxAttempts {
 		return httpclient.RetryConfig{}, fmt.Errorf(
 			"invalid %s value %d: must be <= %d",
-			HTTPRetryMaxAttemptsConfigPath, maxAttempts, httpclient.MaxRetryMaxAttempts)
+			HTTPRetryMaxAttemptsConfigPath, maxAttempts, httpclient.MaxRetryMaxAttempts,
+		)
 	}
 	if maxAttempts == 0 {
 		maxAttempts = httpclient.DefaultRetryMaxAttempts
@@ -261,12 +434,14 @@ func ResolveRetryConfig(cfg config.Hook) (httpclient.RetryConfig, error) {
 	if initialIntervalMS < httpclient.MinRetryInitialIntervalMS {
 		return httpclient.RetryConfig{}, fmt.Errorf(
 			"invalid %s value %d: must be >= %d ms",
-			HTTPRetryInitialIntervalConfigPath, initialIntervalMS, httpclient.MinRetryInitialIntervalMS)
+			HTTPRetryInitialIntervalConfigPath, initialIntervalMS, httpclient.MinRetryInitialIntervalMS,
+		)
 	}
 	if initialIntervalMS > httpclient.MaxRetryInitialIntervalMS {
 		return httpclient.RetryConfig{}, fmt.Errorf(
 			"invalid %s value %d: must be <= %d ms",
-			HTTPRetryInitialIntervalConfigPath, initialIntervalMS, httpclient.MaxRetryInitialIntervalMS)
+			HTTPRetryInitialIntervalConfigPath, initialIntervalMS, httpclient.MaxRetryInitialIntervalMS,
+		)
 	}
 
 	maxIntervalMS, err := resolveOptionalInt(cfg, HTTPRetryMaxIntervalConfigPath)
@@ -279,18 +454,21 @@ func ResolveRetryConfig(cfg config.Hook) (httpclient.RetryConfig, error) {
 	if maxIntervalMS < httpclient.MinRetryMaxIntervalMS {
 		return httpclient.RetryConfig{}, fmt.Errorf(
 			"invalid %s value %d: must be >= %d ms",
-			HTTPRetryMaxIntervalConfigPath, maxIntervalMS, httpclient.MinRetryMaxIntervalMS)
+			HTTPRetryMaxIntervalConfigPath, maxIntervalMS, httpclient.MinRetryMaxIntervalMS,
+		)
 	}
 	if maxIntervalMS > httpclient.MaxRetryMaxIntervalMS {
 		return httpclient.RetryConfig{}, fmt.Errorf(
 			"invalid %s value %d: must be <= %d ms",
-			HTTPRetryMaxIntervalConfigPath, maxIntervalMS, httpclient.MaxRetryMaxIntervalMS)
+			HTTPRetryMaxIntervalConfigPath, maxIntervalMS, httpclient.MaxRetryMaxIntervalMS,
+		)
 	}
 	if initialIntervalMS > maxIntervalMS {
 		return httpclient.RetryConfig{}, fmt.Errorf(
 			"invalid configuration: %s (%d ms) must be <= %s (%d ms)",
 			HTTPRetryInitialIntervalConfigPath, initialIntervalMS,
-			HTTPRetryMaxIntervalConfigPath, maxIntervalMS)
+			HTTPRetryMaxIntervalConfigPath, maxIntervalMS,
+		)
 	}
 
 	factor, err := resolveOptionalFloat64(cfg, HTTPRetryBackoffFactorConfigPath)
@@ -330,7 +508,8 @@ func ResolveRetryConfig(cfg config.Hook) (httpclient.RetryConfig, error) {
 	if totalBackoffMS > httpclient.MaxRetryTotalBackoffMS {
 		return httpclient.RetryConfig{}, fmt.Errorf(
 			"invalid retry configuration: cumulative backoff budget %d ms must be <= %d ms",
-			totalBackoffMS, httpclient.MaxRetryTotalBackoffMS)
+			totalBackoffMS, httpclient.MaxRetryTotalBackoffMS,
+		)
 	}
 
 	return retryConfig, nil

--- a/internal/cmd/root/products/konnect/common/common.go
+++ b/internal/cmd/root/products/konnect/common/common.go
@@ -44,6 +44,16 @@ const (
 
 	RegionFlagName = "region"
 
+	EnvironmentProduction = "production"
+	EnvironmentTech       = "tech"
+
+	TechGlobalBaseURL       = "https://global.api.konghq.tech"
+	TechBaseURLDefault      = "https://us.api.konghq.tech"
+	TechMachineClientID     = "35b065db-8eaf-4584-9cb6-05b1daea0750"
+	KongTechFlagName        = "kong-tech"
+	konnectProductionDomain = "konghq.com"
+	konnectTechDomain       = "konghq.tech"
+
 	RequestPageSizeFlagName = "page-size"
 	DefaultRequestPageSize  = 10
 )
@@ -74,6 +84,54 @@ var (
 
 var regionPattern = regexp.MustCompile(`^[a-z0-9-]+$`)
 
+type EnvironmentDefaults struct {
+	Name            string
+	BaseURL         string
+	AuthBaseURL     string
+	MachineClientID string
+}
+
+func ProductionEnvironmentDefaults() EnvironmentDefaults {
+	return EnvironmentDefaults{
+		Name:            EnvironmentProduction,
+		BaseURL:         BaseURLDefault,
+		AuthBaseURL:     AuthBaseURLDefault,
+		MachineClientID: MachineClientIDDefault,
+	}
+}
+
+func TechEnvironmentDefaults() EnvironmentDefaults {
+	return EnvironmentDefaults{
+		Name:            EnvironmentTech,
+		BaseURL:         TechBaseURLDefault,
+		AuthBaseURL:     TechGlobalBaseURL,
+		MachineClientID: TechMachineClientID,
+	}
+}
+
+func EnvironmentDefaultsFor(name string) (EnvironmentDefaults, error) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "", EnvironmentProduction, "prod", "com":
+		return ProductionEnvironmentDefaults(), nil
+	case EnvironmentTech:
+		return TechEnvironmentDefaults(), nil
+	default:
+		return EnvironmentDefaults{}, fmt.Errorf("unsupported konnect environment %q", name)
+	}
+}
+
+func InferEnvironmentDefaultsFromURL(rawURL string) (EnvironmentDefaults, bool) {
+	value := strings.ToLower(strings.TrimSpace(rawURL))
+	switch {
+	case strings.Contains(value, konnectTechDomain):
+		return TechEnvironmentDefaults(), true
+	case strings.Contains(value, konnectProductionDomain):
+		return ProductionEnvironmentDefaults(), true
+	default:
+		return EnvironmentDefaults{}, false
+	}
+}
+
 // BuildBaseURLFromRegion converts a region identifier into the corresponding Konnect API host.
 func BuildBaseURLFromRegion(region string) (string, error) {
 	trimmed := strings.ToLower(strings.TrimSpace(region))
@@ -90,6 +148,22 @@ func BuildBaseURLFromRegion(region string) (string, error) {
 	}
 
 	return fmt.Sprintf("https://%s.api.konghq.com", trimmed), nil
+}
+
+func BuildBaseURLFromRegionForEnvironment(region string, environment string) (string, error) {
+	defaults, err := EnvironmentDefaultsFor(environment)
+	if err != nil {
+		return "", err
+	}
+
+	baseURL, err := BuildBaseURLFromRegion(region)
+	if err != nil {
+		return "", err
+	}
+	if defaults.Name == EnvironmentTech {
+		return strings.Replace(baseURL, konnectProductionDomain, konnectTechDomain, 1), nil
+	}
+	return baseURL, nil
 }
 
 // ResolveBaseURL determines the effective Konnect base URL, honoring the precedence rules:

--- a/internal/cmd/root/products/konnect/common/common_test.go
+++ b/internal/cmd/root/products/konnect/common/common_test.go
@@ -141,8 +141,15 @@ func TestEnvironmentDefaultsFor(t *testing.T) {
 			wantClient:  MachineClientIDDefault,
 		},
 		{
-			name:        "production alias",
+			name:        "com",
 			env:         "com",
+			wantBaseURL: BaseURLDefault,
+			wantAuthURL: AuthBaseURLDefault,
+			wantClient:  MachineClientIDDefault,
+		},
+		{
+			name:        "production alias",
+			env:         "production",
 			wantBaseURL: BaseURLDefault,
 			wantAuthURL: AuthBaseURLDefault,
 			wantClient:  MachineClientIDDefault,
@@ -168,6 +175,58 @@ func TestEnvironmentDefaultsFor(t *testing.T) {
 			require.Equal(t, tt.wantBaseURL, got.BaseURL)
 			require.Equal(t, tt.wantAuthURL, got.AuthBaseURL)
 			require.Equal(t, tt.wantClient, got.MachineClientID)
+		})
+	}
+}
+
+func TestSelectedEnvironmentFromArgs(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		wantValue    string
+		wantSelected bool
+	}{
+		{
+			name:         "space separated",
+			args:         []string{"get", "org", "--konnect-env", "tech"},
+			wantValue:    "tech",
+			wantSelected: true,
+		},
+		{
+			name:         "equals separated",
+			args:         []string{"get", "org", "--konnect-env=tech"},
+			wantValue:    "tech",
+			wantSelected: true,
+		},
+		{
+			name:         "last value wins",
+			args:         []string{"--konnect-env", "com", "get", "org", "--konnect-env=tech"},
+			wantValue:    "tech",
+			wantSelected: true,
+		},
+		{
+			name:         "missing value is selected",
+			args:         []string{"get", "org", "--konnect-env"},
+			wantValue:    "",
+			wantSelected: true,
+		},
+		{
+			name:         "after double dash ignored",
+			args:         []string{"get", "org", "--", "--konnect-env", "tech"},
+			wantSelected: false,
+		},
+		{
+			name:         "not selected",
+			args:         []string{"get", "org"},
+			wantSelected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotValue, gotSelected := selectedEnvironmentFromArgs(tt.args)
+			require.Equal(t, tt.wantSelected, gotSelected)
+			require.Equal(t, tt.wantValue, gotValue)
 		})
 	}
 }

--- a/internal/cmd/root/products/konnect/common/common_test.go
+++ b/internal/cmd/root/products/konnect/common/common_test.go
@@ -303,6 +303,22 @@ func TestInferEnvironmentDefaultsFromURL(t *testing.T) {
 			wantOK:      true,
 			wantBaseURL: BaseURLDefault,
 		},
+		{
+			name:        "tech URL with query",
+			url:         "https://global.api.konghq.tech/v3?redirect=https://example.test",
+			wantOK:      true,
+			wantBaseURL: TechBaseURLDefault,
+		},
+		{
+			name:   "tech string in path does not infer",
+			url:    "https://example.test/konghq.tech",
+			wantOK: false,
+		},
+		{
+			name:   "tech string in query does not infer",
+			url:    "https://example.test?target=global.api.konghq.tech",
+			wantOK: false,
+		},
 		{name: "custom URL", url: "https://example.test", wantOK: false},
 	}
 

--- a/internal/cmd/root/products/konnect/common/common_test.go
+++ b/internal/cmd/root/products/konnect/common/common_test.go
@@ -124,6 +124,140 @@ func TestResolveBaseURL(t *testing.T) {
 	})
 }
 
+func TestEnvironmentDefaultsFor(t *testing.T) {
+	tests := []struct {
+		name        string
+		env         string
+		wantBaseURL string
+		wantAuthURL string
+		wantClient  string
+		wantErr     bool
+	}{
+		{
+			name:        "default production",
+			env:         "",
+			wantBaseURL: BaseURLDefault,
+			wantAuthURL: AuthBaseURLDefault,
+			wantClient:  MachineClientIDDefault,
+		},
+		{
+			name:        "production alias",
+			env:         "com",
+			wantBaseURL: BaseURLDefault,
+			wantAuthURL: AuthBaseURLDefault,
+			wantClient:  MachineClientIDDefault,
+		},
+		{
+			name:        "tech",
+			env:         "tech",
+			wantBaseURL: TechBaseURLDefault,
+			wantAuthURL: TechGlobalBaseURL,
+			wantClient:  TechMachineClientID,
+		},
+		{name: "unknown", env: "stage", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := EnvironmentDefaultsFor(tt.env)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantBaseURL, got.BaseURL)
+			require.Equal(t, tt.wantAuthURL, got.AuthBaseURL)
+			require.Equal(t, tt.wantClient, got.MachineClientID)
+		})
+	}
+}
+
+func TestBuildBaseURLFromRegionForEnvironment(t *testing.T) {
+	tests := []struct {
+		name        string
+		region      string
+		environment string
+		want        string
+		wantErr     bool
+	}{
+		{
+			name:        "production regional",
+			region:      "eu",
+			environment: EnvironmentProduction,
+			want:        "https://eu.api.konghq.com",
+		},
+		{
+			name:        "tech regional",
+			region:      "eu",
+			environment: EnvironmentTech,
+			want:        "https://eu.api.konghq.tech",
+		},
+		{
+			name:        "tech global",
+			region:      "global",
+			environment: EnvironmentTech,
+			want:        TechGlobalBaseURL,
+		},
+		{
+			name:        "invalid environment",
+			region:      "eu",
+			environment: "stage",
+			wantErr:     true,
+		},
+		{
+			name:        "invalid region",
+			region:      "bad/region",
+			environment: EnvironmentTech,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := BuildBaseURLFromRegionForEnvironment(tt.region, tt.environment)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestInferEnvironmentDefaultsFromURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		url         string
+		wantOK      bool
+		wantBaseURL string
+	}{
+		{
+			name:        "tech regional URL",
+			url:         "https://us.api.konghq.tech",
+			wantOK:      true,
+			wantBaseURL: TechBaseURLDefault,
+		},
+		{
+			name:        "production global URL",
+			url:         "https://global.api.konghq.com",
+			wantOK:      true,
+			wantBaseURL: BaseURLDefault,
+		},
+		{name: "custom URL", url: "https://example.test", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := InferEnvironmentDefaultsFromURL(tt.url)
+			require.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				require.Equal(t, tt.wantBaseURL, got.BaseURL)
+			}
+		})
+	}
+}
+
 func TestResolveHTTPTimeout(t *testing.T) {
 	t.Run("default fallback", func(t *testing.T) {
 		cfg, _ := newTestConfig(map[string]string{})

--- a/internal/cmd/root/products/konnect/loginKonnect.go
+++ b/internal/cmd/root/products/konnect/loginKonnect.go
@@ -36,7 +36,8 @@ var (
 		i18n.T("root.products.konnect.loginKonnectExample",
 			fmt.Sprintf(`
 # Login to Konnect
-%[1]s login konnect`, meta.CLIName)))
+%[1]s login konnect`, meta.CLIName)),
+	)
 
 	httpClient *http.Client
 
@@ -266,7 +267,8 @@ func (c *loginKonnectCmd) run(helper cmd.Helper) error {
 			return helper.GetContext().Err()
 		case <-time.After(time.Duration(resp.Interval) * time.Second):
 			pollResp, err = auth.PollForToken(
-				helper.GetContext(), httpClient, pollURL, clientID, resp.DeviceCode, logger)
+				helper.GetContext(), httpClient, pollURL, clientID, resp.DeviceCode, logger,
+			)
 		}
 		var dagError *auth.DAGError
 		if errors.As(err, &dagError) && dagError.ErrorCode == auth.AuthorizationPendingErrorCode {
@@ -326,6 +328,10 @@ func (c *loginKonnectCmd) preRunE(cobraCmd *cobra.Command, args []string) error 
 	f = c.Flags().Lookup(common.MachineClientIDFlagName)
 	err = cfg.BindFlag(common.MachineClientIDConfigPath, f)
 	if err != nil {
+		return err
+	}
+
+	if err := common.ApplyEnvironmentDefaults(cobraCmd.Root(), cfg); err != nil {
 		return err
 	}
 

--- a/internal/cmd/root/products/konnect/organization/getOrganization.go
+++ b/internal/cmd/root/products/konnect/organization/getOrganization.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
 	"github.com/kong/kongctl/internal/cmd"
 	"github.com/kong/kongctl/internal/cmd/output/tableview"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
@@ -34,7 +35,8 @@ authentication token.`)
 			fmt.Sprintf(`
 	# Get current organization information
 	%[1]s get organization
-	`, meta.CLIName)))
+	`, meta.CLIName)),
+	)
 )
 
 type textDisplayRecord struct {
@@ -188,8 +190,12 @@ type getOrganizationCmd struct {
 	*cobra.Command
 }
 
-func runGetOrganization(meAPI helpers.MeAPI, helper cmd.Helper) (*kkComps.MeOrganization, error) {
-	res, err := meAPI.GetOrganizationsMe(helper.GetContext())
+func runGetOrganization(meAPI helpers.MeAPI, helper cmd.Helper, baseURL string) (*kkComps.MeOrganization, error) {
+	opts := []kkOps.Option{}
+	if baseURL != "" {
+		opts = append(opts, kkOps.WithServerURL(baseURL))
+	}
+	res, err := meAPI.GetOrganizationsMe(helper.GetContext(), opts...)
 	if err != nil {
 		attrs := cmd.TryConvertErrorToAttrs(err)
 		return nil, cmd.PrepareExecutionError("Failed to get current organization", err, helper.GetCmd(), attrs...)
@@ -239,12 +245,18 @@ func (c *getOrganizationCmd) runE(cobraCmd *cobra.Command, args []string) error 
 		return err
 	}
 
-	org, err := runGetOrganization(sdk.GetMeAPI(), helper)
+	baseURL, err := common.ResolveBaseURL(cfg)
 	if err != nil {
 		return err
 	}
 
-	return tableview.RenderForFormat(helper,
+	org, err := runGetOrganization(sdk.GetMeAPI(), helper, baseURL)
+	if err != nil {
+		return err
+	}
+
+	return tableview.RenderForFormat(
+		helper,
 		false,
 		outType,
 		printer,

--- a/internal/cmd/root/products/konnect/organization/getOrganization_test.go
+++ b/internal/cmd/root/products/konnect/organization/getOrganization_test.go
@@ -101,8 +101,14 @@ func TestRunGetOrganization(t *testing.T) {
 		api := &stubMeAPI{
 			getOrganizationsMe: func(
 				_ context.Context,
-				_ ...kkOps.Option,
+				opts ...kkOps.Option,
 			) (*kkOps.GetOrganizationsMeResponse, error) {
+				options := kkOps.Options{}
+				for _, opt := range opts {
+					require.NoError(t, opt(&options))
+				}
+				require.NotNil(t, options.ServerURL)
+				assert.Equal(t, "https://global.api.konghq.tech", *options.ServerURL)
 				return &kkOps.GetOrganizationsMeResponse{
 					MeOrganization: expected,
 				}, nil
@@ -112,7 +118,7 @@ func TestRunGetOrganization(t *testing.T) {
 		helper := cmd.NewMockHelper(t)
 		helper.EXPECT().GetContext().Return(context.Background())
 
-		org, err := runGetOrganization(api, helper)
+		org, err := runGetOrganization(api, helper, "https://global.api.konghq.tech")
 		require.NoError(t, err)
 		assert.Equal(t, expected, org)
 	})
@@ -131,7 +137,7 @@ func TestRunGetOrganization(t *testing.T) {
 		helper.EXPECT().GetContext().Return(context.Background())
 		helper.EXPECT().GetCmd().Return(&cobra.Command{Use: "organization"})
 
-		org, err := runGetOrganization(api, helper)
+		org, err := runGetOrganization(api, helper, "https://global.api.konghq.tech")
 		assert.Nil(t, org)
 		var execErr *cmd.ExecutionError
 		require.ErrorAs(t, err, &execErr)

--- a/internal/cmd/root/products/konnect/organization/interactive.go
+++ b/internal/cmd/root/products/konnect/organization/interactive.go
@@ -27,7 +27,12 @@ func BuildListView(helper cmd.Helper) (tableview.ChildView, error) {
 		return tableview.ChildView{}, err
 	}
 
-	org, err := runGetOrganization(sdk.GetMeAPI(), helper)
+	baseURL, err := common.ResolveBaseURL(cfg)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	org, err := runGetOrganization(sdk.GetMeAPI(), helper, baseURL)
 	if err != nil {
 		return tableview.ChildView{}, err
 	}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -105,6 +105,10 @@ Find more information at:
 	// highest-priority disable signal in telemetry.resolveEnabled; see the
 	// precedence note there.
 	noTelemetry bool
+
+	// kongTech switches Konnect defaults for this invocation to Kong's .tech
+	// environment. It is intentionally hidden for Kong-internal use.
+	kongTech bool
 )
 
 // NoTelemetryFlagName is the persistent root flag that disables telemetry
@@ -280,6 +284,10 @@ func newRootCmd() *cobra.Command {
 - Env var    : [ %s ]
 - Default    : [ false ]`,
 			telemetry.ConfigKeyEnabled, telemetry.EnvNoTelemetry))
+
+	rootCmd.PersistentFlags().BoolVar(&kongTech, konnectcommon.KongTechFlagName, false,
+		"Use Kong's Konnect .tech environment for this command invocation.")
+	util.CheckError(rootCmd.PersistentFlags().MarkHidden(konnectcommon.KongTechFlagName))
 
 	themeFlag := theme.NewFlag(common.DefaultColorTheme)
 	rootCmd.PersistentFlags().Var(themeFlag, common.ColorThemeFlagName,
@@ -632,9 +640,53 @@ func applyExtensionRuntimeDefaults(runtimeCtx *extensioncore.RuntimeContext, cfg
 	}
 }
 
+func applyKongTechDefaults(command *cobra.Command, cfg config.Hook) error {
+	if !kongTech || command == nil || cfg == nil {
+		return nil
+	}
+
+	defaults := konnectcommon.TechEnvironmentDefaults()
+	if !commandTreeFlagChanged(command, konnectcommon.BaseURLFlagName) {
+		baseURL := defaults.BaseURL
+		if region, ok := commandTreeChangedFlagString(command, konnectcommon.RegionFlagName); ok {
+			resolved, err := konnectcommon.BuildBaseURLFromRegionForEnvironment(region, defaults.Name)
+			if err != nil {
+				return err
+			}
+			baseURL = resolved
+		} else if region := strings.TrimSpace(cfg.GetString(konnectcommon.RegionConfigPath)); region != "" {
+			resolved, err := konnectcommon.BuildBaseURLFromRegionForEnvironment(region, defaults.Name)
+			if err != nil {
+				return err
+			}
+			baseURL = resolved
+		}
+		cfg.SetString(konnectcommon.BaseURLConfigPath, baseURL)
+	}
+	if !commandTreeFlagChanged(command, konnectcommon.AuthBaseURLFlagName) {
+		cfg.SetString(konnectcommon.AuthBaseURLConfigPath, defaults.AuthBaseURL)
+	}
+	if !commandTreeFlagChanged(command, konnectcommon.MachineClientIDFlagName) {
+		cfg.SetString(konnectcommon.MachineClientIDConfigPath, defaults.MachineClientID)
+	}
+	return nil
+}
+
 func commandTreeFlagChanged(command *cobra.Command, name string) bool {
+	return commandTreeChangedFlag(command, name) != nil
+}
+
+func commandTreeChangedFlagString(command *cobra.Command, name string) (string, bool) {
+	flag := commandTreeChangedFlag(command, name)
+	if flag == nil {
+		return "", false
+	}
+	return flag.Value.String(), true
+}
+
+func commandTreeChangedFlag(command *cobra.Command, name string) *pflag.Flag {
 	if command == nil {
-		return false
+		return nil
 	}
 	for _, flags := range []*pflag.FlagSet{
 		command.Flags(),
@@ -646,15 +698,15 @@ func commandTreeFlagChanged(command *cobra.Command, name string) bool {
 			continue
 		}
 		if flag := flags.Lookup(name); flag != nil && flag.Changed {
-			return true
+			return flag
 		}
 	}
 	for _, child := range command.Commands() {
-		if commandTreeFlagChanged(child, name) {
-			return true
+		if flag := commandTreeChangedFlag(child, name); flag != nil {
+			return flag
 		}
 	}
-	return false
+	return nil
 }
 
 func initConfig() {
@@ -673,6 +725,7 @@ func initConfig() {
 
 	bindFlags(currConfig)
 	applyExtensionRuntimeDefaults(runtimeCtx, currConfig)
+	util.CheckError(applyKongTechDefaults(rootCmd, currConfig))
 
 	themeName := strings.TrimSpace(currConfig.GetString(common.ColorThemeConfigPath))
 	if themeName == "" {

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -106,9 +106,9 @@ Find more information at:
 	// precedence note there.
 	noTelemetry bool
 
-	// kongTech switches Konnect defaults for this invocation to Kong's .tech
-	// environment. It is intentionally hidden for Kong-internal use.
-	kongTech bool
+	// konnectEnv switches Konnect target defaults for this invocation. It is
+	// intentionally hidden for Kong-internal use.
+	konnectEnv string
 )
 
 // NoTelemetryFlagName is the persistent root flag that disables telemetry
@@ -215,6 +215,9 @@ func newRootCmd() *cobra.Command {
 			return nil
 		},
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			if err := applyKonnectEnvironmentDefaults(cmd.Root(), currConfig); err != nil {
+				return &cmdpkg.ConfigurationError{Err: err}
+			}
 			if err := validateOutputFormat(cmd); err != nil {
 				return &cmdpkg.ConfigurationError{Err: err}
 			}
@@ -285,9 +288,11 @@ func newRootCmd() *cobra.Command {
 - Default    : [ false ]`,
 			telemetry.ConfigKeyEnabled, telemetry.EnvNoTelemetry))
 
-	rootCmd.PersistentFlags().BoolVar(&kongTech, konnectcommon.KongTechFlagName, false,
-		"Use Kong's Konnect .tech environment for this command invocation.")
-	util.CheckError(rootCmd.PersistentFlags().MarkHidden(konnectcommon.KongTechFlagName))
+	rootCmd.PersistentFlags().StringVar(&konnectEnv, konnectcommon.KonnectEnvFlagName,
+		"",
+		fmt.Sprintf("Konnect environment for this command invocation. Allowed values: %s, %s.",
+			konnectcommon.EnvironmentCom, konnectcommon.EnvironmentTech))
+	util.CheckError(rootCmd.PersistentFlags().MarkHidden(konnectcommon.KonnectEnvFlagName))
 
 	themeFlag := theme.NewFlag(common.DefaultColorTheme)
 	rootCmd.PersistentFlags().Var(themeFlag, common.ColorThemeFlagName,
@@ -640,12 +645,16 @@ func applyExtensionRuntimeDefaults(runtimeCtx *extensioncore.RuntimeContext, cfg
 	}
 }
 
-func applyKongTechDefaults(command *cobra.Command, cfg config.Hook) error {
-	if !kongTech || command == nil || cfg == nil {
+func applyKonnectEnvironmentDefaults(command *cobra.Command, cfg config.Hook) error {
+	if command == nil || cfg == nil {
 		return nil
 	}
 
-	defaults := konnectcommon.TechEnvironmentDefaults()
+	defaults, selected, err := selectedKonnectEnvironmentDefaults(command)
+	if err != nil || !selected {
+		return err
+	}
+
 	if !commandTreeFlagChanged(command, konnectcommon.BaseURLFlagName) {
 		baseURL := defaults.BaseURL
 		if region, ok := commandTreeChangedFlagString(command, konnectcommon.RegionFlagName); ok {
@@ -662,12 +671,81 @@ func applyKongTechDefaults(command *cobra.Command, cfg config.Hook) error {
 			baseURL = resolved
 		}
 		cfg.SetString(konnectcommon.BaseURLConfigPath, baseURL)
+		if err := setCommandTreeFlagValue(command, konnectcommon.BaseURLFlagName, baseURL); err != nil {
+			return err
+		}
 	}
 	if !commandTreeFlagChanged(command, konnectcommon.AuthBaseURLFlagName) {
 		cfg.SetString(konnectcommon.AuthBaseURLConfigPath, defaults.AuthBaseURL)
+		if err := setCommandTreeFlagValue(command, konnectcommon.AuthBaseURLFlagName, defaults.AuthBaseURL); err != nil {
+			return err
+		}
 	}
 	if !commandTreeFlagChanged(command, konnectcommon.MachineClientIDFlagName) {
 		cfg.SetString(konnectcommon.MachineClientIDConfigPath, defaults.MachineClientID)
+		if err := setCommandTreeFlagValue(command, konnectcommon.MachineClientIDFlagName, defaults.MachineClientID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func selectedKonnectEnvironmentDefaults(command *cobra.Command) (konnectcommon.EnvironmentDefaults, bool, error) {
+	if value, ok := commandTreeChangedFlagString(command, konnectcommon.KonnectEnvFlagName); ok {
+		defaults, err := konnectEnvironmentDefaultsForSelector(value)
+		return defaults, true, err
+	}
+
+	if value := strings.TrimSpace(konnectEnv); value != "" {
+		defaults, err := konnectEnvironmentDefaultsForSelector(value)
+		return defaults, true, err
+	}
+
+	value, ok := os.LookupEnv(konnectcommon.KonnectEnvEnvName)
+	if !ok || strings.TrimSpace(value) == "" {
+		return konnectcommon.EnvironmentDefaults{}, false, nil
+	}
+
+	defaults, err := konnectEnvironmentDefaultsForSelector(value)
+	return defaults, true, err
+}
+
+func konnectEnvironmentDefaultsForSelector(value string) (konnectcommon.EnvironmentDefaults, error) {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	switch normalized {
+	case konnectcommon.EnvironmentCom, konnectcommon.EnvironmentTech:
+		return konnectcommon.EnvironmentDefaultsFor(normalized)
+	default:
+		return konnectcommon.EnvironmentDefaults{},
+			fmt.Errorf("unsupported konnect environment %q (allowed: %s, %s)",
+				value, konnectcommon.EnvironmentCom, konnectcommon.EnvironmentTech)
+	}
+}
+
+func setCommandTreeFlagValue(command *cobra.Command, name, value string) error {
+	if command == nil {
+		return nil
+	}
+	for _, flags := range []*pflag.FlagSet{
+		command.Flags(),
+		command.PersistentFlags(),
+		command.LocalNonPersistentFlags(),
+		command.InheritedFlags(),
+	} {
+		if flags == nil {
+			continue
+		}
+		if flag := flags.Lookup(name); flag != nil && !flag.Changed {
+			if err := flag.Value.Set(value); err != nil {
+				return fmt.Errorf("set --%s default: %w", name, err)
+			}
+			flag.DefValue = value
+		}
+	}
+	for _, child := range command.Commands() {
+		if err := setCommandTreeFlagValue(child, name, value); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -725,7 +803,6 @@ func initConfig() {
 
 	bindFlags(currConfig)
 	applyExtensionRuntimeDefaults(runtimeCtx, currConfig)
-	util.CheckError(applyKongTechDefaults(rootCmd, currConfig))
 
 	themeName := strings.TrimSpace(currConfig.GetString(common.ColorThemeConfigPath))
 	if themeName == "" {

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -215,7 +215,7 @@ func newRootCmd() *cobra.Command {
 			return nil
 		},
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			if err := applyKonnectEnvironmentDefaults(cmd.Root(), currConfig); err != nil {
+			if err := konnectcommon.ApplyEnvironmentDefaults(cmd.Root(), currConfig); err != nil {
 				return &cmdpkg.ConfigurationError{Err: err}
 			}
 			if err := validateOutputFormat(cmd); err != nil {
@@ -607,11 +607,11 @@ func applyExtensionRuntimeDefaultsBeforeConfig(runtimeCtx *extensioncore.Runtime
 		return
 	}
 	if value := strings.TrimSpace(runtimeCtx.Resolved.ConfigFile); value != "" &&
-		!commandTreeFlagChanged(rootCmd, common.ConfigFilePathFlagName) {
+		!common.CommandTreeFlagChanged(rootCmd, common.ConfigFilePathFlagName) {
 		configFilePath = value
 	}
 	if value := strings.TrimSpace(runtimeCtx.Resolved.Profile); value != "" &&
-		!commandTreeFlagChanged(rootCmd, common.ProfileFlagName) {
+		!common.CommandTreeFlagChanged(rootCmd, common.ProfileFlagName) {
 		currProfile = value
 	}
 }
@@ -621,170 +621,28 @@ func applyExtensionRuntimeDefaults(runtimeCtx *extensioncore.RuntimeContext, cfg
 		return
 	}
 	if value := strings.TrimSpace(runtimeCtx.Resolved.Output); value != "" &&
-		!commandTreeFlagChanged(rootCmd, common.OutputFlagName) {
+		!common.CommandTreeFlagChanged(rootCmd, common.OutputFlagName) {
 		util.CheckError(outputFormat.Set(value))
 		cfg.SetString(common.OutputConfigPath, value)
 	}
 	if value := strings.TrimSpace(runtimeCtx.Resolved.LogLevel); value != "" &&
-		!commandTreeFlagChanged(rootCmd, common.LogLevelFlagName) {
+		!common.CommandTreeFlagChanged(rootCmd, common.LogLevelFlagName) {
 		util.CheckError(logLevel.Set(value))
 		cfg.SetString(common.LogLevelConfigPath, value)
 	}
 	if value := strings.TrimSpace(runtimeCtx.Resolved.ColorTheme); value != "" &&
-		!commandTreeFlagChanged(rootCmd, common.ColorThemeFlagName) {
+		!common.CommandTreeFlagChanged(rootCmd, common.ColorThemeFlagName) {
 		cfg.SetString(common.ColorThemeConfigPath, value)
 	}
 	if value := strings.TrimSpace(runtimeCtx.Resolved.BaseURL); value != "" &&
-		!commandTreeFlagChanged(rootCmd, konnectcommon.BaseURLFlagName) &&
-		!commandTreeFlagChanged(rootCmd, konnectcommon.RegionFlagName) {
+		!common.CommandTreeFlagChanged(rootCmd, konnectcommon.BaseURLFlagName) &&
+		!common.CommandTreeFlagChanged(rootCmd, konnectcommon.RegionFlagName) {
 		cfg.SetString(konnectcommon.BaseURLConfigPath, value)
 	}
 	if value := strings.TrimSpace(os.Getenv(extensioncore.KonnectPATEnvName)); value != "" &&
-		!commandTreeFlagChanged(rootCmd, konnectcommon.PATFlagName) {
+		!common.CommandTreeFlagChanged(rootCmd, konnectcommon.PATFlagName) {
 		cfg.SetString(konnectcommon.PATConfigPath, value)
 	}
-}
-
-func applyKonnectEnvironmentDefaults(command *cobra.Command, cfg config.Hook) error {
-	if command == nil || cfg == nil {
-		return nil
-	}
-
-	defaults, selected, err := selectedKonnectEnvironmentDefaults(command)
-	if err != nil || !selected {
-		return err
-	}
-
-	if !commandTreeFlagChanged(command, konnectcommon.BaseURLFlagName) {
-		baseURL := defaults.BaseURL
-		if region, ok := commandTreeChangedFlagString(command, konnectcommon.RegionFlagName); ok {
-			resolved, err := konnectcommon.BuildBaseURLFromRegionForEnvironment(region, defaults.Name)
-			if err != nil {
-				return err
-			}
-			baseURL = resolved
-		} else if region := strings.TrimSpace(cfg.GetString(konnectcommon.RegionConfigPath)); region != "" {
-			resolved, err := konnectcommon.BuildBaseURLFromRegionForEnvironment(region, defaults.Name)
-			if err != nil {
-				return err
-			}
-			baseURL = resolved
-		}
-		cfg.SetString(konnectcommon.BaseURLConfigPath, baseURL)
-		if err := setCommandTreeFlagValue(command, konnectcommon.BaseURLFlagName, baseURL); err != nil {
-			return err
-		}
-	}
-	if !commandTreeFlagChanged(command, konnectcommon.AuthBaseURLFlagName) {
-		cfg.SetString(konnectcommon.AuthBaseURLConfigPath, defaults.AuthBaseURL)
-		if err := setCommandTreeFlagValue(command, konnectcommon.AuthBaseURLFlagName, defaults.AuthBaseURL); err != nil {
-			return err
-		}
-	}
-	if !commandTreeFlagChanged(command, konnectcommon.MachineClientIDFlagName) {
-		cfg.SetString(konnectcommon.MachineClientIDConfigPath, defaults.MachineClientID)
-		if err := setCommandTreeFlagValue(command, konnectcommon.MachineClientIDFlagName, defaults.MachineClientID); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func selectedKonnectEnvironmentDefaults(command *cobra.Command) (konnectcommon.EnvironmentDefaults, bool, error) {
-	if value, ok := commandTreeChangedFlagString(command, konnectcommon.KonnectEnvFlagName); ok {
-		defaults, err := konnectEnvironmentDefaultsForSelector(value)
-		return defaults, true, err
-	}
-
-	if value := strings.TrimSpace(konnectEnv); value != "" {
-		defaults, err := konnectEnvironmentDefaultsForSelector(value)
-		return defaults, true, err
-	}
-
-	value, ok := os.LookupEnv(konnectcommon.KonnectEnvEnvName)
-	if !ok || strings.TrimSpace(value) == "" {
-		return konnectcommon.EnvironmentDefaults{}, false, nil
-	}
-
-	defaults, err := konnectEnvironmentDefaultsForSelector(value)
-	return defaults, true, err
-}
-
-func konnectEnvironmentDefaultsForSelector(value string) (konnectcommon.EnvironmentDefaults, error) {
-	normalized := strings.ToLower(strings.TrimSpace(value))
-	switch normalized {
-	case konnectcommon.EnvironmentCom, konnectcommon.EnvironmentTech:
-		return konnectcommon.EnvironmentDefaultsFor(normalized)
-	default:
-		return konnectcommon.EnvironmentDefaults{},
-			fmt.Errorf("unsupported konnect environment %q (allowed: %s, %s)",
-				value, konnectcommon.EnvironmentCom, konnectcommon.EnvironmentTech)
-	}
-}
-
-func setCommandTreeFlagValue(command *cobra.Command, name, value string) error {
-	if command == nil {
-		return nil
-	}
-	for _, flags := range []*pflag.FlagSet{
-		command.Flags(),
-		command.PersistentFlags(),
-		command.LocalNonPersistentFlags(),
-		command.InheritedFlags(),
-	} {
-		if flags == nil {
-			continue
-		}
-		if flag := flags.Lookup(name); flag != nil && !flag.Changed {
-			if err := flag.Value.Set(value); err != nil {
-				return fmt.Errorf("set --%s default: %w", name, err)
-			}
-			flag.DefValue = value
-		}
-	}
-	for _, child := range command.Commands() {
-		if err := setCommandTreeFlagValue(child, name, value); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func commandTreeFlagChanged(command *cobra.Command, name string) bool {
-	return commandTreeChangedFlag(command, name) != nil
-}
-
-func commandTreeChangedFlagString(command *cobra.Command, name string) (string, bool) {
-	flag := commandTreeChangedFlag(command, name)
-	if flag == nil {
-		return "", false
-	}
-	return flag.Value.String(), true
-}
-
-func commandTreeChangedFlag(command *cobra.Command, name string) *pflag.Flag {
-	if command == nil {
-		return nil
-	}
-	for _, flags := range []*pflag.FlagSet{
-		command.Flags(),
-		command.PersistentFlags(),
-		command.LocalNonPersistentFlags(),
-		command.InheritedFlags(),
-	} {
-		if flags == nil {
-			continue
-		}
-		if flag := flags.Lookup(name); flag != nil && flag.Changed {
-			return flag
-		}
-	}
-	for _, child := range command.Commands() {
-		if flag := commandTreeChangedFlag(child, name); flag != nil {
-			return flag
-		}
-	}
-	return nil
 }
 
 func initConfig() {

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -1238,7 +1238,7 @@ func TestApplyKonnectEnvironmentDefaultsNoSelectionDoesNotOverrideProfileConfig(
 	cfg.SetString(konnectcommon.MachineClientIDConfigPath, "client-id")
 	command := newKonnectEnvCommandForTest()
 
-	requireNoError(t, applyKonnectEnvironmentDefaults(command, cfg))
+	requireNoError(t, konnectcommon.ApplyEnvironmentDefaults(command, cfg))
 
 	if got := cfg.GetString(konnectcommon.BaseURLConfigPath); got != "https://custom.example.test" {
 		t.Fatalf("base URL = %q, want profile config to remain unchanged", got)
@@ -1256,7 +1256,7 @@ func TestApplyKonnectEnvironmentDefaultsFromFlagTech(t *testing.T) {
 	command := newKonnectEnvCommandForTest()
 	requireNoError(t, command.Flags().Set(konnectcommon.KonnectEnvFlagName, konnectcommon.EnvironmentTech))
 
-	requireNoError(t, applyKonnectEnvironmentDefaults(command, cfg))
+	requireNoError(t, konnectcommon.ApplyEnvironmentDefaults(command, cfg))
 
 	if got := cfg.GetString(konnectcommon.BaseURLConfigPath); got != konnectcommon.TechBaseURLDefault {
 		t.Fatalf("base URL = %q, want %q", got, konnectcommon.TechBaseURLDefault)
@@ -1272,36 +1272,13 @@ func TestApplyKonnectEnvironmentDefaultsFromFlagTech(t *testing.T) {
 	}
 }
 
-func TestApplyKonnectEnvironmentDefaultsFromParsedFlagValue(t *testing.T) {
-	oldKonnectEnv := konnectEnv
-	t.Cleanup(func() {
-		konnectEnv = oldKonnectEnv
-	})
-	konnectEnv = konnectcommon.EnvironmentTech
-
-	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
-	command := newKonnectEnvCommandForTest()
-
-	requireNoError(t, applyKonnectEnvironmentDefaults(command, cfg))
-
-	if got := cfg.GetString(konnectcommon.BaseURLConfigPath); got != konnectcommon.TechBaseURLDefault {
-		t.Fatalf("base URL = %q, want %q", got, konnectcommon.TechBaseURLDefault)
-	}
-	if got := cfg.GetString(konnectcommon.AuthBaseURLConfigPath); got != konnectcommon.TechGlobalBaseURL {
-		t.Fatalf("auth base URL = %q, want %q", got, konnectcommon.TechGlobalBaseURL)
-	}
-	if got := cfg.GetString(konnectcommon.MachineClientIDConfigPath); got != konnectcommon.TechMachineClientID {
-		t.Fatalf("machine client ID = %q, want %q", got, konnectcommon.TechMachineClientID)
-	}
-}
-
 func TestApplyKonnectEnvironmentDefaultsFromEnvTech(t *testing.T) {
 	t.Setenv(konnectcommon.KonnectEnvEnvName, konnectcommon.EnvironmentTech)
 
 	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
 	command := newKonnectEnvCommandForTest()
 
-	requireNoError(t, applyKonnectEnvironmentDefaults(command, cfg))
+	requireNoError(t, konnectcommon.ApplyEnvironmentDefaults(command, cfg))
 
 	if got := cfg.GetString(konnectcommon.BaseURLConfigPath); got != konnectcommon.TechBaseURLDefault {
 		t.Fatalf("base URL = %q, want %q", got, konnectcommon.TechBaseURLDefault)
@@ -1324,7 +1301,7 @@ func TestApplyKonnectEnvironmentDefaultsFlagOverridesEnv(t *testing.T) {
 	command := newKonnectEnvCommandForTest()
 	requireNoError(t, command.Flags().Set(konnectcommon.KonnectEnvFlagName, konnectcommon.EnvironmentCom))
 
-	requireNoError(t, applyKonnectEnvironmentDefaults(command, cfg))
+	requireNoError(t, konnectcommon.ApplyEnvironmentDefaults(command, cfg))
 
 	if got := cfg.GetString(konnectcommon.BaseURLConfigPath); got != konnectcommon.BaseURLDefault {
 		t.Fatalf("base URL = %q, want %q", got, konnectcommon.BaseURLDefault)
@@ -1348,7 +1325,7 @@ func TestApplyKonnectEnvironmentDefaultsRespectsExplicitEndpointFlags(t *testing
 	requireNoError(t, command.Flags().Set(konnectcommon.AuthBaseURLFlagName, "https://auth.example.test"))
 	requireNoError(t, command.Flags().Set(konnectcommon.MachineClientIDFlagName, "client-id"))
 
-	requireNoError(t, applyKonnectEnvironmentDefaults(command, cfg))
+	requireNoError(t, konnectcommon.ApplyEnvironmentDefaults(command, cfg))
 
 	if got := cfg.GetString(konnectcommon.BaseURLConfigPath); got != "" {
 		t.Fatalf("base URL = %q, want explicit flag to remain unset in config override", got)
@@ -1370,7 +1347,7 @@ func TestApplyKonnectEnvironmentDefaultsSurvivesLaterFlagBinding(t *testing.T) {
 	command.Flags().String(konnectcommon.AuthBaseURLFlagName, "", "")
 	command.Flags().String(konnectcommon.MachineClientIDFlagName, "", "")
 
-	requireNoError(t, applyKonnectEnvironmentDefaults(command, cfg))
+	requireNoError(t, konnectcommon.ApplyEnvironmentDefaults(command, cfg))
 	requireNoError(t, cfg.BindFlag(konnectcommon.BaseURLConfigPath, command.Flags().Lookup(konnectcommon.BaseURLFlagName)))
 	requireNoError(t, cfg.BindFlag(
 		konnectcommon.AuthBaseURLConfigPath,
@@ -1399,7 +1376,7 @@ func TestApplyKonnectEnvironmentDefaultsUsesExplicitRegion(t *testing.T) {
 	command.Flags().String(konnectcommon.RegionFlagName, "", "")
 	requireNoError(t, command.Flags().Set(konnectcommon.RegionFlagName, "eu"))
 
-	requireNoError(t, applyKonnectEnvironmentDefaults(command, cfg))
+	requireNoError(t, konnectcommon.ApplyEnvironmentDefaults(command, cfg))
 
 	if got := cfg.GetString(konnectcommon.BaseURLConfigPath); got != "https://eu.api.konghq.tech" {
 		t.Fatalf("base URL = %q, want https://eu.api.konghq.tech", got)
@@ -1412,7 +1389,7 @@ func TestApplyKonnectEnvironmentDefaultsUsesConfiguredRegion(t *testing.T) {
 	command := newKonnectEnvCommandForTest()
 	requireNoError(t, command.Flags().Set(konnectcommon.KonnectEnvFlagName, konnectcommon.EnvironmentTech))
 
-	requireNoError(t, applyKonnectEnvironmentDefaults(command, cfg))
+	requireNoError(t, konnectcommon.ApplyEnvironmentDefaults(command, cfg))
 
 	if got := cfg.GetString(konnectcommon.BaseURLConfigPath); got != "https://eu.api.konghq.tech" {
 		t.Fatalf("base URL = %q, want https://eu.api.konghq.tech", got)
@@ -1425,7 +1402,7 @@ func TestApplyKonnectEnvironmentDefaultsRejectsInvalidEnv(t *testing.T) {
 	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
 	command := newKonnectEnvCommandForTest()
 
-	err := applyKonnectEnvironmentDefaults(command, cfg)
+	err := konnectcommon.ApplyEnvironmentDefaults(command, cfg)
 	if err == nil {
 		t.Fatal("expected invalid konnect environment error")
 	}
@@ -1440,7 +1417,7 @@ func TestApplyKonnectEnvironmentDefaultsRejectsProductionAlias(t *testing.T) {
 	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
 	command := newKonnectEnvCommandForTest()
 
-	err := applyKonnectEnvironmentDefaults(command, cfg)
+	err := konnectcommon.ApplyEnvironmentDefaults(command, cfg)
 	if err == nil {
 		t.Fatal("expected invalid konnect environment error")
 	}

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -421,7 +422,8 @@ func TestCreatePATTokenOutputAndJQ(t *testing.T) {
 		},
 	})
 
-	result := executeRootForTest(t,
+	result := executeRootForTest(
+		t,
 		"create", "pat",
 		"--name", "ci",
 		"--expires-in", "24h",
@@ -440,7 +442,8 @@ func TestCreatePATTokenOutputAndJQ(t *testing.T) {
 		t.Fatalf("expected 24h ttl to be 86400 seconds, got %d", got)
 	}
 
-	result = executeRootForTest(t,
+	result = executeRootForTest(
+		t,
 		"create", "pat",
 		"--name", "ci",
 		"--expires-in", "7d",
@@ -470,7 +473,8 @@ func TestCreateSPATEnvOutputResolvesSystemAccountName(t *testing.T) {
 		},
 	})
 
-	result := executeRootForTest(t,
+	result := executeRootForTest(
+		t,
 		"--profile", "team-a",
 		"create", "spat",
 		"--system-account-name", "ci-bot",
@@ -487,7 +491,8 @@ func TestCreateSPATEnvOutputResolvesSystemAccountName(t *testing.T) {
 }
 
 func TestCreateSPATRejectsBelowMinDuration(t *testing.T) {
-	result := executeRootForTest(t,
+	result := executeRootForTest(
+		t,
 		"create", "spat",
 		"--system-account-id", "system-account-id",
 		"--name", "ci",
@@ -507,7 +512,8 @@ func TestCreateSPATRejectsBelowMinDuration(t *testing.T) {
 }
 
 func TestCreateSPATRejectsOverMaxDuration(t *testing.T) {
-	result := executeRootForTest(t,
+	result := executeRootForTest(
+		t,
 		"create", "spat",
 		"--system-account-id", "system-account-id",
 		"--name", "ci",
@@ -552,7 +558,8 @@ func TestCreateSPATRejectsExpiresAtOutsideBounds(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := executeRootForTest(t,
+			result := executeRootForTest(
+				t,
 				"create", "spat",
 				"--system-account-id", "system-account-id",
 				"--name", "ci",
@@ -679,7 +686,8 @@ func TestSPATGetAndDeleteCommands(t *testing.T) {
 		t.Fatalf("expected SPAT by name output to include resolved system account name\nstdout:\n%s", result.stdout)
 	}
 
-	result = executeRootForTest(t,
+	result = executeRootForTest(
+		t,
 		"delete", "spat", "ci",
 		"--system-account-name", "ci-bot",
 		"--auto-approve",
@@ -698,7 +706,8 @@ func TestSPATGetAndDeleteCommands(t *testing.T) {
 
 	unnamedID := "55555555-5555-5555-5555-555555555555"
 	spatAPI.tokens = append(spatAPI.tokens, kkComps.SystemAccountAccessToken{ID: &unnamedID})
-	result = executeRootForTest(t,
+	result = executeRootForTest(
+		t,
 		"delete", "spat", unnamedID,
 		"--system-account-id", accountID,
 		"--auto-approve",
@@ -1148,27 +1157,132 @@ func TestRootErrorUX(t *testing.T) {
 	}
 }
 
-func TestKongTechFlagIsHiddenFromHelp(t *testing.T) {
+func TestKonnectEnvFlagIsHiddenFromHelp(t *testing.T) {
 	result := executeRootForTest(t, "--help")
 	if result.exitCode != 0 {
 		t.Fatalf("expected help to succeed\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
 	}
-	if strings.Contains(result.stdout, "--"+konnectcommon.KongTechFlagName) {
-		t.Fatalf("expected hidden kong tech flag not to appear in help\nstdout:\n%s", result.stdout)
+	if strings.Contains(result.stdout, "--"+konnectcommon.KonnectEnvFlagName) {
+		t.Fatalf("expected hidden konnect env flag not to appear in help\nstdout:\n%s", result.stdout)
 	}
 }
 
-func TestApplyKongTechDefaults(t *testing.T) {
-	oldKongTech := kongTech
+func TestKonnectEnvFlagAppliesDuringRootExecution(t *testing.T) {
+	result := executeRootForTest(t, "--"+konnectcommon.KonnectEnvFlagName, konnectcommon.EnvironmentTech)
+	if result.exitCode != 0 {
+		t.Fatalf("expected command to succeed\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+	if currConfig == nil {
+		t.Fatal("expected config to be initialized")
+	}
+	if got := currConfig.GetString(konnectcommon.BaseURLConfigPath); got != konnectcommon.TechBaseURLDefault {
+		t.Fatalf("base URL = %q, want %q", got, konnectcommon.TechBaseURLDefault)
+	}
+	if got := currConfig.GetString(konnectcommon.AuthBaseURLConfigPath); got != konnectcommon.TechGlobalBaseURL {
+		t.Fatalf("auth base URL = %q, want %q", got, konnectcommon.TechGlobalBaseURL)
+	}
+	if got := currConfig.GetString(konnectcommon.MachineClientIDConfigPath); got != konnectcommon.TechMachineClientID {
+		t.Fatalf("machine client ID = %q, want %q", got, konnectcommon.TechMachineClientID)
+	}
+}
+
+func TestKonnectEnvFlagAppliesToKonnectFirstCommand(t *testing.T) {
+	var capturedBaseURL string
+	factoryCalls := 0
+	original := helpers.DefaultSDKFactory
 	t.Cleanup(func() {
-		kongTech = oldKongTech
+		helpers.DefaultSDKFactory = original
 	})
+	helpers.DefaultSDKFactory = func(cfg configpkg.Hook, _ *slog.Logger) (helpers.SDKAPI, error) {
+		factoryCalls++
+		capturedBaseURL = cfg.GetString(konnectcommon.BaseURLConfigPath)
+		orgID := "org-1"
+		return &helpers.MockKonnectSDK{
+			MeFactory: func() helpers.MeAPI {
+				return rootTestMeAPI{
+					organization: &kkComps.MeOrganization{
+						ID: &orgID,
+					},
+				}
+			},
+		}, nil
+	}
+
+	result := executeRootForTest(
+		t,
+		"get", "org",
+		"--"+konnectcommon.KonnectEnvFlagName, konnectcommon.EnvironmentTech,
+		"--output", "json",
+	)
+	if result.exitCode != 0 {
+		t.Fatalf("expected command to succeed\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+	if factoryCalls == 0 {
+		t.Fatalf("expected SDK factory to be called\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+	if capturedBaseURL != konnectcommon.TechBaseURLDefault {
+		t.Fatalf("base URL at SDK factory = %q, want %q", capturedBaseURL, konnectcommon.TechBaseURLDefault)
+	}
+}
+
+func newKonnectEnvCommandForTest() *cobra.Command {
+	command := &cobra.Command{Use: "root"}
+	command.Flags().String(konnectcommon.KonnectEnvFlagName, "", "")
+	return command
+}
+
+func TestApplyKonnectEnvironmentDefaultsNoSelectionDoesNotOverrideProfileConfig(t *testing.T) {
+	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
+	cfg.SetString(konnectcommon.BaseURLConfigPath, "https://custom.example.test")
+	cfg.SetString(konnectcommon.AuthBaseURLConfigPath, "https://auth.example.test")
+	cfg.SetString(konnectcommon.MachineClientIDConfigPath, "client-id")
+	command := newKonnectEnvCommandForTest()
+
+	requireNoError(t, applyKonnectEnvironmentDefaults(command, cfg))
+
+	if got := cfg.GetString(konnectcommon.BaseURLConfigPath); got != "https://custom.example.test" {
+		t.Fatalf("base URL = %q, want profile config to remain unchanged", got)
+	}
+	if got := cfg.GetString(konnectcommon.AuthBaseURLConfigPath); got != "https://auth.example.test" {
+		t.Fatalf("auth base URL = %q, want profile config to remain unchanged", got)
+	}
+	if got := cfg.GetString(konnectcommon.MachineClientIDConfigPath); got != "client-id" {
+		t.Fatalf("machine client ID = %q, want profile config to remain unchanged", got)
+	}
+}
+
+func TestApplyKonnectEnvironmentDefaultsFromFlagTech(t *testing.T) {
+	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
+	command := newKonnectEnvCommandForTest()
+	requireNoError(t, command.Flags().Set(konnectcommon.KonnectEnvFlagName, konnectcommon.EnvironmentTech))
+
+	requireNoError(t, applyKonnectEnvironmentDefaults(command, cfg))
+
+	if got := cfg.GetString(konnectcommon.BaseURLConfigPath); got != konnectcommon.TechBaseURLDefault {
+		t.Fatalf("base URL = %q, want %q", got, konnectcommon.TechBaseURLDefault)
+	}
+	if got := cfg.GetString(konnectcommon.AuthBaseURLConfigPath); got != konnectcommon.TechGlobalBaseURL {
+		t.Fatalf("auth base URL = %q, want %q", got, konnectcommon.TechGlobalBaseURL)
+	}
+	if got := cfg.GetString(konnectcommon.MachineClientIDConfigPath); got != konnectcommon.TechMachineClientID {
+		t.Fatalf("machine client ID = %q, want %q", got, konnectcommon.TechMachineClientID)
+	}
+	if got := cfg.GetProfile(); got != "default" {
+		t.Fatalf("profile = %q, want default", got)
+	}
+}
+
+func TestApplyKonnectEnvironmentDefaultsFromParsedFlagValue(t *testing.T) {
+	oldKonnectEnv := konnectEnv
+	t.Cleanup(func() {
+		konnectEnv = oldKonnectEnv
+	})
+	konnectEnv = konnectcommon.EnvironmentTech
 
 	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
-	command := &cobra.Command{Use: "root"}
-	kongTech = true
+	command := newKonnectEnvCommandForTest()
 
-	requireNoError(t, applyKongTechDefaults(command, cfg))
+	requireNoError(t, applyKonnectEnvironmentDefaults(command, cfg))
 
 	if got := cfg.GetString(konnectcommon.BaseURLConfigPath); got != konnectcommon.TechBaseURLDefault {
 		t.Fatalf("base URL = %q, want %q", got, konnectcommon.TechBaseURLDefault)
@@ -1181,23 +1295,60 @@ func TestApplyKongTechDefaults(t *testing.T) {
 	}
 }
 
-func TestApplyKongTechDefaultsRespectsExplicitEndpointFlags(t *testing.T) {
-	oldKongTech := kongTech
-	t.Cleanup(func() {
-		kongTech = oldKongTech
-	})
+func TestApplyKonnectEnvironmentDefaultsFromEnvTech(t *testing.T) {
+	t.Setenv(konnectcommon.KonnectEnvEnvName, konnectcommon.EnvironmentTech)
 
 	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
-	command := &cobra.Command{Use: "root"}
+	command := newKonnectEnvCommandForTest()
+
+	requireNoError(t, applyKonnectEnvironmentDefaults(command, cfg))
+
+	if got := cfg.GetString(konnectcommon.BaseURLConfigPath); got != konnectcommon.TechBaseURLDefault {
+		t.Fatalf("base URL = %q, want %q", got, konnectcommon.TechBaseURLDefault)
+	}
+	if got := cfg.GetString(konnectcommon.AuthBaseURLConfigPath); got != konnectcommon.TechGlobalBaseURL {
+		t.Fatalf("auth base URL = %q, want %q", got, konnectcommon.TechGlobalBaseURL)
+	}
+	if got := cfg.GetString(konnectcommon.MachineClientIDConfigPath); got != konnectcommon.TechMachineClientID {
+		t.Fatalf("machine client ID = %q, want %q", got, konnectcommon.TechMachineClientID)
+	}
+}
+
+func TestApplyKonnectEnvironmentDefaultsFlagOverridesEnv(t *testing.T) {
+	t.Setenv(konnectcommon.KonnectEnvEnvName, konnectcommon.EnvironmentTech)
+
+	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
+	cfg.SetString(konnectcommon.BaseURLConfigPath, konnectcommon.TechBaseURLDefault)
+	cfg.SetString(konnectcommon.AuthBaseURLConfigPath, konnectcommon.TechGlobalBaseURL)
+	cfg.SetString(konnectcommon.MachineClientIDConfigPath, konnectcommon.TechMachineClientID)
+	command := newKonnectEnvCommandForTest()
+	requireNoError(t, command.Flags().Set(konnectcommon.KonnectEnvFlagName, konnectcommon.EnvironmentCom))
+
+	requireNoError(t, applyKonnectEnvironmentDefaults(command, cfg))
+
+	if got := cfg.GetString(konnectcommon.BaseURLConfigPath); got != konnectcommon.BaseURLDefault {
+		t.Fatalf("base URL = %q, want %q", got, konnectcommon.BaseURLDefault)
+	}
+	if got := cfg.GetString(konnectcommon.AuthBaseURLConfigPath); got != konnectcommon.AuthBaseURLDefault {
+		t.Fatalf("auth base URL = %q, want %q", got, konnectcommon.AuthBaseURLDefault)
+	}
+	if got := cfg.GetString(konnectcommon.MachineClientIDConfigPath); got != konnectcommon.MachineClientIDDefault {
+		t.Fatalf("machine client ID = %q, want %q", got, konnectcommon.MachineClientIDDefault)
+	}
+}
+
+func TestApplyKonnectEnvironmentDefaultsRespectsExplicitEndpointFlags(t *testing.T) {
+	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
+	command := newKonnectEnvCommandForTest()
+	requireNoError(t, command.Flags().Set(konnectcommon.KonnectEnvFlagName, konnectcommon.EnvironmentTech))
 	command.Flags().String(konnectcommon.BaseURLFlagName, "", "")
 	command.Flags().String(konnectcommon.AuthBaseURLFlagName, "", "")
 	command.Flags().String(konnectcommon.MachineClientIDFlagName, "", "")
 	requireNoError(t, command.Flags().Set(konnectcommon.BaseURLFlagName, "https://custom.example.test"))
 	requireNoError(t, command.Flags().Set(konnectcommon.AuthBaseURLFlagName, "https://auth.example.test"))
 	requireNoError(t, command.Flags().Set(konnectcommon.MachineClientIDFlagName, "client-id"))
-	kongTech = true
 
-	requireNoError(t, applyKongTechDefaults(command, cfg))
+	requireNoError(t, applyKonnectEnvironmentDefaults(command, cfg))
 
 	if got := cfg.GetString(konnectcommon.BaseURLConfigPath); got != "" {
 		t.Fatalf("base URL = %q, want explicit flag to remain unset in config override", got)
@@ -1210,40 +1361,91 @@ func TestApplyKongTechDefaultsRespectsExplicitEndpointFlags(t *testing.T) {
 	}
 }
 
-func TestApplyKongTechDefaultsUsesExplicitRegion(t *testing.T) {
-	oldKongTech := kongTech
-	t.Cleanup(func() {
-		kongTech = oldKongTech
-	})
-
+func TestApplyKonnectEnvironmentDefaultsSurvivesLaterFlagBinding(t *testing.T) {
 	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
-	command := &cobra.Command{Use: "root"}
+	cfg.SetString(konnectcommon.RegionConfigPath, "global")
+	command := newKonnectEnvCommandForTest()
+	requireNoError(t, command.Flags().Set(konnectcommon.KonnectEnvFlagName, konnectcommon.EnvironmentTech))
+	command.Flags().String(konnectcommon.BaseURLFlagName, "", "")
+	command.Flags().String(konnectcommon.AuthBaseURLFlagName, "", "")
+	command.Flags().String(konnectcommon.MachineClientIDFlagName, "", "")
+
+	requireNoError(t, applyKonnectEnvironmentDefaults(command, cfg))
+	requireNoError(t, cfg.BindFlag(konnectcommon.BaseURLConfigPath, command.Flags().Lookup(konnectcommon.BaseURLFlagName)))
+	requireNoError(t, cfg.BindFlag(
+		konnectcommon.AuthBaseURLConfigPath,
+		command.Flags().Lookup(konnectcommon.AuthBaseURLFlagName),
+	))
+	requireNoError(t, cfg.BindFlag(
+		konnectcommon.MachineClientIDConfigPath,
+		command.Flags().Lookup(konnectcommon.MachineClientIDFlagName),
+	))
+
+	if got := cfg.GetString(konnectcommon.BaseURLConfigPath); got != konnectcommon.TechGlobalBaseURL {
+		t.Fatalf("base URL = %q, want %q", got, konnectcommon.TechGlobalBaseURL)
+	}
+	if got := cfg.GetString(konnectcommon.AuthBaseURLConfigPath); got != konnectcommon.TechGlobalBaseURL {
+		t.Fatalf("auth base URL = %q, want %q", got, konnectcommon.TechGlobalBaseURL)
+	}
+	if got := cfg.GetString(konnectcommon.MachineClientIDConfigPath); got != konnectcommon.TechMachineClientID {
+		t.Fatalf("machine client ID = %q, want %q", got, konnectcommon.TechMachineClientID)
+	}
+}
+
+func TestApplyKonnectEnvironmentDefaultsUsesExplicitRegion(t *testing.T) {
+	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
+	command := newKonnectEnvCommandForTest()
+	requireNoError(t, command.Flags().Set(konnectcommon.KonnectEnvFlagName, konnectcommon.EnvironmentTech))
 	command.Flags().String(konnectcommon.RegionFlagName, "", "")
 	requireNoError(t, command.Flags().Set(konnectcommon.RegionFlagName, "eu"))
-	kongTech = true
 
-	requireNoError(t, applyKongTechDefaults(command, cfg))
+	requireNoError(t, applyKonnectEnvironmentDefaults(command, cfg))
 
 	if got := cfg.GetString(konnectcommon.BaseURLConfigPath); got != "https://eu.api.konghq.tech" {
 		t.Fatalf("base URL = %q, want https://eu.api.konghq.tech", got)
 	}
 }
 
-func TestApplyKongTechDefaultsUsesConfiguredRegion(t *testing.T) {
-	oldKongTech := kongTech
-	t.Cleanup(func() {
-		kongTech = oldKongTech
-	})
-
+func TestApplyKonnectEnvironmentDefaultsUsesConfiguredRegion(t *testing.T) {
 	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
 	cfg.SetString(konnectcommon.RegionConfigPath, "eu")
-	command := &cobra.Command{Use: "root"}
-	kongTech = true
+	command := newKonnectEnvCommandForTest()
+	requireNoError(t, command.Flags().Set(konnectcommon.KonnectEnvFlagName, konnectcommon.EnvironmentTech))
 
-	requireNoError(t, applyKongTechDefaults(command, cfg))
+	requireNoError(t, applyKonnectEnvironmentDefaults(command, cfg))
 
 	if got := cfg.GetString(konnectcommon.BaseURLConfigPath); got != "https://eu.api.konghq.tech" {
 		t.Fatalf("base URL = %q, want https://eu.api.konghq.tech", got)
+	}
+}
+
+func TestApplyKonnectEnvironmentDefaultsRejectsInvalidEnv(t *testing.T) {
+	t.Setenv(konnectcommon.KonnectEnvEnvName, "stage")
+
+	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
+	command := newKonnectEnvCommandForTest()
+
+	err := applyKonnectEnvironmentDefaults(command, cfg)
+	if err == nil {
+		t.Fatal("expected invalid konnect environment error")
+	}
+	if !strings.Contains(err.Error(), "unsupported konnect environment") {
+		t.Fatalf("expected unsupported environment error, got %v", err)
+	}
+}
+
+func TestApplyKonnectEnvironmentDefaultsRejectsProductionAlias(t *testing.T) {
+	t.Setenv(konnectcommon.KonnectEnvEnvName, konnectcommon.EnvironmentProduction)
+
+	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
+	command := newKonnectEnvCommandForTest()
+
+	err := applyKonnectEnvironmentDefaults(command, cfg)
+	if err == nil {
+		t.Fatal("expected invalid konnect environment error")
+	}
+	if !strings.Contains(err.Error(), "allowed: com, tech") {
+		t.Fatalf("expected allowed values error, got %v", err)
 	}
 }
 
@@ -1347,8 +1549,9 @@ func executeRootForTest(t *testing.T, args ...string) rootCommandResult {
 	oldOutputFormat := outputFormat
 	oldLogLevel := logLevel
 	oldLogFile := logFile
-	oldKongTech := kongTech
+	oldKonnectEnv := konnectEnv
 	oldEnableTraverseRunHooks := cobra.EnableTraverseRunHooks
+	oldArgs := os.Args
 	t.Cleanup(func() {
 		rootCmd = oldRootCmd
 		defaultConfigFilePath = oldDefaultConfigFilePath
@@ -1360,12 +1563,13 @@ func executeRootForTest(t *testing.T, args ...string) rootCommandResult {
 		buildInfo = oldBuildInfo
 		outputFormat = oldOutputFormat
 		logLevel = oldLogLevel
-		kongTech = oldKongTech
+		konnectEnv = oldKonnectEnv
 		if logFile != nil && logFile != oldLogFile {
 			_ = logFile.Close()
 		}
 		logFile = oldLogFile
 		cobra.EnableTraverseRunHooks = oldEnableTraverseRunHooks
+		os.Args = oldArgs
 	})
 
 	cobra.EnableTraverseRunHooks = true
@@ -1378,7 +1582,7 @@ func executeRootForTest(t *testing.T, args ...string) rootCommandResult {
 	configFilePath = ""
 	currProfile = profile.DefaultProfile
 	currConfig = nil
-	kongTech = false
+	konnectEnv = ""
 	buildInfo = nil
 	outputFormat = cmdpkg.NewDeferredEnum([]string{
 		common.JSON.String(),
@@ -1401,6 +1605,7 @@ func executeRootForTest(t *testing.T, args ...string) rootCommandResult {
 	}
 	logger = slog.New(log.NewFriendlyErrorHandler(&stderr))
 
+	os.Args = append([]string{"kongctl"}, args...)
 	rootCmd = newRootCmd()
 	requireNoError(t, addCommands())
 	rootCmd.SetArgs(args)
@@ -1482,7 +1687,8 @@ func installRootTokenSDK(t *testing.T, sdk helpers.SDKAPI) {
 }
 
 type rootTestMeAPI struct {
-	userID string
+	userID       string
+	organization *kkComps.MeOrganization
 }
 
 func (m rootTestMeAPI) GetUsersMe(context.Context, ...kkOps.Option) (*kkOps.GetUsersMeResponse, error) {
@@ -1495,7 +1701,9 @@ func (m rootTestMeAPI) GetOrganizationsMe(
 	context.Context,
 	...kkOps.Option,
 ) (*kkOps.GetOrganizationsMeResponse, error) {
-	return &kkOps.GetOrganizationsMeResponse{}, nil
+	return &kkOps.GetOrganizationsMeResponse{
+		MeOrganization: m.organization,
+	}, nil
 }
 
 func rootTestPAT(id, name string) kkComps.PersonalAccessToken {

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -15,6 +15,7 @@ import (
 	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
 	cmdpkg "github.com/kong/kongctl/internal/cmd"
 	"github.com/kong/kongctl/internal/cmd/common"
+	konnectcommon "github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
 	configpkg "github.com/kong/kongctl/internal/config"
 	"github.com/kong/kongctl/internal/iostreams"
 	"github.com/kong/kongctl/internal/konnect/helpers"
@@ -1147,6 +1148,105 @@ func TestRootErrorUX(t *testing.T) {
 	}
 }
 
+func TestKongTechFlagIsHiddenFromHelp(t *testing.T) {
+	result := executeRootForTest(t, "--help")
+	if result.exitCode != 0 {
+		t.Fatalf("expected help to succeed\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+	if strings.Contains(result.stdout, "--"+konnectcommon.KongTechFlagName) {
+		t.Fatalf("expected hidden kong tech flag not to appear in help\nstdout:\n%s", result.stdout)
+	}
+}
+
+func TestApplyKongTechDefaults(t *testing.T) {
+	oldKongTech := kongTech
+	t.Cleanup(func() {
+		kongTech = oldKongTech
+	})
+
+	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
+	command := &cobra.Command{Use: "root"}
+	kongTech = true
+
+	requireNoError(t, applyKongTechDefaults(command, cfg))
+
+	if got := cfg.GetString(konnectcommon.BaseURLConfigPath); got != konnectcommon.TechBaseURLDefault {
+		t.Fatalf("base URL = %q, want %q", got, konnectcommon.TechBaseURLDefault)
+	}
+	if got := cfg.GetString(konnectcommon.AuthBaseURLConfigPath); got != konnectcommon.TechGlobalBaseURL {
+		t.Fatalf("auth base URL = %q, want %q", got, konnectcommon.TechGlobalBaseURL)
+	}
+	if got := cfg.GetString(konnectcommon.MachineClientIDConfigPath); got != konnectcommon.TechMachineClientID {
+		t.Fatalf("machine client ID = %q, want %q", got, konnectcommon.TechMachineClientID)
+	}
+}
+
+func TestApplyKongTechDefaultsRespectsExplicitEndpointFlags(t *testing.T) {
+	oldKongTech := kongTech
+	t.Cleanup(func() {
+		kongTech = oldKongTech
+	})
+
+	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
+	command := &cobra.Command{Use: "root"}
+	command.Flags().String(konnectcommon.BaseURLFlagName, "", "")
+	command.Flags().String(konnectcommon.AuthBaseURLFlagName, "", "")
+	command.Flags().String(konnectcommon.MachineClientIDFlagName, "", "")
+	requireNoError(t, command.Flags().Set(konnectcommon.BaseURLFlagName, "https://custom.example.test"))
+	requireNoError(t, command.Flags().Set(konnectcommon.AuthBaseURLFlagName, "https://auth.example.test"))
+	requireNoError(t, command.Flags().Set(konnectcommon.MachineClientIDFlagName, "client-id"))
+	kongTech = true
+
+	requireNoError(t, applyKongTechDefaults(command, cfg))
+
+	if got := cfg.GetString(konnectcommon.BaseURLConfigPath); got != "" {
+		t.Fatalf("base URL = %q, want explicit flag to remain unset in config override", got)
+	}
+	if got := cfg.GetString(konnectcommon.AuthBaseURLConfigPath); got != "" {
+		t.Fatalf("auth base URL = %q, want explicit flag to remain unset in config override", got)
+	}
+	if got := cfg.GetString(konnectcommon.MachineClientIDConfigPath); got != "" {
+		t.Fatalf("machine client ID = %q, want explicit flag to remain unset in config override", got)
+	}
+}
+
+func TestApplyKongTechDefaultsUsesExplicitRegion(t *testing.T) {
+	oldKongTech := kongTech
+	t.Cleanup(func() {
+		kongTech = oldKongTech
+	})
+
+	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
+	command := &cobra.Command{Use: "root"}
+	command.Flags().String(konnectcommon.RegionFlagName, "", "")
+	requireNoError(t, command.Flags().Set(konnectcommon.RegionFlagName, "eu"))
+	kongTech = true
+
+	requireNoError(t, applyKongTechDefaults(command, cfg))
+
+	if got := cfg.GetString(konnectcommon.BaseURLConfigPath); got != "https://eu.api.konghq.tech" {
+		t.Fatalf("base URL = %q, want https://eu.api.konghq.tech", got)
+	}
+}
+
+func TestApplyKongTechDefaultsUsesConfiguredRegion(t *testing.T) {
+	oldKongTech := kongTech
+	t.Cleanup(func() {
+		kongTech = oldKongTech
+	})
+
+	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
+	cfg.SetString(konnectcommon.RegionConfigPath, "eu")
+	command := &cobra.Command{Use: "root"}
+	kongTech = true
+
+	requireNoError(t, applyKongTechDefaults(command, cfg))
+
+	if got := cfg.GetString(konnectcommon.BaseURLConfigPath); got != "https://eu.api.konghq.tech" {
+		t.Fatalf("base URL = %q, want https://eu.api.konghq.tech", got)
+	}
+}
+
 func TestPlainCommandErrorDoesNotShowUsageHint(t *testing.T) {
 	var stderr bytes.Buffer
 	command := &cobra.Command{Use: "runtime"}
@@ -1247,6 +1347,7 @@ func executeRootForTest(t *testing.T, args ...string) rootCommandResult {
 	oldOutputFormat := outputFormat
 	oldLogLevel := logLevel
 	oldLogFile := logFile
+	oldKongTech := kongTech
 	oldEnableTraverseRunHooks := cobra.EnableTraverseRunHooks
 	t.Cleanup(func() {
 		rootCmd = oldRootCmd
@@ -1259,6 +1360,7 @@ func executeRootForTest(t *testing.T, args ...string) rootCommandResult {
 		buildInfo = oldBuildInfo
 		outputFormat = oldOutputFormat
 		logLevel = oldLogLevel
+		kongTech = oldKongTech
 		if logFile != nil && logFile != oldLogFile {
 			_ = logFile.Close()
 		}
@@ -1276,6 +1378,7 @@ func executeRootForTest(t *testing.T, args ...string) rootCommandResult {
 	configFilePath = ""
 	currProfile = profile.DefaultProfile
 	currConfig = nil
+	kongTech = false
 	buildInfo = nil
 	outputFormat = cmdpkg.NewDeferredEnum([]string{
 		common.JSON.String(),

--- a/internal/cmd/root/verbs/get/organization.go
+++ b/internal/cmd/root/verbs/get/organization.go
@@ -23,7 +23,8 @@ func NewDirectOrganizationCmd() (*cobra.Command, error) {
 - Default   : [ %s ]`,
 				common.BaseURLConfigPath, common.BaseURLDefault))
 
-		cmd.Flags().String(common.RegionFlagName, "",
+		cmd.Flags().String(
+			common.RegionFlagName, "",
 			fmt.Sprintf(`Konnect region identifier (for example "eu"). Used to construct the base URL when --%s is not provided.
 - Config path: [ %s ]`,
 				common.BaseURLFlagName, common.RegionConfigPath),
@@ -42,7 +43,7 @@ Setting this value overrides tokens obtained from the login command.
 			ctx = context.Background()
 		}
 		ctx = context.WithValue(ctx, products.Product, konnect.Product)
-		ctx = context.WithValue(ctx, helpers.SDKAPIFactoryKey, helpers.SDKAPIFactory(common.KonnectSDKFactory))
+		ctx = context.WithValue(ctx, helpers.SDKAPIFactoryKey, common.GetSDKFactoryForVerb(Verb))
 		c.SetContext(ctx)
 
 		return bindOrganizationFlags(c, args)

--- a/internal/konnect/auth/auth.go
+++ b/internal/konnect/auth/auth.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -456,7 +457,8 @@ func GetAuthenticatedClient(
 		}),
 		logger,
 	)
-	refreshingClient := NewRefreshingHTTPClient(loggingClient, tokenSource)
+	rewriteClient := NewKonnectHostRewriteClient(loggingClient, baseURL)
+	refreshingClient := NewRefreshingHTTPClient(rewriteClient, tokenSource)
 
 	var sdkHTTPClient kk.HTTPClient = refreshingClient
 	if retryConfig != nil && retryConfig.Strategy == httpclient.RetryStrategyBackoff {
@@ -465,4 +467,53 @@ func GetAuthenticatedClient(
 	opts = append(opts, kk.WithClient(sdkHTTPClient))
 
 	return kk.New(opts...), sdkHTTPClient, nil
+}
+
+type KonnectHostRewriteClient struct {
+	wrapped kk.HTTPClient
+	baseURL string
+}
+
+func NewKonnectHostRewriteClient(wrapped kk.HTTPClient, baseURL string) kk.HTTPClient {
+	return &KonnectHostRewriteClient{
+		wrapped: wrapped,
+		baseURL: baseURL,
+	}
+}
+
+func (c *KonnectHostRewriteClient) Do(req *http.Request) (*http.Response, error) {
+	if c == nil || c.wrapped == nil {
+		return nil, fmt.Errorf("http client is not configured")
+	}
+	return c.wrapped.Do(rewriteKonnectHostForBaseURL(req, c.baseURL))
+}
+
+func rewriteKonnectHostForBaseURL(req *http.Request, baseURL string) *http.Request {
+	if req == nil || req.URL == nil || !isKonnectTechBaseURL(baseURL) {
+		return req
+	}
+
+	hostname := req.URL.Hostname()
+	if !strings.HasSuffix(hostname, ".konghq.com") {
+		return req
+	}
+
+	rewritten := req.Clone(req.Context())
+	rewrittenHost := strings.TrimSuffix(hostname, ".konghq.com") + ".konghq.tech"
+	if port := req.URL.Port(); port != "" {
+		rewrittenHost = net.JoinHostPort(rewrittenHost, port)
+	}
+	rewritten.URL.Host = rewrittenHost
+	if rewritten.Host != "" {
+		rewritten.Host = rewrittenHost
+	}
+	return rewritten
+}
+
+func isKonnectTechBaseURL(rawURL string) bool {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	return strings.HasSuffix(parsed.Hostname(), ".konghq.tech")
 }

--- a/internal/konnect/auth/auth_test.go
+++ b/internal/konnect/auth/auth_test.go
@@ -27,6 +27,54 @@ func buildTestJWT(exp int64) string {
 	return strings.Join([]string{header, payloadEnc, "signature"}, ".")
 }
 
+func TestRewriteKonnectHostForBaseURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		reqURL  string
+		wantURL string
+	}{
+		{
+			name:    "tech rewrites konghq com host",
+			baseURL: "https://us.api.konghq.tech",
+			reqURL:  "https://global.api.konghq.com/v3/organizations/me",
+			wantURL: "https://global.api.konghq.tech/v3/organizations/me",
+		},
+		{
+			name:    "tech preserves port",
+			baseURL: "https://us.api.konghq.tech",
+			reqURL:  "https://global.api.konghq.com:8443/v3/organizations/me",
+			wantURL: "https://global.api.konghq.tech:8443/v3/organizations/me",
+		},
+		{
+			name:    "com leaves host unchanged",
+			baseURL: "https://us.api.konghq.com",
+			reqURL:  "https://global.api.konghq.com/v3/organizations/me",
+			wantURL: "https://global.api.konghq.com/v3/organizations/me",
+		},
+		{
+			name:    "tech leaves non kong host unchanged",
+			baseURL: "https://us.api.konghq.tech",
+			reqURL:  "https://example.test/v3/organizations/me",
+			wantURL: "https://example.test/v3/organizations/me",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, tt.reqURL, nil)
+			require.NoError(t, err)
+
+			got := rewriteKonnectHostForBaseURL(req, tt.baseURL)
+			require.Equal(t, tt.wantURL, got.URL.String())
+		})
+	}
+}
+
+func TestRewriteKonnectHostForBaseURLHandlesNilRequest(t *testing.T) {
+	require.Nil(t, rewriteKonnectHostForBaseURL(nil, "https://us.api.konghq.tech"))
+}
+
 type stubConfig struct {
 	profile string
 	path    string

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -39,6 +39,14 @@ KONGCTL_E2E_SHARD_INDEX=1 \
 make test-e2e-scenarios
 ```
 
+Run against the Kong Konnect `.tech` environment:
+
+```bash
+KONGCTL_E2E_KONNECT_ENV=tech \
+KONGCTL_E2E_KONNECT_PAT=$(cat ~/.konnect/your-tech-pat) \
+make test-e2e-scenarios
+```
+
 Include the opt-in user profile smoke scenario:
 
 ```bash
@@ -86,8 +94,19 @@ Core harness settings:
 - `KONGCTL_E2E_BIN`: Path to an existing `kongctl` binary to skip building.
 - `KONGCTL_E2E_RESET`: Reset the Konnect org before tests. Destructive.
   Defaults to enabled; set to `0` or `false` to disable.
-- `KONGCTL_E2E_KONNECT_BASE_URL`: Base URL for Konnect API. Default:
-  `https://us.api.konghq.com`.
+- `KONGCTL_E2E_KONNECT_ENV`: Konnect environment selector. Supported values
+  are `production` (default) and `tech`. The `tech` value selects
+  `https://us.api.konghq.tech`, `https://global.api.konghq.tech`, and the
+  `.tech` machine client ID for generated CLI profile config.
+- `KONGCTL_E2E_KONNECT_BASE_URL`: Optional regional Konnect API override.
+  When unset, the harness uses the selected `KONGCTL_E2E_KONNECT_ENV`
+  default. If this points at `konghq.tech`, the harness also infers the
+  `.tech` global URL and machine client ID unless explicitly overridden.
+- `KONGCTL_E2E_KONNECT_BASE_AUTH_URL`: Optional global/auth Konnect API
+  override. The harness uses this for global Identity APIs, org reset, and
+  generated CLI profile `konnect.base-auth-url`.
+- `KONGCTL_E2E_KONNECT_MACHINE_CLIENT_ID`: Optional machine client ID
+  override for generated CLI profile `konnect.machine-client-id`.
 - `KONGCTL_E2E_HTTP_TIMEOUT`: Per-request timeout for raw Konnect HTTP helpers
   used by scenario create/delete flows. The harness also writes the same
   value into the generated `e2e.http-timeout` profile setting so
@@ -340,7 +359,9 @@ The E2E GitHub Actions workflow scales wall-clock time by running one matrix
 job per Konnect org. Each job gets:
 
 - one environment-scoped PAT
-- the shared Konnect base URL from the repository variable
+- the Konnect environment selector from workflow dispatch or repository
+  variables
+- optional shared Konnect URL overrides from repository variables
 - one shard index
 - the common shard total from the matrix size
 
@@ -351,9 +372,10 @@ The workflow derives sharding directly from GitHub Actions strategy context:
 - `KONGCTL_E2E_MATRIX_ORG=${{ matrix.org_name }}`
 - `KONGCTL_E2E_ORGS_JSON=${{ vars.KONGCTL_E2E_ORGS_JSON }}`
 
-The workflow also exposes the test timeout, HTTP timeout, and retry
-knobs above as repository or organization variables of the same names,
-so CI can tune runtime behavior without changing Go code.
+The workflow also exposes the Konnect target, test timeout, HTTP timeout, and
+retry knobs above as repository or organization variables of the same names,
+so CI can tune runtime behavior without changing Go code. Manual dispatch
+runs can choose `production` or `tech` with the `konnect_environment` input.
 
 For transport debugging, the workflow currently defaults to:
 
@@ -387,7 +409,7 @@ When enabled, each matrix job records a `tcpdump/` directory in the normal E2E
 artifact bundle containing:
 
 - `konnect.pcap`: packet capture filtered to the regional Konnect host and
-  `global.api.konghq.com` on port `443`
+  selected global Konnect host on port `443`
 - `tcpdump.log`: tcpdump startup and shutdown output
 - `context.txt`: runner host, DNS resolution, interfaces, and routes
 
@@ -404,8 +426,13 @@ The org pool is defined as JSON in the repository or organization variable
 Each `org_name` must match a GitHub Actions environment that defines the
 secret `KONGCTL_E2E_KONNECT_PAT`.
 
-Set the shared Konnect API endpoint as the repository or organization variable
-`KONGCTL_E2E_KONNECT_BASE_URL`.
+Set `KONGCTL_E2E_KONNECT_ENV=tech` as a repository or organization variable
+to run the shared matrix against `.tech`. If the `.tech` run needs a different
+org pool, set `KONGCTL_E2E_ORGS_JSON` to environments backed by `.tech` PATs.
+Use `KONGCTL_E2E_KONNECT_BASE_URL`,
+`KONGCTL_E2E_KONNECT_BASE_AUTH_URL`, and
+`KONGCTL_E2E_KONNECT_MACHINE_CLIENT_ID` only when the standard production or
+tech defaults are not sufficient.
 
 If the org-pool variable is unset, the workflow falls back to a single-org
 matrix entry named `default`, which is useful during migration if you still

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -161,7 +161,12 @@ Scenario selection and sharding:
 - `KONGCTL_E2E_MATRIX_ORG`: Optional diagnostic label for the current CI job.
 - `KONGCTL_E2E_ORGS_JSON`: JSON array of matrix org entries. Used in CI to
   validate scenario environment assignments. Each entry must include
-  `org_name`.
+  `org_name`. In GitHub Actions, this is also the default org matrix when an
+  environment-specific org matrix is not configured.
+- `KONGCTL_E2E_PRODUCTION_ORGS_JSON`: Optional GitHub Actions org matrix for
+  production Konnect runs.
+- `KONGCTL_E2E_TECH_ORGS_JSON`: Optional GitHub Actions org matrix for
+  `.tech` Konnect runs.
 
 Authentication and opt-in scenarios:
 
@@ -370,7 +375,7 @@ The workflow derives sharding directly from GitHub Actions strategy context:
 - `KONGCTL_E2E_SHARD_INDEX=${{ strategy.job-index }}`
 - `KONGCTL_E2E_SHARD_TOTAL=${{ strategy.job-total }}`
 - `KONGCTL_E2E_MATRIX_ORG=${{ matrix.org_name }}`
-- `KONGCTL_E2E_ORGS_JSON=${{ vars.KONGCTL_E2E_ORGS_JSON }}`
+- `KONGCTL_E2E_ORGS_JSON` set to the selected org matrix
 
 The workflow also exposes the Konnect target, test timeout, HTTP timeout, and
 retry knobs above as repository or organization variables of the same names,
@@ -413,8 +418,8 @@ artifact bundle containing:
 - `tcpdump.log`: tcpdump startup and shutdown output
 - `context.txt`: runner host, DNS resolution, interfaces, and routes
 
-The org pool is defined as JSON in the repository or organization variable
-`KONGCTL_E2E_ORGS_JSON`. Example:
+The default org pool is defined as JSON in the repository or organization
+variable `KONGCTL_E2E_ORGS_JSON`. Example:
 
 ```json
 [
@@ -427,8 +432,19 @@ Each `org_name` must match a GitHub Actions environment that defines the
 secret `KONGCTL_E2E_KONNECT_PAT`.
 
 Set `KONGCTL_E2E_KONNECT_ENV=tech` as a repository or organization variable
-to run the shared matrix against `.tech`. If the `.tech` run needs a different
-org pool, set `KONGCTL_E2E_ORGS_JSON` to environments backed by `.tech` PATs.
+to run scheduled or PR-triggered E2E against `.tech`. Manual dispatch can
+override this with the `konnect_environment` input.
+
+If production and `.tech` need separate org pools, set
+`KONGCTL_E2E_PRODUCTION_ORGS_JSON` and `KONGCTL_E2E_TECH_ORGS_JSON` to
+environment names backed by matching PATs. The workflow selects an org matrix
+with this fallback order:
+
+1. `KONGCTL_E2E_TECH_ORGS_JSON` for `.tech`, or
+   `KONGCTL_E2E_PRODUCTION_ORGS_JSON` for production.
+2. `KONGCTL_E2E_ORGS_JSON`.
+3. A single `default` matrix entry.
+
 Use `KONGCTL_E2E_KONNECT_BASE_URL`,
 `KONGCTL_E2E_KONNECT_BASE_AUTH_URL`, and
 `KONGCTL_E2E_KONNECT_MACHINE_CLIENT_ID` only when the standard production or

--- a/test/e2e/harness/cli.go
+++ b/test/e2e/harness/cli.go
@@ -101,7 +101,9 @@ func NewCLI() (*CLI, error) {
 		AutoOutput:   getHarnessDefaultOutput(),
 	}
 	// Pre-write a minimal profile config to align artifacts with e2e defaults.
-	_ = writeProfileConfig(cli.ConfigDir, cli.Profile, cli.AutoOutput, cli.AutoLogLevel)
+	if err := writeProfileConfig(cli.ConfigDir, cli.Profile, cli.AutoOutput, cli.AutoLogLevel); err != nil {
+		return nil, err
+	}
 	Infof(
 		"TestConfig: bin=%s configDir=%s profile=%s timeout=%s log-level=%s output=%s",
 		bin,
@@ -159,7 +161,9 @@ func NewCLIForArtifacts(name, group string) (*CLI, error) {
 		AutoOutput:   getHarnessDefaultOutput(),
 	}
 	// Pre-write a minimal profile config to align artifacts with e2e defaults.
-	_ = writeProfileConfig(cli.ConfigDir, cli.Profile, cli.AutoOutput, cli.AutoLogLevel)
+	if err := writeProfileConfig(cli.ConfigDir, cli.Profile, cli.AutoOutput, cli.AutoLogLevel); err != nil {
+		return nil, err
+	}
 	Infof(
 		"TestConfig: test=%s dir=%s bin=%s configDir=%s log-level=%s output=%s",
 		name,
@@ -755,6 +759,10 @@ func writeProfileConfig(cfgDir, profile, output, logLevel string) error {
 		return err
 	}
 	options := HTTPTransportOptionsFromEnv()
+	konnectTarget, err := ResolveKonnectTargetFromEnv()
+	if err != nil {
+		return err
+	}
 
 	var y strings.Builder
 	fmt.Fprintf(&y, "%s:\n", profile)
@@ -768,6 +776,10 @@ func writeProfileConfig(cfgDir, profile, output, logLevel string) error {
 	}
 	fmt.Fprintf(&y, "  http-disable-keepalives: %t\n", options.DisableKeepAlives)
 	fmt.Fprintf(&y, "  http-recycle-connections-on-error: %t\n", options.RecycleConnectionsOnError)
+	fmt.Fprintf(&y, "  konnect:\n")
+	fmt.Fprintf(&y, "    base-url: %s\n", konnectTarget.BaseURL)
+	fmt.Fprintf(&y, "    base-auth-url: %s\n", konnectTarget.BaseAuthURL)
+	fmt.Fprintf(&y, "    machine-client-id: %s\n", konnectTarget.MachineClientID)
 
 	path := filepath.Join(appDir, "config.yaml")
 	// Best-effort write; if file exists, do not overwrite.

--- a/test/e2e/harness/cli_test.go
+++ b/test/e2e/harness/cli_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestWriteProfileConfigIncludesHTTPSettings(t *testing.T) {
+	clearKonnectTargetEnv(t)
 	t.Setenv("KONGCTL_E2E_HTTP_TIMEOUT", "13s")
 	t.Setenv("KONGCTL_E2E_HTTP_TCP_USER_TIMEOUT", "45s")
 	t.Setenv("KONGCTL_E2E_HTTP_DISABLE_KEEPALIVES", "true")
@@ -53,6 +54,7 @@ func TestWriteProfileConfigIncludesHTTPSettings(t *testing.T) {
 }
 
 func TestWriteProfileConfigOmitsDisabledHTTPTimeouts(t *testing.T) {
+	clearKonnectTargetEnv(t)
 	t.Setenv("KONGCTL_E2E_HTTP_TIMEOUT", "0s")
 	t.Setenv("KONGCTL_E2E_HTTP_TCP_USER_TIMEOUT", "default")
 
@@ -76,6 +78,7 @@ func TestWriteProfileConfigOmitsDisabledHTTPTimeouts(t *testing.T) {
 }
 
 func TestWriteProfileConfigIncludesTechKonnectSettings(t *testing.T) {
+	clearKonnectTargetEnv(t)
 	t.Setenv(KonnectEnvironmentEnvName, konnectcommon.EnvironmentTech)
 
 	cfgDir := t.TempDir()

--- a/test/e2e/harness/cli_test.go
+++ b/test/e2e/harness/cli_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	konnectcommon "github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
 )
 
 func TestWriteProfileConfigIncludesHTTPSettings(t *testing.T) {
@@ -38,6 +40,16 @@ func TestWriteProfileConfigIncludesHTTPSettings(t *testing.T) {
 	if !strings.Contains(content, "http-recycle-connections-on-error: true") {
 		t.Fatalf("config missing http-recycle-connections-on-error: %s", content)
 	}
+	for _, want := range []string{
+		"konnect:",
+		"base-url: " + konnectcommon.BaseURLDefault,
+		"base-auth-url: " + konnectcommon.AuthBaseURLDefault,
+		"machine-client-id: " + konnectcommon.MachineClientIDDefault,
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("config missing %q: %s", want, content)
+		}
+	}
 }
 
 func TestWriteProfileConfigOmitsDisabledHTTPTimeouts(t *testing.T) {
@@ -60,6 +72,31 @@ func TestWriteProfileConfigOmitsDisabledHTTPTimeouts(t *testing.T) {
 	}
 	if strings.Contains(content, "http-tcp-user-timeout:") {
 		t.Fatalf("config unexpectedly contains http-tcp-user-timeout: %s", content)
+	}
+}
+
+func TestWriteProfileConfigIncludesTechKonnectSettings(t *testing.T) {
+	t.Setenv(KonnectEnvironmentEnvName, konnectcommon.EnvironmentTech)
+
+	cfgDir := t.TempDir()
+	if err := writeProfileConfig(cfgDir, "e2e", "json", "debug"); err != nil {
+		t.Fatalf("writeProfileConfig() error = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(cfgDir, "kongctl", "config.yaml"))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	content := string(data)
+	for _, want := range []string{
+		"base-url: " + konnectcommon.TechBaseURLDefault,
+		"base-auth-url: " + konnectcommon.TechGlobalBaseURL,
+		"machine-client-id: " + konnectcommon.TechMachineClientID,
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("config missing %q: %s", want, content)
+		}
 	}
 }
 

--- a/test/e2e/harness/konnect_env.go
+++ b/test/e2e/harness/konnect_env.go
@@ -1,0 +1,100 @@
+//go:build e2e
+
+package harness
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	konnectcommon "github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
+)
+
+const (
+	KonnectEnvironmentEnvName     = "KONGCTL_E2E_KONNECT_ENV"
+	KonnectBaseURLEnvName         = "KONGCTL_E2E_KONNECT_BASE_URL"
+	KonnectBaseAuthURLEnvName     = "KONGCTL_E2E_KONNECT_BASE_AUTH_URL"
+	KonnectMachineClientIDEnvName = "KONGCTL_E2E_KONNECT_MACHINE_CLIENT_ID"
+)
+
+type KonnectTarget struct {
+	Name            string
+	BaseURL         string
+	BaseAuthURL     string
+	MachineClientID string
+}
+
+func ResolveKonnectTargetFromEnv() (KonnectTarget, error) {
+	defaults, err := konnectcommon.EnvironmentDefaultsFor(os.Getenv(KonnectEnvironmentEnvName))
+	if err != nil {
+		return KonnectTarget{}, err
+	}
+
+	target := KonnectTarget{
+		Name:            defaults.Name,
+		BaseURL:         defaults.BaseURL,
+		BaseAuthURL:     defaults.AuthBaseURL,
+		MachineClientID: defaults.MachineClientID,
+	}
+
+	baseURL := strings.TrimSpace(os.Getenv(KonnectBaseURLEnvName))
+	baseAuthURL := strings.TrimSpace(os.Getenv(KonnectBaseAuthURLEnvName))
+	machineClientID := strings.TrimSpace(os.Getenv(KonnectMachineClientIDEnvName))
+
+	if baseURL != "" {
+		target.BaseURL = baseURL
+		if inferred, ok := konnectcommon.InferEnvironmentDefaultsFromURL(baseURL); ok {
+			target.Name = inferred.Name
+			if baseAuthURL == "" {
+				target.BaseAuthURL = inferred.AuthBaseURL
+			}
+			if machineClientID == "" {
+				target.MachineClientID = inferred.MachineClientID
+			}
+		}
+	}
+	if baseAuthURL != "" {
+		target.BaseAuthURL = baseAuthURL
+		if inferred, ok := konnectcommon.InferEnvironmentDefaultsFromURL(baseAuthURL); ok && machineClientID == "" {
+			target.Name = inferred.Name
+			target.MachineClientID = inferred.MachineClientID
+		}
+	}
+	if machineClientID != "" {
+		target.MachineClientID = machineClientID
+	}
+
+	return target, nil
+}
+
+func KonnectBaseURL() (string, error) {
+	target, err := ResolveKonnectTargetFromEnv()
+	if err != nil {
+		return "", err
+	}
+	return target.BaseURL, nil
+}
+
+func KonnectBaseAuthURL() (string, error) {
+	target, err := ResolveKonnectTargetFromEnv()
+	if err != nil {
+		return "", err
+	}
+	return target.BaseAuthURL, nil
+}
+
+func KonnectBaseURLFromRegion(region string) (string, error) {
+	r := strings.TrimSpace(region)
+	if r == "" {
+		return "", fmt.Errorf("konnect region cannot be empty")
+	}
+	if strings.HasPrefix(r, "http://") || strings.HasPrefix(r, "https://") {
+		return r, nil
+	}
+
+	target, err := ResolveKonnectTargetFromEnv()
+	if err != nil {
+		return "", err
+	}
+	return konnectcommon.BuildBaseURLFromRegionForEnvironment(r, target.Name)
+}

--- a/test/e2e/harness/konnect_env_test.go
+++ b/test/e2e/harness/konnect_env_test.go
@@ -1,0 +1,116 @@
+//go:build e2e
+
+package harness
+
+import (
+	"testing"
+
+	konnectcommon "github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
+)
+
+func TestResolveKonnectTargetFromEnvDefaultsToProduction(t *testing.T) {
+	target, err := ResolveKonnectTargetFromEnv()
+	if err != nil {
+		t.Fatalf("ResolveKonnectTargetFromEnv() error = %v", err)
+	}
+
+	if target.BaseURL != konnectcommon.BaseURLDefault {
+		t.Fatalf("BaseURL = %q, want %q", target.BaseURL, konnectcommon.BaseURLDefault)
+	}
+	if target.BaseAuthURL != konnectcommon.AuthBaseURLDefault {
+		t.Fatalf("BaseAuthURL = %q, want %q", target.BaseAuthURL, konnectcommon.AuthBaseURLDefault)
+	}
+	if target.MachineClientID != konnectcommon.MachineClientIDDefault {
+		t.Fatalf("MachineClientID = %q, want %q", target.MachineClientID, konnectcommon.MachineClientIDDefault)
+	}
+}
+
+func TestResolveKonnectTargetFromEnvSupportsTech(t *testing.T) {
+	t.Setenv(KonnectEnvironmentEnvName, konnectcommon.EnvironmentTech)
+
+	target, err := ResolveKonnectTargetFromEnv()
+	if err != nil {
+		t.Fatalf("ResolveKonnectTargetFromEnv() error = %v", err)
+	}
+
+	if target.BaseURL != konnectcommon.TechBaseURLDefault {
+		t.Fatalf("BaseURL = %q, want %q", target.BaseURL, konnectcommon.TechBaseURLDefault)
+	}
+	if target.BaseAuthURL != konnectcommon.TechGlobalBaseURL {
+		t.Fatalf("BaseAuthURL = %q, want %q", target.BaseAuthURL, konnectcommon.TechGlobalBaseURL)
+	}
+	if target.MachineClientID != konnectcommon.TechMachineClientID {
+		t.Fatalf("MachineClientID = %q, want %q", target.MachineClientID, konnectcommon.TechMachineClientID)
+	}
+}
+
+func TestResolveKonnectTargetFromEnvInfersTechFromBaseURL(t *testing.T) {
+	t.Setenv(KonnectBaseURLEnvName, "https://eu.api.konghq.tech")
+
+	target, err := ResolveKonnectTargetFromEnv()
+	if err != nil {
+		t.Fatalf("ResolveKonnectTargetFromEnv() error = %v", err)
+	}
+
+	if target.BaseURL != "https://eu.api.konghq.tech" {
+		t.Fatalf("BaseURL = %q, want explicit override", target.BaseURL)
+	}
+	if target.BaseAuthURL != konnectcommon.TechGlobalBaseURL {
+		t.Fatalf("BaseAuthURL = %q, want %q", target.BaseAuthURL, konnectcommon.TechGlobalBaseURL)
+	}
+	if target.MachineClientID != konnectcommon.TechMachineClientID {
+		t.Fatalf("MachineClientID = %q, want %q", target.MachineClientID, konnectcommon.TechMachineClientID)
+	}
+}
+
+func TestResolveKonnectTargetFromEnvInfersMachineClientWithExplicitAuthURL(t *testing.T) {
+	t.Setenv(KonnectBaseURLEnvName, "https://eu.api.konghq.tech")
+	t.Setenv(KonnectBaseAuthURLEnvName, "https://global.example.test")
+
+	target, err := ResolveKonnectTargetFromEnv()
+	if err != nil {
+		t.Fatalf("ResolveKonnectTargetFromEnv() error = %v", err)
+	}
+
+	if target.BaseAuthURL != "https://global.example.test" {
+		t.Fatalf("BaseAuthURL = %q, want explicit override", target.BaseAuthURL)
+	}
+	if target.MachineClientID != konnectcommon.TechMachineClientID {
+		t.Fatalf("MachineClientID = %q, want %q", target.MachineClientID, konnectcommon.TechMachineClientID)
+	}
+}
+
+func TestResolveKonnectTargetFromEnvAllowsExplicitOverrides(t *testing.T) {
+	t.Setenv(KonnectEnvironmentEnvName, konnectcommon.EnvironmentTech)
+	t.Setenv(KonnectBaseURLEnvName, "https://regional.example.test")
+	t.Setenv(KonnectBaseAuthURLEnvName, "https://global.example.test")
+	t.Setenv(KonnectMachineClientIDEnvName, "client-id")
+
+	target, err := ResolveKonnectTargetFromEnv()
+	if err != nil {
+		t.Fatalf("ResolveKonnectTargetFromEnv() error = %v", err)
+	}
+
+	if target.BaseURL != "https://regional.example.test" {
+		t.Fatalf("BaseURL = %q, want explicit override", target.BaseURL)
+	}
+	if target.BaseAuthURL != "https://global.example.test" {
+		t.Fatalf("BaseAuthURL = %q, want explicit override", target.BaseAuthURL)
+	}
+	if target.MachineClientID != "client-id" {
+		t.Fatalf("MachineClientID = %q, want explicit override", target.MachineClientID)
+	}
+}
+
+func TestKonnectBaseURLFromRegionUsesSelectedEnvironment(t *testing.T) {
+	t.Setenv(KonnectEnvironmentEnvName, konnectcommon.EnvironmentTech)
+
+	got, err := KonnectBaseURLFromRegion("global")
+	if err != nil {
+		t.Fatalf("KonnectBaseURLFromRegion() error = %v", err)
+	}
+
+	if got != konnectcommon.TechGlobalBaseURL {
+		t.Fatalf("KonnectBaseURLFromRegion() = %q, want %q", got, konnectcommon.TechGlobalBaseURL)
+	}
+}

--- a/test/e2e/harness/konnect_env_test.go
+++ b/test/e2e/harness/konnect_env_test.go
@@ -8,7 +8,21 @@ import (
 	konnectcommon "github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
 )
 
+func clearKonnectTargetEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		KonnectEnvironmentEnvName,
+		KonnectBaseURLEnvName,
+		KonnectBaseAuthURLEnvName,
+		KonnectMachineClientIDEnvName,
+	} {
+		t.Setenv(name, "")
+	}
+}
+
 func TestResolveKonnectTargetFromEnvDefaultsToProduction(t *testing.T) {
+	clearKonnectTargetEnv(t)
+
 	target, err := ResolveKonnectTargetFromEnv()
 	if err != nil {
 		t.Fatalf("ResolveKonnectTargetFromEnv() error = %v", err)
@@ -26,6 +40,7 @@ func TestResolveKonnectTargetFromEnvDefaultsToProduction(t *testing.T) {
 }
 
 func TestResolveKonnectTargetFromEnvSupportsTech(t *testing.T) {
+	clearKonnectTargetEnv(t)
 	t.Setenv(KonnectEnvironmentEnvName, konnectcommon.EnvironmentTech)
 
 	target, err := ResolveKonnectTargetFromEnv()
@@ -45,6 +60,7 @@ func TestResolveKonnectTargetFromEnvSupportsTech(t *testing.T) {
 }
 
 func TestResolveKonnectTargetFromEnvInfersTechFromBaseURL(t *testing.T) {
+	clearKonnectTargetEnv(t)
 	t.Setenv(KonnectBaseURLEnvName, "https://eu.api.konghq.tech")
 
 	target, err := ResolveKonnectTargetFromEnv()
@@ -64,6 +80,7 @@ func TestResolveKonnectTargetFromEnvInfersTechFromBaseURL(t *testing.T) {
 }
 
 func TestResolveKonnectTargetFromEnvInfersMachineClientWithExplicitAuthURL(t *testing.T) {
+	clearKonnectTargetEnv(t)
 	t.Setenv(KonnectBaseURLEnvName, "https://eu.api.konghq.tech")
 	t.Setenv(KonnectBaseAuthURLEnvName, "https://global.example.test")
 
@@ -81,6 +98,7 @@ func TestResolveKonnectTargetFromEnvInfersMachineClientWithExplicitAuthURL(t *te
 }
 
 func TestResolveKonnectTargetFromEnvAllowsExplicitOverrides(t *testing.T) {
+	clearKonnectTargetEnv(t)
 	t.Setenv(KonnectEnvironmentEnvName, konnectcommon.EnvironmentTech)
 	t.Setenv(KonnectBaseURLEnvName, "https://regional.example.test")
 	t.Setenv(KonnectBaseAuthURLEnvName, "https://global.example.test")
@@ -103,6 +121,7 @@ func TestResolveKonnectTargetFromEnvAllowsExplicitOverrides(t *testing.T) {
 }
 
 func TestKonnectBaseURLFromRegionUsesSelectedEnvironment(t *testing.T) {
+	clearKonnectTargetEnv(t)
 	t.Setenv(KonnectEnvironmentEnvName, konnectcommon.EnvironmentTech)
 
 	got, err := KonnectBaseURLFromRegion("global")

--- a/test/e2e/harness/portalclient/cmd/devworkflow/main.go
+++ b/test/e2e/harness/portalclient/cmd/devworkflow/main.go
@@ -14,6 +14,7 @@ import (
 	kkcomponents "github.com/Kong/sdk-konnect-go/models/components"
 	kkoperations "github.com/Kong/sdk-konnect-go/models/operations"
 	"github.com/google/uuid"
+	konnectcommon "github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
 	"github.com/kong/kongctl/test/e2e/harness/portalclient"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
@@ -301,12 +302,9 @@ func approveDeveloper(ctx context.Context, portalID, email, baseURLFlag string) 
 		return fmt.Errorf("KONGCTL_E2E_KONNECT_PAT is required when --portal-id is provided")
 	}
 
-	baseURL := strings.TrimSpace(baseURLFlag)
-	if baseURL == "" {
-		baseURL = strings.TrimSpace(os.Getenv("KONGCTL_E2E_KONNECT_BASE_URL"))
-	}
-	if baseURL == "" {
-		baseURL = "https://us.api.konghq.com"
+	baseURL, err := resolveKonnectBaseURL(baseURLFlag)
+	if err != nil {
+		return err
 	}
 
 	log.Printf("approving developer via Konnect API (portal=%s)", portalID)
@@ -397,6 +395,21 @@ func approveDeveloper(ctx context.Context, portalID, email, baseURLFlag string) 
 	time.Sleep(5 * time.Second)
 
 	return nil
+}
+
+func resolveKonnectBaseURL(baseURLFlag string) (string, error) {
+	if baseURL := strings.TrimSpace(baseURLFlag); baseURL != "" {
+		return baseURL, nil
+	}
+	if baseURL := strings.TrimSpace(os.Getenv("KONGCTL_E2E_KONNECT_BASE_URL")); baseURL != "" {
+		return baseURL, nil
+	}
+
+	defaults, err := konnectcommon.EnvironmentDefaultsFor(os.Getenv("KONGCTL_E2E_KONNECT_ENV"))
+	if err != nil {
+		return "", err
+	}
+	return defaults.BaseURL, nil
 }
 
 func retryCreateApplication(

--- a/test/e2e/harness/reset.go
+++ b/test/e2e/harness/reset.go
@@ -54,9 +54,9 @@ func resetOrg(stage string, capture bool) error {
 			return nil
 		}
 	}
-	baseURL := os.Getenv("KONGCTL_E2E_KONNECT_BASE_URL")
-	if baseURL == "" {
-		baseURL = "https://us.api.konghq.com"
+	baseURL, err := KonnectBaseURL()
+	if err != nil {
+		return err
 	}
 	token := os.Getenv("KONGCTL_E2E_KONNECT_PAT")
 	if token == "" {
@@ -347,7 +347,7 @@ func (s *resetHTTPSession) Close() {
 type resetResourceSpec struct {
 	Version  string
 	Endpoint string
-	// Use global.api.konghq.com instead of regional URL
+	// Use the global Konnect URL instead of the regional URL.
 	UseGlobal bool
 	// Optional delete override for resources whose list and delete APIs differ.
 	DeleteVersion     string
@@ -428,6 +428,10 @@ func tryDeletePortalCustomDomain(
 
 func executeReset(baseURL, token string, policy HTTPRetryPolicy) (resetResult, error) {
 	transportOptions := HTTPTransportOptionsFromEnv()
+	globalBaseURL, envErr := KonnectBaseAuthURL()
+	if envErr != nil {
+		return resetResult{}, envErr
+	}
 	ctx := context.Background()
 	cancel := func() {}
 	if policy.TotalTimeout > 0 {
@@ -438,7 +442,7 @@ func executeReset(baseURL, token string, policy HTTPRetryPolicy) (resetResult, e
 	var result resetResult
 	var firstErr error
 
-	tot, del, err := resetConfiguredE2EUserAssignments(ctx, token, policy, transportOptions)
+	tot, del, err := resetConfiguredE2EUserAssignments(ctx, globalBaseURL, token, policy, transportOptions)
 	if err != nil && firstErr == nil {
 		firstErr = err
 	}
@@ -464,7 +468,7 @@ func executeReset(baseURL, token string, policy HTTPRetryPolicy) (resetResult, e
 		}
 		targetURL := baseURL
 		if step.UseGlobal {
-			targetURL = "https://global.api.konghq.com"
+			targetURL = globalBaseURL
 		}
 		deleteTargetURL := targetURL
 		if step.DeleteUseRegional {
@@ -506,6 +510,7 @@ type resetUser struct {
 
 func resetConfiguredE2EUserAssignments(
 	ctx context.Context,
+	globalBaseURL string,
 	token string,
 	policy HTTPRetryPolicy,
 	transportOptions HTTPTransportOptions,
@@ -519,7 +524,7 @@ func resetConfiguredE2EUserAssignments(
 	session := newResetHTTPSession(policy.RequestTimeout, transportOptions)
 	defer session.Close()
 
-	usersByEmail, err := listUsersByEmail(ctx, session, token, policy)
+	usersByEmail, err := listUsersByEmail(ctx, session, globalBaseURL, token, policy)
 	if err != nil {
 		return len(emails), 0, err
 	}
@@ -532,7 +537,7 @@ func resetConfiguredE2EUserAssignments(
 			Warnf("reset: configured E2E user was not found; skipping assignment reset")
 			continue
 		}
-		userTotal, userDeleted, err := resetUserAssignments(ctx, session, token, policy, user)
+		userTotal, userDeleted, err := resetUserAssignments(ctx, session, globalBaseURL, token, policy, user)
 		total += userTotal
 		deleted += userDeleted
 		if err != nil {
@@ -566,6 +571,7 @@ func configuredE2EUserEmails() []string {
 func listUsersByEmail(
 	ctx context.Context,
 	session *resetHTTPSession,
+	globalBaseURL string,
 	token string,
 	policy HTTPRetryPolicy,
 ) (map[string]resetUser, error) {
@@ -575,7 +581,7 @@ func listUsersByEmail(
 		items, err := retryListItems(
 			ctx,
 			session,
-			pagedURL("https://global.api.konghq.com/v3/users", pageSize, pageNumber),
+			pagedURL(strings.TrimRight(globalBaseURL, "/")+"/v3/users", pageSize, pageNumber),
 			token,
 			"users",
 			policy,
@@ -601,6 +607,7 @@ func listUsersByEmail(
 func resetUserAssignments(
 	ctx context.Context,
 	session *resetHTTPSession,
+	globalBaseURL string,
 	token string,
 	policy HTTPRetryPolicy,
 	user resetUser,
@@ -611,7 +618,7 @@ func resetUserAssignments(
 	teamItems, err := retryListItems(
 		ctx,
 		session,
-		pagedURL(fmt.Sprintf("https://global.api.konghq.com/v3/users/%s/teams", url.PathEscape(user.ID)), 100, 1),
+		pagedURL(fmt.Sprintf("%s/v3/users/%s/teams", strings.TrimRight(globalBaseURL, "/"), url.PathEscape(user.ID)), 100, 1),
 		token,
 		"user teams",
 		policy,
@@ -625,7 +632,7 @@ func resetUserAssignments(
 		if teamID == "" {
 			continue
 		}
-		deleteURL := fmt.Sprintf("https://global.api.konghq.com/v3/teams/%s/users", url.PathEscape(teamID))
+		deleteURL := fmt.Sprintf("%s/v3/teams/%s/users", strings.TrimRight(globalBaseURL, "/"), url.PathEscape(teamID))
 		if err := retryDeleteOne(ctx, session, deleteURL, token, "user team assignment", user.ID, policy); err != nil {
 			if he, ok := err.(*httpError); ok && he.status == http.StatusNotFound {
 				continue
@@ -638,7 +645,7 @@ func resetUserAssignments(
 	roleItems, err := retryListItems(
 		ctx,
 		session,
-		fmt.Sprintf("https://global.api.konghq.com/v3/users/%s/assigned-roles", url.PathEscape(user.ID)),
+		fmt.Sprintf("%s/v3/users/%s/assigned-roles", strings.TrimRight(globalBaseURL, "/"), url.PathEscape(user.ID)),
 		token,
 		"user roles",
 		policy,
@@ -652,7 +659,7 @@ func resetUserAssignments(
 		if roleID == "" {
 			continue
 		}
-		deleteURL := fmt.Sprintf("https://global.api.konghq.com/v3/users/%s/assigned-roles", url.PathEscape(user.ID))
+		deleteURL := fmt.Sprintf("%s/v3/users/%s/assigned-roles", strings.TrimRight(globalBaseURL, "/"), url.PathEscape(user.ID))
 		if err := retryDeleteOne(ctx, session, deleteURL, token, "user role assignment", roleID, policy); err != nil {
 			if he, ok := err.(*httpError); ok && he.status == http.StatusNotFound {
 				continue

--- a/test/e2e/harness/step.go
+++ b/test/e2e/harness/step.go
@@ -554,12 +554,15 @@ func (s *Step) requestResource(
 	if err != nil {
 		return result, err
 	}
-	baseURL := os.Getenv("KONGCTL_E2E_KONNECT_BASE_URL")
-	if baseURL == "" {
-		baseURL = "https://us.api.konghq.com"
+	baseURL, err := KonnectBaseURL()
+	if err != nil {
+		return result, err
 	}
 	if endpoint.UseGlobal {
-		baseURL = "https://global.api.konghq.com"
+		baseURL, err = KonnectBaseAuthURL()
+		if err != nil {
+			return result, err
+		}
 	}
 	fullURL := strings.TrimRight(baseURL, "/") + path
 	token := os.Getenv("KONGCTL_E2E_KONNECT_PAT")
@@ -696,9 +699,9 @@ func (s *Step) GetKonnectJSON(name string, path string, out any, selector any) e
 		return err
 	}
 
-	baseURL := os.Getenv("KONGCTL_E2E_KONNECT_BASE_URL")
-	if baseURL == "" {
-		baseURL = "https://us.api.konghq.com"
+	baseURL, err := KonnectBaseURL()
+	if err != nil {
+		return err
 	}
 	fullURL := strings.TrimRight(baseURL, "/") + path
 	token := os.Getenv("KONGCTL_E2E_KONNECT_PAT")
@@ -1134,9 +1137,9 @@ func (s *Step) ResetOrgForRegions(stage string, regions []string) error {
 
 func resolveResetBaseURLs(regions []string) ([]string, error) {
 	if len(regions) == 0 {
-		baseURL := os.Getenv("KONGCTL_E2E_KONNECT_BASE_URL")
-		if baseURL == "" {
-			baseURL = "https://us.api.konghq.com"
+		baseURL, err := KonnectBaseURL()
+		if err != nil {
+			return nil, err
 		}
 		return []string{baseURL}, nil
 	}
@@ -1148,9 +1151,9 @@ func resolveResetBaseURLs(regions []string) ([]string, error) {
 		if r == "" {
 			continue
 		}
-		baseURL := r
-		if !strings.HasPrefix(r, "http://") && !strings.HasPrefix(r, "https://") {
-			baseURL = fmt.Sprintf("https://%s.api.konghq.com", r)
+		baseURL, err := KonnectBaseURLFromRegion(r)
+		if err != nil {
+			return nil, err
 		}
 		if _, ok := seen[baseURL]; ok {
 			continue

--- a/test/e2e/tools/reset/main.go
+++ b/test/e2e/tools/reset/main.go
@@ -14,7 +14,8 @@ import (
 //
 //	go run -tags e2e ./test/e2e/tools/reset
 //
-// Respects KONGCTL_E2E_{KONNECT_PAT,KONNECT_BASE_URL,RESET,ARTIFACTS_DIR} like the harness.
+// Respects KONGCTL_E2E_{KONNECT_PAT,KONNECT_ENV,KONNECT_BASE_URL,RESET,ARTIFACTS_DIR}
+// like the harness.
 func main() {
 	stage := flag.String("stage", "manual-reset", "label used in log output")
 	flag.Parse()


### PR DESCRIPTION
## Summary

Add a shared Konnect environment selector so kongctl and the e2e harness can target either production `.com` or Kong's `.tech` Konnect environment.

- replace the hidden `--kong-tech` switch with hidden `--konnect-env {com,tech}` plus pre-profile `KONGCTL_KONNECT_ENV`
- keep profile selection unchanged; the environment selector only changes `konnect.base-url`, `konnect.base-auth-url`, and `konnect.machine-client-id` defaults at runtime
- apply environment defaults before SDK/auth setup, including `login` and direct `get org` flows
- rewrite generated SDK `.com` operation hosts to `.tech` when the selected Konnect base URL targets `.tech`
- teach e2e profile generation, raw Konnect steps, org reset, portal dev workflow helpers, and tcpdump filtering to use the selected Konnect target
- add GitHub Actions workflow dispatch/repository variable controls for production vs tech e2e runs
- document local and CI `.tech` e2e usage

## Validation

- `GOFLAGS=-mod=mod make test`
- `GOFLAGS=-mod=mod make build`
- `git diff --check`
- local smoke check with an invalid PAT confirmed `--konnect-env tech` routes SDK traffic to `global.api.konghq.tech`

Focused tests and builds used `GOFLAGS=-mod=mod` because the current vendor tree is inconsistent with `go.mod`. Live e2e runs against `.com` or `.tech` were not run; they require real PATs and configured org environments.