### PR TITLE
feat(declarative): add AI Gateway vault support

### DIFF
--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -318,17 +318,18 @@ control_plane_data_plane_certificates:
 ## AI Gateways
 
 This section covers the root AI Gateway resource backed by the Konnect
-`/v1/ai-gateways` API, AI Gateway Providers, AI Gateway Models, and AI Gateway
-MCP Servers. Use `kongctl explain ai_gateway --output yaml`,
+`/v1/ai-gateways` API, AI Gateway Providers, AI Gateway Models, AI Gateway
+MCP Servers, and AI Gateway Vaults. Use
+`kongctl explain ai_gateway --output yaml`,
 `kongctl explain ai_gateway_provider --output yaml`,
 `kongctl explain ai_gateway.models --output yaml`, and
-`kongctl explain ai_gateway.mcp_servers --output yaml` as the authoritative
-schemas.
+`kongctl explain ai_gateway.mcp_servers --output yaml`, and
+`kongctl explain ai_gateway.vaults --output yaml` as the authoritative schemas.
 
 The `ref` value is used as the stable Konnect API `name` when creating an AI
 Gateway. Use `display_name` for the human-readable name shown in Konnect.
-AI Gateway Providers, Policies, Models, and MCP Servers use their own required
-`name` field as the stable Konnect child name. Child entries inherit
+AI Gateway Providers, Policies, Models, MCP Servers, and Vaults use their own
+required `name` field as the stable Konnect child name. Child entries inherit
 management scope from their parent AI Gateway and do not accept `kongctl`
 metadata.
 
@@ -340,13 +341,14 @@ For AI Gateway Models and MCP Servers, `policies` entries refer to AI Gateway
 Policy names under the same parent gateway. The policy can already exist or be
 declared in the same gateway configuration.
 
-For AI Gateway Policies and MCP Servers, root-level declarations must include
-`ai_gateway`, while nested declarations inherit the parent gateway. Omit
-`policies` or `mcp_servers` to leave existing child resources unmanaged during
-sync. Use `policies: []` or `mcp_servers: []` under a specific AI Gateway to
-sync-delete that child type for that gateway. Root-level
-`ai_gateway_policies: []` and `ai_gateway_mcp_servers: []` are rejected because
-they do not identify a parent gateway.
+For AI Gateway Policies, MCP Servers, and Vaults, root-level declarations must
+include `ai_gateway`, while nested declarations inherit the parent gateway.
+Omit `policies`, `mcp_servers`, or `vaults` to leave existing child resources
+unmanaged during sync. Use `policies: []`, `mcp_servers: []`, or `vaults: []`
+under a specific AI Gateway to sync-delete that child type for that gateway.
+Root-level `ai_gateway_policies: []`, `ai_gateway_mcp_servers: []`, and
+`ai_gateway_vaults: []` are rejected because they do not identify a parent
+gateway.
 
 ```yaml
 ai_gateways:
@@ -425,6 +427,16 @@ ai_gateways:
         key: value
       acls: object
       managed_by: object
+   vaults:
+    - ref: string
+      type: env # or konnect, aws, gcp, azure, conjur, hcv
+      name: string required
+      description: string
+      config: object required
+      labels: object [string]string
+        key: value
+      managed_by: object [string]string
+        key: value
 ```
 
 AI Gateway Providers can also be declared as root resources. Root-level
@@ -516,6 +528,23 @@ ai_gateway_mcp_servers:
      key: value
    acls: object
    managed_by: object
+```
+
+AI Gateway Vaults can also be declared as root resources. Include `ai_gateway`
+to point at the parent gateway `ref`.
+
+```yaml
+ai_gateway_vaults:
+ - ref: string
+   ai_gateway: string required # AI Gateway ref
+   type: env # or konnect, aws, gcp, azure, conjur, hcv
+   name: string required
+   description: string
+   config: object required
+   labels: object [string]string
+     key: value
+   managed_by: object [string]string
+     key: value
 ```
 
 ## Event Gateways

--- a/docs/examples/declarative/ai-gateway/README.md
+++ b/docs/examples/declarative/ai-gateway/README.md
@@ -4,12 +4,12 @@ This directory contains declarative configuration examples for Konnect AI
 Gateway resources.
 
 - [ai-gateway.yaml](ai-gateway.yaml) defines a root AI Gateway resource with
-  a nested OpenAI provider and policy, a model that targets that provider, and
-  a conversion-only MCP Server.
+  a nested OpenAI provider, env vault, and policy, a model that targets that
+  provider, and a conversion-only MCP Server.
 - [federated](federated) shows a multi-folder
   layout where a central team owns an AI Gateway and providers, while a peer
-  team owns root-level policies, models, and MCP Servers that reference the
-  shared gateway.
+  team owns root-level policies, models, MCP Servers, and vaults that reference
+  the shared gateway.
 
 Set `OPENAI_AUTH_HEADER` to the full upstream authorization header value
 before applying the example, for example `Bearer ...`.

--- a/docs/examples/declarative/ai-gateway/ai-gateway.yaml
+++ b/docs/examples/declarative/ai-gateway/ai-gateway.yaml
@@ -24,6 +24,17 @@ ai_gateways:
             headers:
               - name: Authorization
                 value: !env OPENAI_AUTH_HEADER
+    vaults:
+      - ref: support-env
+        name: support-env
+        type: env
+        description: "Environment variables for support AI Gateway secrets"
+        labels:
+          team: support
+          purpose: runtime-secrets
+        config:
+          prefix: SUPPORT_AI_
+          base64_decode: false
     policies:
       - ref: mask-sensitive-data
         name: mask-sensitive-data

--- a/docs/examples/declarative/ai-gateway/federated/README.md
+++ b/docs/examples/declarative/ai-gateway/federated/README.md
@@ -2,8 +2,8 @@
 
 This example shows a federated layout for AI Gateway resources where a central
 AI platform team owns the shared AI Gateway and upstream providers, while a peer
-team owns root-level policies, models, and MCP Servers that target the shared
-gateway.
+team owns root-level policies, models, MCP Servers, and vaults that target the
+shared gateway.
 
 ## Structure
 
@@ -16,7 +16,8 @@ ai-gateway/federated/
 `-- peer-team/
     |-- support-mcp-server.yaml
     |-- support-model.yaml
-    `-- support-policy.yaml
+    |-- support-policy.yaml
+    `-- support-vault.yaml
 ```
 
 ## Ownership
@@ -31,6 +32,8 @@ ai-gateway/federated/
 - `peer-team/support-mcp-server.yaml` defines a standalone
   `ai_gateway_mcp_servers` entry that references the central gateway with
   `!ref shared-ai-gateway#id`.
+- `peer-team/support-vault.yaml` defines a standalone `ai_gateway_vaults` entry
+  that references the central gateway with `!ref shared-ai-gateway#id`.
 - `external-peer-team/support-model.yaml` defines an `_external` AI Gateway
   stub and points a standalone model at it with
   `!ref external-shared-ai-gateway#id`.

--- a/docs/examples/declarative/ai-gateway/federated/peer-team/support-vault.yaml
+++ b/docs/examples/declarative/ai-gateway/federated/peer-team/support-vault.yaml
@@ -1,0 +1,16 @@
+_defaults:
+  kongctl:
+    namespace: federated-ai-gateway
+
+ai_gateway_vaults:
+  - ref: peer-support-env
+    ai_gateway: !ref shared-ai-gateway#id
+    name: peer-support-env
+    type: env
+    description: "Peer-owned environment variable vault"
+    labels:
+      team: support-experience
+      ownership: peer
+    config:
+      prefix: PEER_SUPPORT_
+      base64_decode: false

--- a/internal/cmd/root/products/konnect/aigateway/ai-gateway.go
+++ b/internal/cmd/root/products/konnect/aigateway/ai-gateway.go
@@ -33,6 +33,7 @@ func NewAIGatewayCmd(
 		root.AddCommand(newGetAIGatewayPoliciesCmd(verb, addParentFlags, parentPreRun))
 		root.AddCommand(newGetAIGatewayModelsCmd(verb, addParentFlags, parentPreRun))
 		root.AddCommand(newGetAIGatewayMCPServersCmd(verb, addParentFlags, parentPreRun))
+		root.AddCommand(newGetAIGatewayVaultsCmd(verb, addParentFlags, parentPreRun))
 		return root, nil
 	}
 

--- a/internal/cmd/root/products/konnect/aigateway/child_common.go
+++ b/internal/cmd/root/products/konnect/aigateway/child_common.go
@@ -33,6 +33,12 @@ const (
 	aiGatewayMCPServerIDConfigPath   = "konnect.ai-gateway.mcp-server.id"
 	aiGatewayMCPServerNameConfigPath = "konnect.ai-gateway.mcp-server.name"
 
+	aiGatewayVaultIDFlagName   = "vault-id"
+	aiGatewayVaultNameFlagName = "vault-name"
+
+	aiGatewayVaultIDConfigPath   = "konnect.ai-gateway.vault.id"
+	aiGatewayVaultNameConfigPath = "konnect.ai-gateway.vault.name"
+
 	aiGatewayMissingValue = "n/a"
 )
 
