### PR TITLE
feat(ai-gateway): add consumer support

### DIFF
--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -319,9 +319,11 @@ control_plane_data_plane_certificates:
 
 This section covers the root AI Gateway resource backed by the Konnect
 `/v1/ai-gateways` API, AI Gateway Providers, AI Gateway Models, AI Gateway
-MCP Servers, AI Gateway Consumer Groups, and AI Gateway Vaults. Use
+MCP Servers, AI Gateway Consumers, AI Gateway Consumer Groups, and AI Gateway
+Vaults. Use
 `kongctl explain ai_gateway --output yaml`,
 `kongctl explain ai_gateway_provider --output yaml`,
+`kongctl explain ai_gateway.consumers --output yaml`,
 `kongctl explain ai_gateway.consumer_groups --output yaml`,
 `kongctl explain ai_gateway.models --output yaml`,
 `kongctl explain ai_gateway.mcp_servers --output yaml`, and
@@ -329,28 +331,29 @@ MCP Servers, AI Gateway Consumer Groups, and AI Gateway Vaults. Use
 
 The `ref` value is used as the stable Konnect API `name` when creating an AI
 Gateway. Use `display_name` for the human-readable name shown in Konnect.
-AI Gateway Providers, Policies, Consumer Groups, Models, MCP Servers, and
-Vaults use their own required `name` field as the stable Konnect child name.
-Child entries inherit management scope from their parent AI Gateway and do not
-accept `kongctl` metadata.
+AI Gateway Providers, Policies, Consumers, Consumer Groups, Models, MCP
+Servers, and Vaults use their own required `name` field as the stable Konnect
+child name. Child entries inherit management scope from their parent AI
+Gateway and do not accept `kongctl` metadata.
 
 For AI Gateway Models, `target_models[].provider` must match an AI Gateway
 Provider `name` under the parent gateway. The provider can already exist or be
 declared in the same gateway configuration.
 
-For AI Gateway Models, MCP Servers, and Consumer Groups, `policies` entries
-reference AI Gateway Policies under the same parent gateway. Existing Konnect
-policy names or IDs can be supplied as strings. Declarative references should
-use `!ref <policy-ref>` so the relationship is explicit and same-plan policy
-creates are ordered and resolved.
+For AI Gateway Consumers, Consumer Groups, Models, and MCP Servers, `policies`
+entries reference AI Gateway Policies under the same parent gateway. Existing
+Konnect policy names or IDs can be supplied as strings. Declarative references
+should use `!ref <policy-ref>` so the relationship is explicit and same-plan
+policy creates are ordered and resolved.
 
-For AI Gateway Policies, Consumer Groups, MCP Servers, and Vaults, root-level
-declarations must include `ai_gateway`, while nested declarations inherit the
-parent gateway. Omit `policies`, `consumer_groups`, `mcp_servers`, or `vaults`
-to leave existing child resources unmanaged during sync. Use `policies: []`,
-`consumer_groups: []`, `mcp_servers: []`, or `vaults: []` under a specific AI
-Gateway to sync-delete that child type for that gateway. Root-level
-`ai_gateway_policies: []`, `ai_gateway_consumer_groups: []`,
+For AI Gateway Policies, Consumers, Consumer Groups, MCP Servers, and Vaults,
+root-level declarations must include `ai_gateway`, while nested declarations
+inherit the parent gateway. Omit `policies`, `consumers`, `consumer_groups`,
+`mcp_servers`, or `vaults` to leave existing child resources unmanaged during
+sync. Use `policies: []`, `consumers: []`, `consumer_groups: []`,
+`mcp_servers: []`, or `vaults: []` under a specific AI Gateway to sync-delete
+that child type for that gateway. Root-level `ai_gateway_policies: []`,
+`ai_gateway_consumers: []`, `ai_gateway_consumer_groups: []`,
 `ai_gateway_mcp_servers: []`, and `ai_gateway_vaults: []` are rejected because
 they do not identify a parent gateway.
 
@@ -390,6 +393,18 @@ ai_gateways:
          key: value
        managed_by: object [string]string
          key: value
+   consumers:
+    - ref: string
+      name: string required
+      type: api-key # or oauth
+      display_name: string required
+      custom_id: string
+      policies:
+       - !ref policy-ref
+      labels: object [string]string
+        key: value
+      managed_by: object [string]string
+        key: value
    consumer_groups:
     - ref: string
       name: string required
@@ -485,6 +500,25 @@ ai_gateway_policies:
    enabled: boolean
    global: boolean
    config: object required
+   labels: object [string]string
+     key: value
+   managed_by: object [string]string
+     key: value
+```
+
+AI Gateway Consumers can also be declared as root resources. Include
+`ai_gateway` to point at the parent gateway `ref`.
+
+```yaml
+ai_gateway_consumers:
+ - ref: string
+   ai_gateway: string required # AI Gateway ref
+   name: string required
+   type: api-key # or oauth
+   display_name: string required
+   custom_id: string
+   policies:
+    - !ref policy-ref
    labels: object [string]string
      key: value
    managed_by: object [string]string

--- a/docs/examples/declarative/ai-gateway/README.md
+++ b/docs/examples/declarative/ai-gateway/README.md
@@ -4,12 +4,12 @@ This directory contains declarative configuration examples for Konnect AI
 Gateway resources.
 
 - [ai-gateway.yaml](ai-gateway.yaml) defines a root AI Gateway resource with
-  a nested OpenAI provider, env vault, policy, consumer group, model that
-  targets that provider, and a conversion-only MCP Server.
+  a nested OpenAI provider, env vault, policy, consumer, consumer group, model
+  that targets that provider, and a conversion-only MCP Server.
 - [federated](federated) shows a multi-folder
   layout where a central team owns an AI Gateway and providers, while a peer
-  team owns root-level policies, consumer groups, models, MCP Servers, and
-  vaults that reference the shared gateway.
+  team owns root-level policies, consumers, consumer groups, models, MCP
+  Servers, and vaults that reference the shared gateway.
 
 Set `OPENAI_AUTH_HEADER` to the full upstream authorization header value
 before applying the example, for example `Bearer ...`.

--- a/docs/examples/declarative/ai-gateway/ai-gateway.yaml
+++ b/docs/examples/declarative/ai-gateway/ai-gateway.yaml
@@ -48,6 +48,16 @@ ai_gateways:
         config:
           anonymize:
             - email
+    consumers:
+      - ref: support-agent
+        name: support-agent
+        type: api-key
+        display_name: "Support Agent"
+        policies:
+          - !ref mask-sensitive-data
+        labels:
+          team: support
+          access: agent
     consumer_groups:
       - ref: premium-support-users
         name: premium-support-users

--- a/docs/examples/declarative/ai-gateway/federated/README.md
+++ b/docs/examples/declarative/ai-gateway/federated/README.md
@@ -2,8 +2,8 @@
 
 This example shows a federated layout for AI Gateway resources where a central
 AI platform team owns the shared AI Gateway and upstream providers, while a peer
-team owns root-level policies, consumer groups, models, MCP Servers, and vaults
-that target the shared gateway.
+team owns root-level policies, consumers, consumer groups, models, MCP Servers,
+and vaults that target the shared gateway.
 
 ## Structure
 
@@ -14,6 +14,7 @@ ai-gateway/federated/
 |-- external-peer-team/
 |   `-- support-model.yaml
 `-- peer-team/
+    |-- support-consumer.yaml
     |-- support-consumer-group.yaml
     |-- support-mcp-server.yaml
     |-- support-model.yaml
@@ -27,6 +28,10 @@ ai-gateway/federated/
   providers: OpenAI and Anthropic.
 - `peer-team/support-policy.yaml` defines a standalone `ai_gateway_policies`
   entry that references the central gateway with `!ref shared-ai-gateway#id`.
+- `peer-team/support-consumer.yaml` defines a standalone
+  `ai_gateway_consumers` entry that references the central gateway with
+  `!ref shared-ai-gateway#id` and attaches the policy with an explicit
+  `!ref peer-mask-sensitive-data`.
 - `peer-team/support-consumer-group.yaml` defines a standalone
   `ai_gateway_consumer_groups` entry that references the central gateway with
   `!ref shared-ai-gateway#id` and attaches the policy with an explicit

--- a/docs/examples/declarative/ai-gateway/federated/peer-team/support-consumer.yaml
+++ b/docs/examples/declarative/ai-gateway/federated/peer-team/support-consumer.yaml
@@ -1,0 +1,15 @@
+_defaults:
+  kongctl:
+    namespace: federated-ai-gateway
+
+ai_gateway_consumers:
+  - ref: support-agent
+    ai_gateway: !ref shared-ai-gateway#id
+    name: support-agent
+    type: api-key
+    display_name: "Support Agent"
+    policies:
+      - !ref peer-mask-sensitive-data
+    labels:
+      team: support-experience
+      access: agent

