### PR TITLE
feat(declarative): add AI Gateway consumer group support

### DIFF
--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -319,36 +319,40 @@ control_plane_data_plane_certificates:
 
 This section covers the root AI Gateway resource backed by the Konnect
 `/v1/ai-gateways` API, AI Gateway Providers, AI Gateway Models, AI Gateway
-MCP Servers, and AI Gateway Vaults. Use
+MCP Servers, AI Gateway Consumer Groups, and AI Gateway Vaults. Use
 `kongctl explain ai_gateway --output yaml`,
 `kongctl explain ai_gateway_provider --output yaml`,
-`kongctl explain ai_gateway.models --output yaml`, and
+`kongctl explain ai_gateway.consumer_groups --output yaml`,
+`kongctl explain ai_gateway.models --output yaml`,
 `kongctl explain ai_gateway.mcp_servers --output yaml`, and
 `kongctl explain ai_gateway.vaults --output yaml` as the authoritative schemas.
 
 The `ref` value is used as the stable Konnect API `name` when creating an AI
 Gateway. Use `display_name` for the human-readable name shown in Konnect.
-AI Gateway Providers, Policies, Models, MCP Servers, and Vaults use their own
-required `name` field as the stable Konnect child name. Child entries inherit
-management scope from their parent AI Gateway and do not accept `kongctl`
-metadata.
+AI Gateway Providers, Policies, Consumer Groups, Models, MCP Servers, and
+Vaults use their own required `name` field as the stable Konnect child name.
+Child entries inherit management scope from their parent AI Gateway and do not
+accept `kongctl` metadata.
 
 For AI Gateway Models, `target_models[].provider` must match an AI Gateway
 Provider `name` under the parent gateway. The provider can already exist or be
 declared in the same gateway configuration.
 
-For AI Gateway Models and MCP Servers, `policies` entries refer to AI Gateway
-Policy names under the same parent gateway. The policy can already exist or be
-declared in the same gateway configuration.
+For AI Gateway Models, MCP Servers, and Consumer Groups, `policies` entries
+reference AI Gateway Policies under the same parent gateway. Existing Konnect
+policy names or IDs can be supplied as strings. Declarative references should
+use `!ref <policy-ref>` so the relationship is explicit and same-plan policy
+creates are ordered and resolved.
 
-For AI Gateway Policies, MCP Servers, and Vaults, root-level declarations must
-include `ai_gateway`, while nested declarations inherit the parent gateway.
-Omit `policies`, `mcp_servers`, or `vaults` to leave existing child resources
-unmanaged during sync. Use `policies: []`, `mcp_servers: []`, or `vaults: []`
-under a specific AI Gateway to sync-delete that child type for that gateway.
-Root-level `ai_gateway_policies: []`, `ai_gateway_mcp_servers: []`, and
-`ai_gateway_vaults: []` are rejected because they do not identify a parent
-gateway.
+For AI Gateway Policies, Consumer Groups, MCP Servers, and Vaults, root-level
+declarations must include `ai_gateway`, while nested declarations inherit the
+parent gateway. Omit `policies`, `consumer_groups`, `mcp_servers`, or `vaults`
+to leave existing child resources unmanaged during sync. Use `policies: []`,
+`consumer_groups: []`, `mcp_servers: []`, or `vaults: []` under a specific AI
+Gateway to sync-delete that child type for that gateway. Root-level
+`ai_gateway_policies: []`, `ai_gateway_consumer_groups: []`,
+`ai_gateway_mcp_servers: []`, and `ai_gateway_vaults: []` are rejected because
+they do not identify a parent gateway.
 
 ```yaml
 ai_gateways:
@@ -386,6 +390,16 @@ ai_gateways:
          key: value
        managed_by: object [string]string
          key: value
+   consumer_groups:
+    - ref: string
+      name: string required
+      display_name: string required
+      policies:
+       - !ref policy-ref
+      labels: object [string]string
+        key: value
+      managed_by: object [string]string
+        key: value
    models:
     - ref: string
       type: model # or api
@@ -402,7 +416,8 @@ ai_gateways:
          provider: string required # provider name in parent AI Gateway
          config:
            type: string required
-      policies: array[object]
+      policies:
+       - !ref policy-ref
       capabilities: array[string]
       labels: object [string]string
         key: value
@@ -422,7 +437,8 @@ ai_gateways:
          description: string required
          method: string required
          path: string
-      policies: array[string]
+      policies:
+       - !ref policy-ref
       labels: object [string]string
         key: value
       acls: object
@@ -475,6 +491,23 @@ ai_gateway_policies:
      key: value
 ```
 
+AI Gateway Consumer Groups can also be declared as root resources. Include
+`ai_gateway` to point at the parent gateway `ref`.
+
+```yaml
+ai_gateway_consumer_groups:
+ - ref: string
+   ai_gateway: string required # AI Gateway ref
+   name: string required
+   display_name: string required
+   policies:
+    - !ref policy-ref
+   labels: object [string]string
+     key: value
+   managed_by: object [string]string
+     key: value
+```
+
 AI Gateway Models can also be declared as root resources. Include
 `ai_gateway` to point at the parent gateway `ref`.
 
@@ -496,7 +529,8 @@ ai_gateway_models:
       provider: string required # provider name in parent AI Gateway
       config:
         type: string required
-   policies: array[object]
+   policies:
+    - !ref policy-ref
    capabilities: array[string]
    labels: object [string]string
      key: value
@@ -523,7 +557,8 @@ ai_gateway_mcp_servers:
       description: string required
       method: string required
       path: string
-   policies: array[string]
+   policies:
+    - !ref policy-ref
    labels: object [string]string
      key: value
    acls: object

--- a/docs/examples/declarative/ai-gateway/README.md
+++ b/docs/examples/declarative/ai-gateway/README.md
@@ -4,12 +4,12 @@ This directory contains declarative configuration examples for Konnect AI
 Gateway resources.
 
 - [ai-gateway.yaml](ai-gateway.yaml) defines a root AI Gateway resource with
-  a nested OpenAI provider, env vault, and policy, a model that targets that
-  provider, and a conversion-only MCP Server.
+  a nested OpenAI provider, env vault, policy, consumer group, model that
+  targets that provider, and a conversion-only MCP Server.
 - [federated](federated) shows a multi-folder
   layout where a central team owns an AI Gateway and providers, while a peer
-  team owns root-level policies, models, MCP Servers, and vaults that reference
-  the shared gateway.
+  team owns root-level policies, consumer groups, models, MCP Servers, and
+  vaults that reference the shared gateway.
 
 Set `OPENAI_AUTH_HEADER` to the full upstream authorization header value
 before applying the example, for example `Bearer ...`.

--- a/docs/examples/declarative/ai-gateway/ai-gateway.yaml
+++ b/docs/examples/declarative/ai-gateway/ai-gateway.yaml
@@ -48,6 +48,15 @@ ai_gateways:
         config:
           anonymize:
             - email
+    consumer_groups:
+      - ref: premium-support-users
+        name: premium-support-users
+        display_name: "Premium Support Users"
+        policies:
+          - !ref mask-sensitive-data
+        labels:
+          team: support
+          tier: premium
     models:
       - ref: customer-support-gpt
         type: model
@@ -65,7 +74,7 @@ ai_gateways:
             config:
               type: openai
         policies:
-          - mask-sensitive-data
+          - !ref mask-sensitive-data
         capabilities:
           - generate
     mcp_servers:
@@ -85,4 +94,4 @@ ai_gateways:
             method: GET
             path: /customers/{customer_id}
         policies:
-          - mask-sensitive-data
+          - !ref mask-sensitive-data

--- a/docs/examples/declarative/ai-gateway/federated/README.md
+++ b/docs/examples/declarative/ai-gateway/federated/README.md
@@ -2,8 +2,8 @@
 
 This example shows a federated layout for AI Gateway resources where a central
 AI platform team owns the shared AI Gateway and upstream providers, while a peer
-team owns root-level policies, models, MCP Servers, and vaults that target the
-shared gateway.
+team owns root-level policies, consumer groups, models, MCP Servers, and vaults
+that target the shared gateway.
 
 ## Structure
 
@@ -14,6 +14,7 @@ ai-gateway/federated/
 |-- external-peer-team/
 |   `-- support-model.yaml
 `-- peer-team/
+    |-- support-consumer-group.yaml
     |-- support-mcp-server.yaml
     |-- support-model.yaml
     |-- support-policy.yaml
@@ -26,12 +27,17 @@ ai-gateway/federated/
   providers: OpenAI and Anthropic.
 - `peer-team/support-policy.yaml` defines a standalone `ai_gateway_policies`
   entry that references the central gateway with `!ref shared-ai-gateway#id`.
-  The peer model and MCP Server attach the policy by policy name.
+- `peer-team/support-consumer-group.yaml` defines a standalone
+  `ai_gateway_consumer_groups` entry that references the central gateway with
+  `!ref shared-ai-gateway#id` and attaches the policy with an explicit
+  `!ref peer-mask-sensitive-data`.
 - `peer-team/support-model.yaml` defines a standalone `ai_gateway_models`
-  entry that references the central gateway with `!ref shared-ai-gateway#id`.
+  entry that references the central gateway with `!ref shared-ai-gateway#id`
+  and attaches the policy with an explicit `!ref peer-mask-sensitive-data`.
 - `peer-team/support-mcp-server.yaml` defines a standalone
   `ai_gateway_mcp_servers` entry that references the central gateway with
-  `!ref shared-ai-gateway#id`.
+  `!ref shared-ai-gateway#id` and attaches the policy with an explicit
+  `!ref peer-mask-sensitive-data`.
 - `peer-team/support-vault.yaml` defines a standalone `ai_gateway_vaults` entry
   that references the central gateway with `!ref shared-ai-gateway#id`.
 - `external-peer-team/support-model.yaml` defines an `_external` AI Gateway

--- a/docs/examples/declarative/ai-gateway/federated/peer-team/support-consumer-group.yaml
+++ b/docs/examples/declarative/ai-gateway/federated/peer-team/support-consumer-group.yaml
@@ -1,0 +1,14 @@
+_defaults:
+  kongctl:
+    namespace: federated-ai-gateway
+
+ai_gateway_consumer_groups:
+  - ref: premium-support-users
+    ai_gateway: !ref shared-ai-gateway#id
+    name: premium-support-users
+    display_name: "Premium Support Users"
+    policies:
+      - !ref peer-mask-sensitive-data
+    labels:
+      team: support
+      tier: premium

--- a/docs/examples/declarative/ai-gateway/federated/peer-team/support-mcp-server.yaml
+++ b/docs/examples/declarative/ai-gateway/federated/peer-team/support-mcp-server.yaml
@@ -20,4 +20,4 @@ ai_gateway_mcp_servers:
         method: GET
         path: /customers/{customer_id}
     policies:
-      - peer-mask-sensitive-data
+      - !ref peer-mask-sensitive-data

--- a/docs/examples/declarative/ai-gateway/federated/peer-team/support-model.yaml
+++ b/docs/examples/declarative/ai-gateway/federated/peer-team/support-model.yaml
@@ -27,6 +27,6 @@ ai_gateway_models:
         config:
           type: anthropic
     policies:
-      - peer-mask-sensitive-data
+      - !ref peer-mask-sensitive-data
     capabilities:
       - generate