@@ -170,4 +176,38 @@ func bindAIGatewayMCPServerFlags(c *cobra.Command, args []string) error {
 
 func getAIGatewayMCPServerIdentifiers(cfg config.Hook) (id string, name string) {
 	return cfg.GetString(aiGatewayMCPServerIDConfigPath), cfg.GetString(aiGatewayMCPServerNameConfigPath)
+}
+
+func addAIGatewayVaultFlags(c *cobra.Command) {
+	c.Flags().String(aiGatewayVaultIDFlagName, "",
+		fmt.Sprintf(`The ID of the AI Gateway Vault to retrieve.
+- Config path: [ %s ]`, aiGatewayVaultIDConfigPath))
+	c.Flags().String(aiGatewayVaultNameFlagName, "",
+		fmt.Sprintf(`The name of the AI Gateway Vault to retrieve.
+- Config path: [ %s ]`, aiGatewayVaultNameConfigPath))
+	c.MarkFlagsMutuallyExclusive(aiGatewayVaultIDFlagName, aiGatewayVaultNameFlagName)
+}
+
+func bindAIGatewayVaultFlags(c *cobra.Command, args []string) error {
+	helper := cmd.BuildHelper(c, args)
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	if flag := c.Flags().Lookup(aiGatewayVaultIDFlagName); flag != nil {
+		if err := cfg.BindFlag(aiGatewayVaultIDConfigPath, flag); err != nil {
+			return err
+		}
+	}
+	if flag := c.Flags().Lookup(aiGatewayVaultNameFlagName); flag != nil {
+		if err := cfg.BindFlag(aiGatewayVaultNameConfigPath, flag); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getAIGatewayVaultIdentifiers(cfg config.Hook) (id string, name string) {
+	return cfg.GetString(aiGatewayVaultIDConfigPath), cfg.GetString(aiGatewayVaultNameConfigPath)
 }

--- a/internal/cmd/root/products/konnect/aigateway/vaults.go
+++ b/internal/cmd/root/products/konnect/aigateway/vaults.go
@@ -1,0 +1,421 @@
+package aigateway
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/table"
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/cmd"
+	cmdCommon "github.com/kong/kongctl/internal/cmd/common"
+	"github.com/kong/kongctl/internal/cmd/output/tableview"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
+	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/kong/kongctl/internal/config"
+	declresources "github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/konnect/helpers"
+	"github.com/kong/kongctl/internal/meta"
+	"github.com/kong/kongctl/internal/util"
+	"github.com/kong/kongctl/internal/util/i18n"
+	"github.com/kong/kongctl/internal/util/normalizers"
+	"github.com/kong/kongctl/internal/util/pagination"
+	"github.com/segmentio/cli"
+	"github.com/spf13/cobra"
+)
+
+type aiGatewayVaultRecord struct {
+	ID               string
+	Name             string
+	Type             string
+	Description      string
+	LocalUpdatedTime string
+}
+
+var (
+	aiGatewayVaultsUse   = "vaults [vault-id|vault-name]"
+	aiGatewayVaultsShort = i18n.T(
+		"root.products.konnect.ai-gateway.vaultsShort",
+		"List or get Vaults for a Konnect AI Gateway",
+	)
+	aiGatewayVaultsLong = normalizers.LongDesc(i18n.T(
+		"root.products.konnect.ai-gateway.vaultsLong",
+		`Use the vaults command to list or retrieve Vaults for a specific Konnect AI Gateway.`,
+	))
+	aiGatewayVaultsExample = normalizers.Examples(
+		i18n.T("root.products.konnect.ai-gateway.vaultsExamples",
+			fmt.Sprintf(`# List Vaults for an AI Gateway by display name
+%[1]s get ai-gateway vaults --gateway-name "Customer Support Gateway"
+# List Vaults for an AI Gateway by ID
+%[1]s get ai-gateway vaults --gateway-id <gateway-id>
+# Get a Vault by name
+%[1]s get ai-gateway vaults --gateway-name "Customer Support Gateway" support-env
+# Get a Vault by ID
+%[1]s get ai-gateway vaults --gateway-id <gateway-id> --vault-id <vault-id>
+`, meta.CLIName)),
+	)
+)
+
+func newGetAIGatewayVaultsCmd(
+	verb verbs.VerbValue,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) *cobra.Command {
+	c := &cobra.Command{
+		Use:     aiGatewayVaultsUse,
+		Short:   aiGatewayVaultsShort,
+		Long:    aiGatewayVaultsLong,
+		Example: aiGatewayVaultsExample,
+		Aliases: []string{"vault"},
+		PreRunE: func(c *cobra.Command, args []string) error {
+			if parentPreRun != nil {
+				if err := parentPreRun(c, args); err != nil {
+					return err
+				}
+			}
+			if err := bindAIGatewayChildFlags(c, args); err != nil {
+				return err
+			}
+			return bindAIGatewayVaultFlags(c, args)
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			handler := aiGatewayVaultsHandler{cmd: c}
+			return handler.run(args)
+		},
+	}
+
+	addAIGatewayChildFlags(c)
+	addAIGatewayVaultFlags(c)
+	if addParentFlags != nil {
+		addParentFlags(verb, c)
+	}
+	return c
+}
+
+type aiGatewayVaultsHandler struct {
+	cmd *cobra.Command
+}
+
+func (h aiGatewayVaultsHandler) run(args []string) error {
+	helper := cmd.BuildHelper(h.cmd, args)
+	if len(args) > 1 {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf("too many arguments. Listing AI Gateway Vaults requires 0 or 1 arguments (ID or name)"),
+		}
+	}
+
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	if len(args) == 1 {
+		vaultID, vaultName := getAIGatewayVaultIdentifiers(cfg)
+		if vaultID != "" || vaultName != "" {
+			return &cmd.ConfigurationError{
+				Err: fmt.Errorf(
+					"cannot specify both positional argument and --%s or --%s flags",
+					aiGatewayVaultIDFlagName,
+					aiGatewayVaultNameFlagName,
+				),
+			}
+		}
+	}
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+	outType, err := helper.GetOutputFormat()
+	if err != nil {
+		return err
+	}
+	printer, err := cli.Format(outType.String(), helper.GetStreams().Out)
+	if err != nil {
+		return err
+	}
+	defer printer.Flush()
+
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return err
+	}
+
+	gatewayID, gatewayName := getAIGatewayIdentifiers(cfg)
+	if gatewayID != "" && gatewayName != "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf("only one of --%s or --%s can be provided", aiGatewayIDFlagName, aiGatewayNameFlagName),
+		}
+	}
+	if gatewayID == "" && gatewayName == "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf(
+				"an AI Gateway identifier is required. Provide --%s or --%s",
+				aiGatewayIDFlagName,
+				aiGatewayNameFlagName,
+			),
+		}
+	}
+	if gatewayID == "" {
+		gatewayID, err = resolveAIGatewayIDByDisplayName(gatewayName, sdk.GetAIGatewayAPI(), helper, cfg)
+		if err != nil {
+			return err
+		}
+	}
+
+	vaultAPI := sdk.GetAIGatewayVaultsAPI()
+	if vaultAPI == nil {
+		return &cmd.ExecutionError{
+			Msg: "AI Gateway Vaults client is not available",
+			Err: fmt.Errorf("AI Gateway Vaults client not configured"),
+		}
+	}
+
+	vaultID, vaultName := getAIGatewayVaultIdentifiers(cfg)
+	if vaultID != "" && vaultName != "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf(
+				"only one of --%s or --%s can be provided",
+				aiGatewayVaultIDFlagName,
+				aiGatewayVaultNameFlagName,
+			),
+		}
+	}
+
+	identifier := ""
+	if len(args) == 1 {
+		identifier = strings.TrimSpace(args[0])
+	} else if vaultID != "" {
+		identifier = vaultID
+	} else if vaultName != "" {
+		identifier = vaultName
+	}
+
+	if identifier != "" {
+		return h.getSingleVault(helper, vaultAPI, gatewayID, identifier, outType, printer, cfg)
+	}
+	return h.listVaults(helper, vaultAPI, gatewayID, outType, printer, cfg)
+}
+
+func (h aiGatewayVaultsHandler) listVaults(
+	helper cmd.Helper,
+	vaultAPI helpers.AIGatewayVaultsAPI,
+	gatewayID string,
+	outType cmdCommon.OutputFormat,
+	printer cli.PrintFlusher,
+	cfg config.Hook,
+) error {
+	vaults, err := fetchAIGatewayVaults(helper, vaultAPI, gatewayID, cfg)
+	if err != nil {
+		return err
+	}
+
+	records := make([]aiGatewayVaultRecord, 0, len(vaults))
+	tableRows := make([]table.Row, 0, len(vaults))
+	for _, vault := range vaults {
+		record := aiGatewayVaultToRecord(vault)
+		records = append(records, record)
+		tableRows = append(tableRows, table.Row{
+			record.ID,
+			record.Name,
+			record.Type,
+			record.Description,
+			record.LocalUpdatedTime,
+		})
+	}
+
+	return tableview.RenderForFormat(
+		helper,
+		false,
+		outType,
+		printer,
+		helper.GetStreams(),
+		records,
+		vaults,
+		"",
+		tableview.WithCustomTable(
+			[]string{"ID", "NAME", "TYPE", "DESCRIPTION", "UPDATED"},
+			tableRows,
+		),
+		tableview.WithRootLabel(helper.GetCmd().Name()),
+		tableview.WithDetailHelper(helper),
+		tableview.WithDetailRenderer(func(index int) string {
+			if index < 0 || index >= len(vaults) {
+				return ""
+			}
+			return aiGatewayVaultDetailView(vaults[index])
+		}),
+		tableview.WithDetailContext(common.ViewParentAIGatewayVault, func(index int) any {
+			if index < 0 || index >= len(vaults) {
+				return nil
+			}
+			return &vaults[index]
+		}),
+	)
+}
+
+func (h aiGatewayVaultsHandler) getSingleVault(
+	helper cmd.Helper,
+	vaultAPI helpers.AIGatewayVaultsAPI,
+	gatewayID string,
+	identifier string,
+	outType cmdCommon.OutputFormat,
+	printer cli.PrintFlusher,
+	cfg config.Hook,
+) error {
+	vaultIdentifier := identifier
+	if !util.IsValidUUID(identifier) {
+		vaults, err := fetchAIGatewayVaults(helper, vaultAPI, gatewayID, cfg)
+		if err != nil {
+			return err
+		}
+		match := findAIGatewayVaultByNameOrID(vaults, identifier)
+		if match == nil {
+			return &cmd.ConfigurationError{
+				Err: fmt.Errorf("AI Gateway Vault %q not found", identifier),
+			}
+		}
+		vaultIdentifier = declresources.AIGatewayVaultID(*match)
+		if vaultIdentifier == "" {
+			vaultIdentifier = declresources.AIGatewayVaultName(*match)
+		}
+		if vaultIdentifier == "" {
+			return &cmd.ConfigurationError{
+				Err: fmt.Errorf("AI Gateway Vault %q does not have an ID or name", identifier),
+			}
+		}
+	}
+
+	res, err := vaultAPI.GetAiGatewayVault(helper.GetContext(), gatewayID, vaultIdentifier)
+	if err != nil {
+		attrs := cmd.TryConvertErrorToAttrs(err)
+		return cmd.PrepareExecutionError("Failed to get AI Gateway Vault", err, helper.GetCmd(), attrs...)
+	}
+	vault := res.GetAIGatewayVault()
+	if vault == nil {
+		return &cmd.ExecutionError{
+			Msg: "AI Gateway Vault response was empty",
+			Err: fmt.Errorf("no Vault returned for id or name %s", vaultIdentifier),
+		}
+	}
+
+	record := aiGatewayVaultToRecord(*vault)
+	return tableview.RenderForFormat(
+		helper,
+		false,
+		outType,
+		printer,
+		helper.GetStreams(),
+		record,
+		vault,
+		"",
+		tableview.WithRootLabel(helper.GetCmd().Name()),
+		tableview.WithDetailHelper(helper),
+		tableview.WithDetailRenderer(func(index int) string {
+			if index != 0 {
+				return ""
+			}
+			return aiGatewayVaultDetailView(*vault)
+		}),
+		tableview.WithDetailContext(common.ViewParentAIGatewayVault, func(index int) any {
+			if index != 0 {
+				return nil
+			}
+			return vault
+		}),
+	)
+}
+
+func fetchAIGatewayVaults(
+	helper cmd.Helper,
+	vaultAPI helpers.AIGatewayVaultsAPI,
+	gatewayID string,
+	cfg config.Hook,
+) ([]kkComps.AIGatewayVault, error) {
+	requestPageSize := common.ResolveRequestPageSize(cfg)
+	var pageAfter *string
+	var allData []kkComps.AIGatewayVault
+
+	for {
+		req := kkOps.ListAiGatewayVaultsRequest{
+			GatewayID: gatewayID,
+			PageSize:  &requestPageSize,
+		}
+		if pageAfter != nil {
+			req.PageAfter = pageAfter
+		}
+
+		res, err := vaultAPI.ListAiGatewayVaults(helper.GetContext(), req)
+		if err != nil {
+			attrs := cmd.TryConvertErrorToAttrs(err)
+			return nil, cmd.PrepareExecutionError("Failed to list AI Gateway Vaults", err, helper.GetCmd(), attrs...)
+		}
+		if res.GetListAIGatewayVaultsResponse() == nil {
+			break
+		}
+
+		allData = append(allData, res.GetListAIGatewayVaultsResponse().Data...)
+		nextCursor := pagination.ExtractPageAfterCursor(res.GetListAIGatewayVaultsResponse().Meta.Page.Next)
+		if nextCursor == "" {
+			break
+		}
+		pageAfter = &nextCursor
+	}
+
+	return allData, nil
+}
+
+func aiGatewayVaultToRecord(vault kkComps.AIGatewayVault) aiGatewayVaultRecord {
+	record := aiGatewayVaultRecord{
+		ID:               aiGatewayMissingValue,
+		Name:             valueOrMissing(declresources.AIGatewayVaultName(vault)),
+		Type:             valueOrMissing(declresources.AIGatewayVaultType(vault)),
+		Description:      valueOrMissing(declresources.AIGatewayVaultDescription(vault)),
+		LocalUpdatedTime: aiGatewayMissingValue,
+	}
+	if id := declresources.AIGatewayVaultID(vault); id != "" {
+		record.ID = util.AbbreviateUUID(id)
+	}
+	if updatedAt := declresources.AIGatewayVaultUpdatedAt(vault); !updatedAt.IsZero() {
+		record.LocalUpdatedTime = updatedAt.In(time.Local).Format("2006-01-02 15:04:05")
+	}
+	return record
+}
+
+func findAIGatewayVaultByNameOrID(vaults []kkComps.AIGatewayVault, identifier string) *kkComps.AIGatewayVault {
+	for i := range vaults {
+		if declresources.AIGatewayVaultID(vaults[i]) == identifier ||
+			declresources.AIGatewayVaultName(vaults[i]) == identifier {
+			return &vaults[i]
+		}
+	}
+	return nil
+}
+
+func aiGatewayVaultDetailView(vault kkComps.AIGatewayVault) string {
+	payload := make(map[string]any)
+	data, err := json.Marshal(vault)
+	if err == nil {
+		_ = json.Unmarshal(data, &payload)
+	}
+
+	order := []string{
+		"id",
+		"name",
+		"description",
+		"type",
+		"config",
+		"labels",
+		"managed_by",
+		"created_at",
+		"updated_at",
+	}
+
+	var b strings.Builder
+	for _, field := range order {
+		fmt.Fprintf(&b, "%s: %s\n", field, formatAIGatewayModelDetailValue(payload[field]))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/internal/cmd/root/products/konnect/common/view_identifiers.go
+++ b/internal/cmd/root/products/konnect/common/view_identifiers.go
@@ -10,6 +10,7 @@ const (
 	ViewParentAIGatewayPolicy               = "ai-gateway-policy"
 	ViewParentAIGatewayModel                = "ai-gateway-model"
 	ViewParentAIGatewayMCPServer            = "ai-gateway-mcp-server"
+	ViewParentAIGatewayVault                = "ai-gateway-vault"
 	ViewParentAPIDocument                   = "api-document"
 	ViewParentAPIImplementation             = "api-implementation"
 	ViewParentAPIPublication                = "api-publication"

--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -2846,6 +2846,7 @@ func createStateClient(kkClient helpers.SDKAPI) *state.Client {
 		AIGatewayPoliciesAPI:    kkClient.GetAIGatewayPoliciesAPI(),
 		AIGatewayModelAPI:       kkClient.GetAIGatewayModelAPI(),
 		AIGatewayMCPServersAPI:  kkClient.GetAIGatewayMCPServersAPI(),
+		AIGatewayVaultsAPI:      kkClient.GetAIGatewayVaultsAPI(),
 		DashboardsAPI:           kkClient.GetDashboardsAPI(),
 
 		// Portal child resource APIs

--- a/internal/cmd/root/verbs/dump/common.go
+++ b/internal/cmd/root/verbs/dump/common.go
@@ -166,6 +166,8 @@ func mapResourceName(name string) string {
 		return "ai_gateway_models"
 	case "ai-gateway-mcp-server", "ai-gateway-mcp-servers", "ai_gateway_mcp_server", "ai_gateway_mcp_servers":
 		return "ai_gateway_mcp_servers"
+	case "ai-gateway-vault", "ai-gateway-vaults", "ai_gateway_vault", "ai_gateway_vaults":
+		return "ai_gateway_vaults"
 	case "org.team", "org.teams", "organization.team", "organization.teams":
 		return "organization.teams"
 	default:

--- a/internal/cmd/root/verbs/dump/declarative.go
+++ b/internal/cmd/root/verbs/dump/declarative.go
@@ -56,6 +56,7 @@ var declarativeAllowedResources = map[string]struct{}{
 	"ai_gateway_policies":         {},
 	"ai_gateway_models":           {},
 	"ai_gateway_mcp_servers":      {},
+	"ai_gateway_vaults":           {},
 	"organization.teams":          {},
 }
 
@@ -89,7 +90,7 @@ func newDeclarativeCmd() *cobra.Command {
 		"Comma separated list of resource types to dump "+
 			"(portals, apis, application_auth_strategies, dcr_providers, control_planes, "+
 			resourceAnalyticsDashboards+", event_gateways, ai_gateways, ai_gateway_policies, "+
-			"ai_gateway_models, ai_gateway_mcp_servers, organization.teams).")
+			"ai_gateway_models, ai_gateway_mcp_servers, ai_gateway_vaults, organization.teams).")
 	_ = cmd.MarkFlagRequired("resources")
 
 	cmd.Flags().BoolVar(&opts.includeChildResources, "include-child-resources", false,
@@ -206,7 +207,8 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 	if opts.includeChildResources ||
 		slices.Contains(opts.resources, "ai_gateway_policies") ||
 		slices.Contains(opts.resources, "ai_gateway_models") ||
-		slices.Contains(opts.resources, "ai_gateway_mcp_servers") {
+		slices.Contains(opts.resources, "ai_gateway_mcp_servers") ||
+		slices.Contains(opts.resources, "ai_gateway_vaults") {
 		stateClient = declstate.NewClient(declstate.ClientConfig{
 			PortalAPI:                           sdk.GetPortalAPI(),
 			APIAPI:                              sdk.GetAPIAPI(),
@@ -222,6 +224,7 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 			AIGatewayPoliciesAPI:                sdk.GetAIGatewayPoliciesAPI(),
 			AIGatewayModelAPI:                   sdk.GetAIGatewayModelAPI(),
 			AIGatewayMCPServersAPI:              sdk.GetAIGatewayMCPServersAPI(),
+			AIGatewayVaultsAPI:                  sdk.GetAIGatewayVaultsAPI(),
 			DashboardsAPI:                       sdk.GetDashboardsAPI(),
 			PortalPageAPI:                       sdk.GetPortalPageAPI(),
 			PortalAuthSettingsAPI:               sdk.GetPortalAuthSettingsAPI(),
@@ -402,6 +405,18 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 				return err
 			}
 			resourceSet.AIGatewayMCPServers = append(resourceSet.AIGatewayMCPServers, servers...)
+		case "ai_gateway_vaults":
+			vaults, err := collectDeclarativeAIGatewayVaults(
+				ctx,
+				stateClient,
+				sdk.GetAIGatewayAPI(),
+				requestPageSize,
+				opts.filter,
+			)
+			if err != nil {
+				return err
+			}
+			resourceSet.AIGatewayVaults = append(resourceSet.AIGatewayVaults, vaults...)
 		case "organization.teams":
 			teams, err := collectDeclarativeOrganizationTeams(
 				ctx,
@@ -883,6 +898,44 @@ func collectDeclarativeAIGatewayMCPServers(
 	})
 
 	return servers, nil
+}
+
+func collectDeclarativeAIGatewayVaults(
+	ctx context.Context,
+	client *declstate.Client,
+	aiGatewayClient helpers.AIGatewayAPI,
+	requestPageSize int64,
+	filter filterOptions,
+) ([]declresources.AIGatewayVaultResource, error) {
+	if client == nil {
+		return nil, fmt.Errorf("AI Gateway Vaults API client is not configured")
+	}
+
+	gateways, err := collectDeclarativeAIGateways(ctx, aiGatewayClient, requestPageSize, filterOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var vaults []declresources.AIGatewayVaultResource
+	for _, gateway := range gateways {
+		gatewayVaults, err := buildAIGatewayVaults(ctx, client, gateway.Ref, gateway.DisplayName, gateway.Ref)
+		if err != nil {
+			return nil, err
+		}
+		vaults = append(vaults, gatewayVaults...)
+	}
+
+	vaults = filterByNameOrID(vaults, filter, func(r declresources.AIGatewayVaultResource) (string, string) {
+		return r.Name(), r.Ref
+	})
+	slices.SortFunc(vaults, func(a, b declresources.AIGatewayVaultResource) int {
+		if a.AIGateway == b.AIGateway {
+			return cmp.Compare(a.Name(), b.Name())
+		}
+		return cmp.Compare(a.AIGateway, b.AIGateway)
+	})
+
+	return vaults, nil
 }
 
 func collectDeclarativeOrganizationTeams(

--- a/internal/cmd/root/verbs/dump/declarative_children.go
+++ b/internal/cmd/root/verbs/dump/declarative_children.go
@@ -301,6 +301,15 @@ func populateAIGatewayChildren(
 		if len(servers) > 0 {
 			gateway.MCPServers = servers
 		}
+
+		vaults, err := buildAIGatewayVaults(ctx, client, gatewayID, gateway.DisplayName, "")
+		if err != nil {
+			logWarn(logger, "failed to load AI Gateway Vaults", gatewayID, gateway.DisplayName, err)
+			continue
+		}
+		if len(vaults) > 0 {
+			gateway.Vaults = vaults
+		}
 	}
 }
 
@@ -445,6 +454,36 @@ func buildAIGatewayMCPServers(
 	}
 
 	slices.SortFunc(result, func(a, b declresources.AIGatewayMCPServerResource) int {
+		if a.Name() == b.Name() {
+			return cmp.Compare(a.Ref, b.Ref)
+		}
+		return cmp.Compare(a.Name(), b.Name())
+	})
+
+	return result, nil
+}
+
+func buildAIGatewayVaults(
+	ctx context.Context,
+	client *declstate.Client,
+	gatewayID string,
+	gatewayName string,
+	gatewayRef string,
+) ([]declresources.AIGatewayVaultResource, error) {
+	vaults, err := client.ListAIGatewayVaults(ctx, gatewayID)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]declresources.AIGatewayVaultResource, 0, len(vaults))
+	for _, vault := range vaults {
+		resource, err := declresources.AIGatewayVaultResourceFromResponse(gatewayRef, vault.AIGatewayVault)
+		if err != nil {
+			return nil, fmt.Errorf("failed to map AI Gateway Vault for gateway %s: %w", gatewayName, err)
+		}
+		result = append(result, resource)
+	}
+
+	slices.SortFunc(result, func(a, b declresources.AIGatewayVaultResource) int {
 		if a.Name() == b.Name() {
 			return cmp.Compare(a.Ref, b.Ref)
 		}

--- a/internal/declarative/executor/ai_gateway_vault_adapter.go
+++ b/internal/declarative/executor/ai_gateway_vault_adapter.go
@@ -1,0 +1,189 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+)
+
+// AIGatewayVaultAdapter implements ResourceOperations for AI Gateway Vaults.
+type AIGatewayVaultAdapter struct {
+	client *state.Client
+}
+
+// NewAIGatewayVaultAdapter creates a new AI Gateway Vault adapter.
+func NewAIGatewayVaultAdapter(client *state.Client) *AIGatewayVaultAdapter {
+	return &AIGatewayVaultAdapter{client: client}
+}
+
+// MapCreateFields maps planner fields to CreateAIGatewayVaultRequest.
+func (a *AIGatewayVaultAdapter) MapCreateFields(
+	_ context.Context,
+	_ *ExecutionContext,
+	fields map[string]any,
+	create *kkComps.CreateAIGatewayVaultRequest,
+) error {
+	data, err := json.Marshal(fields)
+	if err != nil {
+		return fmt.Errorf("failed to encode AI Gateway Vault create fields: %w", err)
+	}
+	if err := json.Unmarshal(data, create); err != nil {
+		return fmt.Errorf("failed to decode AI Gateway Vault create fields: %w", err)
+	}
+	if create.KonnectConfigStoreVault == nil &&
+		create.EnvironmentVariableVault == nil &&
+		create.AwsSecretsManagerVault == nil &&
+		create.GoogleSecretManagerVault == nil &&
+		create.AzureKeyVault == nil &&
+		create.ConjurVault == nil &&
+		create.HashiCorpVault == nil {
+		return fmt.Errorf("type must be a supported AI Gateway Vault type")
+	}
+	return nil
+}
+
+// MapUpdateFields maps planner fields to UpdateAIGatewayVaultRequest.
+func (a *AIGatewayVaultAdapter) MapUpdateFields(
+	_ context.Context,
+	_ *ExecutionContext,
+	fields map[string]any,
+	update *kkComps.UpdateAIGatewayVaultRequest,
+	_ map[string]string,
+) error {
+	data, err := json.Marshal(fields)
+	if err != nil {
+		return fmt.Errorf("failed to encode AI Gateway Vault update fields: %w", err)
+	}
+	if err := json.Unmarshal(data, update); err != nil {
+		return fmt.Errorf("failed to decode AI Gateway Vault update fields: %w", err)
+	}
+	if update.KonnectConfigStoreVault == nil &&
+		update.EnvironmentVariableVault == nil &&
+		update.AwsSecretsManagerVault == nil &&
+		update.GoogleSecretManagerVault == nil &&
+		update.AzureKeyVault == nil &&
+		update.ConjurVault == nil &&
+		update.HashiCorpVault == nil {
+		return fmt.Errorf("type must be a supported AI Gateway Vault type")
+	}
+	return nil
+}
+
+// Create creates an AI Gateway Vault.
+func (a *AIGatewayVaultAdapter) Create(
+	ctx context.Context,
+	req kkComps.CreateAIGatewayVaultRequest,
+	namespace string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	gatewayID, err := a.getAIGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return "", err
+	}
+	return a.client.CreateAIGatewayVault(ctx, gatewayID, req, namespace)
+}
+
+// Update updates an AI Gateway Vault.
+func (a *AIGatewayVaultAdapter) Update(
+	ctx context.Context,
+	id string,
+	req kkComps.UpdateAIGatewayVaultRequest,
+	namespace string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	gatewayID, err := a.getAIGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return "", err
+	}
+	return a.client.UpdateAIGatewayVault(ctx, gatewayID, id, req, namespace)
+}
+
+// Delete deletes an AI Gateway Vault.
+func (a *AIGatewayVaultAdapter) Delete(ctx context.Context, id string, execCtx *ExecutionContext) error {
+	gatewayID, err := a.getAIGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return err
+	}
+	return a.client.DeleteAIGatewayVault(ctx, gatewayID, id)
+}
+
+// GetByID gets an AI Gateway Vault by ID.
+func (a *AIGatewayVaultAdapter) GetByID(
+	ctx context.Context,
+	id string,
+	execCtx *ExecutionContext,
+) (ResourceInfo, error) {
+	gatewayID, err := a.getAIGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return nil, err
+	}
+	vault, err := a.client.GetAIGatewayVault(ctx, gatewayID, id)
+	if err != nil {
+		return nil, err
+	}
+	if vault == nil {
+		return nil, nil
+	}
+	return &aiGatewayVaultResourceInfo{vault: vault}, nil
+}
+
+// GetByName is not supported without a parent gateway context.
+func (a *AIGatewayVaultAdapter) GetByName(_ context.Context, _ string) (ResourceInfo, error) {
+	return nil, fmt.Errorf("GetByName not supported for AI Gateway Vaults")
+}
+
+// ResourceType returns the resource type.
+func (a *AIGatewayVaultAdapter) ResourceType() string {
+	return planner.ResourceTypeAIGatewayVault
+}
+
+// RequiredFields returns required fields for create.
+func (a *AIGatewayVaultAdapter) RequiredFields() []string {
+	return []string{planner.FieldType, planner.FieldName, planner.FieldConfig}
+}
+
+// SupportsUpdate indicates update support.
+func (a *AIGatewayVaultAdapter) SupportsUpdate() bool {
+	return true
+}
+
+func (a *AIGatewayVaultAdapter) getAIGatewayIDFromExecutionContext(execCtx *ExecutionContext) (string, error) {
+	if execCtx == nil || execCtx.PlannedChange == nil {
+		return "", fmt.Errorf("execution context required")
+	}
+
+	change := *execCtx.PlannedChange
+	if gatewayRef, ok := change.References[planner.FieldAIGatewayID]; ok && !unresolvedReferenceID(gatewayRef.ID) {
+		return gatewayRef.ID, nil
+	}
+	if change.Parent != nil && !unresolvedReferenceID(change.Parent.ID) {
+		return change.Parent.ID, nil
+	}
+
+	return "", fmt.Errorf("AI Gateway ID required for Vault operations")
+}
+
+type aiGatewayVaultResourceInfo struct {
+	vault *state.AIGatewayVault
+}
+
+func (a *aiGatewayVaultResourceInfo) GetID() string {
+	return resources.AIGatewayVaultID(a.vault.AIGatewayVault)
+}
+
+func (a *aiGatewayVaultResourceInfo) GetName() string {
+	return resources.AIGatewayVaultName(a.vault.AIGatewayVault)
+}
+
+func (a *aiGatewayVaultResourceInfo) GetLabels() map[string]string {
+	return resources.AIGatewayVaultLabels(a.vault.AIGatewayVault)
+}
+
+func (a *aiGatewayVaultResourceInfo) GetNormalizedLabels() map[string]string {
+	return a.vault.NormalizedLabels
+}

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -62,6 +62,8 @@ type Executor struct {
 		kkComps.CreateAIGatewayModelRequest, kkComps.UpdateAIGatewayModelRequest]
 	aiGatewayMCPServerExecutor *BaseExecutor[
 		kkComps.CreateAIGatewayMCPServerRequest, kkComps.UpdateAIGatewayMCPServerRequest]
+	aiGatewayVaultExecutor *BaseExecutor[
+		kkComps.CreateAIGatewayVaultRequest, kkComps.UpdateAIGatewayVaultRequest]
 	dashboardExecutor                      *BaseExecutor[kkComps.DashboardUpdateRequest, kkComps.DashboardUpdateRequest]
 	eventGatewayControlPlaneExecutor       *BaseExecutor[kkComps.CreateGatewayRequest, kkComps.UpdateGatewayRequest]
 	organizationTeamExecutor               *BaseExecutor[kkComps.CreateTeam, kkComps.UpdateTeam]
@@ -263,6 +265,12 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 	e.aiGatewayMCPServerExecutor = NewBaseExecutor[
 		kkComps.CreateAIGatewayMCPServerRequest, kkComps.UpdateAIGatewayMCPServerRequest](
 		NewAIGatewayMCPServerAdapter(client),
+		client,
+		dryRun,
+	)
+	e.aiGatewayVaultExecutor = NewBaseExecutor[
+		kkComps.CreateAIGatewayVaultRequest, kkComps.UpdateAIGatewayVaultRequest](
+		NewAIGatewayVaultAdapter(client),
 		client,
 		dryRun,
 	)
@@ -2355,6 +2363,11 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 			return "", err
 		}
 		return e.aiGatewayMCPServerExecutor.Create(ctx, *change)
+	case planner.ResourceTypeAIGatewayVault:
+		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
+			return "", err
+		}
+		return e.aiGatewayVaultExecutor.Create(ctx, *change)
 	case planner.ResourceTypeDashboard:
 		return e.dashboardExecutor.Create(ctx, *change)
 	case planner.ResourceTypeDCRProvider:
@@ -2957,6 +2970,11 @@ func (e *Executor) updateResource(ctx context.Context, change *planner.PlannedCh
 			return "", err
 		}
 		return e.aiGatewayMCPServerExecutor.Update(ctx, *change)
+	case planner.ResourceTypeAIGatewayVault:
+		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
+			return "", err
+		}
+		return e.aiGatewayVaultExecutor.Update(ctx, *change)
 	case planner.ResourceTypeDashboard:
 		return e.dashboardExecutor.Update(ctx, *change)
 	case planner.ResourceTypeAPIDocument:
