### PR TITLE
feat(declarative): add AI Gateway MCP server support

### DIFF
--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -318,21 +318,29 @@ control_plane_data_plane_certificates:
 ## AI Gateways
 
 This section covers the root AI Gateway resource backed by the Konnect
-`/v1/ai-gateways` API, AI Gateway Providers, and AI Gateway Models. Use
-`kongctl explain ai_gateway --output yaml`,
-`kongctl explain ai_gateway_provider --output yaml`, and
-`kongctl explain ai_gateway.models --output yaml` as the authoritative
+`/v1/ai-gateways` API, AI Gateway Providers, AI Gateway Models, and AI Gateway
+MCP Servers. Use `kongctl explain ai_gateway --output yaml`,
+`kongctl explain ai_gateway_provider --output yaml`,
+`kongctl explain ai_gateway.models --output yaml`, and
+`kongctl explain ai_gateway.mcp_servers --output yaml` as the authoritative
 schemas.
 
 The `ref` value is used as the stable Konnect API `name` when creating an AI
 Gateway. Use `display_name` for the human-readable name shown in Konnect.
-AI Gateway Providers use their own required `name` field as the stable
-Konnect provider name. Provider and model child entries inherit management
-scope from their parent AI Gateway and do not accept `kongctl` metadata.
+AI Gateway Providers, Models, and MCP Servers use their own required `name`
+field as the stable Konnect child name. Child entries inherit management scope
+from their parent AI Gateway and do not accept `kongctl` metadata.
 
 For AI Gateway Models, `target_models[].provider` must match an AI Gateway
 Provider `name` under the parent gateway. The provider can already exist or be
 declared in the same gateway configuration.
+
+For AI Gateway MCP Servers, root-level declarations must include
+`ai_gateway`, while nested declarations inherit the parent gateway. Omit
+`mcp_servers` to leave existing MCP Servers unmanaged during sync. Use a nested
+`mcp_servers: []` under a specific AI Gateway to sync-delete MCP Servers for
+that gateway. Root-level `ai_gateway_mcp_servers: []` is rejected because it
+does not identify a parent gateway.
 
 ```yaml
 ai_gateways:
@@ -380,6 +388,25 @@ ai_gateways:
         key: value
       acls: object
       managed_by: object
+   mcp_servers:
+    - ref: string
+      type: conversion-only # or conversion-listener, listener,
+                            # passthrough-listener, upstream-server
+      name: string required
+      display_name: string required
+      enabled: boolean
+      config:
+        url: string required
+      tools:
+       - name: string required
+         description: string required
+         method: string required
+         path: string
+      policies: array[string]
+      labels: object [string]string
+        key: value
+      acls: object
+      managed_by: object
 ```
 
 AI Gateway Providers can also be declared as root resources. Root-level
@@ -422,6 +449,32 @@ ai_gateway_models:
         type: string required
    policies: array[object]
    capabilities: array[string]
+   labels: object [string]string
+     key: value
+   acls: object
+   managed_by: object
+```
+
+AI Gateway MCP Servers can also be declared as root resources. Include
+`ai_gateway` to point at the parent gateway `ref`.
+
+```yaml
+ai_gateway_mcp_servers:
+ - ref: string
+   ai_gateway: string required # AI Gateway ref
+   type: conversion-only # or conversion-listener, listener,
+                         # passthrough-listener, upstream-server
+   name: string required
+   display_name: string required
+   enabled: boolean
+   config:
+     url: string required
+   tools:
+    - name: string required
+      description: string required
+      method: string required
+      path: string
+   policies: array[string]
    labels: object [string]string
      key: value
    acls: object

--- a/docs/examples/declarative/ai-gateway/README.md
+++ b/docs/examples/declarative/ai-gateway/README.md
@@ -4,10 +4,12 @@ This directory contains declarative configuration examples for Konnect AI
 Gateway resources.
 
 - [ai-gateway.yaml](ai-gateway.yaml) defines a root AI Gateway resource with
-  a nested OpenAI provider and a model that targets that provider.
+  a nested OpenAI provider, a model that targets that provider, and a
+  conversion-only MCP Server.
 - [federated](federated) shows a multi-folder
   layout where a central team owns an AI Gateway and providers, while a peer
-  team owns a root-level model that references the shared gateway.
+  team owns root-level models and MCP Servers that reference the shared
+  gateway.
 
 Set `OPENAI_AUTH_HEADER` to the full upstream authorization header value
 before applying the example, for example `Bearer ...`.

--- a/docs/examples/declarative/ai-gateway/ai-gateway.yaml
+++ b/docs/examples/declarative/ai-gateway/ai-gateway.yaml
@@ -43,3 +43,20 @@ ai_gateways:
         policies: []
         capabilities:
           - generate
+    mcp_servers:
+      - ref: customer-support-tools
+        type: conversion-only
+        name: customer-support-tools
+        display_name: "Customer Support Tools"
+        enabled: true
+        labels:
+          team: support
+          toolset: customer-profile
+        config:
+          url: https://support-tools.example.com
+        tools:
+          - name: lookup-customer
+            description: "Look up a customer profile"
+            method: GET
+            path: /customers/{customer_id}
+        policies: []

--- a/docs/examples/declarative/ai-gateway/federated/README.md
+++ b/docs/examples/declarative/ai-gateway/federated/README.md
@@ -2,7 +2,7 @@
 
 This example shows a federated layout for AI Gateway resources where a central
 AI platform team owns the shared AI Gateway and upstream providers, while a peer
-team owns a root-level model that targets those shared providers.
+team owns root-level models and MCP Servers that target the shared gateway.
 
 ## Structure
 
@@ -13,6 +13,7 @@ ai-gateway/federated/
 |-- external-peer-team/
 |   `-- support-model.yaml
 `-- peer-team/
+    |-- support-mcp-server.yaml
     `-- support-model.yaml
 ```
 
@@ -22,13 +23,16 @@ ai-gateway/federated/
   providers: OpenAI and Anthropic.
 - `peer-team/support-model.yaml` defines a standalone `ai_gateway_models`
   entry that references the central gateway with `!ref shared-ai-gateway#id`.
+- `peer-team/support-mcp-server.yaml` defines a standalone
+  `ai_gateway_mcp_servers` entry that references the central gateway with
+  `!ref shared-ai-gateway#id`.
 - `external-peer-team/support-model.yaml` defines an `_external` AI Gateway
   stub and points a standalone model at it with
   `!ref external-shared-ai-gateway#id`.
 
-The peer file is standalone in shape, but it still needs the parent gateway
+The peer files are standalone in shape, but they still need the parent gateway
 declaration in the same declarative load. Run the directory recursively so
