### PR TITLE
test(e2e): add deck apply idempotency scenario

### DIFF
--- a/test/e2e/scenarios/deck/idempotent/scenario.yaml
+++ b/test/e2e/scenarios/deck/idempotent/scenario.yaml
@@ -1,0 +1,71 @@
+baseInputsPath: testdata
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-initial-apply
+    commands:
+      - name: 000-apply
+        outputFormat: json
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/platform.yaml"
+          - --auto-approve
+        assertions:
+          - select: "summary"
+            expect:
+              fields:
+                failed: 0
+                status: success
+          - select: "plan.metadata"
+            expect:
+              fields:
+                mode: apply
+          - select: "plan.changes[?resource_type=='_deck']"
+            expect:
+              fields:
+                "length(@)": 1
+
+  - name: 002-repeat-apply
+    commands:
+      - name: 000-apply
+        outputFormat: json
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/platform.yaml"
+          - --auto-approve
+        assertions:
+          - select: "summary"
+            expect:
+              fields:
+                failed: 0
+                status: success
+          - select: "plan.metadata"
+            expect:
+              fields:
+                mode: apply
+          - select: "plan.changes"
+            expect:
+              fields:
+                "length(@)": 0
+
+  - name: 003-delete-cleanup
+    commands:
+      - name: 000-delete
+        outputFormat: json
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/platform.yaml"
+          - --auto-approve
+        assertions:
+          - select: "summary"
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/deck/idempotent/testdata/cp1/deck/_info.yaml
+++ b/test/e2e/scenarios/deck/idempotent/testdata/cp1/deck/_info.yaml
@@ -1,0 +1,1 @@
+_format_version: "3.0"

--- a/test/e2e/scenarios/deck/idempotent/testdata/cp1/deck/httpbin.yaml
+++ b/test/e2e/scenarios/deck/idempotent/testdata/cp1/deck/httpbin.yaml
@@ -1,0 +1,8 @@
+services:
+  - name: httpbin
+    url: https://httpbin.konghq.com/anything
+    routes:
+      - name: httpbin
+        paths:
+          - /echo
+        strip_path: true

--- a/test/e2e/scenarios/deck/idempotent/testdata/platform.yaml
+++ b/test/e2e/scenarios/deck/idempotent/testdata/platform.yaml
@@ -1,0 +1,9 @@
+control_planes:
+  - ref: cp1
+    name: cp1
+    description: "Repro CP for kongctl _deck non-idempotency"
+    cluster_type: CLUSTER_TYPE_CONTROL_PLANE
+    auth_type: pinned_client_certs
+    _deck:
+      files:
+        - cp1/deck


### PR DESCRIPTION
## Summary
- Add an e2e scenario covering `_deck.files` with a directory-based decK config.
- Assert that applying the same platform config twice is idempotent: the first apply creates resources and the second apply reports no changes.
- Keep cleanup in the scenario by deleting the created control plane.

Refs #1376

## Testing
- `GOTMPDIR=$PWD/.codex-go-tmp KONGCTL_E2E_ARTIFACTS_DIR=$PWD/.e2e-artifacts make test-e2e-scenarios SCENARIO=deck/idempotent`
- `PATH=$PWD/.codex-tmp/deck143:$PATH GOTMPDIR=$PWD/.codex-go-tmp KONGCTL_E2E_ARTIFACTS_DIR=$PWD/.e2e-artifacts make test-e2e-scenarios SCENARIO=deck/idempotent`