@@ -3435,6 +3453,8 @@ func (e *Executor) deleteResource(ctx context.Context, change *planner.PlannedCh
 		return e.aiGatewayModelExecutor.Delete(ctx, *change)
 	case planner.ResourceTypeAIGatewayMCPServer:
 		return e.aiGatewayMCPServerExecutor.Delete(ctx, *change)
+	case planner.ResourceTypeAIGatewayVault:
+		return e.aiGatewayVaultExecutor.Delete(ctx, *change)
 	case planner.ResourceTypeDashboard:
 		return e.dashboardExecutor.Delete(ctx, *change)
 	case planner.ResourceTypeAPIVersion:

--- a/internal/declarative/loader/ai_gateway_vault_test.go
+++ b/internal/declarative/loader/ai_gateway_vault_test.go
@@ -1,0 +1,107 @@
+package loader
+
+import (
+	"testing"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/tags"
+	"github.com/stretchr/testify/require"
+)
+
+const aiGatewayVaultYAML = `
+ai_gateways:
+  - ref: support-gateway
+    display_name: Support Gateway
+    vaults:
+      - ref: support-env
+        type: env
+        name: support-env
+        description: Support environment variables
+        config:
+          prefix: SUPPORT_
+          base64_decode: false
+`
+
+func TestLoaderExtractsNestedAIGatewayVaults(t *testing.T) {
+	path := writeLoaderTestFile(t, aiGatewayVaultYAML)
+
+	rs, err := New().LoadFromSources([]Source{{Path: path, Type: SourceTypeFile}}, false)
+	require.NoError(t, err)
+	require.Len(t, rs.AIGateways, 1)
+	require.Empty(t, rs.AIGateways[0].Vaults)
+	require.Len(t, rs.AIGatewayVaults, 1)
+	require.Equal(t, "support-gateway", rs.AIGatewayVaults[0].AIGateway)
+	require.Equal(t, "support-env", rs.AIGatewayVaults[0].Name())
+	require.True(t, rs.SyncScope.ChildInScope(
+		resources.ResourceTypeAIGateway,
+		"support-gateway",
+		resources.ResourceTypeAIGatewayVault,
+	))
+}
+
+func TestLoaderValidatesAIGatewayVaultParentAndDuplicates(t *testing.T) {
+	rootOnly := `
+ai_gateway_vaults:
+  - ref: support-env
+    ai_gateway: missing-gateway
+    type: env
+    name: support-env
+    config: {prefix: SUPPORT_}
+`
+	_, err := New().LoadFromSources([]Source{{Path: writeLoaderTestFile(t, rootOnly), Type: SourceTypeFile}}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "references unknown ai_gateway")
+
+	duplicates := `
+ai_gateways:
+  - ref: support-gateway
+    display_name: Support Gateway
+    vaults:
+      - ref: support-env
+        type: env
+        name: support-env
+        config: {prefix: SUPPORT_}
+      - ref: support-env-2
+        type: env
+        name: support-env
+        config: {prefix: SUPPORT_}
+`
+	_, err = New().LoadFromSources([]Source{{Path: writeLoaderTestFile(t, duplicates), Type: SourceTypeFile}}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate ai_gateway_vault name")
+}
+
+func TestLoaderRejectsRootLevelEmptyAIGatewayVaults(t *testing.T) {
+	input := `ai_gateway_vaults: []`
+
+	_, err := New().LoadFromSources([]Source{{Path: writeLoaderTestFile(t, input), Type: SourceTypeFile}}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ai_gateway_vaults cannot be empty")
+}
+
+func TestLoaderAcceptsAIGatewayVaultDeferredExternalParentRef(t *testing.T) {
+	input := `
+ai_gateways:
+  - ref: external-shared-gateway
+    _external:
+      selector:
+        matchFields:
+          display_name: Shared Gateway
+ai_gateway_vaults:
+  - ref: support-env
+    ai_gateway: !ref external-shared-gateway#id
+    type: env
+    name: support-env
+    config: {prefix: SUPPORT_}
+`
+
+	rs, err := New().LoadFromSources([]Source{{Path: writeLoaderTestFile(t, input), Type: SourceTypeFile}}, false)
+	require.NoError(t, err)
+	require.Len(t, rs.AIGatewayVaults, 1)
+	require.Equal(t, tags.RefPlaceholderPrefix+"external-shared-gateway#id", rs.AIGatewayVaults[0].AIGateway)
+	require.True(t, rs.SyncScope.ChildInScope(
+		resources.ResourceTypeAIGateway,
+		"external-shared-gateway",
+		resources.ResourceTypeAIGatewayVault,
+	))
+}

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -1049,6 +1049,13 @@ func (l *Loader) extractNestedResources(rs *resources.ResourceSet) {
 			rs.AIGatewayMCPServers = append(rs.AIGatewayMCPServers, server)
 		}
 		gateway.MCPServers = nil
+
+		for j := range gateway.Vaults {
+			vault := gateway.Vaults[j]
+			vault.AIGateway = gateway.Ref
+			rs.AIGatewayVaults = append(rs.AIGatewayVaults, vault)
+		}
+		gateway.Vaults = nil
 	}
 
 	for i := range rs.APIs {

--- a/internal/declarative/loader/sync_scope.go
+++ b/internal/declarative/loader/sync_scope.go
@@ -56,6 +56,12 @@ var rootChildCollectionScopes = []childCollectionScope{
 		parentType:   resources.ResourceTypeAIGateway,
 	},
 	{
+		key:          "ai_gateway_vaults",
+		resourceType: resources.ResourceTypeAIGatewayVault,
+		parentKey:    resources.SchemaFieldAIGateway,
+		parentType:   resources.ResourceTypeAIGateway,
+	},
+	{
 		key:          "control_plane_data_plane_certificates",
 		resourceType: resources.ResourceTypeControlPlaneDataPlaneCertificate,
 		parentKey:    "control_plane",
@@ -353,6 +359,11 @@ var aiGatewayChildCollectionScopes = []childCollectionScope{
 		resourceType: resources.ResourceTypeAIGatewayMCPServer,
 		parentType:   resources.ResourceTypeAIGateway,
 	},
+	{
+		key:          "vaults",
+		resourceType: resources.ResourceTypeAIGatewayVault,
+		parentType:   resources.ResourceTypeAIGateway,
+	},
 }
 
 var eventGatewayChildCollectionScopes = []childCollectionScope{
@@ -477,6 +488,9 @@ func captureRootChildScope(scope *resources.SyncScope, raw map[string]any, entry
 		}
 		if entry.resourceType == resources.ResourceTypeAIGatewayMCPServer {
 			return fmt.Errorf("%s cannot be empty because each MCP Server must declare an ai_gateway parent", entry.key)
+		}
+		if entry.resourceType == resources.ResourceTypeAIGatewayVault {
+			return fmt.Errorf("%s cannot be empty because each Vault must declare an ai_gateway parent", entry.key)
 		}
 		scope.AddRootChildCollection(entry.resourceType)
 		return nil

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -56,6 +56,9 @@ func (l *Loader) validateResourceSet(rs *resources.ResourceSet) error {
 	if err := l.validateAIGatewayMCPServers(rs); err != nil {
 		return err
 	}
+	if err := l.validateAIGatewayVaults(rs); err != nil {
+		return err
+	}
 
 	// Validate dashboards
 	if err := l.validateDashboards(rs.Dashboards, rs); err != nil {
@@ -933,6 +936,58 @@ func (l *Loader) validateAIGatewayMCPServers(rs *resources.ResourceSet) error {
 			)
 		}
 		namesByGateway[nameKey] = server.GetRef()
+	}
+
+	return nil
+}
+
+// validateAIGatewayVaults validates AI Gateway child Vault resources.
+func (l *Loader) validateAIGatewayVaults(rs *resources.ResourceSet) error {
+	namesByGateway := make(map[string]string)
+
+	for i := range rs.AIGatewayVaults {
+		vault := &rs.AIGatewayVaults[i]
+
+		if err := vault.Validate(); err != nil {
+			return fmt.Errorf("invalid ai_gateway_vault %q: %w", vault.GetRef(), err)
+		}
+
+		if existing, found := rs.GetResourceByRef(vault.GetRef()); found {
+			if existing.GetType() != resources.ResourceTypeAIGatewayVault {
+				return fmt.Errorf("duplicate ref '%s' (already defined as %s)",
+					vault.GetRef(), existing.GetType())
+			}
+		}
+
+		gatewayRef := resources.NormalizeResourceRef(vault.AIGateway)
+		gateway, found := rs.GetResourceByRef(gatewayRef)
+		if !found {
+			return fmt.Errorf(
+				"ai_gateway_vault %q references unknown ai_gateway %q",
+				vault.GetRef(),
+				vault.AIGateway,
+			)
+		}
+		if gateway.GetType() != resources.ResourceTypeAIGateway {
+			return fmt.Errorf(
+				"ai_gateway_vault %q references %q which is %s, not ai_gateway",
+				vault.GetRef(),
+				vault.AIGateway,
+				gateway.GetType(),
+			)
+		}
+
+		nameKey := gatewayRef + "\x00" + vault.Name()
+		if existingRef, exists := namesByGateway[nameKey]; exists {
+			return fmt.Errorf(
+				"duplicate ai_gateway_vault name %q for ai_gateway %q (ref: %s conflicts with ref: %s)",
+				vault.Name(),
+				gatewayRef,
+				vault.GetRef(),
+				existingRef,
+			)
+		}
+		namesByGateway[nameKey] = vault.GetRef()
 	}
 
 	return nil

--- a/internal/declarative/planner/ai_gateway_planner.go
+++ b/internal/declarative/planner/ai_gateway_planner.go
@@ -154,6 +154,27 @@ func (p *Planner) planAIGatewayChanges(
 			}
 		}
 
+		vaults := p.resources.GetAIGatewayVaultsForGateway(desiredGateway.Ref)
+		if p.shouldPlanChild(
+			plan,
+			resources.ResourceTypeAIGateway,
+			desiredGateway.Ref,
+			resources.ResourceTypeAIGatewayVault,
+		) && (len(vaults) > 0 || plan.Metadata.Mode == PlanModeSync) {
+			if err := p.planAIGatewayVaultChanges(
+				ctx,
+				namespace,
+				desiredGateway.Ref,
+				desiredGateway.DisplayName,
+				gatewayID,
+				gatewayChangeID,
+				vaults,
+				plan,
+			); err != nil {
+				return err
+			}
+		}
+
 		providers := p.resources.GetAIGatewayProvidersForGateway(desiredGateway.Ref)
 		if p.shouldPlanChild(
 			plan,
@@ -274,6 +295,27 @@ func (p *Planner) planExternalAIGatewayChildren(
 			desiredGateway.GetRef(),
 		))
 		return nil
+	}
+
+	vaults := p.resources.GetAIGatewayVaultsForGateway(desiredGateway.Ref)
+	if p.shouldPlanChild(
+		plan,
+		resources.ResourceTypeAIGateway,
+		desiredGateway.Ref,
+		resources.ResourceTypeAIGatewayVault,
+	) && len(vaults) > 0 {
+		if err := p.planAIGatewayVaultChanges(
+			ctx,
+			namespace,
+			desiredGateway.Ref,
+			desiredGateway.DisplayName,
+			gatewayID,
+			"",
+			vaults,
+			plan,
+		); err != nil {
+			return err
+		}
 	}
 
 	providers := p.resources.GetAIGatewayProvidersForGateway(desiredGateway.Ref)

--- a/internal/declarative/planner/ai_gateway_vault_planner.go
+++ b/internal/declarative/planner/ai_gateway_vault_planner.go
@@ -1,0 +1,277 @@
+package planner
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"maps"
+	"reflect"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/util"
+)
+
+func (p *Planner) planAIGatewayVaultChanges(
+	ctx context.Context,
+	namespace string,
+	gatewayRef string,
+	gatewayName string,
+	gatewayID string,
+	gatewayChangeID string,
+	desired []resources.AIGatewayVaultResource,
+	plan *Plan,
+) error {
+	p.logger.Debug(
+		"Planning AI Gateway Vault changes",
+		slog.String("gateway_ref", gatewayRef),
+		slog.String("gateway_id", gatewayID),
+		slog.String("gateway_change_id", gatewayChangeID),
+		slog.Int("desired_count", len(desired)),
+	)
+
+	if gatewayID == "" {
+		p.planAIGatewayVaultCreatesForNewGateway(namespace, gatewayRef, gatewayName, gatewayChangeID, desired, plan)
+		return nil
+	}
+
+	currentVaults, err := p.client.ListAIGatewayVaults(ctx, gatewayID)
+	if err != nil {
+		return fmt.Errorf("failed to list AI Gateway Vaults for gateway %s: %w", gatewayID, err)
+	}
+
+	currentByID, currentByName := indexAIGatewayVaults(currentVaults)
+	desiredKeys := make(map[string]bool)
+
+	for _, desiredVault := range desired {
+		current, exists := matchCurrentAIGatewayVault(desiredVault, currentByID, currentByName)
+		desiredKeys[desiredVault.Name()] = true
+		if id := aiGatewayVaultDesiredID(desiredVault); id != "" {
+			desiredKeys[id] = true
+		}
+
+		if !exists {
+			p.planAIGatewayVaultCreate(namespace, gatewayRef, gatewayName, gatewayID, desiredVault, nil, plan)
+			continue
+		}
+
+		vaultID := resources.AIGatewayVaultID(current.AIGatewayVault)
+		fullVault, err := p.client.GetAIGatewayVault(ctx, gatewayID, vaultID)
+		if err != nil {
+			return fmt.Errorf("failed to get AI Gateway Vault %s: %w", vaultID, err)
+		}
+		if fullVault == nil {
+			p.planAIGatewayVaultCreate(namespace, gatewayRef, gatewayName, gatewayID, desiredVault, nil, plan)
+			continue
+		}
+
+		needsUpdate, updateFields, changedFields, err := shouldUpdateAIGatewayVault(*fullVault, desiredVault)
+		if err != nil {
+			return err
+		}
+		if needsUpdate {
+			p.planAIGatewayVaultUpdate(
+				namespace,
+				gatewayRef,
+				gatewayID,
+				vaultID,
+				desiredVault,
+				updateFields,
+				changedFields,
+				nil,
+				plan,
+			)
+		}
+	}
+
+	if plan.Metadata.Mode == PlanModeSync {
+		for _, current := range currentVaults {
+			vaultID := resources.AIGatewayVaultID(current.AIGatewayVault)
+			vaultName := resources.AIGatewayVaultName(current.AIGatewayVault)
+			if desiredKeys[vaultID] || desiredKeys[vaultName] {
+				continue
+			}
+			p.planAIGatewayVaultDelete(gatewayRef, gatewayID, vaultID, vaultName, plan)
+		}
+	}
+
+	return nil
+}
+
+func (p *Planner) planAIGatewayVaultCreatesForNewGateway(
+	namespace string,
+	gatewayRef string,
+	gatewayName string,
+	gatewayChangeID string,
+	vaults []resources.AIGatewayVaultResource,
+	plan *Plan,
+) {
+	var dependsOn []string
+	if gatewayChangeID != "" {
+		dependsOn = []string{gatewayChangeID}
+	}
+	for _, vault := range vaults {
+		p.planAIGatewayVaultCreate(namespace, gatewayRef, gatewayName, "", vault, dependsOn, plan)
+	}
+}
+
+func (p *Planner) planAIGatewayVaultCreate(
+	namespace string,
+	gatewayRef string,
+	gatewayName string,
+	gatewayID string,
+	vault resources.AIGatewayVaultResource,
+	dependsOn []string,
+	plan *Plan,
+) {
+	fields, err := vault.MutablePayloadMap()
+	if err != nil {
+		plan.AddWarning(vault.GetRef(), fmt.Sprintf("failed to build AI Gateway Vault create payload: %s", err))
+		return
+	}
+
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionCreate, ResourceTypeAIGatewayVault, vault.Ref),
+		ResourceType: ResourceTypeAIGatewayVault,
+		ResourceRef:  vault.Ref,
+		Action:       ActionCreate,
+		Fields:       fields,
+		Namespace:    namespace,
+		DependsOn:    dependsOn,
+	}
+	if gatewayID != "" {
+		change.Parent = &ParentInfo{Ref: gatewayRef, ID: gatewayID}
+	} else {
+		change.References = map[string]ReferenceInfo{
+			FieldAIGatewayID: {
+				Ref: gatewayRef,
+				LookupFields: map[string]string{
+					FieldDisplayName: gatewayName,
+				},
+			},
+		}
+	}
+
+	plan.AddChange(change)
+}
+
+func (p *Planner) planAIGatewayVaultUpdate(
+	namespace string,
+	gatewayRef string,
+	gatewayID string,
+	vaultID string,
+	vault resources.AIGatewayVaultResource,
+	updateFields map[string]any,
+	changedFields map[string]FieldChange,
+	dependsOn []string,
+	plan *Plan,
+) {
+	change := PlannedChange{
+		ID:            p.nextChangeID(ActionUpdate, ResourceTypeAIGatewayVault, vault.Ref),
+		ResourceType:  ResourceTypeAIGatewayVault,
+		ResourceRef:   vault.Ref,
+		ResourceID:    vaultID,
+		Action:        ActionUpdate,
+		Fields:        updateFields,
+		ChangedFields: changedFields,
+		Namespace:     namespace,
+		DependsOn:     dependsOn,
+		Parent:        &ParentInfo{Ref: gatewayRef, ID: gatewayID},
+	}
+	plan.AddChange(change)
+}
+
+func (p *Planner) planAIGatewayVaultDelete(
+	gatewayRef string,
+	gatewayID string,
+	vaultID string,
+	vaultName string,
+	plan *Plan,
+) {
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionDelete, ResourceTypeAIGatewayVault, vaultName),
+		ResourceType: ResourceTypeAIGatewayVault,
+		ResourceRef:  vaultName,
+		ResourceID:   vaultID,
+		Action:       ActionDelete,
+		Fields: map[string]any{
+			FieldName: vaultName,
+		},
+		Parent: &ParentInfo{Ref: gatewayRef, ID: gatewayID},
+	}
+	plan.AddChange(change)
+}
+
+func shouldUpdateAIGatewayVault(
+	current state.AIGatewayVault,
+	desired resources.AIGatewayVaultResource,
+) (bool, map[string]any, map[string]FieldChange, error) {
+	currentPayload, err := resources.AIGatewayVaultMutablePayloadMap(current.AIGatewayVault)
+	if err != nil {
+		return false, nil, nil, fmt.Errorf("failed to normalize current AI Gateway Vault: %w", err)
+	}
+	desiredPayload, err := desired.MutablePayloadMap()
+	if err != nil {
+		return false, nil, nil, fmt.Errorf("failed to normalize desired AI Gateway Vault %q: %w", desired.Ref, err)
+	}
+
+	changedFields := make(map[string]FieldChange)
+	keys := make(map[string]struct{}, len(currentPayload)+len(desiredPayload))
+	for key := range currentPayload {
+		keys[key] = struct{}{}
+	}
+	for key := range desiredPayload {
+		keys[key] = struct{}{}
+	}
+	for key := range keys {
+		if !reflect.DeepEqual(currentPayload[key], desiredPayload[key]) {
+			changedFields[key] = FieldChange{Old: currentPayload[key], New: desiredPayload[key]}
+		}
+	}
+	if len(changedFields) == 0 {
+		return false, nil, nil, nil
+	}
+
+	updateFields := make(map[string]any, len(desiredPayload))
+	maps.Copy(updateFields, desiredPayload)
+	return true, updateFields, changedFields, nil
+}
+
+func indexAIGatewayVaults(
+	vaults []state.AIGatewayVault,
+) (map[string]state.AIGatewayVault, map[string]state.AIGatewayVault) {
+	byID := make(map[string]state.AIGatewayVault)
+	byName := make(map[string]state.AIGatewayVault)
+	for _, vault := range vaults {
+		if id := resources.AIGatewayVaultID(vault.AIGatewayVault); id != "" {
+			byID[id] = vault
+		}
+		if name := resources.AIGatewayVaultName(vault.AIGatewayVault); name != "" {
+			byName[name] = vault
+		}
+	}
+	return byID, byName
+}
+
+func matchCurrentAIGatewayVault(
+	desired resources.AIGatewayVaultResource,
+	currentByID map[string]state.AIGatewayVault,
+	currentByName map[string]state.AIGatewayVault,
+) (state.AIGatewayVault, bool) {
+	if id := aiGatewayVaultDesiredID(desired); id != "" {
+		current, exists := currentByID[id]
+		return current, exists
+	}
+	current, exists := currentByName[desired.Name()]
+	return current, exists
+}
+
+func aiGatewayVaultDesiredID(desired resources.AIGatewayVaultResource) string {
+	if id := desired.GetKonnectID(); id != "" {
+		return id
+	}
+	if util.IsValidUUID(desired.Ref) {
+		return desired.Ref
+	}
+	return ""
+}