-kongctl sees both the central gateway and the peer-owned model:
+kongctl sees both the central gateway and the peer-owned resources:
 
 ```sh
 kongctl plan -f docs/examples/declarative/ai-gateway/federated --recursive \

--- a/docs/examples/declarative/ai-gateway/federated/peer-team/support-mcp-server.yaml
+++ b/docs/examples/declarative/ai-gateway/federated/peer-team/support-mcp-server.yaml
@@ -1,0 +1,22 @@
+_defaults:
+  kongctl:
+    namespace: federated-ai-gateway
+
+ai_gateway_mcp_servers:
+  - ref: peer-support-tools
+    ai_gateway: !ref shared-ai-gateway#id
+    type: conversion-only
+    name: peer-support-tools
+    display_name: "Peer Support Tools"
+    enabled: true
+    labels:
+      team: support-experience
+      ownership: peer
+    config:
+      url: https://support-tools.example.com
+    tools:
+      - name: lookup-customer
+        description: "Look up a customer profile"
+        method: GET
+        path: /customers/{customer_id}
+    policies: []

--- a/internal/cmd/root/products/konnect/aigateway/ai-gateway.go
+++ b/internal/cmd/root/products/konnect/aigateway/ai-gateway.go
@@ -31,6 +31,7 @@ func NewAIGatewayCmd(
 		root := newGetAIGatewayCmd(verb, &baseCmd, addParentFlags, parentPreRun).Command
 		root.AddCommand(newGetAIGatewayProvidersCmd(verb, addParentFlags, parentPreRun))
 		root.AddCommand(newGetAIGatewayModelsCmd(verb, addParentFlags, parentPreRun))
+		root.AddCommand(newGetAIGatewayMCPServersCmd(verb, addParentFlags, parentPreRun))
 		return root, nil
 	}
 

--- a/internal/cmd/root/products/konnect/aigateway/child_common.go
+++ b/internal/cmd/root/products/konnect/aigateway/child_common.go
@@ -21,6 +21,12 @@ const (
 	aiGatewayProviderIDConfigPath   = "konnect.ai-gateway.provider.id"
 	aiGatewayProviderNameConfigPath = "konnect.ai-gateway.provider.name"
 
+	aiGatewayMCPServerIDFlagName   = "mcp-server-id"
+	aiGatewayMCPServerNameFlagName = "mcp-server-name"
+
+	aiGatewayMCPServerIDConfigPath   = "konnect.ai-gateway.mcp-server.id"
+	aiGatewayMCPServerNameConfigPath = "konnect.ai-gateway.mcp-server.name"
+
 	aiGatewayMissingValue = "n/a"
 )
 
@@ -90,4 +96,38 @@ func bindAIGatewayProviderFlags(c *cobra.Command, args []string) error {
 
 func getAIGatewayProviderIdentifiers(cfg config.Hook) (id string, name string) {
 	return cfg.GetString(aiGatewayProviderIDConfigPath), cfg.GetString(aiGatewayProviderNameConfigPath)
+}
+
+func addAIGatewayMCPServerFlags(c *cobra.Command) {
+	c.Flags().String(aiGatewayMCPServerIDFlagName, "",
+		fmt.Sprintf(`The ID of the AI Gateway MCP Server to retrieve.
+- Config path: [ %s ]`, aiGatewayMCPServerIDConfigPath))
+	c.Flags().String(aiGatewayMCPServerNameFlagName, "",
+		fmt.Sprintf(`The name of the AI Gateway MCP Server to retrieve.
+- Config path: [ %s ]`, aiGatewayMCPServerNameConfigPath))
+	c.MarkFlagsMutuallyExclusive(aiGatewayMCPServerIDFlagName, aiGatewayMCPServerNameFlagName)
+}
+
+func bindAIGatewayMCPServerFlags(c *cobra.Command, args []string) error {
+	helper := cmd.BuildHelper(c, args)
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	if flag := c.Flags().Lookup(aiGatewayMCPServerIDFlagName); flag != nil {
+		if err := cfg.BindFlag(aiGatewayMCPServerIDConfigPath, flag); err != nil {
+			return err
+		}
+	}
+	if flag := c.Flags().Lookup(aiGatewayMCPServerNameFlagName); flag != nil {
+		if err := cfg.BindFlag(aiGatewayMCPServerNameConfigPath, flag); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getAIGatewayMCPServerIdentifiers(cfg config.Hook) (id string, name string) {
+	return cfg.GetString(aiGatewayMCPServerIDConfigPath), cfg.GetString(aiGatewayMCPServerNameConfigPath)
 }

--- a/internal/cmd/root/products/konnect/aigateway/mcp_servers.go
+++ b/internal/cmd/root/products/konnect/aigateway/mcp_servers.go
@@ -1,0 +1,399 @@
+package aigateway
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/table"
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/cmd"
+	cmdCommon "github.com/kong/kongctl/internal/cmd/common"
+	"github.com/kong/kongctl/internal/cmd/output/tableview"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
+	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/kong/kongctl/internal/config"
+	declresources "github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/konnect/helpers"
+	"github.com/kong/kongctl/internal/meta"
+	"github.com/kong/kongctl/internal/util"
+	"github.com/kong/kongctl/internal/util/i18n"
+	"github.com/kong/kongctl/internal/util/normalizers"
+	"github.com/kong/kongctl/internal/util/pagination"
+	"github.com/segmentio/cli"
+	"github.com/spf13/cobra"
+)
+
+type aiGatewayMCPServerRecord struct {
+	ID               string
+	Name             string
+	DisplayName      string
+	Type             string
+	Enabled          string
+	LocalUpdatedTime string
+}
+
+var (
+	aiGatewayMCPServersUse   = "mcp-servers [mcp-server-id|mcp-server-name]"
+	aiGatewayMCPServersShort = i18n.T(
+		"root.products.konnect.ai-gateway.mcpServersShort",
+		"List or get MCP Servers for a Konnect AI Gateway",
+	)
+	aiGatewayMCPServersLong = normalizers.LongDesc(i18n.T(
+		"root.products.konnect.ai-gateway.mcpServersLong",
+		`Use the mcp-servers command to list or retrieve MCP Servers for a specific Konnect AI Gateway.`,
+	))
+	aiGatewayMCPServersExample = normalizers.Examples(
+		i18n.T("root.products.konnect.ai-gateway.mcpServersExamples",
+			fmt.Sprintf(`# List MCP Servers for an AI Gateway by display name
+%[1]s get ai-gateway mcp-servers --gateway-name "Customer Support Gateway"
+# List MCP Servers for an AI Gateway by ID
+%[1]s get ai-gateway mcp-servers --gateway-id <gateway-id>
+# Get an MCP Server by name
+%[1]s get ai-gateway mcp-servers --gateway-name "Customer Support Gateway" customer-support-tools
+# Get an MCP Server by ID
+%[1]s get ai-gateway mcp-servers --gateway-id <gateway-id> --mcp-server-id <mcp-server-id>
+`, meta.CLIName)),
+	)
+)
+
+func newGetAIGatewayMCPServersCmd(
+	verb verbs.VerbValue,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) *cobra.Command {
+	c := &cobra.Command{
+		Use:     aiGatewayMCPServersUse,
+		Short:   aiGatewayMCPServersShort,
+		Long:    aiGatewayMCPServersLong,
+		Example: aiGatewayMCPServersExample,
+		Aliases: []string{"mcp-server"},
+		PreRunE: func(c *cobra.Command, args []string) error {
+			if parentPreRun != nil {
+				if err := parentPreRun(c, args); err != nil {
+					return err
+				}
+			}
+			if err := bindAIGatewayChildFlags(c, args); err != nil {
+				return err
+			}
+			return bindAIGatewayMCPServerFlags(c, args)
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			handler := aiGatewayMCPServersHandler{cmd: c}
+			return handler.run(args)
+		},
+	}
+
+	addAIGatewayChildFlags(c)
+	addAIGatewayMCPServerFlags(c)
+	if addParentFlags != nil {
+		addParentFlags(verb, c)
+	}
+	return c
+}
+
+type aiGatewayMCPServersHandler struct {
+	cmd *cobra.Command
+}
+
+func (h aiGatewayMCPServersHandler) run(args []string) error {
+	helper := cmd.BuildHelper(h.cmd, args)
+	if len(args) > 1 {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf("too many arguments. Listing AI Gateway MCP Servers requires 0 or 1 arguments (ID or name)"),
+		}
+	}
+
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	if len(args) == 1 {
+		serverID, serverName := getAIGatewayMCPServerIdentifiers(cfg)
+		if serverID != "" || serverName != "" {
+			return &cmd.ConfigurationError{
+				Err: fmt.Errorf(
+					"cannot specify both positional argument and --%s or --%s flags",
+					aiGatewayMCPServerIDFlagName,
+					aiGatewayMCPServerNameFlagName,
+				),
+			}
+		}
+	}
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+	outType, err := helper.GetOutputFormat()
+	if err != nil {
+		return err
+	}
+	printer, err := cli.Format(outType.String(), helper.GetStreams().Out)
+	if err != nil {
+		return err
+	}
+	defer printer.Flush()
+
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return err
+	}
+
+	gatewayID, gatewayName := getAIGatewayIdentifiers(cfg)
+	if gatewayID != "" && gatewayName != "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf("only one of --%s or --%s can be provided", aiGatewayIDFlagName, aiGatewayNameFlagName),
+		}
+	}
+	if gatewayID == "" && gatewayName == "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf(
+				"an AI Gateway identifier is required. Provide --%s or --%s",
+				aiGatewayIDFlagName,
+				aiGatewayNameFlagName,
+			),
+		}
+	}
+	if gatewayID == "" {
+		gatewayID, err = resolveAIGatewayIDByDisplayName(gatewayName, sdk.GetAIGatewayAPI(), helper, cfg)
+		if err != nil {
+			return err
+		}
+	}
+
+	serverAPI := sdk.GetAIGatewayMCPServersAPI()
+	if serverAPI == nil {
+		return &cmd.ExecutionError{
+			Msg: "AI Gateway MCP Servers client is not available",
+			Err: fmt.Errorf("AI Gateway MCP Servers client not configured"),
+		}
+	}
+
+	serverID, serverName := getAIGatewayMCPServerIdentifiers(cfg)
+	if serverID != "" && serverName != "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf(
+				"only one of --%s or --%s can be provided",
+				aiGatewayMCPServerIDFlagName,
+				aiGatewayMCPServerNameFlagName,
+			),
+		}
+	}
+
+	identifier := ""
+	if len(args) == 1 {
+		identifier = strings.TrimSpace(args[0])
+	} else if serverID != "" {
+		identifier = serverID
+	} else if serverName != "" {
+		identifier = serverName
+	}
+
+	if identifier != "" {
+		return h.getSingleMCPServer(helper, serverAPI, gatewayID, identifier, outType, printer)
+	}
+	return h.listMCPServers(helper, serverAPI, gatewayID, outType, printer, cfg)
+}
+
+func (h aiGatewayMCPServersHandler) listMCPServers(
+	helper cmd.Helper,
+	serverAPI helpers.AIGatewayMCPServersAPI,
+	gatewayID string,
+	outType cmdCommon.OutputFormat,
+	printer cli.PrintFlusher,
+	cfg config.Hook,
+) error {
+	servers, err := fetchAIGatewayMCPServers(helper, serverAPI, gatewayID, cfg)
+	if err != nil {
+		return err
+	}
+
+	records := make([]aiGatewayMCPServerRecord, 0, len(servers))
+	tableRows := make([]table.Row, 0, len(servers))
+	for _, server := range servers {
+		record := aiGatewayMCPServerToRecord(server)
+		records = append(records, record)
+		tableRows = append(tableRows, table.Row{
+			record.ID,
+			record.Name,
+			record.DisplayName,
+			record.Type,
+			record.Enabled,
+			record.LocalUpdatedTime,
+		})
+	}
+
+	return tableview.RenderForFormat(
+		helper,
+		false,
+		outType,
+		printer,
+		helper.GetStreams(),
+		records,
+		servers,
+		"",
+		tableview.WithCustomTable(
+			[]string{"ID", "NAME", "DISPLAY NAME", "TYPE", "ENABLED", "UPDATED"},
+			tableRows,
+		),
+		tableview.WithRootLabel(helper.GetCmd().Name()),
+		tableview.WithDetailHelper(helper),
+		tableview.WithDetailRenderer(func(index int) string {
+			if index < 0 || index >= len(servers) {
+				return ""
+			}
+			return aiGatewayMCPServerDetailView(servers[index])
+		}),
+		tableview.WithDetailContext(common.ViewParentAIGatewayMCPServer, func(index int) any {
+			if index < 0 || index >= len(servers) {
+				return nil
+			}
+			return &servers[index]
+		}),
+	)
+}
+
+func (h aiGatewayMCPServersHandler) getSingleMCPServer(
+	helper cmd.Helper,
+	serverAPI helpers.AIGatewayMCPServersAPI,
+	gatewayID string,
+	identifier string,
+	outType cmdCommon.OutputFormat,
+	printer cli.PrintFlusher,
+) error {
+	res, err := serverAPI.GetAiGatewayMcpServer(helper.GetContext(), gatewayID, identifier)
+	if err != nil {
+		attrs := cmd.TryConvertErrorToAttrs(err)
+		return cmd.PrepareExecutionError("Failed to get AI Gateway MCP Server", err, helper.GetCmd(), attrs...)
+	}
+	server := res.GetAIGatewayMCPServer()
+	if server == nil {
+		return &cmd.ExecutionError{
+			Msg: "AI Gateway MCP Server response was empty",
+			Err: fmt.Errorf("no MCP Server returned for id or name %s", identifier),
+		}
+	}
+
+	record := aiGatewayMCPServerToRecord(*server)
+	return tableview.RenderForFormat(
+		helper,
+		false,
+		outType,
+		printer,
+		helper.GetStreams(),
+		record,
+		server,
+		"",
+		tableview.WithRootLabel(helper.GetCmd().Name()),
+		tableview.WithDetailHelper(helper),
+		tableview.WithDetailRenderer(func(index int) string {
+			if index != 0 {
+				return ""
+			}
+			return aiGatewayMCPServerDetailView(*server)
+		}),
+		tableview.WithDetailContext(common.ViewParentAIGatewayMCPServer, func(index int) any {
+			if index != 0 {
+				return nil
+			}
+			return server
+		}),
+	)
+}
+
+func fetchAIGatewayMCPServers(
+	helper cmd.Helper,
+	serverAPI helpers.AIGatewayMCPServersAPI,
+	gatewayID string,
+	cfg config.Hook,
+) ([]kkComps.AIGatewayMCPServer, error) {
+	requestPageSize := common.ResolveRequestPageSize(cfg)
+	var pageAfter *string
+	var allData []kkComps.AIGatewayMCPServer
+
+	for {
+		req := kkOps.ListAiGatewayMcpServersRequest{
+			GatewayID: gatewayID,
+			PageSize:  &requestPageSize,
+		}
+		if pageAfter != nil {
+			req.PageAfter = pageAfter
+		}
+
+		res, err := serverAPI.ListAiGatewayMcpServers(helper.GetContext(), req)
+		if err != nil {
+			attrs := cmd.TryConvertErrorToAttrs(err)
+			return nil, cmd.PrepareExecutionError("Failed to list AI Gateway MCP Servers", err, helper.GetCmd(), attrs...)
+		}
+		if res.GetListAIGatewayMCPServersResponse() == nil {
+			break
+		}
+
+		allData = append(allData, res.GetListAIGatewayMCPServersResponse().Data...)
+		nextCursor := pagination.ExtractPageAfterCursor(res.GetListAIGatewayMCPServersResponse().Meta.Page.Next)
+		if nextCursor == "" {
+			break
+		}
+		pageAfter = &nextCursor
+	}
+
+	return allData, nil
+}
+
+func aiGatewayMCPServerToRecord(server kkComps.AIGatewayMCPServer) aiGatewayMCPServerRecord {
+	record := aiGatewayMCPServerRecord{
+		ID:               aiGatewayMissingValue,
+		Name:             valueOrMissing(declresources.AIGatewayMCPServerName(server)),
+		DisplayName:      valueOrMissing(declresources.AIGatewayMCPServerDisplayName(server)),
+		Type:             valueOrMissing(declresources.AIGatewayMCPServerType(server)),
+		Enabled:          aiGatewayMissingValue,
+		LocalUpdatedTime: aiGatewayMissingValue,
+	}
+	if id := declresources.AIGatewayMCPServerID(server); id != "" {
+		record.ID = util.AbbreviateUUID(id)
+	}
+	if enabled := declresources.AIGatewayMCPServerEnabled(server); enabled != nil {
+		record.Enabled = fmt.Sprintf("%t", *enabled)
+	}
+	if updatedAt := declresources.AIGatewayMCPServerUpdatedAt(server); !updatedAt.IsZero() {
+		record.LocalUpdatedTime = updatedAt.In(time.Local).Format("2006-01-02 15:04:05")
+	}
+	return record
+}
+
+func aiGatewayMCPServerDetailView(server kkComps.AIGatewayMCPServer) string {
+	payload := make(map[string]any)
+	data, err := json.Marshal(server)
+	if err == nil {
+		_ = json.Unmarshal(data, &payload)
+	}
+
+	order := []string{
+		"id",
+		"name",
+		"display_name",
+		"type",
+		"enabled",
+		"acl_attribute_type",
+		"acls",
+		"default_tool_acls",
+		"config",
+		"tools",
+		"policies",
+		"labels",
+		"managed_by",
+		"created_at",
+		"updated_at",
+	}
+
+	var b strings.Builder
+	for _, field := range order {
+		fmt.Fprintf(&b, "%s: %s\n", field, formatAIGatewayModelDetailValue(payload[field]))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/internal/cmd/root/products/konnect/common/view_identifiers.go
+++ b/internal/cmd/root/products/konnect/common/view_identifiers.go
@@ -8,6 +8,7 @@ const (
 	ViewParentAIGateway                     = "ai-gateway"
 	ViewParentAIGatewayProvider             = "ai-gateway-provider"
 	ViewParentAIGatewayModel                = "ai-gateway-model"
+	ViewParentAIGatewayMCPServer            = "ai-gateway-mcp-server"
 	ViewParentAPIDocument                   = "api-document"
 	ViewParentAPIImplementation             = "api-implementation"
 	ViewParentAPIPublication                = "api-publication"

--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -2844,6 +2844,7 @@ func createStateClient(kkClient helpers.SDKAPI) *state.Client {
 		AIGatewayAPI:            kkClient.GetAIGatewayAPI(),
 		AIGatewayProvidersAPI:   kkClient.GetAIGatewayProvidersAPI(),
 		AIGatewayModelAPI:       kkClient.GetAIGatewayModelAPI(),
+		AIGatewayMCPServersAPI:  kkClient.GetAIGatewayMCPServersAPI(),
 		DashboardsAPI:           kkClient.GetDashboardsAPI(),
 
 		// Portal child resource APIs

--- a/internal/cmd/root/verbs/dump/common.go
+++ b/internal/cmd/root/verbs/dump/common.go
@@ -162,6 +162,8 @@ func mapResourceName(name string) string {
 		return "ai_gateways"
 	case "ai-gateway-model", "ai-gateway-models", "ai_gateway_model", "ai_gateway_models":
 		return "ai_gateway_models"
+	case "ai-gateway-mcp-server", "ai-gateway-mcp-servers", "ai_gateway_mcp_server", "ai_gateway_mcp_servers":
+		return "ai_gateway_mcp_servers"
 	case "org.team", "org.teams", "organization.team", "organization.teams":
 		return "organization.teams"
 	default:

--- a/internal/cmd/root/verbs/dump/declarative.go
+++ b/internal/cmd/root/verbs/dump/declarative.go
@@ -54,6 +54,7 @@ var declarativeAllowedResources = map[string]struct{}{
 	"event_gateways":              {},
 	"ai_gateways":                 {},
 	"ai_gateway_models":           {},
+	"ai_gateway_mcp_servers":      {},
 	"organization.teams":          {},
 }
 
@@ -86,7 +87,8 @@ func newDeclarativeCmd() *cobra.Command {
 	cmd.Flags().String("resources", "",
 		"Comma separated list of resource types to dump "+
 			"(portals, apis, application_auth_strategies, dcr_providers, control_planes, "+
-			resourceAnalyticsDashboards+", event_gateways, ai_gateways, ai_gateway_models, organization.teams).")
+			resourceAnalyticsDashboards+", event_gateways, ai_gateways, ai_gateway_models, "+
+			"ai_gateway_mcp_servers, organization.teams).")
 	_ = cmd.MarkFlagRequired("resources")
 
 	cmd.Flags().BoolVar(&opts.includeChildResources, "include-child-resources", false,
@@ -200,7 +202,9 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 	}
 
 	var stateClient *declstate.Client
-	if opts.includeChildResources || slices.Contains(opts.resources, "ai_gateway_models") {
+	if opts.includeChildResources ||
+		slices.Contains(opts.resources, "ai_gateway_models") ||
+		slices.Contains(opts.resources, "ai_gateway_mcp_servers") {
 		stateClient = declstate.NewClient(declstate.ClientConfig{
 			PortalAPI:                           sdk.GetPortalAPI(),
 			APIAPI:                              sdk.GetAPIAPI(),
@@ -214,6 +218,7 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 			AIGatewayAPI:                        sdk.GetAIGatewayAPI(),
 			AIGatewayProvidersAPI:               sdk.GetAIGatewayProvidersAPI(),
 			AIGatewayModelAPI:                   sdk.GetAIGatewayModelAPI(),
+			AIGatewayMCPServersAPI:              sdk.GetAIGatewayMCPServersAPI(),
 			DashboardsAPI:                       sdk.GetDashboardsAPI(),
 			PortalPageAPI:                       sdk.GetPortalPageAPI(),
 			PortalAuthSettingsAPI:               sdk.GetPortalAuthSettingsAPI(),
@@ -370,6 +375,18 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 				return err
 			}
 			resourceSet.AIGatewayModels = append(resourceSet.AIGatewayModels, models...)
+		case "ai_gateway_mcp_servers":
+			servers, err := collectDeclarativeAIGatewayMCPServers(
+				ctx,
+				stateClient,
+				sdk.GetAIGatewayAPI(),
+				requestPageSize,
+				opts.filter,
+			)
+			if err != nil {
+				return err
+			}
+			resourceSet.AIGatewayMCPServers = append(resourceSet.AIGatewayMCPServers, servers...)
 		case "organization.teams":
 			teams, err := collectDeclarativeOrganizationTeams(
 				ctx,
@@ -775,6 +792,44 @@ func collectDeclarativeAIGatewayModels(
 	})
 
 	return models, nil
+}
+
+func collectDeclarativeAIGatewayMCPServers(
+	ctx context.Context,
+	client *declstate.Client,
+	aiGatewayClient helpers.AIGatewayAPI,
+	requestPageSize int64,
+	filter filterOptions,
+) ([]declresources.AIGatewayMCPServerResource, error) {
+	if client == nil {
+		return nil, fmt.Errorf("AI Gateway MCP Servers API client is not configured")
+	}
+
+	gateways, err := collectDeclarativeAIGateways(ctx, aiGatewayClient, requestPageSize, filterOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var servers []declresources.AIGatewayMCPServerResource
+	for _, gateway := range gateways {
+		gatewayServers, err := buildAIGatewayMCPServers(ctx, client, gateway.Ref, gateway.DisplayName, gateway.Ref)
+		if err != nil {
+			return nil, err
+		}
+		servers = append(servers, gatewayServers...)
+	}
+
+	servers = filterByNameOrID(servers, filter, func(r declresources.AIGatewayMCPServerResource) (string, string) {
+		return r.Name(), r.Ref
+	})
+	slices.SortFunc(servers, func(a, b declresources.AIGatewayMCPServerResource) int {
+		if a.AIGateway == b.AIGateway {
+			return cmp.Compare(a.Name(), b.Name())
+		}
+		return cmp.Compare(a.AIGateway, b.AIGateway)
+	})
+
+	return servers, nil
 }
 
 func collectDeclarativeOrganizationTeams(

--- a/internal/cmd/root/verbs/dump/declarative_children.go
+++ b/internal/cmd/root/verbs/dump/declarative_children.go
@@ -283,6 +283,15 @@ func populateAIGatewayChildren(
 		if len(models) > 0 {
 			gateway.Models = models
 		}
+
+		servers, err := buildAIGatewayMCPServers(ctx, client, gatewayID, gateway.DisplayName, "")
+		if err != nil {
+			logWarn(logger, "failed to load AI Gateway MCP Servers", gatewayID, gateway.DisplayName, err)
+			continue
+		}
+		if len(servers) > 0 {
+			gateway.MCPServers = servers
+		}
 	}
 }
 
@@ -367,6 +376,36 @@ func buildAIGatewayModels(
 	}
 
 	slices.SortFunc(result, func(a, b declresources.AIGatewayModelResource) int {
+		if a.Name() == b.Name() {
+			return cmp.Compare(a.Ref, b.Ref)
+		}
+		return cmp.Compare(a.Name(), b.Name())
+	})
+
+	return result, nil
+}
+
+func buildAIGatewayMCPServers(
+	ctx context.Context,
+	client *declstate.Client,
+	gatewayID string,
+	gatewayName string,
+	gatewayRef string,
+) ([]declresources.AIGatewayMCPServerResource, error) {
+	servers, err := client.ListAIGatewayMCPServers(ctx, gatewayID)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]declresources.AIGatewayMCPServerResource, 0, len(servers))
+	for _, server := range servers {
+		resource, err := declresources.AIGatewayMCPServerResourceFromResponse(gatewayRef, server.AIGatewayMCPServer)
+		if err != nil {
+			return nil, fmt.Errorf("failed to map AI Gateway MCP Server for gateway %s: %w", gatewayName, err)
+		}
+		result = append(result, resource)
+	}
+
+	slices.SortFunc(result, func(a, b declresources.AIGatewayMCPServerResource) int {
 		if a.Name() == b.Name() {
 			return cmp.Compare(a.Ref, b.Ref)
 		}

--- a/internal/declarative/executor/ai_gateway_mcp_server_adapter.go
+++ b/internal/declarative/executor/ai_gateway_mcp_server_adapter.go
@@ -1,0 +1,185 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+)
+
+// AIGatewayMCPServerAdapter implements ResourceOperations for AI Gateway MCP Servers.
+type AIGatewayMCPServerAdapter struct {
+	client *state.Client
+}
+
+// NewAIGatewayMCPServerAdapter creates a new AI Gateway MCP Server adapter.
+func NewAIGatewayMCPServerAdapter(client *state.Client) *AIGatewayMCPServerAdapter {
+	return &AIGatewayMCPServerAdapter{client: client}
+}
+
+// MapCreateFields maps planner fields to CreateAIGatewayMCPServerRequest.
+func (a *AIGatewayMCPServerAdapter) MapCreateFields(
+	_ context.Context,
+	_ *ExecutionContext,
+	fields map[string]any,
+	create *kkComps.CreateAIGatewayMCPServerRequest,
+) error {
+	data, err := json.Marshal(fields)
+	if err != nil {
+		return fmt.Errorf("failed to encode AI Gateway MCP Server create fields: %w", err)
+	}
+	if err := json.Unmarshal(data, create); err != nil {
+		return fmt.Errorf("failed to decode AI Gateway MCP Server create fields: %w", err)
+	}
+	if create.AIGatewayMCPServerConversionOnly == nil &&
+		create.AIGatewayMCPServerConversionListener == nil &&
+		create.AIGatewayMCPServerListener == nil &&
+		create.AIGatewayMCPServerPassthroughListener == nil &&
+		create.AIGatewayMCPServerUpstreamServer == nil {
+		return fmt.Errorf("type must be a supported AI Gateway MCP Server type")
+	}
+	return nil
+}
+
+// MapUpdateFields maps planner fields to UpdateAIGatewayMCPServerRequest.
+func (a *AIGatewayMCPServerAdapter) MapUpdateFields(
+	_ context.Context,
+	_ *ExecutionContext,
+	fields map[string]any,
+	update *kkComps.UpdateAIGatewayMCPServerRequest,
+	_ map[string]string,
+) error {
+	data, err := json.Marshal(fields)
+	if err != nil {
+		return fmt.Errorf("failed to encode AI Gateway MCP Server update fields: %w", err)
+	}
+	if err := json.Unmarshal(data, update); err != nil {
+		return fmt.Errorf("failed to decode AI Gateway MCP Server update fields: %w", err)
+	}
+	if update.AIGatewayMCPServerConversionOnly == nil &&
+		update.AIGatewayMCPServerConversionListener == nil &&
+		update.AIGatewayMCPServerListener == nil &&
+		update.AIGatewayMCPServerPassthroughListener == nil &&
+		update.AIGatewayMCPServerUpstreamServer == nil {
+		return fmt.Errorf("type must be a supported AI Gateway MCP Server type")
+	}
+	return nil
+}
+
+// Create creates an AI Gateway MCP Server.
+func (a *AIGatewayMCPServerAdapter) Create(
+	ctx context.Context,
+	req kkComps.CreateAIGatewayMCPServerRequest,
+	namespace string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	gatewayID, err := a.getAIGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return "", err
+	}
+	return a.client.CreateAIGatewayMCPServer(ctx, gatewayID, req, namespace)
+}
+
+// Update updates an AI Gateway MCP Server.
+func (a *AIGatewayMCPServerAdapter) Update(
+	ctx context.Context,
+	id string,
+	req kkComps.UpdateAIGatewayMCPServerRequest,
+	namespace string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	gatewayID, err := a.getAIGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return "", err
+	}
+	return a.client.UpdateAIGatewayMCPServer(ctx, gatewayID, id, req, namespace)
+}
+
+// Delete deletes an AI Gateway MCP Server.
+func (a *AIGatewayMCPServerAdapter) Delete(ctx context.Context, id string, execCtx *ExecutionContext) error {
+	gatewayID, err := a.getAIGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return err
+	}
+	return a.client.DeleteAIGatewayMCPServer(ctx, gatewayID, id)
+}
+
+// GetByID gets an AI Gateway MCP Server by ID.
+func (a *AIGatewayMCPServerAdapter) GetByID(
+	ctx context.Context,
+	id string,
+	execCtx *ExecutionContext,
+) (ResourceInfo, error) {
+	gatewayID, err := a.getAIGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return nil, err
+	}
+	server, err := a.client.GetAIGatewayMCPServer(ctx, gatewayID, id)
+	if err != nil {
+		return nil, err
+	}
+	if server == nil {
+		return nil, nil
+	}
+	return &aiGatewayMCPServerResourceInfo{server: server}, nil
+}
+
+// GetByName is not supported without a parent gateway context.
+func (a *AIGatewayMCPServerAdapter) GetByName(_ context.Context, _ string) (ResourceInfo, error) {
+	return nil, fmt.Errorf("GetByName not supported for AI Gateway MCP Servers")
+}
+
+// ResourceType returns the resource type.
+func (a *AIGatewayMCPServerAdapter) ResourceType() string {
+	return planner.ResourceTypeAIGatewayMCPServer
+}
+
+// RequiredFields returns required fields for create.
+func (a *AIGatewayMCPServerAdapter) RequiredFields() []string {
+	return []string{planner.FieldType, planner.FieldName, planner.FieldDisplayName}
+}
+
+// SupportsUpdate indicates update support.
+func (a *AIGatewayMCPServerAdapter) SupportsUpdate() bool {
+	return true
+}
+
+func (a *AIGatewayMCPServerAdapter) getAIGatewayIDFromExecutionContext(execCtx *ExecutionContext) (string, error) {
+	if execCtx == nil || execCtx.PlannedChange == nil {
+		return "", fmt.Errorf("execution context required")
+	}
+
+	change := *execCtx.PlannedChange
+	if gatewayRef, ok := change.References[planner.FieldAIGatewayID]; ok && !unresolvedReferenceID(gatewayRef.ID) {
+		return gatewayRef.ID, nil
+	}
+	if change.Parent != nil && !unresolvedReferenceID(change.Parent.ID) {
+		return change.Parent.ID, nil
+	}
+
+	return "", fmt.Errorf("AI Gateway ID required for MCP Server operations")
+}
+
+type aiGatewayMCPServerResourceInfo struct {
+	server *state.AIGatewayMCPServer
+}
+
+func (a *aiGatewayMCPServerResourceInfo) GetID() string {
+	return resources.AIGatewayMCPServerID(a.server.AIGatewayMCPServer)
+}
+
+func (a *aiGatewayMCPServerResourceInfo) GetName() string {
+	return resources.AIGatewayMCPServerName(a.server.AIGatewayMCPServer)
+}
+
+func (a *aiGatewayMCPServerResourceInfo) GetLabels() map[string]string {
+	return resources.AIGatewayMCPServerLabels(a.server.AIGatewayMCPServer)
+}
+
+func (a *aiGatewayMCPServerResourceInfo) GetNormalizedLabels() map[string]string {
+	return a.server.NormalizedLabels
+}

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -57,6 +57,8 @@ type Executor struct {
 		kkComps.UpdateAIGatewayProviderRequest]
 	aiGatewayModelExecutor *BaseExecutor[
 		kkComps.CreateAIGatewayModelRequest, kkComps.UpdateAIGatewayModelRequest]
+	aiGatewayMCPServerExecutor *BaseExecutor[
+		kkComps.CreateAIGatewayMCPServerRequest, kkComps.UpdateAIGatewayMCPServerRequest]
 	dashboardExecutor                      *BaseExecutor[kkComps.DashboardUpdateRequest, kkComps.DashboardUpdateRequest]
 	eventGatewayControlPlaneExecutor       *BaseExecutor[kkComps.CreateGatewayRequest, kkComps.UpdateGatewayRequest]
 	organizationTeamExecutor               *BaseExecutor[kkComps.CreateTeam, kkComps.UpdateTeam]
@@ -245,6 +247,12 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 	e.aiGatewayModelExecutor = NewBaseExecutor[
 		kkComps.CreateAIGatewayModelRequest, kkComps.UpdateAIGatewayModelRequest](
 		NewAIGatewayModelAdapter(client),
+		client,
+		dryRun,
+	)
+	e.aiGatewayMCPServerExecutor = NewBaseExecutor[
+		kkComps.CreateAIGatewayMCPServerRequest, kkComps.UpdateAIGatewayMCPServerRequest](
+		NewAIGatewayMCPServerAdapter(client),
 		client,
 		dryRun,
 	)
@@ -2327,6 +2335,11 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 			return "", err
 		}
 		return e.aiGatewayModelExecutor.Create(ctx, *change)
+	case planner.ResourceTypeAIGatewayMCPServer:
+		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
+			return "", err
+		}
+		return e.aiGatewayMCPServerExecutor.Create(ctx, *change)
 	case planner.ResourceTypeDashboard:
 		return e.dashboardExecutor.Create(ctx, *change)
 	case planner.ResourceTypeDCRProvider:
@@ -2919,6 +2932,11 @@ func (e *Executor) updateResource(ctx context.Context, change *planner.PlannedCh
 			return "", err
 		}
 		return e.aiGatewayModelExecutor.Update(ctx, *change)
+	case planner.ResourceTypeAIGatewayMCPServer:
+		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
+			return "", err
+		}
+		return e.aiGatewayMCPServerExecutor.Update(ctx, *change)
 	case planner.ResourceTypeDashboard:
 		return e.dashboardExecutor.Update(ctx, *change)
 	case planner.ResourceTypeAPIDocument:
@@ -3390,6 +3408,8 @@ func (e *Executor) deleteResource(ctx context.Context, change *planner.PlannedCh
 		return e.aiGatewayProviderExecutor.Delete(ctx, *change)
 	case planner.ResourceTypeAIGatewayModel:
 		return e.aiGatewayModelExecutor.Delete(ctx, *change)
+	case planner.ResourceTypeAIGatewayMCPServer:
+		return e.aiGatewayMCPServerExecutor.Delete(ctx, *change)
 	case planner.ResourceTypeDashboard:
 		return e.dashboardExecutor.Delete(ctx, *change)
 	case planner.ResourceTypeAPIVersion:

--- a/internal/declarative/loader/ai_gateway_mcp_server_test.go
+++ b/internal/declarative/loader/ai_gateway_mcp_server_test.go
@@ -1,0 +1,125 @@
+package loader
+
+import (
+	"testing"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/tags"
+	"github.com/stretchr/testify/require"
+)
+
+const aiGatewayMCPServerYAML = `
+ai_gateways:
+  - ref: support-gateway
+    display_name: Support Gateway
+    mcp_servers:
+      - ref: support-tools
+        type: conversion-only
+        name: support-tools
+        display_name: Support Tools
+        enabled: true
+        config:
+          url: https://support-tools.example.com
+        tools:
+          - name: lookup-customer
+            description: Look up a customer profile
+            method: GET
+            path: /customers/{customer_id}
+        policies: []
+`
+
+func TestLoaderExtractsNestedAIGatewayMCPServers(t *testing.T) {
+	path := writeLoaderTestFile(t, aiGatewayMCPServerYAML)
+
+	rs, err := New().LoadFromSources([]Source{{Path: path, Type: SourceTypeFile}}, false)
+	require.NoError(t, err)
+	require.Len(t, rs.AIGateways, 1)
+	require.Empty(t, rs.AIGateways[0].MCPServers)
+	require.Len(t, rs.AIGatewayMCPServers, 1)
+	require.Equal(t, "support-gateway", rs.AIGatewayMCPServers[0].AIGateway)
+	require.Equal(t, "support-tools", rs.AIGatewayMCPServers[0].Name())
+	require.True(t, rs.SyncScope.ChildInScope(
+		resources.ResourceTypeAIGateway,
+		"support-gateway",
+		resources.ResourceTypeAIGatewayMCPServer,
+	))
+}
+
+func TestLoaderValidatesAIGatewayMCPServerParentAndDuplicates(t *testing.T) {
+	rootOnly := `
+ai_gateway_mcp_servers:
+  - ref: support-tools
+    ai_gateway: missing-gateway
+    type: conversion-only
+    name: support-tools
+    display_name: Support Tools
+    config: {url: https://support-tools.example.com}
+    tools: [{name: lookup-customer, description: Look up a customer profile, method: GET}]
+    policies: []
+`
+	_, err := New().LoadFromSources([]Source{{Path: writeLoaderTestFile(t, rootOnly), Type: SourceTypeFile}}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "references unknown ai_gateway")
+
+	duplicates := `
+ai_gateways:
+  - ref: support-gateway
+    display_name: Support Gateway
+    mcp_servers:
+      - ref: support-tools
+        type: conversion-only
+        name: support-tools
+        display_name: Support Tools
+        config: {url: https://support-tools.example.com}
+        tools: [{name: lookup-customer, description: Look up a customer profile, method: GET}]
+        policies: []
+      - ref: support-tools-2
+        type: conversion-only
+        name: support-tools
+        display_name: Support Tools 2
+        config: {url: https://support-tools.example.com}
+        tools: [{name: lookup-customer, description: Look up a customer profile, method: GET}]
+        policies: []
+`
+	_, err = New().LoadFromSources([]Source{{Path: writeLoaderTestFile(t, duplicates), Type: SourceTypeFile}}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate ai_gateway_mcp_server name")
+}
+
+func TestLoaderRejectsRootLevelEmptyAIGatewayMCPServers(t *testing.T) {
+	input := `ai_gateway_mcp_servers: []`
+
+	_, err := New().LoadFromSources([]Source{{Path: writeLoaderTestFile(t, input), Type: SourceTypeFile}}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ai_gateway_mcp_servers cannot be empty")
+}
+
+func TestLoaderAcceptsAIGatewayMCPServerDeferredExternalParentRef(t *testing.T) {
+	input := `
+ai_gateways:
+  - ref: external-shared-gateway
+    _external:
+      selector:
+        matchFields:
+          display_name: Shared Gateway
+ai_gateway_mcp_servers:
+  - ref: support-tools
+    ai_gateway: !ref external-shared-gateway#id
+    type: conversion-only
+    name: support-tools
+    display_name: Support Tools
+    config: {url: https://support-tools.example.com}
+    tools: [{name: lookup-customer, description: Look up a customer profile, method: GET}]
+    policies: []
+`
+
+	rs, err := New().LoadFromSources([]Source{{Path: writeLoaderTestFile(t, input), Type: SourceTypeFile}}, false)
+	require.NoError(t, err)
+	require.Len(t, rs.AIGatewayMCPServers, 1)
+	require.Equal(t, tags.RefPlaceholderPrefix+"external-shared-gateway#id", rs.AIGatewayMCPServers[0].AIGateway)
+	require.True(t, rs.SyncScope.ChildInScope(
+		resources.ResourceTypeAIGateway,
+		"external-shared-gateway",
+		resources.ResourceTypeAIGatewayMCPServer,
+	))
+}

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -1035,6 +1035,13 @@ func (l *Loader) extractNestedResources(rs *resources.ResourceSet) {
 			rs.AIGatewayModels = append(rs.AIGatewayModels, model)
 		}
 		gateway.Models = nil
+
+		for j := range gateway.MCPServers {
+			server := gateway.MCPServers[j]
+			server.AIGateway = gateway.Ref
+			rs.AIGatewayMCPServers = append(rs.AIGatewayMCPServers, server)
+		}
+		gateway.MCPServers = nil
 	}
 
 	for i := range rs.APIs {

--- a/internal/declarative/loader/sync_scope.go
+++ b/internal/declarative/loader/sync_scope.go
@@ -44,6 +44,12 @@ var rootChildCollectionScopes = []childCollectionScope{
 		parentType:   resources.ResourceTypeAIGateway,
 	},
 	{
+		key:          "ai_gateway_mcp_servers",
+		resourceType: resources.ResourceTypeAIGatewayMCPServer,
+		parentKey:    resources.SchemaFieldAIGateway,
+		parentType:   resources.ResourceTypeAIGateway,
+	},
+	{
 		key:          "control_plane_data_plane_certificates",
 		resourceType: resources.ResourceTypeControlPlaneDataPlaneCertificate,
 		parentKey:    "control_plane",
@@ -331,6 +337,11 @@ var aiGatewayChildCollectionScopes = []childCollectionScope{
 		resourceType: resources.ResourceTypeAIGatewayModel,
 		parentType:   resources.ResourceTypeAIGateway,
 	},
+	{
+		key:          "mcp_servers",
+		resourceType: resources.ResourceTypeAIGatewayMCPServer,
+		parentType:   resources.ResourceTypeAIGateway,
+	},
 }
 
 var eventGatewayChildCollectionScopes = []childCollectionScope{
@@ -449,6 +460,9 @@ func captureRootChildScope(scope *resources.SyncScope, raw map[string]any, entry
 	if !ok || len(items) == 0 {
 		if entry.resourceType == resources.ResourceTypeAIGatewayModel {
 			return fmt.Errorf("%s cannot be empty because each model must declare an ai_gateway parent", entry.key)
+		}
+		if entry.resourceType == resources.ResourceTypeAIGatewayMCPServer {
+			return fmt.Errorf("%s cannot be empty because each MCP Server must declare an ai_gateway parent", entry.key)
 		}
 		scope.AddRootChildCollection(entry.resourceType)
 		return nil

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -50,6 +50,9 @@ func (l *Loader) validateResourceSet(rs *resources.ResourceSet) error {
 	if err := l.validateAIGatewayModels(rs); err != nil {
 		return err
 	}
+	if err := l.validateAIGatewayMCPServers(rs); err != nil {
+		return err
+	}
 
 	// Validate dashboards
 	if err := l.validateDashboards(rs.Dashboards, rs); err != nil {
@@ -823,6 +826,58 @@ func (l *Loader) validateAIGatewayModels(rs *resources.ResourceSet) error {
 			)
 		}
 		modelNamesByGateway[nameKey] = model.GetRef()
+	}
+
+	return nil
+}
+
+// validateAIGatewayMCPServers validates AI Gateway child MCP Server resources.
+func (l *Loader) validateAIGatewayMCPServers(rs *resources.ResourceSet) error {
+	namesByGateway := make(map[string]string)
+
+	for i := range rs.AIGatewayMCPServers {
+		server := &rs.AIGatewayMCPServers[i]
+
+		if err := server.Validate(); err != nil {
+			return fmt.Errorf("invalid ai_gateway_mcp_server %q: %w", server.GetRef(), err)
+		}
+
+		if existing, found := rs.GetResourceByRef(server.GetRef()); found {
+			if existing.GetType() != resources.ResourceTypeAIGatewayMCPServer {
+				return fmt.Errorf("duplicate ref '%s' (already defined as %s)",
+					server.GetRef(), existing.GetType())
+			}
+		}
+
+		gatewayRef := resources.NormalizeResourceRef(server.AIGateway)
+		gateway, found := rs.GetResourceByRef(gatewayRef)
+		if !found {
+			return fmt.Errorf(
+				"ai_gateway_mcp_server %q references unknown ai_gateway %q",
+				server.GetRef(),
+				server.AIGateway,
+			)
+		}
+		if gateway.GetType() != resources.ResourceTypeAIGateway {
+			return fmt.Errorf(
+				"ai_gateway_mcp_server %q references %q which is %s, not ai_gateway",
+				server.GetRef(),
+				server.AIGateway,
+				gateway.GetType(),
+			)
+		}
+
+		nameKey := gatewayRef + "\x00" + server.Name()
+		if existingRef, exists := namesByGateway[nameKey]; exists {
+			return fmt.Errorf(
+				"duplicate ai_gateway_mcp_server name %q for ai_gateway %q (ref: %s conflicts with ref: %s)",
+				server.Name(),
+				gatewayRef,
+				server.GetRef(),
+				existingRef,
+			)
+		}
+		namesByGateway[nameKey] = server.GetRef()
 	}
 
 	return nil

--- a/internal/declarative/planner/ai_gateway_mcp_server_planner.go
+++ b/internal/declarative/planner/ai_gateway_mcp_server_planner.go
@@ -1,0 +1,274 @@
+package planner
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"maps"
+	"reflect"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/util"
+)
+
+func (p *Planner) planAIGatewayMCPServerChanges(
+	ctx context.Context,
+	namespace string,
+	gatewayRef string,
+	gatewayName string,
+	gatewayID string,
+	gatewayChangeID string,
+	desired []resources.AIGatewayMCPServerResource,
+	plan *Plan,
+) error {
+	p.logger.Debug(
+		"Planning AI Gateway MCP Server changes",
+		slog.String("gateway_ref", gatewayRef),
+		slog.String("gateway_id", gatewayID),
+		slog.String("gateway_change_id", gatewayChangeID),
+		slog.Int("desired_count", len(desired)),
+	)
+
+	if gatewayID == "" {
+		p.planAIGatewayMCPServerCreatesForNewGateway(namespace, gatewayRef, gatewayName, gatewayChangeID, desired, plan)
+		return nil
+	}
+
+	currentServers, err := p.client.ListAIGatewayMCPServers(ctx, gatewayID)
+	if err != nil {
+		return fmt.Errorf("failed to list AI Gateway MCP Servers for gateway %s: %w", gatewayID, err)
+	}
+
+	currentByID, currentByName := indexAIGatewayMCPServers(currentServers)
+	desiredKeys := make(map[string]bool)
+
+	for _, desiredServer := range desired {
+		current, exists := matchCurrentAIGatewayMCPServer(desiredServer, currentByID, currentByName)
+		desiredKeys[desiredServer.Name()] = true
+		if id := aiGatewayMCPServerDesiredID(desiredServer); id != "" {
+			desiredKeys[id] = true
+		}
+
+		if !exists {
+			p.planAIGatewayMCPServerCreate(namespace, gatewayRef, gatewayName, gatewayID, desiredServer, nil, plan)
+			continue
+		}
+
+		serverID := resources.AIGatewayMCPServerID(current.AIGatewayMCPServer)
+		fullServer, err := p.client.GetAIGatewayMCPServer(ctx, gatewayID, serverID)
+		if err != nil {
+			return fmt.Errorf("failed to get AI Gateway MCP Server %s: %w", serverID, err)
+		}
+		if fullServer == nil {
+			p.planAIGatewayMCPServerCreate(namespace, gatewayRef, gatewayName, gatewayID, desiredServer, nil, plan)
+			continue
+		}
+
+		needsUpdate, updateFields, changedFields, err := shouldUpdateAIGatewayMCPServer(*fullServer, desiredServer)
+		if err != nil {
+			return err
+		}
+		if needsUpdate {
+			p.planAIGatewayMCPServerUpdate(
+				namespace,
+				gatewayRef,
+				gatewayID,
+				serverID,
+				desiredServer,
+				updateFields,
+				changedFields,
+				plan,
+			)
+		}
+	}
+
+	if plan.Metadata.Mode == PlanModeSync {
+		for _, current := range currentServers {
+			serverID := resources.AIGatewayMCPServerID(current.AIGatewayMCPServer)
+			serverName := resources.AIGatewayMCPServerName(current.AIGatewayMCPServer)
+			if desiredKeys[serverID] || desiredKeys[serverName] {
+				continue
+			}
+			p.planAIGatewayMCPServerDelete(gatewayRef, gatewayID, serverID, serverName, plan)
+		}
+	}
+
+	return nil
+}
+
+func (p *Planner) planAIGatewayMCPServerCreatesForNewGateway(
+	namespace string,
+	gatewayRef string,
+	gatewayName string,
+	gatewayChangeID string,
+	servers []resources.AIGatewayMCPServerResource,
+	plan *Plan,
+) {
+	var dependsOn []string
+	if gatewayChangeID != "" {
+		dependsOn = []string{gatewayChangeID}
+	}
+	for _, server := range servers {
+		p.planAIGatewayMCPServerCreate(namespace, gatewayRef, gatewayName, "", server, dependsOn, plan)
+	}
+}
+
+func (p *Planner) planAIGatewayMCPServerCreate(
+	namespace string,
+	gatewayRef string,
+	gatewayName string,
+	gatewayID string,
+	server resources.AIGatewayMCPServerResource,
+	dependsOn []string,
+	plan *Plan,
+) {
+	fields, err := server.MutablePayloadMap()
+	if err != nil {
+		plan.AddWarning(server.GetRef(), fmt.Sprintf("failed to build AI Gateway MCP Server create payload: %s", err))
+		return
+	}
+
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionCreate, ResourceTypeAIGatewayMCPServer, server.Ref),
+		ResourceType: ResourceTypeAIGatewayMCPServer,
+		ResourceRef:  server.Ref,
+		Action:       ActionCreate,
+		Fields:       fields,
+		Namespace:    namespace,
+		DependsOn:    dependsOn,
+	}
+	if gatewayID != "" {
+		change.Parent = &ParentInfo{Ref: gatewayRef, ID: gatewayID}
+	} else {
+		change.References = map[string]ReferenceInfo{
+			FieldAIGatewayID: {
+				Ref: gatewayRef,
+				LookupFields: map[string]string{
+					FieldDisplayName: gatewayName,
+				},
+			},
+		}
+	}
+
+	plan.AddChange(change)
+}
+
+func (p *Planner) planAIGatewayMCPServerUpdate(
+	namespace string,
+	gatewayRef string,
+	gatewayID string,
+	serverID string,
+	server resources.AIGatewayMCPServerResource,
+	updateFields map[string]any,
+	changedFields map[string]FieldChange,
+	plan *Plan,
+) {
+	change := PlannedChange{
+		ID:            p.nextChangeID(ActionUpdate, ResourceTypeAIGatewayMCPServer, server.Ref),
+		ResourceType:  ResourceTypeAIGatewayMCPServer,
+		ResourceRef:   server.Ref,
+		ResourceID:    serverID,
+		Action:        ActionUpdate,
+		Fields:        updateFields,
+		ChangedFields: changedFields,
+		Namespace:     namespace,
+		Parent:        &ParentInfo{Ref: gatewayRef, ID: gatewayID},
+	}
+	plan.AddChange(change)
+}
+
+func (p *Planner) planAIGatewayMCPServerDelete(
+	gatewayRef string,
+	gatewayID string,
+	serverID string,
+	serverName string,
+	plan *Plan,
+) {
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionDelete, ResourceTypeAIGatewayMCPServer, serverName),
+		ResourceType: ResourceTypeAIGatewayMCPServer,
+		ResourceRef:  serverName,
+		ResourceID:   serverID,
+		Action:       ActionDelete,
+		Fields: map[string]any{
+			FieldName: serverName,
+		},
+		Parent: &ParentInfo{Ref: gatewayRef, ID: gatewayID},
+	}
+	plan.AddChange(change)
+}
+
+func shouldUpdateAIGatewayMCPServer(
+	current state.AIGatewayMCPServer,
+	desired resources.AIGatewayMCPServerResource,
+) (bool, map[string]any, map[string]FieldChange, error) {
+	currentPayload, err := resources.AIGatewayMCPServerMutablePayloadMap(current.AIGatewayMCPServer)
+	if err != nil {
+		return false, nil, nil, fmt.Errorf("failed to normalize current AI Gateway MCP Server: %w", err)
+	}
+	desiredPayload, err := desired.MutablePayloadMap()
+	if err != nil {
+		return false, nil, nil, fmt.Errorf("failed to normalize desired AI Gateway MCP Server %q: %w", desired.Ref, err)
+	}
+
+	changedFields := make(map[string]FieldChange)
+	keys := make(map[string]struct{}, len(currentPayload)+len(desiredPayload))
+	for key := range currentPayload {
+		keys[key] = struct{}{}
+	}
+	for key := range desiredPayload {
+		keys[key] = struct{}{}
+	}
+	for key := range keys {
+		if !reflect.DeepEqual(currentPayload[key], desiredPayload[key]) {
+			changedFields[key] = FieldChange{Old: currentPayload[key], New: desiredPayload[key]}
+		}
+	}
+	if len(changedFields) == 0 {
+		return false, nil, nil, nil
+	}
+
+	updateFields := make(map[string]any, len(desiredPayload))
+	maps.Copy(updateFields, desiredPayload)
+	return true, updateFields, changedFields, nil
+}
+
+func indexAIGatewayMCPServers(
+	servers []state.AIGatewayMCPServer,
+) (map[string]state.AIGatewayMCPServer, map[string]state.AIGatewayMCPServer) {
+	byID := make(map[string]state.AIGatewayMCPServer)
+	byName := make(map[string]state.AIGatewayMCPServer)
+	for _, server := range servers {
+		if id := resources.AIGatewayMCPServerID(server.AIGatewayMCPServer); id != "" {
+			byID[id] = server
+		}
+		if name := resources.AIGatewayMCPServerName(server.AIGatewayMCPServer); name != "" {
+			byName[name] = server
+		}
+	}
+	return byID, byName
+}
+
+func matchCurrentAIGatewayMCPServer(
+	desired resources.AIGatewayMCPServerResource,
+	currentByID map[string]state.AIGatewayMCPServer,
+	currentByName map[string]state.AIGatewayMCPServer,
+) (state.AIGatewayMCPServer, bool) {
+	if id := aiGatewayMCPServerDesiredID(desired); id != "" {
+		current, exists := currentByID[id]
+		return current, exists
+	}
+	current, exists := currentByName[desired.Name()]
+	return current, exists
+}
+
+func aiGatewayMCPServerDesiredID(desired resources.AIGatewayMCPServerResource) string {
+	if id := desired.GetKonnectID(); id != "" {
+		return id
+	}
+	if util.IsValidUUID(desired.Ref) {
+		return desired.Ref
+	}
+	return ""
+}

--- a/internal/declarative/planner/ai_gateway_mcp_server_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_mcp_server_planner_test.go
@@ -17,7 +17,7 @@ func TestAIGatewayMCPServerPlannerCreatesChildForExistingGateway(t *testing.T) {
 	server := testAIGatewayMCPServerResource(t)
 	client := state.NewClient(state.ClientConfig{
 		AIGatewayAPI: &testAIGatewayAPI{
-			gateways: []kkComps.AIGateway{testAIGateway("gateway-id", "Support Gateway")},
+			gateways: []kkComps.AIGateway{testAIGateway()},
 		},
 		AIGatewayMCPServersAPI: &testAIGatewayMCPServerAPI{},
 	})
@@ -54,7 +54,7 @@ func TestAIGatewayMCPServerPlannerSyncDeletesScopedServers(t *testing.T) {
 	scope.AddChild(resources.ResourceTypeAIGateway, "support-gateway", resources.ResourceTypeAIGatewayMCPServer)
 	client := state.NewClient(state.ClientConfig{
 		AIGatewayAPI: &testAIGatewayAPI{
-			gateways: []kkComps.AIGateway{testAIGateway("gateway-id", "Support Gateway")},
+			gateways: []kkComps.AIGateway{testAIGateway()},
 		},
 		AIGatewayMCPServersAPI: &testAIGatewayMCPServerAPI{
 			servers: []kkComps.AIGatewayMCPServer{testAIGatewayMCPServer(t, "server-id", "support-tools")},

--- a/internal/declarative/planner/ai_gateway_mcp_server_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_mcp_server_planner_test.go
@@ -1,0 +1,174 @@
+package planner
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAIGatewayMCPServerPlannerCreatesChildForExistingGateway(t *testing.T) {
+	server := testAIGatewayMCPServerResource(t)
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{
+			gateways: []kkComps.AIGateway{testAIGateway("gateway-id", "Support Gateway")},
+		},
+		AIGatewayMCPServersAPI: &testAIGatewayMCPServerAPI{},
+	})
+	rs := &resources.ResourceSet{
+		AIGateways: []resources.AIGatewayResource{{
+			BaseResource: resources.BaseResource{
+				Ref:     "support-gateway",
+				Kongctl: &resources.KongctlMeta{Namespace: new("default")},
+			},
+			CreateAIGatewayRequest: kkComps.CreateAIGatewayRequest{
+				Name:        "support-gateway",
+				DisplayName: "Support Gateway",
+			},
+		}},
+		AIGatewayMCPServers: []resources.AIGatewayMCPServerResource{server},
+	}
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	change := plan.Changes[0]
+	require.Equal(t, ActionCreate, change.Action)
+	require.Equal(t, ResourceTypeAIGatewayMCPServer, change.ResourceType)
+	require.Equal(t, "support-tools", change.ResourceRef)
+	require.NotNil(t, change.Parent)
+	require.Equal(t, "gateway-id", change.Parent.ID)
+	require.Equal(t, "support-gateway", change.Parent.Ref)
+	require.Equal(t, "conversion-only", change.Fields[FieldType])
+}
+
+func TestAIGatewayMCPServerPlannerSyncDeletesScopedServers(t *testing.T) {
+	scope := resources.NewSyncScope()
+	scope.AddRoot(resources.ResourceTypeAIGateway)
+	scope.AddChild(resources.ResourceTypeAIGateway, "support-gateway", resources.ResourceTypeAIGatewayMCPServer)
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{
+			gateways: []kkComps.AIGateway{testAIGateway("gateway-id", "Support Gateway")},
+		},
+		AIGatewayMCPServersAPI: &testAIGatewayMCPServerAPI{
+			servers: []kkComps.AIGatewayMCPServer{testAIGatewayMCPServer(t, "server-id", "support-tools")},
+		},
+	})
+	rs := &resources.ResourceSet{
+		AIGateways: []resources.AIGatewayResource{{
+			BaseResource: resources.BaseResource{
+				Ref:     "support-gateway",
+				Kongctl: &resources.KongctlMeta{Namespace: new("default")},
+			},
+			CreateAIGatewayRequest: kkComps.CreateAIGatewayRequest{
+				Name:        "support-gateway",
+				DisplayName: "Support Gateway",
+			},
+		}},
+		SyncScope: scope,
+	}
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeSync})
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	change := plan.Changes[0]
+	require.Equal(t, ActionDelete, change.Action)
+	require.Equal(t, ResourceTypeAIGatewayMCPServer, change.ResourceType)
+	require.Equal(t, "server-id", change.ResourceID)
+	require.NotNil(t, change.Parent)
+	require.Equal(t, "gateway-id", change.Parent.ID)
+}
+
+func testAIGatewayMCPServerResource(t *testing.T) resources.AIGatewayMCPServerResource {
+	t.Helper()
+	payload := `{
+		"ref": "support-tools",
+		"ai_gateway": "support-gateway",
+		"type": "conversion-only",
+		"name": "support-tools",
+		"display_name": "Support Tools",
+		"enabled": true,
+		"config": {"url": "https://support-tools.example.com"},
+		"tools": [{"name": "lookup-customer", "description": "Look up a customer profile", "method": "GET"}],
+		"policies": []
+	}`
+	var server resources.AIGatewayMCPServerResource
+	require.NoError(t, json.Unmarshal([]byte(payload), &server))
+	return server
+}
+
+func testAIGatewayMCPServer(t *testing.T, id string, name string) kkComps.AIGatewayMCPServer {
+	t.Helper()
+	payload := `{
+		"id": "` + id + `",
+		"type": "conversion-only",
+		"name": "` + name + `",
+		"display_name": "` + name + `",
+		"enabled": true,
+		"config": {"url": "https://support-tools.example.com"},
+		"tools": [{"name": "lookup-customer", "description": "Look up a customer profile", "method": "GET"}],
+		"policies": [],
+		"created_at": "2026-01-01T00:00:00Z",
+		"updated_at": "2026-01-01T00:00:00Z"
+	}`
+	var server kkComps.AIGatewayMCPServer
+	require.NoError(t, json.Unmarshal([]byte(payload), &server))
+	return server
+}
+
+type testAIGatewayMCPServerAPI struct {
+	servers []kkComps.AIGatewayMCPServer
+}
+
+func (t *testAIGatewayMCPServerAPI) ListAiGatewayMcpServers(
+	context.Context,
+	kkOps.ListAiGatewayMcpServersRequest,
+	...kkOps.Option,
+) (*kkOps.ListAiGatewayMcpServersResponse, error) {
+	return &kkOps.ListAiGatewayMcpServersResponse{
+		ListAIGatewayMCPServersResponse: &kkComps.ListAIGatewayMCPServersResponse{
+			Data: t.servers,
+		},
+	}, nil
+}
+
+func (t *testAIGatewayMCPServerAPI) CreateAiGatewayMcpServer(
+	context.Context,
+	string,
+	kkComps.CreateAIGatewayMCPServerRequest,
+	...kkOps.Option,
+) (*kkOps.CreateAiGatewayMcpServerResponse, error) {
+	return nil, nil
+}
+
+func (t *testAIGatewayMCPServerAPI) GetAiGatewayMcpServer(
+	context.Context,
+	string,
+	string,
+	...kkOps.Option,
+) (*kkOps.GetAiGatewayMcpServerResponse, error) {
+	return nil, nil
+}
+
+func (t *testAIGatewayMCPServerAPI) UpdateAiGatewayMcpServer(
+	context.Context,
+	kkOps.UpdateAiGatewayMcpServerRequest,
+	...kkOps.Option,
+) (*kkOps.UpdateAiGatewayMcpServerResponse, error) {
+	return nil, nil
+}
+
+func (t *testAIGatewayMCPServerAPI) DeleteAiGatewayMcpServer(
+	context.Context,
+	string,
+	string,
+	...kkOps.Option,
+) (*kkOps.DeleteAiGatewayMcpServerResponse, error) {
+	return nil, nil
+}

--- a/internal/declarative/planner/ai_gateway_model_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_model_planner_test.go
@@ -19,7 +19,7 @@ func TestAIGatewayModelPlannerCreatesChildForExistingGateway(t *testing.T) {
 	model := testAIGatewayModelResource(t)
 	client := state.NewClient(state.ClientConfig{
 		AIGatewayAPI: &testAIGatewayAPI{
-			gateways: []kkComps.AIGateway{testAIGateway("gateway-id", "Support Gateway")},
+			gateways: []kkComps.AIGateway{testAIGateway()},
 		},
 		AIGatewayModelAPI: &testAIGatewayModelAPI{},
 	})
@@ -93,7 +93,7 @@ func TestAIGatewayModelPlannerSyncDeletesScopedModels(t *testing.T) {
 	scope.AddChild(resources.ResourceTypeAIGateway, "support-gateway", resources.ResourceTypeAIGatewayModel)
 	client := state.NewClient(state.ClientConfig{
 		AIGatewayAPI: &testAIGatewayAPI{
-			gateways: []kkComps.AIGateway{testAIGateway("gateway-id", "Support Gateway")},
+			gateways: []kkComps.AIGateway{testAIGateway()},
 		},
 		AIGatewayModelAPI: &testAIGatewayModelAPI{
 			models: []kkComps.AIGatewayModel{testAIGatewayModel("model-id", "support-gpt")},
@@ -204,7 +204,11 @@ func testAIGatewayModelResource(t *testing.T) resources.AIGatewayModelResource {
 	return model
 }
 
-func testAIGateway(id string, displayName string) kkComps.AIGateway {
+func testAIGateway() kkComps.AIGateway {
+	const (
+		id          = "gateway-id"
+		displayName = "Support Gateway"
+	)
 	return kkComps.AIGateway{
 		ID:          id,
 		Name:        id,

--- a/internal/declarative/planner/ai_gateway_planner.go
+++ b/internal/declarative/planner/ai_gateway_planner.go
@@ -191,6 +191,27 @@ func (p *Planner) planAIGatewayChanges(
 				return err
 			}
 		}
+
+		mcpServers := p.resources.GetAIGatewayMCPServersForGateway(desiredGateway.Ref)
+		if p.shouldPlanChild(
+			plan,
+			resources.ResourceTypeAIGateway,
+			desiredGateway.Ref,
+			resources.ResourceTypeAIGatewayMCPServer,
+		) && (len(mcpServers) > 0 || plan.Metadata.Mode == PlanModeSync) {
+			if err := p.planAIGatewayMCPServerChanges(
+				ctx,
+				namespace,
+				desiredGateway.Ref,
+				desiredGateway.DisplayName,
+				gatewayID,
+				gatewayChangeID,
+				mcpServers,
+				plan,
+			); err != nil {
+				return err
+			}
+		}
 	}
 
 	if plan.Metadata.Mode == PlanModeSync {
@@ -262,6 +283,27 @@ func (p *Planner) planExternalAIGatewayChildren(
 			"",
 			providerCreateDepsByName,
 			models,
+			plan,
+		); err != nil {
+			return err
+		}
+	}
+
+	mcpServers := p.resources.GetAIGatewayMCPServersForGateway(desiredGateway.Ref)
+	if p.shouldPlanChild(
+		plan,
+		resources.ResourceTypeAIGateway,
+		desiredGateway.Ref,
+		resources.ResourceTypeAIGatewayMCPServer,
+	) && len(mcpServers) > 0 {
+		if err := p.planAIGatewayMCPServerChanges(
+			ctx,
+			namespace,
+			desiredGateway.Ref,
+			desiredGateway.DisplayName,
+			gatewayID,
+			"",
+			mcpServers,
 			plan,
 		); err != nil {
 			return err

--- a/internal/declarative/planner/constants.go
+++ b/internal/declarative/planner/constants.go
@@ -206,6 +206,7 @@ const (
 	ResourceTypeAIGateway                        = string(resources.ResourceTypeAIGateway)
 	ResourceTypeAIGatewayProvider                = string(resources.ResourceTypeAIGatewayProvider)
 	ResourceTypeAIGatewayModel                   = string(resources.ResourceTypeAIGatewayModel)
+	ResourceTypeAIGatewayMCPServer               = string(resources.ResourceTypeAIGatewayMCPServer)
 	ResourceTypeDashboard                        = string(resources.ResourceTypeDashboard)
 	ResourceTypeAPIVersion                       = string(resources.ResourceTypeAPIVersion)
 	ResourceTypeAPIPublication                   = string(resources.ResourceTypeAPIPublication)

--- a/internal/declarative/planner/dependencies.go
+++ b/internal/declarative/planner/dependencies.go
@@ -233,7 +233,7 @@ func (d *DependencyResolver) ResolveDependenciesWithGroups(
 
 func aiGatewayChildSerializationParentKey(change PlannedChange) string {
 	switch change.ResourceType {
-	case ResourceTypeAIGatewayProvider, ResourceTypeAIGatewayModel:
+	case ResourceTypeAIGatewayProvider, ResourceTypeAIGatewayModel, ResourceTypeAIGatewayMCPServer:
 	default:
 		return ""
 	}
@@ -337,7 +337,7 @@ func (d *DependencyResolver) getParentType(childType string) string {
 		return ResourceTypeAPI
 	case ResourceTypePortalPage:
 		return ResourceTypePortal
-	case ResourceTypeAIGatewayProvider, ResourceTypeAIGatewayModel:
+	case ResourceTypeAIGatewayProvider, ResourceTypeAIGatewayModel, ResourceTypeAIGatewayMCPServer:
 		return ResourceTypeAIGateway
 	default:
 		return ""

--- a/internal/declarative/planner/sync_scope.go
+++ b/internal/declarative/planner/sync_scope.go
@@ -162,6 +162,13 @@ func addAIGatewayChildScopes(scope *resources.SyncScope, rs *resources.ResourceS
 			resources.ResourceTypeAIGatewayModel,
 		)
 	}
+	for _, child := range rs.AIGatewayMCPServers {
+		scope.AddChild(
+			resources.ResourceTypeAIGateway,
+			resources.NormalizeResourceRef(child.AIGateway),
+			resources.ResourceTypeAIGatewayMCPServer,
+		)
+	}
 }
 
 func addEventGatewayChildScopes(scope *resources.SyncScope, rs *resources.ResourceSet) {

--- a/internal/declarative/protection/lookup.go
+++ b/internal/declarative/protection/lookup.go
@@ -155,7 +155,8 @@ func IsManagedResourceProtected(
 		resources.ResourceTypeEventGatewayStaticKey,
 		resources.ResourceTypeEventGatewayTLSTrustBundle,
 		resources.ResourceTypeAIGatewayProvider,
-		resources.ResourceTypeAIGatewayModel:
+		resources.ResourceTypeAIGatewayModel,
+		resources.ResourceTypeAIGatewayMCPServer:
 		return false, nil
 	}
 

--- a/internal/declarative/resources/ai_gateway.go
+++ b/internal/declarative/resources/ai_gateway.go
@@ -23,9 +23,10 @@ func init() {
 type AIGatewayResource struct {
 	BaseResource `yaml:",inline" json:",inline"`
 	kkComps.CreateAIGatewayRequest
-	External  *ExternalBlock              `yaml:"_external,omitempty" json:"_external,omitempty"`
-	Providers []AIGatewayProviderResource `yaml:"providers,omitempty" json:"providers,omitempty"`
-	Models    []AIGatewayModelResource    `yaml:"models,omitempty"    json:"models,omitempty"`
+	External   *ExternalBlock               `yaml:"_external,omitempty" json:"_external,omitempty"`
+	Providers  []AIGatewayProviderResource  `yaml:"providers,omitempty" json:"providers,omitempty"`
+	Models     []AIGatewayModelResource     `yaml:"models,omitempty"    json:"models,omitempty"`
+	MCPServers []AIGatewayMCPServerResource `yaml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
 }
 
 func (a AIGatewayResource) MarshalJSON() ([]byte, error) {
@@ -38,15 +39,16 @@ func (a AIGatewayResource) MarshalYAML() (any, error) {
 }
 
 type aiGatewayAlias struct {
-	Ref         string                      `json:"ref"                   yaml:"ref"`
-	Kongctl     *KongctlMeta                `json:"kongctl,omitempty"     yaml:"kongctl,omitempty"`
-	External    *ExternalBlock              `json:"_external,omitempty"   yaml:"_external,omitempty"`
-	DisplayName string                      `json:"display_name"          yaml:"display_name"`
-	Description *string                     `json:"description,omitempty" yaml:"description,omitempty"`
-	ProxyURLs   []kkComps.AIGatewayProxyURL `json:"proxy_urls,omitempty"  yaml:"proxy_urls,omitempty"`
-	Labels      map[string]string           `json:"labels,omitempty"      yaml:"labels,omitempty"`
-	Providers   []AIGatewayProviderResource `json:"providers,omitempty"   yaml:"providers,omitempty"`
-	Models      []AIGatewayModelResource    `json:"models,omitempty"      yaml:"models,omitempty"`
+	Ref         string                       `json:"ref"                   yaml:"ref"`
+	Kongctl     *KongctlMeta                 `json:"kongctl,omitempty"     yaml:"kongctl,omitempty"`
+	External    *ExternalBlock               `json:"_external,omitempty"   yaml:"_external,omitempty"`
+	DisplayName string                       `json:"display_name"          yaml:"display_name"`
+	Description *string                      `json:"description,omitempty" yaml:"description,omitempty"`
+	ProxyURLs   []kkComps.AIGatewayProxyURL  `json:"proxy_urls,omitempty"  yaml:"proxy_urls,omitempty"`
+	Labels      map[string]string            `json:"labels,omitempty"      yaml:"labels,omitempty"`
+	Providers   []AIGatewayProviderResource  `json:"providers,omitempty"   yaml:"providers,omitempty"`
+	Models      []AIGatewayModelResource     `json:"models,omitempty"      yaml:"models,omitempty"`
+	MCPServers  []AIGatewayMCPServerResource `json:"mcp_servers,omitempty" yaml:"mcp_servers,omitempty"`
 }
 
 func (a AIGatewayResource) aiGatewayAlias() aiGatewayAlias {
@@ -60,6 +62,7 @@ func (a AIGatewayResource) aiGatewayAlias() aiGatewayAlias {
 		Labels:      a.Labels,
 		Providers:   a.Providers,
 		Models:      a.Models,
+		MCPServers:  a.MCPServers,
 	}
 }
 
@@ -67,15 +70,16 @@ func (a AIGatewayResource) aiGatewayAlias() aiGatewayAlias {
 // type only carries JSON tags.
 func (a *AIGatewayResource) UnmarshalYAML(unmarshal func(any) error) error {
 	var raw struct {
-		Ref         string                      `yaml:"ref"`
-		Kongctl     *KongctlMeta                `yaml:"kongctl,omitempty"`
-		External    *ExternalBlock              `yaml:"_external,omitempty"`
-		DisplayName string                      `yaml:"display_name"`
-		Description *string                     `yaml:"description,omitempty"`
-		ProxyURLs   []kkComps.AIGatewayProxyURL `yaml:"proxy_urls,omitempty"`
-		Labels      map[string]string           `yaml:"labels,omitempty"`
-		Providers   []AIGatewayProviderResource `yaml:"providers,omitempty"`
-		Models      []AIGatewayModelResource    `yaml:"models,omitempty"`
+		Ref         string                       `yaml:"ref"`
+		Kongctl     *KongctlMeta                 `yaml:"kongctl,omitempty"`
+		External    *ExternalBlock               `yaml:"_external,omitempty"`
+		DisplayName string                       `yaml:"display_name"`
+		Description *string                      `yaml:"description,omitempty"`
+		ProxyURLs   []kkComps.AIGatewayProxyURL  `yaml:"proxy_urls,omitempty"`
+		Labels      map[string]string            `yaml:"labels,omitempty"`
+		Providers   []AIGatewayProviderResource  `yaml:"providers,omitempty"`
+		Models      []AIGatewayModelResource     `yaml:"models,omitempty"`
+		MCPServers  []AIGatewayMCPServerResource `yaml:"mcp_servers,omitempty"`
 	}
 	if err := unmarshal(&raw); err != nil {
 		return err
@@ -94,6 +98,7 @@ func (a *AIGatewayResource) UnmarshalYAML(unmarshal func(any) error) error {
 	}
 	a.Providers = raw.Providers
 	a.Models = raw.Models
+	a.MCPServers = raw.MCPServers
 
 	return nil
 }
@@ -102,15 +107,16 @@ func (a *AIGatewayResource) UnmarshalYAML(unmarshal func(any) error) error {
 // through JSON tags and the embedded SDK request type has a custom unmarshaler.
 func (a *AIGatewayResource) UnmarshalJSON(data []byte) error {
 	var raw struct {
-		Ref         string                      `json:"ref"`
-		Kongctl     *KongctlMeta                `json:"kongctl,omitempty"`
-		External    *ExternalBlock              `json:"_external,omitempty"`
-		DisplayName string                      `json:"display_name"`
-		Description *string                     `json:"description,omitempty"`
-		ProxyURLs   []kkComps.AIGatewayProxyURL `json:"proxy_urls,omitempty"`
-		Labels      map[string]string           `json:"labels,omitempty"`
-		Providers   []AIGatewayProviderResource `json:"providers,omitempty"`
-		Models      []AIGatewayModelResource    `json:"models,omitempty"`
+		Ref         string                       `json:"ref"`
+		Kongctl     *KongctlMeta                 `json:"kongctl,omitempty"`
+		External    *ExternalBlock               `json:"_external,omitempty"`
+		DisplayName string                       `json:"display_name"`
+		Description *string                      `json:"description,omitempty"`
+		ProxyURLs   []kkComps.AIGatewayProxyURL  `json:"proxy_urls,omitempty"`
+		Labels      map[string]string            `json:"labels,omitempty"`
+		Providers   []AIGatewayProviderResource  `json:"providers,omitempty"`
+		Models      []AIGatewayModelResource     `json:"models,omitempty"`
+		MCPServers  []AIGatewayMCPServerResource `json:"mcp_servers,omitempty"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
@@ -129,6 +135,7 @@ func (a *AIGatewayResource) UnmarshalJSON(data []byte) error {
 	}
 	a.Providers = raw.Providers
 	a.Models = raw.Models
+	a.MCPServers = raw.MCPServers
 
 	return nil
 }
@@ -188,6 +195,9 @@ func (a *AIGatewayResource) SetDefaults() {
 	for i := range a.Models {
 		a.Models[i].SetDefaults()
 	}
+	for i := range a.MCPServers {
+		a.MCPServers[i].SetDefaults()
+	}
 }
 
 // GetKonnectMonikerFilter returns the filter string for Konnect API lookup.
@@ -230,11 +240,20 @@ func aiGatewayExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
 		}, false, false),
 		explainField("providers", explainArrayOf(aiGatewayProviderInlineExplainNode()), false, false),
 		explainField("models", explainArrayOf(&ExplainNode{Kind: explainKindObject}), false, false),
+		explainField("mcp_servers", explainArrayOf(aiGatewayMCPServerInlineExplainNode()), false, false),
 	), nil
 }
 
 func aiGatewayProviderInlineExplainNode() *ExplainNode {
 	node, err := aiGatewayProviderExplainNode(ExplainBuildContext{})
+	if err != nil {
+		return explainObject()
+	}
+	return node
+}
+
+func aiGatewayMCPServerInlineExplainNode() *ExplainNode {
+	node, err := aiGatewayMCPServerExplainNode(ExplainBuildContext{})
 	if err != nil {
 		return explainObject()
 	}

--- a/internal/declarative/resources/ai_gateway_mcp_server.go
+++ b/internal/declarative/resources/ai_gateway_mcp_server.go
@@ -1,0 +1,448 @@
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/util"
+)
+
+const (
+	aiGatewayMCPServerFieldID          = "id"
+	aiGatewayMCPServerFieldName        = "name"
+	aiGatewayMCPServerFieldType        = "type"
+	aiGatewayMCPServerFieldDisplayName = "display_name"
+	aiGatewayMCPServerFieldEnabled     = "enabled"
+	aiGatewayMCPServerFieldLabels      = "labels"
+	aiGatewayMCPServerFieldUpdatedAt   = "updated_at"
+)
+
+func init() {
+	registerResourceType(
+		ResourceTypeAIGatewayMCPServer,
+		func(rs *ResourceSet) *[]AIGatewayMCPServerResource { return &rs.AIGatewayMCPServers },
+		AutoExplain[AIGatewayMCPServerResource](
+			WithExplainAliases(
+				"ai_gateway_mcp_servers",
+				"ai-gateway-mcp-server",
+				"ai-gateway-mcp-servers",
+				"ai_gateway.mcp_servers",
+				"aigw-mcp-server",
+			),
+			WithExplainRecommendedFields(
+				"ref",
+				SchemaFieldAIGateway,
+				"type",
+				"name",
+				"display_name",
+				"config",
+				"tools",
+			),
+			WithExplainSchemaBuilder(aiGatewayMCPServerExplainNode),
+		),
+	)
+}
+
+// AIGatewayMCPServerResource represents an MCP Server nested under a Konnect AI Gateway.
+type AIGatewayMCPServerResource struct {
+	BaseResource `yaml:",inline" json:",inline"`
+	// Parent AI Gateway reference for root-level declarations.
+	AIGateway string `yaml:"ai_gateway,omitempty" json:"ai_gateway,omitempty"`
+
+	kkComps.CreateAIGatewayMCPServerRequest `yaml:",inline" json:",inline"`
+}
+
+func (a AIGatewayMCPServerResource) GetType() ResourceType {
+	return ResourceTypeAIGatewayMCPServer
+}
+
+func (a AIGatewayMCPServerResource) GetMoniker() string {
+	return a.Name()
+}
+
+func (a AIGatewayMCPServerResource) GetDependencies() []ResourceRef {
+	if a.AIGateway == "" {
+		return nil
+	}
+	return []ResourceRef{{Kind: ResourceTypeAIGateway, Ref: NormalizeResourceRef(a.AIGateway)}}
+}
+
+func (a AIGatewayMCPServerResource) GetParentRef() *ResourceRef {
+	if a.AIGateway == "" {
+		return nil
+	}
+	return &ResourceRef{Kind: ResourceTypeAIGateway, Ref: NormalizeResourceRef(a.AIGateway)}
+}
+
+func (a AIGatewayMCPServerResource) Validate() error {
+	if err := ValidateRef(a.Ref); err != nil {
+		return fmt.Errorf("invalid AI Gateway MCP Server ref: %w", err)
+	}
+	if a.Kongctl != nil {
+		return fmt.Errorf("kongctl metadata not supported on AI Gateway MCP Server %s", a.Ref)
+	}
+	if a.AIGateway == "" {
+		return fmt.Errorf("ai_gateway is required for AI Gateway MCP Server %s", a.Ref)
+	}
+	if a.Name() == "" {
+		return fmt.Errorf("name is required for AI Gateway MCP Server %s", a.Ref)
+	}
+	if a.DisplayName() == "" {
+		return fmt.Errorf("display_name is required for AI Gateway MCP Server %s", a.Ref)
+	}
+	if a.MCPServerType() == "" {
+		return fmt.Errorf("type is required for AI Gateway MCP Server %s", a.Ref)
+	}
+	if !a.hasPayload() {
+		return fmt.Errorf("AI Gateway MCP Server %s must specify a valid MCP Server payload", a.Ref)
+	}
+	return nil
+}
+
+func (a *AIGatewayMCPServerResource) SetDefaults() {
+	if a == nil || !a.hasPayload() {
+		return
+	}
+
+	payload, err := a.PayloadMap()
+	if err != nil {
+		return
+	}
+	if a.Ref == "" {
+		if name, _ := payload[aiGatewayMCPServerFieldName].(string); name != "" {
+			a.Ref = name
+		}
+	}
+	if name, _ := payload[aiGatewayMCPServerFieldName].(string); name == "" && a.Ref != "" {
+		payload[aiGatewayMCPServerFieldName] = a.Ref
+	}
+	if displayName, _ := payload[aiGatewayMCPServerFieldDisplayName].(string); displayName == "" {
+		if name, _ := payload[aiGatewayMCPServerFieldName].(string); name != "" {
+			payload[aiGatewayMCPServerFieldDisplayName] = name
+		}
+	}
+	if _, ok := payload[aiGatewayMCPServerFieldEnabled]; !ok {
+		payload[aiGatewayMCPServerFieldEnabled] = true
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+	var req kkComps.CreateAIGatewayMCPServerRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return
+	}
+	a.CreateAIGatewayMCPServerRequest = req
+}
+
+func (a AIGatewayMCPServerResource) GetKonnectMonikerFilter() string {
+	return a.Name()
+}
+
+func (a *AIGatewayMCPServerResource) TryMatchKonnectResource(konnectResource any) bool {
+	name := a.Name()
+	if name == "" {
+		return false
+	}
+	if id := AIGatewayMCPServerID(konnectResource); id != "" && (util.IsValidUUID(a.Ref) || a.GetKonnectID() != "") {
+		if a.Ref == id || a.GetKonnectID() == id {
+			a.SetKonnectID(id)
+			return true
+		}
+	}
+	if id := AIGatewayMCPServerID(konnectResource); id != "" && AIGatewayMCPServerName(konnectResource) == name {
+		a.SetKonnectID(id)
+		return true
+	}
+	return false
+}
+
+func (a AIGatewayMCPServerResource) Name() string {
+	return aiGatewayMCPServerStringField(a.CreateAIGatewayMCPServerRequest, aiGatewayMCPServerFieldName)
+}
+
+func (a AIGatewayMCPServerResource) DisplayName() string {
+	return aiGatewayMCPServerStringField(a.CreateAIGatewayMCPServerRequest, aiGatewayMCPServerFieldDisplayName)
+}
+
+func (a AIGatewayMCPServerResource) MCPServerType() string {
+	if a.Type != "" {
+		return string(a.Type)
+	}
+	return aiGatewayMCPServerStringField(a.CreateAIGatewayMCPServerRequest, aiGatewayMCPServerFieldType)
+}
+
+func (a AIGatewayMCPServerResource) CreateRequest() kkComps.CreateAIGatewayMCPServerRequest {
+	return a.CreateAIGatewayMCPServerRequest
+}
+
+func (a AIGatewayMCPServerResource) UpdateRequest() kkComps.UpdateAIGatewayMCPServerRequest {
+	payload, err := a.PayloadMap()
+	if err != nil || len(payload) == 0 {
+		return kkComps.UpdateAIGatewayMCPServerRequest{}
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return kkComps.UpdateAIGatewayMCPServerRequest{}
+	}
+	var req kkComps.UpdateAIGatewayMCPServerRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return kkComps.UpdateAIGatewayMCPServerRequest{}
+	}
+	return req
+}
+
+func (a AIGatewayMCPServerResource) PayloadMap() (map[string]any, error) {
+	if !a.hasPayload() {
+		return map[string]any{}, nil
+	}
+	return marshalObjectToMap(a.CreateRequest(), "AI Gateway MCP Server payload")
+}
+
+func (a AIGatewayMCPServerResource) MutablePayloadMap() (map[string]any, error) {
+	payload, err := a.PayloadMap()
+	if err != nil {
+		return nil, err
+	}
+	stripAIGatewayMCPServerServerFields(payload)
+	return payload, nil
+}
+
+func (a AIGatewayMCPServerResource) hasPayload() bool {
+	return a.AIGatewayMCPServerConversionOnly != nil ||
+		a.AIGatewayMCPServerConversionListener != nil ||
+		a.AIGatewayMCPServerListener != nil ||
+		a.AIGatewayMCPServerPassthroughListener != nil ||
+		a.AIGatewayMCPServerUpstreamServer != nil
+}
+
+func (a AIGatewayMCPServerResource) MarshalJSON() ([]byte, error) {
+	payload, err := a.PayloadMap()
+	if err != nil {
+		return nil, err
+	}
+	payload[SchemaFieldRef] = a.Ref
+	if a.AIGateway != "" {
+		payload[SchemaFieldAIGateway] = a.AIGateway
+	}
+	return json.Marshal(payload)
+}
+
+func (a AIGatewayMCPServerResource) MarshalYAML() (any, error) {
+	payload, err := a.PayloadMap()
+	if err != nil {
+		return nil, err
+	}
+	payload[SchemaFieldRef] = a.Ref
+	if a.AIGateway != "" {
+		payload[SchemaFieldAIGateway] = a.AIGateway
+	}
+	return payload, nil
+}
+
+func (a *AIGatewayMCPServerResource) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	var meta struct {
+		Ref       string          `json:"ref"`
+		AIGateway string          `json:"ai_gateway,omitempty"`
+		Kongctl   json.RawMessage `json:"kongctl,omitempty"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return err
+	}
+	if len(meta.Kongctl) > 0 && string(meta.Kongctl) != "null" {
+		return fmt.Errorf("kongctl metadata not supported on child resources")
+	}
+
+	delete(raw, SchemaFieldRef)
+	delete(raw, SchemaFieldAIGateway)
+	delete(raw, "kongctl")
+
+	payload, err := json.Marshal(raw)
+	if err != nil {
+		return err
+	}
+	var req kkComps.CreateAIGatewayMCPServerRequest
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return err
+	}
+
+	a.BaseResource = BaseResource{Ref: meta.Ref}
+	a.AIGateway = meta.AIGateway
+	a.CreateAIGatewayMCPServerRequest = req
+	return nil
+}
+
+func AIGatewayMCPServerID(server any) string {
+	return aiGatewayMCPServerStringField(server, aiGatewayMCPServerFieldID)
+}
+
+func AIGatewayMCPServerName(server any) string {
+	return aiGatewayMCPServerStringField(server, aiGatewayMCPServerFieldName)
+}
+
+func AIGatewayMCPServerDisplayName(server any) string {
+	return aiGatewayMCPServerStringField(server, aiGatewayMCPServerFieldDisplayName)
+}
+
+func AIGatewayMCPServerType(server any) string {
+	return aiGatewayMCPServerStringField(server, aiGatewayMCPServerFieldType)
+}
+
+func AIGatewayMCPServerEnabled(server any) *bool {
+	payload, err := marshalObjectToMap(server, "AI Gateway MCP Server")
+	if err != nil {
+		return nil
+	}
+	value, ok := payload[aiGatewayMCPServerFieldEnabled].(bool)
+	if !ok {
+		return nil
+	}
+	return &value
+}
+
+func AIGatewayMCPServerLabels(server any) map[string]string {
+	payload, err := marshalObjectToMap(server, "AI Gateway MCP Server")
+	if err != nil {
+		return nil
+	}
+	raw, ok := payload[aiGatewayMCPServerFieldLabels].(map[string]any)
+	if !ok {
+		return nil
+	}
+	labels := make(map[string]string, len(raw))
+	for key, value := range raw {
+		if stringValue, ok := value.(string); ok {
+			labels[key] = stringValue
+		}
+	}
+	return labels
+}
+
+func AIGatewayMCPServerUpdatedAt(server any) time.Time {
+	payload, err := marshalObjectToMap(server, "AI Gateway MCP Server")
+	if err != nil {
+		return time.Time{}
+	}
+	if value, ok := payload[aiGatewayMCPServerFieldUpdatedAt].(string); ok {
+		if parsed, err := time.Parse(time.RFC3339Nano, value); err == nil {
+			return parsed
+		}
+	}
+	return time.Time{}
+}
+
+func AIGatewayMCPServerMutablePayloadMap(server kkComps.AIGatewayMCPServer) (map[string]any, error) {
+	payload, err := marshalObjectToMap(server, "AI Gateway MCP Server response")
+	if err != nil {
+		return nil, err
+	}
+	stripAIGatewayMCPServerServerFields(payload)
+	return payload, nil
+}
+
+func AIGatewayMCPServerResourceFromResponse(
+	gatewayRef string,
+	server kkComps.AIGatewayMCPServer,
+) (AIGatewayMCPServerResource, error) {
+	payload, err := AIGatewayMCPServerMutablePayloadMap(server)
+	if err != nil {
+		return AIGatewayMCPServerResource{}, err
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return AIGatewayMCPServerResource{}, err
+	}
+	var req kkComps.CreateAIGatewayMCPServerRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return AIGatewayMCPServerResource{}, err
+	}
+
+	ref := AIGatewayMCPServerID(server)
+	if ref == "" {
+		ref = AIGatewayMCPServerName(server)
+	}
+	return AIGatewayMCPServerResource{
+		BaseResource:                    BaseResource{Ref: ref},
+		AIGateway:                       gatewayRef,
+		CreateAIGatewayMCPServerRequest: req,
+	}, nil
+}
+
+func stripAIGatewayMCPServerServerFields(payload map[string]any) {
+	delete(payload, aiGatewayMCPServerFieldID)
+	delete(payload, "created_at")
+	delete(payload, aiGatewayMCPServerFieldUpdatedAt)
+}
+
+func aiGatewayMCPServerStringField(value any, key string) string {
+	payload, err := marshalObjectToMap(value, "AI Gateway MCP Server")
+	if err != nil {
+		return ""
+	}
+	if field, ok := payload[key].(string); ok {
+		return field
+	}
+	return ""
+}
+
+func aiGatewayMCPServerExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
+	commonFields := []*ExplainField{
+		explainResourceRefField(),
+		explainRefField(SchemaFieldAIGateway, ResourceTypeAIGateway, true),
+		explainField("name", explainStringNode("customer-support-tools"), true, true),
+		explainField("display_name", explainStringNode("Customer Support Tools"), true, true),
+		explainField("enabled", explainBoolNode("true"), false, true),
+		explainField("config", explainObject(
+			explainField("url", explainStringNode("https://support-tools.example.com"), true, true),
+		), true, true),
+		explainField("tools", explainArrayOf(explainObject(
+			explainField("name", explainStringNode("lookup-customer"), true, true),
+			explainField("description", explainStringNode("Look up a customer profile"), true, true),
+			explainField("method", explainStringNode("GET"), true, true),
+			explainField("path", explainStringNode("/customers/{customer_id}"), false, true),
+		)), true, true),
+		explainField("policies", explainArrayOf(explainStringNode("policy-name")), true, false),
+		explainField("labels", &ExplainNode{Kind: explainKindObject, Additional: explainStringNode("value")}, false, false),
+		explainField(
+			"managed_by",
+			&ExplainNode{Kind: explainKindObject, Additional: explainStringNode("kongctl")},
+			false,
+			false,
+		),
+	}
+
+	return explainUnionNode(
+		explainObject(append(
+			slicesCloneExplainFields(commonFields),
+			explainField("type", explainConstStringNode("conversion-only"), true, true),
+		)...),
+		explainObject(append(
+			slicesCloneExplainFields(commonFields),
+			explainField("type", explainConstStringNode("conversion-listener"), true, true),
+			explainField("acl_attribute_type", explainStringNode("consumer"), true, true),
+		)...),
+		explainObject(append(
+			slicesCloneExplainFields(commonFields),
+			explainField("type", explainConstStringNode("listener"), true, true),
+			explainField("acl_attribute_type", explainStringNode("consumer"), true, true),
+		)...),
+		explainObject(append(
+			slicesCloneExplainFields(commonFields),
+			explainField("type", explainConstStringNode("passthrough-listener"), true, true),
+			explainField("acl_attribute_type", explainStringNode("consumer"), true, true),
+		)...),
+		explainObject(append(
+			slicesCloneExplainFields(commonFields),
+			explainField("type", explainConstStringNode("upstream-server"), true, true),
+			explainField("acl_attribute_type", explainStringNode("consumer"), true, true),
+		)...),
+	), nil
+}

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -20,6 +20,7 @@ const (
 	ResourceTypeAIGateway                               ResourceType = "ai_gateway"
 	ResourceTypeAIGatewayProvider                       ResourceType = "ai_gateway_provider"
 	ResourceTypeAIGatewayModel                          ResourceType = "ai_gateway_model"
+	ResourceTypeAIGatewayMCPServer                      ResourceType = "ai_gateway_mcp_server"
 	ResourceTypeDashboard                               ResourceType = "dashboard"
 	ResourceTypeAPIVersion                              ResourceType = "api_version"
 	ResourceTypeAPIPublication                          ResourceType = "api_publication"
@@ -110,6 +111,7 @@ type ResourceSet struct {
 	AIGateways                        []AIGatewayResource                        `yaml:"ai_gateways,omitempty"                                    json:"ai_gateways,omitempty"`                           //nolint:lll
 	AIGatewayProviders                []AIGatewayProviderResource                `yaml:"ai_gateway_providers,omitempty"                          json:"ai_gateway_providers,omitempty"`                   //nolint:lll
 	AIGatewayModels                   []AIGatewayModelResource                   `yaml:"ai_gateway_models,omitempty"                              json:"ai_gateway_models,omitempty"`                     //nolint:lll
+	AIGatewayMCPServers               []AIGatewayMCPServerResource               `yaml:"ai_gateway_mcp_servers,omitempty"                         json:"ai_gateway_mcp_servers,omitempty"`                //nolint:lll
 	APIs                              []APIResource                              `yaml:"apis,omitempty"                                           json:"apis,omitempty"`                                  //nolint:lll
 	GatewayServices                   []GatewayServiceResource                   `yaml:"gateway_services,omitempty"                               json:"gateway_services,omitempty"`                      //nolint:lll
 	ControlPlaneDataPlaneCertificates []ControlPlaneDataPlaneCertificateResource `yaml:"control_plane_data_plane_certificates,omitempty"          json:"control_plane_data_plane_certificates,omitempty"` //nolint:lll
@@ -357,6 +359,16 @@ func (rs *ResourceSet) GetAIGatewayModelByRef(ref string) *AIGatewayModelResourc
 	return nil
 }
 
+// GetAIGatewayMCPServerByRef returns an AI Gateway MCP Server resource by its ref from any namespace.
+func (rs *ResourceSet) GetAIGatewayMCPServerByRef(ref string) *AIGatewayMCPServerResource {
+	for i := range rs.AIGatewayMCPServers {
+		if rs.AIGatewayMCPServers[i].GetRef() == ref {
+			return &rs.AIGatewayMCPServers[i]
+		}
+	}
+	return nil
+}
+
 // GetAuthStrategyByRef returns an auth strategy resource by its ref from any namespace
 func (rs *ResourceSet) GetAuthStrategyByRef(ref string) *ApplicationAuthStrategyResource {
 	for i := range rs.ApplicationAuthStrategies {
@@ -464,6 +476,25 @@ func (rs *ResourceSet) GetAIGatewayModelsByNamespace(namespace string) []AIGatew
 			}
 			if GetNamespace(gateway.Kongctl) == namespace {
 				filtered = append(filtered, model)
+			}
+		}
+	}
+	return filtered
+}
+
+// GetAIGatewayMCPServersByNamespace returns AI Gateway MCP Server resources from the specified namespace.
+func (rs *ResourceSet) GetAIGatewayMCPServersByNamespace(namespace string) []AIGatewayMCPServerResource {
+	var filtered []AIGatewayMCPServerResource
+	for _, server := range rs.AIGatewayMCPServers {
+		if gateway := rs.GetAIGatewayByRef(server.AIGateway); gateway != nil {
+			if gateway.IsExternal() {
+				if namespace == NamespaceExternal {
+					filtered = append(filtered, server)
+				}
+				continue
+			}
+			if GetNamespace(gateway.Kongctl) == namespace {
+				filtered = append(filtered, server)
 			}
 		}
 	}
@@ -1421,4 +1452,15 @@ func (rs *ResourceSet) GetAIGatewayModelsForGateway(gatewayRef string) []AIGatew
 		}
 	}
 	return models
+}
+
+// GetAIGatewayMCPServersForGateway returns all AI Gateway MCP Servers for a given gateway ref.
+func (rs *ResourceSet) GetAIGatewayMCPServersForGateway(gatewayRef string) []AIGatewayMCPServerResource {
+	var servers []AIGatewayMCPServerResource
+	for _, server := range rs.AIGatewayMCPServers {
+		if NormalizeResourceRef(server.AIGateway) == gatewayRef {
+			servers = append(servers, server)
+		}
+	}
+	return servers
 }

--- a/internal/declarative/state/ai_gateway_mcp_servers.go
+++ b/internal/declarative/state/ai_gateway_mcp_servers.go
@@ -1,0 +1,216 @@
+package state
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/util/pagination"
+)
+
+// ListAIGatewayMCPServers lists all MCP Servers for an AI Gateway.
+func (c *Client) ListAIGatewayMCPServers(ctx context.Context, gatewayID string) ([]AIGatewayMCPServer, error) {
+	if err := ValidateAPIClient(c.aiGatewayMCPServersAPI, "AI Gateway MCP Servers API"); err != nil {
+		return nil, err
+	}
+
+	var allData []kkComps.AIGatewayMCPServer
+	var pageAfter *string
+	pageSize := int64(100)
+
+	for {
+		req := kkOps.ListAiGatewayMcpServersRequest{
+			GatewayID: gatewayID,
+			PageSize:  &pageSize,
+			PageAfter: pageAfter,
+		}
+
+		resp, err := c.aiGatewayMCPServersAPI.ListAiGatewayMcpServers(ctx, req)
+		if err != nil {
+			return nil, WrapAPIError(err, "list AI Gateway MCP Servers", nil)
+		}
+
+		if resp == nil || resp.ListAIGatewayMCPServersResponse == nil {
+			return []AIGatewayMCPServer{}, nil
+		}
+
+		allData = append(allData, resp.ListAIGatewayMCPServersResponse.Data...)
+
+		nextCursor := pagination.ExtractPageAfterCursor(resp.ListAIGatewayMCPServersResponse.Meta.Page.Next)
+		if nextCursor == "" {
+			break
+		}
+		pageAfter = &nextCursor
+	}
+
+	servers := make([]AIGatewayMCPServer, 0, len(allData))
+	for _, server := range allData {
+		servers = append(servers, AIGatewayMCPServer{
+			AIGatewayMCPServer: server,
+			NormalizedLabels:   normalizedAIGatewayMCPServerLabels(server),
+		})
+	}
+	return servers, nil
+}
+
+// GetAIGatewayMCPServer fetches an AI Gateway MCP Server by ID or name.
+func (c *Client) GetAIGatewayMCPServer(
+	ctx context.Context,
+	gatewayID string,
+	mcpServerID string,
+) (*AIGatewayMCPServer, error) {
+	if err := ValidateAPIClient(c.aiGatewayMCPServersAPI, "AI Gateway MCP Servers API"); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.aiGatewayMCPServersAPI.GetAiGatewayMcpServer(ctx, gatewayID, mcpServerID)
+	if err != nil {
+		return nil, WrapAPIError(err, "get AI Gateway MCP Server by ID", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeAIGatewayMCPServer),
+			UseEnhanced:  true,
+		})
+	}
+
+	if resp == nil || resp.AIGatewayMCPServer == nil {
+		return nil, nil
+	}
+
+	return &AIGatewayMCPServer{
+		AIGatewayMCPServer: *resp.AIGatewayMCPServer,
+		NormalizedLabels:   normalizedAIGatewayMCPServerLabels(*resp.AIGatewayMCPServer),
+	}, nil
+}
+
+// GetAIGatewayMCPServerByName finds an AI Gateway MCP Server by name within a gateway.
+func (c *Client) GetAIGatewayMCPServerByName(
+	ctx context.Context,
+	gatewayID string,
+	name string,
+) (*AIGatewayMCPServer, error) {
+	servers, err := c.ListAIGatewayMCPServers(ctx, gatewayID)
+	if err != nil {
+		return nil, WrapAPIError(err, "list AI Gateway MCP Servers to find by name", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeAIGatewayMCPServer),
+			ResourceName: name,
+			UseEnhanced:  true,
+		})
+	}
+
+	for i := range servers {
+		if resources.AIGatewayMCPServerName(servers[i].AIGatewayMCPServer) == name {
+			return &servers[i], nil
+		}
+	}
+
+	return nil, nil
+}
+
+// CreateAIGatewayMCPServer creates a new MCP Server under an AI Gateway.
+func (c *Client) CreateAIGatewayMCPServer(
+	ctx context.Context,
+	gatewayID string,
+	req kkComps.CreateAIGatewayMCPServerRequest,
+	namespace string,
+) (string, error) {
+	if err := ValidateAPIClient(c.aiGatewayMCPServersAPI, "AI Gateway MCP Servers API"); err != nil {
+		return "", err
+	}
+
+	resp, err := c.aiGatewayMCPServersAPI.CreateAiGatewayMcpServer(ctx, gatewayID, req)
+	if err != nil {
+		return "", WrapAPIError(err, "create AI Gateway MCP Server", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeAIGatewayMCPServer),
+			ResourceName: aiGatewayMCPServerCreateRequestName(req),
+			Namespace:    namespace,
+			UseEnhanced:  true,
+		})
+	}
+
+	if resp == nil || resp.AIGatewayMCPServer == nil {
+		return "", fmt.Errorf("create AI Gateway MCP Server response missing data")
+	}
+
+	return resources.AIGatewayMCPServerID(*resp.AIGatewayMCPServer), nil
+}
+
+// UpdateAIGatewayMCPServer updates an existing MCP Server under an AI Gateway.
+func (c *Client) UpdateAIGatewayMCPServer(
+	ctx context.Context,
+	gatewayID string,
+	mcpServerID string,
+	req kkComps.UpdateAIGatewayMCPServerRequest,
+	namespace string,
+) (string, error) {
+	if err := ValidateAPIClient(c.aiGatewayMCPServersAPI, "AI Gateway MCP Servers API"); err != nil {
+		return "", err
+	}
+
+	resp, err := c.aiGatewayMCPServersAPI.UpdateAiGatewayMcpServer(ctx, kkOps.UpdateAiGatewayMcpServerRequest{
+		GatewayID:                       gatewayID,
+		McpServerID:                     mcpServerID,
+		UpdateAIGatewayMCPServerRequest: req,
+	})
+	if err != nil {
+		return "", WrapAPIError(err, "update AI Gateway MCP Server", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeAIGatewayMCPServer),
+			ResourceName: aiGatewayMCPServerUpdateRequestName(req),
+			Namespace:    namespace,
+			UseEnhanced:  true,
+		})
+	}
+
+	if resp == nil || resp.AIGatewayMCPServer == nil {
+		return "", fmt.Errorf("update AI Gateway MCP Server response missing data")
+	}
+
+	return resources.AIGatewayMCPServerID(*resp.AIGatewayMCPServer), nil
+}
+
+// DeleteAIGatewayMCPServer deletes an AI Gateway MCP Server by ID.
+func (c *Client) DeleteAIGatewayMCPServer(ctx context.Context, gatewayID string, mcpServerID string) error {
+	if err := ValidateAPIClient(c.aiGatewayMCPServersAPI, "AI Gateway MCP Servers API"); err != nil {
+		return err
+	}
+
+	_, err := c.aiGatewayMCPServersAPI.DeleteAiGatewayMcpServer(ctx, gatewayID, mcpServerID)
+	if err != nil {
+		return WrapAPIError(err, "delete AI Gateway MCP Server", nil)
+	}
+
+	return nil
+}
+
+func normalizedAIGatewayMCPServerLabels(server kkComps.AIGatewayMCPServer) map[string]string {
+	normalized := resources.AIGatewayMCPServerLabels(server)
+	if normalized == nil {
+		normalized = make(map[string]string)
+	}
+	return normalized
+}
+
+func aiGatewayMCPServerCreateRequestName(req kkComps.CreateAIGatewayMCPServerRequest) string {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return ""
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return ""
+	}
+	return stringFromRaw(raw["name"])
+}
+
+func aiGatewayMCPServerUpdateRequestName(req kkComps.UpdateAIGatewayMCPServerRequest) string {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return ""
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return ""
+	}
+	return stringFromRaw(raw["name"])
+}

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -38,6 +38,7 @@ type ClientConfig struct {
 	AIGatewayAPI            helpers.AIGatewayAPI
 	AIGatewayProvidersAPI   helpers.AIGatewayProvidersAPI
 	AIGatewayModelAPI       helpers.AIGatewayModelAPI
+	AIGatewayMCPServersAPI  helpers.AIGatewayMCPServersAPI
 	DashboardsAPI           helpers.DashboardsAPI
 
 	// Portal child resource APIs
@@ -103,6 +104,7 @@ type Client struct {
 	aiGatewayAPI            helpers.AIGatewayAPI
 	aiGatewayProvidersAPI   helpers.AIGatewayProvidersAPI
 	aiGatewayModelAPI       helpers.AIGatewayModelAPI
+	aiGatewayMCPServersAPI  helpers.AIGatewayMCPServersAPI
 	dashboardsAPI           helpers.DashboardsAPI
 
 	// Portal child resource APIs
@@ -169,6 +171,7 @@ func NewClient(config ClientConfig) *Client {
 		aiGatewayAPI:            config.AIGatewayAPI,
 		aiGatewayProvidersAPI:   config.AIGatewayProvidersAPI,
 		aiGatewayModelAPI:       config.AIGatewayModelAPI,
+		aiGatewayMCPServersAPI:  config.AIGatewayMCPServersAPI,
 		dashboardsAPI:           config.DashboardsAPI,
 
 		// Portal child resource APIs
@@ -275,6 +278,12 @@ type AIGatewayProvider struct {
 // AIGatewayModel represents a Konnect AI Gateway model for internal use.
 type AIGatewayModel struct {
 	kkComps.AIGatewayModel
+	NormalizedLabels map[string]string
+}
+
+// AIGatewayMCPServer represents a Konnect AI Gateway MCP Server for internal use.
+type AIGatewayMCPServer struct {
+	kkComps.AIGatewayMCPServer
 	NormalizedLabels map[string]string
 }
 

--- a/internal/konnect/helpers/ai_gateway_mcp_servers.go
+++ b/internal/konnect/helpers/ai_gateway_mcp_servers.go
@@ -1,0 +1,89 @@
+package helpers
+
+import (
+	"context"
+
+	kkSDK "github.com/Kong/sdk-konnect-go"
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+)
+
+// AIGatewayMCPServersAPI defines the interface for AI Gateway MCP Server operations needed by kongctl.
+type AIGatewayMCPServersAPI interface {
+	ListAiGatewayMcpServers(
+		ctx context.Context,
+		request kkOps.ListAiGatewayMcpServersRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.ListAiGatewayMcpServersResponse, error)
+	CreateAiGatewayMcpServer(
+		ctx context.Context,
+		gatewayID string,
+		request kkComps.CreateAIGatewayMCPServerRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.CreateAiGatewayMcpServerResponse, error)
+	GetAiGatewayMcpServer(
+		ctx context.Context,
+		gatewayID string,
+		mcpServerID string,
+		opts ...kkOps.Option,
+	) (*kkOps.GetAiGatewayMcpServerResponse, error)
+	UpdateAiGatewayMcpServer(
+		ctx context.Context,
+		request kkOps.UpdateAiGatewayMcpServerRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.UpdateAiGatewayMcpServerResponse, error)
+	DeleteAiGatewayMcpServer(
+		ctx context.Context,
+		gatewayID string,
+		mcpServerID string,
+		opts ...kkOps.Option,
+	) (*kkOps.DeleteAiGatewayMcpServerResponse, error)
+}
+
+// AIGatewayMCPServersAPIImpl provides the real SDK implementation.
+type AIGatewayMCPServersAPIImpl struct {
+	SDK *kkSDK.SDK
+}
+
+func (a *AIGatewayMCPServersAPIImpl) ListAiGatewayMcpServers(
+	ctx context.Context,
+	request kkOps.ListAiGatewayMcpServersRequest,
+	opts ...kkOps.Option,
+) (*kkOps.ListAiGatewayMcpServersResponse, error) {
+	return a.SDK.AIGatewayMCPServers.ListAiGatewayMcpServers(ctx, request, opts...)
+}
+
+func (a *AIGatewayMCPServersAPIImpl) CreateAiGatewayMcpServer(
+	ctx context.Context,
+	gatewayID string,
+	request kkComps.CreateAIGatewayMCPServerRequest,
+	opts ...kkOps.Option,
+) (*kkOps.CreateAiGatewayMcpServerResponse, error) {
+	return a.SDK.AIGatewayMCPServers.CreateAiGatewayMcpServer(ctx, gatewayID, request, opts...)
+}
+
+func (a *AIGatewayMCPServersAPIImpl) GetAiGatewayMcpServer(
+	ctx context.Context,
+	gatewayID string,
+	mcpServerID string,
+	opts ...kkOps.Option,
+) (*kkOps.GetAiGatewayMcpServerResponse, error) {
+	return a.SDK.AIGatewayMCPServers.GetAiGatewayMcpServer(ctx, gatewayID, mcpServerID, opts...)
+}
+
+func (a *AIGatewayMCPServersAPIImpl) UpdateAiGatewayMcpServer(
+	ctx context.Context,
+	request kkOps.UpdateAiGatewayMcpServerRequest,
+	opts ...kkOps.Option,
+) (*kkOps.UpdateAiGatewayMcpServerResponse, error) {
+	return a.SDK.AIGatewayMCPServers.UpdateAiGatewayMcpServer(ctx, request, opts...)
+}
+
+func (a *AIGatewayMCPServersAPIImpl) DeleteAiGatewayMcpServer(
+	ctx context.Context,
+	gatewayID string,
+	mcpServerID string,
+	opts ...kkOps.Option,
+) (*kkOps.DeleteAiGatewayMcpServerResponse, error) {
+	return a.SDK.AIGatewayMCPServers.DeleteAiGatewayMcpServer(ctx, gatewayID, mcpServerID, opts...)
+}

--- a/internal/konnect/helpers/sdk.go
+++ b/internal/konnect/helpers/sdk.go
@@ -25,6 +25,7 @@ type SDKAPI interface {
 	GetAIGatewayAPI() AIGatewayAPI
 	GetAIGatewayProvidersAPI() AIGatewayProvidersAPI
 	GetAIGatewayModelAPI() AIGatewayModelAPI
+	GetAIGatewayMCPServersAPI() AIGatewayMCPServersAPI
 	GetCatalogServicesAPI() CatalogServicesAPI
 	GetDashboardsAPI() DashboardsAPI
 	GetAPIDocumentAPI() APIDocumentAPI
@@ -154,6 +155,15 @@ func (k *KonnectSDK) GetAIGatewayModelAPI() AIGatewayModelAPI {
 		TokenSource: k.TokenSource,
 		HTTPClient:  k.HTTPClient,
 	}
+}
+
+// Returns the implementation of the AIGatewayMCPServersAPI interface.
+func (k *KonnectSDK) GetAIGatewayMCPServersAPI() AIGatewayMCPServersAPI {
+	if k.SDK == nil || k.SDK.AIGatewayMCPServers == nil {
+		return nil
+	}
+
+	return &AIGatewayMCPServersAPIImpl{SDK: k.SDK}
 }
 
 // Returns the implementation of the CatalogServicesAPI interface

--- a/internal/konnect/helpers/sdk_mock.go
+++ b/internal/konnect/helpers/sdk_mock.go
@@ -13,6 +13,7 @@ type MockKonnectSDK struct {
 	AIGatewayFactory                   func() AIGatewayAPI
 	AIGatewayProvidersFactory          func() AIGatewayProvidersAPI
 	AIGatewayModelFactory              func() AIGatewayModelAPI
+	AIGatewayMCPServersFactory         func() AIGatewayMCPServersAPI
 	CatalogServicesFactory             func() CatalogServicesAPI
 	DashboardsFactory                  func() DashboardsAPI
 	APIDocumentFactory                 func() APIDocumentAPI
@@ -117,6 +118,14 @@ func (m *MockKonnectSDK) GetAIGatewayProvidersAPI() AIGatewayProvidersAPI {
 func (m *MockKonnectSDK) GetAIGatewayModelAPI() AIGatewayModelAPI {
 	if m.AIGatewayModelFactory != nil {
 		return m.AIGatewayModelFactory()
+	}
+	return nil
+}
+
+// Returns a mock instance of the AIGatewayMCPServersAPI.
+func (m *MockKonnectSDK) GetAIGatewayMCPServersAPI() AIGatewayMCPServersAPI {
+	if m.AIGatewayMCPServersFactory != nil {
+		return m.AIGatewayMCPServersFactory()
 	}
 	return nil
 }

--- a/test/e2e/scenarios/ai-gateway/mcp-server/overlays/001-update/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/mcp-server/overlays/001-update/config.yaml
@@ -1,0 +1,28 @@
+ai_gateways:
+  - ref: ai-gateway-mcp-e2e
+    display_name: "AI Gateway MCP Server E2E"
+    description: "AI Gateway MCP Server e2e"
+    proxy_urls:
+      - host: ai-gateway-mcp-e2e.example.com
+        port: 443
+        protocol: https
+    labels:
+      owner: platform
+      lifecycle: dev
+    mcp_servers:
+      - ref: support-tools
+        type: conversion-only
+        name: support-tools
+        display_name: "Support Tools Updated"
+        enabled: false
+        labels:
+          team: support
+          phase: update
+        config:
+          url: https://support-tools-updated.example.com
+        tools:
+          - name: lookup-customer
+            description: "Look up an updated customer profile"
+            method: GET
+            path: /customers/{customer_id}
+        policies: []

--- a/test/e2e/scenarios/ai-gateway/mcp-server/overlays/002-sync-delete-mcp/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/mcp-server/overlays/002-sync-delete-mcp/config.yaml
@@ -1,0 +1,12 @@
+ai_gateways:
+  - ref: ai-gateway-mcp-e2e
+    display_name: "AI Gateway MCP Server E2E"
+    description: "AI Gateway MCP Server e2e"
+    proxy_urls:
+      - host: ai-gateway-mcp-e2e.example.com
+        port: 443
+        protocol: https
+    labels:
+      owner: platform
+      lifecycle: dev
+    mcp_servers: []

--- a/test/e2e/scenarios/ai-gateway/mcp-server/overlays/003-sync-delete-gateway/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/mcp-server/overlays/003-sync-delete-gateway/config.yaml
@@ -1,0 +1,1 @@
+ai_gateways: []

--- a/test/e2e/scenarios/ai-gateway/mcp-server/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/mcp-server/scenario.yaml
@@ -1,0 +1,363 @@
+baseInputsPath: testdata
+
+env:
+  KONGCTL_LOG_LEVEL: info
+
+vars:
+  namespace: "ai-gateway-mcp-server-e2e"
+  gateway_name: "AI Gateway MCP Server E2E"
+  gateway_ref: "ai-gateway-mcp-e2e"
+  server_ref: "support-tools"
+  server_name: "support-tools"
+  server_display_name: "Support Tools"
+  server_updated_display_name: "Support Tools Updated"
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - created_at
+      - updated_at
+      - config_hash
+      - endpoints
+      - resource_id
+      - change_id
+      - generated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-explain-and-scaffold
+    skipInputs: true
+    commands:
+      - name: 000-explain-ai-gateway-mcp-server-json
+        run:
+          - explain
+          - ai_gateway_mcp_server
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                type: object
+                title: "kongctl declarative schema: ai_gateway_mcp_server"
+                '"x-kongctl-root-key"': ai_gateway_mcp_servers
+          - select: "contains(keys(properties), 'ai_gateway')"
+            expect:
+              fields:
+                "@": true
+      - name: 001-scaffold-ai-gateway-mcp-server
+        run:
+          - scaffold
+          - ai_gateway_mcp_server
+        outputFormat: disable
+        parseAs: raw
+        assertions:
+          - expect:
+              fields:
+                "contains(stdout, 'ai_gateway_mcp_servers:')": true
+                "contains(stdout, 'type: conversion-only')": true
+                "contains(stdout, 'tools:')": true
+
+  - name: 002-plan-apply-create
+    commands:
+      - name: 000-plan-create
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-create.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 2
+                by_action.CREATE: 2
+          - select: >-
+              changes[?resource_type=='ai_gateway_mcp_server' && resource_ref=='{{ .vars.server_ref }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                fields.name: "{{ .vars.server_name }}"
+                fields.type: conversion-only
+                fields.display_name: "{{ .vars.server_display_name }}"
+                fields.config.url: https://support-tools.example.com
+      - name: 001-apply-create
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-create.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 2
+                failed: 0
+                status: success
+      - name: 002-list-mcp-servers
+        run:
+          - get
+          - ai-gateway
+          - mcp-servers
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - -o
+          - json
+        recordVar:
+          name: mcp_server_id
+          responsePath: "[?name=='{{ .vars.server_name }}'] | [0].id"
+        assertions:
+          - select: "[?name=='{{ .vars.server_name }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.server_name }}"
+                display_name: "{{ .vars.server_display_name }}"
+                type: conversion-only
+                enabled: true
+                config.url: https://support-tools.example.com
+                tools[0].name: lookup-customer
+      - name: 003-get-mcp-server-by-name
+        run:
+          - get
+          - ai-gateway
+          - mcp-server
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - "{{ .vars.server_name }}"
+          - -o
+          - json
+        assertions:
+          - select: name
+            expect:
+              fields:
+                "@": "{{ .vars.server_name }}"
+      - name: 004-get-mcp-server-by-id
+        run:
+          - get
+          - ai-gateway
+          - mcp-servers
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - "{{ .vars.mcp_server_id }}"
+          - -o
+          - json
+        assertions:
+          - select: name
+            expect:
+              fields:
+                "@": "{{ .vars.server_name }}"
+
+  - name: 003-plan-apply-update
+    inputOverlayDirs:
+      - overlays/001-update
+    commands:
+      - name: 000-plan-update
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-update.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+          - select: >-
+              changes[?resource_type=='ai_gateway_mcp_server' && resource_ref=='{{ .vars.server_ref }}'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                fields.display_name: "{{ .vars.server_updated_display_name }}"
+                fields.enabled: false
+                fields.labels.phase: update
+      - name: 001-apply-update
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-update.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 002-verify-update
+        run:
+          - get
+          - ai-gateway
+          - mcp-servers
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - "{{ .vars.server_name }}"
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                display_name: "{{ .vars.server_updated_display_name }}"
+                enabled: false
+                labels.phase: update
+                config.url: https://support-tools-updated.example.com
+      - name: 003-diff-no-changes
+        outputFormat: text
+        parseAs: raw
+        run:
+          - diff
+          - -f
+          - "{{ .workdir }}/config.yaml"
+        assertions:
+          - select: stdout
+            expect:
+              fields:
+                "contains(@, 'No changes detected. Konnect is up to date.')": true
+
+  - name: 004-dump-round-trip
+    skipInputs: true
+    commands:
+      - name: 000-dump-ai-gateway-with-children
+        run:
+          - dump
+          - declarative
+          - "--resources=ai_gateways"
+          - "--include-child-resources"
+          - "--default-namespace={{ .vars.namespace }}"
+        outputFormat: none
+        parseAs: yaml
+        stdoutFile: "{{ .workdir }}/dump-ai-gateway.yaml"
+        assertions:
+          - select: >-
+              ai_gateways[?display_name=='{{ .vars.gateway_name }}'] | [0].mcp_servers[?name=='{{ .vars.server_name }}'] | [0]
+            expect:
+              fields:
+                name: "{{ .vars.server_name }}"
+                display_name: "{{ .vars.server_updated_display_name }}"
+                type: conversion-only
+      - name: 001-plan-from-ai-gateway-dump
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/dump-ai-gateway.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+      - name: 002-dump-root-mcp-servers
+        run:
+          - dump
+          - declarative
+          - "--resources=ai_gateway_mcp_servers"
+          - "--filter-name={{ .vars.server_name }}"
+          - "--default-namespace={{ .vars.namespace }}"
+        outputFormat: none
+        parseAs: yaml
+        assertions:
+          - select: "ai_gateway_mcp_servers[0]"
+            expect:
+              fields:
+                name: "{{ .vars.server_name }}"
+          - select: "ai_gateway_mcp_servers[0].ai_gateway != ''"
+            expect:
+              fields:
+                "@": true
+
+  - name: 005-sync-delete-mcp-server
+    inputOverlayDirs:
+      - overlays/002-sync-delete-mcp
+    commands:
+      - name: 000-sync-delete-mcp-server
+        outputFormat: json
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: >-
+              plan.changes[?resource_type=='ai_gateway_mcp_server' && action=='DELETE'] | [0]
+            expect:
+              fields:
+                resource_ref: "{{ .vars.server_name }}"
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+                status: success
+      - name: 001-list-mcp-servers-empty
+        run:
+          - get
+          - ai-gateway
+          - mcp-servers
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 0
+
+  - name: 006-sync-delete-gateway
+    inputOverlayDirs:
+      - overlays/003-sync-delete-gateway
+    commands:
+      - name: 000-sync-delete-gateway
+        outputFormat: json
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+                status: success
+      - name: 001-get-ai-gateways
+        run:
+          - get
+          - ai-gateways
+          - -o
+          - json
+        assertions:
+          - select: "[?display_name=='{{ .vars.gateway_name }}']"
+            expect:
+              fields:
+                "length(@)": 0

--- a/test/e2e/scenarios/ai-gateway/mcp-server/testdata/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/mcp-server/testdata/config.yaml
@@ -1,0 +1,32 @@
+_defaults:
+  kongctl:
+    namespace: ai-gateway-mcp-server-e2e
+
+ai_gateways:
+  - ref: ai-gateway-mcp-e2e
+    display_name: "AI Gateway MCP Server E2E"
+    description: "AI Gateway MCP Server e2e"
+    proxy_urls:
+      - host: ai-gateway-mcp-e2e.example.com
+        port: 443
+        protocol: https
+    labels:
+      owner: platform
+      lifecycle: dev
+    mcp_servers:
+      - ref: support-tools
+        type: conversion-only
+        name: support-tools
+        display_name: "Support Tools"
+        enabled: true
+        labels:
+          team: support
+          phase: create
+        config:
+          url: https://support-tools.example.com
+        tools:
+          - name: lookup-customer
+            description: "Look up a customer profile"
+            method: GET
+            path: /customers/{customer_id}
+        policies: []

--- a/test/e2e/scenarios/explain/command-coverage/scenario.yaml
+++ b/test/e2e/scenarios/explain/command-coverage/scenario.yaml
@@ -207,3 +207,30 @@ steps:
                 type.const: model
                 formats.items.properties.type.type: string
                 target_models.items.properties.config.properties.type.type: string
+
+  - name: 011-explain-ai-gateway-mcp-servers-nested-yaml
+    skipInputs: true
+    commands:
+      - name: 000-explain-ai-gateway-mcp-servers-yaml
+        run:
+          - explain
+          - ai_gateway.mcp_servers
+        outputFormat: yaml
+        parseAs: yaml
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                type: object
+                title: "kongctl declarative schema: ai_gateway.mcp_servers"
+                '"x-kongctl-resource"': ai_gateway_mcp_server
+                '"x-kongctl-root-key"': ai_gateway_mcp_servers
+                '"x-kongctl-resource-class"': child
+                '"x-kongctl-supports-root"': true
+                '"x-kongctl-supports-nested-declaration"': true
+          - select: oneOf[0].properties
+            expect:
+              fields:
+                type.const: conversion-only
+                config.properties.url.type: string
+                tools.items.properties.method.type: string


### PR DESCRIPTION
Closes #746

Stacked on #1405.

## Summary
- add declarative AI Gateway MCP Server resource lifecycle support
- add gateway-scoped get/list commands for AI Gateway MCP Servers
- wire explain, scaffold, dump, docs, examples, unit tests, and E2E scenario coverage

## Validation
- go fix ./...
- make format
- make build
- make test
- golangci-lint run ./internal/declarative/loader ./internal/declarative/protection ./internal/cmd/root/products/konnect/aigateway
- git diff --check

Note: full make lint still reports existing generated/mock lint findings outside this change.