### PR TITLE
feat(declarative): support event gateway field-level encryption

### DIFF
--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -418,6 +418,56 @@ Additional nested Event Gateway resources include `schema_registries`,
 `static_keys`, `tls_trust_bundles`, `data_plane_certificates`,
 `cluster_policies`, `produce_policies`, and `consume_policies`.
 
+Produce policies support `modify_headers`, `schema_validation`, `encrypt`, and
+`encrypt_fields`. Consume policies support `modify_headers`,
+`schema_validation`, `decrypt`, `skip_record`, and `decrypt_fields`.
+Field-level encryption policy types require Event Gateway runtime `1.2` or
+newer.
+
+`encrypt_fields` policies must be children of a produce `schema_validation`
+policy. `decrypt_fields` policies must be children of a consume
+`schema_validation` policy. Use the API field name `parent_policy_id` with a
+declarative `!ref` so the planner can order the schema validation parent before
+the field-level policy and inject the resolved ID during apply.
+
+```yaml
+produce_policies:
+  - ref: produce-schema-validation
+    name: produce-schema-validation
+    type: schema_validation
+    config:
+      type: json
+  - ref: produce-encrypt-fields
+    name: produce-encrypt-fields
+    type: encrypt_fields
+    parent_policy_id: !ref produce-schema-validation#id
+    config:
+      failure_mode: reject
+      encrypt_fields:
+        - paths: $.customer.ssn
+          encryption_key:
+            type: static
+            key:
+              id: !ref default-static-key#id
+
+consume_policies:
+  - ref: consume-schema-validation
+    name: consume-schema-validation
+    type: schema_validation
+    config:
+      type: json
+  - ref: consume-decrypt-fields
+    name: consume-decrypt-fields
+    type: decrypt_fields
+    parent_policy_id: !ref consume-schema-validation#id
+    config:
+      failure_mode: error
+      key_sources:
+        - type: static
+      decrypt_fields:
+        paths: $.customer.ssn
+```
+
 ## Organization
 
 [API Specification](https://developer.konghq.com/api/konnect/identity/v3/#/)

--- a/docs/examples/declarative/event-gateway/event-gateway.yaml
+++ b/docs/examples/declarative/event-gateway/event-gateway.yaml
@@ -82,6 +82,29 @@ event_gateways:
                   value: "${client_id}"
                 - op: remove
                   key: x-original-header
+          - ref: default-produce-schema-validation
+            name: default-produce-schema-validation
+            description: Default Produce Schema Validation Policy
+            type: schema_validation
+            enabled: true
+            config:
+              type: json
+              failure_mode: reject
+              validate_value: true
+          - ref: default-produce-encrypt-fields
+            name: default-produce-encrypt-fields
+            description: Default Produce Field Encryption Policy
+            type: encrypt_fields
+            parent_policy_id: !ref default-produce-schema-validation#id
+            enabled: true
+            config:
+              failure_mode: reject
+              encrypt_fields:
+                - paths: $.customer.ssn
+                  encryption_key:
+                    type: static
+                    key:
+                      id: !ref default-static-key#id
         consume_policies:
           - ref: default-consume-policy
             name: default-consume-policy
@@ -93,6 +116,18 @@ event_gateways:
               key_validation_action: mark
               type: json
               value_validation_action: skip
+          - ref: default-consume-decrypt-fields
+            name: default-consume-decrypt-fields
+            description: Default Consume Field Decryption Policy
+            type: decrypt_fields
+            parent_policy_id: !ref default-consume-policy#id
+            enabled: true
+            config:
+              failure_mode: error
+              key_sources:
+                - type: static
+              decrypt_fields:
+                paths: $.customer.ssn
     schema_registries:
       - ref: default-schema-registry
         name: default-schema-registry

--- a/internal/cmd/root/products/konnect/eventgateway/consume-policies.go
+++ b/internal/cmd/root/products/konnect/eventgateway/consume-policies.go
@@ -46,15 +46,17 @@ type consumePolicySummaryRecord struct {
 // consumePolicyWithConfig is a wrapper that includes the full config from raw API response.
 // The SDK's EventGatewayPolicyConfig struct is empty, so we use map[string]any to capture actual config.
 type consumePolicyWithConfig struct {
-	Type        string            `json:"type" yaml:"type"`
-	Name        *string           `json:"name,omitempty" yaml:"name,omitempty"`
-	Description *string           `json:"description,omitempty" yaml:"description,omitempty"`
-	Enabled     *bool             `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
-	ID          string            `json:"id" yaml:"id"`
-	Config      map[string]any    `json:"config" yaml:"config"`
-	CreatedAt   time.Time         `json:"created_at" yaml:"created_at"`
-	UpdatedAt   time.Time         `json:"updated_at" yaml:"updated_at"`
+	Type           string            `json:"type" yaml:"type"`
+	Name           *string           `json:"name,omitempty" yaml:"name,omitempty"`
+	Description    *string           `json:"description,omitempty" yaml:"description,omitempty"`
+	Enabled        *bool             `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Labels         map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	ID             string            `json:"id" yaml:"id"`
+	Config         map[string]any    `json:"config" yaml:"config"`
+	ParentPolicyID *string           `json:"parent_policy_id,omitempty" yaml:"parent_policy_id,omitempty"`
+	Condition      *string           `json:"condition,omitempty" yaml:"condition,omitempty"`
+	CreatedAt      time.Time         `json:"created_at" yaml:"created_at"`
+	UpdatedAt      time.Time         `json:"updated_at" yaml:"updated_at"`
 }
 
 var (
@@ -592,6 +594,14 @@ func consumePolicyWithConfigDetailView(policy *consumePolicyWithConfig) string {
 	enabled := formatEnabledBool(policy.Enabled)
 	labels := formatLabelPairs(policy.Labels)
 	config := formatJSONValue(policy.Config)
+	parentPolicyID := valueNA
+	if policy.ParentPolicyID != nil && strings.TrimSpace(*policy.ParentPolicyID) != "" {
+		parentPolicyID = strings.TrimSpace(*policy.ParentPolicyID)
+	}
+	condition := valueNA
+	if policy.Condition != nil && strings.TrimSpace(*policy.Condition) != "" {
+		condition = strings.TrimSpace(*policy.Condition)
+	}
 
 	createdAt := policy.CreatedAt.In(time.Local).Format("2006-01-02 15:04:05")
 	updatedAt := policy.UpdatedAt.In(time.Local).Format("2006-01-02 15:04:05")
@@ -603,6 +613,8 @@ func consumePolicyWithConfigDetailView(policy *consumePolicyWithConfig) string {
 	fmt.Fprintf(&b, "description: %s\n", description)
 	fmt.Fprintf(&b, "enabled: %s\n", enabled)
 	fmt.Fprintf(&b, "labels: %s\n", labels)
+	fmt.Fprintf(&b, "condition: %s\n", condition)
+	fmt.Fprintf(&b, "parent_policy_id: %s\n", parentPolicyID)
 	fmt.Fprintf(&b, "config: %s\n", config)
 	fmt.Fprintf(&b, "created_at: %s\n", createdAt)
 	fmt.Fprintf(&b, "updated_at: %s\n", updatedAt)

--- a/internal/cmd/root/products/konnect/eventgateway/consume-policies_test.go
+++ b/internal/cmd/root/products/konnect/eventgateway/consume-policies_test.go
@@ -134,3 +134,35 @@ func TestConsumePolicyToRecordNilFields(t *testing.T) {
 	assert.Equal(t, valueNA, record.Description)
 	assert.Equal(t, valueNA, record.Enabled)
 }
+
+func TestConsumePolicyDetailView(t *testing.T) {
+	assert.Empty(t, consumePolicyWithConfigDetailView(nil))
+
+	name := "Test Policy"
+	description := "Test Description"
+	enabled := true
+	condition := "true"
+	parentPolicyID := "parent-policy-id"
+	policy := &consumePolicyWithConfig{
+		ID:             "test-id",
+		Type:           "decrypt_fields",
+		Name:           &name,
+		Description:    &description,
+		Enabled:        &enabled,
+		Condition:      &condition,
+		ParentPolicyID: &parentPolicyID,
+		Config:         map[string]any{"key": "value"},
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+
+	detail := consumePolicyWithConfigDetailView(policy)
+
+	assert.Contains(t, detail, "id: test-id")
+	assert.Contains(t, detail, "type: decrypt_fields")
+	assert.Contains(t, detail, "name: Test Policy")
+	assert.Contains(t, detail, "description: Test Description")
+	assert.Contains(t, detail, "enabled: true")
+	assert.Contains(t, detail, "condition: true")
+	assert.Contains(t, detail, "parent_policy_id: parent-policy-id")
+}

--- a/internal/cmd/root/verbs/dump/declarative_children.go
+++ b/internal/cmd/root/verbs/dump/declarative_children.go
@@ -1970,6 +1970,12 @@ func convertConsumePolicyToResource(
 	if policy.Labels != nil {
 		policyMap["labels"] = policy.Labels
 	}
+	if policy.Condition != nil {
+		policyMap["condition"] = *policy.Condition
+	}
+	if policy.ParentPolicyID != nil {
+		policyMap["parent_policy_id"] = *policy.ParentPolicyID
+	}
 
 	data, err := json.Marshal(policyMap)
 	if err != nil {

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -1210,40 +1210,46 @@ func (e *Executor) syncResolvedEventGatewayStaticKeyConfigRef(
 	change *planner.PlannedChange,
 ) error {
 	const fieldName = planner.FieldConfig + ".encryption_key.key." + planner.FieldID
-	ref, ok := change.References[fieldName]
-	if !ok {
-		return nil
-	}
+	for currentFieldName, ref := range change.References {
+		if currentFieldName != fieldName && !isEventGatewayEncryptFieldsStaticKeyRef(currentFieldName) {
+			continue
+		}
 
-	if unresolvedReferenceID(ref.ID) {
-		if e.client == nil {
-			return fmt.Errorf("state client not configured")
-		}
-		gatewayID, err := eventGatewayIDFromChange(change)
-		if err != nil {
-			return err
-		}
-		name := referenceLookupName(ref)
-		keys, err := e.client.ListEventGatewayStaticKeys(ctx, gatewayID)
-		if err != nil {
-			return fmt.Errorf("failed to resolve event gateway static key reference: %w", err)
-		}
-		for _, key := range keys {
-			if key.Name == name {
-				ref.ID = key.ID
-				change.References[fieldName] = ref
-				break
+		if unresolvedReferenceID(ref.ID) {
+			if e.client == nil {
+				return fmt.Errorf("state client not configured")
+			}
+			gatewayID, err := eventGatewayIDFromChange(change)
+			if err != nil {
+				return err
+			}
+			name := referenceLookupName(ref)
+			keys, err := e.client.ListEventGatewayStaticKeys(ctx, gatewayID)
+			if err != nil {
+				return fmt.Errorf("failed to resolve event gateway static key reference: %w", err)
+			}
+			for _, key := range keys {
+				if key.Name == name {
+					ref.ID = key.ID
+					change.References[currentFieldName] = ref
+					break
+				}
+			}
+			if unresolvedReferenceID(ref.ID) {
+				return fmt.Errorf("event gateway static key not found: ref=%s", ref.Ref)
 			}
 		}
-		if unresolvedReferenceID(ref.ID) {
-			return fmt.Errorf("event gateway static key not found: ref=%s", ref.Ref)
+
+		if change.Fields != nil {
+			setResolvedFieldValue(change.Fields, currentFieldName, ref.ID)
 		}
 	}
-
-	if change.Fields != nil {
-		setResolvedFieldValue(change.Fields, fieldName, ref.ID)
-	}
 	return nil
+}
+
+func isEventGatewayEncryptFieldsStaticKeyRef(fieldName string) bool {
+	return strings.HasPrefix(fieldName, planner.FieldConfig+".encrypt_fields.") &&
+		strings.HasSuffix(fieldName, ".encryption_key.key."+planner.FieldID)
 }
 
 func eventGatewayIDFromChange(change *planner.PlannedChange) (string, error) {

--- a/internal/declarative/executor/executor_test.go
+++ b/internal/declarative/executor/executor_test.go
@@ -160,6 +160,95 @@ func TestHydrateKnownReferenceIDsUpdatesNestedField(t *testing.T) {
 	assert.NotContains(t, change.Fields, "config.encryption_key.key.id")
 }
 
+func TestHydrateKnownReferenceIDsUpdatesEncryptFieldsStaticKey(t *testing.T) {
+	exec := New(nil, nil, false)
+	exec.createdResources["1-c-static-key"] = "static-key-id"
+
+	plan := planner.NewPlan("1.0", "test", planner.PlanModeApply)
+	plan.AddChange(planner.PlannedChange{
+		ID:           "1-c-static-key",
+		ResourceType: planner.ResourceTypeEventGatewayStaticKey,
+		ResourceRef:  "static-key",
+		Action:       planner.ActionCreate,
+	})
+
+	change := planner.PlannedChange{
+		ID:           "2-c-produce-policy",
+		ResourceType: planner.ResourceTypeEventGatewayProducePolicy,
+		ResourceRef:  "produce-policy",
+		Action:       planner.ActionCreate,
+		DependsOn:    []string{"1-c-static-key"},
+		Fields: map[string]any{
+			planner.FieldConfig: map[string]any{
+				"encrypt_fields": []any{
+					map[string]any{
+						"encryption_key": map[string]any{
+							"key": map[string]any{
+								planner.FieldID: "__REF__:static-key#id",
+							},
+						},
+					},
+				},
+			},
+		},
+		References: map[string]planner.ReferenceInfo{
+			"config.encrypt_fields.0.encryption_key.key.id": {
+				Ref: "__REF__:static-key#id",
+				ID:  resources.UnknownReferenceID,
+			},
+		},
+	}
+	plan.AddChange(change)
+
+	exec.hydrateKnownReferenceIDs(&change, plan)
+
+	ref := change.References["config.encrypt_fields.0.encryption_key.key.id"]
+	assert.Equal(t, "static-key-id", ref.ID)
+	config := change.Fields[planner.FieldConfig].(map[string]any)
+	encryptFields := config["encrypt_fields"].([]any)
+	firstField := encryptFields[0].(map[string]any)
+	encryptionKey := firstField["encryption_key"].(map[string]any)
+	key := encryptionKey["key"].(map[string]any)
+	assert.Equal(t, "static-key-id", key[planner.FieldID])
+}
+
+func TestHydrateKnownReferenceIDsUpdatesPolicyParentID(t *testing.T) {
+	exec := New(nil, nil, false)
+	exec.createdResources["1-c-schema-validation"] = "schema-validation-id"
+
+	plan := planner.NewPlan("1.0", "test", planner.PlanModeApply)
+	plan.AddChange(planner.PlannedChange{
+		ID:           "1-c-schema-validation",
+		ResourceType: planner.ResourceTypeEventGatewayProducePolicy,
+		ResourceRef:  "schema-validation",
+		Action:       planner.ActionCreate,
+	})
+
+	change := planner.PlannedChange{
+		ID:           "2-c-encrypt-fields",
+		ResourceType: planner.ResourceTypeEventGatewayProducePolicy,
+		ResourceRef:  "encrypt-fields",
+		Action:       planner.ActionCreate,
+		DependsOn:    []string{"1-c-schema-validation"},
+		Fields: map[string]any{
+			planner.FieldParentPolicyID: "__REF__:schema-validation#id",
+		},
+		References: map[string]planner.ReferenceInfo{
+			planner.FieldParentPolicyID: {
+				Ref: "__REF__:schema-validation#id",
+				ID:  resources.UnknownReferenceID,
+			},
+		},
+	}
+	plan.AddChange(change)
+
+	exec.hydrateKnownReferenceIDs(&change, plan)
+
+	ref := change.References[planner.FieldParentPolicyID]
+	assert.Equal(t, "schema-validation-id", ref.ID)
+	assert.Equal(t, "schema-validation-id", change.Fields[planner.FieldParentPolicyID])
+}
+
 func TestHydrateKnownReferenceIDsAppliesResolvedNestedField(t *testing.T) {
 	exec := New(nil, nil, false)
 	plan := planner.NewPlan("1.0", "test", planner.PlanModeApply)

--- a/internal/declarative/planner/constants.go
+++ b/internal/declarative/planner/constants.go
@@ -98,6 +98,7 @@ const (
 	FieldParentDocumentID             = "parent_document_id"
 	FieldParentPageID                 = "parent_page_id"
 	FieldParentPath                   = "parent_path"
+	FieldParentPolicyID               = "parent_policy_id"
 	FieldPortalID                     = "portal_id"
 	FieldRoleName                     = "role_name"
 	FieldService                      = "service"

--- a/internal/declarative/planner/event_gateway_consume_policy_planner.go
+++ b/internal/declarative/planner/event_gateway_consume_policy_planner.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"reflect"
 
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/kong/kongctl/internal/declarative/resources"
 	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/declarative/tags"
 )
 
 // planEventGatewayConsumePolicyChanges plans changes for Event Gateway Consume Policies
@@ -45,10 +47,9 @@ func (p *Planner) planEventGatewayConsumePolicyChanges(
 	}
 
 	// Virtual cluster doesn't exist yet: plan creates only, with dependency on virtual cluster creation
-	p.planConsumePolicyCreatesForNewVirtualCluster(
+	return p.planConsumePolicyCreatesForNewVirtualCluster(
 		namespace, gatewayRef, virtualClusterRef, virtualClusterName, virtualClusterChangeID, desired, plan,
 	)
-	return nil
 }
 
 // planConsumePolicyChangesForExistingVirtualCluster handles full diff for consume policies
@@ -92,6 +93,11 @@ func (p *Planner) planConsumePolicyChangesForExistingVirtualCluster(
 		}
 	}
 
+	desired, err = p.prepareConsumePolicyParentRefs(desired, currentByName)
+	if err != nil {
+		return err
+	}
+
 	// 3. Compare desired vs current
 	desiredNames := make(map[string]bool)
 	for _, desiredPolicy := range desired {
@@ -117,16 +123,33 @@ func (p *Planner) planConsumePolicyChangesForExistingVirtualCluster(
 
 			needsUpdate, updateFields, changedFields := p.shouldUpdateConsumePolicy(current, desiredPolicy)
 			if needsUpdate {
-				p.logger.Debug(
-					"Planning consume policy UPDATE",
-					"policy_name", policyName,
-					"policy_id", current.ID,
-					"changed_fields", changedFields,
-				)
-				p.planConsumePolicyUpdate(
-					namespace, gatewayID, gatewayRef, virtualClusterID, virtualClusterRef,
-					current.ID, desiredPolicy, updateFields, changedFields, plan,
-				)
+				if consumePolicyRequiresRecreate(changedFields) {
+					p.logger.Debug(
+						"Planning consume policy DELETE+CREATE due to immutable field change",
+						"policy_name", policyName,
+						"policy_id", current.ID,
+						"changed_fields", changedFields,
+					)
+					deleteID := p.planConsumePolicyDelete(
+						gatewayID, gatewayRef, virtualClusterID, virtualClusterRef,
+						current.ID, policyName, plan,
+					)
+					p.planConsumePolicyCreate(
+						namespace, gatewayID, gatewayRef, virtualClusterID, virtualClusterRef, virtualClusterName,
+						desiredPolicy, []string{deleteID}, plan,
+					)
+				} else {
+					p.logger.Debug(
+						"Planning consume policy UPDATE",
+						"policy_name", policyName,
+						"policy_id", current.ID,
+						"changed_fields", changedFields,
+					)
+					p.planConsumePolicyUpdate(
+						namespace, gatewayID, gatewayRef, virtualClusterID, virtualClusterRef,
+						current.ID, desiredPolicy, updateFields, changedFields, plan,
+					)
+				}
 			}
 		}
 	}
@@ -161,13 +184,18 @@ func (p *Planner) planConsumePolicyCreatesForNewVirtualCluster(
 	virtualClusterChangeID string,
 	policies []resources.EventGatewayConsumePolicyResource,
 	plan *Plan,
-) {
+) error {
 	p.logger.Debug(
 		"Planning consume policy creates for new virtual cluster",
 		"virtual_cluster_ref", virtualClusterRef,
 		"virtual_cluster_change_id", virtualClusterChangeID,
 		"policy_count", len(policies),
 	)
+
+	policies, err := p.prepareConsumePolicyParentRefs(policies, nil)
+	if err != nil {
+		return err
+	}
 
 	var dependsOn []string
 	if virtualClusterChangeID != "" {
@@ -180,6 +208,65 @@ func (p *Planner) planConsumePolicyCreatesForNewVirtualCluster(
 			policy, dependsOn, plan,
 		)
 	}
+	return nil
+}
+
+func (p *Planner) prepareConsumePolicyParentRefs(
+	policies []resources.EventGatewayConsumePolicyResource,
+	currentByName map[string]state.EventGatewayConsumePolicyInfo,
+) ([]resources.EventGatewayConsumePolicyResource, error) {
+	if len(policies) == 0 {
+		return policies, nil
+	}
+
+	byRef := make(map[string]resources.EventGatewayConsumePolicyResource, len(policies))
+	for _, policy := range policies {
+		byRef[policy.Ref] = policy
+	}
+
+	prepared := make([]resources.EventGatewayConsumePolicyResource, len(policies))
+	copy(prepared, policies)
+
+	for i, policy := range prepared {
+		parentPolicyID := consumePolicyParentPolicyID(policy)
+		if parentPolicyID == "" || !tags.IsRefPlaceholder(parentPolicyID) {
+			continue
+		}
+
+		targetRef := referenceTargetRef(parentPolicyID)
+		parentPolicy, ok := byRef[targetRef]
+		if !ok {
+			return nil, fmt.Errorf(
+				"consume policy %q parent_policy_id references unknown policy ref %q",
+				policy.GetMoniker(),
+				targetRef,
+			)
+		}
+		if !consumePolicyIsSchemaValidation(parentPolicy) {
+			return nil, fmt.Errorf(
+				"consume policy %q parent_policy_id must reference a schema_validation consume policy, got %q",
+				policy.GetMoniker(),
+				consumePolicyType(parentPolicy),
+			)
+		}
+
+		if current, ok := currentByName[parentPolicy.GetMoniker()]; ok && current.ID != "" &&
+			current.Type == string(kkComps.EventGatewayConsumePolicyCreateTypeSchemaValidation) {
+			prepared[i] = consumePolicyWithParentPolicyID(policy, current.ID)
+		}
+	}
+
+	return prepared, nil
+}
+
+func consumePolicyRequiresRecreate(changedFields map[string]FieldChange) bool {
+	if _, typeChanged := changedFields[FieldType]; typeChanged {
+		return true
+	}
+	if _, parentPolicyChanged := changedFields[FieldParentPolicyID]; parentPolicyChanged {
+		return true
+	}
+	return false
 }
 
 // planConsumePolicyCreate plans a CREATE change for a consume policy.
@@ -226,6 +313,7 @@ func (p *Planner) planConsumePolicyCreate(
 			},
 		},
 	}
+	p.addConsumePolicyParentPolicyReference(&change)
 
 	p.logger.Debug(
 		"Enqueuing consume policy CREATE",
@@ -278,6 +366,7 @@ func (p *Planner) planConsumePolicyUpdate(
 			},
 		},
 	}
+	p.addConsumePolicyParentPolicyReference(&change)
 
 	p.logger.Debug(
 		"Enqueuing consume policy UPDATE",
@@ -286,6 +375,35 @@ func (p *Planner) planConsumePolicyUpdate(
 		"policy_id", policyID,
 	)
 	plan.AddChange(change)
+}
+
+func (p *Planner) addConsumePolicyParentPolicyReference(change *PlannedChange) {
+	if change == nil || change.Fields == nil {
+		return
+	}
+
+	parentPolicyID, ok := change.Fields[FieldParentPolicyID].(string)
+	if !ok || !tags.IsRefPlaceholder(parentPolicyID) {
+		return
+	}
+
+	refInfo := ReferenceInfo{
+		Ref: parentPolicyID,
+		ID:  resources.UnknownReferenceID,
+	}
+	targetRef := referenceTargetRef(parentPolicyID)
+	if p.resolver != nil {
+		if resource, exists := p.resolver.getResourceByTypeAndRef(ResourceTypeEventGatewayConsumePolicy, targetRef); exists {
+			if moniker := resource.GetMoniker(); moniker != "" {
+				refInfo.LookupFields = map[string]string{FieldName: moniker}
+			}
+		}
+	}
+
+	if change.References == nil {
+		change.References = make(map[string]ReferenceInfo)
+	}
+	change.References[FieldParentPolicyID] = refInfo
 }
 
 // planConsumePolicyDelete plans a DELETE change for a consume policy.
@@ -297,7 +415,7 @@ func (p *Planner) planConsumePolicyDelete(
 	policyID string,
 	policyName string,
 	plan *Plan,
-) {
+) string {
 	change := PlannedChange{
 		ID:           p.nextChangeID(ActionDelete, ResourceTypeEventGatewayConsumePolicy, policyName),
 		ResourceType: ResourceTypeEventGatewayConsumePolicy,
@@ -326,6 +444,7 @@ func (p *Planner) planConsumePolicyDelete(
 		"policy_id", policyID,
 	)
 	plan.AddChange(change)
+	return change.ID
 }
 
 // consumePolicyToFields converts a consume policy resource to a fields map
@@ -430,6 +549,49 @@ func (p *Planner) extractConsumePolicyConfig(
 	return nil
 }
 
+func consumePolicyType(policy resources.EventGatewayConsumePolicyResource) string {
+	if policy.EventGatewayModifyHeadersPolicyCreate != nil {
+		return policy.EventGatewayModifyHeadersPolicyCreate.GetType()
+	}
+	if policy.EventGatewayConsumeSchemaValidationPolicy != nil {
+		return policy.EventGatewayConsumeSchemaValidationPolicy.GetType()
+	}
+	if policy.EventGatewayDecryptPolicy != nil {
+		return policy.EventGatewayDecryptPolicy.GetType()
+	}
+	if policy.EventGatewaySkipRecordPolicyCreate != nil {
+		return policy.EventGatewaySkipRecordPolicyCreate.GetType()
+	}
+	if policy.EventGatewayParsedRecordDecryptFieldsPolicyCreate != nil {
+		return policy.EventGatewayParsedRecordDecryptFieldsPolicyCreate.GetType()
+	}
+	return ""
+}
+
+func consumePolicyIsSchemaValidation(policy resources.EventGatewayConsumePolicyResource) bool {
+	return policy.EventGatewayConsumeSchemaValidationPolicy != nil
+}
+
+func consumePolicyParentPolicyID(policy resources.EventGatewayConsumePolicyResource) string {
+	if policy.EventGatewayParsedRecordDecryptFieldsPolicyCreate == nil {
+		return ""
+	}
+	return policy.EventGatewayParsedRecordDecryptFieldsPolicyCreate.ParentPolicyID
+}
+
+func consumePolicyWithParentPolicyID(
+	policy resources.EventGatewayConsumePolicyResource,
+	parentPolicyID string,
+) resources.EventGatewayConsumePolicyResource {
+	if policy.EventGatewayParsedRecordDecryptFieldsPolicyCreate == nil {
+		return policy
+	}
+	variant := *policy.EventGatewayParsedRecordDecryptFieldsPolicyCreate
+	variant.ParentPolicyID = parentPolicyID
+	policy.EventGatewayParsedRecordDecryptFieldsPolicyCreate = &variant
+	return policy
+}
+
 // shouldUpdateConsumePolicy compares current and desired consume policy state.
 func (p *Planner) shouldUpdateConsumePolicy(
 	current state.EventGatewayConsumePolicyInfo,
@@ -437,6 +599,26 @@ func (p *Planner) shouldUpdateConsumePolicy(
 ) (bool, map[string]any, map[string]FieldChange) {
 	var needsUpdate bool
 	changes := make(map[string]FieldChange)
+
+	// Type changes are not supported by the API and require a DELETE+CREATE.
+	currentType := current.Type
+	desiredType := consumePolicyType(desired)
+	if currentType != desiredType {
+		needsUpdate = true
+		changes[FieldType] = FieldChange{Old: currentType, New: desiredType}
+	}
+
+	desiredParentPolicyID := consumePolicyParentPolicyID(desired)
+	if desiredParentPolicyID != "" {
+		currentParentPolicyID := ""
+		if current.ParentPolicyID != nil {
+			currentParentPolicyID = *current.ParentPolicyID
+		}
+		if currentParentPolicyID != desiredParentPolicyID {
+			needsUpdate = true
+			changes[FieldParentPolicyID] = FieldChange{Old: currentParentPolicyID, New: desiredParentPolicyID}
+		}
+	}
 
 	// Compare name
 	desiredName := desired.GetMoniker()

--- a/internal/declarative/planner/event_gateway_consume_policy_planner_test.go
+++ b/internal/declarative/planner/event_gateway_consume_policy_planner_test.go
@@ -1,6 +1,7 @@
 package planner
 
 import (
+	"encoding/json"
 	"testing"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
@@ -9,6 +10,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func consumePolicyResourceFromJSON(t *testing.T, data string) resources.EventGatewayConsumePolicyResource {
+	t.Helper()
+
+	var policy resources.EventGatewayConsumePolicyResource
+	require.NoError(t, json.Unmarshal([]byte(data), &policy))
+	return policy
+}
 
 func TestShouldUpdateConsumePolicy_NoChanges(t *testing.T) {
 	name := "test-consume-policy"
@@ -154,4 +163,160 @@ func TestShouldUpdateConsumePolicy_ConfigChangedNestedField(t *testing.T) {
 	require.True(t, needsUpdate, "update should be needed when config changes")
 	assert.NotNil(t, updateFields, "updateFields should contain the new config")
 	require.Contains(t, changedFields, "config", "config should be in changed fields")
+}
+
+func TestShouldUpdateConsumePolicy_TypeChanged(t *testing.T) {
+	name := "test-consume-policy"
+	desc := "test description"
+	enabled := true
+
+	current := state.EventGatewayConsumePolicyInfo{
+		EventGatewayPolicy: kkComps.EventGatewayPolicy{
+			ID:          "policy-123",
+			Name:        &name,
+			Description: &desc,
+			Enabled:     &enabled,
+			Type:        "decrypt",
+		},
+		NormalizedLabels: map[string]string{},
+		RawConfig:        map[string]any{},
+	}
+
+	desired := resources.EventGatewayConsumePolicyResource{
+		EventGatewayConsumePolicyCreate: kkComps.CreateEventGatewayConsumePolicyCreateSchemaValidation(
+			kkComps.EventGatewayConsumeSchemaValidationPolicy{
+				Name:        &name,
+				Description: &desc,
+				Enabled:     &enabled,
+				Config: kkComps.CreateEventGatewayConsumeSchemaValidationPolicyConfigJSON(
+					kkComps.EventGatewayConsumeSchemaValidationPolicyJSONConfig{},
+				),
+			},
+		),
+		Ref: "test-consume-policy-ref",
+	}
+
+	p := &Planner{}
+	needsUpdate, _, changedFields := p.shouldUpdateConsumePolicy(current, desired)
+
+	require.True(t, needsUpdate)
+	require.Contains(t, changedFields, FieldType)
+	assert.Equal(t, "decrypt", changedFields[FieldType].Old)
+	assert.Equal(t, "schema_validation", changedFields[FieldType].New)
+}
+
+func TestConsumePolicyToFieldsDecryptFields(t *testing.T) {
+	policy := consumePolicyResourceFromJSON(t, `{
+		"ref": "decrypt-fields",
+		"type": "decrypt_fields",
+		"name": "decrypt-fields",
+		"parent_policy_id": "__REF__:schema-validation#id",
+		"config": {
+			"failure_mode": "error",
+			"key_sources": [
+				{"type": "static"}
+			],
+			"decrypt_fields": {
+				"paths": "$.customer.ssn"
+			}
+		}
+	}`)
+
+	p := &Planner{}
+	fields := p.consumePolicyToFields(policy)
+
+	require.Equal(t, "decrypt_fields", fields[FieldType])
+	require.Equal(t, "__REF__:schema-validation#id", fields[FieldParentPolicyID])
+	config, ok := fields[FieldConfig].(map[string]any)
+	require.True(t, ok)
+	_, ok = config["decrypt_fields"].(map[string]any)
+	require.True(t, ok)
+}
+
+func TestPlanConsumePolicyCreateDecryptFieldsReference(t *testing.T) {
+	policy := consumePolicyResourceFromJSON(t, `{
+		"ref": "decrypt-fields",
+		"type": "decrypt_fields",
+		"name": "decrypt-fields",
+		"parent_policy_id": "__REF__:schema-validation#id",
+		"config": {
+			"failure_mode": "error",
+			"key_sources": [
+				{"type": "static"}
+			],
+			"decrypt_fields": {
+				"paths": "$.customer.ssn"
+			}
+		}
+	}`)
+
+	p := newTestPlanner()
+	plan := NewPlan("1.0", "test", PlanModeApply)
+	p.planConsumePolicyCreate(
+		"default",
+		"gateway-id",
+		"gateway-ref",
+		"virtual-cluster-id",
+		"virtual-cluster-ref",
+		"virtual-cluster",
+		policy,
+		nil,
+		plan,
+	)
+
+	require.Len(t, plan.Changes, 1)
+	parentRef, ok := plan.Changes[0].References[FieldParentPolicyID]
+	require.True(t, ok)
+	require.Equal(t, "__REF__:schema-validation#id", parentRef.Ref)
+}
+
+func TestPrepareConsumePolicyParentRefsResolvesExistingSchemaValidationParent(t *testing.T) {
+	parent := consumePolicyResourceFromJSON(t, `{
+		"ref": "schema-validation",
+		"type": "schema_validation",
+		"name": "schema-validation",
+		"config": {
+			"type": "json"
+		}
+	}`)
+	child := consumePolicyResourceFromJSON(t, `{
+		"ref": "decrypt-fields",
+		"type": "decrypt_fields",
+		"name": "decrypt-fields",
+		"parent_policy_id": "__REF__:schema-validation#id",
+		"config": {
+			"failure_mode": "error",
+			"key_sources": [
+				{"type": "static"}
+			],
+			"decrypt_fields": {
+				"paths": "$.customer.ssn"
+			}
+		}
+	}`)
+
+	parentName := "schema-validation"
+	currentByName := map[string]state.EventGatewayConsumePolicyInfo{
+		parentName: {
+			EventGatewayPolicy: kkComps.EventGatewayPolicy{
+				ID:   "schema-validation-id",
+				Name: &parentName,
+				Type: "schema_validation",
+			},
+		},
+	}
+
+	p := &Planner{}
+	prepared, err := p.prepareConsumePolicyParentRefs(
+		[]resources.EventGatewayConsumePolicyResource{parent, child},
+		currentByName,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, prepared, 2)
+	require.Equal(
+		t,
+		"schema-validation-id",
+		prepared[1].EventGatewayParsedRecordDecryptFieldsPolicyCreate.ParentPolicyID,
+	)
 }

--- a/internal/declarative/planner/event_gateway_produce_policy_planner.go
+++ b/internal/declarative/planner/event_gateway_produce_policy_planner.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/kong/kongctl/internal/declarative/resources"
 	"github.com/kong/kongctl/internal/declarative/state"
 	"github.com/kong/kongctl/internal/declarative/tags"
@@ -46,10 +48,9 @@ func (p *Planner) planEventGatewayVirtualClusterProducePolicyChanges(
 	}
 
 	// Parent doesn't exist yet: plan creates only with dependency
-	p.planProducePolicyCreatesForNewVirtualCluster(
+	return p.planProducePolicyCreatesForNewVirtualCluster(
 		namespace, gatewayRef, virtualClusterRef, virtualClusterName, virtualClusterChangeID, desired, plan,
 	)
-	return nil
 }
 
 func (p *Planner) planProducePolicyChangesForExistingVirtualCluster(
@@ -83,6 +84,11 @@ func (p *Planner) planProducePolicyChangesForExistingVirtualCluster(
 		}
 	}
 
+	desired, err = p.prepareProducePolicyParentRefs(desired, currentByName)
+	if err != nil {
+		return err
+	}
+
 	desiredNames := make(map[string]bool)
 	for _, desiredPolicy := range desired {
 		policyName := desiredPolicy.GetMoniker()
@@ -101,20 +107,20 @@ func (p *Planner) planProducePolicyChangesForExistingVirtualCluster(
 		} else {
 			needsUpdate, updateFields, changedFields := p.shouldUpdateProducePolicy(current, desiredPolicy)
 			if needsUpdate {
-				if _, typeChanged := changedFields[FieldType]; typeChanged {
-					// Type changes are not supported by the API; force DELETE + CREATE.
+				if producePolicyRequiresRecreate(changedFields) {
+					// Type and parent-policy changes are not supported by the API; force DELETE + CREATE.
 					p.logger.Debug(
-						"Planning produce policy DELETE+CREATE due to type change",
+						"Planning produce policy DELETE+CREATE due to immutable field change",
 						"policy_name", policyName,
 						"policy_id", current.ID,
 					)
-					p.planProducePolicyDelete(
+					deleteID := p.planProducePolicyDelete(
 						gatewayID, gatewayRef, virtualClusterID, virtualClusterRef,
 						current.ID, policyName, plan,
 					)
 					p.planProducePolicyCreate(
 						namespace, gatewayID, gatewayRef, virtualClusterID, virtualClusterRef, virtualClusterName,
-						desiredPolicy, []string{}, plan,
+						desiredPolicy, []string{deleteID}, plan,
 					)
 				} else {
 					p.logger.Debug(
@@ -159,13 +165,18 @@ func (p *Planner) planProducePolicyCreatesForNewVirtualCluster(
 	virtualClusterChangeID string,
 	policies []resources.EventGatewayProducePolicyResource,
 	plan *Plan,
-) {
+) error {
 	p.logger.Debug(
 		"Planning produce policy creates for new virtual cluster",
 		"virtual_cluster_ref", virtualClusterRef,
 		"virtual_cluster_change_id", virtualClusterChangeID,
 		"policy_count", len(policies),
 	)
+
+	policies, err := p.prepareProducePolicyParentRefs(policies, nil)
+	if err != nil {
+		return err
+	}
 
 	var dependsOn []string
 	if virtualClusterChangeID != "" {
@@ -178,6 +189,65 @@ func (p *Planner) planProducePolicyCreatesForNewVirtualCluster(
 			policy, dependsOn, plan,
 		)
 	}
+	return nil
+}
+
+func (p *Planner) prepareProducePolicyParentRefs(
+	policies []resources.EventGatewayProducePolicyResource,
+	currentByName map[string]state.EventGatewayVirtualClusterProducePolicyInfo,
+) ([]resources.EventGatewayProducePolicyResource, error) {
+	if len(policies) == 0 {
+		return policies, nil
+	}
+
+	byRef := make(map[string]resources.EventGatewayProducePolicyResource, len(policies))
+	for _, policy := range policies {
+		byRef[policy.Ref] = policy
+	}
+
+	prepared := make([]resources.EventGatewayProducePolicyResource, len(policies))
+	copy(prepared, policies)
+
+	for i, policy := range prepared {
+		parentPolicyID := producePolicyParentPolicyID(policy)
+		if parentPolicyID == "" || !tags.IsRefPlaceholder(parentPolicyID) {
+			continue
+		}
+
+		targetRef := referenceTargetRef(parentPolicyID)
+		parentPolicy, ok := byRef[targetRef]
+		if !ok {
+			return nil, fmt.Errorf(
+				"produce policy %q parent_policy_id references unknown policy ref %q",
+				policy.GetMoniker(),
+				targetRef,
+			)
+		}
+		if !producePolicyIsSchemaValidation(parentPolicy) {
+			return nil, fmt.Errorf(
+				"produce policy %q parent_policy_id must reference a schema_validation produce policy, got %q",
+				policy.GetMoniker(),
+				producePolicyType(parentPolicy),
+			)
+		}
+
+		if current, ok := currentByName[parentPolicy.GetMoniker()]; ok && current.ID != "" &&
+			current.Type == string(kkComps.EventGatewayProducePolicyCreateTypeSchemaValidation) {
+			prepared[i] = producePolicyWithParentPolicyID(policy, current.ID)
+		}
+	}
+
+	return prepared, nil
+}
+
+func producePolicyRequiresRecreate(changedFields map[string]FieldChange) bool {
+	if _, typeChanged := changedFields[FieldType]; typeChanged {
+		return true
+	}
+	if _, parentPolicyChanged := changedFields[FieldParentPolicyID]; parentPolicyChanged {
+		return true
+	}
+	return false
 }
 
 func (p *Planner) planProducePolicyCreate(
@@ -295,6 +365,8 @@ func (p *Planner) addProducePolicyConfigReferences(change *PlannedChange) {
 		FieldConfig+".encryption_key.key."+FieldID,
 		ResourceTypeEventGatewayStaticKey,
 	)
+	p.addProducePolicyEncryptFieldsConfigReferences(change)
+	p.addProducePolicyParentPolicyReference(change)
 }
 
 func (p *Planner) addProducePolicyConfigReference(
@@ -326,6 +398,64 @@ func (p *Planner) addProducePolicyConfigReference(
 	change.References[fieldPath] = refInfo
 }
 
+func (p *Planner) addProducePolicyEncryptFieldsConfigReferences(change *PlannedChange) {
+	if change == nil || change.Fields == nil {
+		return
+	}
+
+	config, ok := change.Fields[FieldConfig].(map[string]any)
+	if !ok {
+		return
+	}
+	encryptFields, ok := config["encrypt_fields"].([]any)
+	if !ok {
+		return
+	}
+
+	for i, field := range encryptFields {
+		fieldMap, ok := field.(map[string]any)
+		if !ok {
+			continue
+		}
+		ref, ok := stringValueAtFieldPath(fieldMap, "encryption_key.key."+FieldID)
+		if !ok || !tags.IsRefPlaceholder(ref) {
+			continue
+		}
+
+		fieldPath := fmt.Sprintf("%s.encrypt_fields.%d.encryption_key.key.%s", FieldConfig, i, FieldID)
+		p.addProducePolicyConfigReference(change, fieldPath, ResourceTypeEventGatewayStaticKey)
+	}
+}
+
+func (p *Planner) addProducePolicyParentPolicyReference(change *PlannedChange) {
+	if change == nil || change.Fields == nil {
+		return
+	}
+
+	parentPolicyID, ok := change.Fields[FieldParentPolicyID].(string)
+	if !ok || !tags.IsRefPlaceholder(parentPolicyID) {
+		return
+	}
+
+	refInfo := ReferenceInfo{
+		Ref: parentPolicyID,
+		ID:  resources.UnknownReferenceID,
+	}
+	targetRef := referenceTargetRef(parentPolicyID)
+	if p.resolver != nil {
+		if resource, exists := p.resolver.getResourceByTypeAndRef(ResourceTypeEventGatewayProducePolicy, targetRef); exists {
+			if moniker := resource.GetMoniker(); moniker != "" {
+				refInfo.LookupFields = map[string]string{FieldName: moniker}
+			}
+		}
+	}
+
+	if change.References == nil {
+		change.References = make(map[string]ReferenceInfo)
+	}
+	change.References[FieldParentPolicyID] = refInfo
+}
+
 func stringValueAtFieldPath(fields map[string]any, fieldPath string) (string, bool) {
 	if fields == nil || fieldPath == "" {
 		return "", false
@@ -336,12 +466,20 @@ func stringValueAtFieldPath(fields map[string]any, fieldPath string) (string, bo
 
 	var current any = fields
 	for segment := range strings.SplitSeq(fieldPath, ".") {
-		currentMap, ok := current.(map[string]any)
-		if !ok {
-			return "", false
-		}
-		current, ok = currentMap[segment]
-		if !ok {
+		switch typed := current.(type) {
+		case map[string]any:
+			next, ok := typed[segment]
+			if !ok {
+				return "", false
+			}
+			current = next
+		case []any:
+			index, err := strconv.Atoi(segment)
+			if err != nil || index < 0 || index >= len(typed) {
+				return "", false
+			}
+			current = typed[index]
+		default:
 			return "", false
 		}
 	}
@@ -358,7 +496,7 @@ func (p *Planner) planProducePolicyDelete(
 	policyID string,
 	policyName string,
 	plan *Plan,
-) {
+) string {
 	change := PlannedChange{
 		ID:           p.nextChangeID(ActionDelete, ResourceTypeEventGatewayProducePolicy, policyName),
 		ResourceType: ResourceTypeEventGatewayProducePolicy,
@@ -387,6 +525,7 @@ func (p *Planner) planProducePolicyDelete(
 		"policy_id", policyID,
 	)
 	plan.AddChange(change)
+	return change.ID
 }
 
 func (p *Planner) producePolicyToFields(policy resources.EventGatewayProducePolicyResource) map[string]any {
@@ -403,6 +542,8 @@ func (p *Planner) producePolicyToFields(policy resources.EventGatewayProducePoli
 		variantData, err = json.Marshal(policy.EventGatewayProduceSchemaValidationPolicy)
 	} else if policy.EventGatewayEncryptPolicy != nil {
 		variantData, err = json.Marshal(policy.EventGatewayEncryptPolicy)
+	} else if policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate != nil {
+		variantData, err = json.Marshal(policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate)
 	}
 
 	if err != nil {
@@ -441,7 +582,51 @@ func extractProducePolicyVariantLabels(policy resources.EventGatewayProducePolic
 	if policy.EventGatewayEncryptPolicy != nil && policy.EventGatewayEncryptPolicy.Labels != nil {
 		return policy.EventGatewayEncryptPolicy.Labels
 	}
+	if policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate != nil &&
+		policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate.Labels != nil {
+		return policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate.Labels
+	}
 	return nil
+}
+
+func producePolicyType(policy resources.EventGatewayProducePolicyResource) string {
+	if policy.EventGatewayModifyHeadersPolicyCreate != nil {
+		return policy.EventGatewayModifyHeadersPolicyCreate.GetType()
+	}
+	if policy.EventGatewayProduceSchemaValidationPolicy != nil {
+		return policy.EventGatewayProduceSchemaValidationPolicy.GetType()
+	}
+	if policy.EventGatewayEncryptPolicy != nil {
+		return policy.EventGatewayEncryptPolicy.GetType()
+	}
+	if policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate != nil {
+		return policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate.GetType()
+	}
+	return ""
+}
+
+func producePolicyIsSchemaValidation(policy resources.EventGatewayProducePolicyResource) bool {
+	return policy.EventGatewayProduceSchemaValidationPolicy != nil
+}
+
+func producePolicyParentPolicyID(policy resources.EventGatewayProducePolicyResource) string {
+	if policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate == nil {
+		return ""
+	}
+	return policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate.ParentPolicyID
+}
+
+func producePolicyWithParentPolicyID(
+	policy resources.EventGatewayProducePolicyResource,
+	parentPolicyID string,
+) resources.EventGatewayProducePolicyResource {
+	if policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate == nil {
+		return policy
+	}
+	variant := *policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate
+	variant.ParentPolicyID = parentPolicyID
+	policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate = &variant
+	return policy
 }
 
 func (p *Planner) shouldUpdateProducePolicy(
@@ -460,10 +645,24 @@ func (p *Planner) shouldUpdateProducePolicy(
 		desiredType = desired.EventGatewayProduceSchemaValidationPolicy.GetType()
 	} else if desired.EventGatewayEncryptPolicy != nil {
 		desiredType = desired.EventGatewayEncryptPolicy.GetType()
+	} else if desired.EventGatewayParsedRecordEncryptFieldsPolicyCreate != nil {
+		desiredType = desired.EventGatewayParsedRecordEncryptFieldsPolicyCreate.GetType()
 	}
 	if currentType != desiredType {
 		needsUpdate = true
 		changes[FieldType] = FieldChange{Old: currentType, New: desiredType}
+	}
+
+	desiredParentPolicyID := producePolicyParentPolicyID(desired)
+	if desiredParentPolicyID != "" {
+		currentParentPolicyID := ""
+		if current.ParentPolicyID != nil {
+			currentParentPolicyID = *current.ParentPolicyID
+		}
+		if currentParentPolicyID != desiredParentPolicyID {
+			needsUpdate = true
+			changes[FieldParentPolicyID] = FieldChange{Old: currentParentPolicyID, New: desiredParentPolicyID}
+		}
 	}
 
 	desiredName := desired.GetMoniker()
@@ -491,6 +690,9 @@ func (p *Planner) shouldUpdateProducePolicy(
 		desiredDesc = *desired.EventGatewayProduceSchemaValidationPolicy.Description
 	} else if desired.EventGatewayEncryptPolicy != nil && desired.EventGatewayEncryptPolicy.Description != nil {
 		desiredDesc = *desired.EventGatewayEncryptPolicy.Description
+	} else if desired.EventGatewayParsedRecordEncryptFieldsPolicyCreate != nil &&
+		desired.EventGatewayParsedRecordEncryptFieldsPolicyCreate.Description != nil {
+		desiredDesc = *desired.EventGatewayParsedRecordEncryptFieldsPolicyCreate.Description
 	}
 	if currentDesc != desiredDesc {
 		needsUpdate = true
@@ -511,6 +713,9 @@ func (p *Planner) shouldUpdateProducePolicy(
 		desiredEnabled = *desired.EventGatewayProduceSchemaValidationPolicy.Enabled
 	} else if desired.EventGatewayEncryptPolicy != nil && desired.EventGatewayEncryptPolicy.Enabled != nil {
 		desiredEnabled = *desired.EventGatewayEncryptPolicy.Enabled
+	} else if desired.EventGatewayParsedRecordEncryptFieldsPolicyCreate != nil &&
+		desired.EventGatewayParsedRecordEncryptFieldsPolicyCreate.Enabled != nil {
+		desiredEnabled = *desired.EventGatewayParsedRecordEncryptFieldsPolicyCreate.Enabled
 	}
 	if currentEnabled != desiredEnabled {
 		needsUpdate = true
@@ -555,6 +760,8 @@ func (p *Planner) extractProducePolicyConfig(policy resources.EventGatewayProduc
 		cfg = policy.EventGatewayProduceSchemaValidationPolicy.Config
 	} else if policy.EventGatewayEncryptPolicy != nil {
 		cfg = policy.EventGatewayEncryptPolicy.Config
+	} else if policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate != nil {
+		cfg = policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate.Config
 	}
 
 	if cfg == nil {

--- a/internal/declarative/planner/event_gateway_produce_policy_planner_test.go
+++ b/internal/declarative/planner/event_gateway_produce_policy_planner_test.go
@@ -1,6 +1,7 @@
 package planner
 
 import (
+	"encoding/json"
 	"log/slog"
 	"os"
 	"testing"
@@ -66,6 +67,14 @@ func rawConfigFromSetAction(key, value string) map[string]any {
 			map[string]any{"op": "set", "key": key, "value": value},
 		},
 	}
+}
+
+func producePolicyResourceFromJSON(t *testing.T, data string) resources.EventGatewayProducePolicyResource {
+	t.Helper()
+
+	var policy resources.EventGatewayProducePolicyResource
+	require.NoError(t, json.Unmarshal([]byte(data), &policy))
+	return policy
 }
 
 // ---------------------------------------------------------------------------
@@ -189,4 +198,140 @@ func TestShouldUpdateProducePolicy_SchemaValidationConfigChanged(t *testing.T) {
 	assert.NotContains(t, changedFields, "name")
 	assert.NotContains(t, changedFields, "description")
 	assert.NotContains(t, changedFields, "enabled")
+}
+
+func TestProducePolicyToFieldsEncryptFields(t *testing.T) {
+	policy := producePolicyResourceFromJSON(t, `{
+		"ref": "encrypt-fields",
+		"type": "encrypt_fields",
+		"name": "encrypt-fields",
+		"parent_policy_id": "__REF__:schema-validation#id",
+		"config": {
+			"failure_mode": "reject",
+			"encrypt_fields": [
+				{
+					"paths": "$.customer.ssn",
+					"encryption_key": {
+						"type": "static",
+						"key": {
+							"id": "__REF__:static-key#id"
+						}
+					}
+				}
+			]
+		}
+	}`)
+
+	p := newTestPlanner()
+	fields := p.producePolicyToFields(policy)
+
+	require.Equal(t, "encrypt_fields", fields[FieldType])
+	require.Equal(t, "__REF__:schema-validation#id", fields[FieldParentPolicyID])
+	config, ok := fields[FieldConfig].(map[string]any)
+	require.True(t, ok)
+	encryptFields, ok := config["encrypt_fields"].([]any)
+	require.True(t, ok)
+	require.Len(t, encryptFields, 1)
+}
+
+func TestPlanProducePolicyCreateEncryptFieldsReferences(t *testing.T) {
+	policy := producePolicyResourceFromJSON(t, `{
+		"ref": "encrypt-fields",
+		"type": "encrypt_fields",
+		"name": "encrypt-fields",
+		"parent_policy_id": "__REF__:schema-validation#id",
+		"config": {
+			"failure_mode": "reject",
+			"encrypt_fields": [
+				{
+					"paths": "$.customer.ssn",
+					"encryption_key": {
+						"type": "static",
+						"key": {
+							"id": "__REF__:static-key#id"
+						}
+					}
+				}
+			]
+		}
+	}`)
+
+	p := newTestPlanner()
+	plan := NewPlan("1.0", "test", PlanModeApply)
+	p.planProducePolicyCreate(
+		"default",
+		"gateway-id",
+		"gateway-ref",
+		"virtual-cluster-id",
+		"virtual-cluster-ref",
+		"virtual-cluster",
+		policy,
+		nil,
+		plan,
+	)
+
+	require.Len(t, plan.Changes, 1)
+	change := plan.Changes[0]
+	parentRef, ok := change.References[FieldParentPolicyID]
+	require.True(t, ok)
+	require.Equal(t, "__REF__:schema-validation#id", parentRef.Ref)
+
+	staticKeyRef, ok := change.References["config.encrypt_fields.0.encryption_key.key.id"]
+	require.True(t, ok)
+	require.Equal(t, "__REF__:static-key#id", staticKeyRef.Ref)
+}
+
+func TestPrepareProducePolicyParentRefsResolvesExistingSchemaValidationParent(t *testing.T) {
+	parent := producePolicyResourceFromJSON(t, `{
+		"ref": "schema-validation",
+		"type": "schema_validation",
+		"name": "schema-validation",
+		"config": {
+			"type": "json"
+		}
+	}`)
+	child := producePolicyResourceFromJSON(t, `{
+		"ref": "encrypt-fields",
+		"type": "encrypt_fields",
+		"name": "encrypt-fields",
+		"parent_policy_id": "__REF__:schema-validation#id",
+		"config": {
+			"failure_mode": "reject",
+			"encrypt_fields": [
+				{
+					"paths": "$.customer.ssn",
+					"encryption_key": {
+						"type": "static",
+						"key": {
+							"id": "__REF__:static-key#id"
+						}
+					}
+				}
+			]
+		}
+	}`)
+
+	currentByName := map[string]state.EventGatewayVirtualClusterProducePolicyInfo{
+		"schema-validation": {
+			EventGatewayPolicy: kkComps.EventGatewayPolicy{
+				ID:   "schema-validation-id",
+				Name: new("schema-validation"),
+				Type: "schema_validation",
+			},
+		},
+	}
+
+	p := newTestPlanner()
+	prepared, err := p.prepareProducePolicyParentRefs(
+		[]resources.EventGatewayProducePolicyResource{parent, child},
+		currentByName,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, prepared, 2)
+	require.Equal(
+		t,
+		"schema-validation-id",
+		prepared[1].EventGatewayParsedRecordEncryptFieldsPolicyCreate.ParentPolicyID,
+	)
 }

--- a/internal/declarative/planner/resolver.go
+++ b/internal/declarative/planner/resolver.go
@@ -230,6 +230,14 @@ func (r *ReferenceResolver) getResourceTypeForChangeField(change PlannedChange, 
 			return string(resourceType)
 		}
 	}
+	if fieldName == FieldParentPolicyID {
+		switch change.ResourceType {
+		case ResourceTypeEventGatewayProducePolicy:
+			return ResourceTypeEventGatewayProducePolicy
+		case ResourceTypeEventGatewayConsumePolicy:
+			return ResourceTypeEventGatewayConsumePolicy
+		}
+	}
 	return r.getResourceTypeForField(fieldName)
 }
 
@@ -335,6 +343,48 @@ func (r *ReferenceResolver) getEventGatewayChildResourceByTypeAndRef(
 					staticKeyCopy := staticKey
 					staticKeyCopy.EventGateway = gateway.Ref
 					return &staticKeyCopy, true
+				}
+			}
+		case ResourceTypeEventGatewayProducePolicy:
+			for _, virtualCluster := range gateway.VirtualClusters {
+				for _, policy := range virtualCluster.ProducePolicies {
+					if policy.Ref == ref {
+						policyCopy := policy
+						policyCopy.EventGateway = gateway.Ref
+						policyCopy.VirtualCluster = virtualCluster.Ref
+						return &policyCopy, true
+					}
+				}
+			}
+		case ResourceTypeEventGatewayConsumePolicy:
+			for _, virtualCluster := range gateway.VirtualClusters {
+				for _, policy := range virtualCluster.ConsumePolicies {
+					if policy.Ref == ref {
+						policyCopy := policy
+						policyCopy.EventGateway = gateway.Ref
+						policyCopy.VirtualCluster = virtualCluster.Ref
+						return &policyCopy, true
+					}
+				}
+			}
+		}
+	}
+	for _, virtualCluster := range r.resources.EventGatewayVirtualClusters {
+		switch resourceType {
+		case ResourceTypeEventGatewayProducePolicy:
+			for _, policy := range virtualCluster.ProducePolicies {
+				if policy.Ref == ref {
+					policyCopy := policy
+					policyCopy.VirtualCluster = virtualCluster.Ref
+					return &policyCopy, true
+				}
+			}
+		case ResourceTypeEventGatewayConsumePolicy:
+			for _, policy := range virtualCluster.ConsumePolicies {
+				if policy.Ref == ref {
+					policyCopy := policy
+					policyCopy.VirtualCluster = virtualCluster.Ref
+					return &policyCopy, true
 				}
 			}
 		}

--- a/internal/declarative/planner/resolver_test.go
+++ b/internal/declarative/planner/resolver_test.go
@@ -698,6 +698,88 @@ func TestResolveReferences_EventGatewayProducePolicyNestedReferencesCreatedInPla
 	assert.Equal(t, "[unknown]", staticKeyRef.ID)
 }
 
+func TestResolveReferences_EventGatewayProducePolicyParentPolicyCreatedInPlan(t *testing.T) {
+	ctx := context.Background()
+	client := state.NewClient(state.ClientConfig{})
+	resolver := NewReferenceResolver(client, nil)
+
+	changes := []PlannedChange{
+		{
+			ID:           "1-c-produce-schema-validation",
+			ResourceType: ResourceTypeEventGatewayProducePolicy,
+			ResourceRef:  "produce-schema-validation",
+			Action:       ActionCreate,
+			Fields: map[string]any{
+				FieldType: "schema_validation",
+				FieldName: "produce-schema-validation",
+			},
+		},
+		{
+			ID:           "2-c-produce-encrypt-fields",
+			ResourceType: ResourceTypeEventGatewayProducePolicy,
+			ResourceRef:  "produce-encrypt-fields",
+			Action:       ActionCreate,
+			Fields: map[string]any{
+				FieldType:           "encrypt_fields",
+				FieldName:           "produce-encrypt-fields",
+				FieldParentPolicyID: "__REF__:produce-schema-validation#id",
+			},
+		},
+	}
+
+	result, err := resolver.ResolveReferences(ctx, changes)
+	require.NoError(t, err)
+	require.Empty(t, result.Errors)
+
+	policyRefs, ok := result.ChangeReferences["2-c-produce-encrypt-fields"]
+	require.True(t, ok, "expected produce policy references")
+	parentRef, ok := policyRefs[FieldParentPolicyID]
+	require.True(t, ok, "expected parent policy reference")
+	assert.Equal(t, "__REF__:produce-schema-validation#id", parentRef.Ref)
+	assert.Equal(t, declresources.UnknownReferenceID, parentRef.ID)
+}
+
+func TestResolveReferences_EventGatewayConsumePolicyParentPolicyCreatedInPlan(t *testing.T) {
+	ctx := context.Background()
+	client := state.NewClient(state.ClientConfig{})
+	resolver := NewReferenceResolver(client, nil)
+
+	changes := []PlannedChange{
+		{
+			ID:           "1-c-consume-schema-validation",
+			ResourceType: ResourceTypeEventGatewayConsumePolicy,
+			ResourceRef:  "consume-schema-validation",
+			Action:       ActionCreate,
+			Fields: map[string]any{
+				FieldType: "schema_validation",
+				FieldName: "consume-schema-validation",
+			},
+		},
+		{
+			ID:           "2-c-consume-decrypt-fields",
+			ResourceType: ResourceTypeEventGatewayConsumePolicy,
+			ResourceRef:  "consume-decrypt-fields",
+			Action:       ActionCreate,
+			Fields: map[string]any{
+				FieldType:           "decrypt_fields",
+				FieldName:           "consume-decrypt-fields",
+				FieldParentPolicyID: "__REF__:consume-schema-validation#id",
+			},
+		},
+	}
+
+	result, err := resolver.ResolveReferences(ctx, changes)
+	require.NoError(t, err)
+	require.Empty(t, result.Errors)
+
+	policyRefs, ok := result.ChangeReferences["2-c-consume-decrypt-fields"]
+	require.True(t, ok, "expected consume policy references")
+	parentRef, ok := policyRefs[FieldParentPolicyID]
+	require.True(t, ok, "expected parent policy reference")
+	assert.Equal(t, "__REF__:consume-schema-validation#id", parentRef.Ref)
+	assert.Equal(t, declresources.UnknownReferenceID, parentRef.ID)
+}
+
 func TestResolveReferences_EventGatewayProducePolicyNestedSchemaRegistryReferenceExistingNestedResource(t *testing.T) {
 	ctx := context.Background()
 	mockCPAPI := helpers.NewMockControlPlaneAPI(t)

--- a/internal/declarative/resources/event_gateway_consume_policy.go
+++ b/internal/declarative/resources/event_gateway_consume_policy.go
@@ -24,7 +24,7 @@ func init() {
 // EventGatewayConsumePolicyResource represents a consume policy in declarative configuration.
 // Consume policies are grandchildren: Event Gateway → Virtual Cluster → Consume Policy.
 // The SDK represents consume policies as a discriminated union type (EventGatewayConsumePolicyCreate)
-// with four variants: modify_headers, schema_validation, decrypt, skip_record.
+// with five variants: modify_headers, schema_validation, decrypt, skip_record, decrypt_fields.
 // The "type" discriminator field is required.
 type EventGatewayConsumePolicyResource struct {
 	kkComps.EventGatewayConsumePolicyCreate `yaml:",inline" json:",inline"`
@@ -60,6 +60,10 @@ func (e EventGatewayConsumePolicyResource) GetMoniker() string {
 	if e.EventGatewaySkipRecordPolicyCreate != nil && e.EventGatewaySkipRecordPolicyCreate.Name != nil {
 		return *e.EventGatewaySkipRecordPolicyCreate.Name
 	}
+	if e.EventGatewayParsedRecordDecryptFieldsPolicyCreate != nil &&
+		e.EventGatewayParsedRecordDecryptFieldsPolicyCreate.Name != nil {
+		return *e.EventGatewayParsedRecordDecryptFieldsPolicyCreate.Name
+	}
 	return e.Ref
 }
 
@@ -85,10 +89,11 @@ func (e EventGatewayConsumePolicyResource) Validate() error {
 	hasVariant := e.EventGatewayModifyHeadersPolicyCreate != nil ||
 		e.EventGatewayConsumeSchemaValidationPolicy != nil ||
 		e.EventGatewayDecryptPolicy != nil ||
-		e.EventGatewaySkipRecordPolicyCreate != nil
+		e.EventGatewaySkipRecordPolicyCreate != nil ||
+		e.EventGatewayParsedRecordDecryptFieldsPolicyCreate != nil
 	if !hasVariant {
 		return fmt.Errorf(
-			"consume policy must specify 'type' field (one of: modify_headers, schema_validation, decrypt, skip_record)",
+			"consume policy must specify 'type' field (one of: modify_headers, schema_validation, decrypt, skip_record, decrypt_fields)",
 		)
 	}
 
@@ -173,6 +178,7 @@ func (e EventGatewayConsumePolicyResource) MarshalJSON() ([]byte, error) {
 //   - "schema_validation" → EventGatewayConsumeSchemaValidationPolicy
 //   - "decrypt" → EventGatewayDecryptPolicy
 //   - "skip_record" → EventGatewaySkipRecordPolicyCreate
+//   - "decrypt_fields" → EventGatewayParsedRecordDecryptFieldsPolicyCreate
 func (e *EventGatewayConsumePolicyResource) UnmarshalJSON(data []byte) error {
 	// Extract our metadata fields
 	var meta struct {
@@ -218,12 +224,13 @@ func validateConsumePolicyType(raw map[string]any) error {
 		string(kkComps.EventGatewayConsumePolicyCreateTypeSchemaValidation),
 		string(kkComps.EventGatewayConsumePolicyCreateTypeDecrypt),
 		string(kkComps.EventGatewayConsumePolicyCreateTypeSkipRecord),
+		string(kkComps.EventGatewayConsumePolicyCreateTypeDecryptFields),
 	}
 
 	policyType, hasType := raw["type"]
 	if !hasType {
 		return fmt.Errorf(
-			"consume policy requires 'type' field (one of: modify_headers, schema_validation, decrypt, skip_record)",
+			"consume policy requires 'type' field (one of: modify_headers, schema_validation, decrypt, skip_record, decrypt_fields)",
 		)
 	}
 
@@ -237,7 +244,7 @@ func validateConsumePolicyType(raw map[string]any) error {
 	}
 
 	return fmt.Errorf(
-		"consume policy 'type' must be one of [modify_headers, schema_validation, decrypt, skip_record], got %q",
+		"consume policy 'type' must be one of [modify_headers, schema_validation, decrypt, skip_record, decrypt_fields], got %q",
 		policyTypeStr,
 	)
 }

--- a/internal/declarative/resources/event_gateway_consume_policy.go
+++ b/internal/declarative/resources/event_gateway_consume_policy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"strings"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 )
@@ -93,7 +94,8 @@ func (e EventGatewayConsumePolicyResource) Validate() error {
 		e.EventGatewayParsedRecordDecryptFieldsPolicyCreate != nil
 	if !hasVariant {
 		return fmt.Errorf(
-			"consume policy must specify 'type' field (one of: modify_headers, schema_validation, decrypt, skip_record, decrypt_fields)",
+			"consume policy must specify 'type' field (one of: %s)",
+			strings.Join(validConsumePolicyTypeStrings(), ", "),
 		)
 	}
 
@@ -219,18 +221,13 @@ func (e *EventGatewayConsumePolicyResource) UnmarshalJSON(data []byte) error {
 
 // validateConsumePolicyType ensures the required type discriminator is present and valid.
 func validateConsumePolicyType(raw map[string]any) error {
-	validTypes := []string{
-		string(kkComps.EventGatewayConsumePolicyCreateTypeModifyHeaders),
-		string(kkComps.EventGatewayConsumePolicyCreateTypeSchemaValidation),
-		string(kkComps.EventGatewayConsumePolicyCreateTypeDecrypt),
-		string(kkComps.EventGatewayConsumePolicyCreateTypeSkipRecord),
-		string(kkComps.EventGatewayConsumePolicyCreateTypeDecryptFields),
-	}
+	validTypes := validConsumePolicyTypeStrings()
 
 	policyType, hasType := raw["type"]
 	if !hasType {
 		return fmt.Errorf(
-			"consume policy requires 'type' field (one of: modify_headers, schema_validation, decrypt, skip_record, decrypt_fields)",
+			"consume policy requires 'type' field (one of: %s)",
+			strings.Join(validTypes, ", "),
 		)
 	}
 
@@ -244,7 +241,18 @@ func validateConsumePolicyType(raw map[string]any) error {
 	}
 
 	return fmt.Errorf(
-		"consume policy 'type' must be one of [modify_headers, schema_validation, decrypt, skip_record, decrypt_fields], got %q",
+		"consume policy 'type' must be one of [%s], got %q",
+		strings.Join(validTypes, ", "),
 		policyTypeStr,
 	)
+}
+
+func validConsumePolicyTypeStrings() []string {
+	return []string{
+		string(kkComps.EventGatewayConsumePolicyCreateTypeModifyHeaders),
+		string(kkComps.EventGatewayConsumePolicyCreateTypeSchemaValidation),
+		string(kkComps.EventGatewayConsumePolicyCreateTypeDecrypt),
+		string(kkComps.EventGatewayConsumePolicyCreateTypeSkipRecord),
+		string(kkComps.EventGatewayConsumePolicyCreateTypeDecryptFields),
+	}
 }

--- a/internal/declarative/resources/event_gateway_field_level_policy_test.go
+++ b/internal/declarative/resources/event_gateway_field_level_policy_test.go
@@ -1,0 +1,78 @@
+package resources
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventGatewayProducePolicyEncryptFieldsUnmarshal(t *testing.T) {
+	data := []byte(`{
+		"ref": "produce-encrypt-fields",
+		"type": "encrypt_fields",
+		"name": "produce-encrypt-fields",
+		"parent_policy_id": "__REF__:produce-schema-validation#id",
+		"config": {
+			"failure_mode": "reject",
+			"encrypt_fields": [
+				{
+					"paths": "$.customer.ssn",
+					"encryption_key": {
+						"type": "static",
+						"key": {
+							"id": "__REF__:static-key#id"
+						}
+					}
+				}
+			]
+		}
+	}`)
+
+	var policy EventGatewayProducePolicyResource
+	require.NoError(t, json.Unmarshal(data, &policy))
+	require.NoError(t, policy.Validate())
+	require.Equal(t, "produce-encrypt-fields", policy.GetMoniker())
+
+	variant := policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate
+	require.NotNil(t, variant)
+	require.Equal(t, "__REF__:produce-schema-validation#id", variant.ParentPolicyID)
+	require.Len(t, variant.Config.EncryptFields, 1)
+
+	staticKey := variant.Config.EncryptFields[0].EncryptionKey.EncryptionKeyStatic
+	require.NotNil(t, staticKey)
+	staticKeyID := staticKey.Key.EncryptionKeyStaticReferenceByID
+	require.NotNil(t, staticKeyID)
+	require.Equal(t, "__REF__:static-key#id", staticKeyID.ID)
+}
+
+func TestEventGatewayConsumePolicyDecryptFieldsUnmarshal(t *testing.T) {
+	data := []byte(`{
+		"ref": "consume-decrypt-fields",
+		"type": "decrypt_fields",
+		"name": "consume-decrypt-fields",
+		"parent_policy_id": "__REF__:consume-schema-validation#id",
+		"config": {
+			"failure_mode": "error",
+			"key_sources": [
+				{"type": "static"}
+			],
+			"decrypt_fields": {
+				"paths": "$.customer.ssn"
+			}
+		}
+	}`)
+
+	var policy EventGatewayConsumePolicyResource
+	require.NoError(t, json.Unmarshal(data, &policy))
+	require.NoError(t, policy.Validate())
+	require.Equal(t, "consume-decrypt-fields", policy.GetMoniker())
+
+	variant := policy.EventGatewayParsedRecordDecryptFieldsPolicyCreate
+	require.NotNil(t, variant)
+	require.Equal(t, "__REF__:consume-schema-validation#id", variant.ParentPolicyID)
+	require.Len(t, variant.Config.KeySources, 1)
+	require.NotNil(t, variant.Config.KeySources[0].EventGatewayStaticKeySource)
+	require.NotNil(t, variant.Config.DecryptFields.Paths.Str)
+	require.Equal(t, "$.customer.ssn", *variant.Config.DecryptFields.Paths.Str)
+}

--- a/internal/declarative/resources/event_gateway_produce_policy.go
+++ b/internal/declarative/resources/event_gateway_produce_policy.go
@@ -22,7 +22,7 @@ func init() {
 
 // EventGatewayProducePolicyResource represents a produce policy in declarative configuration.
 // The SDK represents produce policies as a union type (EventGatewayProducePolicyCreate)
-// with variants: modify_headers, schema_validation, and encrypt.
+// with variants: modify_headers, schema_validation, encrypt, and encrypt_fields.
 type EventGatewayProducePolicyResource struct {
 	kkComps.EventGatewayProducePolicyCreate `yaml:",inline" json:",inline"`
 	Ref                                     string `yaml:"ref"                            json:"ref"`
@@ -52,6 +52,10 @@ func (e EventGatewayProducePolicyResource) GetMoniker() string {
 	}
 	if e.EventGatewayEncryptPolicy != nil && e.EventGatewayEncryptPolicy.Name != nil {
 		return *e.EventGatewayEncryptPolicy.Name
+	}
+	if e.EventGatewayParsedRecordEncryptFieldsPolicyCreate != nil &&
+		e.EventGatewayParsedRecordEncryptFieldsPolicyCreate.Name != nil {
+		return *e.EventGatewayParsedRecordEncryptFieldsPolicyCreate.Name
 	}
 	return e.Ref
 }
@@ -85,13 +89,17 @@ func (e EventGatewayProducePolicyResource) Validate() error {
 	if e.EventGatewayEncryptPolicy != nil {
 		variantCount++
 	}
+	if e.EventGatewayParsedRecordEncryptFieldsPolicyCreate != nil {
+		variantCount++
+	}
 
 	if variantCount == 0 {
 		return fmt.Errorf(
-			"produce policy must specify one of: '%s', '%s', or '%s' type",
+			"produce policy must specify one of: '%s', '%s', '%s', or '%s' type",
 			kkComps.EventGatewayProducePolicyCreateTypeModifyHeaders,
 			kkComps.EventGatewayProducePolicyCreateTypeSchemaValidation,
 			kkComps.EventGatewayProducePolicyCreateTypeEncrypt,
+			kkComps.EventGatewayProducePolicyCreateTypeEncryptFields,
 		)
 	}
 	if variantCount > 1 {
@@ -178,7 +186,7 @@ func (e EventGatewayProducePolicyResource) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON handles the union type correctly.
 // It rejects kongctl metadata and delegates to the SDK union type for the policy body.
 // The SDK union type requires a "type" discriminator field to determine which variant
-// to use. Supported types: modify_headers, schema_validation, encrypt.
+// to use. Supported types: modify_headers, schema_validation, encrypt, encrypt_fields.
 func (e *EventGatewayProducePolicyResource) UnmarshalJSON(data []byte) error {
 	// First extract our metadata fields
 	var meta struct {
@@ -231,6 +239,7 @@ func validateProducePolicyTypeField(raw map[string]any) error {
 		string(kkComps.EventGatewayProducePolicyCreateTypeModifyHeaders),
 		string(kkComps.EventGatewayProducePolicyCreateTypeSchemaValidation),
 		string(kkComps.EventGatewayProducePolicyCreateTypeEncrypt),
+		string(kkComps.EventGatewayProducePolicyCreateTypeEncryptFields),
 	}
 	validTypesFmt := "[" + strings.Join(validTypes, ", ") + "]"
 

--- a/internal/declarative/resources/explain_union_schemas.go
+++ b/internal/declarative/resources/explain_union_schemas.go
@@ -615,7 +615,19 @@ func eventGatewayProducePolicyExplainNode(_ ExplainBuildContext) (*ExplainNode, 
 	if err != nil {
 		return nil, err
 	}
-	return eventGatewayVirtualClusterPolicyUnion(modifyHeaders, schemaValidation, encrypt), nil
+	encryptFields, err := explainVariantNode[kkComps.EventGatewayParsedRecordEncryptFieldsPolicyCreate](
+		"type",
+		"encrypt_fields",
+	)
+	if err != nil {
+		return nil, err
+	}
+	explainReplacePath(
+		encryptFields,
+		[]string{"parent_policy_id"},
+		explainRefField("parent_policy_id", ResourceTypeEventGatewayProducePolicy, true).Node,
+	)
+	return eventGatewayVirtualClusterPolicyUnion(modifyHeaders, schemaValidation, encrypt, encryptFields), nil
 }
 
 func eventGatewayConsumePolicyExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
@@ -638,7 +650,19 @@ func eventGatewayConsumePolicyExplainNode(_ ExplainBuildContext) (*ExplainNode, 
 	if err != nil {
 		return nil, err
 	}
-	return eventGatewayVirtualClusterPolicyUnion(modifyHeaders, schemaValidation, decrypt, skipRecord), nil
+	decryptFields, err := explainVariantNode[kkComps.EventGatewayParsedRecordDecryptFieldsPolicyCreate](
+		"type",
+		"decrypt_fields",
+	)
+	if err != nil {
+		return nil, err
+	}
+	explainReplacePath(
+		decryptFields,
+		[]string{"parent_policy_id"},
+		explainRefField("parent_policy_id", ResourceTypeEventGatewayConsumePolicy, true).Node,
+	)
+	return eventGatewayVirtualClusterPolicyUnion(modifyHeaders, schemaValidation, decrypt, skipRecord, decryptFields), nil
 }
 
 func eventGatewayVirtualClusterPolicyUnion(branches ...*ExplainNode) *ExplainNode {

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -6571,6 +6571,10 @@ func extractProducePolicyCreateName(req kkComps.EventGatewayProducePolicyCreate)
 	if req.EventGatewayEncryptPolicy != nil && req.EventGatewayEncryptPolicy.Name != nil {
 		return *req.EventGatewayEncryptPolicy.Name
 	}
+	if req.EventGatewayParsedRecordEncryptFieldsPolicyCreate != nil &&
+		req.EventGatewayParsedRecordEncryptFieldsPolicyCreate.Name != nil {
+		return *req.EventGatewayParsedRecordEncryptFieldsPolicyCreate.Name
+	}
 	return ""
 }
 
@@ -6585,6 +6589,10 @@ func extractProducePolicyUpdateName(req kkComps.EventGatewayProducePolicyUpdate)
 	}
 	if req.EventGatewayEncryptPolicy != nil && req.EventGatewayEncryptPolicy.Name != nil {
 		return *req.EventGatewayEncryptPolicy.Name
+	}
+	if req.EventGatewayParsedRecordEncryptFieldsPolicy != nil &&
+		req.EventGatewayParsedRecordEncryptFieldsPolicy.Name != nil {
+		return *req.EventGatewayParsedRecordEncryptFieldsPolicy.Name
 	}
 	return ""
 }
@@ -6712,8 +6720,10 @@ func (c *Client) CreateEventGatewayConsumePolicy(
 
 	resp, err := c.eventGatewayConsumePolicyAPI.CreateEventGatewayVirtualClusterConsumePolicy(ctx, createReq)
 	if err != nil {
+		name := extractConsumePolicyCreateName(req)
 		return "", WrapAPIError(err, "create event gateway consume policy", &ErrorWrapperOptions{
 			ResourceType: string(resources.ResourceTypeEventGatewayConsumePolicy),
+			ResourceName: name,
 			Namespace:    namespace,
 			UseEnhanced:  true,
 		})
@@ -6743,8 +6753,10 @@ func (c *Client) UpdateEventGatewayConsumePolicy(
 
 	resp, err := c.eventGatewayConsumePolicyAPI.UpdateEventGatewayVirtualClusterConsumePolicy(ctx, updateReq)
 	if err != nil {
+		name := extractConsumePolicyUpdateName(req)
 		return "", WrapAPIError(err, "update event gateway consume policy", &ErrorWrapperOptions{
 			ResourceType: string(resources.ResourceTypeEventGatewayConsumePolicy),
+			ResourceName: name,
 			Namespace:    namespace,
 			UseEnhanced:  true,
 		})
@@ -6770,6 +6782,50 @@ func (c *Client) DeleteEventGatewayConsumePolicy(
 		return WrapAPIError(err, "delete event gateway consume policy", nil)
 	}
 	return nil
+}
+
+// extractConsumePolicyCreateName extracts the policy name from the union create type.
+func extractConsumePolicyCreateName(req kkComps.EventGatewayConsumePolicyCreate) string {
+	if req.EventGatewayModifyHeadersPolicyCreate != nil && req.EventGatewayModifyHeadersPolicyCreate.Name != nil {
+		return *req.EventGatewayModifyHeadersPolicyCreate.Name
+	}
+	if req.EventGatewayConsumeSchemaValidationPolicy != nil &&
+		req.EventGatewayConsumeSchemaValidationPolicy.Name != nil {
+		return *req.EventGatewayConsumeSchemaValidationPolicy.Name
+	}
+	if req.EventGatewayDecryptPolicy != nil && req.EventGatewayDecryptPolicy.Name != nil {
+		return *req.EventGatewayDecryptPolicy.Name
+	}
+	if req.EventGatewaySkipRecordPolicyCreate != nil && req.EventGatewaySkipRecordPolicyCreate.Name != nil {
+		return *req.EventGatewaySkipRecordPolicyCreate.Name
+	}
+	if req.EventGatewayParsedRecordDecryptFieldsPolicyCreate != nil &&
+		req.EventGatewayParsedRecordDecryptFieldsPolicyCreate.Name != nil {
+		return *req.EventGatewayParsedRecordDecryptFieldsPolicyCreate.Name
+	}
+	return ""
+}
+
+// extractConsumePolicyUpdateName extracts the policy name from the union update type.
+func extractConsumePolicyUpdateName(req kkComps.EventGatewayConsumePolicyUpdate) string {
+	if req.EventGatewayModifyHeadersPolicy != nil && req.EventGatewayModifyHeadersPolicy.Name != nil {
+		return *req.EventGatewayModifyHeadersPolicy.Name
+	}
+	if req.EventGatewayConsumeSchemaValidationPolicy != nil &&
+		req.EventGatewayConsumeSchemaValidationPolicy.Name != nil {
+		return *req.EventGatewayConsumeSchemaValidationPolicy.Name
+	}
+	if req.EventGatewayDecryptPolicy != nil && req.EventGatewayDecryptPolicy.Name != nil {
+		return *req.EventGatewayDecryptPolicy.Name
+	}
+	if req.EventGatewaySkipRecordPolicy != nil && req.EventGatewaySkipRecordPolicy.Name != nil {
+		return *req.EventGatewaySkipRecordPolicy.Name
+	}
+	if req.EventGatewayParsedRecordDecryptFieldsPolicy != nil &&
+		req.EventGatewayParsedRecordDecryptFieldsPolicy.Name != nil {
+		return *req.EventGatewayParsedRecordDecryptFieldsPolicy.Name
+	}
+	return ""
 }
 
 func (c *Client) GetEventGatewayConsumePolicy(


### PR DESCRIPTION
## Summary
- Add declarative support for Event Gateway `encrypt_fields` produce policies and `decrypt_fields` consume policies.
- Resolve `parent_policy_id` refs to schema validation parent policies, including same-plan ordering and existing-parent idempotency.
- Update dump, view, explain, docs, examples, and focused tests for field-level policy coverage.

## Base Branch
- This PR targets `gh-1385-egw-topic-alias` because this branch is based on the topic alias peer change.

## Tests
- `make format`
- `make build`
- `make test`
- `go test ./internal/declarative/planner ./internal/declarative/resources ./internal/declarative/executor ./internal/cmd/root/products/konnect/eventgateway ./internal/cmd/root/verbs/dump`
- `make lint` still fails on pre-existing generated/mock-file issues outside this change path: `internal/konnect/helpers/controlplaneapi_mock.go`, `test/e2e/harness/portalclient/portal_api.gen.go`, and `internal/cmd/helper_mock.go`.

Closes #1386