### PR TITLE
fix(konnect): make environment selector profile-scoped

### DIFF
--- a/internal/cmd/root/products/konnect/common/common.go
+++ b/internal/cmd/root/products/konnect/common/common.go
@@ -195,7 +195,8 @@ func environmentDefaultsForSelector(value string) (EnvironmentDefaults, error) {
 		return EnvironmentDefaultsFor(normalized)
 	default:
 		return EnvironmentDefaults{},
-			fmt.Errorf("unsupported konnect environment %q", value)
+			fmt.Errorf("unsupported konnect environment %q (allowed: %s, %s; aliases: %s, prod)",
+				value, EnvironmentProduction, EnvironmentTech, EnvironmentCom)
 	}
 }
 

--- a/internal/cmd/root/products/konnect/common/common.go
+++ b/internal/cmd/root/products/konnect/common/common.go
@@ -55,7 +55,6 @@ const (
 	TechBaseURLDefault      = "https://us.api.konghq.tech"
 	TechMachineClientID     = "35b065db-8eaf-4584-9cb6-05b1daea0750"
 	KonnectEnvFlagName      = "konnect-env"
-	KonnectEnvEnvName       = "KONGCTL_KONNECT_ENV"
 	konnectProductionDomain = "konghq.com"
 	konnectTechDomain       = "konghq.tech"
 
@@ -78,7 +77,8 @@ var (
 	MachineClientIDConfigPath = "konnect." + MachineClientIDFlagName
 	RequestPageSizeConfigPath = "konnect." + RequestPageSizeFlagName
 
-	RegionConfigPath = "konnect." + RegionFlagName
+	RegionConfigPath      = "konnect." + RegionFlagName
+	EnvironmentConfigPath = "konnect.environment"
 
 	HTTPRetryMaxAttemptsConfigPath        = "konnect." + cmdcommon.HTTPRetryMaxAttemptsConfigPath
 	HTTPRetryInitialIntervalConfigPath    = "konnect." + cmdcommon.HTTPRetryInitialIntervalConfigPath
@@ -130,12 +130,12 @@ func ApplyEnvironmentDefaults(command *cobra.Command, cfg config.Hook) error {
 		return nil
 	}
 
-	defaults, selected, err := SelectedEnvironmentDefaults(command)
+	defaults, selected, err := SelectedEnvironmentDefaults(command, cfg)
 	if err != nil || !selected {
 		return err
 	}
 
-	if !cmdcommon.CommandTreeFlagChanged(command, BaseURLFlagName) {
+	if shouldApplyEnvironmentEndpointDefault(command, cfg, BaseURLFlagName, BaseURLConfigPath) {
 		baseURL := defaults.BaseURL
 		if region, ok := cmdcommon.CommandTreeChangedFlagString(command, RegionFlagName); ok {
 			resolved, err := BuildBaseURLFromRegionForEnvironment(region, defaults.Name)
@@ -155,13 +155,13 @@ func ApplyEnvironmentDefaults(command *cobra.Command, cfg config.Hook) error {
 			return err
 		}
 	}
-	if !cmdcommon.CommandTreeFlagChanged(command, AuthBaseURLFlagName) {
+	if shouldApplyEnvironmentEndpointDefault(command, cfg, AuthBaseURLFlagName, AuthBaseURLConfigPath) {
 		cfg.SetString(AuthBaseURLConfigPath, defaults.AuthBaseURL)
 		if err := cmdcommon.SetCommandTreeFlagValue(command, AuthBaseURLFlagName, defaults.AuthBaseURL); err != nil {
 			return err
 		}
 	}
-	if !cmdcommon.CommandTreeFlagChanged(command, MachineClientIDFlagName) {
+	if shouldApplyEnvironmentEndpointDefault(command, cfg, MachineClientIDFlagName, MachineClientIDConfigPath) {
 		cfg.SetString(MachineClientIDConfigPath, defaults.MachineClientID)
 		if err := cmdcommon.SetCommandTreeFlagValue(command, MachineClientIDFlagName, defaults.MachineClientID); err != nil {
 			return err
@@ -170,60 +170,76 @@ func ApplyEnvironmentDefaults(command *cobra.Command, cfg config.Hook) error {
 	return nil
 }
 
-func SelectedEnvironmentDefaults(command *cobra.Command) (EnvironmentDefaults, bool, error) {
+func SelectedEnvironmentDefaults(command *cobra.Command, cfg config.Hook) (EnvironmentDefaults, bool, error) {
 	if value, ok := cmdcommon.CommandTreeChangedFlagString(command, KonnectEnvFlagName); ok {
 		defaults, err := environmentDefaultsForSelector(value)
 		return defaults, true, err
 	}
 
-	if value, ok := selectedEnvironmentFromArgs(os.Args[1:]); ok {
-		defaults, err := environmentDefaultsForSelector(value)
-		return defaults, true, err
-	}
-
-	value, ok := os.LookupEnv(KonnectEnvEnvName)
-	if !ok || strings.TrimSpace(value) == "" {
+	if cfg == nil {
 		return EnvironmentDefaults{}, false, nil
 	}
 
+	value := cfg.GetString(EnvironmentConfigPath)
+	if strings.TrimSpace(value) == "" {
+		return EnvironmentDefaults{}, false, nil
+	}
 	defaults, err := environmentDefaultsForSelector(value)
 	return defaults, true, err
-}
-
-func selectedEnvironmentFromArgs(args []string) (string, bool) {
-	value := ""
-	selected := false
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		if arg == "--" {
-			break
-		}
-		if arg == "--"+KonnectEnvFlagName {
-			selected = true
-			value = ""
-			if i+1 < len(args) {
-				value = args[i+1]
-				i++
-			}
-			continue
-		}
-		if stripped, ok := strings.CutPrefix(arg, "--"+KonnectEnvFlagName+"="); ok {
-			selected = true
-			value = stripped
-		}
-	}
-	return value, selected
 }
 
 func environmentDefaultsForSelector(value string) (EnvironmentDefaults, error) {
 	normalized := strings.ToLower(strings.TrimSpace(value))
 	switch normalized {
-	case EnvironmentCom, EnvironmentTech:
+	case EnvironmentCom, EnvironmentProduction, "prod", EnvironmentTech:
 		return EnvironmentDefaultsFor(normalized)
 	default:
 		return EnvironmentDefaults{},
-			fmt.Errorf("unsupported konnect environment %q (allowed: %s, %s)",
-				value, EnvironmentCom, EnvironmentTech)
+			fmt.Errorf("unsupported konnect environment %q", value)
+	}
+}
+
+func shouldApplyEnvironmentEndpointDefault(command *cobra.Command, cfg config.Hook, flagName, configPath string) bool {
+	if cmdcommon.CommandTreeFlagChanged(command, flagName) {
+		return false
+	}
+	value := strings.TrimSpace(cfg.GetString(configPath))
+	if value == "" {
+		return true
+	}
+	return !isExplicitEndpointConfig(cfg, configPath, value)
+}
+
+func isExplicitEndpointConfig(cfg config.Hook, configPath, value string) bool {
+	if cfg.InConfig(configPath) || profileConfigEnvSet(cfg.GetProfile(), configPath) {
+		return true
+	}
+	return !isKnownEnvironmentDefault(configPath, value)
+}
+
+func profileConfigEnvSet(profile, configPath string) bool {
+	profile = strings.TrimSpace(profile)
+	configPath = strings.TrimSpace(configPath)
+	if profile == "" || configPath == "" {
+		return false
+	}
+	name := "KONGCTL_" + strings.ToUpper(strings.ReplaceAll(profile, "-", "_")) + "_" +
+		strings.ToUpper(strings.NewReplacer(".", "_", "-", "_").Replace(configPath))
+	value, ok := os.LookupEnv(name)
+	return ok && strings.TrimSpace(value) != ""
+}
+
+func isKnownEnvironmentDefault(configPath, value string) bool {
+	switch configPath {
+	case BaseURLConfigPath:
+		return value == BaseURLDefault || value == TechBaseURLDefault ||
+			value == GlobalBaseURL || value == TechGlobalBaseURL
+	case AuthBaseURLConfigPath:
+		return value == AuthBaseURLDefault || value == TechGlobalBaseURL
+	case MachineClientIDConfigPath:
+		return value == MachineClientIDDefault || value == TechMachineClientID
+	default:
+		return false
 	}
 }
 

--- a/internal/cmd/root/products/konnect/common/common_test.go
+++ b/internal/cmd/root/products/konnect/common/common_test.go
@@ -179,58 +179,6 @@ func TestEnvironmentDefaultsFor(t *testing.T) {
 	}
 }
 
-func TestSelectedEnvironmentFromArgs(t *testing.T) {
-	tests := []struct {
-		name         string
-		args         []string
-		wantValue    string
-		wantSelected bool
-	}{
-		{
-			name:         "space separated",
-			args:         []string{"get", "org", "--konnect-env", "tech"},
-			wantValue:    "tech",
-			wantSelected: true,
-		},
-		{
-			name:         "equals separated",
-			args:         []string{"get", "org", "--konnect-env=tech"},
-			wantValue:    "tech",
-			wantSelected: true,
-		},
-		{
-			name:         "last value wins",
-			args:         []string{"--konnect-env", "com", "get", "org", "--konnect-env=tech"},
-			wantValue:    "tech",
-			wantSelected: true,
-		},
-		{
-			name:         "missing value is selected",
-			args:         []string{"get", "org", "--konnect-env"},
-			wantValue:    "",
-			wantSelected: true,
-		},
-		{
-			name:         "after double dash ignored",
-			args:         []string{"get", "org", "--", "--konnect-env", "tech"},
-			wantSelected: false,
-		},
-		{
-			name:         "not selected",
-			args:         []string{"get", "org"},
-			wantSelected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotValue, gotSelected := selectedEnvironmentFromArgs(tt.args)
-			require.Equal(t, tt.wantSelected, gotSelected)
-			require.Equal(t, tt.wantValue, gotValue)
-		})
-	}
-}
-
 func TestBuildBaseURLFromRegionForEnvironment(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -600,6 +600,9 @@ func bindFlags(config config.Hook) {
 
 	f = rootCmd.Flags().Lookup(common.ColorThemeFlagName)
 	util.CheckError(config.BindFlag(common.ColorThemeConfigPath, f))
+
+	f = rootCmd.Flags().Lookup(konnectcommon.KonnectEnvFlagName)
+	util.CheckError(config.BindFlag(konnectcommon.EnvironmentConfigPath, f))
 }
 
 func applyExtensionRuntimeDefaultsBeforeConfig(runtimeCtx *extensioncore.RuntimeContext) {

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -1448,6 +1448,9 @@ func TestApplyKonnectEnvironmentDefaultsRejectsInvalidEnv(t *testing.T) {
 	if !strings.Contains(err.Error(), "unsupported konnect environment") {
 		t.Fatalf("expected unsupported environment error, got %v", err)
 	}
+	if !strings.Contains(err.Error(), "allowed: production, tech; aliases: com, prod") {
+		t.Fatalf("expected allowed values in error, got %v", err)
+	}
 }
 
 func TestApplyKonnectEnvironmentDefaultsAcceptsProductionEnvironment(t *testing.T) {

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -1178,11 +1178,32 @@ func TestKonnectEnvFlagAppliesDuringRootExecution(t *testing.T) {
 	if got := currConfig.GetString(konnectcommon.BaseURLConfigPath); got != konnectcommon.TechBaseURLDefault {
 		t.Fatalf("base URL = %q, want %q", got, konnectcommon.TechBaseURLDefault)
 	}
+	if got := currConfig.GetString(konnectcommon.EnvironmentConfigPath); got != konnectcommon.EnvironmentTech {
+		t.Fatalf("environment = %q, want %q", got, konnectcommon.EnvironmentTech)
+	}
 	if got := currConfig.GetString(konnectcommon.AuthBaseURLConfigPath); got != konnectcommon.TechGlobalBaseURL {
 		t.Fatalf("auth base URL = %q, want %q", got, konnectcommon.TechGlobalBaseURL)
 	}
 	if got := currConfig.GetString(konnectcommon.MachineClientIDConfigPath); got != konnectcommon.TechMachineClientID {
 		t.Fatalf("machine client ID = %q, want %q", got, konnectcommon.TechMachineClientID)
+	}
+}
+
+func TestKonnectEnvironmentProfileEnvAppliesDuringRootExecution(t *testing.T) {
+	t.Setenv("KONGCTL_DEFAULT_KONNECT_ENVIRONMENT", konnectcommon.EnvironmentTech)
+
+	result := executeRootForTest(t)
+	if result.exitCode != 0 {
+		t.Fatalf("expected command to succeed\nstdout:\n%s\nstderr:\n%s", result.stdout, result.stderr)
+	}
+	if currConfig == nil {
+		t.Fatal("expected config to be initialized")
+	}
+	if got := currConfig.GetString(konnectcommon.BaseURLConfigPath); got != konnectcommon.TechBaseURLDefault {
+		t.Fatalf("base URL = %q, want %q", got, konnectcommon.TechBaseURLDefault)
+	}
+	if got := currConfig.GetString(konnectcommon.EnvironmentConfigPath); got != konnectcommon.EnvironmentTech {
+		t.Fatalf("environment = %q, want %q", got, konnectcommon.EnvironmentTech)
 	}
 }
 
@@ -1272,10 +1293,9 @@ func TestApplyKonnectEnvironmentDefaultsFromFlagTech(t *testing.T) {
 	}
 }
 
-func TestApplyKonnectEnvironmentDefaultsFromEnvTech(t *testing.T) {
-	t.Setenv(konnectcommon.KonnectEnvEnvName, konnectcommon.EnvironmentTech)
-
+func TestApplyKonnectEnvironmentDefaultsFromProfileConfigTech(t *testing.T) {
 	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
+	cfg.SetString(konnectcommon.EnvironmentConfigPath, konnectcommon.EnvironmentTech)
 	command := newKonnectEnvCommandForTest()
 
 	requireNoError(t, konnectcommon.ApplyEnvironmentDefaults(command, cfg))
@@ -1291,10 +1311,9 @@ func TestApplyKonnectEnvironmentDefaultsFromEnvTech(t *testing.T) {
 	}
 }
 
-func TestApplyKonnectEnvironmentDefaultsFlagOverridesEnv(t *testing.T) {
-	t.Setenv(konnectcommon.KonnectEnvEnvName, konnectcommon.EnvironmentTech)
-
+func TestApplyKonnectEnvironmentDefaultsFlagOverridesProfileConfig(t *testing.T) {
 	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
+	cfg.SetString(konnectcommon.EnvironmentConfigPath, konnectcommon.EnvironmentTech)
 	cfg.SetString(konnectcommon.BaseURLConfigPath, konnectcommon.TechBaseURLDefault)
 	cfg.SetString(konnectcommon.AuthBaseURLConfigPath, konnectcommon.TechGlobalBaseURL)
 	cfg.SetString(konnectcommon.MachineClientIDConfigPath, konnectcommon.TechMachineClientID)
@@ -1316,8 +1335,8 @@ func TestApplyKonnectEnvironmentDefaultsFlagOverridesEnv(t *testing.T) {
 
 func TestApplyKonnectEnvironmentDefaultsRespectsExplicitEndpointFlags(t *testing.T) {
 	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
+	cfg.SetString(konnectcommon.EnvironmentConfigPath, konnectcommon.EnvironmentTech)
 	command := newKonnectEnvCommandForTest()
-	requireNoError(t, command.Flags().Set(konnectcommon.KonnectEnvFlagName, konnectcommon.EnvironmentTech))
 	command.Flags().String(konnectcommon.BaseURLFlagName, "", "")
 	command.Flags().String(konnectcommon.AuthBaseURLFlagName, "", "")
 	command.Flags().String(konnectcommon.MachineClientIDFlagName, "", "")
@@ -1338,11 +1357,32 @@ func TestApplyKonnectEnvironmentDefaultsRespectsExplicitEndpointFlags(t *testing
 	}
 }
 
+func TestApplyKonnectEnvironmentDefaultsRespectsExplicitEndpointConfig(t *testing.T) {
+	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
+	cfg.SetString(konnectcommon.EnvironmentConfigPath, konnectcommon.EnvironmentTech)
+	cfg.SetString(konnectcommon.BaseURLConfigPath, "https://regional.example.test")
+	cfg.SetString(konnectcommon.AuthBaseURLConfigPath, "https://global.example.test")
+	cfg.SetString(konnectcommon.MachineClientIDConfigPath, "client-id")
+	command := newKonnectEnvCommandForTest()
+
+	requireNoError(t, konnectcommon.ApplyEnvironmentDefaults(command, cfg))
+
+	if got := cfg.GetString(konnectcommon.BaseURLConfigPath); got != "https://regional.example.test" {
+		t.Fatalf("base URL = %q, want explicit config to remain unchanged", got)
+	}
+	if got := cfg.GetString(konnectcommon.AuthBaseURLConfigPath); got != "https://global.example.test" {
+		t.Fatalf("auth base URL = %q, want explicit config to remain unchanged", got)
+	}
+	if got := cfg.GetString(konnectcommon.MachineClientIDConfigPath); got != "client-id" {
+		t.Fatalf("machine client ID = %q, want explicit config to remain unchanged", got)
+	}
+}
+
 func TestApplyKonnectEnvironmentDefaultsSurvivesLaterFlagBinding(t *testing.T) {
 	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
 	cfg.SetString(konnectcommon.RegionConfigPath, "global")
+	cfg.SetString(konnectcommon.EnvironmentConfigPath, konnectcommon.EnvironmentTech)
 	command := newKonnectEnvCommandForTest()
-	requireNoError(t, command.Flags().Set(konnectcommon.KonnectEnvFlagName, konnectcommon.EnvironmentTech))
 	command.Flags().String(konnectcommon.BaseURLFlagName, "", "")
 	command.Flags().String(konnectcommon.AuthBaseURLFlagName, "", "")
 	command.Flags().String(konnectcommon.MachineClientIDFlagName, "", "")
@@ -1371,8 +1411,8 @@ func TestApplyKonnectEnvironmentDefaultsSurvivesLaterFlagBinding(t *testing.T) {
 
 func TestApplyKonnectEnvironmentDefaultsUsesExplicitRegion(t *testing.T) {
 	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
+	cfg.SetString(konnectcommon.EnvironmentConfigPath, konnectcommon.EnvironmentTech)
 	command := newKonnectEnvCommandForTest()
-	requireNoError(t, command.Flags().Set(konnectcommon.KonnectEnvFlagName, konnectcommon.EnvironmentTech))
 	command.Flags().String(konnectcommon.RegionFlagName, "", "")
 	requireNoError(t, command.Flags().Set(konnectcommon.RegionFlagName, "eu"))
 
@@ -1385,9 +1425,9 @@ func TestApplyKonnectEnvironmentDefaultsUsesExplicitRegion(t *testing.T) {
 
 func TestApplyKonnectEnvironmentDefaultsUsesConfiguredRegion(t *testing.T) {
 	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
+	cfg.SetString(konnectcommon.EnvironmentConfigPath, konnectcommon.EnvironmentTech)
 	cfg.SetString(konnectcommon.RegionConfigPath, "eu")
 	command := newKonnectEnvCommandForTest()
-	requireNoError(t, command.Flags().Set(konnectcommon.KonnectEnvFlagName, konnectcommon.EnvironmentTech))
 
 	requireNoError(t, konnectcommon.ApplyEnvironmentDefaults(command, cfg))
 
@@ -1397,9 +1437,8 @@ func TestApplyKonnectEnvironmentDefaultsUsesConfiguredRegion(t *testing.T) {
 }
 
 func TestApplyKonnectEnvironmentDefaultsRejectsInvalidEnv(t *testing.T) {
-	t.Setenv(konnectcommon.KonnectEnvEnvName, "stage")
-
 	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
+	cfg.SetString(konnectcommon.EnvironmentConfigPath, "stage")
 	command := newKonnectEnvCommandForTest()
 
 	err := konnectcommon.ApplyEnvironmentDefaults(command, cfg)
@@ -1411,18 +1450,18 @@ func TestApplyKonnectEnvironmentDefaultsRejectsInvalidEnv(t *testing.T) {
 	}
 }
 
-func TestApplyKonnectEnvironmentDefaultsRejectsProductionAlias(t *testing.T) {
-	t.Setenv(konnectcommon.KonnectEnvEnvName, konnectcommon.EnvironmentProduction)
-
+func TestApplyKonnectEnvironmentDefaultsAcceptsProductionEnvironment(t *testing.T) {
 	cfg := configpkg.BuildProfiledConfig("default", "", viper.New())
+	cfg.SetString(konnectcommon.EnvironmentConfigPath, konnectcommon.EnvironmentProduction)
 	command := newKonnectEnvCommandForTest()
 
-	err := konnectcommon.ApplyEnvironmentDefaults(command, cfg)
-	if err == nil {
-		t.Fatal("expected invalid konnect environment error")
+	requireNoError(t, konnectcommon.ApplyEnvironmentDefaults(command, cfg))
+
+	if got := cfg.GetString(konnectcommon.BaseURLConfigPath); got != konnectcommon.BaseURLDefault {
+		t.Fatalf("base URL = %q, want %q", got, konnectcommon.BaseURLDefault)
 	}
-	if !strings.Contains(err.Error(), "allowed: com, tech") {
-		t.Fatalf("expected allowed values error, got %v", err)
+	if got := cfg.GetString(konnectcommon.AuthBaseURLConfigPath); got != konnectcommon.AuthBaseURLDefault {
+		t.Fatalf("auth base URL = %q, want %q", got, konnectcommon.AuthBaseURLDefault)
 	}
 }
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -95,18 +95,20 @@ Core harness settings:
 - `KONGCTL_E2E_RESET`: Reset the Konnect org before tests. Destructive.
   Defaults to enabled; set to `0` or `false` to disable.
 - `KONGCTL_E2E_KONNECT_ENV`: Konnect environment selector. Supported values
-  are `production` (default) and `tech`. The `tech` value selects
-  `https://us.api.konghq.tech`, `https://global.api.konghq.tech`, and the
-  `.tech` machine client ID for generated CLI profile config.
+  are `production` (default) and `tech`. The harness writes this into the
+  generated CLI profile, and raw harness HTTP helpers use it to select the
+  matching regional and global Konnect defaults.
 - `KONGCTL_E2E_KONNECT_BASE_URL`: Optional regional Konnect API override.
   When unset, the harness uses the selected `KONGCTL_E2E_KONNECT_ENV`
   default. If this points at `konghq.tech`, the harness also infers the
-  `.tech` global URL and machine client ID unless explicitly overridden.
+  `.tech` global URL and machine client ID for raw harness calls unless
+  explicitly overridden. The generated CLI profile includes
+  `konnect.base-url` only when this variable is set.
 - `KONGCTL_E2E_KONNECT_BASE_AUTH_URL`: Optional global/auth Konnect API
   override. The harness uses this for global Identity APIs, org reset, and
-  generated CLI profile `konnect.base-auth-url`.
+  generated CLI profile `konnect.base-auth-url` when set.
 - `KONGCTL_E2E_KONNECT_MACHINE_CLIENT_ID`: Optional machine client ID
-  override for generated CLI profile `konnect.machine-client-id`.
+  override for generated CLI profile `konnect.machine-client-id` when set.
 - `KONGCTL_E2E_HTTP_TIMEOUT`: Per-request timeout for raw Konnect HTTP helpers
   used by scenario create/delete flows. The harness also writes the same
   value into the generated `e2e.http-timeout` profile setting so

--- a/test/e2e/harness/cli.go
+++ b/test/e2e/harness/cli.go
@@ -777,9 +777,16 @@ func writeProfileConfig(cfgDir, profile, output, logLevel string) error {
 	fmt.Fprintf(&y, "  http-disable-keepalives: %t\n", options.DisableKeepAlives)
 	fmt.Fprintf(&y, "  http-recycle-connections-on-error: %t\n", options.RecycleConnectionsOnError)
 	fmt.Fprintf(&y, "  konnect:\n")
-	fmt.Fprintf(&y, "    base-url: %s\n", konnectTarget.BaseURL)
-	fmt.Fprintf(&y, "    base-auth-url: %s\n", konnectTarget.BaseAuthURL)
-	fmt.Fprintf(&y, "    machine-client-id: %s\n", konnectTarget.MachineClientID)
+	fmt.Fprintf(&y, "    environment: %s\n", konnectTarget.Name)
+	if strings.TrimSpace(os.Getenv(KonnectBaseURLEnvName)) != "" {
+		fmt.Fprintf(&y, "    base-url: %s\n", konnectTarget.BaseURL)
+	}
+	if strings.TrimSpace(os.Getenv(KonnectBaseAuthURLEnvName)) != "" {
+		fmt.Fprintf(&y, "    base-auth-url: %s\n", konnectTarget.BaseAuthURL)
+	}
+	if strings.TrimSpace(os.Getenv(KonnectMachineClientIDEnvName)) != "" {
+		fmt.Fprintf(&y, "    machine-client-id: %s\n", konnectTarget.MachineClientID)
+	}
 
 	path := filepath.Join(appDir, "config.yaml")
 	// Best-effort write; if file exists, do not overwrite.

--- a/test/e2e/harness/cli_test.go
+++ b/test/e2e/harness/cli_test.go
@@ -43,12 +43,19 @@ func TestWriteProfileConfigIncludesHTTPSettings(t *testing.T) {
 	}
 	for _, want := range []string{
 		"konnect:",
-		"base-url: " + konnectcommon.BaseURLDefault,
-		"base-auth-url: " + konnectcommon.AuthBaseURLDefault,
-		"machine-client-id: " + konnectcommon.MachineClientIDDefault,
+		"environment: " + konnectcommon.EnvironmentProduction,
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("config missing %q: %s", want, content)
+		}
+	}
+	for _, forbidden := range []string{
+		"base-url:",
+		"base-auth-url:",
+		"machine-client-id:",
+	} {
+		if strings.Contains(content, forbidden) {
+			t.Fatalf("config unexpectedly contains %q: %s", forbidden, content)
 		}
 	}
 }
@@ -93,9 +100,46 @@ func TestWriteProfileConfigIncludesTechKonnectSettings(t *testing.T) {
 
 	content := string(data)
 	for _, want := range []string{
-		"base-url: " + konnectcommon.TechBaseURLDefault,
-		"base-auth-url: " + konnectcommon.TechGlobalBaseURL,
-		"machine-client-id: " + konnectcommon.TechMachineClientID,
+		"environment: " + konnectcommon.EnvironmentTech,
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("config missing %q: %s", want, content)
+		}
+	}
+	for _, forbidden := range []string{
+		"base-url:",
+		"base-auth-url:",
+		"machine-client-id:",
+	} {
+		if strings.Contains(content, forbidden) {
+			t.Fatalf("config unexpectedly contains %q: %s", forbidden, content)
+		}
+	}
+}
+
+func TestWriteProfileConfigIncludesExplicitKonnectEndpointOverrides(t *testing.T) {
+	clearKonnectTargetEnv(t)
+	t.Setenv(KonnectEnvironmentEnvName, konnectcommon.EnvironmentTech)
+	t.Setenv(KonnectBaseURLEnvName, "https://regional.example.test")
+	t.Setenv(KonnectBaseAuthURLEnvName, "https://global.example.test")
+	t.Setenv(KonnectMachineClientIDEnvName, "client-id")
+
+	cfgDir := t.TempDir()
+	if err := writeProfileConfig(cfgDir, "e2e", "json", "debug"); err != nil {
+		t.Fatalf("writeProfileConfig() error = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(cfgDir, "kongctl", "config.yaml"))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	content := string(data)
+	for _, want := range []string{
+		"environment: " + konnectcommon.EnvironmentTech,
+		"base-url: https://regional.example.test",
+		"base-auth-url: https://global.example.test",
+		"machine-client-id: client-id",
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("config missing %q: %s", want, content)


### PR DESCRIPTION
## Summary

- move the internal Konnect environment selector to profiled config via `konnect.environment`
- keep hidden `--konnect-env` as the flag override for that profile-scoped setting
- stop using the pre-profile `KONGCTL_KONNECT_ENV` path for CLI runtime selection
- preserve explicit endpoint overrides for `base-url`, `base-auth-url`, and `machine-client-id`
- update e2e profile generation to write the selected environment and only emit endpoint overrides when those harness vars are set

## Validation

- `git diff --check`
- `GOFLAGS=-mod=mod go test ./internal/cmd/root/products/konnect/common ./internal/cmd/root`
- `GOFLAGS=-mod=mod go test -tags=e2e ./test/e2e/harness`
- `GOFLAGS=-mod=mod go test ./internal/cmd/...`