### PR TITLE
fix(release): check ad-hoc prerelease tags strictly

### DIFF
--- a/.github/workflows/adhoc-prerelease.yml
+++ b/.github/workflows/adhoc-prerelease.yml
@@ -25,6 +25,8 @@ jobs:
   prerelease:
     name: Build prerelease
     runs-on: ubuntu-latest
+    env:
+      RELEASE_GITHUB_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
     steps:
       - name: Configure GH_HOST for enterprise compatibility
         shell: bash
@@ -63,12 +65,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
           ref: ${{ inputs.source_ref }}
+          token: ${{ env.RELEASE_GITHUB_TOKEN }}
 
       - name: Resolve source and release tag
         id: release
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ env.RELEASE_GITHUB_TOKEN }}
           RELEASE_TAG_INPUT: ${{ inputs.release_tag }}
           SOURCE_REF: ${{ inputs.source_ref }}
         run: |
@@ -365,10 +368,14 @@ jobs:
       - name: Create and push tag
         shell: bash
         env:
+          RELEASE_GITHUB_TOKEN: ${{ env.RELEASE_GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
           SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
         run: |
           set -euo pipefail
+          server_url="${GITHUB_SERVER_URL#https://}"
+          server_url="${server_url#http://}"
+          git remote set-url origin "https://x-access-token:${RELEASE_GITHUB_TOKEN}@${server_url}/${GITHUB_REPOSITORY}.git"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "${RELEASE_TAG}" "${SOURCE_SHA}" -m "Ad-hoc prerelease ${RELEASE_TAG}"
@@ -377,7 +384,7 @@ jobs:
       - name: Create GitHub prerelease
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ env.RELEASE_GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
           SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
         run: |

--- a/.github/workflows/adhoc-prerelease.yml
+++ b/.github/workflows/adhoc-prerelease.yml
@@ -368,14 +368,10 @@ jobs:
       - name: Create and push tag
         shell: bash
         env:
-          RELEASE_GITHUB_TOKEN: ${{ env.RELEASE_GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
           SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
         run: |
           set -euo pipefail
-          server_url="${GITHUB_SERVER_URL#https://}"
-          server_url="${server_url#http://}"
-          git remote set-url origin "https://x-access-token:${RELEASE_GITHUB_TOKEN}@${server_url}/${GITHUB_REPOSITORY}.git"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "${RELEASE_TAG}" "${SOURCE_SHA}" -m "Ad-hoc prerelease ${RELEASE_TAG}"
@@ -396,6 +392,26 @@ jobs:
             --target "${SOURCE_SHA}" \
             --title "${RELEASE_TAG}" \
             --verify-tag
+
+      - name: Verify GitHub prerelease state
+        shell: bash
+        env:
+          GH_TOKEN: ${{ env.RELEASE_GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+
+          is_prerelease="$(gh release view "${RELEASE_TAG}" --json isPrerelease --jq '.isPrerelease')"
+          if [ "${is_prerelease}" != "true" ]; then
+            echo "::error::GitHub release ${RELEASE_TAG} is not marked as a prerelease"
+            exit 1
+          fi
+
+          latest_tag="$(gh api "/repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name' 2>/dev/null || true)"
+          if [ "${latest_tag}" = "${RELEASE_TAG}" ]; then
+            echo "::error::GitHub release ${RELEASE_TAG} is marked as the repository latest release"
+            exit 1
+          fi
 
       - name: Cleanup private SDK workspace
         if: always()

--- a/.github/workflows/adhoc-prerelease.yml
+++ b/.github/workflows/adhoc-prerelease.yml
@@ -39,6 +39,24 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Checkout workflow helper scripts
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 1
+          path: .workflow-source
+          persist-credentials: false
+          ref: ${{ github.ref }}
+
+      - name: Stage workflow helper scripts
+        shell: bash
+        run: |
+          set -euo pipefail
+          helper_dir="${RUNNER_TEMP}/kongctl-adhoc-prerelease"
+          mkdir -p "${helper_dir}"
+          cp ".workflow-source/scripts/setup-private-sdk.sh" "${helper_dir}/setup-private-sdk.sh"
+          chmod +x "${helper_dir}/setup-private-sdk.sh"
+          echo "PRIVATE_SDK_HELPER=${helper_dir}/setup-private-sdk.sh" >> "$GITHUB_ENV"
+
       - name: Checkout source ref
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -183,7 +201,9 @@ jobs:
       - name: Set up private SDK if needed
         id: private_sdk
         shell: bash
-        run: scripts/setup-private-sdk.sh
+        run: |
+          set -euo pipefail
+          "${PRIVATE_SDK_HELPER}"
         env:
           GH_TOKEN_PRIVATE_READ: ${{ secrets.GH_TOKEN_PRIVATE_READ }}
 

--- a/.github/workflows/adhoc-prerelease.yml
+++ b/.github/workflows/adhoc-prerelease.yml
@@ -152,7 +152,7 @@ jobs:
           validate_tag "${release_tag}"
 
           git fetch origin --tags --force
-          if git rev-parse --verify --quiet "refs/tags/${release_tag}" >/dev/null; then
+          if git show-ref --verify --quiet "refs/tags/${release_tag}"; then
             echo "::error::Git tag already exists locally: ${release_tag}"
             exit 1
           fi

--- a/scripts/setup-private-sdk.sh
+++ b/scripts/setup-private-sdk.sh
@@ -103,7 +103,9 @@ clone_private_sdk() {
   git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
     clone "https://github.com/Kong/sdk-konnect-go-internal.git" "${PRIVATE_SDK_DIR}"
 
-  git -C "${PRIVATE_SDK_DIR}" fetch --tags --force origin
+  git -C "${PRIVATE_SDK_DIR}" \
+    -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
+    fetch --tags --force origin
   git -C "${PRIVATE_SDK_DIR}" checkout --detach "${checkout_ref}"
 }
 


### PR DESCRIPTION
## Summary

- Replace the local generated-tag collision check in `adhoc-prerelease.yml` with `git show-ref --verify --quiet`.
- Avoid false positives from `git rev-parse --verify` resolving the generated tag suffix like `g475fe30` as a commit object when no tag ref exists.
- Stage `scripts/setup-private-sdk.sh` from the workflow ref before checking out `source_ref`, so ad-hoc releases can build branches that predate the helper script.
- Use the existing `PAT` secret, falling back to `GITHUB_TOKEN`, for release-writing operations so tag pushes can satisfy GitHub workflow-file permission restrictions when needed.

## Validation

- `actionlint .github/workflows/adhoc-prerelease.yml`
- `git diff --check`
- Reproduced the failed run's generated tag locally: `git rev-parse` returned success for `refs/tags/prerelease-ascii-20260625-1614-g475fe30`, while `git show-ref --verify` correctly returned no matching tag ref.
- Reviewed failed run `28184795773`, where `source_ref=ascii` did not contain `scripts/setup-private-sdk.sh`; the workflow now copies the helper into `RUNNER_TEMP` before source checkout.
- Reviewed failed run `28187842269`, where the Actions GitHub App token was rejected while pushing an ad-hoc tag due to workflow-file permission rules; release writes now use `secrets.PAT || secrets.GITHUB_TOKEN`.