--- a/internal/declarative/planner/ai_gateway_vault_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_vault_planner_test.go
@@ -1,0 +1,207 @@
+package planner
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAIGatewayVaultPlannerCreatesChildForExistingGateway(t *testing.T) {
+	vault := testAIGatewayVaultResource(t)
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{
+			gateways: []kkComps.AIGateway{testAIGateway()},
+		},
+		AIGatewayVaultsAPI: &testAIGatewayVaultAPI{},
+	})
+	rs := &resources.ResourceSet{
+		AIGateways: []resources.AIGatewayResource{{
+			BaseResource: resources.BaseResource{
+				Ref:     "support-gateway",
+				Kongctl: &resources.KongctlMeta{Namespace: new("default")},
+			},
+			CreateAIGatewayRequest: kkComps.CreateAIGatewayRequest{
+				Name:        "support-gateway",
+				DisplayName: "Support Gateway",
+			},
+		}},
+		AIGatewayVaults: []resources.AIGatewayVaultResource{vault},
+	}
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	change := plan.Changes[0]
+	require.Equal(t, ActionCreate, change.Action)
+	require.Equal(t, ResourceTypeAIGatewayVault, change.ResourceType)
+	require.Equal(t, "support-env", change.ResourceRef)
+	require.NotNil(t, change.Parent)
+	require.Equal(t, "gateway-id", change.Parent.ID)
+	require.Equal(t, "support-gateway", change.Parent.Ref)
+	require.Equal(t, "env", change.Fields[FieldType])
+}
+
+func TestAIGatewayVaultPlannerUpdatesChangedVault(t *testing.T) {
+	vault := testAIGatewayVaultResource(t)
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{
+			gateways: []kkComps.AIGateway{testAIGateway()},
+		},
+		AIGatewayVaultsAPI: &testAIGatewayVaultAPI{
+			vaults: []kkComps.AIGatewayVault{testAIGatewayVault(t, "vault-id", "support-env", "OLD_")},
+		},
+	})
+	rs := &resources.ResourceSet{
+		AIGateways: []resources.AIGatewayResource{{
+			BaseResource: resources.BaseResource{
+				Ref:     "support-gateway",
+				Kongctl: &resources.KongctlMeta{Namespace: new("default")},
+			},
+			CreateAIGatewayRequest: kkComps.CreateAIGatewayRequest{
+				Name:        "support-gateway",
+				DisplayName: "Support Gateway",
+			},
+		}},
+		AIGatewayVaults: []resources.AIGatewayVaultResource{vault},
+	}
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	change := plan.Changes[0]
+	require.Equal(t, ActionUpdate, change.Action)
+	require.Equal(t, ResourceTypeAIGatewayVault, change.ResourceType)
+	require.Equal(t, "vault-id", change.ResourceID)
+	require.Contains(t, change.ChangedFields, FieldConfig)
+}
+
+func TestAIGatewayVaultPlannerSyncDeletesScopedVaults(t *testing.T) {
+	scope := resources.NewSyncScope()
+	scope.AddRoot(resources.ResourceTypeAIGateway)
+	scope.AddChild(resources.ResourceTypeAIGateway, "support-gateway", resources.ResourceTypeAIGatewayVault)
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{
+			gateways: []kkComps.AIGateway{testAIGateway()},
+		},
+		AIGatewayVaultsAPI: &testAIGatewayVaultAPI{
+			vaults: []kkComps.AIGatewayVault{testAIGatewayVault(t, "vault-id", "support-env", "SUPPORT_")},
+		},
+	})
+	rs := &resources.ResourceSet{
+		AIGateways: []resources.AIGatewayResource{{
+			BaseResource: resources.BaseResource{
+				Ref:     "support-gateway",
+				Kongctl: &resources.KongctlMeta{Namespace: new("default")},
+			},
+			CreateAIGatewayRequest: kkComps.CreateAIGatewayRequest{
+				Name:        "support-gateway",
+				DisplayName: "Support Gateway",
+			},
+		}},
+		SyncScope: scope,
+	}
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeSync})
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	change := plan.Changes[0]
+	require.Equal(t, ActionDelete, change.Action)
+	require.Equal(t, ResourceTypeAIGatewayVault, change.ResourceType)
+	require.Equal(t, "vault-id", change.ResourceID)
+	require.NotNil(t, change.Parent)
+	require.Equal(t, "gateway-id", change.Parent.ID)
+}
+
+func testAIGatewayVaultResource(t *testing.T) resources.AIGatewayVaultResource {
+	t.Helper()
+	payload := `{
+		"ref": "support-env",
+		"ai_gateway": "support-gateway",
+		"type": "env",
+		"name": "support-env",
+		"description": "Support environment variables",
+		"config": {"prefix": "SUPPORT_", "base64_decode": false}
+	}`
+	var vault resources.AIGatewayVaultResource
+	require.NoError(t, json.Unmarshal([]byte(payload), &vault))
+	return vault
+}
+
+func testAIGatewayVault(t *testing.T, id string, name string, prefix string) kkComps.AIGatewayVault {
+	t.Helper()
+	payload := `{
+		"id": "` + id + `",
+		"type": "env",
+		"name": "` + name + `",
+		"description": "Support environment variables",
+		"config": {"prefix": "` + prefix + `", "base64_decode": false},
+		"created_at": "2026-01-01T00:00:00Z",
+		"updated_at": "2026-01-01T00:00:00Z"
+	}`
+	var vault kkComps.AIGatewayVault
+	require.NoError(t, json.Unmarshal([]byte(payload), &vault))
+	return vault
+}
+
+type testAIGatewayVaultAPI struct {
+	vaults []kkComps.AIGatewayVault
+}
+
+func (t *testAIGatewayVaultAPI) ListAiGatewayVaults(
+	context.Context,
+	kkOps.ListAiGatewayVaultsRequest,
+	...kkOps.Option,
+) (*kkOps.ListAiGatewayVaultsResponse, error) {
+	return &kkOps.ListAiGatewayVaultsResponse{
+		ListAIGatewayVaultsResponse: &kkComps.ListAIGatewayVaultsResponse{
+			Data: t.vaults,
+		},
+	}, nil
+}
+
+func (t *testAIGatewayVaultAPI) CreateAiGatewayVault(
+	context.Context,
+	string,
+	kkComps.CreateAIGatewayVaultRequest,
+	...kkOps.Option,
+) (*kkOps.CreateAiGatewayVaultResponse, error) {
+	return nil, nil
+}
+
+func (t *testAIGatewayVaultAPI) GetAiGatewayVault(
+	_ context.Context,
+	_ string,
+	vaultID string,
+	_ ...kkOps.Option,
+) (*kkOps.GetAiGatewayVaultResponse, error) {
+	for _, vault := range t.vaults {
+		if resources.AIGatewayVaultID(vault) == vaultID || resources.AIGatewayVaultName(vault) == vaultID {
+			return &kkOps.GetAiGatewayVaultResponse{AIGatewayVault: &vault}, nil
+		}
+	}
+	return &kkOps.GetAiGatewayVaultResponse{}, nil
+}
+
+func (t *testAIGatewayVaultAPI) UpdateAiGatewayVault(
+	context.Context,
+	kkOps.UpdateAiGatewayVaultRequest,
+	...kkOps.Option,
+) (*kkOps.UpdateAiGatewayVaultResponse, error) {
+	return nil, nil
+}
+
+func (t *testAIGatewayVaultAPI) DeleteAiGatewayVault(
+	context.Context,
+	string,
+	string,
+	...kkOps.Option,
+) (*kkOps.DeleteAiGatewayVaultResponse, error) {
+	return nil, nil
+}