--- a/internal/cmd/root/products/konnect/aigateway/ai-gateway.go
+++ b/internal/cmd/root/products/konnect/aigateway/ai-gateway.go
@@ -31,6 +31,7 @@ func NewAIGatewayCmd(
 		root := newGetAIGatewayCmd(verb, &baseCmd, addParentFlags, parentPreRun).Command
 		root.AddCommand(newGetAIGatewayProvidersCmd(verb, addParentFlags, parentPreRun))
 		root.AddCommand(newGetAIGatewayPoliciesCmd(verb, addParentFlags, parentPreRun))
+		root.AddCommand(newGetAIGatewayConsumerGroupsCmd(verb, addParentFlags, parentPreRun))
 		root.AddCommand(newGetAIGatewayModelsCmd(verb, addParentFlags, parentPreRun))
 		root.AddCommand(newGetAIGatewayMCPServersCmd(verb, addParentFlags, parentPreRun))
 		root.AddCommand(newGetAIGatewayVaultsCmd(verb, addParentFlags, parentPreRun))

--- a/internal/cmd/root/products/konnect/aigateway/child_common.go
+++ b/internal/cmd/root/products/konnect/aigateway/child_common.go
@@ -27,6 +27,12 @@ const (
 	aiGatewayPolicyIDConfigPath   = "konnect.ai-gateway.policy.id"
 	aiGatewayPolicyNameConfigPath = "konnect.ai-gateway.policy.name"
 
+	aiGatewayConsumerGroupIDFlagName   = "consumer-group-id"
+	aiGatewayConsumerGroupNameFlagName = "consumer-group-name"
+
+	aiGatewayConsumerGroupIDConfigPath   = "konnect.ai-gateway.consumer-group.id"
+	aiGatewayConsumerGroupNameConfigPath = "konnect.ai-gateway.consumer-group.name"
+
 	aiGatewayMCPServerIDFlagName   = "mcp-server-id"
 	aiGatewayMCPServerNameFlagName = "mcp-server-name"
 
@@ -142,6 +148,40 @@ func bindAIGatewayPolicyFlags(c *cobra.Command, args []string) error {
 
 func getAIGatewayPolicyIdentifiers(cfg config.Hook) (id string, name string) {
 	return cfg.GetString(aiGatewayPolicyIDConfigPath), cfg.GetString(aiGatewayPolicyNameConfigPath)
+}
+
+func addAIGatewayConsumerGroupFlags(c *cobra.Command) {
+	c.Flags().String(aiGatewayConsumerGroupIDFlagName, "",
+		fmt.Sprintf(`The ID of the AI Gateway Consumer Group to retrieve.
+- Config path: [ %s ]`, aiGatewayConsumerGroupIDConfigPath))
+	c.Flags().String(aiGatewayConsumerGroupNameFlagName, "",
+		fmt.Sprintf(`The name of the AI Gateway Consumer Group to retrieve.
+- Config path: [ %s ]`, aiGatewayConsumerGroupNameConfigPath))
+	c.MarkFlagsMutuallyExclusive(aiGatewayConsumerGroupIDFlagName, aiGatewayConsumerGroupNameFlagName)
+}
+
+func bindAIGatewayConsumerGroupFlags(c *cobra.Command, args []string) error {
+	helper := cmd.BuildHelper(c, args)
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	if flag := c.Flags().Lookup(aiGatewayConsumerGroupIDFlagName); flag != nil {
+		if err := cfg.BindFlag(aiGatewayConsumerGroupIDConfigPath, flag); err != nil {
+			return err
+		}
+	}
+	if flag := c.Flags().Lookup(aiGatewayConsumerGroupNameFlagName); flag != nil {
+		if err := cfg.BindFlag(aiGatewayConsumerGroupNameConfigPath, flag); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getAIGatewayConsumerGroupIdentifiers(cfg config.Hook) (id string, name string) {
+	return cfg.GetString(aiGatewayConsumerGroupIDConfigPath), cfg.GetString(aiGatewayConsumerGroupNameConfigPath)
 }
 
 func addAIGatewayMCPServerFlags(c *cobra.Command) {

--- a/internal/cmd/root/products/konnect/aigateway/consumer_groups.go
+++ b/internal/cmd/root/products/konnect/aigateway/consumer_groups.go
@@ -1,0 +1,423 @@
+package aigateway
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/table"
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/cmd"
+	cmdCommon "github.com/kong/kongctl/internal/cmd/common"
+	"github.com/kong/kongctl/internal/cmd/output/tableview"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
+	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/kong/kongctl/internal/config"
+	declresources "github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/konnect/helpers"
+	"github.com/kong/kongctl/internal/meta"
+	"github.com/kong/kongctl/internal/util"
+	"github.com/kong/kongctl/internal/util/i18n"
+	"github.com/kong/kongctl/internal/util/normalizers"
+	"github.com/kong/kongctl/internal/util/pagination"
+	"github.com/segmentio/cli"
+	"github.com/spf13/cobra"
+)
+
+type aiGatewayConsumerGroupRecord struct {
+	ID               string
+	Name             string
+	DisplayName      string
+	PolicyCount      string
+	LocalUpdatedTime string
+}
+
+var (
+	aiGatewayConsumerGroupsUse   = "consumer-groups [consumer-group-id|consumer-group-name]"
+	aiGatewayConsumerGroupsShort = i18n.T(
+		"root.products.konnect.ai-gateway.consumer-groupsShort",
+		"List or get Consumer Groups for a Konnect AI Gateway",
+	)
+	aiGatewayConsumerGroupsLong = normalizers.LongDesc(i18n.T(
+		"root.products.konnect.ai-gateway.consumer-groupsLong",
+		`Use the consumer-groups command to list or retrieve Consumer Groups for a specific Konnect AI Gateway.`,
+	))
+	aiGatewayConsumerGroupsExample = normalizers.Examples(
+		i18n.T("root.products.konnect.ai-gateway.consumer-groupsExamples",
+			fmt.Sprintf(`# List Consumer Groups for an AI Gateway by display name
+%[1]s get ai-gateway consumer-groups --gateway-name "Customer Support Gateway"
+# List Consumer Groups for an AI Gateway by ID
+%[1]s get ai-gateway consumer-groups --gateway-id <gateway-id>
+# Get a Consumer Group by name
+%[1]s get ai-gateway consumer-groups --gateway-name "Customer Support Gateway" premium-users
+# Get a Consumer Group by ID
+%[1]s get ai-gateway consumer-groups --gateway-id <gateway-id> --consumer-group-id <consumer-group-id>
+`, meta.CLIName)),
+	)
+)
+
+func newGetAIGatewayConsumerGroupsCmd(
+	verb verbs.VerbValue,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) *cobra.Command {
+	c := &cobra.Command{
+		Use:     aiGatewayConsumerGroupsUse,
+		Short:   aiGatewayConsumerGroupsShort,
+		Long:    aiGatewayConsumerGroupsLong,
+		Example: aiGatewayConsumerGroupsExample,
+		Aliases: []string{"consumer-group"},
+		PreRunE: func(c *cobra.Command, args []string) error {
+			if parentPreRun != nil {
+				if err := parentPreRun(c, args); err != nil {
+					return err
+				}
+			}
+			if err := bindAIGatewayChildFlags(c, args); err != nil {
+				return err
+			}
+			return bindAIGatewayConsumerGroupFlags(c, args)
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			handler := aiGatewayConsumerGroupsHandler{cmd: c}
+			return handler.run(args)
+		},
+	}
+
+	addAIGatewayChildFlags(c)
+	addAIGatewayConsumerGroupFlags(c)
+	if addParentFlags != nil {
+		addParentFlags(verb, c)
+	}
+	return c
+}
+
+type aiGatewayConsumerGroupsHandler struct {
+	cmd *cobra.Command
+}
+
+func (h aiGatewayConsumerGroupsHandler) run(args []string) error {
+	helper := cmd.BuildHelper(h.cmd, args)
+	if len(args) > 1 {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf("too many arguments. Listing AI Gateway Consumer Groups requires 0 or 1 arguments (ID or name)"),
+		}
+	}
+
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	if len(args) == 1 {
+		groupID, groupName := getAIGatewayConsumerGroupIdentifiers(cfg)
+		if groupID != "" || groupName != "" {
+			return &cmd.ConfigurationError{
+				Err: fmt.Errorf(
+					"cannot specify both positional argument and --%s or --%s flags",
+					aiGatewayConsumerGroupIDFlagName,
+					aiGatewayConsumerGroupNameFlagName,
+				),
+			}
+		}
+	}
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+	outType, err := helper.GetOutputFormat()
+	if err != nil {
+		return err
+	}
+	printer, err := cli.Format(outType.String(), helper.GetStreams().Out)
+	if err != nil {
+		return err
+	}
+	defer printer.Flush()
+
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return err
+	}
+
+	gatewayID, gatewayName := getAIGatewayIdentifiers(cfg)
+	if gatewayID != "" && gatewayName != "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf("only one of --%s or --%s can be provided", aiGatewayIDFlagName, aiGatewayNameFlagName),
+		}
+	}
+	if gatewayID == "" && gatewayName == "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf(
+				"an AI Gateway identifier is required. Provide --%s or --%s",
+				aiGatewayIDFlagName,
+				aiGatewayNameFlagName,
+			),
+		}
+	}
+	if gatewayID == "" {
+		gatewayID, err = resolveAIGatewayIDByDisplayName(gatewayName, sdk.GetAIGatewayAPI(), helper, cfg)
+		if err != nil {
+			return err
+		}
+	}
+
+	groupAPI := sdk.GetAIGatewayConsumerGroupsAPI()
+	if groupAPI == nil {
+		return &cmd.ExecutionError{
+			Msg: "AI Gateway Consumer Groups client is not available",
+			Err: fmt.Errorf("AI Gateway Consumer Groups client not configured"),
+		}
+	}
+
+	groupID, groupName := getAIGatewayConsumerGroupIdentifiers(cfg)
+	if groupID != "" && groupName != "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf(
+				"only one of --%s or --%s can be provided",
+				aiGatewayConsumerGroupIDFlagName,
+				aiGatewayConsumerGroupNameFlagName,
+			),
+		}
+	}
+
+	identifier := ""
+	if len(args) == 1 {
+		identifier = strings.TrimSpace(args[0])
+	} else if groupID != "" {
+		identifier = groupID
+	} else if groupName != "" {
+		identifier = groupName
+	}
+
+	if identifier != "" {
+		return h.getSingleConsumerGroup(helper, groupAPI, gatewayID, identifier, outType, printer)
+	}
+	return h.listConsumerGroups(helper, groupAPI, gatewayID, outType, printer, cfg)
+}
+
+func (h aiGatewayConsumerGroupsHandler) listConsumerGroups(
+	helper cmd.Helper,
+	groupAPI helpers.AIGatewayConsumerGroupsAPI,
+	gatewayID string,
+	outType cmdCommon.OutputFormat,
+	printer cli.PrintFlusher,
+	cfg config.Hook,
+) error {
+	groups, err := fetchAIGatewayConsumerGroups(helper, groupAPI, gatewayID, cfg)
+	if err != nil {
+		return err
+	}
+
+	records := make([]aiGatewayConsumerGroupRecord, 0, len(groups))
+	tableRows := make([]table.Row, 0, len(groups))
+	for _, group := range groups {
+		record := aiGatewayConsumerGroupToRecord(group)
+		records = append(records, record)
+		tableRows = append(tableRows, table.Row{
+			record.ID,
+			record.Name,
+			record.DisplayName,
+			record.PolicyCount,
+			record.LocalUpdatedTime,
+		})
+	}
+
+	return tableview.RenderForFormat(
+		helper,
+		false,
+		outType,
+		printer,
+		helper.GetStreams(),
+		records,
+		groups,
+		"",
+		tableview.WithCustomTable(
+			[]string{"ID", "NAME", "DISPLAY NAME", "POLICIES", "UPDATED"},
+			tableRows,
+		),
+		tableview.WithRootLabel(helper.GetCmd().Name()),
+		tableview.WithDetailHelper(helper),
+		tableview.WithDetailRenderer(func(index int) string {
+			if index < 0 || index >= len(groups) {
+				return ""
+			}
+			return aiGatewayConsumerGroupDetailView(groups[index])
+		}),
+		tableview.WithDetailContext(common.ViewParentAIGatewayConsumerGroup, func(index int) any {
+			if index < 0 || index >= len(groups) {
+				return nil
+			}
+			return &groups[index]
+		}),
+	)
+}
+
+func (h aiGatewayConsumerGroupsHandler) getSingleConsumerGroup(
+	helper cmd.Helper,
+	groupAPI helpers.AIGatewayConsumerGroupsAPI,
+	gatewayID string,
+	identifier string,
+	outType cmdCommon.OutputFormat,
+	printer cli.PrintFlusher,
+) error {
+	res, err := groupAPI.GetAiGatewayConsumerGroup(helper.GetContext(), gatewayID, identifier)
+	if err != nil {
+		attrs := cmd.TryConvertErrorToAttrs(err)
+		return cmd.PrepareExecutionError("Failed to get AI Gateway Consumer Group", err, helper.GetCmd(), attrs...)
+	}
+	if res == nil || res.AIGatewayConsumerGroup == nil {
+		return &cmd.ExecutionError{
+			Msg: "AI Gateway Consumer Group response was empty",
+			Err: fmt.Errorf("no Consumer Group returned for id or name %s", identifier),
+		}
+	}
+	group := res.AIGatewayConsumerGroup
+
+	record := aiGatewayConsumerGroupToRecord(*group)
+	return tableview.RenderForFormat(
+		helper,
+		false,
+		outType,
+		printer,
+		helper.GetStreams(),
+		record,
+		group,
+		"",
+		tableview.WithRootLabel(helper.GetCmd().Name()),
+		tableview.WithDetailHelper(helper),
+		tableview.WithDetailRenderer(func(index int) string {
+			if index != 0 {
+				return ""
+			}
+			return aiGatewayConsumerGroupDetailView(*group)
+		}),
+		tableview.WithDetailContext(common.ViewParentAIGatewayConsumerGroup, func(index int) any {
+			if index != 0 {
+				return nil
+			}
+			return group
+		}),
+	)
+}
+
+func fetchAIGatewayConsumerGroups(
+	helper cmd.Helper,
+	groupAPI helpers.AIGatewayConsumerGroupsAPI,
+	gatewayID string,
+	cfg config.Hook,
+) ([]kkComps.AIGatewayConsumerGroup, error) {
+	requestPageSize := common.ResolveRequestPageSize(cfg)
+	var pageAfter *string
+	var allData []kkComps.AIGatewayConsumerGroup
+
+	for {
+		req := kkOps.ListAiGatewayConsumerGroupsRequest{
+			GatewayID: gatewayID,
+			PageSize:  &requestPageSize,
+		}
+		if pageAfter != nil {
+			req.PageAfter = pageAfter
+		}
+
+		res, err := groupAPI.ListAiGatewayConsumerGroups(helper.GetContext(), req)
+		if err != nil {
+			attrs := cmd.TryConvertErrorToAttrs(err)
+			return nil, cmd.PrepareExecutionError(
+				"Failed to list AI Gateway Consumer Groups",
+				err,
+				helper.GetCmd(),
+				attrs...,
+			)
+		}
+		if res == nil || res.ListAIGatewayConsumerGroupsResponse == nil {
+			break
+		}
+
+		allData = append(allData, res.ListAIGatewayConsumerGroupsResponse.Data...)
+		nextCursor := pagination.ExtractPageAfterCursor(res.ListAIGatewayConsumerGroupsResponse.Meta.Page.Next)
+		if nextCursor == "" {
+			break
+		}
+		pageAfter = &nextCursor
+	}
+
+	return allData, nil
+}
+
+func aiGatewayConsumerGroupToRecord(group kkComps.AIGatewayConsumerGroup) aiGatewayConsumerGroupRecord {
+	record := aiGatewayConsumerGroupRecord{
+		ID:               aiGatewayMissingValue,
+		Name:             valueOrMissing(declresources.AIGatewayConsumerGroupName(group)),
+		DisplayName:      valueOrMissing(declresources.AIGatewayConsumerGroupDisplayName(group)),
+		PolicyCount:      fmt.Sprintf("%d", len(group.Policies)),
+		LocalUpdatedTime: aiGatewayMissingValue,
+	}
+	if id := declresources.AIGatewayConsumerGroupID(group); id != "" {
+		record.ID = util.AbbreviateUUID(id)
+	}
+	if updatedAt := declresources.AIGatewayConsumerGroupUpdatedAt(group); !updatedAt.IsZero() {
+		record.LocalUpdatedTime = updatedAt.In(time.Local).Format("2006-01-02 15:04:05")
+	}
+	return record
+}
+
+func aiGatewayConsumerGroupDetailView(group kkComps.AIGatewayConsumerGroup) string {
+	payload := make(map[string]any)
+	data, err := json.Marshal(group)
+	if err == nil {
+		_ = json.Unmarshal(data, &payload)
+	}
+
+	order := []string{
+		"id",
+		"name",
+		"display_name",
+		"policies",
+		"labels",
+		"managed_by",
+		"created_at",
+		"updated_at",
+	}
+
+	var b strings.Builder
+	for _, field := range order {
+		fmt.Fprintf(&b, "%s: %s\n", field, formatAIGatewayModelDetailValue(payload[field]))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func buildAIGatewayConsumerGroupChildView(groups []kkComps.AIGatewayConsumerGroup) tableview.ChildView {
+	tableRows := make([]table.Row, 0, len(groups))
+	for i := range groups {
+		record := aiGatewayConsumerGroupToRecord(groups[i])
+		tableRows = append(tableRows, table.Row{
+			record.ID,
+			record.Name,
+			record.DisplayName,
+			record.PolicyCount,
+		})
+	}
+
+	return tableview.ChildView{
+		Headers: []string{"ID", "NAME", "DISPLAY NAME", "POLICIES"},
+		Rows:    tableRows,
+		DetailRenderer: func(index int) string {
+			if index < 0 || index >= len(groups) {
+				return ""
+			}
+			return aiGatewayConsumerGroupDetailView(groups[index])
+		},
+		Title:      "AI Gateway Consumer Groups",
+		ParentType: common.ViewParentAIGatewayConsumerGroup,
+		DetailContext: func(index int) any {
+			if index < 0 || index >= len(groups) {
+				return nil
+			}
+			return &groups[index]
+		},
+	}
+}

--- a/internal/cmd/root/products/konnect/aigateway/interactive_children.go
+++ b/internal/cmd/root/products/konnect/aigateway/interactive_children.go
@@ -14,6 +14,7 @@ import (
 func init() {
 	tableview.RegisterChildLoader(common.ViewParentAIGateway, common.ViewFieldProviders, loadAIGatewayProviders)
 	tableview.RegisterChildLoader(common.ViewParentAIGateway, common.ViewFieldPolicies, loadAIGatewayPolicies)
+	tableview.RegisterChildLoader(common.ViewParentAIGateway, common.ViewFieldConsumerGroups, loadAIGatewayConsumerGroups)
 }
 
 func loadAIGatewayProviders(_ context.Context, helper cmd.Helper, parent any) (tableview.ChildView, error) {
@@ -76,6 +77,37 @@ func loadAIGatewayPolicies(_ context.Context, helper cmd.Helper, parent any) (ta
 		return tableview.ChildView{}, err
 	}
 	return buildAIGatewayPolicyChildView(policies), nil
+}
+
+func loadAIGatewayConsumerGroups(_ context.Context, helper cmd.Helper, parent any) (tableview.ChildView, error) {
+	gatewayID, err := aiGatewayIDFromParent(parent)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	groupAPI := sdk.GetAIGatewayConsumerGroupsAPI()
+	if groupAPI == nil {
+		return tableview.ChildView{}, fmt.Errorf("AI Gateway Consumer Groups client is not available")
+	}
+
+	groups, err := fetchAIGatewayConsumerGroups(helper, groupAPI, gatewayID, cfg)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+	return buildAIGatewayConsumerGroupChildView(groups), nil
 }
 
 func aiGatewayIDFromParent(parent any) (string, error) {

--- a/internal/cmd/root/products/konnect/common/view_identifiers.go
+++ b/internal/cmd/root/products/konnect/common/view_identifiers.go
@@ -8,6 +8,7 @@ const (
 	ViewParentAIGateway                     = "ai-gateway"
 	ViewParentAIGatewayProvider             = "ai-gateway-provider"
 	ViewParentAIGatewayPolicy               = "ai-gateway-policy"
+	ViewParentAIGatewayConsumerGroup        = "ai-gateway-consumer-group"
 	ViewParentAIGatewayModel                = "ai-gateway-model"
 	ViewParentAIGatewayMCPServer            = "ai-gateway-mcp-server"
 	ViewParentAIGatewayVault                = "ai-gateway-vault"

--- a/internal/cmd/root/verbs/dump/common.go
+++ b/internal/cmd/root/verbs/dump/common.go
@@ -162,6 +162,9 @@ func mapResourceName(name string) string {
 		return "ai_gateways"
 	case "ai-gateway-policy", "ai-gateway-policies", "ai_gateway_policy", "ai_gateway_policies":
 		return "ai_gateway_policies"
+	case "ai-gateway-consumer-group", "ai-gateway-consumer-groups",
+		"ai_gateway_consumer_group", "ai_gateway_consumer_groups":
+		return "ai_gateway_consumer_groups"
 	case "ai-gateway-model", "ai-gateway-models", "ai_gateway_model", "ai_gateway_models":
 		return "ai_gateway_models"
 	case "ai-gateway-mcp-server", "ai-gateway-mcp-servers", "ai_gateway_mcp_server", "ai_gateway_mcp_servers":

--- a/internal/cmd/root/verbs/dump/declarative.go
+++ b/internal/cmd/root/verbs/dump/declarative.go
@@ -54,6 +54,7 @@ var declarativeAllowedResources = map[string]struct{}{
 	"event_gateways":              {},
 	"ai_gateways":                 {},
 	"ai_gateway_policies":         {},
+	"ai_gateway_consumer_groups":  {},
 	"ai_gateway_models":           {},
 	"ai_gateway_mcp_servers":      {},
 	"ai_gateway_vaults":           {},
@@ -90,7 +91,8 @@ func newDeclarativeCmd() *cobra.Command {
 		"Comma separated list of resource types to dump "+
 			"(portals, apis, application_auth_strategies, dcr_providers, control_planes, "+
 			resourceAnalyticsDashboards+", event_gateways, ai_gateways, ai_gateway_policies, "+
-			"ai_gateway_models, ai_gateway_mcp_servers, ai_gateway_vaults, organization.teams).")
+			"ai_gateway_consumer_groups, ai_gateway_models, ai_gateway_mcp_servers, ai_gateway_vaults, "+
+			"organization.teams).")
 	_ = cmd.MarkFlagRequired("resources")
 
 	cmd.Flags().BoolVar(&opts.includeChildResources, "include-child-resources", false,
@@ -206,6 +208,7 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 	var stateClient *declstate.Client
 	if opts.includeChildResources ||
 		slices.Contains(opts.resources, "ai_gateway_policies") ||
+		slices.Contains(opts.resources, "ai_gateway_consumer_groups") ||
 		slices.Contains(opts.resources, "ai_gateway_models") ||
 		slices.Contains(opts.resources, "ai_gateway_mcp_servers") ||
 		slices.Contains(opts.resources, "ai_gateway_vaults") {
@@ -222,6 +225,7 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 			AIGatewayAPI:                        sdk.GetAIGatewayAPI(),
 			AIGatewayProvidersAPI:               sdk.GetAIGatewayProvidersAPI(),
 			AIGatewayPoliciesAPI:                sdk.GetAIGatewayPoliciesAPI(),
+			AIGatewayConsumerGroupsAPI:          sdk.GetAIGatewayConsumerGroupsAPI(),
 			AIGatewayModelAPI:                   sdk.GetAIGatewayModelAPI(),
 			AIGatewayMCPServersAPI:              sdk.GetAIGatewayMCPServersAPI(),
 			AIGatewayVaultsAPI:                  sdk.GetAIGatewayVaultsAPI(),
@@ -381,6 +385,18 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 				return err
 			}
 			resourceSet.AIGatewayPolicies = append(resourceSet.AIGatewayPolicies, policies...)
+		case "ai_gateway_consumer_groups":
+			groups, err := collectDeclarativeAIGatewayConsumerGroups(
+				ctx,
+				stateClient,
+				sdk.GetAIGatewayAPI(),
+				requestPageSize,
+				opts.filter,
+			)
+			if err != nil {
+				return err
+			}
+			resourceSet.AIGatewayConsumerGroups = append(resourceSet.AIGatewayConsumerGroups, groups...)
 		case "ai_gateway_models":
 			models, err := collectDeclarativeAIGatewayModels(
 				ctx,
@@ -822,6 +838,44 @@ func collectDeclarativeAIGatewayPolicies(
 	})
 
 	return policies, nil
+}
+
+func collectDeclarativeAIGatewayConsumerGroups(
+	ctx context.Context,
+	client *declstate.Client,
+	aiGatewayClient helpers.AIGatewayAPI,
+	requestPageSize int64,
+	filter filterOptions,
+) ([]declresources.AIGatewayConsumerGroupResource, error) {
+	if client == nil {
+		return nil, fmt.Errorf("AI Gateway Consumer Groups API client is not configured")
+	}
+
+	gateways, err := collectDeclarativeAIGateways(ctx, aiGatewayClient, requestPageSize, filterOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var groups []declresources.AIGatewayConsumerGroupResource
+	for _, gateway := range gateways {
+		gatewayGroups, err := buildAIGatewayConsumerGroups(ctx, client, gateway.Ref, gateway.DisplayName, gateway.Ref)
+		if err != nil {
+			return nil, err
+		}
+		groups = append(groups, gatewayGroups...)
+	}
+
+	groups = filterByNameOrID(groups, filter, func(r declresources.AIGatewayConsumerGroupResource) (string, string) {
+		return r.Name, r.Ref
+	})
+	slices.SortFunc(groups, func(a, b declresources.AIGatewayConsumerGroupResource) int {
+		if a.AIGateway == b.AIGateway {
+			return cmp.Compare(a.Name, b.Name)
+		}
+		return cmp.Compare(a.AIGateway, b.AIGateway)
+	})
+
+	return groups, nil
 }
 
 func collectDeclarativeAIGatewayModels(

--- a/internal/cmd/root/verbs/dump/declarative_children.go
+++ b/internal/cmd/root/verbs/dump/declarative_children.go
@@ -284,6 +284,15 @@ func populateAIGatewayChildren(
 			gateway.Policies = policies
 		}
 
+		groups, err := buildAIGatewayConsumerGroups(ctx, client, gatewayID, gateway.DisplayName, "")
+		if err != nil {
+			logWarn(logger, "failed to load AI Gateway Consumer Groups", gatewayID, gateway.DisplayName, err)
+			continue
+		}
+		if len(groups) > 0 {
+			gateway.ConsumerGroups = groups
+		}
+
 		models, err := buildAIGatewayModels(ctx, client, gatewayID, gateway.DisplayName, "")
 		if err != nil {
 			logWarn(logger, "failed to load AI Gateway models", gatewayID, gateway.DisplayName, err)
@@ -394,6 +403,39 @@ func buildAIGatewayPolicies(
 	}
 
 	slices.SortFunc(result, func(a, b declresources.AIGatewayPolicyResource) int {
+		if a.Name == b.Name {
+			return cmp.Compare(a.Ref, b.Ref)
+		}
+		return cmp.Compare(a.Name, b.Name)
+	})
+
+	return result, nil
+}
+
+func buildAIGatewayConsumerGroups(
+	ctx context.Context,
+	client *declstate.Client,
+	gatewayID string,
+	gatewayName string,
+	gatewayRef string,
+) ([]declresources.AIGatewayConsumerGroupResource, error) {
+	groups, err := client.ListAIGatewayConsumerGroups(ctx, gatewayID)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]declresources.AIGatewayConsumerGroupResource, 0, len(groups))
+	for _, group := range groups {
+		resource, err := declresources.AIGatewayConsumerGroupResourceFromResponse(
+			gatewayRef,
+			group.AIGatewayConsumerGroup,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to map AI Gateway Consumer Group for gateway %s: %w", gatewayName, err)
+		}
+		result = append(result, resource)
+	}
+
+	slices.SortFunc(result, func(a, b declresources.AIGatewayConsumerGroupResource) int {
 		if a.Name == b.Name {
 			return cmp.Compare(a.Ref, b.Ref)
 		}

--- a/internal/declarative/executor/ai_gateway_consumer_group_adapter.go
+++ b/internal/declarative/executor/ai_gateway_consumer_group_adapter.go
@@ -1,0 +1,176 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+)
+
+// AIGatewayConsumerGroupAdapter implements ResourceOperations for AI Gateway Consumer Groups.
+type AIGatewayConsumerGroupAdapter struct {
+	client *state.Client
+}
+
+// NewAIGatewayConsumerGroupAdapter creates a new AI Gateway Consumer Group adapter.
+func NewAIGatewayConsumerGroupAdapter(client *state.Client) *AIGatewayConsumerGroupAdapter {
+	return &AIGatewayConsumerGroupAdapter{client: client}
+}
+
+// MapCreateFields maps planner fields to CreateAIGatewayConsumerGroupRequest.
+func (a *AIGatewayConsumerGroupAdapter) MapCreateFields(
+	_ context.Context,
+	_ *ExecutionContext,
+	fields map[string]any,
+	create *kkComps.CreateAIGatewayConsumerGroupRequest,
+) error {
+	data, err := json.Marshal(fields)
+	if err != nil {
+		return fmt.Errorf("failed to encode AI Gateway Consumer Group create fields: %w", err)
+	}
+	if err := json.Unmarshal(data, create); err != nil {
+		return fmt.Errorf("failed to decode AI Gateway Consumer Group create fields: %w", err)
+	}
+	if create.Name == "" || create.DisplayName == "" {
+		return fmt.Errorf("name and display_name are required")
+	}
+	return nil
+}
+
+// MapUpdateFields maps planner fields to UpdateAIGatewayConsumerGroupRequest.
+func (a *AIGatewayConsumerGroupAdapter) MapUpdateFields(
+	_ context.Context,
+	_ *ExecutionContext,
+	fields map[string]any,
+	update *kkComps.UpdateAIGatewayConsumerGroupRequest,
+	_ map[string]string,
+) error {
+	data, err := json.Marshal(fields)
+	if err != nil {
+		return fmt.Errorf("failed to encode AI Gateway Consumer Group update fields: %w", err)
+	}
+	if err := json.Unmarshal(data, update); err != nil {
+		return fmt.Errorf("failed to decode AI Gateway Consumer Group update fields: %w", err)
+	}
+	return nil
+}
+
+// Create creates an AI Gateway Consumer Group.
+func (a *AIGatewayConsumerGroupAdapter) Create(
+	ctx context.Context,
+	req kkComps.CreateAIGatewayConsumerGroupRequest,
+	namespace string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	gatewayID, err := a.getAIGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return "", err
+	}
+	return a.client.CreateAIGatewayConsumerGroup(ctx, gatewayID, req, namespace)
+}
+
+// Update updates an AI Gateway Consumer Group.
+func (a *AIGatewayConsumerGroupAdapter) Update(
+	ctx context.Context,
+	id string,
+	req kkComps.UpdateAIGatewayConsumerGroupRequest,
+	namespace string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	gatewayID, err := a.getAIGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return "", err
+	}
+	return a.client.UpdateAIGatewayConsumerGroup(ctx, gatewayID, id, req, namespace)
+}
+
+// Delete deletes an AI Gateway Consumer Group.
+func (a *AIGatewayConsumerGroupAdapter) Delete(ctx context.Context, id string, execCtx *ExecutionContext) error {
+	gatewayID, err := a.getAIGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return err
+	}
+	return a.client.DeleteAIGatewayConsumerGroup(ctx, gatewayID, id)
+}
+
+// GetByID gets an AI Gateway Consumer Group by ID.
+func (a *AIGatewayConsumerGroupAdapter) GetByID(
+	ctx context.Context,
+	id string,
+	execCtx *ExecutionContext,
+) (ResourceInfo, error) {
+	gatewayID, err := a.getAIGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return nil, err
+	}
+	group, err := a.client.GetAIGatewayConsumerGroup(ctx, gatewayID, id)
+	if err != nil {
+		return nil, err
+	}
+	if group == nil {
+		return nil, nil
+	}
+	return &aiGatewayConsumerGroupResourceInfo{group: group}, nil
+}
+
+// GetByName is not supported without a parent gateway context.
+func (a *AIGatewayConsumerGroupAdapter) GetByName(_ context.Context, _ string) (ResourceInfo, error) {
+	return nil, fmt.Errorf("GetByName not supported for AI Gateway Consumer Groups")
+}
+
+// ResourceType returns the resource type.
+func (a *AIGatewayConsumerGroupAdapter) ResourceType() string {
+	return planner.ResourceTypeAIGatewayConsumerGroup
+}
+
+// RequiredFields returns required fields for create.
+func (a *AIGatewayConsumerGroupAdapter) RequiredFields() []string {
+	return []string{planner.FieldName, planner.FieldDisplayName}
+}
+
+// SupportsUpdate indicates update support.
+func (a *AIGatewayConsumerGroupAdapter) SupportsUpdate() bool {
+	return true
+}
+
+func (a *AIGatewayConsumerGroupAdapter) getAIGatewayIDFromExecutionContext(
+	execCtx *ExecutionContext,
+) (string, error) {
+	if execCtx == nil || execCtx.PlannedChange == nil {
+		return "", fmt.Errorf("execution context required")
+	}
+
+	change := *execCtx.PlannedChange
+	if gatewayRef, ok := change.References[planner.FieldAIGatewayID]; ok && !unresolvedReferenceID(gatewayRef.ID) {
+		return gatewayRef.ID, nil
+	}
+	if change.Parent != nil && !unresolvedReferenceID(change.Parent.ID) {
+		return change.Parent.ID, nil
+	}
+
+	return "", fmt.Errorf("AI Gateway ID required for Consumer Group operations")
+}
+
+type aiGatewayConsumerGroupResourceInfo struct {
+	group *state.AIGatewayConsumerGroup
+}
+
+func (a *aiGatewayConsumerGroupResourceInfo) GetID() string {
+	return resources.AIGatewayConsumerGroupID(a.group.AIGatewayConsumerGroup)
+}
+
+func (a *aiGatewayConsumerGroupResourceInfo) GetName() string {
+	return resources.AIGatewayConsumerGroupName(a.group.AIGatewayConsumerGroup)
+}
+
+func (a *aiGatewayConsumerGroupResourceInfo) GetLabels() map[string]string {
+	return resources.AIGatewayConsumerGroupLabels(a.group.AIGatewayConsumerGroup)
+}
+
+func (a *aiGatewayConsumerGroupResourceInfo) GetNormalizedLabels() map[string]string {
+	return a.group.NormalizedLabels
+}

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -58,6 +58,9 @@ type Executor struct {
 	aiGatewayPolicyExecutor *BaseExecutor[
 		kkComps.CreateAIGatewayPolicyRequest,
 		kkComps.UpdateAIGatewayPolicyRequest]
+	aiGatewayConsumerGroupExecutor *BaseExecutor[
+		kkComps.CreateAIGatewayConsumerGroupRequest,
+		kkComps.UpdateAIGatewayConsumerGroupRequest]
 	aiGatewayModelExecutor *BaseExecutor[
 		kkComps.CreateAIGatewayModelRequest, kkComps.UpdateAIGatewayModelRequest]
 	aiGatewayMCPServerExecutor *BaseExecutor[
@@ -253,6 +256,13 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 		kkComps.CreateAIGatewayPolicyRequest,
 		kkComps.UpdateAIGatewayPolicyRequest](
 		NewAIGatewayPolicyAdapter(client),
+		client,
+		dryRun,
+	)
+	e.aiGatewayConsumerGroupExecutor = NewBaseExecutor[
+		kkComps.CreateAIGatewayConsumerGroupRequest,
+		kkComps.UpdateAIGatewayConsumerGroupRequest](
+		NewAIGatewayConsumerGroupAdapter(client),
 		client,
 		dryRun,
 	)
@@ -2353,6 +2363,11 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 			return "", err
 		}
 		return e.aiGatewayPolicyExecutor.Create(ctx, *change)
+	case planner.ResourceTypeAIGatewayConsumerGroup:
+		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
+			return "", err
+		}
+		return e.aiGatewayConsumerGroupExecutor.Create(ctx, *change)
 	case planner.ResourceTypeAIGatewayModel:
 		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
 			return "", err
@@ -2960,6 +2975,11 @@ func (e *Executor) updateResource(ctx context.Context, change *planner.PlannedCh
 			return "", err
 		}
 		return e.aiGatewayPolicyExecutor.Update(ctx, *change)
+	case planner.ResourceTypeAIGatewayConsumerGroup:
+		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
+			return "", err
+		}
+		return e.aiGatewayConsumerGroupExecutor.Update(ctx, *change)
 	case planner.ResourceTypeAIGatewayModel:
 		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
 			return "", err
@@ -3449,6 +3469,11 @@ func (e *Executor) deleteResource(ctx context.Context, change *planner.PlannedCh
 			return err
 		}
 		return e.aiGatewayPolicyExecutor.Delete(ctx, *change)
+	case planner.ResourceTypeAIGatewayConsumerGroup:
+		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
+			return err
+		}
+		return e.aiGatewayConsumerGroupExecutor.Delete(ctx, *change)
 	case planner.ResourceTypeAIGatewayModel:
 		return e.aiGatewayModelExecutor.Delete(ctx, *change)
 	case planner.ResourceTypeAIGatewayMCPServer:

--- a/internal/declarative/loader/ai_gateway_consumer_group_test.go
+++ b/internal/declarative/loader/ai_gateway_consumer_group_test.go
@@ -1,0 +1,114 @@
+package loader
+
+import (
+	"testing"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/tags"
+	"github.com/stretchr/testify/require"
+)
+
+const aiGatewayConsumerGroupYAML = `
+ai_gateways:
+  - ref: support-gateway
+    display_name: Support Gateway
+    policies:
+      - ref: mask-sensitive-data
+        type: ai-sanitizer
+        name: mask-sensitive-data
+        display_name: Mask Sensitive Data
+        config:
+          anonymize:
+            - email
+    consumer_groups:
+      - ref: premium-support-users
+        name: premium-support-users
+        display_name: Premium Support Users
+        policies:
+          - !ref mask-sensitive-data
+`
+
+func TestLoaderExtractsNestedAIGatewayConsumerGroups(t *testing.T) {
+	path := writeLoaderTestFile(t, aiGatewayConsumerGroupYAML)
+
+	rs, err := New().LoadFromSources([]Source{{Path: path, Type: SourceTypeFile}}, false)
+	require.NoError(t, err)
+	require.Len(t, rs.AIGateways, 1)
+	require.Empty(t, rs.AIGateways[0].ConsumerGroups)
+	require.Len(t, rs.AIGatewayConsumerGroups, 1)
+	require.Equal(t, "support-gateway", rs.AIGatewayConsumerGroups[0].AIGateway)
+	require.Equal(t, "premium-support-users", rs.AIGatewayConsumerGroups[0].Name)
+	require.Equal(
+		t,
+		[]string{tags.RefPlaceholderPrefix + "mask-sensitive-data#id"},
+		rs.AIGatewayConsumerGroups[0].Policies,
+	)
+	require.True(t, rs.SyncScope.ChildInScope(
+		resources.ResourceTypeAIGateway,
+		"support-gateway",
+		resources.ResourceTypeAIGatewayConsumerGroup,
+	))
+}
+
+func TestLoaderValidatesAIGatewayConsumerGroupParentAndDuplicates(t *testing.T) {
+	rootOnly := `
+ai_gateway_consumer_groups:
+  - ref: premium-support-users
+    ai_gateway: missing-gateway
+    name: premium-support-users
+    display_name: Premium Support Users
+`
+	_, err := New().LoadFromSources([]Source{{Path: writeLoaderTestFile(t, rootOnly), Type: SourceTypeFile}}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "references unknown ai_gateway")
+
+	duplicates := `
+ai_gateways:
+  - ref: support-gateway
+    display_name: Support Gateway
+    consumer_groups:
+      - ref: premium-support-users
+        name: premium-support-users
+        display_name: Premium Support Users
+      - ref: premium-support-users-2
+        name: premium-support-users
+        display_name: Premium Support Users 2
+`
+	_, err = New().LoadFromSources([]Source{{Path: writeLoaderTestFile(t, duplicates), Type: SourceTypeFile}}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate ai_gateway_consumer_group name")
+}
+
+func TestLoaderRejectsRootLevelEmptyAIGatewayConsumerGroups(t *testing.T) {
+	input := `ai_gateway_consumer_groups: []`
+
+	_, err := New().LoadFromSources([]Source{{Path: writeLoaderTestFile(t, input), Type: SourceTypeFile}}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ai_gateway_consumer_groups cannot be empty")
+}
+
+func TestLoaderAcceptsAIGatewayConsumerGroupDeferredExternalParentRef(t *testing.T) {
+	input := `
+ai_gateways:
+  - ref: external-shared-gateway
+    _external:
+      selector:
+        matchFields:
+          display_name: Shared Gateway
+ai_gateway_consumer_groups:
+  - ref: premium-support-users
+    ai_gateway: !ref external-shared-gateway#id
+    name: premium-support-users
+    display_name: Premium Support Users
+`
+
+	rs, err := New().LoadFromSources([]Source{{Path: writeLoaderTestFile(t, input), Type: SourceTypeFile}}, false)
+	require.NoError(t, err)
+	require.Len(t, rs.AIGatewayConsumerGroups, 1)
+	require.Equal(t, tags.RefPlaceholderPrefix+"external-shared-gateway#id", rs.AIGatewayConsumerGroups[0].AIGateway)
+	require.True(t, rs.SyncScope.ChildInScope(
+		resources.ResourceTypeAIGateway,
+		"external-shared-gateway",
+		resources.ResourceTypeAIGatewayConsumerGroup,
+	))
+}

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -1036,6 +1036,13 @@ func (l *Loader) extractNestedResources(rs *resources.ResourceSet) {
 		}
 		gateway.Policies = nil
 
+		for j := range gateway.ConsumerGroups {
+			group := gateway.ConsumerGroups[j]
+			group.AIGateway = gateway.Ref
+			rs.AIGatewayConsumerGroups = append(rs.AIGatewayConsumerGroups, group)
+		}
+		gateway.ConsumerGroups = nil
+
 		for j := range gateway.Models {
 			model := gateway.Models[j]
 			model.AIGateway = gateway.Ref

--- a/internal/declarative/loader/sync_scope.go
+++ b/internal/declarative/loader/sync_scope.go
@@ -44,6 +44,12 @@ var rootChildCollectionScopes = []childCollectionScope{
 		parentType:   resources.ResourceTypeAIGateway,
 	},
 	{
+		key:          "ai_gateway_consumer_groups",
+		resourceType: resources.ResourceTypeAIGatewayConsumerGroup,
+		parentKey:    resources.SchemaFieldAIGateway,
+		parentType:   resources.ResourceTypeAIGateway,
+	},
+	{
 		key:          "ai_gateway_models",
 		resourceType: resources.ResourceTypeAIGatewayModel,
 		parentKey:    resources.SchemaFieldAIGateway,
@@ -350,6 +356,11 @@ var aiGatewayChildCollectionScopes = []childCollectionScope{
 		parentType:   resources.ResourceTypeAIGateway,
 	},
 	{
+		key:          "consumer_groups",
+		resourceType: resources.ResourceTypeAIGatewayConsumerGroup,
+		parentType:   resources.ResourceTypeAIGateway,
+	},
+	{
 		key:          "models",
 		resourceType: resources.ResourceTypeAIGatewayModel,
 		parentType:   resources.ResourceTypeAIGateway,
@@ -482,6 +493,9 @@ func captureRootChildScope(scope *resources.SyncScope, raw map[string]any, entry
 	if !ok || len(items) == 0 {
 		if entry.resourceType == resources.ResourceTypeAIGatewayPolicy {
 			return fmt.Errorf("%s cannot be empty because each policy must declare an ai_gateway parent", entry.key)
+		}
+		if entry.resourceType == resources.ResourceTypeAIGatewayConsumerGroup {
+			return fmt.Errorf("%s cannot be empty because each Consumer Group must declare an ai_gateway parent", entry.key)
 		}
 		if entry.resourceType == resources.ResourceTypeAIGatewayModel {
 			return fmt.Errorf("%s cannot be empty because each model must declare an ai_gateway parent", entry.key)

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -50,6 +50,9 @@ func (l *Loader) validateResourceSet(rs *resources.ResourceSet) error {
 	if err := l.validateAIGatewayPolicies(rs); err != nil {
 		return err
 	}
+	if err := l.validateAIGatewayConsumerGroups(rs); err != nil {
+		return err
+	}
 	if err := l.validateAIGatewayModels(rs); err != nil {
 		return err
 	}
@@ -832,6 +835,58 @@ func (l *Loader) validateAIGatewayPolicies(rs *resources.ResourceSet) error {
 			)
 		}
 		namesByGateway[nameKey] = policy.GetRef()
+	}
+
+	return nil
+}
+
+// validateAIGatewayConsumerGroups validates AI Gateway child Consumer Group resources.
+func (l *Loader) validateAIGatewayConsumerGroups(rs *resources.ResourceSet) error {
+	namesByGateway := make(map[string]string)
+
+	for i := range rs.AIGatewayConsumerGroups {
+		group := &rs.AIGatewayConsumerGroups[i]
+
+		if err := group.Validate(); err != nil {
+			return fmt.Errorf("invalid ai_gateway_consumer_group %q: %w", group.GetRef(), err)
+		}
+
+		if existing, found := rs.GetResourceByRef(group.GetRef()); found {
+			if existing.GetType() != resources.ResourceTypeAIGatewayConsumerGroup {
+				return fmt.Errorf("duplicate ref '%s' (already defined as %s)",
+					group.GetRef(), existing.GetType())
+			}
+		}
+
+		gatewayRef := resources.NormalizeResourceRef(group.AIGateway)
+		gateway, found := rs.GetResourceByRef(gatewayRef)
+		if !found {
+			return fmt.Errorf(
+				"ai_gateway_consumer_group %q references unknown ai_gateway %q",
+				group.GetRef(),
+				group.AIGateway,
+			)
+		}
+		if gateway.GetType() != resources.ResourceTypeAIGateway {
+			return fmt.Errorf(
+				"ai_gateway_consumer_group %q references %q which is %s, not ai_gateway",
+				group.GetRef(),
+				group.AIGateway,
+				gateway.GetType(),
+			)
+		}
+
+		nameKey := gatewayRef + "\x00" + group.Name
+		if existingRef, exists := namesByGateway[nameKey]; exists {
+			return fmt.Errorf(
+				"duplicate ai_gateway_consumer_group name %q for ai_gateway %q (ref: %s conflicts with ref: %s)",
+				group.Name,
+				gatewayRef,
+				group.GetRef(),
+				existingRef,
+			)
+		}
+		namesByGateway[nameKey] = group.GetRef()
 	}
 
 	return nil

--- a/internal/declarative/planner/ai_gateway_consumer_group_planner.go
+++ b/internal/declarative/planner/ai_gateway_consumer_group_planner.go
@@ -1,0 +1,326 @@
+package planner
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"maps"
+	"reflect"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/util"
+)
+
+func (p *Planner) planAIGatewayConsumerGroupChanges(
+	ctx context.Context,
+	namespace string,
+	gatewayRef string,
+	gatewayName string,
+	gatewayID string,
+	gatewayChangeID string,
+	policyCreateDepsByRefOrName map[string]string,
+	desired []resources.AIGatewayConsumerGroupResource,
+	plan *Plan,
+) error {
+	p.logger.Debug(
+		"Planning AI Gateway Consumer Group changes",
+		slog.String("gateway_ref", gatewayRef),
+		slog.String("gateway_id", gatewayID),
+		slog.String("gateway_change_id", gatewayChangeID),
+		slog.Int("desired_count", len(desired)),
+	)
+
+	if gatewayID == "" {
+		p.planAIGatewayConsumerGroupCreatesForNewGateway(
+			namespace,
+			gatewayRef,
+			gatewayName,
+			gatewayChangeID,
+			policyCreateDepsByRefOrName,
+			desired,
+			plan,
+		)
+		return nil
+	}
+
+	currentGroups, err := p.client.ListAIGatewayConsumerGroups(ctx, gatewayID)
+	if err != nil {
+		return fmt.Errorf("failed to list AI Gateway Consumer Groups for gateway %s: %w", gatewayID, err)
+	}
+
+	currentByID, currentByName := indexAIGatewayConsumerGroups(currentGroups)
+	desiredKeys := make(map[string]bool)
+
+	for _, desiredGroup := range desired {
+		current, exists := matchCurrentAIGatewayConsumerGroup(desiredGroup, currentByID, currentByName)
+		desiredKeys[desiredGroup.Name] = true
+		if id := aiGatewayConsumerGroupDesiredID(desiredGroup); id != "" {
+			desiredKeys[id] = true
+		}
+
+		if !exists {
+			dependsOn := aiGatewayConsumerGroupPolicyCreateDependencies(
+				desiredGroup,
+				policyCreateDepsByRefOrName,
+			)
+			p.planAIGatewayConsumerGroupCreate(namespace, gatewayRef, gatewayName, gatewayID, desiredGroup, dependsOn, plan)
+			continue
+		}
+
+		groupID := resources.AIGatewayConsumerGroupID(current.AIGatewayConsumerGroup)
+		if group := p.resources.GetAIGatewayConsumerGroupByRef(desiredGroup.Ref); group != nil {
+			group.SetKonnectID(groupID)
+		}
+		fullGroup, err := p.client.GetAIGatewayConsumerGroup(ctx, gatewayID, groupID)
+		if err != nil {
+			return fmt.Errorf("failed to get AI Gateway Consumer Group %s: %w", groupID, err)
+		}
+		if fullGroup == nil {
+			dependsOn := aiGatewayConsumerGroupPolicyCreateDependencies(
+				desiredGroup,
+				policyCreateDepsByRefOrName,
+			)
+			p.planAIGatewayConsumerGroupCreate(namespace, gatewayRef, gatewayName, gatewayID, desiredGroup, dependsOn, plan)
+			continue
+		}
+
+		needsUpdate, updateFields, changedFields, err := p.shouldUpdateAIGatewayConsumerGroup(*fullGroup, desiredGroup)
+		if err != nil {
+			return err
+		}
+		if needsUpdate {
+			p.planAIGatewayConsumerGroupUpdate(
+				namespace,
+				gatewayRef,
+				gatewayID,
+				groupID,
+				desiredGroup,
+				updateFields,
+				changedFields,
+				aiGatewayConsumerGroupPolicyCreateDependencies(
+					desiredGroup,
+					policyCreateDepsByRefOrName,
+				),
+				plan,
+			)
+		}
+	}
+
+	if plan.Metadata.Mode == PlanModeSync {
+		for _, current := range currentGroups {
+			groupID := resources.AIGatewayConsumerGroupID(current.AIGatewayConsumerGroup)
+			groupName := resources.AIGatewayConsumerGroupName(current.AIGatewayConsumerGroup)
+			if desiredKeys[groupID] || desiredKeys[groupName] {
+				continue
+			}
+			p.planAIGatewayConsumerGroupDelete(gatewayRef, gatewayID, groupID, groupName, plan)
+		}
+	}
+
+	return nil
+}
+
+func (p *Planner) planAIGatewayConsumerGroupCreatesForNewGateway(
+	namespace string,
+	gatewayRef string,
+	gatewayName string,
+	gatewayChangeID string,
+	policyCreateDepsByRefOrName map[string]string,
+	groups []resources.AIGatewayConsumerGroupResource,
+	plan *Plan,
+) {
+	var dependsOn []string
+	if gatewayChangeID != "" {
+		dependsOn = []string{gatewayChangeID}
+	}
+	for _, group := range groups {
+		groupDependsOn := append([]string{}, dependsOn...)
+		for _, dep := range aiGatewayConsumerGroupPolicyCreateDependencies(group, policyCreateDepsByRefOrName) {
+			groupDependsOn = appendDependsOn(groupDependsOn, dep)
+		}
+		p.planAIGatewayConsumerGroupCreate(namespace, gatewayRef, gatewayName, "", group, groupDependsOn, plan)
+	}
+}
+
+func (p *Planner) planAIGatewayConsumerGroupCreate(
+	namespace string,
+	gatewayRef string,
+	gatewayName string,
+	gatewayID string,
+	group resources.AIGatewayConsumerGroupResource,
+	dependsOn []string,
+	plan *Plan,
+) {
+	fields, err := group.MutablePayloadMap()
+	if err != nil {
+		plan.AddWarning(group.GetRef(), fmt.Sprintf("failed to build AI Gateway Consumer Group create payload: %s", err))
+		return
+	}
+
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionCreate, ResourceTypeAIGatewayConsumerGroup, group.Ref),
+		ResourceType: ResourceTypeAIGatewayConsumerGroup,
+		ResourceRef:  group.Ref,
+		Action:       ActionCreate,
+		Fields:       fields,
+		Namespace:    namespace,
+		DependsOn:    dependsOn,
+	}
+	if gatewayID != "" {
+		change.Parent = &ParentInfo{Ref: gatewayRef, ID: gatewayID}
+	} else {
+		change.References = map[string]ReferenceInfo{
+			FieldAIGatewayID: {
+				Ref: gatewayRef,
+				LookupFields: map[string]string{
+					FieldDisplayName: gatewayName,
+				},
+			},
+		}
+	}
+
+	plan.AddChange(change)
+}
+
+func (p *Planner) planAIGatewayConsumerGroupUpdate(
+	namespace string,
+	gatewayRef string,
+	gatewayID string,
+	groupID string,
+	group resources.AIGatewayConsumerGroupResource,
+	updateFields map[string]any,
+	changedFields map[string]FieldChange,
+	dependsOn []string,
+	plan *Plan,
+) {
+	change := PlannedChange{
+		ID:            p.nextChangeID(ActionUpdate, ResourceTypeAIGatewayConsumerGroup, group.Ref),
+		ResourceType:  ResourceTypeAIGatewayConsumerGroup,
+		ResourceRef:   group.Ref,
+		ResourceID:    groupID,
+		Action:        ActionUpdate,
+		Fields:        updateFields,
+		ChangedFields: changedFields,
+		Namespace:     namespace,
+		DependsOn:     dependsOn,
+		Parent:        &ParentInfo{Ref: gatewayRef, ID: gatewayID},
+	}
+	plan.AddChange(change)
+}
+
+func (p *Planner) planAIGatewayConsumerGroupDelete(
+	gatewayRef string,
+	gatewayID string,
+	groupID string,
+	groupName string,
+	plan *Plan,
+) {
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionDelete, ResourceTypeAIGatewayConsumerGroup, groupName),
+		ResourceType: ResourceTypeAIGatewayConsumerGroup,
+		ResourceRef:  groupName,
+		ResourceID:   groupID,
+		Action:       ActionDelete,
+		Fields: map[string]any{
+			FieldName: groupName,
+		},
+		Parent: &ParentInfo{Ref: gatewayRef, ID: gatewayID},
+	}
+	plan.AddChange(change)
+}
+
+func (p *Planner) shouldUpdateAIGatewayConsumerGroup(
+	current state.AIGatewayConsumerGroup,
+	desired resources.AIGatewayConsumerGroupResource,
+) (bool, map[string]any, map[string]FieldChange, error) {
+	currentPayload, err := resources.AIGatewayConsumerGroupMutablePayloadMap(current.AIGatewayConsumerGroup)
+	if err != nil {
+		return false, nil, nil, fmt.Errorf("failed to normalize current AI Gateway Consumer Group: %w", err)
+	}
+	desiredPayload, err := desired.MutablePayloadMap()
+	if err != nil {
+		return false, nil, nil, fmt.Errorf(
+			"failed to normalize desired AI Gateway Consumer Group %q: %w",
+			desired.Ref,
+			err,
+		)
+	}
+
+	currentCompare, desiredCompare := normalizeAIGatewayPolicyReferencesForComparison(
+		currentPayload,
+		desiredPayload,
+		p.resources,
+	)
+
+	changedFields := make(map[string]FieldChange)
+	keys := make(map[string]struct{}, len(currentCompare)+len(desiredCompare))
+	for key := range currentCompare {
+		keys[key] = struct{}{}
+	}
+	for key := range desiredCompare {
+		keys[key] = struct{}{}
+	}
+	for key := range keys {
+		if !reflect.DeepEqual(currentCompare[key], desiredCompare[key]) {
+			changedFields[key] = FieldChange{Old: currentPayload[key], New: desiredPayload[key]}
+		}
+	}
+	if len(changedFields) == 0 {
+		return false, nil, nil, nil
+	}
+
+	updateFields := make(map[string]any, len(desiredPayload))
+	maps.Copy(updateFields, desiredPayload)
+	return true, updateFields, changedFields, nil
+}
+
+func indexAIGatewayConsumerGroups(
+	groups []state.AIGatewayConsumerGroup,
+) (map[string]state.AIGatewayConsumerGroup, map[string]state.AIGatewayConsumerGroup) {
+	byID := make(map[string]state.AIGatewayConsumerGroup)
+	byName := make(map[string]state.AIGatewayConsumerGroup)
+	for _, group := range groups {
+		if id := resources.AIGatewayConsumerGroupID(group.AIGatewayConsumerGroup); id != "" {
+			byID[id] = group
+		}
+		if name := resources.AIGatewayConsumerGroupName(group.AIGatewayConsumerGroup); name != "" {
+			byName[name] = group
+		}
+	}
+	return byID, byName
+}
+
+func matchCurrentAIGatewayConsumerGroup(
+	desired resources.AIGatewayConsumerGroupResource,
+	currentByID map[string]state.AIGatewayConsumerGroup,
+	currentByName map[string]state.AIGatewayConsumerGroup,
+) (state.AIGatewayConsumerGroup, bool) {
+	if id := aiGatewayConsumerGroupDesiredID(desired); id != "" {
+		current, exists := currentByID[id]
+		return current, exists
+	}
+	current, exists := currentByName[desired.Name]
+	return current, exists
+}
+
+func aiGatewayConsumerGroupDesiredID(desired resources.AIGatewayConsumerGroupResource) string {
+	if id := desired.GetKonnectID(); id != "" {
+		return id
+	}
+	if util.IsValidUUID(desired.Ref) {
+		return desired.Ref
+	}
+	return ""
+}
+
+func aiGatewayConsumerGroupPolicyCreateDependencies(
+	group resources.AIGatewayConsumerGroupResource,
+	policyCreateDepsByRefOrName map[string]string,
+) []string {
+	payload, err := group.MutablePayloadMap()
+	if err != nil {
+		return nil
+	}
+	return aiGatewayPolicyReferenceDependencies(payload, policyCreateDepsByRefOrName)
+}

--- a/internal/declarative/planner/ai_gateway_consumer_group_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_consumer_group_planner_test.go
@@ -1,0 +1,284 @@
+package planner
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/declarative/tags"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAIGatewayConsumerGroupPlannerCreatesChildForExistingGateway(t *testing.T) {
+	group := testAIGatewayConsumerGroupResource(t, nil)
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{
+			gateways: []kkComps.AIGateway{testAIGateway()},
+		},
+		AIGatewayConsumerGroupsAPI: &testAIGatewayConsumerGroupAPI{},
+	})
+	rs := testAIGatewayConsumerGroupResourceSet(group)
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	change := plan.Changes[0]
+	require.Equal(t, ActionCreate, change.Action)
+	require.Equal(t, ResourceTypeAIGatewayConsumerGroup, change.ResourceType)
+	require.Equal(t, "premium-support-users", change.ResourceRef)
+	require.NotNil(t, change.Parent)
+	require.Equal(t, "gateway-id", change.Parent.ID)
+	require.Equal(t, "support-gateway", change.Parent.Ref)
+	require.Equal(t, "Premium Support Users", change.Fields[FieldDisplayName])
+}
+
+func TestAIGatewayConsumerGroupPlannerUpdatesExistingGroup(t *testing.T) {
+	group := testAIGatewayConsumerGroupResource(t, nil)
+	group.DisplayName = "Premium Support Users Updated"
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{
+			gateways: []kkComps.AIGateway{testAIGateway()},
+		},
+		AIGatewayConsumerGroupsAPI: &testAIGatewayConsumerGroupAPI{
+			groups: []kkComps.AIGatewayConsumerGroup{
+				testAIGatewayConsumerGroup("group-id", "premium-support-users", nil),
+			},
+		},
+	})
+	rs := testAIGatewayConsumerGroupResourceSet(group)
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	change := plan.Changes[0]
+	require.Equal(t, ActionUpdate, change.Action)
+	require.Equal(t, ResourceTypeAIGatewayConsumerGroup, change.ResourceType)
+	require.Equal(t, "group-id", change.ResourceID)
+	require.Equal(t, "Premium Support Users Updated", change.Fields[FieldDisplayName])
+	require.Contains(t, change.ChangedFields, FieldDisplayName)
+}
+
+func TestAIGatewayConsumerGroupPlannerSyncDeletesScopedGroups(t *testing.T) {
+	scope := resources.NewSyncScope()
+	scope.AddRoot(resources.ResourceTypeAIGateway)
+	scope.AddChild(resources.ResourceTypeAIGateway, "support-gateway", resources.ResourceTypeAIGatewayConsumerGroup)
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{
+			gateways: []kkComps.AIGateway{testAIGateway()},
+		},
+		AIGatewayConsumerGroupsAPI: &testAIGatewayConsumerGroupAPI{
+			groups: []kkComps.AIGatewayConsumerGroup{
+				testAIGatewayConsumerGroup("group-id", "premium-support-users", nil),
+			},
+		},
+	})
+	rs := &resources.ResourceSet{
+		AIGateways: []resources.AIGatewayResource{testAIGatewayResource()},
+		SyncScope:  scope,
+	}
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeSync})
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	change := plan.Changes[0]
+	require.Equal(t, ActionDelete, change.Action)
+	require.Equal(t, ResourceTypeAIGatewayConsumerGroup, change.ResourceType)
+	require.Equal(t, "group-id", change.ResourceID)
+	require.NotNil(t, change.Parent)
+	require.Equal(t, "gateway-id", change.Parent.ID)
+}
+
+func TestAIGatewayConsumerGroupPlannerDependsOnPolicyCreate(t *testing.T) {
+	policy := testAIGatewayPolicyResource(t)
+	group := testAIGatewayConsumerGroupResource(t, []string{tags.RefPlaceholderPrefix + "mask-sensitive-data#id"})
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{},
+	})
+	rs := &resources.ResourceSet{
+		AIGateways:              []resources.AIGatewayResource{testAIGatewayResource()},
+		AIGatewayPolicies:       []resources.AIGatewayPolicyResource{policy},
+		AIGatewayConsumerGroups: []resources.AIGatewayConsumerGroupResource{group},
+	}
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+	require.NoError(t, err)
+
+	gatewayCreate := findAIGatewayModelTestChange(t, plan, ResourceTypeAIGateway, "support-gateway")
+	policyCreate := findAIGatewayModelTestChange(t, plan, ResourceTypeAIGatewayPolicy, "mask-sensitive-data")
+	groupCreate := findAIGatewayModelTestChange(t, plan, ResourceTypeAIGatewayConsumerGroup, "premium-support-users")
+
+	require.Contains(t, policyCreate.DependsOn, gatewayCreate.ID)
+	require.Contains(t, groupCreate.DependsOn, policyCreate.ID)
+	require.Equal(t, resources.UnknownReferenceID, groupCreate.References[FieldPolicies+".0"].ID)
+	require.Equal(t, tags.RefPlaceholderPrefix+"mask-sensitive-data#id", groupCreate.References[FieldPolicies+".0"].Ref)
+}
+
+func TestAIGatewayConsumerGroupPlannerResolvesExistingPolicyRef(t *testing.T) {
+	policy := testAIGatewayPolicyResource(t)
+	group := testAIGatewayConsumerGroupResource(t, []string{tags.RefPlaceholderPrefix + "mask-sensitive-data#id"})
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{
+			gateways: []kkComps.AIGateway{testAIGateway()},
+		},
+		AIGatewayPoliciesAPI: &testAIGatewayPolicyAPI{
+			policies: []kkComps.AIGatewayPolicy{testAIGatewayPolicy()},
+		},
+		AIGatewayConsumerGroupsAPI: &testAIGatewayConsumerGroupAPI{},
+	})
+	rs := &resources.ResourceSet{
+		AIGateways:              []resources.AIGatewayResource{testAIGatewayResource()},
+		AIGatewayPolicies:       []resources.AIGatewayPolicyResource{policy},
+		AIGatewayConsumerGroups: []resources.AIGatewayConsumerGroupResource{group},
+	}
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+	require.NoError(t, err)
+
+	groupCreate := findAIGatewayModelTestChange(t, plan, ResourceTypeAIGatewayConsumerGroup, "premium-support-users")
+	require.NotContains(t, groupCreate.DependsOn, "policy-id")
+	require.Equal(t, "policy-id", groupCreate.References[FieldPolicies+".0"].ID)
+}
+
+func TestAIGatewayConsumerGroupPlannerPolicyRefNoopForExistingGroup(t *testing.T) {
+	for _, currentPolicyRef := range []string{"policy-id", "mask-sensitive-data"} {
+		t.Run(currentPolicyRef, func(t *testing.T) {
+			policy := testAIGatewayPolicyResource(t)
+			group := testAIGatewayConsumerGroupResource(t, []string{tags.RefPlaceholderPrefix + "mask-sensitive-data#id"})
+			client := state.NewClient(state.ClientConfig{
+				AIGatewayAPI: &testAIGatewayAPI{
+					gateways: []kkComps.AIGateway{testAIGateway()},
+				},
+				AIGatewayPoliciesAPI: &testAIGatewayPolicyAPI{
+					policies: []kkComps.AIGatewayPolicy{testAIGatewayPolicy()},
+				},
+				AIGatewayConsumerGroupsAPI: &testAIGatewayConsumerGroupAPI{
+					groups: []kkComps.AIGatewayConsumerGroup{
+						testAIGatewayConsumerGroup("group-id", "premium-support-users", []string{currentPolicyRef}),
+					},
+				},
+			})
+			rs := &resources.ResourceSet{
+				AIGateways:              []resources.AIGatewayResource{testAIGatewayResource()},
+				AIGatewayPolicies:       []resources.AIGatewayPolicyResource{policy},
+				AIGatewayConsumerGroups: []resources.AIGatewayConsumerGroupResource{group},
+			}
+
+			plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+			require.NoError(t, err)
+			require.Empty(t, plan.Changes)
+		})
+	}
+}
+
+func testAIGatewayResource() resources.AIGatewayResource {
+	return resources.AIGatewayResource{
+		BaseResource: resources.BaseResource{
+			Ref:     "support-gateway",
+			Kongctl: &resources.KongctlMeta{Namespace: new("default")},
+		},
+		CreateAIGatewayRequest: kkComps.CreateAIGatewayRequest{
+			Name:        "support-gateway",
+			DisplayName: "Support Gateway",
+		},
+	}
+}
+
+func testAIGatewayConsumerGroupResourceSet(
+	group resources.AIGatewayConsumerGroupResource,
+) *resources.ResourceSet {
+	return &resources.ResourceSet{
+		AIGateways:              []resources.AIGatewayResource{testAIGatewayResource()},
+		AIGatewayConsumerGroups: []resources.AIGatewayConsumerGroupResource{group},
+	}
+}
+
+func testAIGatewayConsumerGroupResource(
+	t *testing.T,
+	policies []string,
+) resources.AIGatewayConsumerGroupResource {
+	t.Helper()
+	payload := map[string]any{
+		"ref":          "premium-support-users",
+		"ai_gateway":   "support-gateway",
+		"name":         "premium-support-users",
+		"display_name": "Premium Support Users",
+	}
+	if policies != nil {
+		payload[FieldPolicies] = policies
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+	var group resources.AIGatewayConsumerGroupResource
+	require.NoError(t, json.Unmarshal(data, &group))
+	return group
+}
+
+func testAIGatewayConsumerGroup(id string, name string, policies []string) kkComps.AIGatewayConsumerGroup {
+	return kkComps.AIGatewayConsumerGroup{
+		ID:          id,
+		Name:        name,
+		DisplayName: "Premium Support Users",
+		Policies:    policies,
+	}
+}
+
+type testAIGatewayConsumerGroupAPI struct {
+	groups []kkComps.AIGatewayConsumerGroup
+}
+
+func (t *testAIGatewayConsumerGroupAPI) ListAiGatewayConsumerGroups(
+	context.Context,
+	kkOps.ListAiGatewayConsumerGroupsRequest,
+	...kkOps.Option,
+) (*kkOps.ListAiGatewayConsumerGroupsResponse, error) {
+	return &kkOps.ListAiGatewayConsumerGroupsResponse{
+		ListAIGatewayConsumerGroupsResponse: &kkComps.ListAIGatewayConsumerGroupsResponse{
+			Data: t.groups,
+		},
+	}, nil
+}
+
+func (t *testAIGatewayConsumerGroupAPI) CreateAiGatewayConsumerGroup(
+	context.Context,
+	string,
+	kkComps.CreateAIGatewayConsumerGroupRequest,
+	...kkOps.Option,
+) (*kkOps.CreateAiGatewayConsumerGroupResponse, error) {
+	return nil, nil
+}
+
+func (t *testAIGatewayConsumerGroupAPI) GetAiGatewayConsumerGroup(
+	_ context.Context,
+	_ string,
+	groupID string,
+	_ ...kkOps.Option,
+) (*kkOps.GetAiGatewayConsumerGroupResponse, error) {
+	for _, group := range t.groups {
+		if group.ID == groupID || group.Name == groupID {
+			return &kkOps.GetAiGatewayConsumerGroupResponse{AIGatewayConsumerGroup: &group}, nil
+		}
+	}
+	return &kkOps.GetAiGatewayConsumerGroupResponse{}, nil
+}
+
+func (t *testAIGatewayConsumerGroupAPI) UpdateAiGatewayConsumerGroup(
+	context.Context,
+	kkOps.UpdateAiGatewayConsumerGroupRequest,
+	...kkOps.Option,
+) (*kkOps.UpdateAiGatewayConsumerGroupResponse, error) {
+	return nil, nil
+}
+
+func (t *testAIGatewayConsumerGroupAPI) DeleteAiGatewayConsumerGroup(
+	context.Context,
+	string,
+	string,
+	...kkOps.Option,
+) (*kkOps.DeleteAiGatewayConsumerGroupResponse, error) {
+	return nil, nil
+}

--- a/internal/declarative/planner/ai_gateway_mcp_server_planner.go
+++ b/internal/declarative/planner/ai_gateway_mcp_server_planner.go
@@ -76,7 +76,7 @@ func (p *Planner) planAIGatewayMCPServerChanges(
 			continue
 		}
 
-		needsUpdate, updateFields, changedFields, err := shouldUpdateAIGatewayMCPServer(*fullServer, desiredServer)
+		needsUpdate, updateFields, changedFields, err := p.shouldUpdateAIGatewayMCPServer(*fullServer, desiredServer)
 		if err != nil {
 			return err
 		}
@@ -218,7 +218,7 @@ func (p *Planner) planAIGatewayMCPServerDelete(
 	plan.AddChange(change)
 }
 
-func shouldUpdateAIGatewayMCPServer(
+func (p *Planner) shouldUpdateAIGatewayMCPServer(
 	current state.AIGatewayMCPServer,
 	desired resources.AIGatewayMCPServerResource,
 ) (bool, map[string]any, map[string]FieldChange, error) {
@@ -231,16 +231,22 @@ func shouldUpdateAIGatewayMCPServer(
 		return false, nil, nil, fmt.Errorf("failed to normalize desired AI Gateway MCP Server %q: %w", desired.Ref, err)
 	}
 
+	currentCompare, desiredCompare := normalizeAIGatewayPolicyReferencesForComparison(
+		currentPayload,
+		desiredPayload,
+		p.resources,
+	)
+
 	changedFields := make(map[string]FieldChange)
-	keys := make(map[string]struct{}, len(currentPayload)+len(desiredPayload))
-	for key := range currentPayload {
+	keys := make(map[string]struct{}, len(currentCompare)+len(desiredCompare))
+	for key := range currentCompare {
 		keys[key] = struct{}{}
 	}
-	for key := range desiredPayload {
+	for key := range desiredCompare {
 		keys[key] = struct{}{}
 	}
 	for key := range keys {
-		if !reflect.DeepEqual(currentPayload[key], desiredPayload[key]) {
+		if !reflect.DeepEqual(currentCompare[key], desiredCompare[key]) {
 			changedFields[key] = FieldChange{Old: currentPayload[key], New: desiredPayload[key]}
 		}
 	}

--- a/internal/declarative/planner/ai_gateway_model_planner.go
+++ b/internal/declarative/planner/ai_gateway_model_planner.go
@@ -86,7 +86,7 @@ func (p *Planner) planAIGatewayModelChanges(
 			continue
 		}
 
-		needsUpdate, updateFields, changedFields, err := shouldUpdateAIGatewayModel(*fullModel, desiredModel)
+		needsUpdate, updateFields, changedFields, err := p.shouldUpdateAIGatewayModel(*fullModel, desiredModel)
 		if err != nil {
 			return err
 		}
@@ -233,7 +233,7 @@ func (p *Planner) planAIGatewayModelDelete(
 	plan.AddChange(change)
 }
 
-func shouldUpdateAIGatewayModel(
+func (p *Planner) shouldUpdateAIGatewayModel(
 	current state.AIGatewayModel,
 	desired resources.AIGatewayModelResource,
 ) (bool, map[string]any, map[string]FieldChange, error) {
@@ -246,16 +246,22 @@ func shouldUpdateAIGatewayModel(
 		return false, nil, nil, fmt.Errorf("failed to normalize desired AI Gateway model %q: %w", desired.Ref, err)
 	}
 
+	currentCompare, desiredCompare := normalizeAIGatewayPolicyReferencesForComparison(
+		currentPayload,
+		desiredPayload,
+		p.resources,
+	)
+
 	changedFields := make(map[string]FieldChange)
-	keys := make(map[string]struct{}, len(currentPayload)+len(desiredPayload))
-	for key := range currentPayload {
+	keys := make(map[string]struct{}, len(currentCompare)+len(desiredCompare))
+	for key := range currentCompare {
 		keys[key] = struct{}{}
 	}
-	for key := range desiredPayload {
+	for key := range desiredCompare {
 		keys[key] = struct{}{}
 	}
 	for key := range keys {
-		if !reflect.DeepEqual(currentPayload[key], desiredPayload[key]) {
+		if !reflect.DeepEqual(currentCompare[key], desiredCompare[key]) {
 			changedFields[key] = FieldChange{Old: currentPayload[key], New: desiredPayload[key]}
 		}
 	}

--- a/internal/declarative/planner/ai_gateway_planner.go
+++ b/internal/declarative/planner/ai_gateway_planner.go
@@ -213,6 +213,28 @@ func (p *Planner) planAIGatewayChanges(
 		}
 		policyCreateDepsByName := aiGatewayPolicyCreateDependencies(plan, namespace, desiredGateway.Ref)
 
+		consumerGroups := p.resources.GetAIGatewayConsumerGroupsForGateway(desiredGateway.Ref)
+		if p.shouldPlanChild(
+			plan,
+			resources.ResourceTypeAIGateway,
+			desiredGateway.Ref,
+			resources.ResourceTypeAIGatewayConsumerGroup,
+		) && (len(consumerGroups) > 0 || plan.Metadata.Mode == PlanModeSync) {
+			if err := p.planAIGatewayConsumerGroupChanges(
+				ctx,
+				namespace,
+				desiredGateway.Ref,
+				desiredGateway.DisplayName,
+				gatewayID,
+				gatewayChangeID,
+				policyCreateDepsByName,
+				consumerGroups,
+				plan,
+			); err != nil {
+				return err
+			}
+		}
+
 		models := p.resources.GetAIGatewayModelsForGateway(desiredGateway.Ref)
 		if p.shouldPlanChild(
 			plan,
@@ -354,6 +376,28 @@ func (p *Planner) planExternalAIGatewayChildren(
 		}
 	}
 	policyCreateDepsByName := aiGatewayPolicyCreateDependencies(plan, namespace, desiredGateway.Ref)
+
+	consumerGroups := p.resources.GetAIGatewayConsumerGroupsForGateway(desiredGateway.Ref)
+	if p.shouldPlanChild(
+		plan,
+		resources.ResourceTypeAIGateway,
+		desiredGateway.Ref,
+		resources.ResourceTypeAIGatewayConsumerGroup,
+	) && len(consumerGroups) > 0 {
+		if err := p.planAIGatewayConsumerGroupChanges(
+			ctx,
+			namespace,
+			desiredGateway.Ref,
+			desiredGateway.DisplayName,
+			gatewayID,
+			"",
+			policyCreateDepsByName,
+			consumerGroups,
+			plan,
+		); err != nil {
+			return err
+		}
+	}
 
 	models := p.resources.GetAIGatewayModelsForGateway(desiredGateway.Ref)
 	if p.shouldPlanChild(

--- a/internal/declarative/planner/ai_gateway_policy_planner.go
+++ b/internal/declarative/planner/ai_gateway_policy_planner.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kong/kongctl/internal/declarative/resources"
 	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/declarative/tags"
 	"github.com/kong/kongctl/internal/util"
 )
 
@@ -56,6 +57,9 @@ func (p *Planner) planAIGatewayPolicyChanges(
 		}
 
 		policyID := resources.AIGatewayPolicyID(current.AIGatewayPolicy)
+		if policy := p.resources.GetAIGatewayPolicyByRef(desiredPolicy.Ref); policy != nil {
+			policy.SetKonnectID(policyID)
+		}
 		fullPolicy, err := p.client.GetAIGatewayPolicy(ctx, gatewayID, policyID)
 		if err != nil {
 			return fmt.Errorf("failed to get AI Gateway Policy %s: %w", policyID, err)
@@ -278,7 +282,7 @@ func aiGatewayPolicyCreateDependencies(plan *Plan, namespace string, gatewayRef 
 		return nil
 	}
 
-	depsByName := make(map[string]string)
+	depsByRefOrName := make(map[string]string)
 	for _, change := range plan.Changes {
 		if change.Action != ActionCreate ||
 			change.ResourceType != ResourceTypeAIGatewayPolicy ||
@@ -287,33 +291,42 @@ func aiGatewayPolicyCreateDependencies(plan *Plan, namespace string, gatewayRef 
 			continue
 		}
 
+		if change.ResourceRef != "" {
+			depsByRefOrName[change.ResourceRef] = change.ID
+		}
 		name, ok := change.Fields[FieldName].(string)
 		if ok && name != "" {
-			depsByName[name] = change.ID
+			depsByRefOrName[name] = change.ID
 		}
 	}
-	if len(depsByName) == 0 {
+	if len(depsByRefOrName) == 0 {
 		return nil
 	}
-	return depsByName
+	return depsByRefOrName
 }
 
-func aiGatewayPolicyReferenceDependencies(payload map[string]any, policyCreateDepsByName map[string]string) []string {
-	if len(policyCreateDepsByName) == 0 {
+func aiGatewayPolicyReferenceDependencies(
+	payload map[string]any,
+	policyCreateDepsByRefOrName map[string]string,
+) []string {
+	if len(policyCreateDepsByRefOrName) == 0 {
 		return nil
 	}
-	rawPolicies, ok := payload["policies"].([]any)
+	rawPolicies, ok := payload[FieldPolicies].([]any)
 	if !ok {
 		return nil
 	}
 
 	var deps []string
 	for _, rawPolicy := range rawPolicies {
-		policyName, ok := rawPolicy.(string)
-		if !ok || policyName == "" {
+		policyRefOrName, ok := rawPolicy.(string)
+		if !ok || policyRefOrName == "" {
 			continue
 		}
-		if dep := policyCreateDepsByName[policyName]; dep != "" {
+		if parsedRef, _, ok := tags.ParseRefPlaceholder(policyRefOrName); ok {
+			policyRefOrName = parsedRef
+		}
+		if dep := policyCreateDepsByRefOrName[policyRefOrName]; dep != "" {
 			deps = appendDependsOn(deps, dep)
 		}
 	}

--- a/internal/declarative/planner/ai_gateway_policy_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_policy_planner_test.go
@@ -52,7 +52,7 @@ func TestAIGatewayPolicyPlannerCreatesChildForExistingGateway(t *testing.T) {
 func TestAIGatewayPolicyPlannerUpdatesExistingPolicy(t *testing.T) {
 	policy := testAIGatewayPolicyResource(t)
 	policy.DisplayName = "Mask Sensitive Data Updated"
-	current := testAIGatewayPolicy("policy-id", "mask-sensitive-data")
+	current := testAIGatewayPolicy()
 	client := state.NewClient(state.ClientConfig{
 		AIGatewayAPI: &testAIGatewayAPI{
 			gateways: []kkComps.AIGateway{testAIGateway()},
@@ -95,7 +95,7 @@ func TestAIGatewayPolicyPlannerSyncDeletesScopedPolicies(t *testing.T) {
 			gateways: []kkComps.AIGateway{testAIGateway()},
 		},
 		AIGatewayPoliciesAPI: &testAIGatewayPolicyAPI{
-			policies: []kkComps.AIGatewayPolicy{testAIGatewayPolicy("policy-id", "mask-sensitive-data")},
+			policies: []kkComps.AIGatewayPolicy{testAIGatewayPolicy()},
 		},
 	})
 	rs := &resources.ResourceSet{
@@ -197,12 +197,12 @@ func testAIGatewayModelResourceWithPolicy(t *testing.T, policyName string) resou
 	return model
 }
 
-func testAIGatewayPolicy(id string, name string) kkComps.AIGatewayPolicy {
+func testAIGatewayPolicy() kkComps.AIGatewayPolicy {
 	enabled := true
 	global := false
 	return kkComps.AIGatewayPolicy{
-		ID:          id,
-		Name:        name,
+		ID:          "policy-id",
+		Name:        "mask-sensitive-data",
 		Type:        "ai-sanitizer",
 		DisplayName: "Mask Sensitive Data",
 		Enabled:     &enabled,

--- a/internal/declarative/planner/ai_gateway_policy_reference_compare.go
+++ b/internal/declarative/planner/ai_gateway_policy_reference_compare.go
@@ -1,0 +1,99 @@
+package planner
+
+import (
+	"maps"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/tags"
+)
+
+func normalizeAIGatewayPolicyReferencesForComparison(
+	currentPayload map[string]any,
+	desiredPayload map[string]any,
+	rs *resources.ResourceSet,
+) (map[string]any, map[string]any) {
+	currentCompare := clonePayloadMap(currentPayload)
+	desiredCompare := clonePayloadMap(desiredPayload)
+
+	_, currentHasPolicies := currentCompare[FieldPolicies]
+	_, desiredHasPolicies := desiredCompare[FieldPolicies]
+	if !currentHasPolicies || !desiredHasPolicies {
+		return currentCompare, desiredCompare
+	}
+
+	aliases := aiGatewayPolicyReferenceAliases(rs)
+	currentCompare[FieldPolicies] = normalizeAIGatewayPolicyReferenceList(currentCompare[FieldPolicies], aliases)
+	desiredCompare[FieldPolicies] = normalizeAIGatewayPolicyReferenceList(desiredCompare[FieldPolicies], aliases)
+	return currentCompare, desiredCompare
+}
+
+func clonePayloadMap(payload map[string]any) map[string]any {
+	if payload == nil {
+		return nil
+	}
+	clone := make(map[string]any, len(payload))
+	maps.Copy(clone, payload)
+	return clone
+}
+
+func aiGatewayPolicyReferenceAliases(rs *resources.ResourceSet) map[string]string {
+	aliases := make(map[string]string)
+	if rs == nil {
+		return aliases
+	}
+
+	for _, policy := range rs.AIGatewayPolicies {
+		canonical := firstNonEmpty(policy.Ref, policy.Name, policy.GetKonnectID())
+		if canonical == "" {
+			continue
+		}
+		for _, alias := range []string{policy.Ref, policy.Name, policy.GetKonnectID()} {
+			if alias != "" {
+				aliases[alias] = canonical
+			}
+		}
+	}
+	return aliases
+}
+
+func normalizeAIGatewayPolicyReferenceList(raw any, aliases map[string]string) any {
+	switch policies := raw.(type) {
+	case []any:
+		normalized := make([]any, len(policies))
+		for i, policy := range policies {
+			if policyRef, ok := policy.(string); ok {
+				normalized[i] = canonicalAIGatewayPolicyReference(policyRef, aliases)
+				continue
+			}
+			normalized[i] = policy
+		}
+		return normalized
+	case []string:
+		normalized := make([]any, len(policies))
+		for i, policyRef := range policies {
+			normalized[i] = canonicalAIGatewayPolicyReference(policyRef, aliases)
+		}
+		return normalized
+	default:
+		return raw
+	}
+}
+
+func canonicalAIGatewayPolicyReference(policyRef string, aliases map[string]string) string {
+	if parsedRef, _, ok := tags.ParseRefPlaceholder(policyRef); ok {
+		policyRef = parsedRef
+	}
+	if canonical := aliases[policyRef]; canonical != "" {
+		return canonical
+	}
+	return policyRef
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/declarative/planner/constants.go
+++ b/internal/declarative/planner/constants.go
@@ -206,6 +206,7 @@ const (
 	ResourceTypeAIGateway                        = string(resources.ResourceTypeAIGateway)
 	ResourceTypeAIGatewayProvider                = string(resources.ResourceTypeAIGatewayProvider)
 	ResourceTypeAIGatewayPolicy                  = string(resources.ResourceTypeAIGatewayPolicy)
+	ResourceTypeAIGatewayConsumerGroup           = string(resources.ResourceTypeAIGatewayConsumerGroup)
 	ResourceTypeAIGatewayModel                   = string(resources.ResourceTypeAIGatewayModel)
 	ResourceTypeAIGatewayMCPServer               = string(resources.ResourceTypeAIGatewayMCPServer)
 	ResourceTypeAIGatewayVault                   = string(resources.ResourceTypeAIGatewayVault)

--- a/internal/declarative/planner/dependencies.go
+++ b/internal/declarative/planner/dependencies.go
@@ -235,6 +235,7 @@ func aiGatewayChildSerializationParentKey(change PlannedChange) string {
 	switch change.ResourceType {
 	case ResourceTypeAIGatewayProvider,
 		ResourceTypeAIGatewayPolicy,
+		ResourceTypeAIGatewayConsumerGroup,
 		ResourceTypeAIGatewayModel,
 		ResourceTypeAIGatewayMCPServer,
 		ResourceTypeAIGatewayVault:
@@ -343,6 +344,7 @@ func (d *DependencyResolver) getParentType(childType string) string {
 		return ResourceTypePortal
 	case ResourceTypeAIGatewayProvider,
 		ResourceTypeAIGatewayPolicy,
+		ResourceTypeAIGatewayConsumerGroup,
 		ResourceTypeAIGatewayModel,
 		ResourceTypeAIGatewayMCPServer,
 		ResourceTypeAIGatewayVault:

--- a/internal/declarative/planner/resolver.go
+++ b/internal/declarative/planner/resolver.go
@@ -230,7 +230,19 @@ func (r *ReferenceResolver) getResourceTypeForChangeField(change PlannedChange, 
 			return string(resourceType)
 		}
 	}
+	if aiGatewayPolicyReferenceField(change.ResourceType, fieldName) {
+		return ResourceTypeAIGatewayPolicy
+	}
 	return r.getResourceTypeForField(fieldName)
+}
+
+func aiGatewayPolicyReferenceField(resourceType, fieldName string) bool {
+	switch resourceType {
+	case ResourceTypeAIGatewayConsumerGroup, ResourceTypeAIGatewayModel, ResourceTypeAIGatewayMCPServer:
+	default:
+		return false
+	}
+	return fieldName == FieldPolicies || strings.HasPrefix(fieldName, FieldPolicies+".")
 }
 
 func referenceTargetRef(ref string) string {

--- a/internal/declarative/planner/sync_scope.go
+++ b/internal/declarative/planner/sync_scope.go
@@ -162,6 +162,13 @@ func addAIGatewayChildScopes(scope *resources.SyncScope, rs *resources.ResourceS
 			resources.ResourceTypeAIGatewayPolicy,
 		)
 	}
+	for _, child := range rs.AIGatewayConsumerGroups {
+		scope.AddChild(
+			resources.ResourceTypeAIGateway,
+			resources.NormalizeResourceRef(child.AIGateway),
+			resources.ResourceTypeAIGatewayConsumerGroup,
+		)
+	}
 	for _, child := range rs.AIGatewayModels {
 		scope.AddChild(
 			resources.ResourceTypeAIGateway,

--- a/internal/declarative/protection/lookup.go
+++ b/internal/declarative/protection/lookup.go
@@ -156,6 +156,7 @@ func IsManagedResourceProtected(
 		resources.ResourceTypeEventGatewayTLSTrustBundle,
 		resources.ResourceTypeAIGatewayProvider,
 		resources.ResourceTypeAIGatewayPolicy,
+		resources.ResourceTypeAIGatewayConsumerGroup,
 		resources.ResourceTypeAIGatewayModel,
 		resources.ResourceTypeAIGatewayMCPServer,
 		resources.ResourceTypeAIGatewayVault:

--- a/internal/declarative/resources/ai_gateway.go
+++ b/internal/declarative/resources/ai_gateway.go
@@ -23,12 +23,13 @@ func init() {
 type AIGatewayResource struct {
 	BaseResource `yaml:",inline" json:",inline"`
 	kkComps.CreateAIGatewayRequest
-	External   *ExternalBlock               `yaml:"_external,omitempty" json:"_external,omitempty"`
-	Providers  []AIGatewayProviderResource  `yaml:"providers,omitempty" json:"providers,omitempty"`
-	Policies   []AIGatewayPolicyResource    `yaml:"policies,omitempty" json:"policies,omitempty"`
-	Models     []AIGatewayModelResource     `yaml:"models,omitempty"    json:"models,omitempty"`
-	MCPServers []AIGatewayMCPServerResource `yaml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
-	Vaults     []AIGatewayVaultResource     `yaml:"vaults,omitempty" json:"vaults,omitempty"`
+	External       *ExternalBlock                   `yaml:"_external,omitempty" json:"_external,omitempty"`
+	Providers      []AIGatewayProviderResource      `yaml:"providers,omitempty" json:"providers,omitempty"`
+	Policies       []AIGatewayPolicyResource        `yaml:"policies,omitempty" json:"policies,omitempty"`
+	ConsumerGroups []AIGatewayConsumerGroupResource `yaml:"consumer_groups,omitempty" json:"consumer_groups,omitempty"`
+	Models         []AIGatewayModelResource         `yaml:"models,omitempty"    json:"models,omitempty"`
+	MCPServers     []AIGatewayMCPServerResource     `yaml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
+	Vaults         []AIGatewayVaultResource         `yaml:"vaults,omitempty" json:"vaults,omitempty"`
 }
 
 func (a AIGatewayResource) MarshalJSON() ([]byte, error) {
@@ -41,34 +42,36 @@ func (a AIGatewayResource) MarshalYAML() (any, error) {
 }
 
 type aiGatewayAlias struct {
-	Ref         string                       `json:"ref"                   yaml:"ref"`
-	Kongctl     *KongctlMeta                 `json:"kongctl,omitempty"     yaml:"kongctl,omitempty"`
-	External    *ExternalBlock               `json:"_external,omitempty"   yaml:"_external,omitempty"`
-	DisplayName string                       `json:"display_name"          yaml:"display_name"`
-	Description *string                      `json:"description,omitempty" yaml:"description,omitempty"`
-	ProxyURLs   []kkComps.AIGatewayProxyURL  `json:"proxy_urls,omitempty"  yaml:"proxy_urls,omitempty"`
-	Labels      map[string]string            `json:"labels,omitempty"      yaml:"labels,omitempty"`
-	Providers   []AIGatewayProviderResource  `json:"providers,omitempty"   yaml:"providers,omitempty"`
-	Policies    []AIGatewayPolicyResource    `json:"policies,omitempty"    yaml:"policies,omitempty"`
-	Models      []AIGatewayModelResource     `json:"models,omitempty"      yaml:"models,omitempty"`
-	MCPServers  []AIGatewayMCPServerResource `json:"mcp_servers,omitempty" yaml:"mcp_servers,omitempty"`
-	Vaults      []AIGatewayVaultResource     `json:"vaults,omitempty"      yaml:"vaults,omitempty"`
+	Ref            string                           `json:"ref"                   yaml:"ref"`
+	Kongctl        *KongctlMeta                     `json:"kongctl,omitempty"     yaml:"kongctl,omitempty"`
+	External       *ExternalBlock                   `json:"_external,omitempty"   yaml:"_external,omitempty"`
+	DisplayName    string                           `json:"display_name"          yaml:"display_name"`
+	Description    *string                          `json:"description,omitempty" yaml:"description,omitempty"`
+	ProxyURLs      []kkComps.AIGatewayProxyURL      `json:"proxy_urls,omitempty"  yaml:"proxy_urls,omitempty"`
+	Labels         map[string]string                `json:"labels,omitempty"      yaml:"labels,omitempty"`
+	Providers      []AIGatewayProviderResource      `json:"providers,omitempty"   yaml:"providers,omitempty"`
+	Policies       []AIGatewayPolicyResource        `json:"policies,omitempty"    yaml:"policies,omitempty"`
+	ConsumerGroups []AIGatewayConsumerGroupResource `json:"consumer_groups,omitempty" yaml:"consumer_groups,omitempty"`
+	Models         []AIGatewayModelResource         `json:"models,omitempty"      yaml:"models,omitempty"`
+	MCPServers     []AIGatewayMCPServerResource     `json:"mcp_servers,omitempty" yaml:"mcp_servers,omitempty"`
+	Vaults         []AIGatewayVaultResource         `json:"vaults,omitempty"      yaml:"vaults,omitempty"`
 }
 
 func (a AIGatewayResource) aiGatewayAlias() aiGatewayAlias {
 	return aiGatewayAlias{
-		Ref:         a.Ref,
-		Kongctl:     a.Kongctl,
-		External:    a.External,
-		DisplayName: a.DisplayName,
-		Description: a.Description,
-		ProxyURLs:   a.ProxyUrls,
-		Labels:      a.Labels,
-		Providers:   a.Providers,
-		Policies:    a.Policies,
-		Models:      a.Models,
-		MCPServers:  a.MCPServers,
-		Vaults:      a.Vaults,
+		Ref:            a.Ref,
+		Kongctl:        a.Kongctl,
+		External:       a.External,
+		DisplayName:    a.DisplayName,
+		Description:    a.Description,
+		ProxyURLs:      a.ProxyUrls,
+		Labels:         a.Labels,
+		Providers:      a.Providers,
+		Policies:       a.Policies,
+		ConsumerGroups: a.ConsumerGroups,
+		Models:         a.Models,
+		MCPServers:     a.MCPServers,
+		Vaults:         a.Vaults,
 	}
 }
 
@@ -76,18 +79,19 @@ func (a AIGatewayResource) aiGatewayAlias() aiGatewayAlias {
 // type only carries JSON tags.
 func (a *AIGatewayResource) UnmarshalYAML(unmarshal func(any) error) error {
 	var raw struct {
-		Ref         string                       `yaml:"ref"`
-		Kongctl     *KongctlMeta                 `yaml:"kongctl,omitempty"`
-		External    *ExternalBlock               `yaml:"_external,omitempty"`
-		DisplayName string                       `yaml:"display_name"`
-		Description *string                      `yaml:"description,omitempty"`
-		ProxyURLs   []kkComps.AIGatewayProxyURL  `yaml:"proxy_urls,omitempty"`
-		Labels      map[string]string            `yaml:"labels,omitempty"`
-		Providers   []AIGatewayProviderResource  `yaml:"providers,omitempty"`
-		Policies    []AIGatewayPolicyResource    `yaml:"policies,omitempty"`
-		Models      []AIGatewayModelResource     `yaml:"models,omitempty"`
-		MCPServers  []AIGatewayMCPServerResource `yaml:"mcp_servers,omitempty"`
-		Vaults      []AIGatewayVaultResource     `yaml:"vaults,omitempty"`
+		Ref            string                           `yaml:"ref"`
+		Kongctl        *KongctlMeta                     `yaml:"kongctl,omitempty"`
+		External       *ExternalBlock                   `yaml:"_external,omitempty"`
+		DisplayName    string                           `yaml:"display_name"`
+		Description    *string                          `yaml:"description,omitempty"`
+		ProxyURLs      []kkComps.AIGatewayProxyURL      `yaml:"proxy_urls,omitempty"`
+		Labels         map[string]string                `yaml:"labels,omitempty"`
+		Providers      []AIGatewayProviderResource      `yaml:"providers,omitempty"`
+		Policies       []AIGatewayPolicyResource        `yaml:"policies,omitempty"`
+		ConsumerGroups []AIGatewayConsumerGroupResource `yaml:"consumer_groups,omitempty"`
+		Models         []AIGatewayModelResource         `yaml:"models,omitempty"`
+		MCPServers     []AIGatewayMCPServerResource     `yaml:"mcp_servers,omitempty"`
+		Vaults         []AIGatewayVaultResource         `yaml:"vaults,omitempty"`
 	}
 	if err := unmarshal(&raw); err != nil {
 		return err
@@ -106,6 +110,7 @@ func (a *AIGatewayResource) UnmarshalYAML(unmarshal func(any) error) error {
 	}
 	a.Providers = raw.Providers
 	a.Policies = raw.Policies
+	a.ConsumerGroups = raw.ConsumerGroups
 	a.Models = raw.Models
 	a.MCPServers = raw.MCPServers
 	a.Vaults = raw.Vaults
@@ -117,18 +122,19 @@ func (a *AIGatewayResource) UnmarshalYAML(unmarshal func(any) error) error {
 // through JSON tags and the embedded SDK request type has a custom unmarshaler.
 func (a *AIGatewayResource) UnmarshalJSON(data []byte) error {
 	var raw struct {
-		Ref         string                       `json:"ref"`
-		Kongctl     *KongctlMeta                 `json:"kongctl,omitempty"`
-		External    *ExternalBlock               `json:"_external,omitempty"`
-		DisplayName string                       `json:"display_name"`
-		Description *string                      `json:"description,omitempty"`
-		ProxyURLs   []kkComps.AIGatewayProxyURL  `json:"proxy_urls,omitempty"`
-		Labels      map[string]string            `json:"labels,omitempty"`
-		Providers   []AIGatewayProviderResource  `json:"providers,omitempty"`
-		Policies    []AIGatewayPolicyResource    `json:"policies,omitempty"`
-		Models      []AIGatewayModelResource     `json:"models,omitempty"`
-		MCPServers  []AIGatewayMCPServerResource `json:"mcp_servers,omitempty"`
-		Vaults      []AIGatewayVaultResource     `json:"vaults,omitempty"`
+		Ref            string                           `json:"ref"`
+		Kongctl        *KongctlMeta                     `json:"kongctl,omitempty"`
+		External       *ExternalBlock                   `json:"_external,omitempty"`
+		DisplayName    string                           `json:"display_name"`
+		Description    *string                          `json:"description,omitempty"`
+		ProxyURLs      []kkComps.AIGatewayProxyURL      `json:"proxy_urls,omitempty"`
+		Labels         map[string]string                `json:"labels,omitempty"`
+		Providers      []AIGatewayProviderResource      `json:"providers,omitempty"`
+		Policies       []AIGatewayPolicyResource        `json:"policies,omitempty"`
+		ConsumerGroups []AIGatewayConsumerGroupResource `json:"consumer_groups,omitempty"`
+		Models         []AIGatewayModelResource         `json:"models,omitempty"`
+		MCPServers     []AIGatewayMCPServerResource     `json:"mcp_servers,omitempty"`
+		Vaults         []AIGatewayVaultResource         `json:"vaults,omitempty"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
@@ -147,6 +153,7 @@ func (a *AIGatewayResource) UnmarshalJSON(data []byte) error {
 	}
 	a.Providers = raw.Providers
 	a.Policies = raw.Policies
+	a.ConsumerGroups = raw.ConsumerGroups
 	a.Models = raw.Models
 	a.MCPServers = raw.MCPServers
 	a.Vaults = raw.Vaults
@@ -209,6 +216,9 @@ func (a *AIGatewayResource) SetDefaults() {
 	for i := range a.Policies {
 		a.Policies[i].SetDefaults()
 	}
+	for i := range a.ConsumerGroups {
+		a.ConsumerGroups[i].SetDefaults()
+	}
 	for i := range a.Models {
 		a.Models[i].SetDefaults()
 	}
@@ -260,6 +270,7 @@ func aiGatewayExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
 		}, false, false),
 		explainField("providers", explainArrayOf(aiGatewayProviderInlineExplainNode()), false, false),
 		explainField("policies", explainArrayOf(aiGatewayPolicyInlineExplainNode()), false, false),
+		explainField("consumer_groups", explainArrayOf(aiGatewayConsumerGroupInlineExplainNode()), false, false),
 		explainField("models", explainArrayOf(&ExplainNode{Kind: explainKindObject}), false, false),
 		explainField("mcp_servers", explainArrayOf(aiGatewayMCPServerInlineExplainNode()), false, false),
 		explainField("vaults", explainArrayOf(aiGatewayVaultInlineExplainNode()), false, false),
@@ -276,6 +287,14 @@ func aiGatewayProviderInlineExplainNode() *ExplainNode {
 
 func aiGatewayPolicyInlineExplainNode() *ExplainNode {
 	node, err := aiGatewayPolicyExplainNode(ExplainBuildContext{})
+	if err != nil {
+		return explainObject()
+	}
+	return node
+}
+
+func aiGatewayConsumerGroupInlineExplainNode() *ExplainNode {
+	node, err := aiGatewayConsumerGroupExplainNode(ExplainBuildContext{})
 	if err != nil {
 		return explainObject()
 	}

--- a/internal/declarative/resources/ai_gateway_consumer_group.go
+++ b/internal/declarative/resources/ai_gateway_consumer_group.go
@@ -1,0 +1,343 @@
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/util"
+)
+
+const (
+	aiGatewayConsumerGroupFieldID          = "id"
+	aiGatewayConsumerGroupFieldName        = "name"
+	aiGatewayConsumerGroupFieldDisplayName = "display_name"
+	aiGatewayConsumerGroupFieldPolicies    = "policies"
+	aiGatewayConsumerGroupFieldLabels      = "labels"
+	aiGatewayConsumerGroupFieldUpdatedAt   = "updated_at"
+)
+
+func init() {
+	registerResourceType(
+		ResourceTypeAIGatewayConsumerGroup,
+		func(rs *ResourceSet) *[]AIGatewayConsumerGroupResource { return &rs.AIGatewayConsumerGroups },
+		AutoExplain[AIGatewayConsumerGroupResource](
+			WithExplainAliases(
+				"ai_gateway_consumer_groups",
+				"ai-gateway-consumer-group",
+				"ai-gateway-consumer-groups",
+				"ai_gateway.consumer_groups",
+				"aigw-consumer-group",
+			),
+			WithExplainRecommendedFields(
+				"ref",
+				SchemaFieldAIGateway,
+				"name",
+				"display_name",
+				aiGatewayConsumerGroupFieldPolicies,
+			),
+			WithExplainSchemaBuilder(aiGatewayConsumerGroupExplainNode),
+		),
+	)
+}
+
+// AIGatewayConsumerGroupResource represents a Consumer Group nested under a Konnect AI Gateway.
+type AIGatewayConsumerGroupResource struct {
+	BaseResource `yaml:",inline" json:",inline"`
+	// Parent AI Gateway reference for root-level declarations.
+	AIGateway string `yaml:"ai_gateway,omitempty" json:"ai_gateway,omitempty"`
+
+	kkComps.CreateAIGatewayConsumerGroupRequest `yaml:",inline" json:",inline"`
+}
+
+func (a AIGatewayConsumerGroupResource) GetType() ResourceType {
+	return ResourceTypeAIGatewayConsumerGroup
+}
+
+func (a AIGatewayConsumerGroupResource) GetMoniker() string {
+	return a.Name
+}
+
+func (a AIGatewayConsumerGroupResource) GetDependencies() []ResourceRef {
+	if a.AIGateway == "" {
+		return nil
+	}
+	return []ResourceRef{{Kind: ResourceTypeAIGateway, Ref: NormalizeResourceRef(a.AIGateway)}}
+}
+
+func (a AIGatewayConsumerGroupResource) GetParentRef() *ResourceRef {
+	if a.AIGateway == "" {
+		return nil
+	}
+	return &ResourceRef{Kind: ResourceTypeAIGateway, Ref: NormalizeResourceRef(a.AIGateway)}
+}
+
+func (a AIGatewayConsumerGroupResource) Validate() error {
+	if err := ValidateRef(a.Ref); err != nil {
+		return fmt.Errorf("invalid AI Gateway Consumer Group ref: %w", err)
+	}
+	if a.Kongctl != nil {
+		return fmt.Errorf("kongctl metadata not supported on AI Gateway Consumer Group %s", a.Ref)
+	}
+	if a.AIGateway == "" {
+		return fmt.Errorf("ai_gateway is required for AI Gateway Consumer Group %s", a.Ref)
+	}
+	if a.Name == "" {
+		return fmt.Errorf("name is required for AI Gateway Consumer Group %s", a.Ref)
+	}
+	if a.DisplayName == "" {
+		return fmt.Errorf("display_name is required for AI Gateway Consumer Group %s", a.Ref)
+	}
+	return nil
+}
+
+func (a *AIGatewayConsumerGroupResource) SetDefaults() {
+	if a == nil {
+		return
+	}
+	if a.Ref == "" {
+		a.Ref = a.Name
+	}
+	if a.Name == "" {
+		a.Name = a.Ref
+	}
+	if a.DisplayName == "" {
+		a.DisplayName = a.Name
+	}
+}
+
+func (a AIGatewayConsumerGroupResource) GetKonnectMonikerFilter() string {
+	return a.Name
+}
+
+func (a *AIGatewayConsumerGroupResource) TryMatchKonnectResource(konnectResource any) bool {
+	name := a.Name
+	if name == "" {
+		return false
+	}
+	if id := AIGatewayConsumerGroupID(konnectResource); id != "" && (util.IsValidUUID(a.Ref) || a.GetKonnectID() != "") {
+		if a.Ref == id || a.GetKonnectID() == id {
+			a.SetKonnectID(id)
+			return true
+		}
+	}
+	if id := AIGatewayConsumerGroupID(konnectResource); id != "" && AIGatewayConsumerGroupName(konnectResource) == name {
+		a.SetKonnectID(id)
+		return true
+	}
+	return false
+}
+
+func (a AIGatewayConsumerGroupResource) CreateRequest() kkComps.CreateAIGatewayConsumerGroupRequest {
+	return a.CreateAIGatewayConsumerGroupRequest
+}
+
+func (a AIGatewayConsumerGroupResource) UpdateRequest() kkComps.UpdateAIGatewayConsumerGroupRequest {
+	payload, err := a.PayloadMap()
+	if err != nil || len(payload) == 0 {
+		return kkComps.UpdateAIGatewayConsumerGroupRequest{}
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return kkComps.UpdateAIGatewayConsumerGroupRequest{}
+	}
+	var req kkComps.UpdateAIGatewayConsumerGroupRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return kkComps.UpdateAIGatewayConsumerGroupRequest{}
+	}
+	return req
+}
+
+func (a AIGatewayConsumerGroupResource) PayloadMap() (map[string]any, error) {
+	return marshalObjectToMap(a.CreateRequest(), "AI Gateway Consumer Group payload")
+}
+
+func (a AIGatewayConsumerGroupResource) MutablePayloadMap() (map[string]any, error) {
+	payload, err := a.PayloadMap()
+	if err != nil {
+		return nil, err
+	}
+	stripAIGatewayConsumerGroupServerFields(payload)
+	return payload, nil
+}
+
+func (a AIGatewayConsumerGroupResource) MarshalJSON() ([]byte, error) {
+	payload, err := a.PayloadMap()
+	if err != nil {
+		return nil, err
+	}
+	payload[SchemaFieldRef] = a.Ref
+	if a.AIGateway != "" {
+		payload[SchemaFieldAIGateway] = a.AIGateway
+	}
+	return json.Marshal(payload)
+}
+
+func (a AIGatewayConsumerGroupResource) MarshalYAML() (any, error) {
+	payload, err := a.PayloadMap()
+	if err != nil {
+		return nil, err
+	}
+	payload[SchemaFieldRef] = a.Ref
+	if a.AIGateway != "" {
+		payload[SchemaFieldAIGateway] = a.AIGateway
+	}
+	return payload, nil
+}
+
+func (a *AIGatewayConsumerGroupResource) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	var meta struct {
+		Ref       string          `json:"ref"`
+		AIGateway string          `json:"ai_gateway,omitempty"`
+		Kongctl   json.RawMessage `json:"kongctl,omitempty"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return err
+	}
+	if len(meta.Kongctl) > 0 && string(meta.Kongctl) != "null" {
+		return fmt.Errorf("kongctl metadata not supported on child resources")
+	}
+
+	delete(raw, SchemaFieldRef)
+	delete(raw, SchemaFieldAIGateway)
+	delete(raw, "kongctl")
+
+	payload, err := json.Marshal(raw)
+	if err != nil {
+		return err
+	}
+	var req kkComps.CreateAIGatewayConsumerGroupRequest
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return err
+	}
+
+	a.BaseResource = BaseResource{Ref: meta.Ref}
+	a.AIGateway = meta.AIGateway
+	a.CreateAIGatewayConsumerGroupRequest = req
+	return nil
+}
+
+func AIGatewayConsumerGroupID(group any) string {
+	return aiGatewayConsumerGroupStringField(group, aiGatewayConsumerGroupFieldID)
+}
+
+func AIGatewayConsumerGroupName(group any) string {
+	return aiGatewayConsumerGroupStringField(group, aiGatewayConsumerGroupFieldName)
+}
+
+func AIGatewayConsumerGroupDisplayName(group any) string {
+	return aiGatewayConsumerGroupStringField(group, aiGatewayConsumerGroupFieldDisplayName)
+}
+
+func AIGatewayConsumerGroupLabels(group any) map[string]string {
+	payload, err := marshalObjectToMap(group, "AI Gateway Consumer Group")
+	if err != nil {
+		return nil
+	}
+	raw, ok := payload[aiGatewayConsumerGroupFieldLabels].(map[string]any)
+	if !ok {
+		return nil
+	}
+	labels := make(map[string]string, len(raw))
+	for key, value := range raw {
+		if stringValue, ok := value.(string); ok {
+			labels[key] = stringValue
+		}
+	}
+	return labels
+}
+
+func AIGatewayConsumerGroupUpdatedAt(group any) time.Time {
+	payload, err := marshalObjectToMap(group, "AI Gateway Consumer Group")
+	if err != nil {
+		return time.Time{}
+	}
+	if value, ok := payload[aiGatewayConsumerGroupFieldUpdatedAt].(string); ok {
+		if parsed, err := time.Parse(time.RFC3339Nano, value); err == nil {
+			return parsed
+		}
+	}
+	return time.Time{}
+}
+
+func AIGatewayConsumerGroupMutablePayloadMap(group kkComps.AIGatewayConsumerGroup) (map[string]any, error) {
+	payload, err := marshalObjectToMap(group, "AI Gateway Consumer Group response")
+	if err != nil {
+		return nil, err
+	}
+	stripAIGatewayConsumerGroupServerFields(payload)
+	return payload, nil
+}
+
+func AIGatewayConsumerGroupResourceFromResponse(
+	gatewayRef string,
+	group kkComps.AIGatewayConsumerGroup,
+) (AIGatewayConsumerGroupResource, error) {
+	payload, err := AIGatewayConsumerGroupMutablePayloadMap(group)
+	if err != nil {
+		return AIGatewayConsumerGroupResource{}, err
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return AIGatewayConsumerGroupResource{}, err
+	}
+	var req kkComps.CreateAIGatewayConsumerGroupRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return AIGatewayConsumerGroupResource{}, err
+	}
+
+	ref := AIGatewayConsumerGroupID(group)
+	if ref == "" {
+		ref = AIGatewayConsumerGroupName(group)
+	}
+	return AIGatewayConsumerGroupResource{
+		BaseResource:                        BaseResource{Ref: ref},
+		AIGateway:                           gatewayRef,
+		CreateAIGatewayConsumerGroupRequest: req,
+	}, nil
+}
+
+func stripAIGatewayConsumerGroupServerFields(payload map[string]any) {
+	delete(payload, aiGatewayConsumerGroupFieldID)
+	delete(payload, "created_at")
+	delete(payload, aiGatewayConsumerGroupFieldUpdatedAt)
+}
+
+func aiGatewayConsumerGroupStringField(value any, key string) string {
+	payload, err := marshalObjectToMap(value, "AI Gateway Consumer Group")
+	if err != nil {
+		return ""
+	}
+	if field, ok := payload[key].(string); ok {
+		return field
+	}
+	return ""
+}
+
+func aiGatewayConsumerGroupExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
+	return explainObject(
+		explainResourceRefField(),
+		explainRefField(SchemaFieldAIGateway, ResourceTypeAIGateway, true),
+		explainField("name", explainStringNode("premium-users"), true, true),
+		explainField("display_name", explainStringNode("Premium Users"), true, true),
+		explainField(
+			aiGatewayConsumerGroupFieldPolicies,
+			explainArrayOf(explainStringNode("!ref mask-sensitive-data")),
+			false,
+			true,
+		),
+		explainField("labels", &ExplainNode{Kind: explainKindObject, Additional: explainStringNode("value")}, false, false),
+		explainField(
+			"managed_by",
+			&ExplainNode{Kind: explainKindObject, Additional: explainStringNode("kongctl")},
+			false,
+			false,
+		),
+	), nil
+}

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -20,6 +20,7 @@ const (
 	ResourceTypeAIGateway                               ResourceType = "ai_gateway"
 	ResourceTypeAIGatewayProvider                       ResourceType = "ai_gateway_provider"
 	ResourceTypeAIGatewayPolicy                         ResourceType = "ai_gateway_policy"
+	ResourceTypeAIGatewayConsumerGroup                  ResourceType = "ai_gateway_consumer_group"
 	ResourceTypeAIGatewayModel                          ResourceType = "ai_gateway_model"
 	ResourceTypeAIGatewayMCPServer                      ResourceType = "ai_gateway_mcp_server"
 	ResourceTypeAIGatewayVault                          ResourceType = "ai_gateway_vault"
@@ -113,6 +114,7 @@ type ResourceSet struct {
 	AIGateways                        []AIGatewayResource                        `yaml:"ai_gateways,omitempty"                                    json:"ai_gateways,omitempty"`                           //nolint:lll
 	AIGatewayProviders                []AIGatewayProviderResource                `yaml:"ai_gateway_providers,omitempty"                          json:"ai_gateway_providers,omitempty"`                   //nolint:lll
 	AIGatewayPolicies                 []AIGatewayPolicyResource                  `yaml:"ai_gateway_policies,omitempty"                           json:"ai_gateway_policies,omitempty"`                    //nolint:lll
+	AIGatewayConsumerGroups           []AIGatewayConsumerGroupResource           `yaml:"ai_gateway_consumer_groups,omitempty"                    json:"ai_gateway_consumer_groups,omitempty"`             //nolint:lll
 	AIGatewayModels                   []AIGatewayModelResource                   `yaml:"ai_gateway_models,omitempty"                              json:"ai_gateway_models,omitempty"`                     //nolint:lll
 	AIGatewayMCPServers               []AIGatewayMCPServerResource               `yaml:"ai_gateway_mcp_servers,omitempty"                         json:"ai_gateway_mcp_servers,omitempty"`                //nolint:lll
 	AIGatewayVaults                   []AIGatewayVaultResource                   `yaml:"ai_gateway_vaults,omitempty"                              json:"ai_gateway_vaults,omitempty"`                     //nolint:lll
@@ -363,6 +365,16 @@ func (rs *ResourceSet) GetAIGatewayPolicyByRef(ref string) *AIGatewayPolicyResou
 	return nil
 }
 
+// GetAIGatewayConsumerGroupByRef returns an AI Gateway Consumer Group resource by its ref from any namespace.
+func (rs *ResourceSet) GetAIGatewayConsumerGroupByRef(ref string) *AIGatewayConsumerGroupResource {
+	for i := range rs.AIGatewayConsumerGroups {
+		if rs.AIGatewayConsumerGroups[i].GetRef() == ref {
+			return &rs.AIGatewayConsumerGroups[i]
+		}
+	}
+	return nil
+}
+
 // GetAIGatewayModelByRef returns an AI Gateway Model resource by its ref from any namespace.
 func (rs *ResourceSet) GetAIGatewayModelByRef(ref string) *AIGatewayModelResource {
 	for i := range rs.AIGatewayModels {
@@ -500,6 +512,25 @@ func (rs *ResourceSet) GetAIGatewayPoliciesByNamespace(namespace string) []AIGat
 			}
 			if GetNamespace(gateway.Kongctl) == namespace {
 				filtered = append(filtered, policy)
+			}
+		}
+	}
+	return filtered
+}
+
+// GetAIGatewayConsumerGroupsByNamespace returns AI Gateway Consumer Group resources from the specified namespace.
+func (rs *ResourceSet) GetAIGatewayConsumerGroupsByNamespace(namespace string) []AIGatewayConsumerGroupResource {
+	var filtered []AIGatewayConsumerGroupResource
+	for _, group := range rs.AIGatewayConsumerGroups {
+		if gateway := rs.GetAIGatewayByRef(group.AIGateway); gateway != nil {
+			if gateway.IsExternal() {
+				if namespace == NamespaceExternal {
+					filtered = append(filtered, group)
+				}
+				continue
+			}
+			if GetNamespace(gateway.Kongctl) == namespace {
+				filtered = append(filtered, group)
 			}
 		}
 	}
@@ -1153,6 +1184,17 @@ func (rs *ResourceSet) GetAIGatewayPoliciesForGateway(gatewayRef string) []AIGat
 		}
 	}
 	return policies
+}
+
+// GetAIGatewayConsumerGroupsForGateway returns all AI Gateway Consumer Groups for a given gateway ref.
+func (rs *ResourceSet) GetAIGatewayConsumerGroupsForGateway(gatewayRef string) []AIGatewayConsumerGroupResource {
+	var groups []AIGatewayConsumerGroupResource
+	for _, group := range rs.AIGatewayConsumerGroups {
+		if NormalizeResourceRef(group.AIGateway) == gatewayRef {
+			groups = append(groups, group)
+		}
+	}
+	return groups
 }
 
 // GetVirtualClustersForGateway returns all virtual clusters (nested + root-level) for a given gateway ref

--- a/internal/declarative/state/ai_gateway_consumer_groups.go
+++ b/internal/declarative/state/ai_gateway_consumer_groups.go
@@ -1,0 +1,191 @@
+package state
+
+import (
+	"context"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/util/pagination"
+)
+
+// ListAIGatewayConsumerGroups lists all Consumer Groups for an AI Gateway.
+func (c *Client) ListAIGatewayConsumerGroups(ctx context.Context, gatewayID string) ([]AIGatewayConsumerGroup, error) {
+	if err := ValidateAPIClient(c.aiGatewayConsumerGroupsAPI, "AI Gateway Consumer Groups API"); err != nil {
+		return nil, err
+	}
+
+	var allData []kkComps.AIGatewayConsumerGroup
+	var pageAfter *string
+	pageSize := int64(100)
+
+	for {
+		req := kkOps.ListAiGatewayConsumerGroupsRequest{
+			GatewayID: gatewayID,
+			PageSize:  &pageSize,
+			PageAfter: pageAfter,
+		}
+
+		resp, err := c.aiGatewayConsumerGroupsAPI.ListAiGatewayConsumerGroups(ctx, req)
+		if err != nil {
+			return nil, WrapAPIError(err, "list AI Gateway Consumer Groups", nil)
+		}
+
+		if resp == nil || resp.ListAIGatewayConsumerGroupsResponse == nil {
+			return []AIGatewayConsumerGroup{}, nil
+		}
+
+		allData = append(allData, resp.ListAIGatewayConsumerGroupsResponse.Data...)
+
+		nextCursor := pagination.ExtractPageAfterCursor(resp.ListAIGatewayConsumerGroupsResponse.Meta.Page.Next)
+		if nextCursor == "" {
+			break
+		}
+		pageAfter = &nextCursor
+	}
+
+	groups := make([]AIGatewayConsumerGroup, 0, len(allData))
+	for _, group := range allData {
+		groups = append(groups, AIGatewayConsumerGroup{
+			AIGatewayConsumerGroup: group,
+			NormalizedLabels:       normalizedAIGatewayConsumerGroupLabels(group),
+		})
+	}
+	return groups, nil
+}
+
+// GetAIGatewayConsumerGroup fetches an AI Gateway Consumer Group by ID or name.
+func (c *Client) GetAIGatewayConsumerGroup(
+	ctx context.Context,
+	gatewayID string,
+	consumerGroupID string,
+) (*AIGatewayConsumerGroup, error) {
+	if err := ValidateAPIClient(c.aiGatewayConsumerGroupsAPI, "AI Gateway Consumer Groups API"); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.aiGatewayConsumerGroupsAPI.GetAiGatewayConsumerGroup(ctx, gatewayID, consumerGroupID)
+	if err != nil {
+		return nil, WrapAPIError(err, "get AI Gateway Consumer Group by ID", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeAIGatewayConsumerGroup),
+			UseEnhanced:  true,
+		})
+	}
+
+	if resp == nil || resp.AIGatewayConsumerGroup == nil {
+		return nil, nil
+	}
+
+	return &AIGatewayConsumerGroup{
+		AIGatewayConsumerGroup: *resp.AIGatewayConsumerGroup,
+		NormalizedLabels:       normalizedAIGatewayConsumerGroupLabels(*resp.AIGatewayConsumerGroup),
+	}, nil
+}
+
+// GetAIGatewayConsumerGroupByName finds an AI Gateway Consumer Group by name within a gateway.
+func (c *Client) GetAIGatewayConsumerGroupByName(
+	ctx context.Context,
+	gatewayID string,
+	name string,
+) (*AIGatewayConsumerGroup, error) {
+	groups, err := c.ListAIGatewayConsumerGroups(ctx, gatewayID)
+	if err != nil {
+		return nil, WrapAPIError(err, "list AI Gateway Consumer Groups to find by name", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeAIGatewayConsumerGroup),
+			ResourceName: name,
+			UseEnhanced:  true,
+		})
+	}
+
+	for i := range groups {
+		if groups[i].Name == name {
+			return &groups[i], nil
+		}
+	}
+
+	return nil, nil
+}
+
+// CreateAIGatewayConsumerGroup creates a new Consumer Group under an AI Gateway.
+func (c *Client) CreateAIGatewayConsumerGroup(
+	ctx context.Context,
+	gatewayID string,
+	req kkComps.CreateAIGatewayConsumerGroupRequest,
+	namespace string,
+) (string, error) {
+	if err := ValidateAPIClient(c.aiGatewayConsumerGroupsAPI, "AI Gateway Consumer Groups API"); err != nil {
+		return "", err
+	}
+
+	resp, err := c.aiGatewayConsumerGroupsAPI.CreateAiGatewayConsumerGroup(ctx, gatewayID, req)
+	if err != nil {
+		return "", WrapAPIError(err, "create AI Gateway Consumer Group", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeAIGatewayConsumerGroup),
+			ResourceName: req.Name,
+			Namespace:    namespace,
+			UseEnhanced:  true,
+		})
+	}
+
+	if resp == nil || resp.AIGatewayConsumerGroup == nil {
+		return "", fmt.Errorf("create AI Gateway Consumer Group response missing data")
+	}
+
+	return resp.AIGatewayConsumerGroup.ID, nil
+}
+
+// UpdateAIGatewayConsumerGroup updates an existing Consumer Group under an AI Gateway.
+func (c *Client) UpdateAIGatewayConsumerGroup(
+	ctx context.Context,
+	gatewayID string,
+	consumerGroupID string,
+	req kkComps.UpdateAIGatewayConsumerGroupRequest,
+	namespace string,
+) (string, error) {
+	if err := ValidateAPIClient(c.aiGatewayConsumerGroupsAPI, "AI Gateway Consumer Groups API"); err != nil {
+		return "", err
+	}
+
+	resp, err := c.aiGatewayConsumerGroupsAPI.UpdateAiGatewayConsumerGroup(ctx, kkOps.UpdateAiGatewayConsumerGroupRequest{
+		GatewayID:                           gatewayID,
+		ConsumerGroupID:                     consumerGroupID,
+		UpdateAIGatewayConsumerGroupRequest: req,
+	})
+	if err != nil {
+		return "", WrapAPIError(err, "update AI Gateway Consumer Group", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeAIGatewayConsumerGroup),
+			ResourceName: req.Name,
+			Namespace:    namespace,
+			UseEnhanced:  true,
+		})
+	}
+
+	if resp == nil || resp.AIGatewayConsumerGroup == nil {
+		return "", fmt.Errorf("update AI Gateway Consumer Group response missing data")
+	}
+
+	return resp.AIGatewayConsumerGroup.ID, nil
+}
+
+// DeleteAIGatewayConsumerGroup deletes an AI Gateway Consumer Group by ID.
+func (c *Client) DeleteAIGatewayConsumerGroup(ctx context.Context, gatewayID string, consumerGroupID string) error {
+	if err := ValidateAPIClient(c.aiGatewayConsumerGroupsAPI, "AI Gateway Consumer Groups API"); err != nil {
+		return err
+	}
+
+	_, err := c.aiGatewayConsumerGroupsAPI.DeleteAiGatewayConsumerGroup(ctx, gatewayID, consumerGroupID)
+	if err != nil {
+		return WrapAPIError(err, "delete AI Gateway Consumer Group", nil)
+	}
+
+	return nil
+}
+
+func normalizedAIGatewayConsumerGroupLabels(group kkComps.AIGatewayConsumerGroup) map[string]string {
+	normalized := group.Labels
+	if normalized == nil {
+		normalized = make(map[string]string)
+	}
+	return normalized
+}

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -26,22 +26,23 @@ import (
 // ClientConfig contains all the API interfaces needed by the state client
 type ClientConfig struct {
 	// Core APIs
-	PortalAPI               helpers.PortalAPI
-	APIAPI                  helpers.APIAPI
-	AppAuthAPI              helpers.AppAuthStrategiesAPI
-	DCRProviderAPI          helpers.DCRProvidersAPI
-	ControlPlaneAPI         helpers.ControlPlaneAPI
-	GatewayServiceAPI       helpers.GatewayServiceAPI
-	DataPlaneCertificateAPI helpers.DataPlaneCertificateAPI
-	ControlPlaneGroupsAPI   helpers.ControlPlaneGroupsAPI
-	CatalogServiceAPI       helpers.CatalogServicesAPI
-	AIGatewayAPI            helpers.AIGatewayAPI
-	AIGatewayProvidersAPI   helpers.AIGatewayProvidersAPI
-	AIGatewayPoliciesAPI    helpers.AIGatewayPoliciesAPI
-	AIGatewayModelAPI       helpers.AIGatewayModelAPI
-	AIGatewayMCPServersAPI  helpers.AIGatewayMCPServersAPI
-	AIGatewayVaultsAPI      helpers.AIGatewayVaultsAPI
-	DashboardsAPI           helpers.DashboardsAPI
+	PortalAPI                  helpers.PortalAPI
+	APIAPI                     helpers.APIAPI
+	AppAuthAPI                 helpers.AppAuthStrategiesAPI
+	DCRProviderAPI             helpers.DCRProvidersAPI
+	ControlPlaneAPI            helpers.ControlPlaneAPI
+	GatewayServiceAPI          helpers.GatewayServiceAPI
+	DataPlaneCertificateAPI    helpers.DataPlaneCertificateAPI
+	ControlPlaneGroupsAPI      helpers.ControlPlaneGroupsAPI
+	CatalogServiceAPI          helpers.CatalogServicesAPI
+	AIGatewayAPI               helpers.AIGatewayAPI
+	AIGatewayProvidersAPI      helpers.AIGatewayProvidersAPI
+	AIGatewayPoliciesAPI       helpers.AIGatewayPoliciesAPI
+	AIGatewayConsumerGroupsAPI helpers.AIGatewayConsumerGroupsAPI
+	AIGatewayModelAPI          helpers.AIGatewayModelAPI
+	AIGatewayMCPServersAPI     helpers.AIGatewayMCPServersAPI
+	AIGatewayVaultsAPI         helpers.AIGatewayVaultsAPI
+	DashboardsAPI              helpers.DashboardsAPI
 
 	// Portal child resource APIs
 	PortalPageAPI             helpers.PortalPageAPI
@@ -94,22 +95,23 @@ type ClientConfig struct {
 // Client wraps Konnect SDK for state management
 type Client struct {
 	// Core APIs
-	portalAPI               helpers.PortalAPI
-	apiAPI                  helpers.APIAPI
-	appAuthAPI              helpers.AppAuthStrategiesAPI
-	dcrProviderAPI          helpers.DCRProvidersAPI
-	controlPlaneAPI         helpers.ControlPlaneAPI
-	gatewayServiceAPI       helpers.GatewayServiceAPI
-	dataPlaneCertificateAPI helpers.DataPlaneCertificateAPI
-	controlPlaneGroupsAPI   helpers.ControlPlaneGroupsAPI
-	catalogServiceAPI       helpers.CatalogServicesAPI
-	aiGatewayAPI            helpers.AIGatewayAPI
-	aiGatewayProvidersAPI   helpers.AIGatewayProvidersAPI
-	aiGatewayPoliciesAPI    helpers.AIGatewayPoliciesAPI
-	aiGatewayModelAPI       helpers.AIGatewayModelAPI
-	aiGatewayMCPServersAPI  helpers.AIGatewayMCPServersAPI
-	aiGatewayVaultsAPI      helpers.AIGatewayVaultsAPI
-	dashboardsAPI           helpers.DashboardsAPI
+	portalAPI                  helpers.PortalAPI
+	apiAPI                     helpers.APIAPI
+	appAuthAPI                 helpers.AppAuthStrategiesAPI
+	dcrProviderAPI             helpers.DCRProvidersAPI
+	controlPlaneAPI            helpers.ControlPlaneAPI
+	gatewayServiceAPI          helpers.GatewayServiceAPI
+	dataPlaneCertificateAPI    helpers.DataPlaneCertificateAPI
+	controlPlaneGroupsAPI      helpers.ControlPlaneGroupsAPI
+	catalogServiceAPI          helpers.CatalogServicesAPI
+	aiGatewayAPI               helpers.AIGatewayAPI
+	aiGatewayProvidersAPI      helpers.AIGatewayProvidersAPI
+	aiGatewayPoliciesAPI       helpers.AIGatewayPoliciesAPI
+	aiGatewayConsumerGroupsAPI helpers.AIGatewayConsumerGroupsAPI
+	aiGatewayModelAPI          helpers.AIGatewayModelAPI
+	aiGatewayMCPServersAPI     helpers.AIGatewayMCPServersAPI
+	aiGatewayVaultsAPI         helpers.AIGatewayVaultsAPI
+	dashboardsAPI              helpers.DashboardsAPI
 
 	// Portal child resource APIs
 	portalPageAPI             helpers.PortalPageAPI
@@ -163,22 +165,23 @@ type Client struct {
 func NewClient(config ClientConfig) *Client {
 	return &Client{
 		// Core APIs
-		portalAPI:               config.PortalAPI,
-		apiAPI:                  config.APIAPI,
-		appAuthAPI:              config.AppAuthAPI,
-		dcrProviderAPI:          config.DCRProviderAPI,
-		controlPlaneAPI:         config.ControlPlaneAPI,
-		gatewayServiceAPI:       config.GatewayServiceAPI,
-		dataPlaneCertificateAPI: config.DataPlaneCertificateAPI,
-		controlPlaneGroupsAPI:   config.ControlPlaneGroupsAPI,
-		catalogServiceAPI:       config.CatalogServiceAPI,
-		aiGatewayAPI:            config.AIGatewayAPI,
-		aiGatewayProvidersAPI:   config.AIGatewayProvidersAPI,
-		aiGatewayPoliciesAPI:    config.AIGatewayPoliciesAPI,
-		aiGatewayModelAPI:       config.AIGatewayModelAPI,
-		aiGatewayMCPServersAPI:  config.AIGatewayMCPServersAPI,
-		aiGatewayVaultsAPI:      config.AIGatewayVaultsAPI,
-		dashboardsAPI:           config.DashboardsAPI,
+		portalAPI:                  config.PortalAPI,
+		apiAPI:                     config.APIAPI,
+		appAuthAPI:                 config.AppAuthAPI,
+		dcrProviderAPI:             config.DCRProviderAPI,
+		controlPlaneAPI:            config.ControlPlaneAPI,
+		gatewayServiceAPI:          config.GatewayServiceAPI,
+		dataPlaneCertificateAPI:    config.DataPlaneCertificateAPI,
+		controlPlaneGroupsAPI:      config.ControlPlaneGroupsAPI,
+		catalogServiceAPI:          config.CatalogServiceAPI,
+		aiGatewayAPI:               config.AIGatewayAPI,
+		aiGatewayProvidersAPI:      config.AIGatewayProvidersAPI,
+		aiGatewayPoliciesAPI:       config.AIGatewayPoliciesAPI,
+		aiGatewayConsumerGroupsAPI: config.AIGatewayConsumerGroupsAPI,
+		aiGatewayModelAPI:          config.AIGatewayModelAPI,
+		aiGatewayMCPServersAPI:     config.AIGatewayMCPServersAPI,
+		aiGatewayVaultsAPI:         config.AIGatewayVaultsAPI,
+		dashboardsAPI:              config.DashboardsAPI,
 
 		// Portal child resource APIs
 		portalPageAPI:             config.PortalPageAPI,
@@ -284,6 +287,12 @@ type AIGatewayProvider struct {
 // AIGatewayPolicy represents a Konnect AI Gateway Policy for internal use.
 type AIGatewayPolicy struct {
 	kkComps.AIGatewayPolicy
+	NormalizedLabels map[string]string
+}
+
+// AIGatewayConsumerGroup represents a Konnect AI Gateway Consumer Group for internal use.
+type AIGatewayConsumerGroup struct {
+	kkComps.AIGatewayConsumerGroup
 	NormalizedLabels map[string]string
 }
 

--- a/internal/konnect/helpers/ai_gateway_consumer_groups.go
+++ b/internal/konnect/helpers/ai_gateway_consumer_groups.go
@@ -1,0 +1,89 @@
+package helpers
+
+import (
+	"context"
+
+	kkSDK "github.com/Kong/sdk-konnect-go"
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+)
+
+// AIGatewayConsumerGroupsAPI defines the interface for AI Gateway Consumer Group operations needed by kongctl.
+type AIGatewayConsumerGroupsAPI interface {
+	ListAiGatewayConsumerGroups(
+		ctx context.Context,
+		request kkOps.ListAiGatewayConsumerGroupsRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.ListAiGatewayConsumerGroupsResponse, error)
+	CreateAiGatewayConsumerGroup(
+		ctx context.Context,
+		gatewayID string,
+		request kkComps.CreateAIGatewayConsumerGroupRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.CreateAiGatewayConsumerGroupResponse, error)
+	GetAiGatewayConsumerGroup(
+		ctx context.Context,
+		gatewayID string,
+		consumerGroupID string,
+		opts ...kkOps.Option,
+	) (*kkOps.GetAiGatewayConsumerGroupResponse, error)
+	UpdateAiGatewayConsumerGroup(
+		ctx context.Context,
+		request kkOps.UpdateAiGatewayConsumerGroupRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.UpdateAiGatewayConsumerGroupResponse, error)
+	DeleteAiGatewayConsumerGroup(
+		ctx context.Context,
+		gatewayID string,
+		consumerGroupID string,
+		opts ...kkOps.Option,
+	) (*kkOps.DeleteAiGatewayConsumerGroupResponse, error)
+}
+
+// AIGatewayConsumerGroupsAPIImpl provides the real SDK implementation.
+type AIGatewayConsumerGroupsAPIImpl struct {
+	SDK *kkSDK.SDK
+}
+
+func (a *AIGatewayConsumerGroupsAPIImpl) ListAiGatewayConsumerGroups(
+	ctx context.Context,
+	request kkOps.ListAiGatewayConsumerGroupsRequest,
+	opts ...kkOps.Option,
+) (*kkOps.ListAiGatewayConsumerGroupsResponse, error) {
+	return a.SDK.AIGatewayConsumerGroups.ListAiGatewayConsumerGroups(ctx, request, opts...)
+}
+
+func (a *AIGatewayConsumerGroupsAPIImpl) CreateAiGatewayConsumerGroup(
+	ctx context.Context,
+	gatewayID string,
+	request kkComps.CreateAIGatewayConsumerGroupRequest,
+	opts ...kkOps.Option,
+) (*kkOps.CreateAiGatewayConsumerGroupResponse, error) {
+	return a.SDK.AIGatewayConsumerGroups.CreateAiGatewayConsumerGroup(ctx, gatewayID, request, opts...)
+}
+
+func (a *AIGatewayConsumerGroupsAPIImpl) GetAiGatewayConsumerGroup(
+	ctx context.Context,
+	gatewayID string,
+	consumerGroupID string,
+	opts ...kkOps.Option,
+) (*kkOps.GetAiGatewayConsumerGroupResponse, error) {
+	return a.SDK.AIGatewayConsumerGroups.GetAiGatewayConsumerGroup(ctx, gatewayID, consumerGroupID, opts...)
+}
+
+func (a *AIGatewayConsumerGroupsAPIImpl) UpdateAiGatewayConsumerGroup(
+	ctx context.Context,
+	request kkOps.UpdateAiGatewayConsumerGroupRequest,
+	opts ...kkOps.Option,
+) (*kkOps.UpdateAiGatewayConsumerGroupResponse, error) {
+	return a.SDK.AIGatewayConsumerGroups.UpdateAiGatewayConsumerGroup(ctx, request, opts...)
+}
+
+func (a *AIGatewayConsumerGroupsAPIImpl) DeleteAiGatewayConsumerGroup(
+	ctx context.Context,
+	gatewayID string,
+	consumerGroupID string,
+	opts ...kkOps.Option,
+) (*kkOps.DeleteAiGatewayConsumerGroupResponse, error) {
+	return a.SDK.AIGatewayConsumerGroups.DeleteAiGatewayConsumerGroup(ctx, gatewayID, consumerGroupID, opts...)
+}

--- a/internal/konnect/helpers/sdk.go
+++ b/internal/konnect/helpers/sdk.go
@@ -25,6 +25,7 @@ type SDKAPI interface {
 	GetAIGatewayAPI() AIGatewayAPI
 	GetAIGatewayProvidersAPI() AIGatewayProvidersAPI
 	GetAIGatewayPoliciesAPI() AIGatewayPoliciesAPI
+	GetAIGatewayConsumerGroupsAPI() AIGatewayConsumerGroupsAPI
 	GetAIGatewayModelAPI() AIGatewayModelAPI
 	GetAIGatewayMCPServersAPI() AIGatewayMCPServersAPI
 	GetAIGatewayVaultsAPI() AIGatewayVaultsAPI
@@ -151,6 +152,15 @@ func (k *KonnectSDK) GetAIGatewayPoliciesAPI() AIGatewayPoliciesAPI {
 	}
 
 	return &AIGatewayPoliciesAPIImpl{SDK: k.SDK}
+}
+
+// Returns the implementation of the AIGatewayConsumerGroupsAPI interface.
+func (k *KonnectSDK) GetAIGatewayConsumerGroupsAPI() AIGatewayConsumerGroupsAPI {
+	if k.SDK == nil || k.SDK.AIGatewayConsumerGroups == nil {
+		return nil
+	}
+
+	return &AIGatewayConsumerGroupsAPIImpl{SDK: k.SDK}
 }
 
 // Returns the implementation of the AIGatewayModelAPI interface.

--- a/internal/konnect/helpers/sdk_mock.go
+++ b/internal/konnect/helpers/sdk_mock.go
@@ -13,6 +13,7 @@ type MockKonnectSDK struct {
 	AIGatewayFactory                   func() AIGatewayAPI
 	AIGatewayProvidersFactory          func() AIGatewayProvidersAPI
 	AIGatewayPoliciesFactory           func() AIGatewayPoliciesAPI
+	AIGatewayConsumerGroupsFactory     func() AIGatewayConsumerGroupsAPI
 	AIGatewayModelFactory              func() AIGatewayModelAPI
 	AIGatewayMCPServersFactory         func() AIGatewayMCPServersAPI
 	AIGatewayVaultsFactory             func() AIGatewayVaultsAPI
@@ -120,6 +121,14 @@ func (m *MockKonnectSDK) GetAIGatewayProvidersAPI() AIGatewayProvidersAPI {
 func (m *MockKonnectSDK) GetAIGatewayPoliciesAPI() AIGatewayPoliciesAPI {
 	if m.AIGatewayPoliciesFactory != nil {
 		return m.AIGatewayPoliciesFactory()
+	}
+	return nil
+}
+
+// Returns a mock instance of the AIGatewayConsumerGroupsAPI.
+func (m *MockKonnectSDK) GetAIGatewayConsumerGroupsAPI() AIGatewayConsumerGroupsAPI {
+	if m.AIGatewayConsumerGroupsFactory != nil {
+		return m.AIGatewayConsumerGroupsFactory()
 	}
 	return nil
 }

--- a/test/e2e/scenarios/ai-gateway/consumer-group/overlays/001-update/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/consumer-group/overlays/001-update/config.yaml
@@ -1,0 +1,33 @@
+ai_gateways:
+  - ref: ai-gateway-consumer-group-e2e
+    display_name: "AI Gateway Consumer Group E2E"
+    description: "AI Gateway Consumer Group e2e"
+    proxy_urls:
+      - host: ai-gateway-consumer-group-e2e.example.com
+        port: 443
+        protocol: https
+    labels:
+      owner: platform
+      lifecycle: dev
+    policies:
+      - ref: mask-sensitive-data
+        name: mask-sensitive-data
+        type: ai-sanitizer
+        display_name: "Mask Sensitive Data"
+        enabled: true
+        global: false
+        labels:
+          team: support
+          phase: create
+        config:
+          anonymize:
+            - email
+    consumer_groups:
+      - ref: premium-support-users
+        name: premium-support-users
+        display_name: "Premium Support Users Updated"
+        labels:
+          team: support
+          phase: update
+        policies:
+          - !ref mask-sensitive-data

--- a/test/e2e/scenarios/ai-gateway/consumer-group/overlays/002-sync-delete-consumer-group/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/consumer-group/overlays/002-sync-delete-consumer-group/config.yaml
@@ -1,0 +1,25 @@
+ai_gateways:
+  - ref: ai-gateway-consumer-group-e2e
+    display_name: "AI Gateway Consumer Group E2E"
+    description: "AI Gateway Consumer Group e2e"
+    proxy_urls:
+      - host: ai-gateway-consumer-group-e2e.example.com
+        port: 443
+        protocol: https
+    labels:
+      owner: platform
+      lifecycle: dev
+    policies:
+      - ref: mask-sensitive-data
+        name: mask-sensitive-data
+        type: ai-sanitizer
+        display_name: "Mask Sensitive Data"
+        enabled: true
+        global: false
+        labels:
+          team: support
+          phase: create
+        config:
+          anonymize:
+            - email
+    consumer_groups: []

--- a/test/e2e/scenarios/ai-gateway/consumer-group/overlays/003-sync-delete-policy/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/consumer-group/overlays/003-sync-delete-policy/config.yaml
@@ -1,0 +1,13 @@
+ai_gateways:
+  - ref: ai-gateway-consumer-group-e2e
+    display_name: "AI Gateway Consumer Group E2E"
+    description: "AI Gateway Consumer Group e2e"
+    proxy_urls:
+      - host: ai-gateway-consumer-group-e2e.example.com
+        port: 443
+        protocol: https
+    labels:
+      owner: platform
+      lifecycle: dev
+    policies: []
+    consumer_groups: []

--- a/test/e2e/scenarios/ai-gateway/consumer-group/overlays/004-sync-delete-gateway/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/consumer-group/overlays/004-sync-delete-gateway/config.yaml
@@ -1,0 +1,1 @@
+ai_gateways: []

--- a/test/e2e/scenarios/ai-gateway/consumer-group/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/consumer-group/scenario.yaml
@@ -1,0 +1,426 @@
+baseInputsPath: testdata
+
+env:
+  KONGCTL_LOG_LEVEL: info
+
+vars:
+  namespace: "ai-gateway-consumer-group-e2e"
+  gateway_name: "AI Gateway Consumer Group E2E"
+  gateway_ref: "ai-gateway-consumer-group-e2e"
+  policy_ref: "mask-sensitive-data"
+  policy_name: "mask-sensitive-data"
+  policy_display_name: "Mask Sensitive Data"
+  consumer_group_ref: "premium-support-users"
+  consumer_group_name: "premium-support-users"
+  consumer_group_display_name: "Premium Support Users"
+  consumer_group_updated_display_name: "Premium Support Users Updated"
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - created_at
+      - updated_at
+      - config_hash
+      - endpoints
+      - resource_id
+      - change_id
+      - generated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-explain-and-scaffold
+    skipInputs: true
+    commands:
+      - name: 000-explain-ai-gateway-consumer-group-json
+        run:
+          - explain
+          - ai_gateway_consumer_group
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                type: object
+                '"x-kongctl-root-key"': ai_gateway_consumer_groups
+          - select: "contains(keys(properties), 'ai_gateway')"
+            expect:
+              fields:
+                "@": true
+      - name: 001-scaffold-ai-gateway-consumer-group
+        run:
+          - scaffold
+          - ai_gateway_consumer_group
+        outputFormat: disable
+        parseAs: raw
+        assertions:
+          - expect:
+              fields:
+                "contains(stdout, 'ai_gateway_consumer_groups:')": true
+                "contains(stdout, 'ai_gateway: !ref')": true
+                "contains(stdout, 'policies:')": true
+      - name: 002-explain-ai-gateway-consumer-groups-nested-json
+        run:
+          - explain
+          - ai_gateway.consumer_groups
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                type: object
+                '"x-kongctl-resource"': ai_gateway_consumer_group
+                '"x-kongctl-root-key"': ai_gateway_consumer_groups
+
+  - name: 002-plan-apply-create
+    commands:
+      - name: 000-plan-create
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-create.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 3
+                by_action.CREATE: 3
+          - select: >-
+              changes[?resource_type=='ai_gateway_consumer_group' && resource_ref=='{{ .vars.consumer_group_ref }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                fields.name: "{{ .vars.consumer_group_name }}"
+                fields.display_name: "{{ .vars.consumer_group_display_name }}"
+                fields.labels.phase: create
+                fields.policies[0]: "__REF__:{{ .vars.policy_ref }}#id"
+                references."policies.0".ref: "__REF__:{{ .vars.policy_ref }}#id"
+      - name: 001-apply-create
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-create.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 3
+                failed: 0
+                status: success
+      - name: 002-list-consumer-groups
+        run:
+          - get
+          - ai-gateway
+          - consumer-groups
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - -o
+          - json
+        recordVar:
+          name: consumer_group_id
+          responsePath: "[?name=='{{ .vars.consumer_group_name }}'] | [0].id"
+        assertions:
+          - select: "[?name=='{{ .vars.consumer_group_name }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.consumer_group_name }}"
+                display_name: "{{ .vars.consumer_group_display_name }}"
+                labels.phase: create
+                "length(policies)": 1
+      - name: 003-get-consumer-group-by-name
+        run:
+          - get
+          - ai-gateway
+          - consumer-group
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - "{{ .vars.consumer_group_name }}"
+          - -o
+          - json
+        assertions:
+          - select: name
+            expect:
+              fields:
+                "@": "{{ .vars.consumer_group_name }}"
+      - name: 004-get-consumer-group-by-id
+        run:
+          - get
+          - ai-gateway
+          - consumer-groups
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - "{{ .vars.consumer_group_id }}"
+          - -o
+          - json
+        assertions:
+          - select: name
+            expect:
+              fields:
+                "@": "{{ .vars.consumer_group_name }}"
+
+  - name: 003-plan-apply-update
+    inputOverlayDirs:
+      - overlays/001-update
+    commands:
+      - name: 000-plan-update
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-update.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+          - select: >-
+              changes[?resource_type=='ai_gateway_consumer_group' && resource_ref=='{{ .vars.consumer_group_ref }}'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                fields.display_name: "{{ .vars.consumer_group_updated_display_name }}"
+                fields.labels.phase: update
+      - name: 001-apply-update
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-update.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 002-verify-update
+        run:
+          - get
+          - ai-gateway
+          - consumer-groups
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - "{{ .vars.consumer_group_name }}"
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                display_name: "{{ .vars.consumer_group_updated_display_name }}"
+                labels.phase: update
+      - name: 003-diff-no-changes
+        outputFormat: text
+        parseAs: raw
+        run:
+          - diff
+          - -f
+          - "{{ .workdir }}/config.yaml"
+        assertions:
+          - select: stdout
+            expect:
+              fields:
+                "contains(@, 'No changes detected. Konnect is up to date.')": true
+
+  - name: 004-dump-round-trip
+    skipInputs: true
+    commands:
+      - name: 000-dump-ai-gateway-with-children
+        run:
+          - dump
+          - declarative
+          - "--resources=ai_gateways"
+          - "--include-child-resources"
+          - "--default-namespace={{ .vars.namespace }}"
+        outputFormat: none
+        parseAs: yaml
+        stdoutFile: "{{ .workdir }}/dump-ai-gateway.yaml"
+        assertions:
+          - select: >-
+              ai_gateways[?display_name=='{{ .vars.gateway_name }}'] | [0].consumer_groups[?name=='{{ .vars.consumer_group_name }}'] | [0]
+            expect:
+              fields:
+                name: "{{ .vars.consumer_group_name }}"
+                display_name: "{{ .vars.consumer_group_updated_display_name }}"
+                "length(policies)": 1
+          - select: >-
+              ai_gateways[?display_name=='{{ .vars.gateway_name }}'] | [0].policies[?name=='{{ .vars.policy_name }}'] | [0]
+            expect:
+              fields:
+                name: "{{ .vars.policy_name }}"
+                display_name: "{{ .vars.policy_display_name }}"
+                type: ai-sanitizer
+                config.anonymize[0]: email
+      - name: 001-plan-from-ai-gateway-dump
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/dump-ai-gateway.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+      - name: 002-dump-root-consumer-groups
+        run:
+          - dump
+          - declarative
+          - "--resources=ai_gateway_consumer_groups"
+          - "--filter-name={{ .vars.consumer_group_name }}"
+          - "--default-namespace={{ .vars.namespace }}"
+        outputFormat: none
+        parseAs: yaml
+        assertions:
+          - select: "ai_gateway_consumer_groups[0]"
+            expect:
+              fields:
+                name: "{{ .vars.consumer_group_name }}"
+                display_name: "{{ .vars.consumer_group_updated_display_name }}"
+          - select: "ai_gateway_consumer_groups[0].ai_gateway != ''"
+            expect:
+              fields:
+                "@": true
+
+  - name: 005-sync-delete-consumer-group
+    inputOverlayDirs:
+      - overlays/002-sync-delete-consumer-group
+    commands:
+      - name: 000-sync-delete-consumer-group
+        outputFormat: json
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: >-
+              plan.changes[?resource_type=='ai_gateway_consumer_group' && action=='DELETE'] | [0]
+            expect:
+              fields:
+                resource_ref: "{{ .vars.consumer_group_name }}"
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+                status: success
+      - name: 001-list-consumer-groups-empty
+        run:
+          - get
+          - ai-gateway
+          - consumer-groups
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 0
+
+  - name: 006-sync-delete-policy
+    inputOverlayDirs:
+      - overlays/003-sync-delete-policy
+    commands:
+      - name: 000-sync-delete-policy
+        outputFormat: json
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: >-
+              plan.changes[?resource_type=='ai_gateway_policy' && action=='DELETE'] | [0]
+            expect:
+              fields:
+                resource_ref: "{{ .vars.policy_name }}"
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+                status: success
+      - name: 001-list-policies-empty
+        run:
+          - get
+          - ai-gateway
+          - policies
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 0
+
+  - name: 007-sync-delete-gateway
+    inputOverlayDirs:
+      - overlays/004-sync-delete-gateway
+    commands:
+      - name: 000-sync-delete-gateway
+        outputFormat: json
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+                status: success
+      - name: 001-get-ai-gateways
+        run:
+          - get
+          - ai-gateways
+          - -o
+          - json
+        assertions:
+          - select: "[?display_name=='{{ .vars.gateway_name }}']"
+            expect:
+              fields:
+                "length(@)": 0

--- a/test/e2e/scenarios/ai-gateway/consumer-group/testdata/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/consumer-group/testdata/config.yaml
@@ -1,0 +1,37 @@
+_defaults:
+  kongctl:
+    namespace: ai-gateway-consumer-group-e2e
+
+ai_gateways:
+  - ref: ai-gateway-consumer-group-e2e
+    display_name: "AI Gateway Consumer Group E2E"
+    description: "AI Gateway Consumer Group e2e"
+    proxy_urls:
+      - host: ai-gateway-consumer-group-e2e.example.com
+        port: 443
+        protocol: https
+    labels:
+      owner: platform
+      lifecycle: dev
+    policies:
+      - ref: mask-sensitive-data
+        name: mask-sensitive-data
+        type: ai-sanitizer
+        display_name: "Mask Sensitive Data"
+        enabled: true
+        global: false
+        labels:
+          team: support
+          phase: create
+        config:
+          anonymize:
+            - email
+    consumer_groups:
+      - ref: premium-support-users
+        name: premium-support-users
+        display_name: "Premium Support Users"
+        labels:
+          team: support
+          phase: create
+        policies:
+          - !ref mask-sensitive-data


### PR DESCRIPTION
## Summary
- Add declarative AI Gateway consumer group support, including nested and root config, planning, execution, state loading, dump, sync-scope, validation, and protection lookup.
- Add imperative get/list support for `ai-gateway consumer-groups`.
- Update docs, examples, and e2e scenarios, with explicit `!ref` policy references in AI Gateway examples.

Issue: https://github.com/Kong/kongctl/issues/743

Consumer membership remains out of scope and is tracked separately in #1427.

Stacked on #1426.

Closes #743.

## Testing
- `go fix ./...`
- `make format`
- `make build`
- `make test`
- `go test ./internal/declarative/... ./internal/cmd/root/products/konnect/... ./internal/cmd/root/verbs/dump/...`
- `go test -tags=e2e ./test/e2e/harness/scenario ./test/e2e/harness`
- `golangci-lint run ./internal/declarative/... ./internal/cmd/root/products/konnect/aigateway ./internal/cmd/root/products/konnect/common ./internal/cmd/root/verbs/dump ./internal/konnect/helpers`

Full `make lint` was attempted but still reports unrelated generated or adjacent-worktree issues outside this implementation.