--- a/internal/cmd/root/products/konnect/aigateway/ai-gateway.go
+++ b/internal/cmd/root/products/konnect/aigateway/ai-gateway.go
@@ -31,6 +31,7 @@ func NewAIGatewayCmd(
 		root := newGetAIGatewayCmd(verb, &baseCmd, addParentFlags, parentPreRun).Command
 		root.AddCommand(newGetAIGatewayProvidersCmd(verb, addParentFlags, parentPreRun))
 		root.AddCommand(newGetAIGatewayPoliciesCmd(verb, addParentFlags, parentPreRun))
+		root.AddCommand(newGetAIGatewayConsumersCmd(verb, addParentFlags, parentPreRun))
 		root.AddCommand(newGetAIGatewayConsumerGroupsCmd(verb, addParentFlags, parentPreRun))
 		root.AddCommand(newGetAIGatewayModelsCmd(verb, addParentFlags, parentPreRun))
 		root.AddCommand(newGetAIGatewayMCPServersCmd(verb, addParentFlags, parentPreRun))

--- a/internal/cmd/root/products/konnect/aigateway/child_common.go
+++ b/internal/cmd/root/products/konnect/aigateway/child_common.go
@@ -27,6 +27,12 @@ const (
 	aiGatewayPolicyIDConfigPath   = "konnect.ai-gateway.policy.id"
 	aiGatewayPolicyNameConfigPath = "konnect.ai-gateway.policy.name"
 
+	aiGatewayConsumerIDFlagName   = "consumer-id"
+	aiGatewayConsumerNameFlagName = "consumer-name"
+
+	aiGatewayConsumerIDConfigPath   = "konnect.ai-gateway.consumer.id"
+	aiGatewayConsumerNameConfigPath = "konnect.ai-gateway.consumer.name"
+
 	aiGatewayConsumerGroupIDFlagName   = "consumer-group-id"
 	aiGatewayConsumerGroupNameFlagName = "consumer-group-name"
 
@@ -46,6 +52,13 @@ const (
 	aiGatewayVaultNameConfigPath = "konnect.ai-gateway.vault.name"
 
 	aiGatewayMissingValue = "n/a"
+
+	aiGatewayHeaderID          = "ID"
+	aiGatewayHeaderName        = "NAME"
+	aiGatewayHeaderDisplayName = "DISPLAY NAME"
+	aiGatewayHeaderType        = "TYPE"
+	aiGatewayHeaderPolicies    = "POLICIES"
+	aiGatewayHeaderUpdated     = "UPDATED"
 )
 
 func addAIGatewayChildFlags(c *cobra.Command) {
@@ -148,6 +161,40 @@ func bindAIGatewayPolicyFlags(c *cobra.Command, args []string) error {
 
 func getAIGatewayPolicyIdentifiers(cfg config.Hook) (id string, name string) {
 	return cfg.GetString(aiGatewayPolicyIDConfigPath), cfg.GetString(aiGatewayPolicyNameConfigPath)
+}
+
+func addAIGatewayConsumerFlags(c *cobra.Command) {
+	c.Flags().String(aiGatewayConsumerIDFlagName, "",
+		fmt.Sprintf(`The ID of the AI Gateway Consumer to retrieve.
+- Config path: [ %s ]`, aiGatewayConsumerIDConfigPath))
+	c.Flags().String(aiGatewayConsumerNameFlagName, "",
+		fmt.Sprintf(`The name of the AI Gateway Consumer to retrieve.
+- Config path: [ %s ]`, aiGatewayConsumerNameConfigPath))
+	c.MarkFlagsMutuallyExclusive(aiGatewayConsumerIDFlagName, aiGatewayConsumerNameFlagName)
+}
+
+func bindAIGatewayConsumerFlags(c *cobra.Command, args []string) error {
+	helper := cmd.BuildHelper(c, args)
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	if flag := c.Flags().Lookup(aiGatewayConsumerIDFlagName); flag != nil {
+		if err := cfg.BindFlag(aiGatewayConsumerIDConfigPath, flag); err != nil {
+			return err
+		}
+	}
+	if flag := c.Flags().Lookup(aiGatewayConsumerNameFlagName); flag != nil {
+		if err := cfg.BindFlag(aiGatewayConsumerNameConfigPath, flag); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getAIGatewayConsumerIdentifiers(cfg config.Hook) (id string, name string) {
+	return cfg.GetString(aiGatewayConsumerIDConfigPath), cfg.GetString(aiGatewayConsumerNameConfigPath)
 }
 
 func addAIGatewayConsumerGroupFlags(c *cobra.Command) {

--- a/internal/cmd/root/products/konnect/aigateway/consumers.go
+++ b/internal/cmd/root/products/konnect/aigateway/consumers.go
@@ -26,49 +26,50 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type aiGatewayConsumerGroupRecord struct {
+type aiGatewayConsumerRecord struct {
 	ID               string
 	Name             string
 	DisplayName      string
+	Type             string
 	PolicyCount      string
 	LocalUpdatedTime string
 }
 
 var (
-	aiGatewayConsumerGroupsUse   = "consumer-groups [consumer-group-id|consumer-group-name]"
-	aiGatewayConsumerGroupsShort = i18n.T(
-		"root.products.konnect.ai-gateway.consumer-groupsShort",
-		"List or get Consumer Groups for a Konnect AI Gateway",
+	aiGatewayConsumersUse   = "consumers [consumer-id|consumer-name]"
+	aiGatewayConsumersShort = i18n.T(
+		"root.products.konnect.ai-gateway.consumersShort",
+		"List or get Consumers for a Konnect AI Gateway",
 	)
-	aiGatewayConsumerGroupsLong = normalizers.LongDesc(i18n.T(
-		"root.products.konnect.ai-gateway.consumer-groupsLong",
-		`Use the consumer-groups command to list or retrieve Consumer Groups for a specific Konnect AI Gateway.`,
+	aiGatewayConsumersLong = normalizers.LongDesc(i18n.T(
+		"root.products.konnect.ai-gateway.consumersLong",
+		`Use the consumers command to list or retrieve Consumers for a specific Konnect AI Gateway.`,
 	))
-	aiGatewayConsumerGroupsExample = normalizers.Examples(
-		i18n.T("root.products.konnect.ai-gateway.consumer-groupsExamples",
-			fmt.Sprintf(`# List Consumer Groups for an AI Gateway by display name
-%[1]s get ai-gateway consumer-groups --gateway-name "Customer Support Gateway"
-# List Consumer Groups for an AI Gateway by ID
-%[1]s get ai-gateway consumer-groups --gateway-id <gateway-id>
-# Get a Consumer Group by name
-%[1]s get ai-gateway consumer-groups --gateway-name "Customer Support Gateway" premium-users
-# Get a Consumer Group by ID
-%[1]s get ai-gateway consumer-groups --gateway-id <gateway-id> --consumer-group-id <consumer-group-id>
+	aiGatewayConsumersExample = normalizers.Examples(
+		i18n.T("root.products.konnect.ai-gateway.consumersExamples",
+			fmt.Sprintf(`# List Consumers for an AI Gateway by display name
+%[1]s get ai-gateway consumers --gateway-name "Customer Support Gateway"
+# List Consumers for an AI Gateway by ID
+%[1]s get ai-gateway consumers --gateway-id <gateway-id>
+# Get a Consumer by name
+%[1]s get ai-gateway consumers --gateway-name "Customer Support Gateway" support-user
+# Get a Consumer by ID
+%[1]s get ai-gateway consumers --gateway-id <gateway-id> --consumer-id <consumer-id>
 `, meta.CLIName)),
 	)
 )
 
-func newGetAIGatewayConsumerGroupsCmd(
+func newGetAIGatewayConsumersCmd(
 	verb verbs.VerbValue,
 	addParentFlags func(verbs.VerbValue, *cobra.Command),
 	parentPreRun func(*cobra.Command, []string) error,
 ) *cobra.Command {
 	c := &cobra.Command{
-		Use:     aiGatewayConsumerGroupsUse,
-		Short:   aiGatewayConsumerGroupsShort,
-		Long:    aiGatewayConsumerGroupsLong,
-		Example: aiGatewayConsumerGroupsExample,
-		Aliases: []string{"consumer-group"},
+		Use:     aiGatewayConsumersUse,
+		Short:   aiGatewayConsumersShort,
+		Long:    aiGatewayConsumersLong,
+		Example: aiGatewayConsumersExample,
+		Aliases: []string{"consumer"},
 		PreRunE: func(c *cobra.Command, args []string) error {
 			if parentPreRun != nil {
 				if err := parentPreRun(c, args); err != nil {
@@ -78,31 +79,31 @@ func newGetAIGatewayConsumerGroupsCmd(
 			if err := bindAIGatewayChildFlags(c, args); err != nil {
 				return err
 			}
-			return bindAIGatewayConsumerGroupFlags(c, args)
+			return bindAIGatewayConsumerFlags(c, args)
 		},
 		RunE: func(c *cobra.Command, args []string) error {
-			handler := aiGatewayConsumerGroupsHandler{cmd: c}
+			handler := aiGatewayConsumersHandler{cmd: c}
 			return handler.run(args)
 		},
 	}
 
 	addAIGatewayChildFlags(c)
-	addAIGatewayConsumerGroupFlags(c)
+	addAIGatewayConsumerFlags(c)
 	if addParentFlags != nil {
 		addParentFlags(verb, c)
 	}
 	return c
 }
 
-type aiGatewayConsumerGroupsHandler struct {
+type aiGatewayConsumersHandler struct {
 	cmd *cobra.Command
 }
 
-func (h aiGatewayConsumerGroupsHandler) run(args []string) error {
+func (h aiGatewayConsumersHandler) run(args []string) error {
 	helper := cmd.BuildHelper(h.cmd, args)
 	if len(args) > 1 {
 		return &cmd.ConfigurationError{
-			Err: fmt.Errorf("too many arguments. Listing AI Gateway Consumer Groups requires 0 or 1 arguments (ID or name)"),
+			Err: fmt.Errorf("too many arguments. Listing AI Gateway Consumers requires 0 or 1 arguments (ID or name)"),
 		}
 	}
 
@@ -112,13 +113,13 @@ func (h aiGatewayConsumerGroupsHandler) run(args []string) error {
 	}
 
 	if len(args) == 1 {
-		groupID, groupName := getAIGatewayConsumerGroupIdentifiers(cfg)
-		if groupID != "" || groupName != "" {
+		consumerID, consumerName := getAIGatewayConsumerIdentifiers(cfg)
+		if consumerID != "" || consumerName != "" {
 			return &cmd.ConfigurationError{
 				Err: fmt.Errorf(
 					"cannot specify both positional argument and --%s or --%s flags",
-					aiGatewayConsumerGroupIDFlagName,
-					aiGatewayConsumerGroupNameFlagName,
+					aiGatewayConsumerIDFlagName,
+					aiGatewayConsumerNameFlagName,
 				),
 			}
 		}
@@ -165,21 +166,21 @@ func (h aiGatewayConsumerGroupsHandler) run(args []string) error {
 		}
 	}
 
-	groupAPI := sdk.GetAIGatewayConsumerGroupsAPI()
-	if groupAPI == nil {
+	consumerAPI := sdk.GetAIGatewayConsumersAPI()
+	if consumerAPI == nil {
 		return &cmd.ExecutionError{
-			Msg: "AI Gateway Consumer Groups client is not available",
-			Err: fmt.Errorf("AI Gateway Consumer Groups client not configured"),
+			Msg: "AI Gateway Consumers client is not available",
+			Err: fmt.Errorf("AI Gateway Consumers client not configured"),
 		}
 	}
 
-	groupID, groupName := getAIGatewayConsumerGroupIdentifiers(cfg)
-	if groupID != "" && groupName != "" {
+	consumerID, consumerName := getAIGatewayConsumerIdentifiers(cfg)
+	if consumerID != "" && consumerName != "" {
 		return &cmd.ConfigurationError{
 			Err: fmt.Errorf(
 				"only one of --%s or --%s can be provided",
-				aiGatewayConsumerGroupIDFlagName,
-				aiGatewayConsumerGroupNameFlagName,
+				aiGatewayConsumerIDFlagName,
+				aiGatewayConsumerNameFlagName,
 			),
 		}
 	}
@@ -187,40 +188,41 @@ func (h aiGatewayConsumerGroupsHandler) run(args []string) error {
 	identifier := ""
 	if len(args) == 1 {
 		identifier = strings.TrimSpace(args[0])
-	} else if groupID != "" {
-		identifier = groupID
-	} else if groupName != "" {
-		identifier = groupName
+	} else if consumerID != "" {
+		identifier = consumerID
+	} else if consumerName != "" {
+		identifier = consumerName
 	}
 
 	if identifier != "" {
-		return h.getSingleConsumerGroup(helper, groupAPI, gatewayID, identifier, outType, printer)
+		return h.getSingleConsumer(helper, consumerAPI, gatewayID, identifier, outType, printer)
 	}
-	return h.listConsumerGroups(helper, groupAPI, gatewayID, outType, printer, cfg)
+	return h.listConsumers(helper, consumerAPI, gatewayID, outType, printer, cfg)
 }
 
-func (h aiGatewayConsumerGroupsHandler) listConsumerGroups(
+func (h aiGatewayConsumersHandler) listConsumers(
 	helper cmd.Helper,
-	groupAPI helpers.AIGatewayConsumerGroupsAPI,
+	consumerAPI helpers.AIGatewayConsumersAPI,
 	gatewayID string,
 	outType cmdCommon.OutputFormat,
 	printer cli.PrintFlusher,
 	cfg config.Hook,
 ) error {
-	groups, err := fetchAIGatewayConsumerGroups(helper, groupAPI, gatewayID, cfg)
+	consumers, err := fetchAIGatewayConsumers(helper, consumerAPI, gatewayID, cfg)
 	if err != nil {
 		return err
 	}
 
-	records := make([]aiGatewayConsumerGroupRecord, 0, len(groups))
-	tableRows := make([]table.Row, 0, len(groups))
-	for _, group := range groups {
-		record := aiGatewayConsumerGroupToRecord(group)
+	records := make([]aiGatewayConsumerRecord, 0, len(consumers))
+	tableRows := make([]table.Row, 0, len(consumers))
+	for _, consumer := range consumers {
+		record := aiGatewayConsumerToRecord(consumer)
 		records = append(records, record)
 		tableRows = append(tableRows, table.Row{
 			record.ID,
 			record.Name,
 			record.DisplayName,
+			record.Type,
 			record.PolicyCount,
 			record.LocalUpdatedTime,
 		})
@@ -233,13 +235,14 @@ func (h aiGatewayConsumerGroupsHandler) listConsumerGroups(
 		printer,
 		helper.GetStreams(),
 		records,
-		groups,
+		consumers,
 		"",
 		tableview.WithCustomTable(
 			[]string{
 				aiGatewayHeaderID,
 				aiGatewayHeaderName,
 				aiGatewayHeaderDisplayName,
+				aiGatewayHeaderType,
 				aiGatewayHeaderPolicies,
 				aiGatewayHeaderUpdated,
 			},
@@ -248,42 +251,42 @@ func (h aiGatewayConsumerGroupsHandler) listConsumerGroups(
 		tableview.WithRootLabel(helper.GetCmd().Name()),
 		tableview.WithDetailHelper(helper),
 		tableview.WithDetailRenderer(func(index int) string {
-			if index < 0 || index >= len(groups) {
+			if index < 0 || index >= len(consumers) {
 				return ""
 			}
-			return aiGatewayConsumerGroupDetailView(groups[index])
+			return aiGatewayConsumerDetailView(consumers[index])
 		}),
-		tableview.WithDetailContext(common.ViewParentAIGatewayConsumerGroup, func(index int) any {
-			if index < 0 || index >= len(groups) {
+		tableview.WithDetailContext(common.ViewParentAIGatewayConsumer, func(index int) any {
+			if index < 0 || index >= len(consumers) {
 				return nil
 			}
-			return &groups[index]
+			return &consumers[index]
 		}),
 	)
 }
 
-func (h aiGatewayConsumerGroupsHandler) getSingleConsumerGroup(
+func (h aiGatewayConsumersHandler) getSingleConsumer(
 	helper cmd.Helper,
-	groupAPI helpers.AIGatewayConsumerGroupsAPI,
+	consumerAPI helpers.AIGatewayConsumersAPI,
 	gatewayID string,
 	identifier string,
 	outType cmdCommon.OutputFormat,
 	printer cli.PrintFlusher,
 ) error {
-	res, err := groupAPI.GetAiGatewayConsumerGroup(helper.GetContext(), gatewayID, identifier)
+	res, err := consumerAPI.GetAiGatewayConsumer(helper.GetContext(), gatewayID, identifier)
 	if err != nil {
 		attrs := cmd.TryConvertErrorToAttrs(err)
-		return cmd.PrepareExecutionError("Failed to get AI Gateway Consumer Group", err, helper.GetCmd(), attrs...)
+		return cmd.PrepareExecutionError("Failed to get AI Gateway Consumer", err, helper.GetCmd(), attrs...)
 	}
-	if res == nil || res.AIGatewayConsumerGroup == nil {
+	if res == nil || res.AIGatewayConsumer == nil {
 		return &cmd.ExecutionError{
-			Msg: "AI Gateway Consumer Group response was empty",
-			Err: fmt.Errorf("no Consumer Group returned for id or name %s", identifier),
+			Msg: "AI Gateway Consumer response was empty",
+			Err: fmt.Errorf("no Consumer returned for id or name %s", identifier),
 		}
 	}
-	group := res.AIGatewayConsumerGroup
+	consumer := res.AIGatewayConsumer
 
-	record := aiGatewayConsumerGroupToRecord(*group)
+	record := aiGatewayConsumerToRecord(*consumer)
 	return tableview.RenderForFormat(
 		helper,
 		false,
@@ -291,7 +294,7 @@ func (h aiGatewayConsumerGroupsHandler) getSingleConsumerGroup(
 		printer,
 		helper.GetStreams(),
 		record,
-		group,
+		consumer,
 		"",
 		tableview.WithRootLabel(helper.GetCmd().Name()),
 		tableview.WithDetailHelper(helper),
@@ -299,29 +302,29 @@ func (h aiGatewayConsumerGroupsHandler) getSingleConsumerGroup(
 			if index != 0 {
 				return ""
 			}
-			return aiGatewayConsumerGroupDetailView(*group)
+			return aiGatewayConsumerDetailView(*consumer)
 		}),
-		tableview.WithDetailContext(common.ViewParentAIGatewayConsumerGroup, func(index int) any {
+		tableview.WithDetailContext(common.ViewParentAIGatewayConsumer, func(index int) any {
 			if index != 0 {
 				return nil
 			}
-			return group
+			return consumer
 		}),
 	)
 }
 
-func fetchAIGatewayConsumerGroups(
+func fetchAIGatewayConsumers(
 	helper cmd.Helper,
-	groupAPI helpers.AIGatewayConsumerGroupsAPI,
+	consumerAPI helpers.AIGatewayConsumersAPI,
 	gatewayID string,
 	cfg config.Hook,
-) ([]kkComps.AIGatewayConsumerGroup, error) {
+) ([]kkComps.AIGatewayConsumer, error) {
 	requestPageSize := common.ResolveRequestPageSize(cfg)
 	var pageAfter *string
-	var allData []kkComps.AIGatewayConsumerGroup
+	var allData []kkComps.AIGatewayConsumer
 
 	for {
-		req := kkOps.ListAiGatewayConsumerGroupsRequest{
+		req := kkOps.ListAiGatewayConsumersRequest{
 			GatewayID: gatewayID,
 			PageSize:  &requestPageSize,
 		}
@@ -329,22 +332,17 @@ func fetchAIGatewayConsumerGroups(
 			req.PageAfter = pageAfter
 		}
 
-		res, err := groupAPI.ListAiGatewayConsumerGroups(helper.GetContext(), req)
+		res, err := consumerAPI.ListAiGatewayConsumers(helper.GetContext(), req)
 		if err != nil {
 			attrs := cmd.TryConvertErrorToAttrs(err)
-			return nil, cmd.PrepareExecutionError(
-				"Failed to list AI Gateway Consumer Groups",
-				err,
-				helper.GetCmd(),
-				attrs...,
-			)
+			return nil, cmd.PrepareExecutionError("Failed to list AI Gateway Consumers", err, helper.GetCmd(), attrs...)
 		}
-		if res == nil || res.ListAIGatewayConsumerGroupsResponse == nil {
+		if res == nil || res.ListAIGatewayConsumersResponse == nil {
 			break
 		}
 
-		allData = append(allData, res.ListAIGatewayConsumerGroupsResponse.Data...)
-		nextCursor := pagination.ExtractPageAfterCursor(res.ListAIGatewayConsumerGroupsResponse.Meta.Page.Next)
+		allData = append(allData, res.ListAIGatewayConsumersResponse.Data...)
+		nextCursor := pagination.ExtractPageAfterCursor(res.ListAIGatewayConsumersResponse.Meta.Page.Next)
 		if nextCursor == "" {
 			break
 		}
@@ -354,26 +352,27 @@ func fetchAIGatewayConsumerGroups(
 	return allData, nil
 }
 
-func aiGatewayConsumerGroupToRecord(group kkComps.AIGatewayConsumerGroup) aiGatewayConsumerGroupRecord {
-	record := aiGatewayConsumerGroupRecord{
+func aiGatewayConsumerToRecord(consumer kkComps.AIGatewayConsumer) aiGatewayConsumerRecord {
+	record := aiGatewayConsumerRecord{
 		ID:               aiGatewayMissingValue,
-		Name:             valueOrMissing(declresources.AIGatewayConsumerGroupName(group)),
-		DisplayName:      valueOrMissing(declresources.AIGatewayConsumerGroupDisplayName(group)),
-		PolicyCount:      fmt.Sprintf("%d", len(group.Policies)),
+		Name:             valueOrMissing(declresources.AIGatewayConsumerName(consumer)),
+		DisplayName:      valueOrMissing(declresources.AIGatewayConsumerDisplayName(consumer)),
+		Type:             valueOrMissing(string(consumer.Type)),
+		PolicyCount:      fmt.Sprintf("%d", len(consumer.Policies)),
 		LocalUpdatedTime: aiGatewayMissingValue,
 	}
-	if id := declresources.AIGatewayConsumerGroupID(group); id != "" {
+	if id := declresources.AIGatewayConsumerID(consumer); id != "" {
 		record.ID = util.AbbreviateUUID(id)
 	}
-	if updatedAt := declresources.AIGatewayConsumerGroupUpdatedAt(group); !updatedAt.IsZero() {
+	if updatedAt := declresources.AIGatewayConsumerUpdatedAt(consumer); !updatedAt.IsZero() {
 		record.LocalUpdatedTime = updatedAt.In(time.Local).Format("2006-01-02 15:04:05")
 	}
 	return record
 }
 
-func aiGatewayConsumerGroupDetailView(group kkComps.AIGatewayConsumerGroup) string {
+func aiGatewayConsumerDetailView(consumer kkComps.AIGatewayConsumer) string {
 	payload := make(map[string]any)
-	data, err := json.Marshal(group)
+	data, err := json.Marshal(consumer)
 	if err == nil {
 		_ = json.Unmarshal(data, &payload)
 	}
@@ -381,7 +380,9 @@ func aiGatewayConsumerGroupDetailView(group kkComps.AIGatewayConsumerGroup) stri
 	order := []string{
 		"id",
 		"name",
+		"type",
 		"display_name",
+		"custom_id",
 		"policies",
 		"labels",
 		"managed_by",
@@ -396,14 +397,15 @@ func aiGatewayConsumerGroupDetailView(group kkComps.AIGatewayConsumerGroup) stri
 	return strings.TrimRight(b.String(), "\n")
 }
 
-func buildAIGatewayConsumerGroupChildView(groups []kkComps.AIGatewayConsumerGroup) tableview.ChildView {
-	tableRows := make([]table.Row, 0, len(groups))
-	for i := range groups {
-		record := aiGatewayConsumerGroupToRecord(groups[i])
+func buildAIGatewayConsumerChildView(consumers []kkComps.AIGatewayConsumer) tableview.ChildView {
+	tableRows := make([]table.Row, 0, len(consumers))
+	for i := range consumers {
+		record := aiGatewayConsumerToRecord(consumers[i])
 		tableRows = append(tableRows, table.Row{
 			record.ID,
 			record.Name,
 			record.DisplayName,
+			record.Type,
 			record.PolicyCount,
 		})
 	}
@@ -413,22 +415,23 @@ func buildAIGatewayConsumerGroupChildView(groups []kkComps.AIGatewayConsumerGrou
 			aiGatewayHeaderID,
 			aiGatewayHeaderName,
 			aiGatewayHeaderDisplayName,
+			aiGatewayHeaderType,
 			aiGatewayHeaderPolicies,
 		},
 		Rows: tableRows,
 		DetailRenderer: func(index int) string {
-			if index < 0 || index >= len(groups) {
+			if index < 0 || index >= len(consumers) {
 				return ""
 			}
-			return aiGatewayConsumerGroupDetailView(groups[index])
+			return aiGatewayConsumerDetailView(consumers[index])
 		},
-		Title:      "AI Gateway Consumer Groups",
-		ParentType: common.ViewParentAIGatewayConsumerGroup,
+		Title:      "AI Gateway Consumers",
+		ParentType: common.ViewParentAIGatewayConsumer,
 		DetailContext: func(index int) any {
-			if index < 0 || index >= len(groups) {
+			if index < 0 || index >= len(consumers) {
 				return nil
 			}
-			return &groups[index]
+			return &consumers[index]
 		},
 	}
 }

--- a/internal/cmd/root/products/konnect/aigateway/getAIGateway.go
+++ b/internal/cmd/root/products/konnect/aigateway/getAIGateway.go
@@ -312,7 +312,7 @@ func buildAIGatewayChildView(gateways []kkComps.AIGateway) tableview.ChildView {
 	}
 
 	return tableview.ChildView{
-		Headers:        []string{"ID", "DISPLAY NAME"},
+		Headers:        []string{aiGatewayHeaderID, aiGatewayHeaderDisplayName},
 		Rows:           tableRows,
 		DetailRenderer: detailFn,
 		Title:          "AI Gateways",

--- a/internal/cmd/root/products/konnect/aigateway/interactive_children.go
+++ b/internal/cmd/root/products/konnect/aigateway/interactive_children.go
@@ -14,6 +14,7 @@ import (
 func init() {
 	tableview.RegisterChildLoader(common.ViewParentAIGateway, common.ViewFieldProviders, loadAIGatewayProviders)
 	tableview.RegisterChildLoader(common.ViewParentAIGateway, common.ViewFieldPolicies, loadAIGatewayPolicies)
+	tableview.RegisterChildLoader(common.ViewParentAIGateway, common.ViewFieldConsumers, loadAIGatewayConsumers)
 	tableview.RegisterChildLoader(common.ViewParentAIGateway, common.ViewFieldConsumerGroups, loadAIGatewayConsumerGroups)
 }
 
@@ -77,6 +78,37 @@ func loadAIGatewayPolicies(_ context.Context, helper cmd.Helper, parent any) (ta
 		return tableview.ChildView{}, err
 	}
 	return buildAIGatewayPolicyChildView(policies), nil
+}
+
+func loadAIGatewayConsumers(_ context.Context, helper cmd.Helper, parent any) (tableview.ChildView, error) {
+	gatewayID, err := aiGatewayIDFromParent(parent)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	consumerAPI := sdk.GetAIGatewayConsumersAPI()
+	if consumerAPI == nil {
+		return tableview.ChildView{}, fmt.Errorf("AI Gateway Consumers client is not available")
+	}
+
+	consumers, err := fetchAIGatewayConsumers(helper, consumerAPI, gatewayID, cfg)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+	return buildAIGatewayConsumerChildView(consumers), nil
 }
 
 func loadAIGatewayConsumerGroups(_ context.Context, helper cmd.Helper, parent any) (tableview.ChildView, error) {

--- a/internal/cmd/root/products/konnect/aigateway/mcp_servers.go
+++ b/internal/cmd/root/products/konnect/aigateway/mcp_servers.go
@@ -238,7 +238,14 @@ func (h aiGatewayMCPServersHandler) listMCPServers(
 		servers,
 		"",
 		tableview.WithCustomTable(
-			[]string{"ID", "NAME", "DISPLAY NAME", "TYPE", "ENABLED", "UPDATED"},
+			[]string{
+				aiGatewayHeaderID,
+				aiGatewayHeaderName,
+				aiGatewayHeaderDisplayName,
+				aiGatewayHeaderType,
+				"ENABLED",
+				aiGatewayHeaderUpdated,
+			},
 			tableRows,
 		),
 		tableview.WithRootLabel(helper.GetCmd().Name()),

--- a/internal/cmd/root/products/konnect/aigateway/models.go
+++ b/internal/cmd/root/products/konnect/aigateway/models.go
@@ -268,7 +268,14 @@ func (h aiGatewayModelsHandler) listModels(
 		models,
 		"",
 		tableview.WithCustomTable(
-			[]string{"ID", "NAME", "DISPLAY NAME", "TYPE", "ENABLED", "UPDATED"},
+			[]string{
+				aiGatewayHeaderID,
+				aiGatewayHeaderName,
+				aiGatewayHeaderDisplayName,
+				aiGatewayHeaderType,
+				"ENABLED",
+				aiGatewayHeaderUpdated,
+			},
 			tableRows,
 		),
 		tableview.WithRootLabel(helper.GetCmd().Name()),

--- a/internal/cmd/root/products/konnect/aigateway/policies.go
+++ b/internal/cmd/root/products/konnect/aigateway/policies.go
@@ -240,7 +240,15 @@ func (h aiGatewayPoliciesHandler) listPolicies(
 		policies,
 		"",
 		tableview.WithCustomTable(
-			[]string{"ID", "NAME", "DISPLAY NAME", "TYPE", "ENABLED", "GLOBAL", "UPDATED"},
+			[]string{
+				aiGatewayHeaderID,
+				aiGatewayHeaderName,
+				aiGatewayHeaderDisplayName,
+				aiGatewayHeaderType,
+				"ENABLED",
+				"GLOBAL",
+				aiGatewayHeaderUpdated,
+			},
 			tableRows,
 		),
 		tableview.WithRootLabel(helper.GetCmd().Name()),
@@ -415,8 +423,15 @@ func buildAIGatewayPolicyChildView(policies []kkComps.AIGatewayPolicy) tableview
 	}
 
 	return tableview.ChildView{
-		Headers: []string{"ID", "NAME", "TYPE", "DISPLAY NAME", "ENABLED", "GLOBAL"},
-		Rows:    tableRows,
+		Headers: []string{
+			aiGatewayHeaderID,
+			aiGatewayHeaderName,
+			aiGatewayHeaderType,
+			aiGatewayHeaderDisplayName,
+			"ENABLED",
+			"GLOBAL",
+		},
+		Rows: tableRows,
 		DetailRenderer: func(index int) string {
 			if index < 0 || index >= len(policies) {
 				return ""

--- a/internal/cmd/root/products/konnect/aigateway/providers.go
+++ b/internal/cmd/root/products/konnect/aigateway/providers.go
@@ -233,7 +233,10 @@ func (h aiGatewayProvidersHandler) listProviders(
 		records,
 		providers,
 		"",
-		tableview.WithCustomTable([]string{"ID", "NAME", "TYPE", "DISPLAY NAME"}, tableRows),
+		tableview.WithCustomTable(
+			[]string{aiGatewayHeaderID, aiGatewayHeaderName, aiGatewayHeaderType, aiGatewayHeaderDisplayName},
+			tableRows,
+		),
 		tableview.WithRootLabel(helper.GetCmd().Name()),
 		tableview.WithDetailHelper(helper),
 		tableview.WithDetailContext(common.ViewParentAIGatewayProvider, func(index int) any {
@@ -375,7 +378,7 @@ func buildAIGatewayProviderChildView(providers []kkComps.AIGatewayProvider) tabl
 	}
 
 	return tableview.ChildView{
-		Headers: []string{"ID", "NAME", "TYPE", "DISPLAY NAME"},
+		Headers: []string{aiGatewayHeaderID, aiGatewayHeaderName, aiGatewayHeaderType, aiGatewayHeaderDisplayName},
 		Rows:    tableRows,
 		DetailRenderer: func(index int) string {
 			if index < 0 || index >= len(providers) {

--- a/internal/cmd/root/products/konnect/aigateway/vaults.go
+++ b/internal/cmd/root/products/konnect/aigateway/vaults.go
@@ -236,7 +236,13 @@ func (h aiGatewayVaultsHandler) listVaults(
 		vaults,
 		"",
 		tableview.WithCustomTable(
-			[]string{"ID", "NAME", "TYPE", "DESCRIPTION", "UPDATED"},
+			[]string{
+				aiGatewayHeaderID,
+				aiGatewayHeaderName,
+				aiGatewayHeaderType,
+				"DESCRIPTION",
+				aiGatewayHeaderUpdated,
+			},
 			tableRows,
 		),
 		tableview.WithRootLabel(helper.GetCmd().Name()),

--- a/internal/cmd/root/products/konnect/common/view_identifiers.go
+++ b/internal/cmd/root/products/konnect/common/view_identifiers.go
@@ -8,6 +8,7 @@ const (
 	ViewParentAIGateway                     = "ai-gateway"
 	ViewParentAIGatewayProvider             = "ai-gateway-provider"
 	ViewParentAIGatewayPolicy               = "ai-gateway-policy"
+	ViewParentAIGatewayConsumer             = "ai-gateway-consumer"
 	ViewParentAIGatewayConsumerGroup        = "ai-gateway-consumer-group"
 	ViewParentAIGatewayModel                = "ai-gateway-model"
 	ViewParentAIGatewayMCPServer            = "ai-gateway-mcp-server"

--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -2844,6 +2844,7 @@ func createStateClient(kkClient helpers.SDKAPI) *state.Client {
 		AIGatewayAPI:            kkClient.GetAIGatewayAPI(),
 		AIGatewayProvidersAPI:   kkClient.GetAIGatewayProvidersAPI(),
 		AIGatewayPoliciesAPI:    kkClient.GetAIGatewayPoliciesAPI(),
+		AIGatewayConsumersAPI:   kkClient.GetAIGatewayConsumersAPI(),
 		AIGatewayModelAPI:       kkClient.GetAIGatewayModelAPI(),
 		AIGatewayMCPServersAPI:  kkClient.GetAIGatewayMCPServersAPI(),
 		AIGatewayVaultsAPI:      kkClient.GetAIGatewayVaultsAPI(),

--- a/internal/cmd/root/verbs/dump/common.go
+++ b/internal/cmd/root/verbs/dump/common.go
@@ -162,6 +162,8 @@ func mapResourceName(name string) string {
 		return "ai_gateways"
 	case "ai-gateway-policy", "ai-gateway-policies", "ai_gateway_policy", "ai_gateway_policies":
 		return "ai_gateway_policies"
+	case "ai-gateway-consumer", "ai-gateway-consumers", "ai_gateway_consumer", "ai_gateway_consumers":
+		return "ai_gateway_consumers"
 	case "ai-gateway-consumer-group", "ai-gateway-consumer-groups",
 		"ai_gateway_consumer_group", "ai_gateway_consumer_groups":
 		return "ai_gateway_consumer_groups"

--- a/internal/cmd/root/verbs/dump/declarative.go
+++ b/internal/cmd/root/verbs/dump/declarative.go
@@ -54,6 +54,7 @@ var declarativeAllowedResources = map[string]struct{}{
 	"event_gateways":              {},
 	"ai_gateways":                 {},
 	"ai_gateway_policies":         {},
+	"ai_gateway_consumers":        {},
 	"ai_gateway_consumer_groups":  {},
 	"ai_gateway_models":           {},
 	"ai_gateway_mcp_servers":      {},
@@ -91,7 +92,8 @@ func newDeclarativeCmd() *cobra.Command {
 		"Comma separated list of resource types to dump "+
 			"(portals, apis, application_auth_strategies, dcr_providers, control_planes, "+
 			resourceAnalyticsDashboards+", event_gateways, ai_gateways, ai_gateway_policies, "+
-			"ai_gateway_consumer_groups, ai_gateway_models, ai_gateway_mcp_servers, ai_gateway_vaults, "+
+			"ai_gateway_consumers, ai_gateway_consumer_groups, ai_gateway_models, "+
+			"ai_gateway_mcp_servers, ai_gateway_vaults, "+
 			"organization.teams).")
 	_ = cmd.MarkFlagRequired("resources")
 
@@ -208,6 +210,7 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 	var stateClient *declstate.Client
 	if opts.includeChildResources ||
 		slices.Contains(opts.resources, "ai_gateway_policies") ||
+		slices.Contains(opts.resources, "ai_gateway_consumers") ||
 		slices.Contains(opts.resources, "ai_gateway_consumer_groups") ||
 		slices.Contains(opts.resources, "ai_gateway_models") ||
 		slices.Contains(opts.resources, "ai_gateway_mcp_servers") ||
@@ -225,6 +228,7 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 			AIGatewayAPI:                        sdk.GetAIGatewayAPI(),
 			AIGatewayProvidersAPI:               sdk.GetAIGatewayProvidersAPI(),
 			AIGatewayPoliciesAPI:                sdk.GetAIGatewayPoliciesAPI(),
+			AIGatewayConsumersAPI:               sdk.GetAIGatewayConsumersAPI(),
 			AIGatewayConsumerGroupsAPI:          sdk.GetAIGatewayConsumerGroupsAPI(),
 			AIGatewayModelAPI:                   sdk.GetAIGatewayModelAPI(),
 			AIGatewayMCPServersAPI:              sdk.GetAIGatewayMCPServersAPI(),
@@ -385,6 +389,18 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 				return err
 			}
 			resourceSet.AIGatewayPolicies = append(resourceSet.AIGatewayPolicies, policies...)
+		case "ai_gateway_consumers":
+			consumers, err := collectDeclarativeAIGatewayConsumers(
+				ctx,
+				stateClient,
+				sdk.GetAIGatewayAPI(),
+				requestPageSize,
+				opts.filter,
+			)
+			if err != nil {
+				return err
+			}
+			resourceSet.AIGatewayConsumers = append(resourceSet.AIGatewayConsumers, consumers...)
 		case "ai_gateway_consumer_groups":
 			groups, err := collectDeclarativeAIGatewayConsumerGroups(
 				ctx,
@@ -876,6 +892,44 @@ func collectDeclarativeAIGatewayConsumerGroups(
 	})
 
 	return groups, nil
+}
+
+func collectDeclarativeAIGatewayConsumers(
+	ctx context.Context,
+	client *declstate.Client,
+	aiGatewayClient helpers.AIGatewayAPI,
+	requestPageSize int64,
+	filter filterOptions,
+) ([]declresources.AIGatewayConsumerResource, error) {
+	if client == nil {
+		return nil, fmt.Errorf("AI Gateway Consumers API client is not configured")
+	}
+
+	gateways, err := collectDeclarativeAIGateways(ctx, aiGatewayClient, requestPageSize, filterOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var consumers []declresources.AIGatewayConsumerResource
+	for _, gateway := range gateways {
+		gatewayConsumers, err := buildAIGatewayConsumers(ctx, client, gateway.Ref, gateway.DisplayName, gateway.Ref)
+		if err != nil {
+			return nil, err
+		}
+		consumers = append(consumers, gatewayConsumers...)
+	}
+
+	consumers = filterByNameOrID(consumers, filter, func(r declresources.AIGatewayConsumerResource) (string, string) {
+		return r.Name, r.Ref
+	})
+	slices.SortFunc(consumers, func(a, b declresources.AIGatewayConsumerResource) int {
+		if a.AIGateway == b.AIGateway {
+			return cmp.Compare(a.Name, b.Name)
+		}
+		return cmp.Compare(a.AIGateway, b.AIGateway)
+	})
+
+	return consumers, nil
 }
 
 func collectDeclarativeAIGatewayModels(

--- a/internal/cmd/root/verbs/dump/declarative_children.go
+++ b/internal/cmd/root/verbs/dump/declarative_children.go
@@ -284,6 +284,15 @@ func populateAIGatewayChildren(
 			gateway.Policies = policies
 		}
 
+		consumers, err := buildAIGatewayConsumers(ctx, client, gatewayID, gateway.DisplayName, "")
+		if err != nil {
+			logWarn(logger, "failed to load AI Gateway Consumers", gatewayID, gateway.DisplayName, err)
+			continue
+		}
+		if len(consumers) > 0 {
+			gateway.Consumers = consumers
+		}
+
 		groups, err := buildAIGatewayConsumerGroups(ctx, client, gatewayID, gateway.DisplayName, "")
 		if err != nil {
 			logWarn(logger, "failed to load AI Gateway Consumer Groups", gatewayID, gateway.DisplayName, err)
@@ -403,6 +412,39 @@ func buildAIGatewayPolicies(
 	}
 
 	slices.SortFunc(result, func(a, b declresources.AIGatewayPolicyResource) int {
+		if a.Name == b.Name {
+			return cmp.Compare(a.Ref, b.Ref)
+		}
+		return cmp.Compare(a.Name, b.Name)
+	})
+
+	return result, nil
+}
+
+func buildAIGatewayConsumers(
+	ctx context.Context,
+	client *declstate.Client,
+	gatewayID string,
+	gatewayName string,
+	gatewayRef string,
+) ([]declresources.AIGatewayConsumerResource, error) {
+	consumers, err := client.ListAIGatewayConsumers(ctx, gatewayID)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]declresources.AIGatewayConsumerResource, 0, len(consumers))
+	for _, consumer := range consumers {
+		resource, err := declresources.AIGatewayConsumerResourceFromResponse(
+			gatewayRef,
+			consumer.AIGatewayConsumer,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to map AI Gateway Consumer for gateway %s: %w", gatewayName, err)
+		}
+		result = append(result, resource)
+	}
+
+	slices.SortFunc(result, func(a, b declresources.AIGatewayConsumerResource) int {
 		if a.Name == b.Name {
 			return cmp.Compare(a.Ref, b.Ref)
 		}

--- a/internal/declarative/executor/ai_gateway_consumer_adapter.go
+++ b/internal/declarative/executor/ai_gateway_consumer_adapter.go
@@ -1,0 +1,176 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+)
+
+// AIGatewayConsumerAdapter implements ResourceOperations for AI Gateway Consumers.
+type AIGatewayConsumerAdapter struct {
+	client *state.Client
+}
+
+// NewAIGatewayConsumerAdapter creates a new AI Gateway Consumer adapter.
+func NewAIGatewayConsumerAdapter(client *state.Client) *AIGatewayConsumerAdapter {
+	return &AIGatewayConsumerAdapter{client: client}
+}
+
+// MapCreateFields maps planner fields to CreateAIGatewayConsumerRequest.
+func (a *AIGatewayConsumerAdapter) MapCreateFields(
+	_ context.Context,
+	_ *ExecutionContext,
+	fields map[string]any,
+	create *kkComps.CreateAIGatewayConsumerRequest,
+) error {
+	data, err := json.Marshal(fields)
+	if err != nil {
+		return fmt.Errorf("failed to encode AI Gateway Consumer create fields: %w", err)
+	}
+	if err := json.Unmarshal(data, create); err != nil {
+		return fmt.Errorf("failed to decode AI Gateway Consumer create fields: %w", err)
+	}
+	if create.Name == "" || create.DisplayName == "" || create.Type == "" {
+		return fmt.Errorf("name, display_name, and type are required")
+	}
+	return nil
+}
+
+// MapUpdateFields maps planner fields to UpdateAIGatewayConsumerRequest.
+func (a *AIGatewayConsumerAdapter) MapUpdateFields(
+	_ context.Context,
+	_ *ExecutionContext,
+	fields map[string]any,
+	update *kkComps.UpdateAIGatewayConsumerRequest,
+	_ map[string]string,
+) error {
+	data, err := json.Marshal(fields)
+	if err != nil {
+		return fmt.Errorf("failed to encode AI Gateway Consumer update fields: %w", err)
+	}
+	if err := json.Unmarshal(data, update); err != nil {
+		return fmt.Errorf("failed to decode AI Gateway Consumer update fields: %w", err)
+	}
+	return nil
+}
+
+// Create creates an AI Gateway Consumer.
+func (a *AIGatewayConsumerAdapter) Create(
+	ctx context.Context,
+	req kkComps.CreateAIGatewayConsumerRequest,
+	namespace string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	gatewayID, err := a.getAIGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return "", err
+	}
+	return a.client.CreateAIGatewayConsumer(ctx, gatewayID, req, namespace)
+}
+
+// Update updates an AI Gateway Consumer.
+func (a *AIGatewayConsumerAdapter) Update(
+	ctx context.Context,
+	id string,
+	req kkComps.UpdateAIGatewayConsumerRequest,
+	namespace string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	gatewayID, err := a.getAIGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return "", err
+	}
+	return a.client.UpdateAIGatewayConsumer(ctx, gatewayID, id, req, namespace)
+}
+
+// Delete deletes an AI Gateway Consumer.
+func (a *AIGatewayConsumerAdapter) Delete(ctx context.Context, id string, execCtx *ExecutionContext) error {
+	gatewayID, err := a.getAIGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return err
+	}
+	return a.client.DeleteAIGatewayConsumer(ctx, gatewayID, id)
+}
+
+// GetByID gets an AI Gateway Consumer by ID.
+func (a *AIGatewayConsumerAdapter) GetByID(
+	ctx context.Context,
+	id string,
+	execCtx *ExecutionContext,
+) (ResourceInfo, error) {
+	gatewayID, err := a.getAIGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return nil, err
+	}
+	consumer, err := a.client.GetAIGatewayConsumer(ctx, gatewayID, id)
+	if err != nil {
+		return nil, err
+	}
+	if consumer == nil {
+		return nil, nil
+	}
+	return &aiGatewayConsumerResourceInfo{consumer: consumer}, nil
+}
+
+// GetByName is not supported without a parent gateway context.
+func (a *AIGatewayConsumerAdapter) GetByName(_ context.Context, _ string) (ResourceInfo, error) {
+	return nil, fmt.Errorf("GetByName not supported for AI Gateway Consumers")
+}
+
+// ResourceType returns the resource type.
+func (a *AIGatewayConsumerAdapter) ResourceType() string {
+	return planner.ResourceTypeAIGatewayConsumer
+}
+
+// RequiredFields returns required fields for create.
+func (a *AIGatewayConsumerAdapter) RequiredFields() []string {
+	return []string{planner.FieldName, planner.FieldDisplayName, planner.FieldType}
+}
+
+// SupportsUpdate indicates update support.
+func (a *AIGatewayConsumerAdapter) SupportsUpdate() bool {
+	return true
+}
+
+func (a *AIGatewayConsumerAdapter) getAIGatewayIDFromExecutionContext(
+	execCtx *ExecutionContext,
+) (string, error) {
+	if execCtx == nil || execCtx.PlannedChange == nil {
+		return "", fmt.Errorf("execution context required")
+	}
+
+	change := *execCtx.PlannedChange
+	if gatewayRef, ok := change.References[planner.FieldAIGatewayID]; ok && !unresolvedReferenceID(gatewayRef.ID) {
+		return gatewayRef.ID, nil
+	}
+	if change.Parent != nil && !unresolvedReferenceID(change.Parent.ID) {
+		return change.Parent.ID, nil
+	}
+
+	return "", fmt.Errorf("AI Gateway ID required for Consumer operations")
+}
+
+type aiGatewayConsumerResourceInfo struct {
+	consumer *state.AIGatewayConsumer
+}
+
+func (a *aiGatewayConsumerResourceInfo) GetID() string {
+	return resources.AIGatewayConsumerID(a.consumer.AIGatewayConsumer)
+}
+
+func (a *aiGatewayConsumerResourceInfo) GetName() string {
+	return resources.AIGatewayConsumerName(a.consumer.AIGatewayConsumer)
+}
+
+func (a *aiGatewayConsumerResourceInfo) GetLabels() map[string]string {
+	return resources.AIGatewayConsumerLabels(a.consumer.AIGatewayConsumer)
+}
+
+func (a *aiGatewayConsumerResourceInfo) GetNormalizedLabels() map[string]string {
+	return a.consumer.NormalizedLabels
+}

--- a/internal/declarative/executor/ai_gateway_consumer_adapter_test.go
+++ b/internal/declarative/executor/ai_gateway_consumer_adapter_test.go
@@ -1,0 +1,46 @@
+package executor
+
+import (
+	"context"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAIGatewayConsumerAdapterMapCreateFields(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewAIGatewayConsumerAdapter(nil)
+	fields := map[string]any{
+		planner.FieldName:        "support-user",
+		planner.FieldType:        "api-key",
+		planner.FieldDisplayName: "Support User",
+		planner.FieldPolicies:    []string{"mask-sensitive-data"},
+		planner.FieldLabels:      map[string]string{"team": "support"},
+	}
+
+	var req kkComps.CreateAIGatewayConsumerRequest
+	require.NoError(t, adapter.MapCreateFields(context.Background(), nil, fields, &req))
+	require.Equal(t, "support-user", req.Name)
+	require.Equal(t, kkComps.CreateAIGatewayConsumerRequestTypeAPIKey, req.Type)
+	require.Equal(t, "Support User", req.DisplayName)
+	require.Equal(t, []string{"mask-sensitive-data"}, req.Policies)
+	require.Equal(t, map[string]string{"team": "support"}, req.Labels)
+}
+
+func TestAIGatewayConsumerAdapterMapCreateFieldsRequiresType(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewAIGatewayConsumerAdapter(nil)
+	fields := map[string]any{
+		planner.FieldName:        "support-user",
+		planner.FieldDisplayName: "Support User",
+	}
+
+	var req kkComps.CreateAIGatewayConsumerRequest
+	err := adapter.MapCreateFields(context.Background(), nil, fields, &req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "type")
+}

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -58,6 +58,9 @@ type Executor struct {
 	aiGatewayPolicyExecutor *BaseExecutor[
 		kkComps.CreateAIGatewayPolicyRequest,
 		kkComps.UpdateAIGatewayPolicyRequest]
+	aiGatewayConsumerExecutor *BaseExecutor[
+		kkComps.CreateAIGatewayConsumerRequest,
+		kkComps.UpdateAIGatewayConsumerRequest]
 	aiGatewayConsumerGroupExecutor *BaseExecutor[
 		kkComps.CreateAIGatewayConsumerGroupRequest,
 		kkComps.UpdateAIGatewayConsumerGroupRequest]
@@ -256,6 +259,13 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 		kkComps.CreateAIGatewayPolicyRequest,
 		kkComps.UpdateAIGatewayPolicyRequest](
 		NewAIGatewayPolicyAdapter(client),
+		client,
+		dryRun,
+	)
+	e.aiGatewayConsumerExecutor = NewBaseExecutor[
+		kkComps.CreateAIGatewayConsumerRequest,
+		kkComps.UpdateAIGatewayConsumerRequest](
+		NewAIGatewayConsumerAdapter(client),
 		client,
 		dryRun,
 	)
@@ -2363,6 +2373,11 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 			return "", err
 		}
 		return e.aiGatewayPolicyExecutor.Create(ctx, *change)
+	case planner.ResourceTypeAIGatewayConsumer:
+		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
+			return "", err
+		}
+		return e.aiGatewayConsumerExecutor.Create(ctx, *change)
 	case planner.ResourceTypeAIGatewayConsumerGroup:
 		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
 			return "", err
@@ -2975,6 +2990,11 @@ func (e *Executor) updateResource(ctx context.Context, change *planner.PlannedCh
 			return "", err
 		}
 		return e.aiGatewayPolicyExecutor.Update(ctx, *change)
+	case planner.ResourceTypeAIGatewayConsumer:
+		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
+			return "", err
+		}
+		return e.aiGatewayConsumerExecutor.Update(ctx, *change)
 	case planner.ResourceTypeAIGatewayConsumerGroup:
 		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
 			return "", err
@@ -3469,6 +3489,11 @@ func (e *Executor) deleteResource(ctx context.Context, change *planner.PlannedCh
 			return err
 		}
 		return e.aiGatewayPolicyExecutor.Delete(ctx, *change)
+	case planner.ResourceTypeAIGatewayConsumer:
+		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
+			return err
+		}
+		return e.aiGatewayConsumerExecutor.Delete(ctx, *change)
 	case planner.ResourceTypeAIGatewayConsumerGroup:
 		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
 			return err

--- a/internal/declarative/loader/ai_gateway_consumer_test.go
+++ b/internal/declarative/loader/ai_gateway_consumer_test.go
@@ -1,0 +1,120 @@
+package loader
+
+import (
+	"testing"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/tags"
+	"github.com/stretchr/testify/require"
+)
+
+const aiGatewayConsumerYAML = `
+ai_gateways:
+  - ref: support-gateway
+    display_name: Support Gateway
+    policies:
+      - ref: mask-sensitive-data
+        type: ai-sanitizer
+        name: mask-sensitive-data
+        display_name: Mask Sensitive Data
+        config:
+          anonymize:
+            - email
+    consumers:
+      - ref: support-user
+        name: support-user
+        type: api-key
+        display_name: Support User
+        policies:
+          - !ref mask-sensitive-data
+`
+
+func TestLoaderExtractsNestedAIGatewayConsumers(t *testing.T) {
+	path := writeLoaderTestFile(t, aiGatewayConsumerYAML)
+
+	rs, err := New().LoadFromSources([]Source{{Path: path, Type: SourceTypeFile}}, false)
+	require.NoError(t, err)
+	require.Len(t, rs.AIGateways, 1)
+	require.Empty(t, rs.AIGateways[0].Consumers)
+	require.Len(t, rs.AIGatewayConsumers, 1)
+	require.Equal(t, "support-gateway", rs.AIGatewayConsumers[0].AIGateway)
+	require.Equal(t, "support-user", rs.AIGatewayConsumers[0].Name)
+	require.Equal(t, "api-key", string(rs.AIGatewayConsumers[0].Type))
+	require.Equal(
+		t,
+		[]string{tags.RefPlaceholderPrefix + "mask-sensitive-data#id"},
+		rs.AIGatewayConsumers[0].Policies,
+	)
+	require.True(t, rs.SyncScope.ChildInScope(
+		resources.ResourceTypeAIGateway,
+		"support-gateway",
+		resources.ResourceTypeAIGatewayConsumer,
+	))
+}
+
+func TestLoaderValidatesAIGatewayConsumerParentAndDuplicates(t *testing.T) {
+	rootOnly := `
+ai_gateway_consumers:
+  - ref: support-user
+    ai_gateway: missing-gateway
+    name: support-user
+    type: api-key
+    display_name: Support User
+`
+	_, err := New().LoadFromSources([]Source{{Path: writeLoaderTestFile(t, rootOnly), Type: SourceTypeFile}}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "references unknown ai_gateway")
+
+	duplicates := `
+ai_gateways:
+  - ref: support-gateway
+    display_name: Support Gateway
+    consumers:
+      - ref: support-user
+        name: support-user
+        type: api-key
+        display_name: Support User
+      - ref: support-user-2
+        name: support-user
+        type: api-key
+        display_name: Support User 2
+`
+	_, err = New().LoadFromSources([]Source{{Path: writeLoaderTestFile(t, duplicates), Type: SourceTypeFile}}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate ai_gateway_consumer name")
+}
+
+func TestLoaderRejectsRootLevelEmptyAIGatewayConsumers(t *testing.T) {
+	input := `ai_gateway_consumers: []`
+
+	_, err := New().LoadFromSources([]Source{{Path: writeLoaderTestFile(t, input), Type: SourceTypeFile}}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ai_gateway_consumers cannot be empty")
+}
+
+func TestLoaderAcceptsAIGatewayConsumerDeferredExternalParentRef(t *testing.T) {
+	input := `
+ai_gateways:
+  - ref: external-shared-gateway
+    _external:
+      selector:
+        matchFields:
+          display_name: Shared Gateway
+ai_gateway_consumers:
+  - ref: support-user
+    ai_gateway: !ref external-shared-gateway#id
+    name: support-user
+    type: api-key
+    display_name: Support User
+`
+
+	rs, err := New().LoadFromSources([]Source{{Path: writeLoaderTestFile(t, input), Type: SourceTypeFile}}, false)
+	require.NoError(t, err)
+	require.Len(t, rs.AIGatewayConsumers, 1)
+	require.Equal(t, tags.RefPlaceholderPrefix+"external-shared-gateway#id", rs.AIGatewayConsumers[0].AIGateway)
+	require.True(t, rs.SyncScope.ChildInScope(
+		resources.ResourceTypeAIGateway,
+		"external-shared-gateway",
+		resources.ResourceTypeAIGatewayConsumer,
+	))
+}

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -1036,6 +1036,13 @@ func (l *Loader) extractNestedResources(rs *resources.ResourceSet) {
 		}
 		gateway.Policies = nil
 
+		for j := range gateway.Consumers {
+			consumer := gateway.Consumers[j]
+			consumer.AIGateway = gateway.Ref
+			rs.AIGatewayConsumers = append(rs.AIGatewayConsumers, consumer)
+		}
+		gateway.Consumers = nil
+
 		for j := range gateway.ConsumerGroups {
 			group := gateway.ConsumerGroups[j]
 			group.AIGateway = gateway.Ref

--- a/internal/declarative/loader/sync_scope.go
+++ b/internal/declarative/loader/sync_scope.go
@@ -44,6 +44,12 @@ var rootChildCollectionScopes = []childCollectionScope{
 		parentType:   resources.ResourceTypeAIGateway,
 	},
 	{
+		key:          "ai_gateway_consumers",
+		resourceType: resources.ResourceTypeAIGatewayConsumer,
+		parentKey:    resources.SchemaFieldAIGateway,
+		parentType:   resources.ResourceTypeAIGateway,
+	},
+	{
 		key:          "ai_gateway_consumer_groups",
 		resourceType: resources.ResourceTypeAIGatewayConsumerGroup,
 		parentKey:    resources.SchemaFieldAIGateway,
@@ -356,6 +362,11 @@ var aiGatewayChildCollectionScopes = []childCollectionScope{
 		parentType:   resources.ResourceTypeAIGateway,
 	},
 	{
+		key:          "consumers",
+		resourceType: resources.ResourceTypeAIGatewayConsumer,
+		parentType:   resources.ResourceTypeAIGateway,
+	},
+	{
 		key:          "consumer_groups",
 		resourceType: resources.ResourceTypeAIGatewayConsumerGroup,
 		parentType:   resources.ResourceTypeAIGateway,
@@ -493,6 +504,9 @@ func captureRootChildScope(scope *resources.SyncScope, raw map[string]any, entry
 	if !ok || len(items) == 0 {
 		if entry.resourceType == resources.ResourceTypeAIGatewayPolicy {
 			return fmt.Errorf("%s cannot be empty because each policy must declare an ai_gateway parent", entry.key)
+		}
+		if entry.resourceType == resources.ResourceTypeAIGatewayConsumer {
+			return fmt.Errorf("%s cannot be empty because each Consumer must declare an ai_gateway parent", entry.key)
 		}
 		if entry.resourceType == resources.ResourceTypeAIGatewayConsumerGroup {
 			return fmt.Errorf("%s cannot be empty because each Consumer Group must declare an ai_gateway parent", entry.key)

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -50,6 +50,9 @@ func (l *Loader) validateResourceSet(rs *resources.ResourceSet) error {
 	if err := l.validateAIGatewayPolicies(rs); err != nil {
 		return err
 	}
+	if err := l.validateAIGatewayConsumers(rs); err != nil {
+		return err
+	}
 	if err := l.validateAIGatewayConsumerGroups(rs); err != nil {
 		return err
 	}
@@ -835,6 +838,58 @@ func (l *Loader) validateAIGatewayPolicies(rs *resources.ResourceSet) error {
 			)
 		}
 		namesByGateway[nameKey] = policy.GetRef()
+	}
+
+	return nil
+}
+
+// validateAIGatewayConsumers validates AI Gateway child Consumer resources.
+func (l *Loader) validateAIGatewayConsumers(rs *resources.ResourceSet) error {
+	namesByGateway := make(map[string]string)
+
+	for i := range rs.AIGatewayConsumers {
+		consumer := &rs.AIGatewayConsumers[i]
+
+		if err := consumer.Validate(); err != nil {
+			return fmt.Errorf("invalid ai_gateway_consumer %q: %w", consumer.GetRef(), err)
+		}
+
+		if existing, found := rs.GetResourceByRef(consumer.GetRef()); found {
+			if existing.GetType() != resources.ResourceTypeAIGatewayConsumer {
+				return fmt.Errorf("duplicate ref '%s' (already defined as %s)",
+					consumer.GetRef(), existing.GetType())
+			}
+		}
+
+		gatewayRef := resources.NormalizeResourceRef(consumer.AIGateway)
+		gateway, found := rs.GetResourceByRef(gatewayRef)
+		if !found {
+			return fmt.Errorf(
+				"ai_gateway_consumer %q references unknown ai_gateway %q",
+				consumer.GetRef(),
+				consumer.AIGateway,
+			)
+		}
+		if gateway.GetType() != resources.ResourceTypeAIGateway {
+			return fmt.Errorf(
+				"ai_gateway_consumer %q references %q which is %s, not ai_gateway",
+				consumer.GetRef(),
+				consumer.AIGateway,
+				gateway.GetType(),
+			)
+		}
+
+		nameKey := gatewayRef + "\x00" + consumer.Name
+		if existingRef, exists := namesByGateway[nameKey]; exists {
+			return fmt.Errorf(
+				"duplicate ai_gateway_consumer name %q for ai_gateway %q (ref: %s conflicts with ref: %s)",
+				consumer.Name,
+				gatewayRef,
+				consumer.GetRef(),
+				existingRef,
+			)
+		}
+		namesByGateway[nameKey] = consumer.GetRef()
 	}
 
 	return nil

--- a/internal/declarative/planner/ai_gateway_consumer_planner.go
+++ b/internal/declarative/planner/ai_gateway_consumer_planner.go
@@ -1,0 +1,326 @@
+package planner
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"maps"
+	"reflect"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/util"
+)
+
+func (p *Planner) planAIGatewayConsumerChanges(
+	ctx context.Context,
+	namespace string,
+	gatewayRef string,
+	gatewayName string,
+	gatewayID string,
+	gatewayChangeID string,
+	policyCreateDepsByRefOrName map[string]string,
+	desired []resources.AIGatewayConsumerResource,
+	plan *Plan,
+) error {
+	p.logger.Debug(
+		"Planning AI Gateway Consumer changes",
+		slog.String("gateway_ref", gatewayRef),
+		slog.String("gateway_id", gatewayID),
+		slog.String("gateway_change_id", gatewayChangeID),
+		slog.Int("desired_count", len(desired)),
+	)
+
+	if gatewayID == "" {
+		p.planAIGatewayConsumerCreatesForNewGateway(
+			namespace,
+			gatewayRef,
+			gatewayName,
+			gatewayChangeID,
+			policyCreateDepsByRefOrName,
+			desired,
+			plan,
+		)
+		return nil
+	}
+
+	currentConsumers, err := p.client.ListAIGatewayConsumers(ctx, gatewayID)
+	if err != nil {
+		return fmt.Errorf("failed to list AI Gateway Consumers for gateway %s: %w", gatewayID, err)
+	}
+
+	currentByID, currentByName := indexAIGatewayConsumers(currentConsumers)
+	desiredKeys := make(map[string]bool)
+
+	for _, desiredConsumer := range desired {
+		current, exists := matchCurrentAIGatewayConsumer(desiredConsumer, currentByID, currentByName)
+		desiredKeys[desiredConsumer.Name] = true
+		if id := aiGatewayConsumerDesiredID(desiredConsumer); id != "" {
+			desiredKeys[id] = true
+		}
+
+		if !exists {
+			dependsOn := aiGatewayConsumerPolicyCreateDependencies(
+				desiredConsumer,
+				policyCreateDepsByRefOrName,
+			)
+			p.planAIGatewayConsumerCreate(namespace, gatewayRef, gatewayName, gatewayID, desiredConsumer, dependsOn, plan)
+			continue
+		}
+
+		consumerID := resources.AIGatewayConsumerID(current.AIGatewayConsumer)
+		if consumer := p.resources.GetAIGatewayConsumerByRef(desiredConsumer.Ref); consumer != nil {
+			consumer.SetKonnectID(consumerID)
+		}
+		fullConsumer, err := p.client.GetAIGatewayConsumer(ctx, gatewayID, consumerID)
+		if err != nil {
+			return fmt.Errorf("failed to get AI Gateway Consumer %s: %w", consumerID, err)
+		}
+		if fullConsumer == nil {
+			dependsOn := aiGatewayConsumerPolicyCreateDependencies(
+				desiredConsumer,
+				policyCreateDepsByRefOrName,
+			)
+			p.planAIGatewayConsumerCreate(namespace, gatewayRef, gatewayName, gatewayID, desiredConsumer, dependsOn, plan)
+			continue
+		}
+
+		needsUpdate, updateFields, changedFields, err := p.shouldUpdateAIGatewayConsumer(*fullConsumer, desiredConsumer)
+		if err != nil {
+			return err
+		}
+		if needsUpdate {
+			p.planAIGatewayConsumerUpdate(
+				namespace,
+				gatewayRef,
+				gatewayID,
+				consumerID,
+				desiredConsumer,
+				updateFields,
+				changedFields,
+				aiGatewayConsumerPolicyCreateDependencies(
+					desiredConsumer,
+					policyCreateDepsByRefOrName,
+				),
+				plan,
+			)
+		}
+	}
+
+	if plan.Metadata.Mode == PlanModeSync {
+		for _, current := range currentConsumers {
+			consumerID := resources.AIGatewayConsumerID(current.AIGatewayConsumer)
+			consumerName := resources.AIGatewayConsumerName(current.AIGatewayConsumer)
+			if desiredKeys[consumerID] || desiredKeys[consumerName] {
+				continue
+			}
+			p.planAIGatewayConsumerDelete(gatewayRef, gatewayID, consumerID, consumerName, plan)
+		}
+	}
+
+	return nil
+}
+
+func (p *Planner) planAIGatewayConsumerCreatesForNewGateway(
+	namespace string,
+	gatewayRef string,
+	gatewayName string,
+	gatewayChangeID string,
+	policyCreateDepsByRefOrName map[string]string,
+	consumers []resources.AIGatewayConsumerResource,
+	plan *Plan,
+) {
+	var dependsOn []string
+	if gatewayChangeID != "" {
+		dependsOn = []string{gatewayChangeID}
+	}
+	for _, consumer := range consumers {
+		consumerDependsOn := append([]string{}, dependsOn...)
+		for _, dep := range aiGatewayConsumerPolicyCreateDependencies(consumer, policyCreateDepsByRefOrName) {
+			consumerDependsOn = appendDependsOn(consumerDependsOn, dep)
+		}
+		p.planAIGatewayConsumerCreate(namespace, gatewayRef, gatewayName, "", consumer, consumerDependsOn, plan)
+	}
+}
+
+func (p *Planner) planAIGatewayConsumerCreate(
+	namespace string,
+	gatewayRef string,
+	gatewayName string,
+	gatewayID string,
+	consumer resources.AIGatewayConsumerResource,
+	dependsOn []string,
+	plan *Plan,
+) {
+	fields, err := consumer.MutablePayloadMap()
+	if err != nil {
+		plan.AddWarning(consumer.GetRef(), fmt.Sprintf("failed to build AI Gateway Consumer create payload: %s", err))
+		return
+	}
+
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionCreate, ResourceTypeAIGatewayConsumer, consumer.Ref),
+		ResourceType: ResourceTypeAIGatewayConsumer,
+		ResourceRef:  consumer.Ref,
+		Action:       ActionCreate,
+		Fields:       fields,
+		Namespace:    namespace,
+		DependsOn:    dependsOn,
+	}
+	if gatewayID != "" {
+		change.Parent = &ParentInfo{Ref: gatewayRef, ID: gatewayID}
+	} else {
+		change.References = map[string]ReferenceInfo{
+			FieldAIGatewayID: {
+				Ref: gatewayRef,
+				LookupFields: map[string]string{
+					FieldDisplayName: gatewayName,
+				},
+			},
+		}
+	}
+
+	plan.AddChange(change)
+}
+
+func (p *Planner) planAIGatewayConsumerUpdate(
+	namespace string,
+	gatewayRef string,
+	gatewayID string,
+	consumerID string,
+	consumer resources.AIGatewayConsumerResource,
+	updateFields map[string]any,
+	changedFields map[string]FieldChange,
+	dependsOn []string,
+	plan *Plan,
+) {
+	change := PlannedChange{
+		ID:            p.nextChangeID(ActionUpdate, ResourceTypeAIGatewayConsumer, consumer.Ref),
+		ResourceType:  ResourceTypeAIGatewayConsumer,
+		ResourceRef:   consumer.Ref,
+		ResourceID:    consumerID,
+		Action:        ActionUpdate,
+		Fields:        updateFields,
+		ChangedFields: changedFields,
+		Namespace:     namespace,
+		DependsOn:     dependsOn,
+		Parent:        &ParentInfo{Ref: gatewayRef, ID: gatewayID},
+	}
+	plan.AddChange(change)
+}
+
+func (p *Planner) planAIGatewayConsumerDelete(
+	gatewayRef string,
+	gatewayID string,
+	consumerID string,
+	consumerName string,
+	plan *Plan,
+) {
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionDelete, ResourceTypeAIGatewayConsumer, consumerName),
+		ResourceType: ResourceTypeAIGatewayConsumer,
+		ResourceRef:  consumerName,
+		ResourceID:   consumerID,
+		Action:       ActionDelete,
+		Fields: map[string]any{
+			FieldName: consumerName,
+		},
+		Parent: &ParentInfo{Ref: gatewayRef, ID: gatewayID},
+	}
+	plan.AddChange(change)
+}
+
+func (p *Planner) shouldUpdateAIGatewayConsumer(
+	current state.AIGatewayConsumer,
+	desired resources.AIGatewayConsumerResource,
+) (bool, map[string]any, map[string]FieldChange, error) {
+	currentPayload, err := resources.AIGatewayConsumerMutablePayloadMap(current.AIGatewayConsumer)
+	if err != nil {
+		return false, nil, nil, fmt.Errorf("failed to normalize current AI Gateway Consumer: %w", err)
+	}
+	desiredPayload, err := desired.MutablePayloadMap()
+	if err != nil {
+		return false, nil, nil, fmt.Errorf(
+			"failed to normalize desired AI Gateway Consumer %q: %w",
+			desired.Ref,
+			err,
+		)
+	}
+
+	currentCompare, desiredCompare := normalizeAIGatewayPolicyReferencesForComparison(
+		currentPayload,
+		desiredPayload,
+		p.resources,
+	)
+
+	changedFields := make(map[string]FieldChange)
+	keys := make(map[string]struct{}, len(currentCompare)+len(desiredCompare))
+	for key := range currentCompare {
+		keys[key] = struct{}{}
+	}
+	for key := range desiredCompare {
+		keys[key] = struct{}{}
+	}
+	for key := range keys {
+		if !reflect.DeepEqual(currentCompare[key], desiredCompare[key]) {
+			changedFields[key] = FieldChange{Old: currentPayload[key], New: desiredPayload[key]}
+		}
+	}
+	if len(changedFields) == 0 {
+		return false, nil, nil, nil
+	}
+
+	updateFields := make(map[string]any, len(desiredPayload))
+	maps.Copy(updateFields, desiredPayload)
+	return true, updateFields, changedFields, nil
+}
+
+func indexAIGatewayConsumers(
+	consumers []state.AIGatewayConsumer,
+) (map[string]state.AIGatewayConsumer, map[string]state.AIGatewayConsumer) {
+	byID := make(map[string]state.AIGatewayConsumer)
+	byName := make(map[string]state.AIGatewayConsumer)
+	for _, consumer := range consumers {
+		if id := resources.AIGatewayConsumerID(consumer.AIGatewayConsumer); id != "" {
+			byID[id] = consumer
+		}
+		if name := resources.AIGatewayConsumerName(consumer.AIGatewayConsumer); name != "" {
+			byName[name] = consumer
+		}
+	}
+	return byID, byName
+}
+
+func matchCurrentAIGatewayConsumer(
+	desired resources.AIGatewayConsumerResource,
+	currentByID map[string]state.AIGatewayConsumer,
+	currentByName map[string]state.AIGatewayConsumer,
+) (state.AIGatewayConsumer, bool) {
+	if id := aiGatewayConsumerDesiredID(desired); id != "" {
+		current, exists := currentByID[id]
+		return current, exists
+	}
+	current, exists := currentByName[desired.Name]
+	return current, exists
+}
+
+func aiGatewayConsumerDesiredID(desired resources.AIGatewayConsumerResource) string {
+	if id := desired.GetKonnectID(); id != "" {
+		return id
+	}
+	if util.IsValidUUID(desired.Ref) {
+		return desired.Ref
+	}
+	return ""
+}
+
+func aiGatewayConsumerPolicyCreateDependencies(
+	consumer resources.AIGatewayConsumerResource,
+	policyCreateDepsByRefOrName map[string]string,
+) []string {
+	payload, err := consumer.MutablePayloadMap()
+	if err != nil {
+		return nil
+	}
+	return aiGatewayPolicyReferenceDependencies(payload, policyCreateDepsByRefOrName)
+}

--- a/internal/declarative/planner/ai_gateway_consumer_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_consumer_planner_test.go
@@ -1,0 +1,252 @@
+package planner
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/declarative/tags"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAIGatewayConsumerPlannerCreatesChildForExistingGateway(t *testing.T) {
+	consumer := testAIGatewayConsumerResource(t, nil)
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{
+			gateways: []kkComps.AIGateway{testAIGateway()},
+		},
+		AIGatewayConsumersAPI: &testAIGatewayConsumerAPI{},
+	})
+	rs := testAIGatewayConsumerResourceSet(consumer)
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	change := plan.Changes[0]
+	require.Equal(t, ActionCreate, change.Action)
+	require.Equal(t, ResourceTypeAIGatewayConsumer, change.ResourceType)
+	require.Equal(t, "support-user", change.ResourceRef)
+	require.NotNil(t, change.Parent)
+	require.Equal(t, "gateway-id", change.Parent.ID)
+	require.Equal(t, "support-gateway", change.Parent.Ref)
+	require.Equal(t, "Support User", change.Fields[FieldDisplayName])
+	require.Equal(t, "api-key", change.Fields[FieldType])
+}
+
+func TestAIGatewayConsumerPlannerUpdatesExistingConsumer(t *testing.T) {
+	consumer := testAIGatewayConsumerResource(t, nil)
+	consumer.DisplayName = "Support User Updated"
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{
+			gateways: []kkComps.AIGateway{testAIGateway()},
+		},
+		AIGatewayConsumersAPI: &testAIGatewayConsumerAPI{
+			consumers: []kkComps.AIGatewayConsumer{
+				testAIGatewayConsumer("consumer-id", "support-user", nil),
+			},
+		},
+	})
+	rs := testAIGatewayConsumerResourceSet(consumer)
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	change := plan.Changes[0]
+	require.Equal(t, ActionUpdate, change.Action)
+	require.Equal(t, ResourceTypeAIGatewayConsumer, change.ResourceType)
+	require.Equal(t, "consumer-id", change.ResourceID)
+	require.Equal(t, "Support User Updated", change.Fields[FieldDisplayName])
+	require.Contains(t, change.ChangedFields, FieldDisplayName)
+}
+
+func TestAIGatewayConsumerPlannerSyncDeletesScopedConsumers(t *testing.T) {
+	scope := resources.NewSyncScope()
+	scope.AddRoot(resources.ResourceTypeAIGateway)
+	scope.AddChild(resources.ResourceTypeAIGateway, "support-gateway", resources.ResourceTypeAIGatewayConsumer)
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{
+			gateways: []kkComps.AIGateway{testAIGateway()},
+		},
+		AIGatewayConsumersAPI: &testAIGatewayConsumerAPI{
+			consumers: []kkComps.AIGatewayConsumer{
+				testAIGatewayConsumer("consumer-id", "support-user", nil),
+			},
+		},
+	})
+	rs := &resources.ResourceSet{
+		AIGateways: []resources.AIGatewayResource{testAIGatewayResource()},
+		SyncScope:  scope,
+	}
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeSync})
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	change := plan.Changes[0]
+	require.Equal(t, ActionDelete, change.Action)
+	require.Equal(t, ResourceTypeAIGatewayConsumer, change.ResourceType)
+	require.Equal(t, "consumer-id", change.ResourceID)
+	require.NotNil(t, change.Parent)
+	require.Equal(t, "gateway-id", change.Parent.ID)
+}
+
+func TestAIGatewayConsumerPlannerDependsOnPolicyCreate(t *testing.T) {
+	policy := testAIGatewayPolicyResource(t)
+	consumer := testAIGatewayConsumerResource(t, []string{tags.RefPlaceholderPrefix + "mask-sensitive-data#id"})
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{},
+	})
+	rs := &resources.ResourceSet{
+		AIGateways:          []resources.AIGatewayResource{testAIGatewayResource()},
+		AIGatewayPolicies:   []resources.AIGatewayPolicyResource{policy},
+		AIGatewayConsumers:  []resources.AIGatewayConsumerResource{consumer},
+		AIGatewayProviders:  nil,
+		AIGatewayModels:     nil,
+		AIGatewayMCPServers: nil,
+		AIGatewayVaults:     nil,
+	}
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+	require.NoError(t, err)
+
+	gatewayCreate := findAIGatewayModelTestChange(t, plan, ResourceTypeAIGateway, "support-gateway")
+	policyCreate := findAIGatewayModelTestChange(t, plan, ResourceTypeAIGatewayPolicy, "mask-sensitive-data")
+	consumerCreate := findAIGatewayModelTestChange(t, plan, ResourceTypeAIGatewayConsumer, "support-user")
+
+	require.Contains(t, policyCreate.DependsOn, gatewayCreate.ID)
+	require.Contains(t, consumerCreate.DependsOn, policyCreate.ID)
+	require.Equal(t, resources.UnknownReferenceID, consumerCreate.References[FieldPolicies+".0"].ID)
+	require.Equal(t, tags.RefPlaceholderPrefix+"mask-sensitive-data#id", consumerCreate.References[FieldPolicies+".0"].Ref)
+}
+
+func TestAIGatewayConsumerPlannerPolicyRefNoopForExistingConsumer(t *testing.T) {
+	for _, currentPolicyRef := range []string{"policy-id", "mask-sensitive-data"} {
+		t.Run(currentPolicyRef, func(t *testing.T) {
+			policy := testAIGatewayPolicyResource(t)
+			consumer := testAIGatewayConsumerResource(t, []string{tags.RefPlaceholderPrefix + "mask-sensitive-data#id"})
+			client := state.NewClient(state.ClientConfig{
+				AIGatewayAPI: &testAIGatewayAPI{
+					gateways: []kkComps.AIGateway{testAIGateway()},
+				},
+				AIGatewayPoliciesAPI: &testAIGatewayPolicyAPI{
+					policies: []kkComps.AIGatewayPolicy{testAIGatewayPolicy()},
+				},
+				AIGatewayConsumersAPI: &testAIGatewayConsumerAPI{
+					consumers: []kkComps.AIGatewayConsumer{
+						testAIGatewayConsumer("consumer-id", "support-user", []string{currentPolicyRef}),
+					},
+				},
+			})
+			rs := &resources.ResourceSet{
+				AIGateways:         []resources.AIGatewayResource{testAIGatewayResource()},
+				AIGatewayPolicies:  []resources.AIGatewayPolicyResource{policy},
+				AIGatewayConsumers: []resources.AIGatewayConsumerResource{consumer},
+			}
+
+			plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+			require.NoError(t, err)
+			require.Empty(t, plan.Changes)
+		})
+	}
+}
+
+func testAIGatewayConsumerResourceSet(
+	consumer resources.AIGatewayConsumerResource,
+) *resources.ResourceSet {
+	return &resources.ResourceSet{
+		AIGateways:         []resources.AIGatewayResource{testAIGatewayResource()},
+		AIGatewayConsumers: []resources.AIGatewayConsumerResource{consumer},
+	}
+}
+
+func testAIGatewayConsumerResource(
+	t *testing.T,
+	policies []string,
+) resources.AIGatewayConsumerResource {
+	t.Helper()
+	payload := map[string]any{
+		"ref":          "support-user",
+		"ai_gateway":   "support-gateway",
+		"name":         "support-user",
+		"type":         "api-key",
+		"display_name": "Support User",
+	}
+	if policies != nil {
+		payload[FieldPolicies] = policies
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+	var consumer resources.AIGatewayConsumerResource
+	require.NoError(t, json.Unmarshal(data, &consumer))
+	return consumer
+}
+
+func testAIGatewayConsumer(id string, name string, policies []string) kkComps.AIGatewayConsumer {
+	return kkComps.AIGatewayConsumer{
+		ID:          id,
+		Name:        name,
+		Type:        kkComps.AIGatewayConsumerTypeAPIKey,
+		DisplayName: "Support User",
+		Policies:    policies,
+	}
+}
+
+type testAIGatewayConsumerAPI struct {
+	consumers []kkComps.AIGatewayConsumer
+}
+
+func (t *testAIGatewayConsumerAPI) ListAiGatewayConsumers(
+	context.Context,
+	kkOps.ListAiGatewayConsumersRequest,
+	...kkOps.Option,
+) (*kkOps.ListAiGatewayConsumersResponse, error) {
+	return &kkOps.ListAiGatewayConsumersResponse{
+		ListAIGatewayConsumersResponse: &kkComps.ListAIGatewayConsumersResponse{
+			Data: t.consumers,
+		},
+	}, nil
+}
+
+func (t *testAIGatewayConsumerAPI) CreateAiGatewayConsumer(
+	context.Context,
+	string,
+	kkComps.CreateAIGatewayConsumerRequest,
+	...kkOps.Option,
+) (*kkOps.CreateAiGatewayConsumerResponse, error) {
+	return nil, nil
+}
+
+func (t *testAIGatewayConsumerAPI) GetAiGatewayConsumer(
+	_ context.Context,
+	_ string,
+	consumerID string,
+	_ ...kkOps.Option,
+) (*kkOps.GetAiGatewayConsumerResponse, error) {
+	for _, consumer := range t.consumers {
+		if consumer.ID == consumerID || consumer.Name == consumerID {
+			return &kkOps.GetAiGatewayConsumerResponse{AIGatewayConsumer: &consumer}, nil
+		}
+	}
+	return &kkOps.GetAiGatewayConsumerResponse{}, nil
+}
+
+func (t *testAIGatewayConsumerAPI) UpdateAiGatewayConsumer(
+	context.Context,
+	kkOps.UpdateAiGatewayConsumerRequest,
+	...kkOps.Option,
+) (*kkOps.UpdateAiGatewayConsumerResponse, error) {
+	return nil, nil
+}
+
+func (t *testAIGatewayConsumerAPI) DeleteAiGatewayConsumer(
+	context.Context,
+	string,
+	string,
+	...kkOps.Option,
+) (*kkOps.DeleteAiGatewayConsumerResponse, error) {
+	return nil, nil
+}

--- a/internal/declarative/planner/ai_gateway_planner.go
+++ b/internal/declarative/planner/ai_gateway_planner.go
@@ -213,6 +213,28 @@ func (p *Planner) planAIGatewayChanges(
 		}
 		policyCreateDepsByName := aiGatewayPolicyCreateDependencies(plan, namespace, desiredGateway.Ref)
 
+		consumers := p.resources.GetAIGatewayConsumersForGateway(desiredGateway.Ref)
+		if p.shouldPlanChild(
+			plan,
+			resources.ResourceTypeAIGateway,
+			desiredGateway.Ref,
+			resources.ResourceTypeAIGatewayConsumer,
+		) && (len(consumers) > 0 || plan.Metadata.Mode == PlanModeSync) {
+			if err := p.planAIGatewayConsumerChanges(
+				ctx,
+				namespace,
+				desiredGateway.Ref,
+				desiredGateway.DisplayName,
+				gatewayID,
+				gatewayChangeID,
+				policyCreateDepsByName,
+				consumers,
+				plan,
+			); err != nil {
+				return err
+			}
+		}
+
 		consumerGroups := p.resources.GetAIGatewayConsumerGroupsForGateway(desiredGateway.Ref)
 		if p.shouldPlanChild(
 			plan,
@@ -376,6 +398,28 @@ func (p *Planner) planExternalAIGatewayChildren(
 		}
 	}
 	policyCreateDepsByName := aiGatewayPolicyCreateDependencies(plan, namespace, desiredGateway.Ref)
+
+	consumers := p.resources.GetAIGatewayConsumersForGateway(desiredGateway.Ref)
+	if p.shouldPlanChild(
+		plan,
+		resources.ResourceTypeAIGateway,
+		desiredGateway.Ref,
+		resources.ResourceTypeAIGatewayConsumer,
+	) && len(consumers) > 0 {
+		if err := p.planAIGatewayConsumerChanges(
+			ctx,
+			namespace,
+			desiredGateway.Ref,
+			desiredGateway.DisplayName,
+			gatewayID,
+			"",
+			policyCreateDepsByName,
+			consumers,
+			plan,
+		); err != nil {
+			return err
+		}
+	}
 
 	consumerGroups := p.resources.GetAIGatewayConsumerGroupsForGateway(desiredGateway.Ref)
 	if p.shouldPlanChild(

--- a/internal/declarative/planner/constants.go
+++ b/internal/declarative/planner/constants.go
@@ -206,6 +206,7 @@ const (
 	ResourceTypeAIGateway                        = string(resources.ResourceTypeAIGateway)
 	ResourceTypeAIGatewayProvider                = string(resources.ResourceTypeAIGatewayProvider)
 	ResourceTypeAIGatewayPolicy                  = string(resources.ResourceTypeAIGatewayPolicy)
+	ResourceTypeAIGatewayConsumer                = string(resources.ResourceTypeAIGatewayConsumer)
 	ResourceTypeAIGatewayConsumerGroup           = string(resources.ResourceTypeAIGatewayConsumerGroup)
 	ResourceTypeAIGatewayModel                   = string(resources.ResourceTypeAIGatewayModel)
 	ResourceTypeAIGatewayMCPServer               = string(resources.ResourceTypeAIGatewayMCPServer)

--- a/internal/declarative/planner/dependencies.go
+++ b/internal/declarative/planner/dependencies.go
@@ -235,6 +235,7 @@ func aiGatewayChildSerializationParentKey(change PlannedChange) string {
 	switch change.ResourceType {
 	case ResourceTypeAIGatewayProvider,
 		ResourceTypeAIGatewayPolicy,
+		ResourceTypeAIGatewayConsumer,
 		ResourceTypeAIGatewayConsumerGroup,
 		ResourceTypeAIGatewayModel,
 		ResourceTypeAIGatewayMCPServer,
@@ -344,6 +345,7 @@ func (d *DependencyResolver) getParentType(childType string) string {
 		return ResourceTypePortal
 	case ResourceTypeAIGatewayProvider,
 		ResourceTypeAIGatewayPolicy,
+		ResourceTypeAIGatewayConsumer,
 		ResourceTypeAIGatewayConsumerGroup,
 		ResourceTypeAIGatewayModel,
 		ResourceTypeAIGatewayMCPServer,

--- a/internal/declarative/planner/resolver.go
+++ b/internal/declarative/planner/resolver.go
@@ -238,7 +238,10 @@ func (r *ReferenceResolver) getResourceTypeForChangeField(change PlannedChange, 
 
 func aiGatewayPolicyReferenceField(resourceType, fieldName string) bool {
 	switch resourceType {
-	case ResourceTypeAIGatewayConsumerGroup, ResourceTypeAIGatewayModel, ResourceTypeAIGatewayMCPServer:
+	case ResourceTypeAIGatewayConsumer,
+		ResourceTypeAIGatewayConsumerGroup,
+		ResourceTypeAIGatewayModel,
+		ResourceTypeAIGatewayMCPServer:
 	default:
 		return false
 	}

--- a/internal/declarative/planner/sync_scope.go
+++ b/internal/declarative/planner/sync_scope.go
@@ -162,6 +162,13 @@ func addAIGatewayChildScopes(scope *resources.SyncScope, rs *resources.ResourceS
 			resources.ResourceTypeAIGatewayPolicy,
 		)
 	}
+	for _, child := range rs.AIGatewayConsumers {
+		scope.AddChild(
+			resources.ResourceTypeAIGateway,
+			resources.NormalizeResourceRef(child.AIGateway),
+			resources.ResourceTypeAIGatewayConsumer,
+		)
+	}
 	for _, child := range rs.AIGatewayConsumerGroups {
 		scope.AddChild(
 			resources.ResourceTypeAIGateway,

--- a/internal/declarative/protection/lookup.go
+++ b/internal/declarative/protection/lookup.go
@@ -156,6 +156,7 @@ func IsManagedResourceProtected(
 		resources.ResourceTypeEventGatewayTLSTrustBundle,
 		resources.ResourceTypeAIGatewayProvider,
 		resources.ResourceTypeAIGatewayPolicy,
+		resources.ResourceTypeAIGatewayConsumer,
 		resources.ResourceTypeAIGatewayConsumerGroup,
 		resources.ResourceTypeAIGatewayModel,
 		resources.ResourceTypeAIGatewayMCPServer,

--- a/internal/declarative/resources/ai_gateway.go
+++ b/internal/declarative/resources/ai_gateway.go
@@ -26,6 +26,7 @@ type AIGatewayResource struct {
 	External       *ExternalBlock                   `yaml:"_external,omitempty" json:"_external,omitempty"`
 	Providers      []AIGatewayProviderResource      `yaml:"providers,omitempty" json:"providers,omitempty"`
 	Policies       []AIGatewayPolicyResource        `yaml:"policies,omitempty" json:"policies,omitempty"`
+	Consumers      []AIGatewayConsumerResource      `yaml:"consumers,omitempty" json:"consumers,omitempty"`
 	ConsumerGroups []AIGatewayConsumerGroupResource `yaml:"consumer_groups,omitempty" json:"consumer_groups,omitempty"`
 	Models         []AIGatewayModelResource         `yaml:"models,omitempty"    json:"models,omitempty"`
 	MCPServers     []AIGatewayMCPServerResource     `yaml:"mcp_servers,omitempty" json:"mcp_servers,omitempty"`
@@ -51,6 +52,7 @@ type aiGatewayAlias struct {
 	Labels         map[string]string                `json:"labels,omitempty"      yaml:"labels,omitempty"`
 	Providers      []AIGatewayProviderResource      `json:"providers,omitempty"   yaml:"providers,omitempty"`
 	Policies       []AIGatewayPolicyResource        `json:"policies,omitempty"    yaml:"policies,omitempty"`
+	Consumers      []AIGatewayConsumerResource      `json:"consumers,omitempty"   yaml:"consumers,omitempty"`
 	ConsumerGroups []AIGatewayConsumerGroupResource `json:"consumer_groups,omitempty" yaml:"consumer_groups,omitempty"`
 	Models         []AIGatewayModelResource         `json:"models,omitempty"      yaml:"models,omitempty"`
 	MCPServers     []AIGatewayMCPServerResource     `json:"mcp_servers,omitempty" yaml:"mcp_servers,omitempty"`
@@ -68,6 +70,7 @@ func (a AIGatewayResource) aiGatewayAlias() aiGatewayAlias {
 		Labels:         a.Labels,
 		Providers:      a.Providers,
 		Policies:       a.Policies,
+		Consumers:      a.Consumers,
 		ConsumerGroups: a.ConsumerGroups,
 		Models:         a.Models,
 		MCPServers:     a.MCPServers,
@@ -88,6 +91,7 @@ func (a *AIGatewayResource) UnmarshalYAML(unmarshal func(any) error) error {
 		Labels         map[string]string                `yaml:"labels,omitempty"`
 		Providers      []AIGatewayProviderResource      `yaml:"providers,omitempty"`
 		Policies       []AIGatewayPolicyResource        `yaml:"policies,omitempty"`
+		Consumers      []AIGatewayConsumerResource      `yaml:"consumers,omitempty"`
 		ConsumerGroups []AIGatewayConsumerGroupResource `yaml:"consumer_groups,omitempty"`
 		Models         []AIGatewayModelResource         `yaml:"models,omitempty"`
 		MCPServers     []AIGatewayMCPServerResource     `yaml:"mcp_servers,omitempty"`
@@ -110,6 +114,7 @@ func (a *AIGatewayResource) UnmarshalYAML(unmarshal func(any) error) error {
 	}
 	a.Providers = raw.Providers
 	a.Policies = raw.Policies
+	a.Consumers = raw.Consumers
 	a.ConsumerGroups = raw.ConsumerGroups
 	a.Models = raw.Models
 	a.MCPServers = raw.MCPServers
@@ -131,6 +136,7 @@ func (a *AIGatewayResource) UnmarshalJSON(data []byte) error {
 		Labels         map[string]string                `json:"labels,omitempty"`
 		Providers      []AIGatewayProviderResource      `json:"providers,omitempty"`
 		Policies       []AIGatewayPolicyResource        `json:"policies,omitempty"`
+		Consumers      []AIGatewayConsumerResource      `json:"consumers,omitempty"`
 		ConsumerGroups []AIGatewayConsumerGroupResource `json:"consumer_groups,omitempty"`
 		Models         []AIGatewayModelResource         `json:"models,omitempty"`
 		MCPServers     []AIGatewayMCPServerResource     `json:"mcp_servers,omitempty"`
@@ -153,6 +159,7 @@ func (a *AIGatewayResource) UnmarshalJSON(data []byte) error {
 	}
 	a.Providers = raw.Providers
 	a.Policies = raw.Policies
+	a.Consumers = raw.Consumers
 	a.ConsumerGroups = raw.ConsumerGroups
 	a.Models = raw.Models
 	a.MCPServers = raw.MCPServers
@@ -216,6 +223,9 @@ func (a *AIGatewayResource) SetDefaults() {
 	for i := range a.Policies {
 		a.Policies[i].SetDefaults()
 	}
+	for i := range a.Consumers {
+		a.Consumers[i].SetDefaults()
+	}
 	for i := range a.ConsumerGroups {
 		a.ConsumerGroups[i].SetDefaults()
 	}
@@ -270,6 +280,7 @@ func aiGatewayExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
 		}, false, false),
 		explainField("providers", explainArrayOf(aiGatewayProviderInlineExplainNode()), false, false),
 		explainField("policies", explainArrayOf(aiGatewayPolicyInlineExplainNode()), false, false),
+		explainField("consumers", explainArrayOf(aiGatewayConsumerInlineExplainNode()), false, false),
 		explainField("consumer_groups", explainArrayOf(aiGatewayConsumerGroupInlineExplainNode()), false, false),
 		explainField("models", explainArrayOf(&ExplainNode{Kind: explainKindObject}), false, false),
 		explainField("mcp_servers", explainArrayOf(aiGatewayMCPServerInlineExplainNode()), false, false),
@@ -295,6 +306,14 @@ func aiGatewayPolicyInlineExplainNode() *ExplainNode {
 
 func aiGatewayConsumerGroupInlineExplainNode() *ExplainNode {
 	node, err := aiGatewayConsumerGroupExplainNode(ExplainBuildContext{})
+	if err != nil {
+		return explainObject()
+	}
+	return node
+}
+
+func aiGatewayConsumerInlineExplainNode() *ExplainNode {
+	node, err := aiGatewayConsumerExplainNode(ExplainBuildContext{})
 	if err != nil {
 		return explainObject()
 	}

--- a/internal/declarative/resources/ai_gateway_consumer.go
+++ b/internal/declarative/resources/ai_gateway_consumer.go
@@ -1,0 +1,351 @@
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/util"
+)
+
+const (
+	aiGatewayConsumerFieldID          = "id"
+	aiGatewayConsumerFieldName        = "name"
+	aiGatewayConsumerFieldType        = "type"
+	aiGatewayConsumerFieldDisplayName = "display_name"
+	aiGatewayConsumerFieldCustomID    = "custom_id"
+	aiGatewayConsumerFieldPolicies    = "policies"
+	aiGatewayConsumerFieldLabels      = "labels"
+	aiGatewayConsumerFieldUpdatedAt   = "updated_at"
+)
+
+func init() {
+	registerResourceType(
+		ResourceTypeAIGatewayConsumer,
+		func(rs *ResourceSet) *[]AIGatewayConsumerResource { return &rs.AIGatewayConsumers },
+		AutoExplain[AIGatewayConsumerResource](
+			WithExplainAliases(
+				"ai_gateway_consumers",
+				"ai-gateway-consumer",
+				"ai-gateway-consumers",
+				"ai_gateway.consumers",
+				"aigw-consumer",
+			),
+			WithExplainRecommendedFields(
+				"ref",
+				SchemaFieldAIGateway,
+				"name",
+				"type",
+				"display_name",
+				aiGatewayConsumerFieldPolicies,
+			),
+			WithExplainSchemaBuilder(aiGatewayConsumerExplainNode),
+		),
+	)
+}
+
+// AIGatewayConsumerResource represents a Consumer nested under a Konnect AI Gateway.
+type AIGatewayConsumerResource struct {
+	BaseResource `yaml:",inline" json:",inline"`
+	// Parent AI Gateway reference for root-level declarations.
+	AIGateway string `yaml:"ai_gateway,omitempty" json:"ai_gateway,omitempty"`
+
+	kkComps.CreateAIGatewayConsumerRequest `yaml:",inline" json:",inline"`
+}
+
+func (a AIGatewayConsumerResource) GetType() ResourceType {
+	return ResourceTypeAIGatewayConsumer
+}
+
+func (a AIGatewayConsumerResource) GetMoniker() string {
+	return a.Name
+}
+
+func (a AIGatewayConsumerResource) GetDependencies() []ResourceRef {
+	if a.AIGateway == "" {
+		return nil
+	}
+	return []ResourceRef{{Kind: ResourceTypeAIGateway, Ref: NormalizeResourceRef(a.AIGateway)}}
+}
+
+func (a AIGatewayConsumerResource) GetParentRef() *ResourceRef {
+	if a.AIGateway == "" {
+		return nil
+	}
+	return &ResourceRef{Kind: ResourceTypeAIGateway, Ref: NormalizeResourceRef(a.AIGateway)}
+}
+
+func (a AIGatewayConsumerResource) Validate() error {
+	if err := ValidateRef(a.Ref); err != nil {
+		return fmt.Errorf("invalid AI Gateway Consumer ref: %w", err)
+	}
+	if a.Kongctl != nil {
+		return fmt.Errorf("kongctl metadata not supported on AI Gateway Consumer %s", a.Ref)
+	}
+	if a.AIGateway == "" {
+		return fmt.Errorf("ai_gateway is required for AI Gateway Consumer %s", a.Ref)
+	}
+	if a.Name == "" {
+		return fmt.Errorf("name is required for AI Gateway Consumer %s", a.Ref)
+	}
+	if a.Type == "" {
+		return fmt.Errorf("type is required for AI Gateway Consumer %s", a.Ref)
+	}
+	if a.DisplayName == "" {
+		return fmt.Errorf("display_name is required for AI Gateway Consumer %s", a.Ref)
+	}
+	return nil
+}
+
+func (a *AIGatewayConsumerResource) SetDefaults() {
+	if a == nil {
+		return
+	}
+	if a.Ref == "" {
+		a.Ref = a.Name
+	}
+	if a.Name == "" {
+		a.Name = a.Ref
+	}
+	if a.DisplayName == "" {
+		a.DisplayName = a.Name
+	}
+}
+
+func (a AIGatewayConsumerResource) GetKonnectMonikerFilter() string {
+	return a.Name
+}
+
+func (a *AIGatewayConsumerResource) TryMatchKonnectResource(konnectResource any) bool {
+	name := a.Name
+	if name == "" {
+		return false
+	}
+	if id := AIGatewayConsumerID(konnectResource); id != "" && (util.IsValidUUID(a.Ref) || a.GetKonnectID() != "") {
+		if a.Ref == id || a.GetKonnectID() == id {
+			a.SetKonnectID(id)
+			return true
+		}
+	}
+	if id := AIGatewayConsumerID(konnectResource); id != "" && AIGatewayConsumerName(konnectResource) == name {
+		a.SetKonnectID(id)
+		return true
+	}
+	return false
+}
+
+func (a AIGatewayConsumerResource) CreateRequest() kkComps.CreateAIGatewayConsumerRequest {
+	return a.CreateAIGatewayConsumerRequest
+}
+
+func (a AIGatewayConsumerResource) UpdateRequest() kkComps.UpdateAIGatewayConsumerRequest {
+	payload, err := a.PayloadMap()
+	if err != nil || len(payload) == 0 {
+		return kkComps.UpdateAIGatewayConsumerRequest{}
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return kkComps.UpdateAIGatewayConsumerRequest{}
+	}
+	var req kkComps.UpdateAIGatewayConsumerRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return kkComps.UpdateAIGatewayConsumerRequest{}
+	}
+	return req
+}
+
+func (a AIGatewayConsumerResource) PayloadMap() (map[string]any, error) {
+	return marshalObjectToMap(a.CreateRequest(), "AI Gateway Consumer payload")
+}
+
+func (a AIGatewayConsumerResource) MutablePayloadMap() (map[string]any, error) {
+	payload, err := a.PayloadMap()
+	if err != nil {
+		return nil, err
+	}
+	stripAIGatewayConsumerServerFields(payload)
+	return payload, nil
+}
+
+func (a AIGatewayConsumerResource) MarshalJSON() ([]byte, error) {
+	payload, err := a.PayloadMap()
+	if err != nil {
+		return nil, err
+	}
+	payload[SchemaFieldRef] = a.Ref
+	if a.AIGateway != "" {
+		payload[SchemaFieldAIGateway] = a.AIGateway
+	}
+	return json.Marshal(payload)
+}
+
+func (a AIGatewayConsumerResource) MarshalYAML() (any, error) {
+	payload, err := a.PayloadMap()
+	if err != nil {
+		return nil, err
+	}
+	payload[SchemaFieldRef] = a.Ref
+	if a.AIGateway != "" {
+		payload[SchemaFieldAIGateway] = a.AIGateway
+	}
+	return payload, nil
+}
+
+func (a *AIGatewayConsumerResource) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	var meta struct {
+		Ref       string          `json:"ref"`
+		AIGateway string          `json:"ai_gateway,omitempty"`
+		Kongctl   json.RawMessage `json:"kongctl,omitempty"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return err
+	}
+	if len(meta.Kongctl) > 0 && string(meta.Kongctl) != jsonNullLiteral {
+		return fmt.Errorf("kongctl metadata not supported on child resources")
+	}
+
+	delete(raw, SchemaFieldRef)
+	delete(raw, SchemaFieldAIGateway)
+	delete(raw, "kongctl")
+
+	payload, err := json.Marshal(raw)
+	if err != nil {
+		return err
+	}
+	var req kkComps.CreateAIGatewayConsumerRequest
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return err
+	}
+
+	a.BaseResource = BaseResource{Ref: meta.Ref}
+	a.AIGateway = meta.AIGateway
+	a.CreateAIGatewayConsumerRequest = req
+	return nil
+}
+
+func AIGatewayConsumerID(consumer any) string {
+	return aiGatewayConsumerStringField(consumer, aiGatewayConsumerFieldID)
+}
+
+func AIGatewayConsumerName(consumer any) string {
+	return aiGatewayConsumerStringField(consumer, aiGatewayConsumerFieldName)
+}
+
+func AIGatewayConsumerDisplayName(consumer any) string {
+	return aiGatewayConsumerStringField(consumer, aiGatewayConsumerFieldDisplayName)
+}
+
+func AIGatewayConsumerLabels(consumer any) map[string]string {
+	payload, err := marshalObjectToMap(consumer, "AI Gateway Consumer")
+	if err != nil {
+		return nil
+	}
+	raw, ok := payload[aiGatewayConsumerFieldLabels].(map[string]any)
+	if !ok {
+		return nil
+	}
+	labels := make(map[string]string, len(raw))
+	for key, value := range raw {
+		if stringValue, ok := value.(string); ok {
+			labels[key] = stringValue
+		}
+	}
+	return labels
+}
+
+func AIGatewayConsumerUpdatedAt(consumer any) time.Time {
+	payload, err := marshalObjectToMap(consumer, "AI Gateway Consumer")
+	if err != nil {
+		return time.Time{}
+	}
+	if value, ok := payload[aiGatewayConsumerFieldUpdatedAt].(string); ok {
+		if parsed, err := time.Parse(time.RFC3339Nano, value); err == nil {
+			return parsed
+		}
+	}
+	return time.Time{}
+}
+
+func AIGatewayConsumerMutablePayloadMap(consumer kkComps.AIGatewayConsumer) (map[string]any, error) {
+	payload, err := marshalObjectToMap(consumer, "AI Gateway Consumer response")
+	if err != nil {
+		return nil, err
+	}
+	stripAIGatewayConsumerServerFields(payload)
+	return payload, nil
+}
+
+func AIGatewayConsumerResourceFromResponse(
+	gatewayRef string,
+	consumer kkComps.AIGatewayConsumer,
+) (AIGatewayConsumerResource, error) {
+	payload, err := AIGatewayConsumerMutablePayloadMap(consumer)
+	if err != nil {
+		return AIGatewayConsumerResource{}, err
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return AIGatewayConsumerResource{}, err
+	}
+	var req kkComps.CreateAIGatewayConsumerRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return AIGatewayConsumerResource{}, err
+	}
+
+	ref := AIGatewayConsumerID(consumer)
+	if ref == "" {
+		ref = AIGatewayConsumerName(consumer)
+	}
+	return AIGatewayConsumerResource{
+		BaseResource:                   BaseResource{Ref: ref},
+		AIGateway:                      gatewayRef,
+		CreateAIGatewayConsumerRequest: req,
+	}, nil
+}
+
+func stripAIGatewayConsumerServerFields(payload map[string]any) {
+	delete(payload, aiGatewayConsumerFieldID)
+	delete(payload, "created_at")
+	delete(payload, aiGatewayConsumerFieldUpdatedAt)
+}
+
+func aiGatewayConsumerStringField(value any, key string) string {
+	payload, err := marshalObjectToMap(value, "AI Gateway Consumer")
+	if err != nil {
+		return ""
+	}
+	if field, ok := payload[key].(string); ok {
+		return field
+	}
+	return ""
+}
+
+func aiGatewayConsumerExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
+	return explainObject(
+		explainResourceRefField(),
+		explainRefField(SchemaFieldAIGateway, ResourceTypeAIGateway, true),
+		explainField("name", explainStringNode("support-user"), true, true),
+		explainField("type", explainStringNode("api-key"), true, true),
+		explainField("display_name", explainStringNode("Support User"), true, true),
+		explainField(aiGatewayConsumerFieldCustomID, explainStringNode("support-user"), false, false),
+		explainField(
+			aiGatewayConsumerFieldPolicies,
+			explainArrayOf(explainStringNode("!ref mask-sensitive-data")),
+			false,
+			true,
+		),
+		explainField("labels", &ExplainNode{Kind: explainKindObject, Additional: explainStringNode("value")}, false, false),
+		explainField(
+			"managed_by",
+			&ExplainNode{Kind: explainKindObject, Additional: explainStringNode("kongctl")},
+			false,
+			false,
+		),
+	), nil
+}

--- a/internal/declarative/resources/ai_gateway_consumer_group.go
+++ b/internal/declarative/resources/ai_gateway_consumer_group.go
@@ -200,7 +200,7 @@ func (a *AIGatewayConsumerGroupResource) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &meta); err != nil {
 		return err
 	}
-	if len(meta.Kongctl) > 0 && string(meta.Kongctl) != "null" {
+	if len(meta.Kongctl) > 0 && string(meta.Kongctl) != jsonNullLiteral {
 		return fmt.Errorf("kongctl metadata not supported on child resources")
 	}
 

--- a/internal/declarative/resources/ai_gateway_mcp_server.go
+++ b/internal/declarative/resources/ai_gateway_mcp_server.go
@@ -257,7 +257,7 @@ func (a *AIGatewayMCPServerResource) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &meta); err != nil {
 		return err
 	}
-	if len(meta.Kongctl) > 0 && string(meta.Kongctl) != "null" {
+	if len(meta.Kongctl) > 0 && string(meta.Kongctl) != jsonNullLiteral {
 		return fmt.Errorf("kongctl metadata not supported on child resources")
 	}
 

--- a/internal/declarative/resources/ai_gateway_model.go
+++ b/internal/declarative/resources/ai_gateway_model.go
@@ -250,7 +250,7 @@ func (a *AIGatewayModelResource) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &meta); err != nil {
 		return err
 	}
-	if len(meta.Kongctl) > 0 && string(meta.Kongctl) != "null" {
+	if len(meta.Kongctl) > 0 && string(meta.Kongctl) != jsonNullLiteral {
 		return fmt.Errorf("kongctl metadata not supported on child resources")
 	}
 
@@ -350,7 +350,7 @@ func rawStringField(raw map[string]json.RawMessage, field string) (string, bool,
 }
 
 func isJSONNull(raw json.RawMessage) bool {
-	return string(raw) == "null"
+	return string(raw) == jsonNullLiteral
 }
 
 func AIGatewayModelID(model any) string {

--- a/internal/declarative/resources/ai_gateway_policy.go
+++ b/internal/declarative/resources/ai_gateway_policy.go
@@ -217,7 +217,7 @@ func (a *AIGatewayPolicyResource) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &meta); err != nil {
 		return err
 	}
-	if len(meta.Kongctl) > 0 && string(meta.Kongctl) != "null" {
+	if len(meta.Kongctl) > 0 && string(meta.Kongctl) != jsonNullLiteral {
 		return fmt.Errorf("kongctl metadata not supported on child resources")
 	}
 

--- a/internal/declarative/resources/ai_gateway_vault.go
+++ b/internal/declarative/resources/ai_gateway_vault.go
@@ -249,7 +249,7 @@ func (a *AIGatewayVaultResource) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &meta); err != nil {
 		return err
 	}
-	if len(meta.Kongctl) > 0 && string(meta.Kongctl) != "null" {
+	if len(meta.Kongctl) > 0 && string(meta.Kongctl) != jsonNullLiteral {
 		return fmt.Errorf("kongctl metadata not supported on child resources")
 	}
 

--- a/internal/declarative/resources/explain.go
+++ b/internal/declarative/resources/explain.go
@@ -1724,7 +1724,7 @@ func scaffoldSkippedField(node *ExplainNode, omit map[string]struct{}, skipFirst
 
 func scaffoldLiteral(node *ExplainNode) string {
 	if node == nil {
-		return "null"
+		return jsonNullLiteral
 	}
 	node = scaffoldActiveNode(node)
 	if node.Const != nil {
@@ -1903,14 +1903,14 @@ func explainOneOfBranchesShareKind(branches []*ExplainNode) bool {
 func schemaTypeValue(kind string, nullable bool) any {
 	if kind == "any" || kind == "" {
 		if nullable {
-			return []string{"null"}
+			return []string{jsonNullLiteral}
 		}
 		return nil
 	}
 	if !nullable {
 		return kind
 	}
-	return []string{kind, "null"}
+	return []string{kind, jsonNullLiteral}
 }
 
 func nestedRelationsFor(target ResourceType) []ExplainRelation {

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -20,6 +20,7 @@ const (
 	ResourceTypeAIGateway                               ResourceType = "ai_gateway"
 	ResourceTypeAIGatewayProvider                       ResourceType = "ai_gateway_provider"
 	ResourceTypeAIGatewayPolicy                         ResourceType = "ai_gateway_policy"
+	ResourceTypeAIGatewayConsumer                       ResourceType = "ai_gateway_consumer"
 	ResourceTypeAIGatewayConsumerGroup                  ResourceType = "ai_gateway_consumer_group"
 	ResourceTypeAIGatewayModel                          ResourceType = "ai_gateway_model"
 	ResourceTypeAIGatewayMCPServer                      ResourceType = "ai_gateway_mcp_server"
@@ -82,6 +83,7 @@ const (
 	SchemaFieldPortal    = "portal"
 	SchemaFieldTeams     = "teams"
 	SchemaFieldAIGateway = "ai_gateway"
+	jsonNullLiteral      = "null"
 )
 
 // ResourceRef represents a reference to another resource
@@ -114,6 +116,7 @@ type ResourceSet struct {
 	AIGateways                        []AIGatewayResource                        `yaml:"ai_gateways,omitempty"                                    json:"ai_gateways,omitempty"`                           //nolint:lll
 	AIGatewayProviders                []AIGatewayProviderResource                `yaml:"ai_gateway_providers,omitempty"                          json:"ai_gateway_providers,omitempty"`                   //nolint:lll
 	AIGatewayPolicies                 []AIGatewayPolicyResource                  `yaml:"ai_gateway_policies,omitempty"                           json:"ai_gateway_policies,omitempty"`                    //nolint:lll
+	AIGatewayConsumers                []AIGatewayConsumerResource                `yaml:"ai_gateway_consumers,omitempty"                          json:"ai_gateway_consumers,omitempty"`                   //nolint:lll
 	AIGatewayConsumerGroups           []AIGatewayConsumerGroupResource           `yaml:"ai_gateway_consumer_groups,omitempty"                    json:"ai_gateway_consumer_groups,omitempty"`             //nolint:lll
 	AIGatewayModels                   []AIGatewayModelResource                   `yaml:"ai_gateway_models,omitempty"                              json:"ai_gateway_models,omitempty"`                     //nolint:lll
 	AIGatewayMCPServers               []AIGatewayMCPServerResource               `yaml:"ai_gateway_mcp_servers,omitempty"                         json:"ai_gateway_mcp_servers,omitempty"`                //nolint:lll
@@ -365,6 +368,16 @@ func (rs *ResourceSet) GetAIGatewayPolicyByRef(ref string) *AIGatewayPolicyResou
 	return nil
 }
 
+// GetAIGatewayConsumerByRef returns an AI Gateway Consumer resource by its ref from any namespace.
+func (rs *ResourceSet) GetAIGatewayConsumerByRef(ref string) *AIGatewayConsumerResource {
+	for i := range rs.AIGatewayConsumers {
+		if rs.AIGatewayConsumers[i].GetRef() == ref {
+			return &rs.AIGatewayConsumers[i]
+		}
+	}
+	return nil
+}
+
 // GetAIGatewayConsumerGroupByRef returns an AI Gateway Consumer Group resource by its ref from any namespace.
 func (rs *ResourceSet) GetAIGatewayConsumerGroupByRef(ref string) *AIGatewayConsumerGroupResource {
 	for i := range rs.AIGatewayConsumerGroups {
@@ -512,6 +525,25 @@ func (rs *ResourceSet) GetAIGatewayPoliciesByNamespace(namespace string) []AIGat
 			}
 			if GetNamespace(gateway.Kongctl) == namespace {
 				filtered = append(filtered, policy)
+			}
+		}
+	}
+	return filtered
+}
+
+// GetAIGatewayConsumersByNamespace returns AI Gateway Consumer resources from the specified namespace.
+func (rs *ResourceSet) GetAIGatewayConsumersByNamespace(namespace string) []AIGatewayConsumerResource {
+	var filtered []AIGatewayConsumerResource
+	for _, consumer := range rs.AIGatewayConsumers {
+		if gateway := rs.GetAIGatewayByRef(consumer.AIGateway); gateway != nil {
+			if gateway.IsExternal() {
+				if namespace == NamespaceExternal {
+					filtered = append(filtered, consumer)
+				}
+				continue
+			}
+			if GetNamespace(gateway.Kongctl) == namespace {
+				filtered = append(filtered, consumer)
 			}
 		}
 	}
@@ -1184,6 +1216,17 @@ func (rs *ResourceSet) GetAIGatewayPoliciesForGateway(gatewayRef string) []AIGat
 		}
 	}
 	return policies
+}
+
+// GetAIGatewayConsumersForGateway returns all AI Gateway Consumers for a given gateway ref.
+func (rs *ResourceSet) GetAIGatewayConsumersForGateway(gatewayRef string) []AIGatewayConsumerResource {
+	var consumers []AIGatewayConsumerResource
+	for _, consumer := range rs.AIGatewayConsumers {
+		if NormalizeResourceRef(consumer.AIGateway) == gatewayRef {
+			consumers = append(consumers, consumer)
+		}
+	}
+	return consumers
 }
 
 // GetAIGatewayConsumerGroupsForGateway returns all AI Gateway Consumer Groups for a given gateway ref.

--- a/internal/declarative/state/ai_gateway_consumers.go
+++ b/internal/declarative/state/ai_gateway_consumers.go
@@ -1,0 +1,191 @@
+package state
+
+import (
+	"context"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/util/pagination"
+)
+
+// ListAIGatewayConsumers lists all Consumers for an AI Gateway.
+func (c *Client) ListAIGatewayConsumers(ctx context.Context, gatewayID string) ([]AIGatewayConsumer, error) {
+	if err := ValidateAPIClient(c.aiGatewayConsumersAPI, "AI Gateway Consumers API"); err != nil {
+		return nil, err
+	}
+
+	var allData []kkComps.AIGatewayConsumer
+	var pageAfter *string
+	pageSize := int64(100)
+
+	for {
+		req := kkOps.ListAiGatewayConsumersRequest{
+			GatewayID: gatewayID,
+			PageSize:  &pageSize,
+			PageAfter: pageAfter,
+		}
+
+		resp, err := c.aiGatewayConsumersAPI.ListAiGatewayConsumers(ctx, req)
+		if err != nil {
+			return nil, WrapAPIError(err, "list AI Gateway Consumers", nil)
+		}
+
+		if resp == nil || resp.ListAIGatewayConsumersResponse == nil {
+			return []AIGatewayConsumer{}, nil
+		}
+
+		allData = append(allData, resp.ListAIGatewayConsumersResponse.Data...)
+
+		nextCursor := pagination.ExtractPageAfterCursor(resp.ListAIGatewayConsumersResponse.Meta.Page.Next)
+		if nextCursor == "" {
+			break
+		}
+		pageAfter = &nextCursor
+	}
+
+	consumers := make([]AIGatewayConsumer, 0, len(allData))
+	for _, consumer := range allData {
+		consumers = append(consumers, AIGatewayConsumer{
+			AIGatewayConsumer: consumer,
+			NormalizedLabels:  normalizedAIGatewayConsumerLabels(consumer),
+		})
+	}
+	return consumers, nil
+}
+
+// GetAIGatewayConsumer fetches an AI Gateway Consumer by ID or name.
+func (c *Client) GetAIGatewayConsumer(
+	ctx context.Context,
+	gatewayID string,
+	consumerID string,
+) (*AIGatewayConsumer, error) {
+	if err := ValidateAPIClient(c.aiGatewayConsumersAPI, "AI Gateway Consumers API"); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.aiGatewayConsumersAPI.GetAiGatewayConsumer(ctx, gatewayID, consumerID)
+	if err != nil {
+		return nil, WrapAPIError(err, "get AI Gateway Consumer by ID", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeAIGatewayConsumer),
+			UseEnhanced:  true,
+		})
+	}
+
+	if resp == nil || resp.AIGatewayConsumer == nil {
+		return nil, nil
+	}
+
+	return &AIGatewayConsumer{
+		AIGatewayConsumer: *resp.AIGatewayConsumer,
+		NormalizedLabels:  normalizedAIGatewayConsumerLabels(*resp.AIGatewayConsumer),
+	}, nil
+}
+
+// GetAIGatewayConsumerByName finds an AI Gateway Consumer by name within a gateway.
+func (c *Client) GetAIGatewayConsumerByName(
+	ctx context.Context,
+	gatewayID string,
+	name string,
+) (*AIGatewayConsumer, error) {
+	consumers, err := c.ListAIGatewayConsumers(ctx, gatewayID)
+	if err != nil {
+		return nil, WrapAPIError(err, "list AI Gateway Consumers to find by name", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeAIGatewayConsumer),
+			ResourceName: name,
+			UseEnhanced:  true,
+		})
+	}
+
+	for i := range consumers {
+		if consumers[i].Name == name {
+			return &consumers[i], nil
+		}
+	}
+
+	return nil, nil
+}
+
+// CreateAIGatewayConsumer creates a new Consumer under an AI Gateway.
+func (c *Client) CreateAIGatewayConsumer(
+	ctx context.Context,
+	gatewayID string,
+	req kkComps.CreateAIGatewayConsumerRequest,
+	namespace string,
+) (string, error) {
+	if err := ValidateAPIClient(c.aiGatewayConsumersAPI, "AI Gateway Consumers API"); err != nil {
+		return "", err
+	}
+
+	resp, err := c.aiGatewayConsumersAPI.CreateAiGatewayConsumer(ctx, gatewayID, req)
+	if err != nil {
+		return "", WrapAPIError(err, "create AI Gateway Consumer", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeAIGatewayConsumer),
+			ResourceName: req.Name,
+			Namespace:    namespace,
+			UseEnhanced:  true,
+		})
+	}
+
+	if resp == nil || resp.AIGatewayConsumer == nil {
+		return "", fmt.Errorf("create AI Gateway Consumer response missing data")
+	}
+
+	return resp.AIGatewayConsumer.ID, nil
+}
+
+// UpdateAIGatewayConsumer updates an existing Consumer under an AI Gateway.
+func (c *Client) UpdateAIGatewayConsumer(
+	ctx context.Context,
+	gatewayID string,
+	consumerID string,
+	req kkComps.UpdateAIGatewayConsumerRequest,
+	namespace string,
+) (string, error) {
+	if err := ValidateAPIClient(c.aiGatewayConsumersAPI, "AI Gateway Consumers API"); err != nil {
+		return "", err
+	}
+
+	resp, err := c.aiGatewayConsumersAPI.UpdateAiGatewayConsumer(ctx, kkOps.UpdateAiGatewayConsumerRequest{
+		GatewayID:                      gatewayID,
+		ConsumerID:                     consumerID,
+		UpdateAIGatewayConsumerRequest: req,
+	})
+	if err != nil {
+		return "", WrapAPIError(err, "update AI Gateway Consumer", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeAIGatewayConsumer),
+			ResourceName: req.Name,
+			Namespace:    namespace,
+			UseEnhanced:  true,
+		})
+	}
+
+	if resp == nil || resp.AIGatewayConsumer == nil {
+		return "", fmt.Errorf("update AI Gateway Consumer response missing data")
+	}
+
+	return resp.AIGatewayConsumer.ID, nil
+}
+
+// DeleteAIGatewayConsumer deletes an AI Gateway Consumer by ID.
+func (c *Client) DeleteAIGatewayConsumer(ctx context.Context, gatewayID string, consumerID string) error {
+	if err := ValidateAPIClient(c.aiGatewayConsumersAPI, "AI Gateway Consumers API"); err != nil {
+		return err
+	}
+
+	_, err := c.aiGatewayConsumersAPI.DeleteAiGatewayConsumer(ctx, gatewayID, consumerID)
+	if err != nil {
+		return WrapAPIError(err, "delete AI Gateway Consumer", nil)
+	}
+
+	return nil
+}
+
+func normalizedAIGatewayConsumerLabels(consumer kkComps.AIGatewayConsumer) map[string]string {
+	normalized := consumer.Labels
+	if normalized == nil {
+		normalized = make(map[string]string)
+	}
+	return normalized
+}

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -38,6 +38,7 @@ type ClientConfig struct {
 	AIGatewayAPI               helpers.AIGatewayAPI
 	AIGatewayProvidersAPI      helpers.AIGatewayProvidersAPI
 	AIGatewayPoliciesAPI       helpers.AIGatewayPoliciesAPI
+	AIGatewayConsumersAPI      helpers.AIGatewayConsumersAPI
 	AIGatewayConsumerGroupsAPI helpers.AIGatewayConsumerGroupsAPI
 	AIGatewayModelAPI          helpers.AIGatewayModelAPI
 	AIGatewayMCPServersAPI     helpers.AIGatewayMCPServersAPI
@@ -107,6 +108,7 @@ type Client struct {
 	aiGatewayAPI               helpers.AIGatewayAPI
 	aiGatewayProvidersAPI      helpers.AIGatewayProvidersAPI
 	aiGatewayPoliciesAPI       helpers.AIGatewayPoliciesAPI
+	aiGatewayConsumersAPI      helpers.AIGatewayConsumersAPI
 	aiGatewayConsumerGroupsAPI helpers.AIGatewayConsumerGroupsAPI
 	aiGatewayModelAPI          helpers.AIGatewayModelAPI
 	aiGatewayMCPServersAPI     helpers.AIGatewayMCPServersAPI
@@ -177,6 +179,7 @@ func NewClient(config ClientConfig) *Client {
 		aiGatewayAPI:               config.AIGatewayAPI,
 		aiGatewayProvidersAPI:      config.AIGatewayProvidersAPI,
 		aiGatewayPoliciesAPI:       config.AIGatewayPoliciesAPI,
+		aiGatewayConsumersAPI:      config.AIGatewayConsumersAPI,
 		aiGatewayConsumerGroupsAPI: config.AIGatewayConsumerGroupsAPI,
 		aiGatewayModelAPI:          config.AIGatewayModelAPI,
 		aiGatewayMCPServersAPI:     config.AIGatewayMCPServersAPI,
@@ -287,6 +290,12 @@ type AIGatewayProvider struct {
 // AIGatewayPolicy represents a Konnect AI Gateway Policy for internal use.
 type AIGatewayPolicy struct {
 	kkComps.AIGatewayPolicy
+	NormalizedLabels map[string]string
+}
+
+// AIGatewayConsumer represents a Konnect AI Gateway Consumer for internal use.
+type AIGatewayConsumer struct {
+	kkComps.AIGatewayConsumer
 	NormalizedLabels map[string]string
 }
 

--- a/internal/konnect/helpers/ai_gateway_consumers.go
+++ b/internal/konnect/helpers/ai_gateway_consumers.go
@@ -1,0 +1,89 @@
+package helpers
+
+import (
+	"context"
+
+	kkSDK "github.com/Kong/sdk-konnect-go"
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+)
+
+// AIGatewayConsumersAPI defines the interface for AI Gateway Consumer operations needed by kongctl.
+type AIGatewayConsumersAPI interface {
+	ListAiGatewayConsumers(
+		ctx context.Context,
+		request kkOps.ListAiGatewayConsumersRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.ListAiGatewayConsumersResponse, error)
+	CreateAiGatewayConsumer(
+		ctx context.Context,
+		gatewayID string,
+		request kkComps.CreateAIGatewayConsumerRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.CreateAiGatewayConsumerResponse, error)
+	GetAiGatewayConsumer(
+		ctx context.Context,
+		gatewayID string,
+		consumerID string,
+		opts ...kkOps.Option,
+	) (*kkOps.GetAiGatewayConsumerResponse, error)
+	UpdateAiGatewayConsumer(
+		ctx context.Context,
+		request kkOps.UpdateAiGatewayConsumerRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.UpdateAiGatewayConsumerResponse, error)
+	DeleteAiGatewayConsumer(
+		ctx context.Context,
+		gatewayID string,
+		consumerID string,
+		opts ...kkOps.Option,
+	) (*kkOps.DeleteAiGatewayConsumerResponse, error)
+}
+
+// AIGatewayConsumersAPIImpl provides the real SDK implementation.
+type AIGatewayConsumersAPIImpl struct {
+	SDK *kkSDK.SDK
+}
+
+func (a *AIGatewayConsumersAPIImpl) ListAiGatewayConsumers(
+	ctx context.Context,
+	request kkOps.ListAiGatewayConsumersRequest,
+	opts ...kkOps.Option,
+) (*kkOps.ListAiGatewayConsumersResponse, error) {
+	return a.SDK.AIGatewayConsumers.ListAiGatewayConsumers(ctx, request, opts...)
+}
+
+func (a *AIGatewayConsumersAPIImpl) CreateAiGatewayConsumer(
+	ctx context.Context,
+	gatewayID string,
+	request kkComps.CreateAIGatewayConsumerRequest,
+	opts ...kkOps.Option,
+) (*kkOps.CreateAiGatewayConsumerResponse, error) {
+	return a.SDK.AIGatewayConsumers.CreateAiGatewayConsumer(ctx, gatewayID, request, opts...)
+}
+
+func (a *AIGatewayConsumersAPIImpl) GetAiGatewayConsumer(
+	ctx context.Context,
+	gatewayID string,
+	consumerID string,
+	opts ...kkOps.Option,
+) (*kkOps.GetAiGatewayConsumerResponse, error) {
+	return a.SDK.AIGatewayConsumers.GetAiGatewayConsumer(ctx, gatewayID, consumerID, opts...)
+}
+
+func (a *AIGatewayConsumersAPIImpl) UpdateAiGatewayConsumer(
+	ctx context.Context,
+	request kkOps.UpdateAiGatewayConsumerRequest,
+	opts ...kkOps.Option,
+) (*kkOps.UpdateAiGatewayConsumerResponse, error) {
+	return a.SDK.AIGatewayConsumers.UpdateAiGatewayConsumer(ctx, request, opts...)
+}
+
+func (a *AIGatewayConsumersAPIImpl) DeleteAiGatewayConsumer(
+	ctx context.Context,
+	gatewayID string,
+	consumerID string,
+	opts ...kkOps.Option,
+) (*kkOps.DeleteAiGatewayConsumerResponse, error) {
+	return a.SDK.AIGatewayConsumers.DeleteAiGatewayConsumer(ctx, gatewayID, consumerID, opts...)
+}

--- a/internal/konnect/helpers/sdk.go
+++ b/internal/konnect/helpers/sdk.go
@@ -25,6 +25,7 @@ type SDKAPI interface {
 	GetAIGatewayAPI() AIGatewayAPI
 	GetAIGatewayProvidersAPI() AIGatewayProvidersAPI
 	GetAIGatewayPoliciesAPI() AIGatewayPoliciesAPI
+	GetAIGatewayConsumersAPI() AIGatewayConsumersAPI
 	GetAIGatewayConsumerGroupsAPI() AIGatewayConsumerGroupsAPI
 	GetAIGatewayModelAPI() AIGatewayModelAPI
 	GetAIGatewayMCPServersAPI() AIGatewayMCPServersAPI
@@ -152,6 +153,15 @@ func (k *KonnectSDK) GetAIGatewayPoliciesAPI() AIGatewayPoliciesAPI {
 	}
 
 	return &AIGatewayPoliciesAPIImpl{SDK: k.SDK}
+}
+
+// Returns the implementation of the AIGatewayConsumersAPI interface.
+func (k *KonnectSDK) GetAIGatewayConsumersAPI() AIGatewayConsumersAPI {
+	if k.SDK == nil || k.SDK.AIGatewayConsumers == nil {
+		return nil
+	}
+
+	return &AIGatewayConsumersAPIImpl{SDK: k.SDK}
 }
 
 // Returns the implementation of the AIGatewayConsumerGroupsAPI interface.

--- a/internal/konnect/helpers/sdk_mock.go
+++ b/internal/konnect/helpers/sdk_mock.go
@@ -13,6 +13,7 @@ type MockKonnectSDK struct {
 	AIGatewayFactory                   func() AIGatewayAPI
 	AIGatewayProvidersFactory          func() AIGatewayProvidersAPI
 	AIGatewayPoliciesFactory           func() AIGatewayPoliciesAPI
+	AIGatewayConsumersFactory          func() AIGatewayConsumersAPI
 	AIGatewayConsumerGroupsFactory     func() AIGatewayConsumerGroupsAPI
 	AIGatewayModelFactory              func() AIGatewayModelAPI
 	AIGatewayMCPServersFactory         func() AIGatewayMCPServersAPI
@@ -121,6 +122,14 @@ func (m *MockKonnectSDK) GetAIGatewayProvidersAPI() AIGatewayProvidersAPI {
 func (m *MockKonnectSDK) GetAIGatewayPoliciesAPI() AIGatewayPoliciesAPI {
 	if m.AIGatewayPoliciesFactory != nil {
 		return m.AIGatewayPoliciesFactory()
+	}
+	return nil
+}
+
+// Returns a mock instance of the AIGatewayConsumersAPI.
+func (m *MockKonnectSDK) GetAIGatewayConsumersAPI() AIGatewayConsumersAPI {
+	if m.AIGatewayConsumersFactory != nil {
+		return m.AIGatewayConsumersFactory()
 	}
 	return nil
 }

--- a/test/e2e/scenarios/ai-gateway/consumer/overlays/001-update/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/consumer/overlays/001-update/config.yaml
@@ -1,0 +1,34 @@
+ai_gateways:
+  - ref: ai-gateway-consumer-e2e
+    display_name: "AI Gateway Consumer E2E"
+    description: "AI Gateway Consumer e2e"
+    proxy_urls:
+      - host: ai-gateway-consumer-e2e.example.com
+        port: 443
+        protocol: https
+    labels:
+      owner: platform
+      lifecycle: dev
+    policies:
+      - ref: mask-sensitive-data
+        name: mask-sensitive-data
+        type: ai-sanitizer
+        display_name: "Mask Sensitive Data"
+        enabled: true
+        global: false
+        labels:
+          team: support
+          phase: create
+        config:
+          anonymize:
+            - email
+    consumers:
+      - ref: support-agent
+        name: support-agent
+        type: api-key
+        display_name: "Support Agent Updated"
+        labels:
+          team: support
+          phase: update
+        policies:
+          - !ref mask-sensitive-data

--- a/test/e2e/scenarios/ai-gateway/consumer/overlays/002-sync-delete-consumer/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/consumer/overlays/002-sync-delete-consumer/config.yaml
@@ -1,0 +1,25 @@
+ai_gateways:
+  - ref: ai-gateway-consumer-e2e
+    display_name: "AI Gateway Consumer E2E"
+    description: "AI Gateway Consumer e2e"
+    proxy_urls:
+      - host: ai-gateway-consumer-e2e.example.com
+        port: 443
+        protocol: https
+    labels:
+      owner: platform
+      lifecycle: dev
+    policies:
+      - ref: mask-sensitive-data
+        name: mask-sensitive-data
+        type: ai-sanitizer
+        display_name: "Mask Sensitive Data"
+        enabled: true
+        global: false
+        labels:
+          team: support
+          phase: create
+        config:
+          anonymize:
+            - email
+    consumers: []

--- a/test/e2e/scenarios/ai-gateway/consumer/overlays/003-sync-delete-policy/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/consumer/overlays/003-sync-delete-policy/config.yaml
@@ -1,0 +1,13 @@
+ai_gateways:
+  - ref: ai-gateway-consumer-e2e
+    display_name: "AI Gateway Consumer E2E"
+    description: "AI Gateway Consumer e2e"
+    proxy_urls:
+      - host: ai-gateway-consumer-e2e.example.com
+        port: 443
+        protocol: https
+    labels:
+      owner: platform
+      lifecycle: dev
+    policies: []
+    consumers: []

--- a/test/e2e/scenarios/ai-gateway/consumer/overlays/004-sync-delete-gateway/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/consumer/overlays/004-sync-delete-gateway/config.yaml
@@ -1,0 +1,1 @@
+ai_gateways: []

--- a/test/e2e/scenarios/ai-gateway/consumer/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/consumer/scenario.yaml
@@ -1,0 +1,439 @@
+baseInputsPath: testdata
+
+env:
+  KONGCTL_LOG_LEVEL: info
+
+vars:
+  namespace: "ai-gateway-consumer-e2e"
+  gateway_name: "AI Gateway Consumer E2E"
+  gateway_ref: "ai-gateway-consumer-e2e"
+  policy_ref: "mask-sensitive-data"
+  policy_name: "mask-sensitive-data"
+  policy_display_name: "Mask Sensitive Data"
+  consumer_ref: "support-agent"
+  consumer_name: "support-agent"
+  consumer_display_name: "Support Agent"
+  consumer_updated_display_name: "Support Agent Updated"
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - created_at
+      - updated_at
+      - config_hash
+      - endpoints
+      - resource_id
+      - change_id
+      - generated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-explain-and-scaffold
+    skipInputs: true
+    commands:
+      - name: 000-explain-ai-gateway-consumer-json
+        run:
+          - explain
+          - ai_gateway_consumer
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                type: object
+                '"x-kongctl-root-key"': ai_gateway_consumers
+          - select: "contains(keys(properties), 'ai_gateway')"
+            expect:
+              fields:
+                "@": true
+          - select: "contains(keys(properties), 'type')"
+            expect:
+              fields:
+                "@": true
+      - name: 001-scaffold-ai-gateway-consumer
+        run:
+          - scaffold
+          - ai_gateway_consumer
+        outputFormat: disable
+        parseAs: raw
+        assertions:
+          - expect:
+              fields:
+                "contains(stdout, 'ai_gateway_consumers:')": true
+                "contains(stdout, 'ai_gateway: !ref')": true
+                "contains(stdout, 'type: api-key')": true
+                "contains(stdout, 'policies:')": true
+      - name: 002-explain-ai-gateway-consumers-nested-json
+        run:
+          - explain
+          - ai_gateway.consumers
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                type: object
+                '"x-kongctl-resource"': ai_gateway_consumer
+                '"x-kongctl-root-key"': ai_gateway_consumers
+
+  - name: 002-plan-apply-create
+    commands:
+      - name: 000-plan-create
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-create.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 3
+                by_action.CREATE: 3
+          - select: >-
+              changes[?resource_type=='ai_gateway_consumer' && resource_ref=='{{ .vars.consumer_ref }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                fields.name: "{{ .vars.consumer_name }}"
+                fields.type: api-key
+                fields.display_name: "{{ .vars.consumer_display_name }}"
+                fields.labels.phase: create
+                fields.policies[0]: "__REF__:{{ .vars.policy_ref }}#id"
+                references."policies.0".ref: "__REF__:{{ .vars.policy_ref }}#id"
+      - name: 001-apply-create
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-create.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 3
+                failed: 0
+                status: success
+      - name: 002-list-consumers
+        run:
+          - get
+          - ai-gateway
+          - consumers
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - -o
+          - json
+        recordVar:
+          name: consumer_id
+          responsePath: "[?name=='{{ .vars.consumer_name }}'] | [0].id"
+        assertions:
+          - select: "[?name=='{{ .vars.consumer_name }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.consumer_name }}"
+                type: api-key
+                display_name: "{{ .vars.consumer_display_name }}"
+                labels.phase: create
+                "length(policies)": 1
+      - name: 003-get-consumer-by-name
+        run:
+          - get
+          - ai-gateway
+          - consumer
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - "{{ .vars.consumer_name }}"
+          - -o
+          - json
+        assertions:
+          - select: name
+            expect:
+              fields:
+                "@": "{{ .vars.consumer_name }}"
+          - select: type
+            expect:
+              fields:
+                "@": api-key
+      - name: 004-get-consumer-by-id
+        run:
+          - get
+          - ai-gateway
+          - consumers
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - "{{ .vars.consumer_id }}"
+          - -o
+          - json
+        assertions:
+          - select: name
+            expect:
+              fields:
+                "@": "{{ .vars.consumer_name }}"
+
+  - name: 003-plan-apply-update
+    inputOverlayDirs:
+      - overlays/001-update
+    commands:
+      - name: 000-plan-update
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-update.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+          - select: >-
+              changes[?resource_type=='ai_gateway_consumer' && resource_ref=='{{ .vars.consumer_ref }}'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                fields.display_name: "{{ .vars.consumer_updated_display_name }}"
+                fields.labels.phase: update
+      - name: 001-apply-update
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-update.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 002-verify-update
+        run:
+          - get
+          - ai-gateway
+          - consumers
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - "{{ .vars.consumer_name }}"
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                display_name: "{{ .vars.consumer_updated_display_name }}"
+                labels.phase: update
+      - name: 003-diff-no-changes
+        outputFormat: text
+        parseAs: raw
+        run:
+          - diff
+          - -f
+          - "{{ .workdir }}/config.yaml"
+        assertions:
+          - select: stdout
+            expect:
+              fields:
+                "contains(@, 'No changes detected. Konnect is up to date.')": true
+
+  - name: 004-dump-round-trip
+    skipInputs: true
+    commands:
+      - name: 000-dump-ai-gateway-with-children
+        run:
+          - dump
+          - declarative
+          - "--resources=ai_gateways"
+          - "--include-child-resources"
+          - "--default-namespace={{ .vars.namespace }}"
+        outputFormat: none
+        parseAs: yaml
+        stdoutFile: "{{ .workdir }}/dump-ai-gateway.yaml"
+        assertions:
+          - select: >-
+              ai_gateways[?display_name=='{{ .vars.gateway_name }}'] | [0].consumers[?name=='{{ .vars.consumer_name }}'] | [0]
+            expect:
+              fields:
+                name: "{{ .vars.consumer_name }}"
+                type: api-key
+                display_name: "{{ .vars.consumer_updated_display_name }}"
+                "length(policies)": 1
+          - select: >-
+              ai_gateways[?display_name=='{{ .vars.gateway_name }}'] | [0].policies[?name=='{{ .vars.policy_name }}'] | [0]
+            expect:
+              fields:
+                name: "{{ .vars.policy_name }}"
+                display_name: "{{ .vars.policy_display_name }}"
+                type: ai-sanitizer
+                config.anonymize[0]: email
+      - name: 001-plan-from-ai-gateway-dump
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/dump-ai-gateway.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+      - name: 002-dump-root-consumers
+        run:
+          - dump
+          - declarative
+          - "--resources=ai_gateway_consumers"
+          - "--filter-name={{ .vars.consumer_name }}"
+          - "--default-namespace={{ .vars.namespace }}"
+        outputFormat: none
+        parseAs: yaml
+        assertions:
+          - select: "ai_gateway_consumers[0]"
+            expect:
+              fields:
+                name: "{{ .vars.consumer_name }}"
+                type: api-key
+                display_name: "{{ .vars.consumer_updated_display_name }}"
+          - select: "ai_gateway_consumers[0].ai_gateway != ''"
+            expect:
+              fields:
+                "@": true
+
+  - name: 005-sync-delete-consumer
+    inputOverlayDirs:
+      - overlays/002-sync-delete-consumer
+    commands:
+      - name: 000-sync-delete-consumer
+        outputFormat: json
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: >-
+              plan.changes[?resource_type=='ai_gateway_consumer' && action=='DELETE'] | [0]
+            expect:
+              fields:
+                resource_ref: "{{ .vars.consumer_name }}"
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+                status: success
+      - name: 001-list-consumers-empty
+        run:
+          - get
+          - ai-gateway
+          - consumers
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 0
+
+  - name: 006-sync-delete-policy
+    inputOverlayDirs:
+      - overlays/003-sync-delete-policy
+    commands:
+      - name: 000-sync-delete-policy
+        outputFormat: json
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: >-
+              plan.changes[?resource_type=='ai_gateway_policy' && action=='DELETE'] | [0]
+            expect:
+              fields:
+                resource_ref: "{{ .vars.policy_name }}"
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+                status: success
+      - name: 001-list-policies-empty
+        run:
+          - get
+          - ai-gateway
+          - policies
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 0
+
+  - name: 007-sync-delete-gateway
+    inputOverlayDirs:
+      - overlays/004-sync-delete-gateway
+    commands:
+      - name: 000-sync-delete-gateway
+        outputFormat: json
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+                status: success
+      - name: 001-get-ai-gateways
+        run:
+          - get
+          - ai-gateways
+          - -o
+          - json
+        assertions:
+          - select: "[?display_name=='{{ .vars.gateway_name }}']"
+            expect:
+              fields:
+                "length(@)": 0

--- a/test/e2e/scenarios/ai-gateway/consumer/testdata/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/consumer/testdata/config.yaml
@@ -1,0 +1,38 @@
+_defaults:
+  kongctl:
+    namespace: ai-gateway-consumer-e2e
+
+ai_gateways:
+  - ref: ai-gateway-consumer-e2e
+    display_name: "AI Gateway Consumer E2E"
+    description: "AI Gateway Consumer e2e"
+    proxy_urls:
+      - host: ai-gateway-consumer-e2e.example.com
+        port: 443
+        protocol: https
+    labels:
+      owner: platform
+      lifecycle: dev
+    policies:
+      - ref: mask-sensitive-data
+        name: mask-sensitive-data
+        type: ai-sanitizer
+        display_name: "Mask Sensitive Data"
+        enabled: true
+        global: false
+        labels:
+          team: support
+          phase: create
+        config:
+          anonymize:
+            - email
+    consumers:
+      - ref: support-agent
+        name: support-agent
+        type: api-key
+        display_name: "Support Agent"
+        labels:
+          team: support
+          phase: create
+        policies:
+          - !ref mask-sensitive-data

--- a/test/e2e/scenarios/explain/command-coverage/scenario.yaml
+++ b/test/e2e/scenarios/explain/command-coverage/scenario.yaml
@@ -181,7 +181,34 @@ steps:
                 "contains(stdout, 'ROOT YAML PATH: control_plane_data_plane_certificates[].cert')": true
                 "contains(stdout, 'NESTED YAML PATH: control_planes[].data_plane_certificates[].cert')": true
 
-  - name: 010-explain-ai-gateway-models-nested-yaml
+  - name: 010-explain-ai-gateway-consumers-nested-yaml
+    skipInputs: true
+    commands:
+      - name: 000-explain-ai-gateway-consumers-yaml
+        run:
+          - explain
+          - ai_gateway.consumers
+        outputFormat: yaml
+        parseAs: yaml
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                type: object
+                title: "kongctl declarative schema: ai_gateway.consumers"
+                '"x-kongctl-resource"': ai_gateway_consumer
+                '"x-kongctl-root-key"': ai_gateway_consumers
+                '"x-kongctl-resource-class"': child
+                '"x-kongctl-supports-root"': true
+                '"x-kongctl-supports-nested-declaration"': true
+          - select: properties
+            expect:
+              fields:
+                type.type: string
+                custom_id.type: string
+                policies.items.type: string
+
+  - name: 011-explain-ai-gateway-models-nested-yaml
     skipInputs: true
     commands:
       - name: 000-explain-ai-gateway-models-yaml
@@ -208,7 +235,7 @@ steps:
                 formats.items.properties.type.type: string
                 target_models.items.properties.config.properties.type.type: string
 
-  - name: 011-explain-ai-gateway-mcp-servers-nested-yaml
+  - name: 012-explain-ai-gateway-mcp-servers-nested-yaml
     skipInputs: true
     commands:
       - name: 000-explain-ai-gateway-mcp-servers-yaml
@@ -235,7 +262,7 @@ steps:
                 config.properties.url.type: string
                 tools.items.properties.method.type: string
 
-  - name: 012-explain-ai-gateway-vaults-nested-yaml
+  - name: 013-explain-ai-gateway-vaults-nested-yaml
     skipInputs: true
     commands:
       - name: 000-explain-ai-gateway-vaults-yaml


### PR DESCRIPTION
## Summary
- add declarative AI Gateway Consumers as root and nested child resources
- wire planner/executor/state/dump plus get/list CLI support
- add docs, examples, unit coverage, and AI Gateway consumer e2e scenario coverage

Closes #742

## Verification
- go fix ./...
- make format
- make build
- make test
- golangci-lint run ./internal/cmd/root/products/konnect/aigateway ./internal/cmd/root/products/konnect/common ./internal/cmd/root/products/konnect/declarative ./internal/cmd/root/verbs/dump ./internal/declarative/executor ./internal/declarative/loader ./internal/declarative/planner ./internal/declarative/protection ./internal/declarative/resources ./internal/declarative/state ./internal/konnect/helpers
- KONGCTL_E2E_BIN=/home/rspurgeon/.local/share/worktrees/kong/kongctl/gh-742-aigw-consumer/kongctl KONGCTL_E2E_ARTIFACTS_DIR=.e2e-artifacts make test-e2e-scenarios SCENARIO=explain/command-coverage

Note: full make lint still reports pre-existing generated/mock issues outside this change. The touched packages are lint-clean.