--- a/internal/declarative/planner/constants.go
+++ b/internal/declarative/planner/constants.go
@@ -208,6 +208,7 @@ const (
 	ResourceTypeAIGatewayPolicy                  = string(resources.ResourceTypeAIGatewayPolicy)
 	ResourceTypeAIGatewayModel                   = string(resources.ResourceTypeAIGatewayModel)
 	ResourceTypeAIGatewayMCPServer               = string(resources.ResourceTypeAIGatewayMCPServer)
+	ResourceTypeAIGatewayVault                   = string(resources.ResourceTypeAIGatewayVault)
 	ResourceTypeDashboard                        = string(resources.ResourceTypeDashboard)
 	ResourceTypeAPIVersion                       = string(resources.ResourceTypeAPIVersion)
 	ResourceTypeAPIPublication                   = string(resources.ResourceTypeAPIPublication)

--- a/internal/declarative/planner/dependencies.go
+++ b/internal/declarative/planner/dependencies.go
@@ -236,7 +236,8 @@ func aiGatewayChildSerializationParentKey(change PlannedChange) string {
 	case ResourceTypeAIGatewayProvider,
 		ResourceTypeAIGatewayPolicy,
 		ResourceTypeAIGatewayModel,
-		ResourceTypeAIGatewayMCPServer:
+		ResourceTypeAIGatewayMCPServer,
+		ResourceTypeAIGatewayVault:
 	default:
 		return ""
 	}
@@ -343,7 +344,8 @@ func (d *DependencyResolver) getParentType(childType string) string {
 	case ResourceTypeAIGatewayProvider,
 		ResourceTypeAIGatewayPolicy,
 		ResourceTypeAIGatewayModel,
-		ResourceTypeAIGatewayMCPServer:
+		ResourceTypeAIGatewayMCPServer,
+		ResourceTypeAIGatewayVault:
 		return ResourceTypeAIGateway
 	default:
 		return ""

--- a/internal/declarative/planner/sync_scope.go
+++ b/internal/declarative/planner/sync_scope.go
@@ -176,6 +176,13 @@ func addAIGatewayChildScopes(scope *resources.SyncScope, rs *resources.ResourceS
 			resources.ResourceTypeAIGatewayMCPServer,
 		)
 	}
+	for _, child := range rs.AIGatewayVaults {
+		scope.AddChild(
+			resources.ResourceTypeAIGateway,
+			resources.NormalizeResourceRef(child.AIGateway),
+			resources.ResourceTypeAIGatewayVault,
+		)
+	}
 }
 
 func addEventGatewayChildScopes(scope *resources.SyncScope, rs *resources.ResourceSet) {

--- a/internal/declarative/protection/lookup.go
+++ b/internal/declarative/protection/lookup.go
@@ -157,7 +157,8 @@ func IsManagedResourceProtected(
 		resources.ResourceTypeAIGatewayProvider,
 		resources.ResourceTypeAIGatewayPolicy,
 		resources.ResourceTypeAIGatewayModel,
-		resources.ResourceTypeAIGatewayMCPServer:
+		resources.ResourceTypeAIGatewayMCPServer,
+		resources.ResourceTypeAIGatewayVault:
 		return false, nil
 	}
 

--- a/internal/declarative/resources/ai_gateway.go
+++ b/internal/declarative/resources/ai_gateway.go
@@ -28,6 +28,7 @@ type AIGatewayResource struct {
 	Policies   []AIGatewayPolicyResource    `yaml:"policies,omitempty" json:"policies,omitempty"`
 	Models     []AIGatewayModelResource     `yaml:"models,omitempty"    json:"models,omitempty"`
 	MCPServers []AIGatewayMCPServerResource `yaml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
+	Vaults     []AIGatewayVaultResource     `yaml:"vaults,omitempty" json:"vaults,omitempty"`
 }
 
 func (a AIGatewayResource) MarshalJSON() ([]byte, error) {
@@ -51,6 +52,7 @@ type aiGatewayAlias struct {
 	Policies    []AIGatewayPolicyResource    `json:"policies,omitempty"    yaml:"policies,omitempty"`
 	Models      []AIGatewayModelResource     `json:"models,omitempty"      yaml:"models,omitempty"`
 	MCPServers  []AIGatewayMCPServerResource `json:"mcp_servers,omitempty" yaml:"mcp_servers,omitempty"`
+	Vaults      []AIGatewayVaultResource     `json:"vaults,omitempty"      yaml:"vaults,omitempty"`
 }
 
 func (a AIGatewayResource) aiGatewayAlias() aiGatewayAlias {
@@ -66,6 +68,7 @@ func (a AIGatewayResource) aiGatewayAlias() aiGatewayAlias {
 		Policies:    a.Policies,
 		Models:      a.Models,
 		MCPServers:  a.MCPServers,
+		Vaults:      a.Vaults,
 	}
 }
 
@@ -84,6 +87,7 @@ func (a *AIGatewayResource) UnmarshalYAML(unmarshal func(any) error) error {
 		Policies    []AIGatewayPolicyResource    `yaml:"policies,omitempty"`
 		Models      []AIGatewayModelResource     `yaml:"models,omitempty"`
 		MCPServers  []AIGatewayMCPServerResource `yaml:"mcp_servers,omitempty"`
+		Vaults      []AIGatewayVaultResource     `yaml:"vaults,omitempty"`
 	}
 	if err := unmarshal(&raw); err != nil {
 		return err
@@ -104,6 +108,7 @@ func (a *AIGatewayResource) UnmarshalYAML(unmarshal func(any) error) error {
 	a.Policies = raw.Policies
 	a.Models = raw.Models
 	a.MCPServers = raw.MCPServers
+	a.Vaults = raw.Vaults
 
 	return nil
 }
@@ -123,6 +128,7 @@ func (a *AIGatewayResource) UnmarshalJSON(data []byte) error {
 		Policies    []AIGatewayPolicyResource    `json:"policies,omitempty"`
 		Models      []AIGatewayModelResource     `json:"models,omitempty"`
 		MCPServers  []AIGatewayMCPServerResource `json:"mcp_servers,omitempty"`
+		Vaults      []AIGatewayVaultResource     `json:"vaults,omitempty"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
@@ -143,6 +149,7 @@ func (a *AIGatewayResource) UnmarshalJSON(data []byte) error {
 	a.Policies = raw.Policies
 	a.Models = raw.Models
 	a.MCPServers = raw.MCPServers
+	a.Vaults = raw.Vaults
 
 	return nil
 }
@@ -208,6 +215,9 @@ func (a *AIGatewayResource) SetDefaults() {
 	for i := range a.MCPServers {
 		a.MCPServers[i].SetDefaults()
 	}
+	for i := range a.Vaults {
+		a.Vaults[i].SetDefaults()
+	}
 }
 
 // GetKonnectMonikerFilter returns the filter string for Konnect API lookup.
@@ -252,6 +262,7 @@ func aiGatewayExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
 		explainField("policies", explainArrayOf(aiGatewayPolicyInlineExplainNode()), false, false),
 		explainField("models", explainArrayOf(&ExplainNode{Kind: explainKindObject}), false, false),
 		explainField("mcp_servers", explainArrayOf(aiGatewayMCPServerInlineExplainNode()), false, false),
+		explainField("vaults", explainArrayOf(aiGatewayVaultInlineExplainNode()), false, false),
 	), nil
 }
 
