### PR TITLE
task(release): add ad-hoc prerelease workflow

### DIFF
--- a/.github/workflows/adhoc-prerelease.yml
+++ b/.github/workflows/adhoc-prerelease.yml
@@ -1,0 +1,373 @@
+name: Ad-hoc prerelease
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: Branch, tag, or SHA to build
+        required: true
+        type: string
+      release_tag:
+        description: Optional prerelease tag to create
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: adhoc-prerelease-${{ github.event.inputs.source_ref }}
+  cancel-in-progress: false
+
+run-name: Ad-hoc prerelease ${{ inputs.source_ref }}
+
+jobs:
+  prerelease:
+    name: Build prerelease
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure GH_HOST for enterprise compatibility
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh_host="${GITHUB_SERVER_URL#https://}"
+          gh_host="${gh_host#http://}"
+          echo "GH_HOST=${gh_host}" >> "$GITHUB_ENV"
+
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout source ref
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+          ref: ${{ inputs.source_ref }}
+
+      - name: Resolve source and release tag
+        id: release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG_INPUT: ${{ inputs.release_tag }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+        run: |
+          set -euo pipefail
+
+          sanitize_ref() {
+            local value="$1"
+
+            case "${value}" in
+              refs/pull/*/head | refs/pull/*/merge)
+                value="pr-${value#refs/pull/}"
+                value="${value%/head}"
+                value="${value%/merge}"
+                ;;
+              pull/*/head | pull/*/merge)
+                value="pr-${value#pull/}"
+                value="${value%/head}"
+                value="${value%/merge}"
+                ;;
+              refs/heads/*)
+                value="${value#refs/heads/}"
+                ;;
+              refs/tags/*)
+                value="${value#refs/tags/}"
+                ;;
+              origin/*)
+                value="${value#origin/}"
+                ;;
+            esac
+
+            value="$(printf '%s' "${value}" | tr '[:upper:]' '[:lower:]')"
+            value="$(printf '%s' "${value}" | sed -E 's/[^a-z0-9._-]+/-/g; s/-+/-/g')"
+            value="$(printf '%s' "${value}" | sed -E 's/^[._-]+//; s/[._-]+$//')"
+
+            if [ -z "${value}" ]; then
+              value="source"
+            fi
+
+            if [[ "${value}" =~ ^[0-9] ]]; then
+              value="ref-${value}"
+            fi
+
+            printf '%.80s\n' "${value}"
+          }
+
+          validate_tag() {
+            local tag="$1"
+
+            if [ -z "${tag}" ]; then
+              echo "::error::release_tag must not be empty"
+              exit 1
+            fi
+
+            if [ "${#tag}" -gt 128 ]; then
+              echo "::error::release tag is too long (${#tag} characters); maximum is 128"
+              exit 1
+            fi
+
+            if [[ "${tag}" == */* ]]; then
+              echo "::error::release tag must not contain '/': ${tag}"
+              exit 1
+            fi
+
+            if [[ "${tag}" =~ ^[0-9] ]]; then
+              echo "::error::release tag must not start with a digit: ${tag}"
+              exit 1
+            fi
+
+            if [[ "${tag}" == -* ]]; then
+              echo "::error::release tag must not start with '-': ${tag}"
+              exit 1
+            fi
+
+            if ! git check-ref-format --allow-onelevel "${tag}"; then
+              echo "::error::release tag is not a valid Git tag name: ${tag}"
+              exit 1
+            fi
+          }
+
+          source_sha="$(git rev-parse HEAD)"
+          short_sha="$(git rev-parse --short=7 HEAD)"
+          safe_ref="$(sanitize_ref "${SOURCE_REF}")"
+
+          if [ -n "${RELEASE_TAG_INPUT}" ]; then
+            release_tag="${RELEASE_TAG_INPUT}"
+          else
+            timestamp="$(date -u +%Y%m%d-%H%M)"
+            release_tag="prerelease-${safe_ref}-${timestamp}-g${short_sha}"
+          fi
+
+          validate_tag "${release_tag}"
+
+          git fetch origin --tags --force
+          if git rev-parse --verify --quiet "refs/tags/${release_tag}" >/dev/null; then
+            echo "::error::Git tag already exists locally: ${release_tag}"
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${release_tag}" >/dev/null 2>&1; then
+            echo "::error::Git tag already exists on origin: ${release_tag}"
+            exit 1
+          fi
+
+          if gh release view "${release_tag}" >/dev/null 2>&1; then
+            echo "::error::GitHub release already exists: ${release_tag}"
+            exit 1
+          fi
+
+          {
+            echo "release_tag=${release_tag}"
+            echo "safe_ref=${safe_ref}"
+            echo "short_sha=${short_sha}"
+            echo "source_sha=${source_sha}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          cache: false
+          go-version-file: go.mod
+
+      - name: Set up private SDK if needed
+        id: private_sdk
+        shell: bash
+        run: scripts/setup-private-sdk.sh
+        env:
+          GH_TOKEN_PRIVATE_READ: ${{ secrets.GH_TOKEN_PRIVATE_READ }}
+
+      - name: Validate build
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION=dev make build-ci
+
+      - name: Run unit tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          go test -race -count=1 ./...
+
+      - name: Prepare GoReleaser config
+        id: goreleaser_config
+        shell: bash
+        run: |
+          set -euo pipefail
+          config="${RUNNER_TEMP}/goreleaser-adhoc.yml"
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          src = Path(".goreleaser.yml")
+          dst = Path(os.environ["RUNNER_TEMP"]) / "goreleaser-adhoc.yml"
+          text = src.read_text()
+          needle = "- -X main.version={{.Version}}"
+          replacement = "- -X main.version=dev"
+          if needle not in text:
+              raise SystemExit("could not find GoReleaser main.version ldflag")
+          dst.write_text(text.replace(needle, replacement, 1))
+          PY
+          echo "config=${config}" >> "$GITHUB_OUTPUT"
+
+      - name: Build release binaries
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        env:
+          CGO_ENABLED: "0"
+        with:
+          args: build --snapshot --clean --config ${{ steps.goreleaser_config.outputs.config }}
+          distribution: goreleaser
+          version: v2.13.3
+
+      - name: Package ZIP assets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          command -v zip >/dev/null 2>&1 || {
+            echo "::error::zip is required to package prerelease assets"
+            exit 1
+          }
+
+          linux_amd64_bin="$(find dist -type f -path "*/kongctl_linux_amd64*" -name kongctl | sort | head -n 1)"
+          if [ -z "${linux_amd64_bin}" ]; then
+            echo "::error::GoReleaser did not produce a linux/amd64 kongctl binary"
+            exit 1
+          fi
+
+          version_output="$("${linux_amd64_bin}" version --full)"
+          if [[ "${version_output}" != dev\ * && "${version_output}" != "dev" ]]; then
+            echo "::error::ad-hoc prerelease binary version must be dev; got: ${version_output}"
+            exit 1
+          fi
+
+          rm -rf release-assets
+          mkdir -p release-assets
+
+          targets=(
+            "linux/amd64"
+            "linux/arm64"
+            "darwin/amd64"
+            "darwin/arm64"
+            "windows/amd64"
+            "windows/arm64"
+          )
+
+          for target in "${targets[@]}"; do
+            os="${target%/*}"
+            arch="${target#*/}"
+            binary="kongctl"
+            if [ "${os}" = "windows" ]; then
+              binary="kongctl.exe"
+            fi
+
+            built_binary="$(find dist -type f -path "*/kongctl_${os}_${arch}*" -name "${binary}" | sort | head -n 1)"
+            if [ -z "${built_binary}" ]; then
+              echo "::error::GoReleaser did not produce ${target} binary"
+              exit 1
+            fi
+
+            stage="${RUNNER_TEMP}/kongctl-${os}-${arch}"
+            rm -rf "${stage}"
+            mkdir -p "${stage}"
+            cp "${built_binary}" "${stage}/${binary}"
+
+            files=("${binary}")
+            if [ -f LICENSE ]; then
+              cp LICENSE "${stage}/LICENSE"
+              files+=("LICENSE")
+            fi
+            if [ -f README.md ]; then
+              cp README.md "${stage}/README.md"
+              files+=("README.md")
+            fi
+
+            archive="${GITHUB_WORKSPACE}/release-assets/kongctl_${os}_${arch}.zip"
+            (cd "${stage}" && zip -q "${archive}" "${files[@]}")
+          done
+
+          (cd release-assets && sha256sum kongctl_*.zip > checksums.txt)
+
+      - name: Prepare release notes
+        id: notes
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
+          SDK_COMMIT: ${{ steps.private_sdk.outputs.sdk_commit }}
+          SDK_MODE: ${{ steps.private_sdk.outputs.sdk_mode }}
+          SDK_VERSION: ${{ steps.private_sdk.outputs.sdk_version }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+          SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          notes="${RUNNER_TEMP}/release-notes.md"
+
+          {
+            echo "## Ad-hoc prerelease"
+            echo ""
+            echo "- Source ref: \`${SOURCE_REF}\`"
+            echo "- Source SHA: \`${SOURCE_SHA}\`"
+            echo "- Binary version: \`dev\`"
+            echo "- SDK mode: \`${SDK_MODE:-public}\`"
+            if [ -n "${SDK_VERSION}" ]; then
+              echo "- Internal SDK version: \`${SDK_VERSION}\`"
+            fi
+            if [ -n "${SDK_COMMIT}" ]; then
+              echo "- Internal SDK commit: \`${SDK_COMMIT}\`"
+            fi
+            echo ""
+            echo "### Validation"
+            echo ""
+            echo "- \`VERSION=dev make build-ci\`"
+            echo "- \`go test -race -count=1 ./...\`"
+            echo "- GoReleaser snapshot cross-compile completed"
+            echo "- ZIP assets and \`checksums.txt\` generated"
+            echo ""
+            echo "### Install"
+            echo ""
+            echo "\`\`\`sh"
+            echo "curl -fsSL https://raw.githubusercontent.com/Kong/kongctl/main/scripts/install.sh | sh -s -- --version ${RELEASE_TAG}"
+            echo "\`\`\`"
+          } > "${notes}"
+
+          echo "path=${notes}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
+          SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${RELEASE_TAG}" "${SOURCE_SHA}" -m "Ad-hoc prerelease ${RELEASE_TAG}"
+          git push origin "refs/tags/${RELEASE_TAG}"
+
+      - name: Create GitHub prerelease
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
+          SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          gh release create "${RELEASE_TAG}" release-assets/*.zip release-assets/checksums.txt \
+            --notes-file "${{ steps.notes.outputs.path }}" \
+            --prerelease \
+            --latest=false \
+            --target "${SOURCE_SHA}" \
+            --title "${RELEASE_TAG}" \
+            --verify-tag
+
+      - name: Cleanup private SDK workspace
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf .private
+          if [ -d .git ]; then
+            git checkout -- go.mod go.sum || true
+          fi

--- a/.github/workflows/adhoc-prerelease.yml
+++ b/.github/workflows/adhoc-prerelease.yml
@@ -83,6 +83,7 @@ jobs:
 
             value="$(printf '%s' "${value}" | tr '[:upper:]' '[:lower:]')"
             value="$(printf '%s' "${value}" | sed -E 's/[^a-z0-9._-]+/-/g; s/-+/-/g')"
+            value="$(printf '%s' "${value}" | sed -E 's/[.]{2,}/-/g; s/\.lock($|[._-])/-lock\1/g')"
             value="$(printf '%s' "${value}" | sed -E 's/^[._-]+//; s/[._-]+$//')"
 
             if [ -z "${value}" ]; then
@@ -93,7 +94,14 @@ jobs:
               value="ref-${value}"
             fi
 
-            printf '%.80s\n' "${value}"
+            value="$(printf '%.80s' "${value}")"
+            value="$(printf '%s' "${value}" | sed -E 's/[._-]+$//; s/\.lock$/-lock/')"
+
+            if [ -z "${value}" ]; then
+              value="source"
+            fi
+
+            printf '%s\n' "${value}"
           }
 
           validate_tag() {

--- a/scripts/release-preview.sh
+++ b/scripts/release-preview.sh
@@ -17,7 +17,7 @@ Options:
                           $GITHUB_REPOSITORY, gh repo context, or origin.
   --head REF              Commit/ref to preview. Defaults to $HEAD_REF or HEAD.
   --base-tag TAG          Previous release/tag override. Defaults to
-                          $BASE_TAG, latest non-draft GitHub release tag,
+                          $BASE_TAG, latest stable non-draft GitHub release tag,
                           then latest local stable semver tag.
   --extended              Include commit-by-commit details and changed paths.
   -h, --help              Show this help.
@@ -491,12 +491,15 @@ if [ -n "${base_tag_override}" ]; then
   base_sha="$(git rev-parse --verify "${base_tag}^{commit}" 2>/dev/null)" \
     || die "base tag does not resolve to a local commit: ${base_tag}"
 elif [ "${github_release_data_available}" = "true" ]; then
-  github_latest_release_tag="$(jq -r '.[].tagName // empty' "${gh_releases_file}" | awk 'NF { print; exit }')"
-  if [ -n "${github_latest_release_tag}" ]; then
-    if base_sha="$(git rev-parse --verify "${github_latest_release_tag}^{commit}" 2>/dev/null)"; then
-      base_tag="${github_latest_release_tag}"
+  github_latest_stable_release_tag="$(
+    jq -r '.[].tagName // empty | select(test("^v?[0-9]+\\.[0-9]+\\.[0-9]+$"))' "${gh_releases_file}" \
+      | awk 'NF { print; exit }'
+  )"
+  if [ -n "${github_latest_stable_release_tag}" ]; then
+    if base_sha="$(git rev-parse --verify "${github_latest_stable_release_tag}^{commit}" 2>/dev/null)"; then
+      base_tag="${github_latest_stable_release_tag}"
     else
-      warnings+=("Latest non-draft GitHub release tag ${github_latest_release_tag} is not available locally.")
+      warnings+=("Latest stable non-draft GitHub release tag ${github_latest_stable_release_tag} is not available locally.")
     fi
   fi
 fi

--- a/scripts/setup-private-sdk.sh
+++ b/scripts/setup-private-sdk.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PUBLIC_SDK_MODULE="${PUBLIC_SDK_MODULE:-github.com/Kong/sdk-konnect-go}"
+INTERNAL_SDK_MODULE="${INTERNAL_SDK_MODULE:-github.com/Kong/sdk-konnect-go-internal}"
+PRIVATE_SDK_DIR="${PRIVATE_SDK_DIR:-.private/sdk-konnect-go-internal}"
+
+die() {
+  echo "setup-private-sdk: $*" >&2
+  exit 1
+}
+
+write_output() {
+  local name="$1"
+  local value="$2"
+
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf '%s=%s\n' "${name}" "${value}" >> "${GITHUB_OUTPUT}"
+  fi
+}
+
+append_go_env_pattern() {
+  local current="$1"
+  local pattern="$2"
+
+  case ",${current}," in
+    *",${pattern},"*)
+      printf '%s\n' "${current}"
+      ;;
+    ",,")
+      printf '%s\n' "${pattern}"
+      ;;
+    *)
+      printf '%s,%s\n' "${current}" "${pattern}"
+      ;;
+  esac
+}
+
+export_private_go_env() {
+  local current_goprivate
+  local current_gonosumdb
+
+  current_goprivate="${GOPRIVATE:-$(go env GOPRIVATE 2>/dev/null || true)}"
+  current_gonosumdb="${GONOSUMDB:-$(go env GONOSUMDB 2>/dev/null || true)}"
+
+  GOPRIVATE="$(append_go_env_pattern "${current_goprivate}" "${INTERNAL_SDK_MODULE}")"
+  GONOSUMDB="$(append_go_env_pattern "${current_gonosumdb}" "${INTERNAL_SDK_MODULE}")"
+  export GOPRIVATE GONOSUMDB
+
+  if [ -n "${GITHUB_ENV:-}" ]; then
+    {
+      printf 'GOPRIVATE=%s\n' "${GOPRIVATE}"
+      printf 'GONOSUMDB=%s\n' "${GONOSUMDB}"
+    } >> "${GITHUB_ENV}"
+  fi
+}
+
+sdk_replacement() {
+  PUBLIC_SDK_MODULE="${PUBLIC_SDK_MODULE}" python3 -c '
+import json
+import os
+import sys
+
+public_module = os.environ["PUBLIC_SDK_MODULE"]
+data = json.load(sys.stdin)
+
+for replacement in data.get("Replace") or []:
+    old = replacement.get("Old", {})
+    new = replacement.get("New", {})
+    if old.get("Path") == public_module:
+        print("{}\t{}".format(new.get("Path", ""), new.get("Version", "")))
+        break
+' < <(go mod edit -json)
+}
+
+checkout_ref_for_version() {
+  local version="$1"
+
+  if [[ "${version}" =~ -([0-9a-fA-F]{12,})(\+incompatible)?$ ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+    return
+  fi
+
+  printf '%s\n' "${version}"
+}
+
+clone_private_sdk() {
+  local token="$1"
+  local checkout_ref="$2"
+  local auth_header
+  local parent_dir
+
+  parent_dir="$(dirname "${PRIVATE_SDK_DIR}")"
+  mkdir -p "${parent_dir}"
+
+  if [ -e "${PRIVATE_SDK_DIR}" ]; then
+    die "private SDK directory already exists: ${PRIVATE_SDK_DIR}"
+  fi
+
+  auth_header="$(printf 'x-access-token:%s' "${token}" | base64 | tr -d '\n')"
+
+  git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
+    clone "https://github.com/Kong/sdk-konnect-go-internal.git" "${PRIVATE_SDK_DIR}"
+
+  git -C "${PRIVATE_SDK_DIR}" fetch --tags --force origin
+  git -C "${PRIVATE_SDK_DIR}" checkout --detach "${checkout_ref}"
+}
+
+main() {
+  local replacement
+  local replacement_path
+  local replacement_version
+  local token
+  local checkout_ref
+  local local_replace_path
+  local sdk_commit
+
+  replacement="$(sdk_replacement)"
+  if [ -z "${replacement}" ]; then
+    echo "No ${PUBLIC_SDK_MODULE} replacement found; using public SDK."
+    write_output "sdk_mode" "public"
+    write_output "sdk_module" "${PUBLIC_SDK_MODULE}"
+    return
+  fi
+
+  IFS=$'\t' read -r replacement_path replacement_version <<< "${replacement}"
+  if [ "${replacement_path}" != "${INTERNAL_SDK_MODULE}" ]; then
+    echo "${PUBLIC_SDK_MODULE} replacement points to ${replacement_path}; private SDK setup not needed."
+    write_output "sdk_mode" "public"
+    write_output "sdk_module" "${replacement_path}"
+    return
+  fi
+
+  if [ -z "${replacement_version}" ]; then
+    die "${PUBLIC_SDK_MODULE} replacement points to ${INTERNAL_SDK_MODULE} without a pinned version"
+  fi
+
+  token="${GH_TOKEN_PRIVATE_READ:-${GH_PRIVATE_READ_TOKEN:-}}"
+  if [ -z "${token}" ]; then
+    die "GH_TOKEN_PRIVATE_READ is required when go.mod replaces ${PUBLIC_SDK_MODULE} with ${INTERNAL_SDK_MODULE}"
+  fi
+
+  export_private_go_env
+
+  checkout_ref="$(checkout_ref_for_version "${replacement_version}")"
+  clone_private_sdk "${token}" "${checkout_ref}"
+
+  local_replace_path="./${PRIVATE_SDK_DIR#./}"
+  go mod edit -replace="${PUBLIC_SDK_MODULE}=${local_replace_path}"
+
+  sdk_commit="$(git -C "${PRIVATE_SDK_DIR}" rev-parse HEAD)"
+
+  echo "Configured ${PUBLIC_SDK_MODULE} to use ${INTERNAL_SDK_MODULE} at ${sdk_commit}."
+  write_output "sdk_mode" "internal"
+  write_output "sdk_module" "${INTERNAL_SDK_MODULE}"
+  write_output "sdk_version" "${replacement_version}"
+  write_output "sdk_commit" "${sdk_commit}"
+}
+
+main "$@"

--- a/test/installer/install_test.sh
+++ b/test/installer/install_test.sh
@@ -283,6 +283,17 @@ test_version_pin_and_install_dir() {
   assert_executable "${LAST_INSTALL_DIR}/kongctl" "install-dir override is honored"
 }
 
+test_prerelease_tag_version_pin() {
+  local release_dir="${TMP_ROOT}/release-prerelease"
+  local tag="prerelease-gh-1391-ad-hoc-20260625-1842-gabcdef1"
+
+  make_release "$release_dir" "$tag"
+  expect_success "supports non-semver prerelease version pinning" "$release_dir" \
+    --version "$tag" --os linux --arch amd64
+  assert_contains "$LAST_OUTPUT" "Resolved version: $tag" "prerelease tag is not normalized"
+  assert_executable "${LAST_INSTALL_DIR}/kongctl" "prerelease install succeeds"
+}
+
 test_completion_output() {
   local release_dir="${TMP_ROOT}/release-completion"
 
@@ -460,6 +471,7 @@ test_path_shadow_warning() {
 
 test_success_matrix
 test_version_pin_and_install_dir
+test_prerelease_tag_version_pin
 test_completion_output
 test_yes_flag_compatibility
 test_update_status


### PR DESCRIPTION
## Summary

- Add a manual ad-hoc prerelease workflow that builds from a requested `source_ref`, generates or validates a safe non-semver prerelease tag, and publishes ZIP assets plus `checksums.txt` as a GitHub prerelease.
- Add a reusable private SDK setup helper that no-ops for the public SDK and rewrites `sdk-konnect-go-internal` replacements to a local checkout when `GH_TOKEN_PRIVATE_READ` is available.
- Keep ad-hoc prerelease binaries reporting `dev` while preserving provenance through commit/date, release notes, checksums, and the release tag.
- Prevent ad-hoc prerelease tags from being selected as the default stable release preview base and cover non-semver installer `--version` usage.

Closes #1391.

## Validation

- `go fix ./...`
- `actionlint .github/workflows/adhoc-prerelease.yml`
- `bash -n scripts/setup-private-sdk.sh scripts/release-preview.sh test/installer/install_test.sh`
- `scripts/setup-private-sdk.sh`
- temporary internal-SDK replacement fixture without `GH_TOKEN_PRIVATE_READ` to verify clear failure messaging
- `VERSION=dev make build-ci`
- `make test-installer`
- `make lint`
- `make test`

Note: `make test-installer` skipped shellcheck because shellcheck is not installed in this local environment.