@@ -273,6 +284,14 @@ func aiGatewayPolicyInlineExplainNode() *ExplainNode {
 
 func aiGatewayMCPServerInlineExplainNode() *ExplainNode {
 	node, err := aiGatewayMCPServerExplainNode(ExplainBuildContext{})
+	if err != nil {
+		return explainObject()
+	}
+	return node
+}
+
+func aiGatewayVaultInlineExplainNode() *ExplainNode {
+	node, err := aiGatewayVaultExplainNode(ExplainBuildContext{})
 	if err != nil {
 		return explainObject()
 	}

--- a/internal/declarative/resources/ai_gateway_vault.go
+++ b/internal/declarative/resources/ai_gateway_vault.go
@@ -1,0 +1,439 @@
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/util"
+)
+
+const (
+	aiGatewayVaultFieldID          = "id"
+	aiGatewayVaultFieldName        = "name"
+	aiGatewayVaultFieldType        = "type"
+	aiGatewayVaultFieldDescription = "description"
+	aiGatewayVaultFieldConfig      = "config"
+	aiGatewayVaultFieldLabels      = "labels"
+	aiGatewayVaultFieldUpdatedAt   = "updated_at"
+)
+
+func init() {
+	registerResourceType(
+		ResourceTypeAIGatewayVault,
+		func(rs *ResourceSet) *[]AIGatewayVaultResource { return &rs.AIGatewayVaults },
+		AutoExplain[AIGatewayVaultResource](
+			WithExplainAliases(
+				"ai_gateway_vaults",
+				"ai-gateway-vault",
+				"ai-gateway-vaults",
+				"ai_gateway.vaults",
+				"aigw-vault",
+			),
+			WithExplainRecommendedFields(
+				"ref",
+				SchemaFieldAIGateway,
+				"type",
+				"name",
+				aiGatewayVaultFieldConfig,
+			),
+			WithExplainSchemaBuilder(aiGatewayVaultExplainNode),
+		),
+	)
+}
+
+// AIGatewayVaultResource represents a Vault nested under a Konnect AI Gateway.
+type AIGatewayVaultResource struct {
+	BaseResource `yaml:",inline" json:",inline"`
+	// Parent AI Gateway reference for root-level declarations.
+	AIGateway string `yaml:"ai_gateway,omitempty" json:"ai_gateway,omitempty"`
+
+	kkComps.CreateAIGatewayVaultRequest `yaml:",inline" json:",inline"`
+}
+
+func (a AIGatewayVaultResource) GetType() ResourceType {
+	return ResourceTypeAIGatewayVault
+}
+
+func (a AIGatewayVaultResource) GetMoniker() string {
+	return a.Name()
+}
+
+func (a AIGatewayVaultResource) GetDependencies() []ResourceRef {
+	if a.AIGateway == "" {
+		return nil
+	}
+	return []ResourceRef{{Kind: ResourceTypeAIGateway, Ref: NormalizeResourceRef(a.AIGateway)}}
+}
+
+func (a AIGatewayVaultResource) GetParentRef() *ResourceRef {
+	if a.AIGateway == "" {
+		return nil
+	}
+	return &ResourceRef{Kind: ResourceTypeAIGateway, Ref: NormalizeResourceRef(a.AIGateway)}
+}
+
+func (a AIGatewayVaultResource) Validate() error {
+	if err := ValidateRef(a.Ref); err != nil {
+		return fmt.Errorf("invalid AI Gateway Vault ref: %w", err)
+	}
+	if a.Kongctl != nil {
+		return fmt.Errorf("kongctl metadata not supported on AI Gateway Vault %s", a.Ref)
+	}
+	if a.AIGateway == "" {
+		return fmt.Errorf("ai_gateway is required for AI Gateway Vault %s", a.Ref)
+	}
+	if a.Name() == "" {
+		return fmt.Errorf("name is required for AI Gateway Vault %s", a.Ref)
+	}
+	if a.VaultType() == "" {
+		return fmt.Errorf("type is required for AI Gateway Vault %s", a.Ref)
+	}
+	if !a.hasPayload() {
+		return fmt.Errorf("AI Gateway Vault %s must specify a valid Vault payload", a.Ref)
+	}
+	payload, err := a.PayloadMap()
+	if err != nil {
+		return err
+	}
+	if _, ok := payload[aiGatewayVaultFieldConfig]; !ok {
+		return fmt.Errorf("config is required for AI Gateway Vault %s", a.Ref)
+	}
+	return nil
+}
+
+func (a *AIGatewayVaultResource) SetDefaults() {
+	if a == nil || !a.hasPayload() {
+		return
+	}
+
+	payload, err := a.PayloadMap()
+	if err != nil {
+		return
+	}
+	if a.Ref == "" {
+		if name, _ := payload[aiGatewayVaultFieldName].(string); name != "" {
+			a.Ref = name
+		}
+	}
+	if name, _ := payload[aiGatewayVaultFieldName].(string); name == "" && a.Ref != "" {
+		payload[aiGatewayVaultFieldName] = a.Ref
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+	var req kkComps.CreateAIGatewayVaultRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return
+	}
+	a.CreateAIGatewayVaultRequest = req
+}
+
+func (a AIGatewayVaultResource) GetKonnectMonikerFilter() string {
+	return a.Name()
+}
+
+func (a *AIGatewayVaultResource) TryMatchKonnectResource(konnectResource any) bool {
+	name := a.Name()
+	if name == "" {
+		return false
+	}
+	if id := AIGatewayVaultID(konnectResource); id != "" && (util.IsValidUUID(a.Ref) || a.GetKonnectID() != "") {
+		if a.Ref == id || a.GetKonnectID() == id {
+			a.SetKonnectID(id)
+			return true
+		}
+	}
+	if id := AIGatewayVaultID(konnectResource); id != "" && AIGatewayVaultName(konnectResource) == name {
+		a.SetKonnectID(id)
+		return true
+	}
+	return false
+}
+
+func (a AIGatewayVaultResource) Name() string {
+	return aiGatewayVaultStringField(a.CreateAIGatewayVaultRequest, aiGatewayVaultFieldName)
+}
+
+func (a AIGatewayVaultResource) VaultType() string {
+	if a.Type != "" {
+		return string(a.Type)
+	}
+	return aiGatewayVaultStringField(a.CreateAIGatewayVaultRequest, aiGatewayVaultFieldType)
+}
+
+func (a AIGatewayVaultResource) CreateRequest() kkComps.CreateAIGatewayVaultRequest {
+	return a.CreateAIGatewayVaultRequest
+}
+
+func (a AIGatewayVaultResource) UpdateRequest() kkComps.UpdateAIGatewayVaultRequest {
+	payload, err := a.PayloadMap()
+	if err != nil || len(payload) == 0 {
+		return kkComps.UpdateAIGatewayVaultRequest{}
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return kkComps.UpdateAIGatewayVaultRequest{}
+	}
+	var req kkComps.UpdateAIGatewayVaultRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return kkComps.UpdateAIGatewayVaultRequest{}
+	}
+	return req
+}
+
+func (a AIGatewayVaultResource) PayloadMap() (map[string]any, error) {
+	if !a.hasPayload() {
+		return map[string]any{}, nil
+	}
+	return marshalObjectToMap(a.CreateRequest(), "AI Gateway Vault payload")
+}
+
+func (a AIGatewayVaultResource) MutablePayloadMap() (map[string]any, error) {
+	payload, err := a.PayloadMap()
+	if err != nil {
+		return nil, err
+	}
+	stripAIGatewayVaultServerFields(payload)
+	return payload, nil
+}
+
+func (a AIGatewayVaultResource) hasPayload() bool {
+	return a.KonnectConfigStoreVault != nil ||
+		a.EnvironmentVariableVault != nil ||
+		a.AwsSecretsManagerVault != nil ||
+		a.GoogleSecretManagerVault != nil ||
+		a.AzureKeyVault != nil ||
+		a.ConjurVault != nil ||
+		a.HashiCorpVault != nil
+}
+
+func (a AIGatewayVaultResource) MarshalJSON() ([]byte, error) {
+	payload, err := a.PayloadMap()
+	if err != nil {
+		return nil, err
+	}
+	payload[SchemaFieldRef] = a.Ref
+	if a.AIGateway != "" {
+		payload[SchemaFieldAIGateway] = a.AIGateway
+	}
+	return json.Marshal(payload)
+}
+
+func (a AIGatewayVaultResource) MarshalYAML() (any, error) {
+	payload, err := a.PayloadMap()
+	if err != nil {
+		return nil, err
+	}
+	payload[SchemaFieldRef] = a.Ref
+	if a.AIGateway != "" {
+		payload[SchemaFieldAIGateway] = a.AIGateway
+	}
+	return payload, nil
+}
+
+func (a *AIGatewayVaultResource) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	var meta struct {
+		Ref       string          `json:"ref"`
+		AIGateway string          `json:"ai_gateway,omitempty"`
+		Kongctl   json.RawMessage `json:"kongctl,omitempty"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return err
+	}
+	if len(meta.Kongctl) > 0 && string(meta.Kongctl) != "null" {
+		return fmt.Errorf("kongctl metadata not supported on child resources")
+	}
+
+	delete(raw, SchemaFieldRef)
+	delete(raw, SchemaFieldAIGateway)
+	delete(raw, "kongctl")
+
+	payload, err := json.Marshal(raw)
+	if err != nil {
+		return err
+	}
+	var req kkComps.CreateAIGatewayVaultRequest
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return err
+	}
+
+	a.BaseResource = BaseResource{Ref: meta.Ref}
+	a.AIGateway = meta.AIGateway
+	a.CreateAIGatewayVaultRequest = req
+	return nil
+}
+
+func AIGatewayVaultID(vault any) string {
+	return aiGatewayVaultStringField(vault, aiGatewayVaultFieldID)
+}
+
+func AIGatewayVaultName(vault any) string {
+	return aiGatewayVaultStringField(vault, aiGatewayVaultFieldName)
+}
+
+func AIGatewayVaultType(vault any) string {
+	return aiGatewayVaultStringField(vault, aiGatewayVaultFieldType)
+}
+
+func AIGatewayVaultDescription(vault any) string {
+	return aiGatewayVaultStringField(vault, aiGatewayVaultFieldDescription)
+}
+
+func AIGatewayVaultLabels(vault any) map[string]string {
+	payload, err := marshalObjectToMap(vault, "AI Gateway Vault")
+	if err != nil {
+		return nil
+	}
+	raw, ok := payload[aiGatewayVaultFieldLabels].(map[string]any)
+	if !ok {
+		return nil
+	}
+	labels := make(map[string]string, len(raw))
+	for key, value := range raw {
+		if stringValue, ok := value.(string); ok {
+			labels[key] = stringValue
+		}
+	}
+	return labels
+}
+
+func AIGatewayVaultUpdatedAt(vault any) time.Time {
+	payload, err := marshalObjectToMap(vault, "AI Gateway Vault")
+	if err != nil {
+		return time.Time{}
+	}
+	if value, ok := payload[aiGatewayVaultFieldUpdatedAt].(string); ok {
+		if parsed, err := time.Parse(time.RFC3339Nano, value); err == nil {
+			return parsed
+		}
+	}
+	return time.Time{}
+}
+
+func AIGatewayVaultMutablePayloadMap(vault kkComps.AIGatewayVault) (map[string]any, error) {
+	payload, err := marshalObjectToMap(vault, "AI Gateway Vault response")
+	if err != nil {
+		return nil, err
+	}
+	stripAIGatewayVaultServerFields(payload)
+	return payload, nil
+}
+
+func AIGatewayVaultResourceFromResponse(
+	gatewayRef string,
+	vault kkComps.AIGatewayVault,
+) (AIGatewayVaultResource, error) {
+	payload, err := AIGatewayVaultMutablePayloadMap(vault)
+	if err != nil {
+		return AIGatewayVaultResource{}, err
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return AIGatewayVaultResource{}, err
+	}
+	var req kkComps.CreateAIGatewayVaultRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return AIGatewayVaultResource{}, err
+	}
+
+	ref := AIGatewayVaultID(vault)
+	if ref == "" {
+		ref = AIGatewayVaultName(vault)
+	}
+	return AIGatewayVaultResource{
+		BaseResource:                BaseResource{Ref: ref},
+		AIGateway:                   gatewayRef,
+		CreateAIGatewayVaultRequest: req,
+	}, nil
+}
+
+func stripAIGatewayVaultServerFields(payload map[string]any) {
+	delete(payload, aiGatewayVaultFieldID)
+	delete(payload, "created_at")
+	delete(payload, aiGatewayVaultFieldUpdatedAt)
+}
+
+func aiGatewayVaultStringField(value any, key string) string {
+	payload, err := marshalObjectToMap(value, "AI Gateway Vault")
+	if err != nil {
+		return ""
+	}
+	if field, ok := payload[key].(string); ok {
+		return field
+	}
+	return ""
+}
+
+func aiGatewayVaultExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
+	commonFields := []*ExplainField{
+		explainResourceRefField(),
+		explainRefField(SchemaFieldAIGateway, ResourceTypeAIGateway, true),
+		explainField("name", explainStringNode("support-env"), true, true),
+		explainField("description", &ExplainNode{Kind: explainKindString, Nullable: true}, false, false),
+		explainField("labels", &ExplainNode{Kind: explainKindObject, Additional: explainStringNode("value")}, false, false),
+		explainField(
+			"managed_by",
+			&ExplainNode{Kind: explainKindObject, Additional: explainStringNode("kongctl")},
+			false,
+			false,
+		),
+	}
+
+	return explainUnionNode(
+		explainObject(append(
+			slicesCloneExplainFields(commonFields),
+			explainField("type", explainConstStringNode("env"), true, true),
+			explainField("config", explainObject(
+				explainField("prefix", explainStringNode("SUPPORT_"), false, true),
+				explainField("base64_decode", explainBoolNode("false"), false, false),
+			), true, true),
+		)...),
+		explainObject(append(
+			slicesCloneExplainFields(commonFields),
+			explainField("type", explainConstStringNode("konnect"), true, true),
+			explainField("config", explainObject(
+				explainField("config_store_id", explainStringNode("config-store-id"), true, true),
+			), true, true),
+		)...),
+		explainObject(append(
+			slicesCloneExplainFields(commonFields),
+			explainField("type", explainConstStringNode("aws"), true, true),
+			explainField("config", explainObject(
+				explainField("region", explainStringNode("us-east-1"), false, true),
+			), true, true),
+		)...),
+		explainObject(append(
+			slicesCloneExplainFields(commonFields),
+			explainField("type", explainConstStringNode("gcp"), true, true),
+			explainField("config", explainObject(
+				explainField("project_id", explainStringNode("my-project"), true, true),
+			), true, true),
+		)...),
+		explainObject(append(
+			slicesCloneExplainFields(commonFields),
+			explainField("type", explainConstStringNode("azure"), true, true),
+			explainField("config", explainObject(
+				explainField("vault_uri", explainStringNode("https://vault.example.net"), true, true),
+			), true, true),
+		)...),
+		explainObject(append(
+			slicesCloneExplainFields(commonFields),
+			explainField("type", explainConstStringNode("conjur"), true, true),
+			explainField("config", &ExplainNode{Kind: explainKindObject, Additional: &ExplainNode{}}, true, true),
+		)...),
+		explainObject(append(
+			slicesCloneExplainFields(commonFields),
+			explainField("type", explainConstStringNode("hcv"), true, true),
+			explainField("config", &ExplainNode{Kind: explainKindObject, Additional: &ExplainNode{}}, true, true),
+		)...),
+	), nil
+}

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -22,6 +22,7 @@ const (
 	ResourceTypeAIGatewayPolicy                         ResourceType = "ai_gateway_policy"
 	ResourceTypeAIGatewayModel                          ResourceType = "ai_gateway_model"
 	ResourceTypeAIGatewayMCPServer                      ResourceType = "ai_gateway_mcp_server"
+	ResourceTypeAIGatewayVault                          ResourceType = "ai_gateway_vault"
 	ResourceTypeDashboard                               ResourceType = "dashboard"
 	ResourceTypeAPIVersion                              ResourceType = "api_version"
 	ResourceTypeAPIPublication                          ResourceType = "api_publication"
@@ -114,6 +115,7 @@ type ResourceSet struct {
 	AIGatewayPolicies                 []AIGatewayPolicyResource                  `yaml:"ai_gateway_policies,omitempty"                           json:"ai_gateway_policies,omitempty"`                    //nolint:lll
 	AIGatewayModels                   []AIGatewayModelResource                   `yaml:"ai_gateway_models,omitempty"                              json:"ai_gateway_models,omitempty"`                     //nolint:lll
 	AIGatewayMCPServers               []AIGatewayMCPServerResource               `yaml:"ai_gateway_mcp_servers,omitempty"                         json:"ai_gateway_mcp_servers,omitempty"`                //nolint:lll
+	AIGatewayVaults                   []AIGatewayVaultResource                   `yaml:"ai_gateway_vaults,omitempty"                              json:"ai_gateway_vaults,omitempty"`                     //nolint:lll
 	APIs                              []APIResource                              `yaml:"apis,omitempty"                                           json:"apis,omitempty"`                                  //nolint:lll
 	GatewayServices                   []GatewayServiceResource                   `yaml:"gateway_services,omitempty"                               json:"gateway_services,omitempty"`                      //nolint:lll
 	ControlPlaneDataPlaneCertificates []ControlPlaneDataPlaneCertificateResource `yaml:"control_plane_data_plane_certificates,omitempty"          json:"control_plane_data_plane_certificates,omitempty"` //nolint:lll
@@ -381,6 +383,16 @@ func (rs *ResourceSet) GetAIGatewayMCPServerByRef(ref string) *AIGatewayMCPServe
 	return nil
 }
 
+// GetAIGatewayVaultByRef returns an AI Gateway Vault resource by its ref from any namespace.
+func (rs *ResourceSet) GetAIGatewayVaultByRef(ref string) *AIGatewayVaultResource {
+	for i := range rs.AIGatewayVaults {
+		if rs.AIGatewayVaults[i].GetRef() == ref {
+			return &rs.AIGatewayVaults[i]
+		}
+	}
+	return nil
+}
+
 // GetAuthStrategyByRef returns an auth strategy resource by its ref from any namespace
 func (rs *ResourceSet) GetAuthStrategyByRef(ref string) *ApplicationAuthStrategyResource {
 	for i := range rs.ApplicationAuthStrategies {
@@ -526,6 +538,25 @@ func (rs *ResourceSet) GetAIGatewayMCPServersByNamespace(namespace string) []AIG
 			}
 			if GetNamespace(gateway.Kongctl) == namespace {
 				filtered = append(filtered, server)
+			}
+		}
+	}
+	return filtered
+}
+
+// GetAIGatewayVaultsByNamespace returns AI Gateway Vault resources from the specified namespace.
+func (rs *ResourceSet) GetAIGatewayVaultsByNamespace(namespace string) []AIGatewayVaultResource {
+	var filtered []AIGatewayVaultResource
+	for _, vault := range rs.AIGatewayVaults {
+		if gateway := rs.GetAIGatewayByRef(vault.AIGateway); gateway != nil {
+			if gateway.IsExternal() {
+				if namespace == NamespaceExternal {
+					filtered = append(filtered, vault)
+				}
+				continue
+			}
+			if GetNamespace(gateway.Kongctl) == namespace {
+				filtered = append(filtered, vault)
 			}
 		}
 	}
@@ -1505,4 +1536,15 @@ func (rs *ResourceSet) GetAIGatewayMCPServersForGateway(gatewayRef string) []AIG
 		}
 	}
 	return servers
+}
+
+// GetAIGatewayVaultsForGateway returns all AI Gateway Vaults for a given gateway ref.
+func (rs *ResourceSet) GetAIGatewayVaultsForGateway(gatewayRef string) []AIGatewayVaultResource {
+	var vaults []AIGatewayVaultResource
+	for _, vault := range rs.AIGatewayVaults {
+		if NormalizeResourceRef(vault.AIGateway) == gatewayRef {
+			vaults = append(vaults, vault)
+		}
+	}
+	return vaults
 }

--- a/internal/declarative/state/ai_gateway_vaults.go
+++ b/internal/declarative/state/ai_gateway_vaults.go
@@ -1,0 +1,216 @@
+package state
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/util/pagination"
+)
+
+// ListAIGatewayVaults lists all Vaults for an AI Gateway.
+func (c *Client) ListAIGatewayVaults(ctx context.Context, gatewayID string) ([]AIGatewayVault, error) {
+	if err := ValidateAPIClient(c.aiGatewayVaultsAPI, "AI Gateway Vaults API"); err != nil {
+		return nil, err
+	}
+
+	var allData []kkComps.AIGatewayVault
+	var pageAfter *string
+	pageSize := int64(100)
+
+	for {
+		req := kkOps.ListAiGatewayVaultsRequest{
+			GatewayID: gatewayID,
+			PageSize:  &pageSize,
+			PageAfter: pageAfter,
+		}
+
+		resp, err := c.aiGatewayVaultsAPI.ListAiGatewayVaults(ctx, req)
+		if err != nil {
+			return nil, WrapAPIError(err, "list AI Gateway Vaults", nil)
+		}
+
+		if resp == nil || resp.ListAIGatewayVaultsResponse == nil {
+			return []AIGatewayVault{}, nil
+		}
+
+		allData = append(allData, resp.ListAIGatewayVaultsResponse.Data...)
+
+		nextCursor := pagination.ExtractPageAfterCursor(resp.ListAIGatewayVaultsResponse.Meta.Page.Next)
+		if nextCursor == "" {
+			break
+		}
+		pageAfter = &nextCursor
+	}
+
+	vaults := make([]AIGatewayVault, 0, len(allData))
+	for _, vault := range allData {
+		vaults = append(vaults, AIGatewayVault{
+			AIGatewayVault:   vault,
+			NormalizedLabels: normalizedAIGatewayVaultLabels(vault),
+		})
+	}
+	return vaults, nil
+}
+
+// GetAIGatewayVault fetches an AI Gateway Vault by ID or name.
+func (c *Client) GetAIGatewayVault(
+	ctx context.Context,
+	gatewayID string,
+	vaultID string,
+) (*AIGatewayVault, error) {
+	if err := ValidateAPIClient(c.aiGatewayVaultsAPI, "AI Gateway Vaults API"); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.aiGatewayVaultsAPI.GetAiGatewayVault(ctx, gatewayID, vaultID)
+	if err != nil {
+		return nil, WrapAPIError(err, "get AI Gateway Vault by ID", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeAIGatewayVault),
+			UseEnhanced:  true,
+		})
+	}
+
+	if resp == nil || resp.AIGatewayVault == nil {
+		return nil, nil
+	}
+
+	return &AIGatewayVault{
+		AIGatewayVault:   *resp.AIGatewayVault,
+		NormalizedLabels: normalizedAIGatewayVaultLabels(*resp.AIGatewayVault),
+	}, nil
+}
+
+// GetAIGatewayVaultByName finds an AI Gateway Vault by name within a gateway.
+func (c *Client) GetAIGatewayVaultByName(
+	ctx context.Context,
+	gatewayID string,
+	name string,
+) (*AIGatewayVault, error) {
+	vaults, err := c.ListAIGatewayVaults(ctx, gatewayID)
+	if err != nil {
+		return nil, WrapAPIError(err, "list AI Gateway Vaults to find by name", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeAIGatewayVault),
+			ResourceName: name,
+			UseEnhanced:  true,
+		})
+	}
+
+	for i := range vaults {
+		if resources.AIGatewayVaultName(vaults[i].AIGatewayVault) == name {
+			return &vaults[i], nil
+		}
+	}
+
+	return nil, nil
+}
+
+// CreateAIGatewayVault creates a new Vault under an AI Gateway.
+func (c *Client) CreateAIGatewayVault(
+	ctx context.Context,
+	gatewayID string,
+	req kkComps.CreateAIGatewayVaultRequest,
+	namespace string,
+) (string, error) {
+	if err := ValidateAPIClient(c.aiGatewayVaultsAPI, "AI Gateway Vaults API"); err != nil {
+		return "", err
+	}
+
+	resp, err := c.aiGatewayVaultsAPI.CreateAiGatewayVault(ctx, gatewayID, req)
+	if err != nil {
+		return "", WrapAPIError(err, "create AI Gateway Vault", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeAIGatewayVault),
+			ResourceName: aiGatewayVaultCreateRequestName(req),
+			Namespace:    namespace,
+			UseEnhanced:  true,
+		})
+	}
+
+	if resp == nil || resp.AIGatewayVault == nil {
+		return "", fmt.Errorf("create AI Gateway Vault response missing data")
+	}
+
+	return resources.AIGatewayVaultID(*resp.AIGatewayVault), nil
+}
+
+// UpdateAIGatewayVault updates an existing Vault under an AI Gateway.
+func (c *Client) UpdateAIGatewayVault(
+	ctx context.Context,
+	gatewayID string,
+	vaultID string,
+	req kkComps.UpdateAIGatewayVaultRequest,
+	namespace string,
+) (string, error) {
+	if err := ValidateAPIClient(c.aiGatewayVaultsAPI, "AI Gateway Vaults API"); err != nil {
+		return "", err
+	}
+
+	resp, err := c.aiGatewayVaultsAPI.UpdateAiGatewayVault(ctx, kkOps.UpdateAiGatewayVaultRequest{
+		GatewayID:                   gatewayID,
+		VaultID:                     vaultID,
+		UpdateAIGatewayVaultRequest: req,
+	})
+	if err != nil {
+		return "", WrapAPIError(err, "update AI Gateway Vault", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeAIGatewayVault),
+			ResourceName: aiGatewayVaultUpdateRequestName(req),
+			Namespace:    namespace,
+			UseEnhanced:  true,
+		})
+	}
+
+	if resp == nil || resp.AIGatewayVault == nil {
+		return "", fmt.Errorf("update AI Gateway Vault response missing data")
+	}
+
+	return resources.AIGatewayVaultID(*resp.AIGatewayVault), nil
+}
+
+// DeleteAIGatewayVault deletes an AI Gateway Vault by ID.
+func (c *Client) DeleteAIGatewayVault(ctx context.Context, gatewayID string, vaultID string) error {
+	if err := ValidateAPIClient(c.aiGatewayVaultsAPI, "AI Gateway Vaults API"); err != nil {
+		return err
+	}
+
+	_, err := c.aiGatewayVaultsAPI.DeleteAiGatewayVault(ctx, gatewayID, vaultID)
+	if err != nil {
+		return WrapAPIError(err, "delete AI Gateway Vault", nil)
+	}
+
+	return nil
+}
+
+func normalizedAIGatewayVaultLabels(vault kkComps.AIGatewayVault) map[string]string {
+	normalized := resources.AIGatewayVaultLabels(vault)
+	if normalized == nil {
+		normalized = make(map[string]string)
+	}
+	return normalized
+}
+
+func aiGatewayVaultCreateRequestName(req kkComps.CreateAIGatewayVaultRequest) string {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return ""
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return ""
+	}
+	return stringFromRaw(raw["name"])
+}
+
+func aiGatewayVaultUpdateRequestName(req kkComps.UpdateAIGatewayVaultRequest) string {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return ""
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return ""
+	}
+	return stringFromRaw(raw["name"])
+}

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -40,6 +40,7 @@ type ClientConfig struct {
 	AIGatewayPoliciesAPI    helpers.AIGatewayPoliciesAPI
 	AIGatewayModelAPI       helpers.AIGatewayModelAPI
 	AIGatewayMCPServersAPI  helpers.AIGatewayMCPServersAPI
+	AIGatewayVaultsAPI      helpers.AIGatewayVaultsAPI
 	DashboardsAPI           helpers.DashboardsAPI
 
 	// Portal child resource APIs
@@ -107,6 +108,7 @@ type Client struct {
 	aiGatewayPoliciesAPI    helpers.AIGatewayPoliciesAPI
 	aiGatewayModelAPI       helpers.AIGatewayModelAPI
 	aiGatewayMCPServersAPI  helpers.AIGatewayMCPServersAPI
+	aiGatewayVaultsAPI      helpers.AIGatewayVaultsAPI
 	dashboardsAPI           helpers.DashboardsAPI
 
 	// Portal child resource APIs
@@ -175,6 +177,7 @@ func NewClient(config ClientConfig) *Client {
 		aiGatewayPoliciesAPI:    config.AIGatewayPoliciesAPI,
 		aiGatewayModelAPI:       config.AIGatewayModelAPI,
 		aiGatewayMCPServersAPI:  config.AIGatewayMCPServersAPI,
+		aiGatewayVaultsAPI:      config.AIGatewayVaultsAPI,
 		dashboardsAPI:           config.DashboardsAPI,
 
 		// Portal child resource APIs
@@ -293,6 +296,12 @@ type AIGatewayModel struct {
 // AIGatewayMCPServer represents a Konnect AI Gateway MCP Server for internal use.
 type AIGatewayMCPServer struct {
 	kkComps.AIGatewayMCPServer
+	NormalizedLabels map[string]string
+}
+
+// AIGatewayVault represents a Konnect AI Gateway Vault for internal use.
+type AIGatewayVault struct {
+	kkComps.AIGatewayVault
 	NormalizedLabels map[string]string
 }
 

--- a/internal/konnect/helpers/ai_gateway_vaults.go
+++ b/internal/konnect/helpers/ai_gateway_vaults.go
@@ -1,0 +1,89 @@
+package helpers
+
+import (
+	"context"
+
+	kkSDK "github.com/Kong/sdk-konnect-go"
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+)
+
+// AIGatewayVaultsAPI defines the interface for AI Gateway Vault operations needed by kongctl.
+type AIGatewayVaultsAPI interface {
+	ListAiGatewayVaults(
+		ctx context.Context,
+		request kkOps.ListAiGatewayVaultsRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.ListAiGatewayVaultsResponse, error)
+	CreateAiGatewayVault(
+		ctx context.Context,
+		gatewayID string,
+		request kkComps.CreateAIGatewayVaultRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.CreateAiGatewayVaultResponse, error)
+	GetAiGatewayVault(
+		ctx context.Context,
+		gatewayID string,
+		vaultID string,
+		opts ...kkOps.Option,
+	) (*kkOps.GetAiGatewayVaultResponse, error)
+	UpdateAiGatewayVault(
+		ctx context.Context,
+		request kkOps.UpdateAiGatewayVaultRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.UpdateAiGatewayVaultResponse, error)
+	DeleteAiGatewayVault(
+		ctx context.Context,
+		gatewayID string,
+		vaultID string,
+		opts ...kkOps.Option,
+	) (*kkOps.DeleteAiGatewayVaultResponse, error)
+}
+
+// AIGatewayVaultsAPIImpl provides the real SDK implementation.
+type AIGatewayVaultsAPIImpl struct {
+	SDK *kkSDK.SDK
+}
+
+func (a *AIGatewayVaultsAPIImpl) ListAiGatewayVaults(
+	ctx context.Context,
+	request kkOps.ListAiGatewayVaultsRequest,
+	opts ...kkOps.Option,
+) (*kkOps.ListAiGatewayVaultsResponse, error) {
+	return a.SDK.AIGatewayVaults.ListAiGatewayVaults(ctx, request, opts...)
+}
+
+func (a *AIGatewayVaultsAPIImpl) CreateAiGatewayVault(
+	ctx context.Context,
+	gatewayID string,
+	request kkComps.CreateAIGatewayVaultRequest,
+	opts ...kkOps.Option,
+) (*kkOps.CreateAiGatewayVaultResponse, error) {
+	return a.SDK.AIGatewayVaults.CreateAiGatewayVault(ctx, gatewayID, request, opts...)
+}
+
+func (a *AIGatewayVaultsAPIImpl) GetAiGatewayVault(
+	ctx context.Context,
+	gatewayID string,
+	vaultID string,
+	opts ...kkOps.Option,
+) (*kkOps.GetAiGatewayVaultResponse, error) {
+	return a.SDK.AIGatewayVaults.GetAiGatewayVault(ctx, gatewayID, vaultID, opts...)
+}
+
+func (a *AIGatewayVaultsAPIImpl) UpdateAiGatewayVault(
+	ctx context.Context,
+	request kkOps.UpdateAiGatewayVaultRequest,
+	opts ...kkOps.Option,
+) (*kkOps.UpdateAiGatewayVaultResponse, error) {
+	return a.SDK.AIGatewayVaults.UpdateAiGatewayVault(ctx, request, opts...)
+}
+
+func (a *AIGatewayVaultsAPIImpl) DeleteAiGatewayVault(
+	ctx context.Context,
+	gatewayID string,
+	vaultID string,
+	opts ...kkOps.Option,
+) (*kkOps.DeleteAiGatewayVaultResponse, error) {
+	return a.SDK.AIGatewayVaults.DeleteAiGatewayVault(ctx, gatewayID, vaultID, opts...)
+}

--- a/internal/konnect/helpers/sdk.go
+++ b/internal/konnect/helpers/sdk.go
@@ -27,6 +27,7 @@ type SDKAPI interface {
 	GetAIGatewayPoliciesAPI() AIGatewayPoliciesAPI
 	GetAIGatewayModelAPI() AIGatewayModelAPI
 	GetAIGatewayMCPServersAPI() AIGatewayMCPServersAPI
+	GetAIGatewayVaultsAPI() AIGatewayVaultsAPI
 	GetCatalogServicesAPI() CatalogServicesAPI
 	GetDashboardsAPI() DashboardsAPI
 	GetAPIDocumentAPI() APIDocumentAPI
@@ -174,6 +175,15 @@ func (k *KonnectSDK) GetAIGatewayMCPServersAPI() AIGatewayMCPServersAPI {
 	}
 
 	return &AIGatewayMCPServersAPIImpl{SDK: k.SDK}
+}
+
+// Returns the implementation of the AIGatewayVaultsAPI interface.
+func (k *KonnectSDK) GetAIGatewayVaultsAPI() AIGatewayVaultsAPI {
+	if k.SDK == nil || k.SDK.AIGatewayVaults == nil {
+		return nil
+	}
+
+	return &AIGatewayVaultsAPIImpl{SDK: k.SDK}
 }
 
 // Returns the implementation of the CatalogServicesAPI interface

--- a/internal/konnect/helpers/sdk_mock.go
+++ b/internal/konnect/helpers/sdk_mock.go
@@ -15,6 +15,7 @@ type MockKonnectSDK struct {
 	AIGatewayPoliciesFactory           func() AIGatewayPoliciesAPI
 	AIGatewayModelFactory              func() AIGatewayModelAPI
 	AIGatewayMCPServersFactory         func() AIGatewayMCPServersAPI
+	AIGatewayVaultsFactory             func() AIGatewayVaultsAPI
 	CatalogServicesFactory             func() CatalogServicesAPI
 	DashboardsFactory                  func() DashboardsAPI
 	APIDocumentFactory                 func() APIDocumentAPI
@@ -135,6 +136,14 @@ func (m *MockKonnectSDK) GetAIGatewayModelAPI() AIGatewayModelAPI {
 func (m *MockKonnectSDK) GetAIGatewayMCPServersAPI() AIGatewayMCPServersAPI {
 	if m.AIGatewayMCPServersFactory != nil {
 		return m.AIGatewayMCPServersFactory()
+	}
+	return nil
+}
+
+// Returns a mock instance of the AIGatewayVaultsAPI.
+func (m *MockKonnectSDK) GetAIGatewayVaultsAPI() AIGatewayVaultsAPI {
+	if m.AIGatewayVaultsFactory != nil {
+		return m.AIGatewayVaultsFactory()
 	}
 	return nil
 }

--- a/test/e2e/scenarios/ai-gateway/vault/overlays/001-update/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/vault/overlays/001-update/config.yaml
@@ -1,0 +1,22 @@
+ai_gateways:
+  - ref: ai-gateway-vault-e2e
+    display_name: "AI Gateway Vault E2E"
+    description: "AI Gateway Vault e2e"
+    proxy_urls:
+      - host: ai-gateway-vault-e2e.example.com
+        port: 443
+        protocol: https
+    labels:
+      owner: platform
+      lifecycle: dev
+    vaults:
+      - ref: support-env
+        type: env
+        name: support-env
+        description: "Support environment variables updated"
+        labels:
+          team: support
+          phase: update
+        config:
+          prefix: SUPPORT_UPDATED_
+          base64_decode: true

--- a/test/e2e/scenarios/ai-gateway/vault/overlays/002-sync-delete-vault/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/vault/overlays/002-sync-delete-vault/config.yaml
@@ -1,0 +1,12 @@
+ai_gateways:
+  - ref: ai-gateway-vault-e2e
+    display_name: "AI Gateway Vault E2E"
+    description: "AI Gateway Vault e2e"
+    proxy_urls:
+      - host: ai-gateway-vault-e2e.example.com
+        port: 443
+        protocol: https
+    labels:
+      owner: platform
+      lifecycle: dev
+    vaults: []

--- a/test/e2e/scenarios/ai-gateway/vault/overlays/003-sync-delete-gateway/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/vault/overlays/003-sync-delete-gateway/config.yaml
@@ -1,0 +1,1 @@
+ai_gateways: []

--- a/test/e2e/scenarios/ai-gateway/vault/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/vault/scenario.yaml
@@ -1,0 +1,386 @@
+baseInputsPath: testdata
+
+env:
+  KONGCTL_LOG_LEVEL: info
+
+vars:
+  namespace: "ai-gateway-vault-e2e"
+  gateway_name: "AI Gateway Vault E2E"
+  gateway_ref: "ai-gateway-vault-e2e"
+  vault_ref: "support-env"
+  vault_name: "support-env"
+  vault_description: "Support environment variables"
+  vault_updated_description: "Support environment variables updated"
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - created_at
+      - updated_at
+      - config_hash
+      - endpoints
+      - resource_id
+      - change_id
+      - generated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-explain-and-scaffold
+    skipInputs: true
+    commands:
+      - name: 000-explain-ai-gateway-vault-json
+        run:
+          - explain
+          - ai_gateway_vault
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                type: object
+                title: "kongctl declarative schema: ai_gateway.vaults"
+                '"x-kongctl-root-key"': ai_gateway_vaults
+          - select: "contains(keys(properties), 'ai_gateway')"
+            expect:
+              fields:
+                "@": true
+      - name: 001-scaffold-ai-gateway-vault
+        run:
+          - scaffold
+          - ai_gateway_vault
+        outputFormat: disable
+        parseAs: raw
+        assertions:
+          - expect:
+              fields:
+                "contains(stdout, 'ai_gateway_vaults:')": true
+                "contains(stdout, 'type: env')": true
+                "contains(stdout, 'config:')": true
+                "contains(stdout, 'ai_gateway: !ref')": true
+      - name: 002-explain-ai-gateway-vault-nested-json
+        run:
+          - explain
+          - ai_gateway.vaults
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                type: object
+                title: "kongctl declarative schema: ai_gateway_vault"
+                '"x-kongctl-root-key"': ai_gateway_vaults
+
+  - name: 002-plan-apply-create
+    commands:
+      - name: 000-plan-create
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-create.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 2
+                by_action.CREATE: 2
+          - select: >-
+              changes[?resource_type=='ai_gateway_vault' && resource_ref=='{{ .vars.vault_ref }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                fields.name: "{{ .vars.vault_name }}"
+                fields.type: env
+                fields.description: "{{ .vars.vault_description }}"
+                fields.config.prefix: SUPPORT_
+                fields.config.base64_decode: false
+      - name: 001-apply-create
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-create.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 2
+                failed: 0
+                status: success
+      - name: 002-list-vaults
+        run:
+          - get
+          - ai-gateway
+          - vaults
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - -o
+          - json
+        recordVar:
+          name: vault_id
+          responsePath: "[?name=='{{ .vars.vault_name }}'] | [0].id"
+        assertions:
+          - select: "[?name=='{{ .vars.vault_name }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.vault_name }}"
+                type: env
+                description: "{{ .vars.vault_description }}"
+                config.prefix: SUPPORT_
+                config.base64_decode: false
+      - name: 003-get-vault-by-name
+        run:
+          - get
+          - ai-gateway
+          - vault
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - "{{ .vars.vault_name }}"
+          - -o
+          - json
+        assertions:
+          - select: name
+            expect:
+              fields:
+                "@": "{{ .vars.vault_name }}"
+          - select: type
+            expect:
+              fields:
+                "@": env
+      - name: 004-get-vault-by-id
+        run:
+          - get
+          - ai-gateway
+          - vaults
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - "{{ .vars.vault_id }}"
+          - -o
+          - json
+        assertions:
+          - select: name
+            expect:
+              fields:
+                "@": "{{ .vars.vault_name }}"
+
+  - name: 003-plan-apply-update
+    inputOverlayDirs:
+      - overlays/001-update
+    commands:
+      - name: 000-plan-update
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-update.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+          - select: >-
+              changes[?resource_type=='ai_gateway_vault' && resource_ref=='{{ .vars.vault_ref }}'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                fields.description: "{{ .vars.vault_updated_description }}"
+                fields.config.prefix: SUPPORT_UPDATED_
+                fields.config.base64_decode: true
+                fields.labels.phase: update
+      - name: 001-apply-update
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-update.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 002-verify-update
+        run:
+          - get
+          - ai-gateway
+          - vaults
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - "{{ .vars.vault_name }}"
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                description: "{{ .vars.vault_updated_description }}"
+                labels.phase: update
+                config.prefix: SUPPORT_UPDATED_
+                config.base64_decode: true
+      - name: 003-diff-no-changes
+        outputFormat: text
+        parseAs: raw
+        run:
+          - diff
+          - -f
+          - "{{ .workdir }}/config.yaml"
+        assertions:
+          - select: stdout
+            expect:
+              fields:
+                "contains(@, 'No changes detected. Konnect is up to date.')": true
+
+  - name: 004-dump-round-trip
+    skipInputs: true
+    commands:
+      - name: 000-dump-ai-gateway-with-children
+        run:
+          - dump
+          - declarative
+          - "--resources=ai_gateways"
+          - "--include-child-resources"
+          - "--default-namespace={{ .vars.namespace }}"
+        outputFormat: none
+        parseAs: yaml
+        stdoutFile: "{{ .workdir }}/dump-ai-gateway.yaml"
+        assertions:
+          - select: >-
+              ai_gateways[?display_name=='{{ .vars.gateway_name }}'] | [0].vaults[?name=='{{ .vars.vault_name }}'] | [0]
+            expect:
+              fields:
+                name: "{{ .vars.vault_name }}"
+                description: "{{ .vars.vault_updated_description }}"
+                type: env
+                config.prefix: SUPPORT_UPDATED_
+                config.base64_decode: true
+      - name: 001-plan-from-ai-gateway-dump
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/dump-ai-gateway.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+      - name: 002-dump-root-vaults
+        run:
+          - dump
+          - declarative
+          - "--resources=ai_gateway_vaults"
+          - "--filter-name={{ .vars.vault_name }}"
+          - "--default-namespace={{ .vars.namespace }}"
+        outputFormat: none
+        parseAs: yaml
+        assertions:
+          - select: "ai_gateway_vaults[0]"
+            expect:
+              fields:
+                name: "{{ .vars.vault_name }}"
+                type: env
+                config.prefix: SUPPORT_UPDATED_
+          - select: "ai_gateway_vaults[0].ai_gateway != ''"
+            expect:
+              fields:
+                "@": true
+
+  - name: 005-sync-delete-vault
+    inputOverlayDirs:
+      - overlays/002-sync-delete-vault
+    commands:
+      - name: 000-sync-delete-vault
+        outputFormat: json
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: >-
+              plan.changes[?resource_type=='ai_gateway_vault' && action=='DELETE'] | [0]
+            expect:
+              fields:
+                resource_ref: "{{ .vars.vault_name }}"
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+                status: success
+      - name: 001-list-vaults-empty
+        run:
+          - get
+          - ai-gateway
+          - vaults
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 0
+
+  - name: 006-sync-delete-gateway
+    inputOverlayDirs:
+      - overlays/003-sync-delete-gateway
+    commands:
+      - name: 000-sync-delete-gateway
+        outputFormat: json
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+                status: success
+      - name: 001-get-ai-gateways
+        run:
+          - get
+          - ai-gateways
+          - -o
+          - json
+        assertions:
+          - select: "[?display_name=='{{ .vars.gateway_name }}']"
+            expect:
+              fields:
+                "length(@)": 0

--- a/test/e2e/scenarios/ai-gateway/vault/testdata/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/vault/testdata/config.yaml
@@ -1,0 +1,26 @@
+_defaults:
+  kongctl:
+    namespace: ai-gateway-vault-e2e
+
+ai_gateways:
+  - ref: ai-gateway-vault-e2e
+    display_name: "AI Gateway Vault E2E"
+    description: "AI Gateway Vault e2e"
+    proxy_urls:
+      - host: ai-gateway-vault-e2e.example.com
+        port: 443
+        protocol: https
+    labels:
+      owner: platform
+      lifecycle: dev
+    vaults:
+      - ref: support-env
+        type: env
+        name: support-env
+        description: "Support environment variables"
+        labels:
+          team: support
+          phase: create
+        config:
+          prefix: SUPPORT_
+          base64_decode: false

--- a/test/e2e/scenarios/explain/command-coverage/scenario.yaml
+++ b/test/e2e/scenarios/explain/command-coverage/scenario.yaml
@@ -234,3 +234,29 @@ steps:
                 type.const: conversion-only
                 config.properties.url.type: string
                 tools.items.properties.method.type: string
+
+  - name: 012-explain-ai-gateway-vaults-nested-yaml
+    skipInputs: true
+    commands:
+      - name: 000-explain-ai-gateway-vaults-yaml
+        run:
+          - explain
+          - ai_gateway.vaults
+        outputFormat: yaml
+        parseAs: yaml
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                type: object
+                title: "kongctl declarative schema: ai_gateway.vaults"
+                '"x-kongctl-resource"': ai_gateway_vault
+                '"x-kongctl-root-key"': ai_gateway_vaults
+                '"x-kongctl-resource-class"': child
+                '"x-kongctl-supports-root"': true
+                '"x-kongctl-supports-nested-declaration"': true
+          - select: oneOf[0].properties
+            expect:
+              fields:
+                type.const: env
+                config.properties.prefix.type: string


### PR DESCRIPTION
## Summary
- add declarative AI Gateway Vault resource support for nested and root declarations
- wire vault planning, execution, state, dump, get/list CLI, explain, and scaffold flows
- update AI Gateway examples and add vault e2e scenario coverage

Closes Kong/kongctl#1424

## Tests
- go fix ./...
- make format
- make build
- make test
- golangci-lint run ./internal/declarative/resources ./internal/declarative/loader ./internal/declarative/planner ./internal/declarative/state ./internal/declarative/executor ./internal/konnect/helpers ./internal/cmd/root/products/konnect/aigateway ./internal/cmd/root/products/konnect/declarative ./internal/cmd/root/verbs/dump
- ./kongctl explain ai_gateway.vaults -o json
- ./kongctl scaffold ai_gateway_vault
- ./kongctl scaffold ai_gateway.vaults
- ./kongctl get ai-gateway vaults --help

Note: make lint was run, but it fails on pre-existing unrelated generated/test harness issues under test/e2e/harness/portalclient plus a permission-denied read from another local worktree. Scoped lint for touched packages passes.