### PR TITLE
feat(ai-gateway): add agent child resources

### DIFF
--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -319,10 +319,11 @@ control_plane_data_plane_certificates:
 
 This section covers the root AI Gateway resource backed by the Konnect
 `/v1/ai-gateways` API, AI Gateway Providers, AI Gateway Models, AI Gateway
-MCP Servers, AI Gateway Consumers, AI Gateway Consumer Groups, and AI Gateway
-Vaults. Use
+MCP Servers, AI Gateway Agents, AI Gateway Consumers, AI Gateway Consumer
+Groups, and AI Gateway Vaults. Use
 `kongctl explain ai_gateway --output yaml`,
 `kongctl explain ai_gateway_provider --output yaml`,
+`kongctl explain ai_gateway.agents --output yaml`,
 `kongctl explain ai_gateway.consumers --output yaml`,
 `kongctl explain ai_gateway.consumer_groups --output yaml`,
 `kongctl explain ai_gateway.models --output yaml`,
@@ -331,7 +332,7 @@ Vaults. Use
 
 The `ref` value is used as the stable Konnect API `name` when creating an AI
 Gateway. Use `display_name` for the human-readable name shown in Konnect.
-AI Gateway Providers, Policies, Consumers, Consumer Groups, Models, MCP
+AI Gateway Providers, Policies, Agents, Consumers, Consumer Groups, Models, MCP
 Servers, and Vaults use their own required `name` field as the stable Konnect
 child name. Child entries inherit management scope from their parent AI
 Gateway and do not accept `kongctl` metadata.
@@ -340,19 +341,20 @@ For AI Gateway Models, `target_models[].provider` must match an AI Gateway
 Provider `name` under the parent gateway. The provider can already exist or be
 declared in the same gateway configuration.
 
-For AI Gateway Consumers, Consumer Groups, Models, and MCP Servers, `policies`
-entries reference AI Gateway Policies under the same parent gateway. Existing
-Konnect policy names or IDs can be supplied as strings. Declarative references
-should use `!ref <policy-ref>` so the relationship is explicit and same-plan
-policy creates are ordered and resolved.
+For AI Gateway Agents, Consumers, Consumer Groups, Models, and MCP Servers,
+`policies` entries reference AI Gateway Policies under the same parent gateway.
+Existing Konnect policy names or IDs can be supplied as strings. Declarative
+references should use `!ref <policy-ref>` so the relationship is explicit and
+same-plan policy creates are ordered and resolved.
 
-For AI Gateway Policies, Consumers, Consumer Groups, MCP Servers, and Vaults,
-root-level declarations must include `ai_gateway`, while nested declarations
-inherit the parent gateway. Omit `policies`, `consumers`, `consumer_groups`,
-`mcp_servers`, or `vaults` to leave existing child resources unmanaged during
-sync. Use `policies: []`, `consumers: []`, `consumer_groups: []`,
-`mcp_servers: []`, or `vaults: []` under a specific AI Gateway to sync-delete
-that child type for that gateway. Root-level `ai_gateway_policies: []`,
+For AI Gateway Policies, Agents, Consumers, Consumer Groups, MCP Servers, and
+Vaults, root-level declarations must include `ai_gateway`, while nested
+declarations inherit the parent gateway. Omit `policies`, `agents`,
+`consumers`, `consumer_groups`, `mcp_servers`, or `vaults` to leave existing
+child resources unmanaged during sync. Use `policies: []`, `agents: []`,
+`consumers: []`, `consumer_groups: []`, `mcp_servers: []`, or `vaults: []`
+under a specific AI Gateway to sync-delete that child type for that gateway.
+Root-level `ai_gateway_policies: []`, `ai_gateway_agents: []`,
 `ai_gateway_consumers: []`, `ai_gateway_consumer_groups: []`,
 `ai_gateway_mcp_servers: []`, and `ai_gateway_vaults: []` are rejected because
 they do not identify a parent gateway.
@@ -393,6 +395,24 @@ ai_gateways:
          key: value
        managed_by: object [string]string
          key: value
+   agents:
+    - ref: string
+      name: string required
+      type: a2a # or http
+      display_name: string required
+      enabled: boolean
+      config:
+        url: string required
+        route: object
+        max_request_body_size: integer
+        logging: object
+      policies:
+       - !ref policy-ref
+      acls: object
+      labels: object [string]string
+        key: value
+      managed_by: object [string]string
+        key: value
    consumers:
     - ref: string
       name: string required
@@ -500,6 +520,31 @@ ai_gateway_policies:
    enabled: boolean
    global: boolean
    config: object required
+   labels: object [string]string
+     key: value
+   managed_by: object [string]string
+     key: value
+```
+
+AI Gateway Agents can also be declared as root resources. Include `ai_gateway`
+to point at the parent gateway `ref`.
+
+```yaml
+ai_gateway_agents:
+ - ref: string
+   ai_gateway: string required # AI Gateway ref
+   name: string required
+   type: a2a # or http
+   display_name: string required
+   enabled: boolean
+   config:
+     url: string required
+     route: object
+     max_request_body_size: integer
+     logging: object
+   policies:
+    - !ref policy-ref
+   acls: object
    labels: object [string]string
      key: value
    managed_by: object [string]string

--- a/docs/examples/declarative/ai-gateway/README.md
+++ b/docs/examples/declarative/ai-gateway/README.md
@@ -4,11 +4,11 @@ This directory contains declarative configuration examples for Konnect AI
 Gateway resources.
 
 - [ai-gateway.yaml](ai-gateway.yaml) defines a root AI Gateway resource with
-  a nested OpenAI provider, env vault, policy, consumer, consumer group, model
-  that targets that provider, and a conversion-only MCP Server.
+  a nested OpenAI provider, env vault, policy, consumer, agent, consumer group,
+  model that targets that provider, and a conversion-only MCP Server.
 - [federated](federated) shows a multi-folder
   layout where a central team owns an AI Gateway and providers, while a peer
-  team owns root-level policies, consumers, consumer groups, models, MCP
+  team owns root-level policies, agents, consumers, consumer groups, models, MCP
   Servers, and vaults that reference the shared gateway.
 
 Set `OPENAI_AUTH_HEADER` to the full upstream authorization header value

--- a/docs/examples/declarative/ai-gateway/ai-gateway.yaml
+++ b/docs/examples/declarative/ai-gateway/ai-gateway.yaml
@@ -58,6 +58,24 @@ ai_gateways:
         labels:
           team: support
           access: agent
+    agents:
+      - ref: customer-support-agent
+        name: customer-support-agent
+        type: a2a
+        display_name: "Customer Support Agent"
+        enabled: true
+        labels:
+          team: support
+          agent: customer-support
+        config:
+          url: https://support-agent.example.com
+          route:
+            paths:
+              - /agents/support
+          logging:
+            max_payload_size: 524288
+        policies:
+          - !ref mask-sensitive-data
     consumer_groups:
       - ref: premium-support-users
         name: premium-support-users

--- a/docs/examples/declarative/ai-gateway/federated/README.md
+++ b/docs/examples/declarative/ai-gateway/federated/README.md
@@ -2,8 +2,8 @@
 
 This example shows a federated layout for AI Gateway resources where a central
 AI platform team owns the shared AI Gateway and upstream providers, while a peer
-team owns root-level policies, consumers, consumer groups, models, MCP Servers,
-and vaults that target the shared gateway.
+team owns root-level policies, agents, consumers, consumer groups, models, MCP
+Servers, and vaults that target the shared gateway.
 
 ## Structure
 
@@ -14,6 +14,7 @@ ai-gateway/federated/
 |-- external-peer-team/
 |   `-- support-model.yaml
 `-- peer-team/
+    |-- support-agent.yaml
     |-- support-consumer.yaml
     |-- support-consumer-group.yaml
     |-- support-mcp-server.yaml
@@ -28,6 +29,9 @@ ai-gateway/federated/
   providers: OpenAI and Anthropic.
 - `peer-team/support-policy.yaml` defines a standalone `ai_gateway_policies`
   entry that references the central gateway with `!ref shared-ai-gateway#id`.
+- `peer-team/support-agent.yaml` defines a standalone `ai_gateway_agents` entry
+  that references the central gateway with `!ref shared-ai-gateway#id` and
+  attaches the policy with an explicit `!ref peer-mask-sensitive-data`.
 - `peer-team/support-consumer.yaml` defines a standalone
   `ai_gateway_consumers` entry that references the central gateway with
   `!ref shared-ai-gateway#id` and attaches the policy with an explicit

--- a/docs/examples/declarative/ai-gateway/federated/peer-team/support-agent.yaml
+++ b/docs/examples/declarative/ai-gateway/federated/peer-team/support-agent.yaml
@@ -1,0 +1,23 @@
+_defaults:
+  kongctl:
+    namespace: federated-ai-gateway
+
+ai_gateway_agents:
+  - ref: peer-support-agent
+    ai_gateway: !ref shared-ai-gateway#id
+    name: peer-support-agent
+    type: a2a
+    display_name: "Peer Support Agent"
+    enabled: true
+    labels:
+      team: support-experience
+      ownership: peer
+    config:
+      url: https://support-agent.example.com
+      route:
+        paths:
+          - /agents/support
+      logging:
+        max_payload_size: 524288
+    policies:
+      - !ref peer-mask-sensitive-data

--- a/internal/cmd/root/products/konnect/aigateway/agents.go
+++ b/internal/cmd/root/products/konnect/aigateway/agents.go
@@ -1,0 +1,448 @@
+package aigateway
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/table"
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/cmd"
+	cmdCommon "github.com/kong/kongctl/internal/cmd/common"
+	"github.com/kong/kongctl/internal/cmd/output/tableview"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
+	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/kong/kongctl/internal/config"
+	declresources "github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/konnect/helpers"
+	"github.com/kong/kongctl/internal/meta"
+	"github.com/kong/kongctl/internal/util"
+	"github.com/kong/kongctl/internal/util/i18n"
+	"github.com/kong/kongctl/internal/util/normalizers"
+	"github.com/kong/kongctl/internal/util/pagination"
+	"github.com/segmentio/cli"
+	"github.com/spf13/cobra"
+)
+
+type aiGatewayAgentRecord struct {
+	ID               string
+	Name             string
+	DisplayName      string
+	Type             string
+	Enabled          string
+	PolicyCount      string
+	LocalUpdatedTime string
+}
+
+var (
+	aiGatewayAgentsUse   = "agents [agent-id|agent-name]"
+	aiGatewayAgentsShort = i18n.T(
+		"root.products.konnect.ai-gateway.agentsShort",
+		"List or get Agents for a Konnect AI Gateway",
+	)
+	aiGatewayAgentsLong = normalizers.LongDesc(i18n.T(
+		"root.products.konnect.ai-gateway.agentsLong",
+		`Use the agents command to list or retrieve Agents for a specific Konnect AI Gateway.`,
+	))
+	aiGatewayAgentsExample = normalizers.Examples(
+		i18n.T("root.products.konnect.ai-gateway.agentsExamples",
+			fmt.Sprintf(`# List Agents for an AI Gateway by display name
+%[1]s get ai-gateway agents --gateway-name "Customer Support Gateway"
+# List Agents for an AI Gateway by ID
+%[1]s get ai-gateway agents --gateway-id <gateway-id>
+# Get an Agent by name
+%[1]s get ai-gateway agents --gateway-name "Customer Support Gateway" booking-agent
+# Get an Agent by ID
+%[1]s get ai-gateway agents --gateway-id <gateway-id> --agent-id <agent-id>
+`, meta.CLIName)),
+	)
+)
+
+func newGetAIGatewayAgentsCmd(
+	verb verbs.VerbValue,
+	addParentFlags func(verbs.VerbValue, *cobra.Command),
+	parentPreRun func(*cobra.Command, []string) error,
+) *cobra.Command {
+	c := &cobra.Command{
+		Use:     aiGatewayAgentsUse,
+		Short:   aiGatewayAgentsShort,
+		Long:    aiGatewayAgentsLong,
+		Example: aiGatewayAgentsExample,
+		Aliases: []string{"agent"},
+		PreRunE: func(c *cobra.Command, args []string) error {
+			if parentPreRun != nil {
+				if err := parentPreRun(c, args); err != nil {
+					return err
+				}
+			}
+			if err := bindAIGatewayChildFlags(c, args); err != nil {
+				return err
+			}
+			return bindAIGatewayAgentFlags(c, args)
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			handler := aiGatewayAgentsHandler{cmd: c}
+			return handler.run(args)
+		},
+	}
+
+	addAIGatewayChildFlags(c)
+	addAIGatewayAgentFlags(c)
+	if addParentFlags != nil {
+		addParentFlags(verb, c)
+	}
+	return c
+}
+
+type aiGatewayAgentsHandler struct {
+	cmd *cobra.Command
+}
+
+func (h aiGatewayAgentsHandler) run(args []string) error {
+	helper := cmd.BuildHelper(h.cmd, args)
+	if len(args) > 1 {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf("too many arguments. Listing AI Gateway Agents requires 0 or 1 arguments (ID or name)"),
+		}
+	}
+
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	if len(args) == 1 {
+		agentID, agentName := getAIGatewayAgentIdentifiers(cfg)
+		if agentID != "" || agentName != "" {
+			return &cmd.ConfigurationError{
+				Err: fmt.Errorf(
+					"cannot specify both positional argument and --%s or --%s flags",
+					aiGatewayAgentIDFlagName,
+					aiGatewayAgentNameFlagName,
+				),
+			}
+		}
+	}
+
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+	outType, err := helper.GetOutputFormat()
+	if err != nil {
+		return err
+	}
+	printer, err := cli.Format(outType.String(), helper.GetStreams().Out)
+	if err != nil {
+		return err
+	}
+	defer printer.Flush()
+
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return err
+	}
+
+	gatewayID, gatewayName := getAIGatewayIdentifiers(cfg)
+	if gatewayID != "" && gatewayName != "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf("only one of --%s or --%s can be provided", aiGatewayIDFlagName, aiGatewayNameFlagName),
+		}
+	}
+	if gatewayID == "" && gatewayName == "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf(
+				"an AI Gateway identifier is required. Provide --%s or --%s",
+				aiGatewayIDFlagName,
+				aiGatewayNameFlagName,
+			),
+		}
+	}
+	if gatewayID == "" {
+		gatewayID, err = resolveAIGatewayIDByDisplayName(gatewayName, sdk.GetAIGatewayAPI(), helper, cfg)
+		if err != nil {
+			return err
+		}
+	}
+
+	agentAPI := sdk.GetAIGatewayAgentsAPI()
+	if agentAPI == nil {
+		return &cmd.ExecutionError{
+			Msg: "AI Gateway Agents client is not available",
+			Err: fmt.Errorf("AI Gateway Agents client not configured"),
+		}
+	}
+
+	agentID, agentName := getAIGatewayAgentIdentifiers(cfg)
+	if agentID != "" && agentName != "" {
+		return &cmd.ConfigurationError{
+			Err: fmt.Errorf(
+				"only one of --%s or --%s can be provided",
+				aiGatewayAgentIDFlagName,
+				aiGatewayAgentNameFlagName,
+			),
+		}
+	}
+
+	identifier := ""
+	if len(args) == 1 {
+		identifier = strings.TrimSpace(args[0])
+	} else if agentID != "" {
+		identifier = agentID
+	} else if agentName != "" {
+		identifier = agentName
+	}
+
+	if identifier != "" {
+		return h.getSingleAgent(helper, agentAPI, gatewayID, identifier, outType, printer)
+	}
+	return h.listAgents(helper, agentAPI, gatewayID, outType, printer, cfg)
+}
+
+func (h aiGatewayAgentsHandler) listAgents(
+	helper cmd.Helper,
+	agentAPI helpers.AIGatewayAgentsAPI,
+	gatewayID string,
+	outType cmdCommon.OutputFormat,
+	printer cli.PrintFlusher,
+	cfg config.Hook,
+) error {
+	agents, err := fetchAIGatewayAgents(helper, agentAPI, gatewayID, cfg)
+	if err != nil {
+		return err
+	}
+
+	records := make([]aiGatewayAgentRecord, 0, len(agents))
+	tableRows := make([]table.Row, 0, len(agents))
+	for _, agent := range agents {
+		record := aiGatewayAgentToRecord(agent)
+		records = append(records, record)
+		tableRows = append(tableRows, table.Row{
+			record.ID,
+			record.Name,
+			record.DisplayName,
+			record.Type,
+			record.Enabled,
+			record.PolicyCount,
+			record.LocalUpdatedTime,
+		})
+	}
+
+	return tableview.RenderForFormat(
+		helper,
+		false,
+		outType,
+		printer,
+		helper.GetStreams(),
+		records,
+		agents,
+		"",
+		tableview.WithCustomTable(
+			[]string{
+				aiGatewayHeaderID,
+				aiGatewayHeaderName,
+				aiGatewayHeaderDisplayName,
+				aiGatewayHeaderType,
+				aiGatewayHeaderEnabled,
+				aiGatewayHeaderPolicies,
+				aiGatewayHeaderUpdated,
+			},
+			tableRows,
+		),
+		tableview.WithRootLabel(helper.GetCmd().Name()),
+		tableview.WithDetailHelper(helper),
+		tableview.WithDetailRenderer(func(index int) string {
+			if index < 0 || index >= len(agents) {
+				return ""
+			}
+			return aiGatewayAgentDetailView(agents[index])
+		}),
+		tableview.WithDetailContext(common.ViewParentAIGatewayAgent, func(index int) any {
+			if index < 0 || index >= len(agents) {
+				return nil
+			}
+			return &agents[index]
+		}),
+	)
+}
+
+func (h aiGatewayAgentsHandler) getSingleAgent(
+	helper cmd.Helper,
+	agentAPI helpers.AIGatewayAgentsAPI,
+	gatewayID string,
+	identifier string,
+	outType cmdCommon.OutputFormat,
+	printer cli.PrintFlusher,
+) error {
+	res, err := agentAPI.GetAiGatewayAgent(helper.GetContext(), gatewayID, identifier)
+	if err != nil {
+		attrs := cmd.TryConvertErrorToAttrs(err)
+		return cmd.PrepareExecutionError("Failed to get AI Gateway Agent", err, helper.GetCmd(), attrs...)
+	}
+	if res == nil || res.AIGatewayAgent == nil {
+		return &cmd.ExecutionError{
+			Msg: "AI Gateway Agent response was empty",
+			Err: fmt.Errorf("no Agent returned for id or name %s", identifier),
+		}
+	}
+	agent := res.AIGatewayAgent
+
+	record := aiGatewayAgentToRecord(*agent)
+	return tableview.RenderForFormat(
+		helper,
+		false,
+		outType,
+		printer,
+		helper.GetStreams(),
+		record,
+		agent,
+		"",
+		tableview.WithRootLabel(helper.GetCmd().Name()),
+		tableview.WithDetailHelper(helper),
+		tableview.WithDetailRenderer(func(index int) string {
+			if index != 0 {
+				return ""
+			}
+			return aiGatewayAgentDetailView(*agent)
+		}),
+		tableview.WithDetailContext(common.ViewParentAIGatewayAgent, func(index int) any {
+			if index != 0 {
+				return nil
+			}
+			return agent
+		}),
+	)
+}
+
+func fetchAIGatewayAgents(
+	helper cmd.Helper,
+	agentAPI helpers.AIGatewayAgentsAPI,
+	gatewayID string,
+	cfg config.Hook,
+) ([]kkComps.AIGatewayAgent, error) {
+	requestPageSize := common.ResolveRequestPageSize(cfg)
+	var pageAfter *string
+	var allData []kkComps.AIGatewayAgent
+
+	for {
+		req := kkOps.ListAiGatewayAgentsRequest{
+			GatewayID: gatewayID,
+			PageSize:  &requestPageSize,
+		}
+		if pageAfter != nil {
+			req.PageAfter = pageAfter
+		}
+
+		res, err := agentAPI.ListAiGatewayAgents(helper.GetContext(), req)
+		if err != nil {
+			attrs := cmd.TryConvertErrorToAttrs(err)
+			return nil, cmd.PrepareExecutionError("Failed to list AI Gateway Agents", err, helper.GetCmd(), attrs...)
+		}
+		if res == nil || res.ListAIGatewayAgentsResponse == nil {
+			break
+		}
+
+		allData = append(allData, res.ListAIGatewayAgentsResponse.Data...)
+		nextCursor := pagination.ExtractPageAfterCursor(res.ListAIGatewayAgentsResponse.Meta.Page.Next)
+		if nextCursor == "" {
+			break
+		}
+		pageAfter = &nextCursor
+	}
+
+	return allData, nil
+}
+
+func aiGatewayAgentToRecord(agent kkComps.AIGatewayAgent) aiGatewayAgentRecord {
+	record := aiGatewayAgentRecord{
+		ID:               aiGatewayMissingValue,
+		Name:             valueOrMissing(declresources.AIGatewayAgentName(agent)),
+		DisplayName:      valueOrMissing(declresources.AIGatewayAgentDisplayName(agent)),
+		Type:             valueOrMissing(string(agent.Type)),
+		Enabled:          aiGatewayMissingValue,
+		PolicyCount:      fmt.Sprintf("%d", len(agent.Policies)),
+		LocalUpdatedTime: aiGatewayMissingValue,
+	}
+	if enabled := declresources.AIGatewayAgentEnabled(agent); enabled != nil {
+		record.Enabled = fmt.Sprintf("%t", *enabled)
+	}
+	if id := declresources.AIGatewayAgentID(agent); id != "" {
+		record.ID = util.AbbreviateUUID(id)
+	}
+	if updatedAt := declresources.AIGatewayAgentUpdatedAt(agent); !updatedAt.IsZero() {
+		record.LocalUpdatedTime = updatedAt.In(time.Local).Format("2006-01-02 15:04:05")
+	}
+	return record
+}
+
+func aiGatewayAgentDetailView(agent kkComps.AIGatewayAgent) string {
+	payload := make(map[string]any)
+	data, err := json.Marshal(agent)
+	if err == nil {
+		_ = json.Unmarshal(data, &payload)
+	}
+
+	order := []string{
+		"id",
+		"name",
+		"display_name",
+		"enabled",
+		"type",
+		"policies",
+		"acls",
+		"config",
+		"labels",
+		"managed_by",
+		"created_at",
+		"updated_at",
+	}
+
+	var b strings.Builder
+	for _, field := range order {
+		fmt.Fprintf(&b, "%s: %s\n", field, formatAIGatewayModelDetailValue(payload[field]))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func buildAIGatewayAgentChildView(agents []kkComps.AIGatewayAgent) tableview.ChildView {
+	tableRows := make([]table.Row, 0, len(agents))
+	for i := range agents {
+		record := aiGatewayAgentToRecord(agents[i])
+		tableRows = append(tableRows, table.Row{
+			record.ID,
+			record.Name,
+			record.DisplayName,
+			record.Type,
+			record.Enabled,
+			record.PolicyCount,
+		})
+	}
+
+	return tableview.ChildView{
+		Headers: []string{
+			aiGatewayHeaderID,
+			aiGatewayHeaderName,
+			aiGatewayHeaderDisplayName,
+			aiGatewayHeaderType,
+			aiGatewayHeaderEnabled,
+			aiGatewayHeaderPolicies,
+		},
+		Rows: tableRows,
+		DetailRenderer: func(index int) string {
+			if index < 0 || index >= len(agents) {
+				return ""
+			}
+			return aiGatewayAgentDetailView(agents[index])
+		},
+		Title:      "AI Gateway Agents",
+		ParentType: common.ViewParentAIGatewayAgent,
+		DetailContext: func(index int) any {
+			if index < 0 || index >= len(agents) {
+				return nil
+			}
+			return &agents[index]
+		},
+	}
+}

--- a/internal/cmd/root/products/konnect/aigateway/ai-gateway.go
+++ b/internal/cmd/root/products/konnect/aigateway/ai-gateway.go
@@ -31,6 +31,7 @@ func NewAIGatewayCmd(
 		root := newGetAIGatewayCmd(verb, &baseCmd, addParentFlags, parentPreRun).Command
 		root.AddCommand(newGetAIGatewayProvidersCmd(verb, addParentFlags, parentPreRun))
 		root.AddCommand(newGetAIGatewayPoliciesCmd(verb, addParentFlags, parentPreRun))
+		root.AddCommand(newGetAIGatewayAgentsCmd(verb, addParentFlags, parentPreRun))
 		root.AddCommand(newGetAIGatewayConsumersCmd(verb, addParentFlags, parentPreRun))
 		root.AddCommand(newGetAIGatewayConsumerGroupsCmd(verb, addParentFlags, parentPreRun))
 		root.AddCommand(newGetAIGatewayModelsCmd(verb, addParentFlags, parentPreRun))

--- a/internal/cmd/root/products/konnect/aigateway/child_common.go
+++ b/internal/cmd/root/products/konnect/aigateway/child_common.go
@@ -27,6 +27,12 @@ const (
 	aiGatewayPolicyIDConfigPath   = "konnect.ai-gateway.policy.id"
 	aiGatewayPolicyNameConfigPath = "konnect.ai-gateway.policy.name"
 
+	aiGatewayAgentIDFlagName   = "agent-id"
+	aiGatewayAgentNameFlagName = "agent-name"
+
+	aiGatewayAgentIDConfigPath   = "konnect.ai-gateway.agent.id"
+	aiGatewayAgentNameConfigPath = "konnect.ai-gateway.agent.name"
+
 	aiGatewayConsumerIDFlagName   = "consumer-id"
 	aiGatewayConsumerNameFlagName = "consumer-name"
 
@@ -57,6 +63,7 @@ const (
 	aiGatewayHeaderName        = "NAME"
 	aiGatewayHeaderDisplayName = "DISPLAY NAME"
 	aiGatewayHeaderType        = "TYPE"
+	aiGatewayHeaderEnabled     = "ENABLED"
 	aiGatewayHeaderPolicies    = "POLICIES"
 	aiGatewayHeaderUpdated     = "UPDATED"
 )
@@ -161,6 +168,40 @@ func bindAIGatewayPolicyFlags(c *cobra.Command, args []string) error {
 
 func getAIGatewayPolicyIdentifiers(cfg config.Hook) (id string, name string) {
 	return cfg.GetString(aiGatewayPolicyIDConfigPath), cfg.GetString(aiGatewayPolicyNameConfigPath)
+}
+
+func addAIGatewayAgentFlags(c *cobra.Command) {
+	c.Flags().String(aiGatewayAgentIDFlagName, "",
+		fmt.Sprintf(`The ID of the AI Gateway Agent to retrieve.
+- Config path: [ %s ]`, aiGatewayAgentIDConfigPath))
+	c.Flags().String(aiGatewayAgentNameFlagName, "",
+		fmt.Sprintf(`The name of the AI Gateway Agent to retrieve.
+- Config path: [ %s ]`, aiGatewayAgentNameConfigPath))
+	c.MarkFlagsMutuallyExclusive(aiGatewayAgentIDFlagName, aiGatewayAgentNameFlagName)
+}
+
+func bindAIGatewayAgentFlags(c *cobra.Command, args []string) error {
+	helper := cmd.BuildHelper(c, args)
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	if flag := c.Flags().Lookup(aiGatewayAgentIDFlagName); flag != nil {
+		if err := cfg.BindFlag(aiGatewayAgentIDConfigPath, flag); err != nil {
+			return err
+		}
+	}
+	if flag := c.Flags().Lookup(aiGatewayAgentNameFlagName); flag != nil {
+		if err := cfg.BindFlag(aiGatewayAgentNameConfigPath, flag); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getAIGatewayAgentIdentifiers(cfg config.Hook) (id string, name string) {
+	return cfg.GetString(aiGatewayAgentIDConfigPath), cfg.GetString(aiGatewayAgentNameConfigPath)
 }
 
 func addAIGatewayConsumerFlags(c *cobra.Command) {

--- a/internal/cmd/root/products/konnect/aigateway/interactive_children.go
+++ b/internal/cmd/root/products/konnect/aigateway/interactive_children.go
@@ -14,6 +14,7 @@ import (
 func init() {
 	tableview.RegisterChildLoader(common.ViewParentAIGateway, common.ViewFieldProviders, loadAIGatewayProviders)
 	tableview.RegisterChildLoader(common.ViewParentAIGateway, common.ViewFieldPolicies, loadAIGatewayPolicies)
+	tableview.RegisterChildLoader(common.ViewParentAIGateway, common.ViewFieldAgents, loadAIGatewayAgents)
 	tableview.RegisterChildLoader(common.ViewParentAIGateway, common.ViewFieldConsumers, loadAIGatewayConsumers)
 	tableview.RegisterChildLoader(common.ViewParentAIGateway, common.ViewFieldConsumerGroups, loadAIGatewayConsumerGroups)
 }
@@ -78,6 +79,37 @@ func loadAIGatewayPolicies(_ context.Context, helper cmd.Helper, parent any) (ta
 		return tableview.ChildView{}, err
 	}
 	return buildAIGatewayPolicyChildView(policies), nil
+}
+
+func loadAIGatewayAgents(_ context.Context, helper cmd.Helper, parent any) (tableview.ChildView, error) {
+	gatewayID, err := aiGatewayIDFromParent(parent)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+
+	agentAPI := sdk.GetAIGatewayAgentsAPI()
+	if agentAPI == nil {
+		return tableview.ChildView{}, fmt.Errorf("AI Gateway Agents client is not available")
+	}
+
+	agents, err := fetchAIGatewayAgents(helper, agentAPI, gatewayID, cfg)
+	if err != nil {
+		return tableview.ChildView{}, err
+	}
+	return buildAIGatewayAgentChildView(agents), nil
 }
 
 func loadAIGatewayConsumers(_ context.Context, helper cmd.Helper, parent any) (tableview.ChildView, error) {

--- a/internal/cmd/root/products/konnect/common/view_identifiers.go
+++ b/internal/cmd/root/products/konnect/common/view_identifiers.go
@@ -8,6 +8,7 @@ const (
 	ViewParentAIGateway                     = "ai-gateway"
 	ViewParentAIGatewayProvider             = "ai-gateway-provider"
 	ViewParentAIGatewayPolicy               = "ai-gateway-policy"
+	ViewParentAIGatewayAgent                = "ai-gateway-agent"
 	ViewParentAIGatewayConsumer             = "ai-gateway-consumer"
 	ViewParentAIGatewayConsumerGroup        = "ai-gateway-consumer-group"
 	ViewParentAIGatewayModel                = "ai-gateway-model"
@@ -59,6 +60,7 @@ const (
 const (
 	ViewFieldApplications          = "applications"
 	ViewFieldAuthSettings          = "auth-settings"
+	ViewFieldAgents                = "agents"
 	ViewFieldBackendClusters       = "backend-clusters"
 	ViewFieldClusterPolicies       = "cluster-policies"
 	ViewFieldConsumePolicies       = "consume-policies"

--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -2844,6 +2844,7 @@ func createStateClient(kkClient helpers.SDKAPI) *state.Client {
 		AIGatewayAPI:            kkClient.GetAIGatewayAPI(),
 		AIGatewayProvidersAPI:   kkClient.GetAIGatewayProvidersAPI(),
 		AIGatewayPoliciesAPI:    kkClient.GetAIGatewayPoliciesAPI(),
+		AIGatewayAgentsAPI:      kkClient.GetAIGatewayAgentsAPI(),
 		AIGatewayConsumersAPI:   kkClient.GetAIGatewayConsumersAPI(),
 		AIGatewayModelAPI:       kkClient.GetAIGatewayModelAPI(),
 		AIGatewayMCPServersAPI:  kkClient.GetAIGatewayMCPServersAPI(),

--- a/internal/cmd/root/verbs/dump/common.go
+++ b/internal/cmd/root/verbs/dump/common.go
@@ -162,6 +162,8 @@ func mapResourceName(name string) string {
 		return "ai_gateways"
 	case "ai-gateway-policy", "ai-gateway-policies", "ai_gateway_policy", "ai_gateway_policies":
 		return "ai_gateway_policies"
+	case "ai-gateway-agent", "ai-gateway-agents", "ai_gateway_agent", "ai_gateway_agents":
+		return "ai_gateway_agents"
 	case "ai-gateway-consumer", "ai-gateway-consumers", "ai_gateway_consumer", "ai_gateway_consumers":
 		return "ai_gateway_consumers"
 	case "ai-gateway-consumer-group", "ai-gateway-consumer-groups",

--- a/internal/cmd/root/verbs/dump/declarative.go
+++ b/internal/cmd/root/verbs/dump/declarative.go
@@ -54,6 +54,7 @@ var declarativeAllowedResources = map[string]struct{}{
 	"event_gateways":              {},
 	"ai_gateways":                 {},
 	"ai_gateway_policies":         {},
+	"ai_gateway_agents":           {},
 	"ai_gateway_consumers":        {},
 	"ai_gateway_consumer_groups":  {},
 	"ai_gateway_models":           {},
@@ -92,7 +93,7 @@ func newDeclarativeCmd() *cobra.Command {
 		"Comma separated list of resource types to dump "+
 			"(portals, apis, application_auth_strategies, dcr_providers, control_planes, "+
 			resourceAnalyticsDashboards+", event_gateways, ai_gateways, ai_gateway_policies, "+
-			"ai_gateway_consumers, ai_gateway_consumer_groups, ai_gateway_models, "+
+			"ai_gateway_agents, ai_gateway_consumers, ai_gateway_consumer_groups, ai_gateway_models, "+
 			"ai_gateway_mcp_servers, ai_gateway_vaults, "+
 			"organization.teams).")
 	_ = cmd.MarkFlagRequired("resources")
@@ -210,6 +211,7 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 	var stateClient *declstate.Client
 	if opts.includeChildResources ||
 		slices.Contains(opts.resources, "ai_gateway_policies") ||
+		slices.Contains(opts.resources, "ai_gateway_agents") ||
 		slices.Contains(opts.resources, "ai_gateway_consumers") ||
 		slices.Contains(opts.resources, "ai_gateway_consumer_groups") ||
 		slices.Contains(opts.resources, "ai_gateway_models") ||
@@ -228,6 +230,7 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 			AIGatewayAPI:                        sdk.GetAIGatewayAPI(),
 			AIGatewayProvidersAPI:               sdk.GetAIGatewayProvidersAPI(),
 			AIGatewayPoliciesAPI:                sdk.GetAIGatewayPoliciesAPI(),
+			AIGatewayAgentsAPI:                  sdk.GetAIGatewayAgentsAPI(),
 			AIGatewayConsumersAPI:               sdk.GetAIGatewayConsumersAPI(),
 			AIGatewayConsumerGroupsAPI:          sdk.GetAIGatewayConsumerGroupsAPI(),
 			AIGatewayModelAPI:                   sdk.GetAIGatewayModelAPI(),
@@ -389,6 +392,18 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 				return err
 			}
 			resourceSet.AIGatewayPolicies = append(resourceSet.AIGatewayPolicies, policies...)
+		case "ai_gateway_agents":
+			agents, err := collectDeclarativeAIGatewayAgents(
+				ctx,
+				stateClient,
+				sdk.GetAIGatewayAPI(),
+				requestPageSize,
+				opts.filter,
+			)
+			if err != nil {
+				return err
+			}
+			resourceSet.AIGatewayAgents = append(resourceSet.AIGatewayAgents, agents...)
 		case "ai_gateway_consumers":
 			consumers, err := collectDeclarativeAIGatewayConsumers(
 				ctx,
@@ -854,6 +869,44 @@ func collectDeclarativeAIGatewayPolicies(
 	})
 
 	return policies, nil
+}
+
+func collectDeclarativeAIGatewayAgents(
+	ctx context.Context,
+	client *declstate.Client,
+	aiGatewayClient helpers.AIGatewayAPI,
+	requestPageSize int64,
+	filter filterOptions,
+) ([]declresources.AIGatewayAgentResource, error) {
+	if client == nil {
+		return nil, fmt.Errorf("AI Gateway Agents API client is not configured")
+	}
+
+	gateways, err := collectDeclarativeAIGateways(ctx, aiGatewayClient, requestPageSize, filterOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var agents []declresources.AIGatewayAgentResource
+	for _, gateway := range gateways {
+		gatewayAgents, err := buildAIGatewayAgents(ctx, client, gateway.Ref, gateway.DisplayName, gateway.Ref)
+		if err != nil {
+			return nil, err
+		}
+		agents = append(agents, gatewayAgents...)
+	}
+
+	agents = filterByNameOrID(agents, filter, func(r declresources.AIGatewayAgentResource) (string, string) {
+		return r.Name, r.Ref
+	})
+	slices.SortFunc(agents, func(a, b declresources.AIGatewayAgentResource) int {
+		if a.AIGateway == b.AIGateway {
+			return cmp.Compare(a.Name, b.Name)
+		}
+		return cmp.Compare(a.AIGateway, b.AIGateway)
+	})
+
+	return agents, nil
 }
 
 func collectDeclarativeAIGatewayConsumerGroups(

--- a/internal/cmd/root/verbs/dump/declarative_children.go
+++ b/internal/cmd/root/verbs/dump/declarative_children.go
@@ -284,6 +284,15 @@ func populateAIGatewayChildren(
 			gateway.Policies = policies
 		}
 
+		agents, err := buildAIGatewayAgents(ctx, client, gatewayID, gateway.DisplayName, "")
+		if err != nil {
+			logWarn(logger, "failed to load AI Gateway Agents", gatewayID, gateway.DisplayName, err)
+			continue
+		}
+		if len(agents) > 0 {
+			gateway.Agents = agents
+		}
+
 		consumers, err := buildAIGatewayConsumers(ctx, client, gatewayID, gateway.DisplayName, "")
 		if err != nil {
 			logWarn(logger, "failed to load AI Gateway Consumers", gatewayID, gateway.DisplayName, err)
@@ -412,6 +421,39 @@ func buildAIGatewayPolicies(
 	}
 
 	slices.SortFunc(result, func(a, b declresources.AIGatewayPolicyResource) int {
+		if a.Name == b.Name {
+			return cmp.Compare(a.Ref, b.Ref)
+		}
+		return cmp.Compare(a.Name, b.Name)
+	})
+
+	return result, nil
+}
+
+func buildAIGatewayAgents(
+	ctx context.Context,
+	client *declstate.Client,
+	gatewayID string,
+	gatewayName string,
+	gatewayRef string,
+) ([]declresources.AIGatewayAgentResource, error) {
+	agents, err := client.ListAIGatewayAgents(ctx, gatewayID)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]declresources.AIGatewayAgentResource, 0, len(agents))
+	for _, agent := range agents {
+		resource, err := declresources.AIGatewayAgentResourceFromResponse(
+			gatewayRef,
+			agent.AIGatewayAgent,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to map AI Gateway Agent for gateway %s: %w", gatewayName, err)
+		}
+		result = append(result, resource)
+	}
+
+	slices.SortFunc(result, func(a, b declresources.AIGatewayAgentResource) int {
 		if a.Name == b.Name {
 			return cmp.Compare(a.Ref, b.Ref)
 		}

--- a/internal/declarative/executor/ai_gateway_agent_adapter.go
+++ b/internal/declarative/executor/ai_gateway_agent_adapter.go
@@ -1,0 +1,176 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+)
+
+// AIGatewayAgentAdapter implements ResourceOperations for AI Gateway Agents.
+type AIGatewayAgentAdapter struct {
+	client *state.Client
+}
+
+// NewAIGatewayAgentAdapter creates a new AI Gateway Agent adapter.
+func NewAIGatewayAgentAdapter(client *state.Client) *AIGatewayAgentAdapter {
+	return &AIGatewayAgentAdapter{client: client}
+}
+
+// MapCreateFields maps planner fields to CreateAIGatewayAgentRequest.
+func (a *AIGatewayAgentAdapter) MapCreateFields(
+	_ context.Context,
+	_ *ExecutionContext,
+	fields map[string]any,
+	create *kkComps.CreateAIGatewayAgentRequest,
+) error {
+	data, err := json.Marshal(fields)
+	if err != nil {
+		return fmt.Errorf("failed to encode AI Gateway Agent create fields: %w", err)
+	}
+	if err := json.Unmarshal(data, create); err != nil {
+		return fmt.Errorf("failed to decode AI Gateway Agent create fields: %w", err)
+	}
+	if create.Name == "" || create.DisplayName == "" || create.Type == "" || create.Config.URL == "" {
+		return fmt.Errorf("name, display_name, type, and config.url are required")
+	}
+	return nil
+}
+
+// MapUpdateFields maps planner fields to UpdateAIGatewayAgentRequest.
+func (a *AIGatewayAgentAdapter) MapUpdateFields(
+	_ context.Context,
+	_ *ExecutionContext,
+	fields map[string]any,
+	update *kkComps.UpdateAIGatewayAgentRequest,
+	_ map[string]string,
+) error {
+	data, err := json.Marshal(fields)
+	if err != nil {
+		return fmt.Errorf("failed to encode AI Gateway Agent update fields: %w", err)
+	}
+	if err := json.Unmarshal(data, update); err != nil {
+		return fmt.Errorf("failed to decode AI Gateway Agent update fields: %w", err)
+	}
+	return nil
+}
+
+// Create creates an AI Gateway Agent.
+func (a *AIGatewayAgentAdapter) Create(
+	ctx context.Context,
+	req kkComps.CreateAIGatewayAgentRequest,
+	namespace string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	gatewayID, err := a.getAIGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return "", err
+	}
+	return a.client.CreateAIGatewayAgent(ctx, gatewayID, req, namespace)
+}
+
+// Update updates an AI Gateway Agent.
+func (a *AIGatewayAgentAdapter) Update(
+	ctx context.Context,
+	id string,
+	req kkComps.UpdateAIGatewayAgentRequest,
+	namespace string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	gatewayID, err := a.getAIGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return "", err
+	}
+	return a.client.UpdateAIGatewayAgent(ctx, gatewayID, id, req, namespace)
+}
+
+// Delete deletes an AI Gateway Agent.
+func (a *AIGatewayAgentAdapter) Delete(ctx context.Context, id string, execCtx *ExecutionContext) error {
+	gatewayID, err := a.getAIGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return err
+	}
+	return a.client.DeleteAIGatewayAgent(ctx, gatewayID, id)
+}
+
+// GetByID gets an AI Gateway Agent by ID.
+func (a *AIGatewayAgentAdapter) GetByID(
+	ctx context.Context,
+	id string,
+	execCtx *ExecutionContext,
+) (ResourceInfo, error) {
+	gatewayID, err := a.getAIGatewayIDFromExecutionContext(execCtx)
+	if err != nil {
+		return nil, err
+	}
+	agent, err := a.client.GetAIGatewayAgent(ctx, gatewayID, id)
+	if err != nil {
+		return nil, err
+	}
+	if agent == nil {
+		return nil, nil
+	}
+	return &aiGatewayAgentResourceInfo{agent: agent}, nil
+}
+
+// GetByName is not supported without a parent gateway context.
+func (a *AIGatewayAgentAdapter) GetByName(_ context.Context, _ string) (ResourceInfo, error) {
+	return nil, fmt.Errorf("GetByName not supported for AI Gateway Agents")
+}
+
+// ResourceType returns the resource type.
+func (a *AIGatewayAgentAdapter) ResourceType() string {
+	return planner.ResourceTypeAIGatewayAgent
+}
+
+// RequiredFields returns required fields for create.
+func (a *AIGatewayAgentAdapter) RequiredFields() []string {
+	return []string{planner.FieldName, planner.FieldDisplayName, planner.FieldType, planner.FieldConfig}
+}
+
+// SupportsUpdate indicates update support.
+func (a *AIGatewayAgentAdapter) SupportsUpdate() bool {
+	return true
+}
+
+func (a *AIGatewayAgentAdapter) getAIGatewayIDFromExecutionContext(
+	execCtx *ExecutionContext,
+) (string, error) {
+	if execCtx == nil || execCtx.PlannedChange == nil {
+		return "", fmt.Errorf("execution context required")
+	}
+
+	change := *execCtx.PlannedChange
+	if gatewayRef, ok := change.References[planner.FieldAIGatewayID]; ok && !unresolvedReferenceID(gatewayRef.ID) {
+		return gatewayRef.ID, nil
+	}
+	if change.Parent != nil && !unresolvedReferenceID(change.Parent.ID) {
+		return change.Parent.ID, nil
+	}
+
+	return "", fmt.Errorf("AI Gateway ID required for Agent operations")
+}
+
+type aiGatewayAgentResourceInfo struct {
+	agent *state.AIGatewayAgent
+}
+
+func (a *aiGatewayAgentResourceInfo) GetID() string {
+	return resources.AIGatewayAgentID(a.agent.AIGatewayAgent)
+}
+
+func (a *aiGatewayAgentResourceInfo) GetName() string {
+	return resources.AIGatewayAgentName(a.agent.AIGatewayAgent)
+}
+
+func (a *aiGatewayAgentResourceInfo) GetLabels() map[string]string {
+	return resources.AIGatewayAgentLabels(a.agent.AIGatewayAgent)
+}
+
+func (a *aiGatewayAgentResourceInfo) GetNormalizedLabels() map[string]string {
+	return a.agent.NormalizedLabels
+}

--- a/internal/declarative/executor/ai_gateway_agent_adapter_test.go
+++ b/internal/declarative/executor/ai_gateway_agent_adapter_test.go
@@ -1,0 +1,52 @@
+package executor
+
+import (
+	"context"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAIGatewayAgentAdapterMapCreateFields(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewAIGatewayAgentAdapter(nil)
+	fields := map[string]any{
+		planner.FieldName:        "booking-agent",
+		planner.FieldType:        "a2a",
+		planner.FieldDisplayName: "Booking Agent",
+		planner.FieldConfig: map[string]any{
+			"url": "https://booking-agent.example.com",
+		},
+		planner.FieldPolicies: []string{"mask-sensitive-data"},
+		planner.FieldLabels:   map[string]string{"team": "support"},
+	}
+
+	var req kkComps.CreateAIGatewayAgentRequest
+	require.NoError(t, adapter.MapCreateFields(context.Background(), nil, fields, &req))
+	require.Equal(t, "booking-agent", req.Name)
+	require.Equal(t, kkComps.CreateAIGatewayAgentRequestTypeA2a, req.Type)
+	require.Equal(t, "Booking Agent", req.DisplayName)
+	require.Equal(t, "https://booking-agent.example.com", req.Config.URL)
+	require.Equal(t, []string{"mask-sensitive-data"}, req.Policies)
+	require.Equal(t, map[string]string{"team": "support"}, req.Labels)
+}
+
+func TestAIGatewayAgentAdapterMapCreateFieldsRequiresConfigURL(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewAIGatewayAgentAdapter(nil)
+	fields := map[string]any{
+		planner.FieldName:        "booking-agent",
+		planner.FieldType:        "a2a",
+		planner.FieldDisplayName: "Booking Agent",
+		planner.FieldConfig:      map[string]any{},
+	}
+
+	var req kkComps.CreateAIGatewayAgentRequest
+	err := adapter.MapCreateFields(context.Background(), nil, fields, &req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "config.url")
+}

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -58,6 +58,9 @@ type Executor struct {
 	aiGatewayPolicyExecutor *BaseExecutor[
 		kkComps.CreateAIGatewayPolicyRequest,
 		kkComps.UpdateAIGatewayPolicyRequest]
+	aiGatewayAgentExecutor *BaseExecutor[
+		kkComps.CreateAIGatewayAgentRequest,
+		kkComps.UpdateAIGatewayAgentRequest]
 	aiGatewayConsumerExecutor *BaseExecutor[
 		kkComps.CreateAIGatewayConsumerRequest,
 		kkComps.UpdateAIGatewayConsumerRequest]
@@ -259,6 +262,13 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 		kkComps.CreateAIGatewayPolicyRequest,
 		kkComps.UpdateAIGatewayPolicyRequest](
 		NewAIGatewayPolicyAdapter(client),
+		client,
+		dryRun,
+	)
+	e.aiGatewayAgentExecutor = NewBaseExecutor[
+		kkComps.CreateAIGatewayAgentRequest,
+		kkComps.UpdateAIGatewayAgentRequest](
+		NewAIGatewayAgentAdapter(client),
 		client,
 		dryRun,
 	)
@@ -2373,6 +2383,11 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 			return "", err
 		}
 		return e.aiGatewayPolicyExecutor.Create(ctx, *change)
+	case planner.ResourceTypeAIGatewayAgent:
+		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
+			return "", err
+		}
+		return e.aiGatewayAgentExecutor.Create(ctx, *change)
 	case planner.ResourceTypeAIGatewayConsumer:
 		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
 			return "", err
@@ -2990,6 +3005,11 @@ func (e *Executor) updateResource(ctx context.Context, change *planner.PlannedCh
 			return "", err
 		}
 		return e.aiGatewayPolicyExecutor.Update(ctx, *change)
+	case planner.ResourceTypeAIGatewayAgent:
+		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
+			return "", err
+		}
+		return e.aiGatewayAgentExecutor.Update(ctx, *change)
 	case planner.ResourceTypeAIGatewayConsumer:
 		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
 			return "", err
@@ -3489,6 +3509,11 @@ func (e *Executor) deleteResource(ctx context.Context, change *planner.PlannedCh
 			return err
 		}
 		return e.aiGatewayPolicyExecutor.Delete(ctx, *change)
+	case planner.ResourceTypeAIGatewayAgent:
+		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
+			return err
+		}
+		return e.aiGatewayAgentExecutor.Delete(ctx, *change)
 	case planner.ResourceTypeAIGatewayConsumer:
 		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
 			return err

--- a/internal/declarative/loader/ai_gateway_agent_test.go
+++ b/internal/declarative/loader/ai_gateway_agent_test.go
@@ -1,0 +1,131 @@
+package loader
+
+import (
+	"testing"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/tags"
+	"github.com/stretchr/testify/require"
+)
+
+const aiGatewayAgentYAML = `
+ai_gateways:
+  - ref: support-gateway
+    display_name: Support Gateway
+    policies:
+      - ref: mask-sensitive-data
+        type: ai-sanitizer
+        name: mask-sensitive-data
+        display_name: Mask Sensitive Data
+        config:
+          anonymize:
+            - email
+    agents:
+      - ref: booking-agent
+        name: booking-agent
+        type: a2a
+        display_name: Booking Agent
+        config:
+          url: https://booking-agent.example.com
+        policies:
+          - !ref mask-sensitive-data
+`
+
+func TestLoaderExtractsNestedAIGatewayAgents(t *testing.T) {
+	path := writeLoaderTestFile(t, aiGatewayAgentYAML)
+
+	rs, err := New().LoadFromSources([]Source{{Path: path, Type: SourceTypeFile}}, false)
+	require.NoError(t, err)
+	require.Len(t, rs.AIGateways, 1)
+	require.Empty(t, rs.AIGateways[0].Agents)
+	require.Len(t, rs.AIGatewayAgents, 1)
+	require.Equal(t, "support-gateway", rs.AIGatewayAgents[0].AIGateway)
+	require.Equal(t, "booking-agent", rs.AIGatewayAgents[0].Name)
+	require.Equal(t, "a2a", string(rs.AIGatewayAgents[0].Type))
+	require.Equal(t, "https://booking-agent.example.com", rs.AIGatewayAgents[0].Config.URL)
+	require.Equal(
+		t,
+		[]string{tags.RefPlaceholderPrefix + "mask-sensitive-data#id"},
+		rs.AIGatewayAgents[0].Policies,
+	)
+	require.True(t, rs.SyncScope.ChildInScope(
+		resources.ResourceTypeAIGateway,
+		"support-gateway",
+		resources.ResourceTypeAIGatewayAgent,
+	))
+}
+
+func TestLoaderValidatesAIGatewayAgentParentAndDuplicates(t *testing.T) {
+	rootOnly := `
+ai_gateway_agents:
+  - ref: booking-agent
+    ai_gateway: missing-gateway
+    name: booking-agent
+    type: a2a
+    display_name: Booking Agent
+    config:
+      url: https://booking-agent.example.com
+`
+	_, err := New().LoadFromSources([]Source{{Path: writeLoaderTestFile(t, rootOnly), Type: SourceTypeFile}}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "references unknown ai_gateway")
+
+	duplicates := `
+ai_gateways:
+  - ref: support-gateway
+    display_name: Support Gateway
+    agents:
+      - ref: booking-agent
+        name: booking-agent
+        type: a2a
+        display_name: Booking Agent
+        config:
+          url: https://booking-agent.example.com
+      - ref: booking-agent-2
+        name: booking-agent
+        type: a2a
+        display_name: Booking Agent 2
+        config:
+          url: https://booking-agent-2.example.com
+`
+	_, err = New().LoadFromSources([]Source{{Path: writeLoaderTestFile(t, duplicates), Type: SourceTypeFile}}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate ai_gateway_agent name")
+}
+
+func TestLoaderRejectsRootLevelEmptyAIGatewayAgents(t *testing.T) {
+	input := `ai_gateway_agents: []`
+
+	_, err := New().LoadFromSources([]Source{{Path: writeLoaderTestFile(t, input), Type: SourceTypeFile}}, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ai_gateway_agents cannot be empty")
+}
+
+func TestLoaderAcceptsAIGatewayAgentDeferredExternalParentRef(t *testing.T) {
+	input := `
+ai_gateways:
+  - ref: external-shared-gateway
+    _external:
+      selector:
+        matchFields:
+          display_name: Shared Gateway
+ai_gateway_agents:
+  - ref: booking-agent
+    ai_gateway: !ref external-shared-gateway#id
+    name: booking-agent
+    type: a2a
+    display_name: Booking Agent
+    config:
+      url: https://booking-agent.example.com
+`
+
+	rs, err := New().LoadFromSources([]Source{{Path: writeLoaderTestFile(t, input), Type: SourceTypeFile}}, false)
+	require.NoError(t, err)
+	require.Len(t, rs.AIGatewayAgents, 1)
+	require.Equal(t, tags.RefPlaceholderPrefix+"external-shared-gateway#id", rs.AIGatewayAgents[0].AIGateway)
+	require.True(t, rs.SyncScope.ChildInScope(
+		resources.ResourceTypeAIGateway,
+		"external-shared-gateway",
+		resources.ResourceTypeAIGatewayAgent,
+	))
+}

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -1036,6 +1036,13 @@ func (l *Loader) extractNestedResources(rs *resources.ResourceSet) {
 		}
 		gateway.Policies = nil
 
+		for j := range gateway.Agents {
+			agent := gateway.Agents[j]
+			agent.AIGateway = gateway.Ref
+			rs.AIGatewayAgents = append(rs.AIGatewayAgents, agent)
+		}
+		gateway.Agents = nil
+
 		for j := range gateway.Consumers {
 			consumer := gateway.Consumers[j]
 			consumer.AIGateway = gateway.Ref

--- a/internal/declarative/loader/sync_scope.go
+++ b/internal/declarative/loader/sync_scope.go
@@ -44,6 +44,12 @@ var rootChildCollectionScopes = []childCollectionScope{
 		parentType:   resources.ResourceTypeAIGateway,
 	},
 	{
+		key:          "ai_gateway_agents",
+		resourceType: resources.ResourceTypeAIGatewayAgent,
+		parentKey:    resources.SchemaFieldAIGateway,
+		parentType:   resources.ResourceTypeAIGateway,
+	},
+	{
 		key:          "ai_gateway_consumers",
 		resourceType: resources.ResourceTypeAIGatewayConsumer,
 		parentKey:    resources.SchemaFieldAIGateway,
@@ -362,6 +368,11 @@ var aiGatewayChildCollectionScopes = []childCollectionScope{
 		parentType:   resources.ResourceTypeAIGateway,
 	},
 	{
+		key:          "agents",
+		resourceType: resources.ResourceTypeAIGatewayAgent,
+		parentType:   resources.ResourceTypeAIGateway,
+	},
+	{
 		key:          "consumers",
 		resourceType: resources.ResourceTypeAIGatewayConsumer,
 		parentType:   resources.ResourceTypeAIGateway,
@@ -504,6 +515,9 @@ func captureRootChildScope(scope *resources.SyncScope, raw map[string]any, entry
 	if !ok || len(items) == 0 {
 		if entry.resourceType == resources.ResourceTypeAIGatewayPolicy {
 			return fmt.Errorf("%s cannot be empty because each policy must declare an ai_gateway parent", entry.key)
+		}
+		if entry.resourceType == resources.ResourceTypeAIGatewayAgent {
+			return fmt.Errorf("%s cannot be empty because each Agent must declare an ai_gateway parent", entry.key)
 		}
 		if entry.resourceType == resources.ResourceTypeAIGatewayConsumer {
 			return fmt.Errorf("%s cannot be empty because each Consumer must declare an ai_gateway parent", entry.key)

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -50,6 +50,9 @@ func (l *Loader) validateResourceSet(rs *resources.ResourceSet) error {
 	if err := l.validateAIGatewayPolicies(rs); err != nil {
 		return err
 	}
+	if err := l.validateAIGatewayAgents(rs); err != nil {
+		return err
+	}
 	if err := l.validateAIGatewayConsumers(rs); err != nil {
 		return err
 	}
@@ -838,6 +841,58 @@ func (l *Loader) validateAIGatewayPolicies(rs *resources.ResourceSet) error {
 			)
 		}
 		namesByGateway[nameKey] = policy.GetRef()
+	}
+
+	return nil
+}
+
+// validateAIGatewayAgents validates AI Gateway child Agent resources.
+func (l *Loader) validateAIGatewayAgents(rs *resources.ResourceSet) error {
+	namesByGateway := make(map[string]string)
+
+	for i := range rs.AIGatewayAgents {
+		agent := &rs.AIGatewayAgents[i]
+
+		if err := agent.Validate(); err != nil {
+			return fmt.Errorf("invalid ai_gateway_agent %q: %w", agent.GetRef(), err)
+		}
+
+		if existing, found := rs.GetResourceByRef(agent.GetRef()); found {
+			if existing.GetType() != resources.ResourceTypeAIGatewayAgent {
+				return fmt.Errorf("duplicate ref '%s' (already defined as %s)",
+					agent.GetRef(), existing.GetType())
+			}
+		}
+
+		gatewayRef := resources.NormalizeResourceRef(agent.AIGateway)
+		gateway, found := rs.GetResourceByRef(gatewayRef)
+		if !found {
+			return fmt.Errorf(
+				"ai_gateway_agent %q references unknown ai_gateway %q",
+				agent.GetRef(),
+				agent.AIGateway,
+			)
+		}
+		if gateway.GetType() != resources.ResourceTypeAIGateway {
+			return fmt.Errorf(
+				"ai_gateway_agent %q references %q which is %s, not ai_gateway",
+				agent.GetRef(),
+				agent.AIGateway,
+				gateway.GetType(),
+			)
+		}
+
+		nameKey := gatewayRef + "\x00" + agent.Name
+		if existingRef, exists := namesByGateway[nameKey]; exists {
+			return fmt.Errorf(
+				"duplicate ai_gateway_agent name %q for ai_gateway %q (ref: %s conflicts with ref: %s)",
+				agent.Name,
+				gatewayRef,
+				agent.GetRef(),
+				existingRef,
+			)
+		}
+		namesByGateway[nameKey] = agent.GetRef()
 	}
 
 	return nil

--- a/internal/declarative/planner/ai_gateway_agent_planner.go
+++ b/internal/declarative/planner/ai_gateway_agent_planner.go
@@ -157,7 +157,7 @@ func (p *Planner) planAIGatewayAgentCreate(
 		plan.AddWarning(agent.GetRef(), fmt.Sprintf("failed to build AI Gateway Agent create payload: %s", err))
 		return
 	}
-	normalizeAIGatewayAgentPolicyReferencesForRequest(fields, p.resources)
+	normalizeAIGatewayPolicyNameReferencesForRequest(fields, p.resources)
 
 	change := PlannedChange{
 		ID:           p.nextChangeID(ActionCreate, ResourceTypeAIGatewayAgent, agent.Ref),
@@ -247,7 +247,7 @@ func (p *Planner) shouldUpdateAIGatewayAgent(
 			err,
 		)
 	}
-	normalizeAIGatewayAgentPolicyReferencesForRequest(desiredPayload, p.resources)
+	normalizeAIGatewayPolicyNameReferencesForRequest(desiredPayload, p.resources)
 
 	currentCompare, desiredCompare := normalizeAIGatewayPolicyReferencesForComparison(
 		currentPayload,

--- a/internal/declarative/planner/ai_gateway_agent_planner.go
+++ b/internal/declarative/planner/ai_gateway_agent_planner.go
@@ -254,6 +254,7 @@ func (p *Planner) shouldUpdateAIGatewayAgent(
 		desiredPayload,
 		p.resources,
 	)
+	currentCompare, desiredCompare = normalizeAIGatewayRouteDefaultsForComparison(currentCompare, desiredCompare)
 
 	changedFields := make(map[string]FieldChange)
 	keys := make(map[string]struct{}, len(currentCompare)+len(desiredCompare))

--- a/internal/declarative/planner/ai_gateway_agent_planner.go
+++ b/internal/declarative/planner/ai_gateway_agent_planner.go
@@ -157,6 +157,7 @@ func (p *Planner) planAIGatewayAgentCreate(
 		plan.AddWarning(agent.GetRef(), fmt.Sprintf("failed to build AI Gateway Agent create payload: %s", err))
 		return
 	}
+	normalizeAIGatewayAgentPolicyReferencesForRequest(fields, p.resources)
 
 	change := PlannedChange{
 		ID:           p.nextChangeID(ActionCreate, ResourceTypeAIGatewayAgent, agent.Ref),
@@ -246,6 +247,7 @@ func (p *Planner) shouldUpdateAIGatewayAgent(
 			err,
 		)
 	}
+	normalizeAIGatewayAgentPolicyReferencesForRequest(desiredPayload, p.resources)
 
 	currentCompare, desiredCompare := normalizeAIGatewayPolicyReferencesForComparison(
 		currentPayload,

--- a/internal/declarative/planner/ai_gateway_agent_planner.go
+++ b/internal/declarative/planner/ai_gateway_agent_planner.go
@@ -1,0 +1,326 @@
+package planner
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"maps"
+	"reflect"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/util"
+)
+
+func (p *Planner) planAIGatewayAgentChanges(
+	ctx context.Context,
+	namespace string,
+	gatewayRef string,
+	gatewayName string,
+	gatewayID string,
+	gatewayChangeID string,
+	policyCreateDepsByRefOrName map[string]string,
+	desired []resources.AIGatewayAgentResource,
+	plan *Plan,
+) error {
+	p.logger.Debug(
+		"Planning AI Gateway Agent changes",
+		slog.String("gateway_ref", gatewayRef),
+		slog.String("gateway_id", gatewayID),
+		slog.String("gateway_change_id", gatewayChangeID),
+		slog.Int("desired_count", len(desired)),
+	)
+
+	if gatewayID == "" {
+		p.planAIGatewayAgentCreatesForNewGateway(
+			namespace,
+			gatewayRef,
+			gatewayName,
+			gatewayChangeID,
+			policyCreateDepsByRefOrName,
+			desired,
+			plan,
+		)
+		return nil
+	}
+
+	currentAgents, err := p.client.ListAIGatewayAgents(ctx, gatewayID)
+	if err != nil {
+		return fmt.Errorf("failed to list AI Gateway Agents for gateway %s: %w", gatewayID, err)
+	}
+
+	currentByID, currentByName := indexAIGatewayAgents(currentAgents)
+	desiredKeys := make(map[string]bool)
+
+	for _, desiredAgent := range desired {
+		current, exists := matchCurrentAIGatewayAgent(desiredAgent, currentByID, currentByName)
+		desiredKeys[desiredAgent.Name] = true
+		if id := aiGatewayAgentDesiredID(desiredAgent); id != "" {
+			desiredKeys[id] = true
+		}
+
+		if !exists {
+			dependsOn := aiGatewayAgentPolicyCreateDependencies(
+				desiredAgent,
+				policyCreateDepsByRefOrName,
+			)
+			p.planAIGatewayAgentCreate(namespace, gatewayRef, gatewayName, gatewayID, desiredAgent, dependsOn, plan)
+			continue
+		}
+
+		agentID := resources.AIGatewayAgentID(current.AIGatewayAgent)
+		if agent := p.resources.GetAIGatewayAgentByRef(desiredAgent.Ref); agent != nil {
+			agent.SetKonnectID(agentID)
+		}
+		fullAgent, err := p.client.GetAIGatewayAgent(ctx, gatewayID, agentID)
+		if err != nil {
+			return fmt.Errorf("failed to get AI Gateway Agent %s: %w", agentID, err)
+		}
+		if fullAgent == nil {
+			dependsOn := aiGatewayAgentPolicyCreateDependencies(
+				desiredAgent,
+				policyCreateDepsByRefOrName,
+			)
+			p.planAIGatewayAgentCreate(namespace, gatewayRef, gatewayName, gatewayID, desiredAgent, dependsOn, plan)
+			continue
+		}
+
+		needsUpdate, updateFields, changedFields, err := p.shouldUpdateAIGatewayAgent(*fullAgent, desiredAgent)
+		if err != nil {
+			return err
+		}
+		if needsUpdate {
+			p.planAIGatewayAgentUpdate(
+				namespace,
+				gatewayRef,
+				gatewayID,
+				agentID,
+				desiredAgent,
+				updateFields,
+				changedFields,
+				aiGatewayAgentPolicyCreateDependencies(
+					desiredAgent,
+					policyCreateDepsByRefOrName,
+				),
+				plan,
+			)
+		}
+	}
+
+	if plan.Metadata.Mode == PlanModeSync {
+		for _, current := range currentAgents {
+			agentID := resources.AIGatewayAgentID(current.AIGatewayAgent)
+			agentName := resources.AIGatewayAgentName(current.AIGatewayAgent)
+			if desiredKeys[agentID] || desiredKeys[agentName] {
+				continue
+			}
+			p.planAIGatewayAgentDelete(gatewayRef, gatewayID, agentID, agentName, plan)
+		}
+	}
+
+	return nil
+}
+
+func (p *Planner) planAIGatewayAgentCreatesForNewGateway(
+	namespace string,
+	gatewayRef string,
+	gatewayName string,
+	gatewayChangeID string,
+	policyCreateDepsByRefOrName map[string]string,
+	agents []resources.AIGatewayAgentResource,
+	plan *Plan,
+) {
+	var dependsOn []string
+	if gatewayChangeID != "" {
+		dependsOn = []string{gatewayChangeID}
+	}
+	for _, agent := range agents {
+		agentDependsOn := append([]string{}, dependsOn...)
+		for _, dep := range aiGatewayAgentPolicyCreateDependencies(agent, policyCreateDepsByRefOrName) {
+			agentDependsOn = appendDependsOn(agentDependsOn, dep)
+		}
+		p.planAIGatewayAgentCreate(namespace, gatewayRef, gatewayName, "", agent, agentDependsOn, plan)
+	}
+}
+
+func (p *Planner) planAIGatewayAgentCreate(
+	namespace string,
+	gatewayRef string,
+	gatewayName string,
+	gatewayID string,
+	agent resources.AIGatewayAgentResource,
+	dependsOn []string,
+	plan *Plan,
+) {
+	fields, err := agent.MutablePayloadMap()
+	if err != nil {
+		plan.AddWarning(agent.GetRef(), fmt.Sprintf("failed to build AI Gateway Agent create payload: %s", err))
+		return
+	}
+
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionCreate, ResourceTypeAIGatewayAgent, agent.Ref),
+		ResourceType: ResourceTypeAIGatewayAgent,
+		ResourceRef:  agent.Ref,
+		Action:       ActionCreate,
+		Fields:       fields,
+		Namespace:    namespace,
+		DependsOn:    dependsOn,
+	}
+	if gatewayID != "" {
+		change.Parent = &ParentInfo{Ref: gatewayRef, ID: gatewayID}
+	} else {
+		change.References = map[string]ReferenceInfo{
+			FieldAIGatewayID: {
+				Ref: gatewayRef,
+				LookupFields: map[string]string{
+					FieldDisplayName: gatewayName,
+				},
+			},
+		}
+	}
+
+	plan.AddChange(change)
+}
+
+func (p *Planner) planAIGatewayAgentUpdate(
+	namespace string,
+	gatewayRef string,
+	gatewayID string,
+	agentID string,
+	agent resources.AIGatewayAgentResource,
+	updateFields map[string]any,
+	changedFields map[string]FieldChange,
+	dependsOn []string,
+	plan *Plan,
+) {
+	change := PlannedChange{
+		ID:            p.nextChangeID(ActionUpdate, ResourceTypeAIGatewayAgent, agent.Ref),
+		ResourceType:  ResourceTypeAIGatewayAgent,
+		ResourceRef:   agent.Ref,
+		ResourceID:    agentID,
+		Action:        ActionUpdate,
+		Fields:        updateFields,
+		ChangedFields: changedFields,
+		Namespace:     namespace,
+		DependsOn:     dependsOn,
+		Parent:        &ParentInfo{Ref: gatewayRef, ID: gatewayID},
+	}
+	plan.AddChange(change)
+}
+
+func (p *Planner) planAIGatewayAgentDelete(
+	gatewayRef string,
+	gatewayID string,
+	agentID string,
+	agentName string,
+	plan *Plan,
+) {
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionDelete, ResourceTypeAIGatewayAgent, agentName),
+		ResourceType: ResourceTypeAIGatewayAgent,
+		ResourceRef:  agentName,
+		ResourceID:   agentID,
+		Action:       ActionDelete,
+		Fields: map[string]any{
+			FieldName: agentName,
+		},
+		Parent: &ParentInfo{Ref: gatewayRef, ID: gatewayID},
+	}
+	plan.AddChange(change)
+}
+
+func (p *Planner) shouldUpdateAIGatewayAgent(
+	current state.AIGatewayAgent,
+	desired resources.AIGatewayAgentResource,
+) (bool, map[string]any, map[string]FieldChange, error) {
+	currentPayload, err := resources.AIGatewayAgentMutablePayloadMap(current.AIGatewayAgent)
+	if err != nil {
+		return false, nil, nil, fmt.Errorf("failed to normalize current AI Gateway Agent: %w", err)
+	}
+	desiredPayload, err := desired.MutablePayloadMap()
+	if err != nil {
+		return false, nil, nil, fmt.Errorf(
+			"failed to normalize desired AI Gateway Agent %q: %w",
+			desired.Ref,
+			err,
+		)
+	}
+
+	currentCompare, desiredCompare := normalizeAIGatewayPolicyReferencesForComparison(
+		currentPayload,
+		desiredPayload,
+		p.resources,
+	)
+
+	changedFields := make(map[string]FieldChange)
+	keys := make(map[string]struct{}, len(currentCompare)+len(desiredCompare))
+	for key := range currentCompare {
+		keys[key] = struct{}{}
+	}
+	for key := range desiredCompare {
+		keys[key] = struct{}{}
+	}
+	for key := range keys {
+		if !reflect.DeepEqual(currentCompare[key], desiredCompare[key]) {
+			changedFields[key] = FieldChange{Old: currentPayload[key], New: desiredPayload[key]}
+		}
+	}
+	if len(changedFields) == 0 {
+		return false, nil, nil, nil
+	}
+
+	updateFields := make(map[string]any, len(desiredPayload))
+	maps.Copy(updateFields, desiredPayload)
+	return true, updateFields, changedFields, nil
+}
+
+func indexAIGatewayAgents(
+	agents []state.AIGatewayAgent,
+) (map[string]state.AIGatewayAgent, map[string]state.AIGatewayAgent) {
+	byID := make(map[string]state.AIGatewayAgent)
+	byName := make(map[string]state.AIGatewayAgent)
+	for _, agent := range agents {
+		if id := resources.AIGatewayAgentID(agent.AIGatewayAgent); id != "" {
+			byID[id] = agent
+		}
+		if name := resources.AIGatewayAgentName(agent.AIGatewayAgent); name != "" {
+			byName[name] = agent
+		}
+	}
+	return byID, byName
+}
+
+func matchCurrentAIGatewayAgent(
+	desired resources.AIGatewayAgentResource,
+	currentByID map[string]state.AIGatewayAgent,
+	currentByName map[string]state.AIGatewayAgent,
+) (state.AIGatewayAgent, bool) {
+	if id := aiGatewayAgentDesiredID(desired); id != "" {
+		current, exists := currentByID[id]
+		return current, exists
+	}
+	current, exists := currentByName[desired.Name]
+	return current, exists
+}
+
+func aiGatewayAgentDesiredID(desired resources.AIGatewayAgentResource) string {
+	if id := desired.GetKonnectID(); id != "" {
+		return id
+	}
+	if util.IsValidUUID(desired.Ref) {
+		return desired.Ref
+	}
+	return ""
+}
+
+func aiGatewayAgentPolicyCreateDependencies(
+	agent resources.AIGatewayAgentResource,
+	policyCreateDepsByRefOrName map[string]string,
+) []string {
+	payload, err := agent.MutablePayloadMap()
+	if err != nil {
+		return nil
+	}
+	return aiGatewayPolicyReferenceDependencies(payload, policyCreateDepsByRefOrName)
+}

--- a/internal/declarative/planner/ai_gateway_agent_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_agent_planner_test.go
@@ -156,6 +156,51 @@ func TestAIGatewayAgentPlannerPolicyRefNoopForExistingAgent(t *testing.T) {
 	}
 }
 
+func TestAIGatewayAgentPlannerIgnoresDefaultRouteProtocols(t *testing.T) {
+	agent := testAIGatewayAgentResourceWithRoute(t)
+	current := testAIGatewayAgent("agent-id", "booking-agent", nil)
+	current.Config.Route = &kkComps.AIGatewayRouteConfig{
+		Paths:     []string{"/booking"},
+		Protocols: []string{"http", "https"},
+	}
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{
+			gateways: []kkComps.AIGateway{testAIGateway()},
+		},
+		AIGatewayAgentsAPI: &testAIGatewayAgentAPI{
+			agents: []kkComps.AIGatewayAgent{current},
+		},
+	})
+	rs := testAIGatewayAgentResourceSet(agent)
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+	require.NoError(t, err)
+	require.Empty(t, plan.Changes)
+}
+
+func TestAIGatewayAgentPlannerDetectsNonDefaultRouteProtocols(t *testing.T) {
+	agent := testAIGatewayAgentResourceWithRoute(t)
+	current := testAIGatewayAgent("agent-id", "booking-agent", nil)
+	current.Config.Route = &kkComps.AIGatewayRouteConfig{
+		Paths:     []string{"/booking"},
+		Protocols: []string{"https"},
+	}
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{
+			gateways: []kkComps.AIGateway{testAIGateway()},
+		},
+		AIGatewayAgentsAPI: &testAIGatewayAgentAPI{
+			agents: []kkComps.AIGatewayAgent{current},
+		},
+	})
+	rs := testAIGatewayAgentResourceSet(agent)
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	require.Contains(t, plan.Changes[0].ChangedFields, FieldConfig)
+}
+
 func testAIGatewayAgentResourceSet(
 	agent resources.AIGatewayAgentResource,
 ) *resources.ResourceSet {
@@ -182,6 +227,28 @@ func testAIGatewayAgentResource(
 	}
 	if policies != nil {
 		payload[FieldPolicies] = policies
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+	var agent resources.AIGatewayAgentResource
+	require.NoError(t, json.Unmarshal(data, &agent))
+	return agent
+}
+
+func testAIGatewayAgentResourceWithRoute(t *testing.T) resources.AIGatewayAgentResource {
+	t.Helper()
+	payload := map[string]any{
+		"ref":          "booking-agent",
+		"ai_gateway":   "support-gateway",
+		"name":         "booking-agent",
+		"type":         "a2a",
+		"display_name": "Booking Agent",
+		"config": map[string]any{
+			"url": "https://booking-agent.example.com",
+			"route": map[string]any{
+				"paths": []string{"/booking"},
+			},
+		},
 	}
 	data, err := json.Marshal(payload)
 	require.NoError(t, err)

--- a/internal/declarative/planner/ai_gateway_agent_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_agent_planner_test.go
@@ -97,7 +97,6 @@ func TestAIGatewayAgentPlannerSyncDeletesScopedAgents(t *testing.T) {
 
 func TestAIGatewayAgentPlannerDependsOnPolicyCreate(t *testing.T) {
 	policy := testAIGatewayPolicyResource(t)
-	policy.Name = "mask-sensitive-data-api-name"
 	agent := testAIGatewayAgentResource(t, []string{tags.RefPlaceholderPrefix + "mask-sensitive-data#id"})
 	client := state.NewClient(state.ClientConfig{
 		AIGatewayAPI: &testAIGatewayAPI{},
@@ -120,6 +119,31 @@ func TestAIGatewayAgentPlannerDependsOnPolicyCreate(t *testing.T) {
 	agentCreate := findAIGatewayModelTestChange(t, plan, ResourceTypeAIGatewayAgent, "booking-agent")
 
 	require.Contains(t, policyCreate.DependsOn, gatewayCreate.ID)
+	require.Contains(t, agentCreate.DependsOn, policyCreate.ID)
+	require.Equal(t, []any{tags.RefPlaceholderPrefix + "mask-sensitive-data#id"}, agentCreate.Fields[FieldPolicies])
+	require.Equal(t, resources.UnknownReferenceID, agentCreate.References[FieldPolicies+".0"].ID)
+	require.Equal(t, tags.RefPlaceholderPrefix+"mask-sensitive-data#id", agentCreate.References[FieldPolicies+".0"].Ref)
+}
+
+func TestAIGatewayAgentPlannerPolicyNameRefSendsName(t *testing.T) {
+	policy := testAIGatewayPolicyResource(t)
+	policy.Name = "mask-sensitive-data-api-name"
+	agent := testAIGatewayAgentResource(t, []string{tags.RefPlaceholderPrefix + "mask-sensitive-data#name"})
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{},
+	})
+	rs := &resources.ResourceSet{
+		AIGateways:        []resources.AIGatewayResource{testAIGatewayResource()},
+		AIGatewayPolicies: []resources.AIGatewayPolicyResource{policy},
+		AIGatewayAgents:   []resources.AIGatewayAgentResource{agent},
+	}
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+	require.NoError(t, err)
+
+	policyCreate := findAIGatewayModelTestChange(t, plan, ResourceTypeAIGatewayPolicy, "mask-sensitive-data")
+	agentCreate := findAIGatewayModelTestChange(t, plan, ResourceTypeAIGatewayAgent, "booking-agent")
+
 	require.Contains(t, agentCreate.DependsOn, policyCreate.ID)
 	require.Equal(t, []any{"mask-sensitive-data-api-name"}, agentCreate.Fields[FieldPolicies])
 	require.NotContains(t, agentCreate.References, FieldPolicies+".0")

--- a/internal/declarative/planner/ai_gateway_agent_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_agent_planner_test.go
@@ -1,0 +1,261 @@
+package planner
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/declarative/tags"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAIGatewayAgentPlannerCreatesChildForExistingGateway(t *testing.T) {
+	agent := testAIGatewayAgentResource(t, nil)
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{
+			gateways: []kkComps.AIGateway{testAIGateway()},
+		},
+		AIGatewayAgentsAPI: &testAIGatewayAgentAPI{},
+	})
+	rs := testAIGatewayAgentResourceSet(agent)
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	change := plan.Changes[0]
+	require.Equal(t, ActionCreate, change.Action)
+	require.Equal(t, ResourceTypeAIGatewayAgent, change.ResourceType)
+	require.Equal(t, "booking-agent", change.ResourceRef)
+	require.NotNil(t, change.Parent)
+	require.Equal(t, "gateway-id", change.Parent.ID)
+	require.Equal(t, "support-gateway", change.Parent.Ref)
+	require.Equal(t, "Booking Agent", change.Fields[FieldDisplayName])
+	require.Equal(t, "a2a", change.Fields[FieldType])
+	require.Equal(t, "https://booking-agent.example.com", change.Fields[FieldConfig].(map[string]any)["url"])
+}
+
+func TestAIGatewayAgentPlannerUpdatesExistingAgent(t *testing.T) {
+	agent := testAIGatewayAgentResource(t, nil)
+	agent.DisplayName = "Booking Agent Updated"
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{
+			gateways: []kkComps.AIGateway{testAIGateway()},
+		},
+		AIGatewayAgentsAPI: &testAIGatewayAgentAPI{
+			agents: []kkComps.AIGatewayAgent{
+				testAIGatewayAgent("agent-id", "booking-agent", nil),
+			},
+		},
+	})
+	rs := testAIGatewayAgentResourceSet(agent)
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	change := plan.Changes[0]
+	require.Equal(t, ActionUpdate, change.Action)
+	require.Equal(t, ResourceTypeAIGatewayAgent, change.ResourceType)
+	require.Equal(t, "agent-id", change.ResourceID)
+	require.Equal(t, "Booking Agent Updated", change.Fields[FieldDisplayName])
+	require.Contains(t, change.ChangedFields, FieldDisplayName)
+}
+
+func TestAIGatewayAgentPlannerSyncDeletesScopedAgents(t *testing.T) {
+	scope := resources.NewSyncScope()
+	scope.AddRoot(resources.ResourceTypeAIGateway)
+	scope.AddChild(resources.ResourceTypeAIGateway, "support-gateway", resources.ResourceTypeAIGatewayAgent)
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{
+			gateways: []kkComps.AIGateway{testAIGateway()},
+		},
+		AIGatewayAgentsAPI: &testAIGatewayAgentAPI{
+			agents: []kkComps.AIGatewayAgent{
+				testAIGatewayAgent("agent-id", "booking-agent", nil),
+			},
+		},
+	})
+	rs := &resources.ResourceSet{
+		AIGateways: []resources.AIGatewayResource{testAIGatewayResource()},
+		SyncScope:  scope,
+	}
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeSync})
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	change := plan.Changes[0]
+	require.Equal(t, ActionDelete, change.Action)
+	require.Equal(t, ResourceTypeAIGatewayAgent, change.ResourceType)
+	require.Equal(t, "agent-id", change.ResourceID)
+	require.NotNil(t, change.Parent)
+	require.Equal(t, "gateway-id", change.Parent.ID)
+}
+
+func TestAIGatewayAgentPlannerDependsOnPolicyCreate(t *testing.T) {
+	policy := testAIGatewayPolicyResource(t)
+	agent := testAIGatewayAgentResource(t, []string{tags.RefPlaceholderPrefix + "mask-sensitive-data#id"})
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{},
+	})
+	rs := &resources.ResourceSet{
+		AIGateways:          []resources.AIGatewayResource{testAIGatewayResource()},
+		AIGatewayPolicies:   []resources.AIGatewayPolicyResource{policy},
+		AIGatewayAgents:     []resources.AIGatewayAgentResource{agent},
+		AIGatewayProviders:  nil,
+		AIGatewayModels:     nil,
+		AIGatewayMCPServers: nil,
+		AIGatewayVaults:     nil,
+	}
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+	require.NoError(t, err)
+
+	gatewayCreate := findAIGatewayModelTestChange(t, plan, ResourceTypeAIGateway, "support-gateway")
+	policyCreate := findAIGatewayModelTestChange(t, plan, ResourceTypeAIGatewayPolicy, "mask-sensitive-data")
+	agentCreate := findAIGatewayModelTestChange(t, plan, ResourceTypeAIGatewayAgent, "booking-agent")
+
+	require.Contains(t, policyCreate.DependsOn, gatewayCreate.ID)
+	require.Contains(t, agentCreate.DependsOn, policyCreate.ID)
+	require.Equal(t, resources.UnknownReferenceID, agentCreate.References[FieldPolicies+".0"].ID)
+	require.Equal(t, tags.RefPlaceholderPrefix+"mask-sensitive-data#id", agentCreate.References[FieldPolicies+".0"].Ref)
+}
+
+func TestAIGatewayAgentPlannerPolicyRefNoopForExistingAgent(t *testing.T) {
+	for _, currentPolicyRef := range []string{"policy-id", "mask-sensitive-data"} {
+		t.Run(currentPolicyRef, func(t *testing.T) {
+			policy := testAIGatewayPolicyResource(t)
+			agent := testAIGatewayAgentResource(t, []string{tags.RefPlaceholderPrefix + "mask-sensitive-data#id"})
+			client := state.NewClient(state.ClientConfig{
+				AIGatewayAPI: &testAIGatewayAPI{
+					gateways: []kkComps.AIGateway{testAIGateway()},
+				},
+				AIGatewayPoliciesAPI: &testAIGatewayPolicyAPI{
+					policies: []kkComps.AIGatewayPolicy{testAIGatewayPolicy()},
+				},
+				AIGatewayAgentsAPI: &testAIGatewayAgentAPI{
+					agents: []kkComps.AIGatewayAgent{
+						testAIGatewayAgent("agent-id", "booking-agent", []string{currentPolicyRef}),
+					},
+				},
+			})
+			rs := &resources.ResourceSet{
+				AIGateways:        []resources.AIGatewayResource{testAIGatewayResource()},
+				AIGatewayPolicies: []resources.AIGatewayPolicyResource{policy},
+				AIGatewayAgents:   []resources.AIGatewayAgentResource{agent},
+			}
+
+			plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+			require.NoError(t, err)
+			require.Empty(t, plan.Changes)
+		})
+	}
+}
+
+func testAIGatewayAgentResourceSet(
+	agent resources.AIGatewayAgentResource,
+) *resources.ResourceSet {
+	return &resources.ResourceSet{
+		AIGateways:      []resources.AIGatewayResource{testAIGatewayResource()},
+		AIGatewayAgents: []resources.AIGatewayAgentResource{agent},
+	}
+}
+
+func testAIGatewayAgentResource(
+	t *testing.T,
+	policies []string,
+) resources.AIGatewayAgentResource {
+	t.Helper()
+	payload := map[string]any{
+		"ref":          "booking-agent",
+		"ai_gateway":   "support-gateway",
+		"name":         "booking-agent",
+		"type":         "a2a",
+		"display_name": "Booking Agent",
+		"config": map[string]any{
+			"url": "https://booking-agent.example.com",
+		},
+	}
+	if policies != nil {
+		payload[FieldPolicies] = policies
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+	var agent resources.AIGatewayAgentResource
+	require.NoError(t, json.Unmarshal(data, &agent))
+	return agent
+}
+
+func testAIGatewayAgent(id string, name string, policies []string) kkComps.AIGatewayAgent {
+	enabled := true
+	return kkComps.AIGatewayAgent{
+		ID:          id,
+		Name:        name,
+		Type:        kkComps.AIGatewayAgentTypeA2a,
+		DisplayName: "Booking Agent",
+		Enabled:     &enabled,
+		Config: kkComps.AIGatewayAgentConfig{
+			URL: "https://booking-agent.example.com",
+		},
+		Policies: policies,
+	}
+}
+
+type testAIGatewayAgentAPI struct {
+	agents []kkComps.AIGatewayAgent
+}
+
+func (t *testAIGatewayAgentAPI) ListAiGatewayAgents(
+	context.Context,
+	kkOps.ListAiGatewayAgentsRequest,
+	...kkOps.Option,
+) (*kkOps.ListAiGatewayAgentsResponse, error) {
+	return &kkOps.ListAiGatewayAgentsResponse{
+		ListAIGatewayAgentsResponse: &kkComps.ListAIGatewayAgentsResponse{
+			Data: t.agents,
+		},
+	}, nil
+}
+
+func (t *testAIGatewayAgentAPI) CreateAiGatewayAgent(
+	context.Context,
+	string,
+	kkComps.CreateAIGatewayAgentRequest,
+	...kkOps.Option,
+) (*kkOps.CreateAiGatewayAgentResponse, error) {
+	return nil, nil
+}
+
+func (t *testAIGatewayAgentAPI) GetAiGatewayAgent(
+	_ context.Context,
+	_ string,
+	agentID string,
+	_ ...kkOps.Option,
+) (*kkOps.GetAiGatewayAgentResponse, error) {
+	for _, agent := range t.agents {
+		if agent.ID == agentID || agent.Name == agentID {
+			return &kkOps.GetAiGatewayAgentResponse{AIGatewayAgent: &agent}, nil
+		}
+	}
+	return &kkOps.GetAiGatewayAgentResponse{}, nil
+}
+
+func (t *testAIGatewayAgentAPI) UpdateAiGatewayAgent(
+	context.Context,
+	kkOps.UpdateAiGatewayAgentRequest,
+	...kkOps.Option,
+) (*kkOps.UpdateAiGatewayAgentResponse, error) {
+	return nil, nil
+}
+
+func (t *testAIGatewayAgentAPI) DeleteAiGatewayAgent(
+	context.Context,
+	string,
+	string,
+	...kkOps.Option,
+) (*kkOps.DeleteAiGatewayAgentResponse, error) {
+	return nil, nil
+}

--- a/internal/declarative/planner/ai_gateway_agent_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_agent_planner_test.go
@@ -97,6 +97,7 @@ func TestAIGatewayAgentPlannerSyncDeletesScopedAgents(t *testing.T) {
 
 func TestAIGatewayAgentPlannerDependsOnPolicyCreate(t *testing.T) {
 	policy := testAIGatewayPolicyResource(t)
+	policy.Name = "mask-sensitive-data-api-name"
 	agent := testAIGatewayAgentResource(t, []string{tags.RefPlaceholderPrefix + "mask-sensitive-data#id"})
 	client := state.NewClient(state.ClientConfig{
 		AIGatewayAPI: &testAIGatewayAPI{},
@@ -120,8 +121,8 @@ func TestAIGatewayAgentPlannerDependsOnPolicyCreate(t *testing.T) {
 
 	require.Contains(t, policyCreate.DependsOn, gatewayCreate.ID)
 	require.Contains(t, agentCreate.DependsOn, policyCreate.ID)
-	require.Equal(t, resources.UnknownReferenceID, agentCreate.References[FieldPolicies+".0"].ID)
-	require.Equal(t, tags.RefPlaceholderPrefix+"mask-sensitive-data#id", agentCreate.References[FieldPolicies+".0"].Ref)
+	require.Equal(t, []any{"mask-sensitive-data-api-name"}, agentCreate.Fields[FieldPolicies])
+	require.NotContains(t, agentCreate.References, FieldPolicies+".0")
 }
 
 func TestAIGatewayAgentPlannerPolicyRefNoopForExistingAgent(t *testing.T) {

--- a/internal/declarative/planner/ai_gateway_agent_policy_reference.go
+++ b/internal/declarative/planner/ai_gateway_agent_policy_reference.go
@@ -1,0 +1,54 @@
+package planner
+
+import (
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/tags"
+)
+
+func normalizeAIGatewayAgentPolicyReferencesForRequest(payload map[string]any, rs *resources.ResourceSet) {
+	if payload == nil {
+		return
+	}
+
+	rawPolicies, ok := payload[FieldPolicies]
+	if !ok {
+		return
+	}
+
+	switch policies := rawPolicies.(type) {
+	case []any:
+		for i, rawPolicy := range policies {
+			policyRef, ok := rawPolicy.(string)
+			if !ok {
+				continue
+			}
+			policies[i] = aiGatewayAgentPolicyReferenceForRequest(policyRef, rs)
+		}
+	case []string:
+		normalized := make([]any, len(policies))
+		for i, policyRef := range policies {
+			normalized[i] = aiGatewayAgentPolicyReferenceForRequest(policyRef, rs)
+		}
+		payload[FieldPolicies] = normalized
+	}
+}
+
+func aiGatewayAgentPolicyReferenceForRequest(policyRef string, rs *resources.ResourceSet) string {
+	targetRef, _, ok := tags.ParseRefPlaceholder(policyRef)
+	if !ok {
+		return policyRef
+	}
+
+	if rs != nil {
+		if policy := rs.GetAIGatewayPolicyByRef(targetRef); policy != nil {
+			if policy.Name != "" {
+				return policy.Name
+			}
+			if policy.Ref != "" {
+				return policy.Ref
+			}
+		}
+	}
+
+	return targetRef
+}

--- a/internal/declarative/planner/ai_gateway_config_defaults.go
+++ b/internal/declarative/planner/ai_gateway_config_defaults.go
@@ -1,0 +1,165 @@
+package planner
+
+import (
+	"encoding/json"
+	"reflect"
+)
+
+const aiGatewayPolicyTypeAISanitizer = "ai-sanitizer"
+
+var aiGatewayAISanitizerConfigDefaults = map[string]any{
+	"allow_all_conversation_history": true,
+	"block_if_detected":              false,
+	"custom_patterns":                nil,
+	"host":                           "localhost",
+	"keepalive_timeout":              float64(60000),
+	"port":                           float64(8080),
+	"proxy_config": map[string]any{
+		"auth_password":    nil,
+		"auth_username":    nil,
+		"http_proxy_host":  nil,
+		"http_proxy_port":  nil,
+		"https_proxy_host": nil,
+		"https_proxy_port": nil,
+		"no_proxy":         nil,
+		"proxy_scheme":     "http",
+	},
+	"recover_redacted":             true,
+	"redact_type":                  "placeholder",
+	"sanitization_mode":            "INPUT",
+	"scheme":                       "http",
+	"skip_logging_sanitized_items": false,
+	"stop_on_error":                true,
+	"timeout":                      float64(10000),
+}
+
+var aiGatewayRouteConfigDefaults = map[string]any{
+	"protocols": []any{"http", "https"},
+}
+
+func normalizeAIGatewayPolicyDefaultsForComparison(
+	currentPayload map[string]any,
+	desiredPayload map[string]any,
+) (map[string]any, map[string]any) {
+	currentCompare := deepClonePayloadMap(currentPayload)
+	desiredCompare := deepClonePayloadMap(desiredPayload)
+
+	if currentCompare == nil || desiredCompare == nil {
+		return currentCompare, desiredCompare
+	}
+
+	policyType, _ := desiredCompare[FieldType].(string)
+	if policyType == "" {
+		policyType, _ = currentCompare[FieldType].(string)
+	}
+	if policyType == aiGatewayPolicyTypeAISanitizer {
+		pruneCurrentDefaultsAtPath(
+			currentCompare,
+			desiredCompare,
+			[]string{FieldConfig},
+			aiGatewayAISanitizerConfigDefaults,
+		)
+	}
+
+	return currentCompare, desiredCompare
+}
+
+func normalizeAIGatewayRouteDefaultsForComparison(
+	currentPayload map[string]any,
+	desiredPayload map[string]any,
+) (map[string]any, map[string]any) {
+	currentCompare := deepClonePayloadMap(currentPayload)
+	desiredCompare := deepClonePayloadMap(desiredPayload)
+
+	pruneCurrentDefaultsAtPath(
+		currentCompare,
+		desiredCompare,
+		[]string{FieldConfig, "route"},
+		aiGatewayRouteConfigDefaults,
+	)
+
+	return currentCompare, desiredCompare
+}
+
+func deepClonePayloadMap(payload map[string]any) map[string]any {
+	if payload == nil {
+		return nil
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return clonePayloadMap(payload)
+	}
+	var clone map[string]any
+	if err := json.Unmarshal(data, &clone); err != nil {
+		return clonePayloadMap(payload)
+	}
+	return clone
+}
+
+func pruneCurrentDefaultsAtPath(
+	current map[string]any,
+	desired map[string]any,
+	path []string,
+	defaults map[string]any,
+) {
+	if current == nil || len(path) == 0 {
+		pruneCurrentDefaults(current, desired, defaults)
+		return
+	}
+
+	key := path[0]
+	currentChild, ok := current[key].(map[string]any)
+	if !ok {
+		return
+	}
+
+	desiredChild, desiredHasMap := desired[key].(map[string]any)
+	if !desiredHasMap {
+		desiredChild = map[string]any{}
+	}
+
+	pruneCurrentDefaultsAtPath(currentChild, desiredChild, path[1:], defaults)
+	if !desiredHasMap && len(currentChild) == 0 {
+		delete(current, key)
+	}
+}
+
+func pruneCurrentDefaults(current map[string]any, desired map[string]any, defaults map[string]any) {
+	if current == nil {
+		return
+	}
+	if desired == nil {
+		desired = map[string]any{}
+	}
+
+	for key, defaultValue := range defaults {
+		currentValue, currentHasValue := current[key]
+		if !currentHasValue {
+			continue
+		}
+
+		defaultMap, defaultIsMap := defaultValue.(map[string]any)
+		if defaultIsMap {
+			currentMap, currentIsMap := currentValue.(map[string]any)
+			if !currentIsMap {
+				continue
+			}
+			desiredMap, desiredIsMap := desired[key].(map[string]any)
+			if !desiredIsMap {
+				desiredMap = map[string]any{}
+			}
+			pruneCurrentDefaults(currentMap, desiredMap, defaultMap)
+			if _, desiredHasValue := desired[key]; !desiredHasValue && len(currentMap) == 0 {
+				delete(current, key)
+			}
+			continue
+		}
+
+		if _, desiredHasValue := desired[key]; desiredHasValue {
+			continue
+		}
+		if reflect.DeepEqual(currentValue, defaultValue) {
+			delete(current, key)
+		}
+	}
+}

--- a/internal/declarative/planner/ai_gateway_consumer_group_planner.go
+++ b/internal/declarative/planner/ai_gateway_consumer_group_planner.go
@@ -157,6 +157,7 @@ func (p *Planner) planAIGatewayConsumerGroupCreate(
 		plan.AddWarning(group.GetRef(), fmt.Sprintf("failed to build AI Gateway Consumer Group create payload: %s", err))
 		return
 	}
+	normalizeAIGatewayPolicyNameReferencesForRequest(fields, p.resources)
 
 	change := PlannedChange{
 		ID:           p.nextChangeID(ActionCreate, ResourceTypeAIGatewayConsumerGroup, group.Ref),
@@ -246,6 +247,7 @@ func (p *Planner) shouldUpdateAIGatewayConsumerGroup(
 			err,
 		)
 	}
+	normalizeAIGatewayPolicyNameReferencesForRequest(desiredPayload, p.resources)
 
 	currentCompare, desiredCompare := normalizeAIGatewayPolicyReferencesForComparison(
 		currentPayload,

--- a/internal/declarative/planner/ai_gateway_consumer_planner.go
+++ b/internal/declarative/planner/ai_gateway_consumer_planner.go
@@ -157,6 +157,7 @@ func (p *Planner) planAIGatewayConsumerCreate(
 		plan.AddWarning(consumer.GetRef(), fmt.Sprintf("failed to build AI Gateway Consumer create payload: %s", err))
 		return
 	}
+	normalizeAIGatewayPolicyNameReferencesForRequest(fields, p.resources)
 
 	change := PlannedChange{
 		ID:           p.nextChangeID(ActionCreate, ResourceTypeAIGatewayConsumer, consumer.Ref),
@@ -246,6 +247,7 @@ func (p *Planner) shouldUpdateAIGatewayConsumer(
 			err,
 		)
 	}
+	normalizeAIGatewayPolicyNameReferencesForRequest(desiredPayload, p.resources)
 
 	currentCompare, desiredCompare := normalizeAIGatewayPolicyReferencesForComparison(
 		currentPayload,

--- a/internal/declarative/planner/ai_gateway_mcp_server_planner.go
+++ b/internal/declarative/planner/ai_gateway_mcp_server_planner.go
@@ -145,6 +145,7 @@ func (p *Planner) planAIGatewayMCPServerCreate(
 		plan.AddWarning(server.GetRef(), fmt.Sprintf("failed to build AI Gateway MCP Server create payload: %s", err))
 		return
 	}
+	normalizeAIGatewayPolicyNameReferencesForRequest(fields, p.resources)
 
 	change := PlannedChange{
 		ID:           p.nextChangeID(ActionCreate, ResourceTypeAIGatewayMCPServer, server.Ref),
@@ -230,6 +231,7 @@ func (p *Planner) shouldUpdateAIGatewayMCPServer(
 	if err != nil {
 		return false, nil, nil, fmt.Errorf("failed to normalize desired AI Gateway MCP Server %q: %w", desired.Ref, err)
 	}
+	normalizeAIGatewayPolicyNameReferencesForRequest(desiredPayload, p.resources)
 
 	currentCompare, desiredCompare := normalizeAIGatewayPolicyReferencesForComparison(
 		currentPayload,

--- a/internal/declarative/planner/ai_gateway_model_planner.go
+++ b/internal/declarative/planner/ai_gateway_model_planner.go
@@ -160,6 +160,7 @@ func (p *Planner) planAIGatewayModelCreate(
 		plan.AddWarning(model.GetRef(), fmt.Sprintf("failed to build AI Gateway model create payload: %s", err))
 		return
 	}
+	normalizeAIGatewayPolicyNameReferencesForRequest(fields, p.resources)
 
 	change := PlannedChange{
 		ID:           p.nextChangeID(ActionCreate, ResourceTypeAIGatewayModel, model.Ref),
@@ -245,6 +246,7 @@ func (p *Planner) shouldUpdateAIGatewayModel(
 	if err != nil {
 		return false, nil, nil, fmt.Errorf("failed to normalize desired AI Gateway model %q: %w", desired.Ref, err)
 	}
+	normalizeAIGatewayPolicyNameReferencesForRequest(desiredPayload, p.resources)
 
 	currentCompare, desiredCompare := normalizeAIGatewayPolicyReferencesForComparison(
 		currentPayload,

--- a/internal/declarative/planner/ai_gateway_planner.go
+++ b/internal/declarative/planner/ai_gateway_planner.go
@@ -213,6 +213,28 @@ func (p *Planner) planAIGatewayChanges(
 		}
 		policyCreateDepsByName := aiGatewayPolicyCreateDependencies(plan, namespace, desiredGateway.Ref)
 
+		agents := p.resources.GetAIGatewayAgentsForGateway(desiredGateway.Ref)
+		if p.shouldPlanChild(
+			plan,
+			resources.ResourceTypeAIGateway,
+			desiredGateway.Ref,
+			resources.ResourceTypeAIGatewayAgent,
+		) && (len(agents) > 0 || plan.Metadata.Mode == PlanModeSync) {
+			if err := p.planAIGatewayAgentChanges(
+				ctx,
+				namespace,
+				desiredGateway.Ref,
+				desiredGateway.DisplayName,
+				gatewayID,
+				gatewayChangeID,
+				policyCreateDepsByName,
+				agents,
+				plan,
+			); err != nil {
+				return err
+			}
+		}
+
 		consumers := p.resources.GetAIGatewayConsumersForGateway(desiredGateway.Ref)
 		if p.shouldPlanChild(
 			plan,
@@ -398,6 +420,28 @@ func (p *Planner) planExternalAIGatewayChildren(
 		}
 	}
 	policyCreateDepsByName := aiGatewayPolicyCreateDependencies(plan, namespace, desiredGateway.Ref)
+
+	agents := p.resources.GetAIGatewayAgentsForGateway(desiredGateway.Ref)
+	if p.shouldPlanChild(
+		plan,
+		resources.ResourceTypeAIGateway,
+		desiredGateway.Ref,
+		resources.ResourceTypeAIGatewayAgent,
+	) && len(agents) > 0 {
+		if err := p.planAIGatewayAgentChanges(
+			ctx,
+			namespace,
+			desiredGateway.Ref,
+			desiredGateway.DisplayName,
+			gatewayID,
+			"",
+			policyCreateDepsByName,
+			agents,
+			plan,
+		); err != nil {
+			return err
+		}
+	}
 
 	consumers := p.resources.GetAIGatewayConsumersForGateway(desiredGateway.Ref)
 	if p.shouldPlanChild(

--- a/internal/declarative/planner/ai_gateway_policy_planner.go
+++ b/internal/declarative/planner/ai_gateway_policy_planner.go
@@ -216,16 +216,18 @@ func shouldUpdateAIGatewayPolicy(
 		return false, nil, nil, fmt.Errorf("failed to normalize desired AI Gateway Policy %q: %w", desired.Ref, err)
 	}
 
+	currentCompare, desiredCompare := normalizeAIGatewayPolicyDefaultsForComparison(currentPayload, desiredPayload)
+
 	changedFields := make(map[string]FieldChange)
-	keys := make(map[string]struct{}, len(currentPayload)+len(desiredPayload))
-	for key := range currentPayload {
+	keys := make(map[string]struct{}, len(currentCompare)+len(desiredCompare))
+	for key := range currentCompare {
 		keys[key] = struct{}{}
 	}
-	for key := range desiredPayload {
+	for key := range desiredCompare {
 		keys[key] = struct{}{}
 	}
 	for key := range keys {
-		if !reflect.DeepEqual(currentPayload[key], desiredPayload[key]) {
+		if !reflect.DeepEqual(currentCompare[key], desiredCompare[key]) {
 			changedFields[key] = FieldChange{Old: currentPayload[key], New: desiredPayload[key]}
 		}
 	}

--- a/internal/declarative/planner/ai_gateway_policy_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_policy_planner_test.go
@@ -86,6 +86,52 @@ func TestAIGatewayPolicyPlannerUpdatesExistingPolicy(t *testing.T) {
 	require.Contains(t, change.ChangedFields, FieldDisplayName)
 }
 
+func TestAIGatewayPolicyPlannerIgnoresAISanitizerResponseDefaults(t *testing.T) {
+	policy := testAIGatewayPolicyResource(t)
+	current := testAIGatewayPolicy()
+	current.Config = testAIGatewayAISanitizerDefaultedConfig()
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{
+			gateways: []kkComps.AIGateway{testAIGateway()},
+		},
+		AIGatewayPoliciesAPI: &testAIGatewayPolicyAPI{
+			policies: []kkComps.AIGatewayPolicy{current},
+		},
+	})
+	rs := &resources.ResourceSet{
+		AIGateways:        []resources.AIGatewayResource{testAIGatewayResource()},
+		AIGatewayPolicies: []resources.AIGatewayPolicyResource{policy},
+	}
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+	require.NoError(t, err)
+	require.Empty(t, plan.Changes)
+}
+
+func TestAIGatewayPolicyPlannerDetectsNonDefaultAISanitizerConfigDrift(t *testing.T) {
+	policy := testAIGatewayPolicyResource(t)
+	current := testAIGatewayPolicy()
+	current.Config = testAIGatewayAISanitizerDefaultedConfig()
+	current.Config["stop_on_error"] = false
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{
+			gateways: []kkComps.AIGateway{testAIGateway()},
+		},
+		AIGatewayPoliciesAPI: &testAIGatewayPolicyAPI{
+			policies: []kkComps.AIGatewayPolicy{current},
+		},
+	})
+	rs := &resources.ResourceSet{
+		AIGateways:        []resources.AIGatewayResource{testAIGatewayResource()},
+		AIGatewayPolicies: []resources.AIGatewayPolicyResource{policy},
+	}
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	require.Contains(t, plan.Changes[0].ChangedFields, FieldConfig)
+}
+
 func TestAIGatewayPolicyPlannerSyncDeletesScopedPolicies(t *testing.T) {
 	scope := resources.NewSyncScope()
 	scope.AddRoot(resources.ResourceTypeAIGateway)
@@ -208,6 +254,35 @@ func testAIGatewayPolicy() kkComps.AIGatewayPolicy {
 		Enabled:     &enabled,
 		Global:      &global,
 		Config:      map[string]any{"anonymize": []any{"email"}},
+	}
+}
+
+func testAIGatewayAISanitizerDefaultedConfig() map[string]any {
+	return map[string]any{
+		"allow_all_conversation_history": true,
+		"anonymize":                      []any{"email"},
+		"block_if_detected":              false,
+		"custom_patterns":                nil,
+		"host":                           "localhost",
+		"keepalive_timeout":              60000,
+		"port":                           8080,
+		"proxy_config": map[string]any{
+			"auth_password":    nil,
+			"auth_username":    nil,
+			"http_proxy_host":  nil,
+			"http_proxy_port":  nil,
+			"https_proxy_host": nil,
+			"https_proxy_port": nil,
+			"no_proxy":         nil,
+			"proxy_scheme":     "http",
+		},
+		"recover_redacted":             true,
+		"redact_type":                  "placeholder",
+		"sanitization_mode":            "INPUT",
+		"scheme":                       "http",
+		"skip_logging_sanitized_items": false,
+		"stop_on_error":                true,
+		"timeout":                      10000,
 	}
 }
 

--- a/internal/declarative/planner/ai_gateway_policy_reference_request.go
+++ b/internal/declarative/planner/ai_gateway_policy_reference_request.go
@@ -5,7 +5,7 @@ import (
 	"github.com/kong/kongctl/internal/declarative/tags"
 )
 
-func normalizeAIGatewayAgentPolicyReferencesForRequest(payload map[string]any, rs *resources.ResourceSet) {
+func normalizeAIGatewayPolicyNameReferencesForRequest(payload map[string]any, rs *resources.ResourceSet) {
 	if payload == nil {
 		return
 	}
@@ -22,20 +22,20 @@ func normalizeAIGatewayAgentPolicyReferencesForRequest(payload map[string]any, r
 			if !ok {
 				continue
 			}
-			policies[i] = aiGatewayAgentPolicyReferenceForRequest(policyRef, rs)
+			policies[i] = aiGatewayPolicyNameReferenceForRequest(policyRef, rs)
 		}
 	case []string:
 		normalized := make([]any, len(policies))
 		for i, policyRef := range policies {
-			normalized[i] = aiGatewayAgentPolicyReferenceForRequest(policyRef, rs)
+			normalized[i] = aiGatewayPolicyNameReferenceForRequest(policyRef, rs)
 		}
 		payload[FieldPolicies] = normalized
 	}
 }
 
-func aiGatewayAgentPolicyReferenceForRequest(policyRef string, rs *resources.ResourceSet) string {
-	targetRef, _, ok := tags.ParseRefPlaceholder(policyRef)
-	if !ok {
+func aiGatewayPolicyNameReferenceForRequest(policyRef string, rs *resources.ResourceSet) string {
+	targetRef, field, ok := tags.ParseRefPlaceholder(policyRef)
+	if !ok || field != FieldName {
 		return policyRef
 	}
 

--- a/internal/declarative/planner/constants.go
+++ b/internal/declarative/planner/constants.go
@@ -206,6 +206,7 @@ const (
 	ResourceTypeAIGateway                        = string(resources.ResourceTypeAIGateway)
 	ResourceTypeAIGatewayProvider                = string(resources.ResourceTypeAIGatewayProvider)
 	ResourceTypeAIGatewayPolicy                  = string(resources.ResourceTypeAIGatewayPolicy)
+	ResourceTypeAIGatewayAgent                   = string(resources.ResourceTypeAIGatewayAgent)
 	ResourceTypeAIGatewayConsumer                = string(resources.ResourceTypeAIGatewayConsumer)
 	ResourceTypeAIGatewayConsumerGroup           = string(resources.ResourceTypeAIGatewayConsumerGroup)
 	ResourceTypeAIGatewayModel                   = string(resources.ResourceTypeAIGatewayModel)

--- a/internal/declarative/planner/dependencies.go
+++ b/internal/declarative/planner/dependencies.go
@@ -235,6 +235,7 @@ func aiGatewayChildSerializationParentKey(change PlannedChange) string {
 	switch change.ResourceType {
 	case ResourceTypeAIGatewayProvider,
 		ResourceTypeAIGatewayPolicy,
+		ResourceTypeAIGatewayAgent,
 		ResourceTypeAIGatewayConsumer,
 		ResourceTypeAIGatewayConsumerGroup,
 		ResourceTypeAIGatewayModel,

--- a/internal/declarative/planner/resolver.go
+++ b/internal/declarative/planner/resolver.go
@@ -238,7 +238,8 @@ func (r *ReferenceResolver) getResourceTypeForChangeField(change PlannedChange, 
 
 func aiGatewayPolicyReferenceField(resourceType, fieldName string) bool {
 	switch resourceType {
-	case ResourceTypeAIGatewayConsumer,
+	case ResourceTypeAIGatewayAgent,
+		ResourceTypeAIGatewayConsumer,
 		ResourceTypeAIGatewayConsumerGroup,
 		ResourceTypeAIGatewayModel,
 		ResourceTypeAIGatewayMCPServer:

--- a/internal/declarative/planner/resolver.go
+++ b/internal/declarative/planner/resolver.go
@@ -238,8 +238,7 @@ func (r *ReferenceResolver) getResourceTypeForChangeField(change PlannedChange, 
 
 func aiGatewayPolicyReferenceField(resourceType, fieldName string) bool {
 	switch resourceType {
-	case ResourceTypeAIGatewayAgent,
-		ResourceTypeAIGatewayConsumer,
+	case ResourceTypeAIGatewayConsumer,
 		ResourceTypeAIGatewayConsumerGroup,
 		ResourceTypeAIGatewayModel,
 		ResourceTypeAIGatewayMCPServer:

--- a/internal/declarative/planner/sync_scope.go
+++ b/internal/declarative/planner/sync_scope.go
@@ -162,6 +162,13 @@ func addAIGatewayChildScopes(scope *resources.SyncScope, rs *resources.ResourceS
 			resources.ResourceTypeAIGatewayPolicy,
 		)
 	}
+	for _, child := range rs.AIGatewayAgents {
+		scope.AddChild(
+			resources.ResourceTypeAIGateway,
+			resources.NormalizeResourceRef(child.AIGateway),
+			resources.ResourceTypeAIGatewayAgent,
+		)
+	}
 	for _, child := range rs.AIGatewayConsumers {
 		scope.AddChild(
 			resources.ResourceTypeAIGateway,

--- a/internal/declarative/protection/lookup.go
+++ b/internal/declarative/protection/lookup.go
@@ -156,6 +156,7 @@ func IsManagedResourceProtected(
 		resources.ResourceTypeEventGatewayTLSTrustBundle,
 		resources.ResourceTypeAIGatewayProvider,
 		resources.ResourceTypeAIGatewayPolicy,
+		resources.ResourceTypeAIGatewayAgent,
 		resources.ResourceTypeAIGatewayConsumer,
 		resources.ResourceTypeAIGatewayConsumerGroup,
 		resources.ResourceTypeAIGatewayModel,

--- a/internal/declarative/resources/ai_gateway.go
+++ b/internal/declarative/resources/ai_gateway.go
@@ -26,6 +26,7 @@ type AIGatewayResource struct {
 	External       *ExternalBlock                   `yaml:"_external,omitempty" json:"_external,omitempty"`
 	Providers      []AIGatewayProviderResource      `yaml:"providers,omitempty" json:"providers,omitempty"`
 	Policies       []AIGatewayPolicyResource        `yaml:"policies,omitempty" json:"policies,omitempty"`
+	Agents         []AIGatewayAgentResource         `yaml:"agents,omitempty" json:"agents,omitempty"`
 	Consumers      []AIGatewayConsumerResource      `yaml:"consumers,omitempty" json:"consumers,omitempty"`
 	ConsumerGroups []AIGatewayConsumerGroupResource `yaml:"consumer_groups,omitempty" json:"consumer_groups,omitempty"`
 	Models         []AIGatewayModelResource         `yaml:"models,omitempty"    json:"models,omitempty"`
@@ -52,6 +53,7 @@ type aiGatewayAlias struct {
 	Labels         map[string]string                `json:"labels,omitempty"      yaml:"labels,omitempty"`
 	Providers      []AIGatewayProviderResource      `json:"providers,omitempty"   yaml:"providers,omitempty"`
 	Policies       []AIGatewayPolicyResource        `json:"policies,omitempty"    yaml:"policies,omitempty"`
+	Agents         []AIGatewayAgentResource         `json:"agents,omitempty"      yaml:"agents,omitempty"`
 	Consumers      []AIGatewayConsumerResource      `json:"consumers,omitempty"   yaml:"consumers,omitempty"`
 	ConsumerGroups []AIGatewayConsumerGroupResource `json:"consumer_groups,omitempty" yaml:"consumer_groups,omitempty"`
 	Models         []AIGatewayModelResource         `json:"models,omitempty"      yaml:"models,omitempty"`
@@ -70,6 +72,7 @@ func (a AIGatewayResource) aiGatewayAlias() aiGatewayAlias {
 		Labels:         a.Labels,
 		Providers:      a.Providers,
 		Policies:       a.Policies,
+		Agents:         a.Agents,
 		Consumers:      a.Consumers,
 		ConsumerGroups: a.ConsumerGroups,
 		Models:         a.Models,
@@ -91,6 +94,7 @@ func (a *AIGatewayResource) UnmarshalYAML(unmarshal func(any) error) error {
 		Labels         map[string]string                `yaml:"labels,omitempty"`
 		Providers      []AIGatewayProviderResource      `yaml:"providers,omitempty"`
 		Policies       []AIGatewayPolicyResource        `yaml:"policies,omitempty"`
+		Agents         []AIGatewayAgentResource         `yaml:"agents,omitempty"`
 		Consumers      []AIGatewayConsumerResource      `yaml:"consumers,omitempty"`
 		ConsumerGroups []AIGatewayConsumerGroupResource `yaml:"consumer_groups,omitempty"`
 		Models         []AIGatewayModelResource         `yaml:"models,omitempty"`
@@ -114,6 +118,7 @@ func (a *AIGatewayResource) UnmarshalYAML(unmarshal func(any) error) error {
 	}
 	a.Providers = raw.Providers
 	a.Policies = raw.Policies
+	a.Agents = raw.Agents
 	a.Consumers = raw.Consumers
 	a.ConsumerGroups = raw.ConsumerGroups
 	a.Models = raw.Models
@@ -136,6 +141,7 @@ func (a *AIGatewayResource) UnmarshalJSON(data []byte) error {
 		Labels         map[string]string                `json:"labels,omitempty"`
 		Providers      []AIGatewayProviderResource      `json:"providers,omitempty"`
 		Policies       []AIGatewayPolicyResource        `json:"policies,omitempty"`
+		Agents         []AIGatewayAgentResource         `json:"agents,omitempty"`
 		Consumers      []AIGatewayConsumerResource      `json:"consumers,omitempty"`
 		ConsumerGroups []AIGatewayConsumerGroupResource `json:"consumer_groups,omitempty"`
 		Models         []AIGatewayModelResource         `json:"models,omitempty"`
@@ -159,6 +165,7 @@ func (a *AIGatewayResource) UnmarshalJSON(data []byte) error {
 	}
 	a.Providers = raw.Providers
 	a.Policies = raw.Policies
+	a.Agents = raw.Agents
 	a.Consumers = raw.Consumers
 	a.ConsumerGroups = raw.ConsumerGroups
 	a.Models = raw.Models
@@ -223,6 +230,9 @@ func (a *AIGatewayResource) SetDefaults() {
 	for i := range a.Policies {
 		a.Policies[i].SetDefaults()
 	}
+	for i := range a.Agents {
+		a.Agents[i].SetDefaults()
+	}
 	for i := range a.Consumers {
 		a.Consumers[i].SetDefaults()
 	}
@@ -271,7 +281,7 @@ func aiGatewayExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
 		explainField("description", &ExplainNode{Kind: explainKindString, Nullable: true}, false, false),
 		explainField("proxy_urls", explainArrayOf(explainObject(
 			explainField("host", explainStringNode("proxy.example.com"), true, true),
-			explainField("port", &ExplainNode{Kind: "integer", Literal: "443"}, true, true),
+			explainField("port", &ExplainNode{Kind: explainKindInteger, Literal: "443"}, true, true),
 			explainField("protocol", explainStringNode("https"), true, true),
 		)), false, false),
 		explainField("labels", &ExplainNode{

--- a/internal/declarative/resources/ai_gateway_agent.go
+++ b/internal/declarative/resources/ai_gateway_agent.go
@@ -1,0 +1,413 @@
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/util"
+)
+
+const (
+	aiGatewayAgentFieldID          = "id"
+	aiGatewayAgentFieldName        = "name"
+	aiGatewayAgentFieldType        = "type"
+	aiGatewayAgentFieldDisplayName = "display_name"
+	aiGatewayAgentFieldEnabled     = "enabled"
+	aiGatewayAgentFieldPolicies    = "policies"
+	aiGatewayAgentFieldConfig      = "config"
+	aiGatewayAgentFieldLabels      = "labels"
+	aiGatewayAgentFieldUpdatedAt   = "updated_at"
+)
+
+func init() {
+	registerResourceType(
+		ResourceTypeAIGatewayAgent,
+		func(rs *ResourceSet) *[]AIGatewayAgentResource { return &rs.AIGatewayAgents },
+		AutoExplain[AIGatewayAgentResource](
+			WithExplainAliases(
+				"ai_gateway_agents",
+				"ai-gateway-agent",
+				"ai-gateway-agents",
+				"ai_gateway.agents",
+				"aigw-agent",
+			),
+			WithExplainRecommendedFields(
+				"ref",
+				SchemaFieldAIGateway,
+				"name",
+				"type",
+				"display_name",
+				aiGatewayAgentFieldConfig,
+				aiGatewayAgentFieldPolicies,
+			),
+			WithExplainSchemaBuilder(aiGatewayAgentExplainNode),
+		),
+	)
+}
+
+// AIGatewayAgentResource represents an Agent nested under a Konnect AI Gateway.
+type AIGatewayAgentResource struct {
+	BaseResource `yaml:",inline" json:",inline"`
+	// Parent AI Gateway reference for root-level declarations.
+	AIGateway string `yaml:"ai_gateway,omitempty" json:"ai_gateway,omitempty"`
+
+	kkComps.CreateAIGatewayAgentRequest `yaml:",inline" json:",inline"`
+}
+
+func (a AIGatewayAgentResource) GetType() ResourceType {
+	return ResourceTypeAIGatewayAgent
+}
+
+func (a AIGatewayAgentResource) GetMoniker() string {
+	return a.Name
+}
+
+func (a AIGatewayAgentResource) GetDependencies() []ResourceRef {
+	if a.AIGateway == "" {
+		return nil
+	}
+	return []ResourceRef{{Kind: ResourceTypeAIGateway, Ref: NormalizeResourceRef(a.AIGateway)}}
+}
+
+func (a AIGatewayAgentResource) GetParentRef() *ResourceRef {
+	if a.AIGateway == "" {
+		return nil
+	}
+	return &ResourceRef{Kind: ResourceTypeAIGateway, Ref: NormalizeResourceRef(a.AIGateway)}
+}
+
+func (a AIGatewayAgentResource) Validate() error {
+	if err := ValidateRef(a.Ref); err != nil {
+		return fmt.Errorf("invalid AI Gateway Agent ref: %w", err)
+	}
+	if a.Kongctl != nil {
+		return fmt.Errorf("kongctl metadata not supported on AI Gateway Agent %s", a.Ref)
+	}
+	if a.AIGateway == "" {
+		return fmt.Errorf("ai_gateway is required for AI Gateway Agent %s", a.Ref)
+	}
+	if a.Name == "" {
+		return fmt.Errorf("name is required for AI Gateway Agent %s", a.Ref)
+	}
+	if a.Type == "" {
+		return fmt.Errorf("type is required for AI Gateway Agent %s", a.Ref)
+	}
+	if a.DisplayName == "" {
+		return fmt.Errorf("display_name is required for AI Gateway Agent %s", a.Ref)
+	}
+	if a.Config.URL == "" {
+		return fmt.Errorf("config.url is required for AI Gateway Agent %s", a.Ref)
+	}
+	return nil
+}
+
+func (a *AIGatewayAgentResource) SetDefaults() {
+	if a == nil {
+		return
+	}
+	if a.Ref == "" {
+		a.Ref = a.Name
+	}
+	if a.Name == "" {
+		a.Name = a.Ref
+	}
+	if a.DisplayName == "" {
+		a.DisplayName = a.Name
+	}
+	if a.Enabled == nil {
+		enabled := true
+		a.Enabled = &enabled
+	}
+}
+
+func (a AIGatewayAgentResource) GetKonnectMonikerFilter() string {
+	return a.Name
+}
+
+func (a *AIGatewayAgentResource) TryMatchKonnectResource(konnectResource any) bool {
+	name := a.Name
+	if name == "" {
+		return false
+	}
+	if id := AIGatewayAgentID(konnectResource); id != "" && (util.IsValidUUID(a.Ref) || a.GetKonnectID() != "") {
+		if a.Ref == id || a.GetKonnectID() == id {
+			a.SetKonnectID(id)
+			return true
+		}
+	}
+	if id := AIGatewayAgentID(konnectResource); id != "" && AIGatewayAgentName(konnectResource) == name {
+		a.SetKonnectID(id)
+		return true
+	}
+	return false
+}
+
+func (a AIGatewayAgentResource) CreateRequest() kkComps.CreateAIGatewayAgentRequest {
+	return a.CreateAIGatewayAgentRequest
+}
+
+func (a AIGatewayAgentResource) UpdateRequest() kkComps.UpdateAIGatewayAgentRequest {
+	payload, err := a.PayloadMap()
+	if err != nil || len(payload) == 0 {
+		return kkComps.UpdateAIGatewayAgentRequest{}
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return kkComps.UpdateAIGatewayAgentRequest{}
+	}
+	var req kkComps.UpdateAIGatewayAgentRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return kkComps.UpdateAIGatewayAgentRequest{}
+	}
+	return req
+}
+
+func (a AIGatewayAgentResource) PayloadMap() (map[string]any, error) {
+	return marshalObjectToMap(a.CreateRequest(), "AI Gateway Agent payload")
+}
+
+func (a AIGatewayAgentResource) MutablePayloadMap() (map[string]any, error) {
+	payload, err := a.PayloadMap()
+	if err != nil {
+		return nil, err
+	}
+	stripAIGatewayAgentServerFields(payload)
+	return payload, nil
+}
+
+func (a AIGatewayAgentResource) MarshalJSON() ([]byte, error) {
+	payload, err := a.PayloadMap()
+	if err != nil {
+		return nil, err
+	}
+	payload[SchemaFieldRef] = a.Ref
+	if a.AIGateway != "" {
+		payload[SchemaFieldAIGateway] = a.AIGateway
+	}
+	return json.Marshal(payload)
+}
+
+func (a AIGatewayAgentResource) MarshalYAML() (any, error) {
+	payload, err := a.PayloadMap()
+	if err != nil {
+		return nil, err
+	}
+	payload[SchemaFieldRef] = a.Ref
+	if a.AIGateway != "" {
+		payload[SchemaFieldAIGateway] = a.AIGateway
+	}
+	return payload, nil
+}
+
+func (a *AIGatewayAgentResource) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	var meta struct {
+		Ref       string          `json:"ref"`
+		AIGateway string          `json:"ai_gateway,omitempty"`
+		Kongctl   json.RawMessage `json:"kongctl,omitempty"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return err
+	}
+	if len(meta.Kongctl) > 0 && string(meta.Kongctl) != jsonNullLiteral {
+		return fmt.Errorf("kongctl metadata not supported on child resources")
+	}
+
+	delete(raw, SchemaFieldRef)
+	delete(raw, SchemaFieldAIGateway)
+	delete(raw, "kongctl")
+
+	payload, err := json.Marshal(raw)
+	if err != nil {
+		return err
+	}
+	var req kkComps.CreateAIGatewayAgentRequest
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return err
+	}
+
+	a.BaseResource = BaseResource{Ref: meta.Ref}
+	a.AIGateway = meta.AIGateway
+	a.CreateAIGatewayAgentRequest = req
+	return nil
+}
+
+func AIGatewayAgentID(agent any) string {
+	return aiGatewayAgentStringField(agent, aiGatewayAgentFieldID)
+}
+
+func AIGatewayAgentName(agent any) string {
+	return aiGatewayAgentStringField(agent, aiGatewayAgentFieldName)
+}
+
+func AIGatewayAgentDisplayName(agent any) string {
+	return aiGatewayAgentStringField(agent, aiGatewayAgentFieldDisplayName)
+}
+
+func AIGatewayAgentType(agent any) string {
+	return aiGatewayAgentStringField(agent, aiGatewayAgentFieldType)
+}
+
+func AIGatewayAgentEnabled(agent any) *bool {
+	payload, err := marshalObjectToMap(agent, "AI Gateway Agent")
+	if err != nil {
+		return nil
+	}
+	if enabled, ok := payload[aiGatewayAgentFieldEnabled].(bool); ok {
+		return &enabled
+	}
+	return nil
+}
+
+func AIGatewayAgentLabels(agent any) map[string]string {
+	payload, err := marshalObjectToMap(agent, "AI Gateway Agent")
+	if err != nil {
+		return nil
+	}
+	raw, ok := payload[aiGatewayAgentFieldLabels].(map[string]any)
+	if !ok {
+		return nil
+	}
+	labels := make(map[string]string, len(raw))
+	for key, value := range raw {
+		if stringValue, ok := value.(string); ok {
+			labels[key] = stringValue
+		}
+	}
+	return labels
+}
+
+func AIGatewayAgentUpdatedAt(agent any) time.Time {
+	payload, err := marshalObjectToMap(agent, "AI Gateway Agent")
+	if err != nil {
+		return time.Time{}
+	}
+	switch value := payload[aiGatewayAgentFieldUpdatedAt].(type) {
+	case string:
+		if parsed, err := time.Parse(time.RFC3339Nano, value); err == nil {
+			return parsed
+		}
+	case time.Time:
+		return value
+	}
+	return time.Time{}
+}
+
+func AIGatewayAgentMutablePayloadMap(agent kkComps.AIGatewayAgent) (map[string]any, error) {
+	payload, err := marshalObjectToMap(agent, "AI Gateway Agent response")
+	if err != nil {
+		return nil, err
+	}
+	stripAIGatewayAgentServerFields(payload)
+	return payload, nil
+}
+
+func AIGatewayAgentResourceFromResponse(
+	gatewayRef string,
+	agent kkComps.AIGatewayAgent,
+) (AIGatewayAgentResource, error) {
+	payload, err := AIGatewayAgentMutablePayloadMap(agent)
+	if err != nil {
+		return AIGatewayAgentResource{}, err
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return AIGatewayAgentResource{}, err
+	}
+	var req kkComps.CreateAIGatewayAgentRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return AIGatewayAgentResource{}, err
+	}
+
+	ref := AIGatewayAgentID(agent)
+	if ref == "" {
+		ref = AIGatewayAgentName(agent)
+	}
+	return AIGatewayAgentResource{
+		BaseResource:                BaseResource{Ref: ref},
+		AIGateway:                   gatewayRef,
+		CreateAIGatewayAgentRequest: req,
+	}, nil
+}
+
+func stripAIGatewayAgentServerFields(payload map[string]any) {
+	delete(payload, aiGatewayAgentFieldID)
+	delete(payload, "created_at")
+	delete(payload, aiGatewayAgentFieldUpdatedAt)
+}
+
+func aiGatewayAgentStringField(value any, key string) string {
+	payload, err := marshalObjectToMap(value, "AI Gateway Agent")
+	if err != nil {
+		return ""
+	}
+	if field, ok := payload[key].(string); ok {
+		return field
+	}
+	return ""
+}
+
+func aiGatewayAgentExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
+	return explainObject(
+		explainResourceRefField(),
+		explainRefField(SchemaFieldAIGateway, ResourceTypeAIGateway, true),
+		explainField("name", explainStringNode("booking-agent"), true, true),
+		explainField("type", explainStringNode("a2a"), true, true),
+		explainField("display_name", explainStringNode("Booking Agent"), true, true),
+		explainField(aiGatewayAgentFieldEnabled, explainBoolNode("true"), false, false),
+		explainField(
+			aiGatewayAgentFieldConfig,
+			explainObject(
+				explainField("url", explainStringNode("https://booking-agent.example.com"), true, true),
+				explainField(
+					"route",
+					explainObject(
+						explainField("paths", explainArrayOf(explainStringNode("/booking")), false, false),
+						explainField("hosts", explainArrayOf(explainStringNode("agents.example.com")), false, false),
+						explainField("methods", explainArrayOf(explainStringNode("POST")), false, false),
+					),
+					false,
+					false,
+				),
+				explainField("max_request_body_size", &ExplainNode{Kind: explainKindInteger, Literal: "1048576"}, false, false),
+				explainField(
+					"logging",
+					explainObject(
+						explainField("payloads", explainBoolNode("true"), false, false),
+						explainField("statistics", explainBoolNode("true"), false, false),
+						explainField("max_payload_size", &ExplainNode{Kind: explainKindInteger, Literal: "524288"}, false, false),
+					),
+					false,
+					false,
+				),
+			),
+			true,
+			true,
+		),
+		explainField(
+			aiGatewayAgentFieldPolicies,
+			explainArrayOf(explainStringNode("!ref mask-sensitive-data")),
+			false,
+			true,
+		),
+		explainField(
+			"acls",
+			explainObject(explainField("allow", explainArrayOf(explainStringNode("support-user")), false, false)),
+			false,
+			false,
+		),
+		explainField("labels", &ExplainNode{Kind: explainKindObject, Additional: explainStringNode("value")}, false, false),
+		explainField(
+			"managed_by",
+			&ExplainNode{Kind: explainKindObject, Additional: explainStringNode("kongctl")},
+			false,
+			false,
+		),
+	), nil
+}

--- a/internal/declarative/resources/explain.go
+++ b/internal/declarative/resources/explain.go
@@ -15,6 +15,7 @@ const (
 	explainKindArray      = "array"
 	explainKindObject     = "object"
 	explainKindString     = "string"
+	explainKindInteger    = "integer"
 
 	explainResourceClassTopLevel = "top-level"
 	explainResourceClassChild    = "child"
@@ -971,7 +972,7 @@ func autoExplainValueNode(
 		node.Kind = "boolean"
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		node.Kind = "integer"
+		node.Kind = explainKindInteger
 	case reflect.Float32, reflect.Float64:
 		node.Kind = "number"
 	case reflect.Interface:
@@ -1074,7 +1075,7 @@ func explainLiteralFor(node *ExplainNode, name string) string {
 		default:
 			return "value"
 		}
-	case "integer":
+	case explainKindInteger:
 		switch name {
 		case "port":
 			return "80"
@@ -1734,7 +1735,7 @@ func scaffoldLiteral(node *ExplainNode) string {
 		return node.Literal
 	}
 	switch node.Kind {
-	case explainKindString, "integer", "number", "boolean":
+	case explainKindString, explainKindInteger, "number", "boolean":
 		return ""
 	case "array":
 		if node.Items != nil {

--- a/internal/declarative/resources/explain_union_schemas.go
+++ b/internal/declarative/resources/explain_union_schemas.go
@@ -395,12 +395,12 @@ func dashboardTileExplainNode() *ExplainNode {
 func dashboardLayoutExplainNode() *ExplainNode {
 	return explainObject(
 		explainField("position", explainObject(
-			explainField("col", &ExplainNode{Kind: "integer", Literal: "0"}, true, true),
-			explainField("row", &ExplainNode{Kind: "integer", Literal: "0"}, true, true),
+			explainField("col", &ExplainNode{Kind: explainKindInteger, Literal: "0"}, true, true),
+			explainField("row", &ExplainNode{Kind: explainKindInteger, Literal: "0"}, true, true),
 		), true, true),
 		explainField("size", explainObject(
-			explainField("cols", &ExplainNode{Kind: "integer", Literal: "6"}, true, true),
-			explainField("rows", &ExplainNode{Kind: "integer", Literal: "2"}, true, true),
+			explainField("cols", &ExplainNode{Kind: explainKindInteger, Literal: "6"}, true, true),
+			explainField("rows", &ExplainNode{Kind: explainKindInteger, Literal: "2"}, true, true),
 		), true, true),
 	)
 }

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -20,6 +20,7 @@ const (
 	ResourceTypeAIGateway                               ResourceType = "ai_gateway"
 	ResourceTypeAIGatewayProvider                       ResourceType = "ai_gateway_provider"
 	ResourceTypeAIGatewayPolicy                         ResourceType = "ai_gateway_policy"
+	ResourceTypeAIGatewayAgent                          ResourceType = "ai_gateway_agent"
 	ResourceTypeAIGatewayConsumer                       ResourceType = "ai_gateway_consumer"
 	ResourceTypeAIGatewayConsumerGroup                  ResourceType = "ai_gateway_consumer_group"
 	ResourceTypeAIGatewayModel                          ResourceType = "ai_gateway_model"
@@ -116,6 +117,7 @@ type ResourceSet struct {
 	AIGateways                        []AIGatewayResource                        `yaml:"ai_gateways,omitempty"                                    json:"ai_gateways,omitempty"`                           //nolint:lll
 	AIGatewayProviders                []AIGatewayProviderResource                `yaml:"ai_gateway_providers,omitempty"                          json:"ai_gateway_providers,omitempty"`                   //nolint:lll
 	AIGatewayPolicies                 []AIGatewayPolicyResource                  `yaml:"ai_gateway_policies,omitempty"                           json:"ai_gateway_policies,omitempty"`                    //nolint:lll
+	AIGatewayAgents                   []AIGatewayAgentResource                   `yaml:"ai_gateway_agents,omitempty"                             json:"ai_gateway_agents,omitempty"`                      //nolint:lll
 	AIGatewayConsumers                []AIGatewayConsumerResource                `yaml:"ai_gateway_consumers,omitempty"                          json:"ai_gateway_consumers,omitempty"`                   //nolint:lll
 	AIGatewayConsumerGroups           []AIGatewayConsumerGroupResource           `yaml:"ai_gateway_consumer_groups,omitempty"                    json:"ai_gateway_consumer_groups,omitempty"`             //nolint:lll
 	AIGatewayModels                   []AIGatewayModelResource                   `yaml:"ai_gateway_models,omitempty"                              json:"ai_gateway_models,omitempty"`                     //nolint:lll
@@ -368,6 +370,16 @@ func (rs *ResourceSet) GetAIGatewayPolicyByRef(ref string) *AIGatewayPolicyResou
 	return nil
 }
 
+// GetAIGatewayAgentByRef returns an AI Gateway Agent resource by its ref from any namespace.
+func (rs *ResourceSet) GetAIGatewayAgentByRef(ref string) *AIGatewayAgentResource {
+	for i := range rs.AIGatewayAgents {
+		if rs.AIGatewayAgents[i].GetRef() == ref {
+			return &rs.AIGatewayAgents[i]
+		}
+	}
+	return nil
+}
+
 // GetAIGatewayConsumerByRef returns an AI Gateway Consumer resource by its ref from any namespace.
 func (rs *ResourceSet) GetAIGatewayConsumerByRef(ref string) *AIGatewayConsumerResource {
 	for i := range rs.AIGatewayConsumers {
@@ -525,6 +537,25 @@ func (rs *ResourceSet) GetAIGatewayPoliciesByNamespace(namespace string) []AIGat
 			}
 			if GetNamespace(gateway.Kongctl) == namespace {
 				filtered = append(filtered, policy)
+			}
+		}
+	}
+	return filtered
+}
+
+// GetAIGatewayAgentsByNamespace returns AI Gateway Agent resources from the specified namespace.
+func (rs *ResourceSet) GetAIGatewayAgentsByNamespace(namespace string) []AIGatewayAgentResource {
+	var filtered []AIGatewayAgentResource
+	for _, agent := range rs.AIGatewayAgents {
+		if gateway := rs.GetAIGatewayByRef(agent.AIGateway); gateway != nil {
+			if gateway.IsExternal() {
+				if namespace == NamespaceExternal {
+					filtered = append(filtered, agent)
+				}
+				continue
+			}
+			if GetNamespace(gateway.Kongctl) == namespace {
+				filtered = append(filtered, agent)
 			}
 		}
 	}
@@ -1216,6 +1247,17 @@ func (rs *ResourceSet) GetAIGatewayPoliciesForGateway(gatewayRef string) []AIGat
 		}
 	}
 	return policies
+}
+
+// GetAIGatewayAgentsForGateway returns all AI Gateway Agents for a given gateway ref.
+func (rs *ResourceSet) GetAIGatewayAgentsForGateway(gatewayRef string) []AIGatewayAgentResource {
+	var agents []AIGatewayAgentResource
+	for _, agent := range rs.AIGatewayAgents {
+		if NormalizeResourceRef(agent.AIGateway) == gatewayRef {
+			agents = append(agents, agent)
+		}
+	}
+	return agents
 }
 
 // GetAIGatewayConsumersForGateway returns all AI Gateway Consumers for a given gateway ref.

--- a/internal/declarative/state/ai_gateway_agents.go
+++ b/internal/declarative/state/ai_gateway_agents.go
@@ -1,0 +1,191 @@
+package state
+
+import (
+	"context"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/util/pagination"
+)
+
+// ListAIGatewayAgents lists all Agents for an AI Gateway.
+func (c *Client) ListAIGatewayAgents(ctx context.Context, gatewayID string) ([]AIGatewayAgent, error) {
+	if err := ValidateAPIClient(c.aiGatewayAgentsAPI, "AI Gateway Agents API"); err != nil {
+		return nil, err
+	}
+
+	var allData []kkComps.AIGatewayAgent
+	var pageAfter *string
+	pageSize := int64(100)
+
+	for {
+		req := kkOps.ListAiGatewayAgentsRequest{
+			GatewayID: gatewayID,
+			PageSize:  &pageSize,
+			PageAfter: pageAfter,
+		}
+
+		resp, err := c.aiGatewayAgentsAPI.ListAiGatewayAgents(ctx, req)
+		if err != nil {
+			return nil, WrapAPIError(err, "list AI Gateway Agents", nil)
+		}
+
+		if resp == nil || resp.ListAIGatewayAgentsResponse == nil {
+			return []AIGatewayAgent{}, nil
+		}
+
+		allData = append(allData, resp.ListAIGatewayAgentsResponse.Data...)
+
+		nextCursor := pagination.ExtractPageAfterCursor(resp.ListAIGatewayAgentsResponse.Meta.Page.Next)
+		if nextCursor == "" {
+			break
+		}
+		pageAfter = &nextCursor
+	}
+
+	agents := make([]AIGatewayAgent, 0, len(allData))
+	for _, agent := range allData {
+		agents = append(agents, AIGatewayAgent{
+			AIGatewayAgent:   agent,
+			NormalizedLabels: normalizedAIGatewayAgentLabels(agent),
+		})
+	}
+	return agents, nil
+}
+
+// GetAIGatewayAgent fetches an AI Gateway Agent by ID or name.
+func (c *Client) GetAIGatewayAgent(
+	ctx context.Context,
+	gatewayID string,
+	agentID string,
+) (*AIGatewayAgent, error) {
+	if err := ValidateAPIClient(c.aiGatewayAgentsAPI, "AI Gateway Agents API"); err != nil {
+		return nil, err
+	}
+
+	resp, err := c.aiGatewayAgentsAPI.GetAiGatewayAgent(ctx, gatewayID, agentID)
+	if err != nil {
+		return nil, WrapAPIError(err, "get AI Gateway Agent by ID", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeAIGatewayAgent),
+			UseEnhanced:  true,
+		})
+	}
+
+	if resp == nil || resp.AIGatewayAgent == nil {
+		return nil, nil
+	}
+
+	return &AIGatewayAgent{
+		AIGatewayAgent:   *resp.AIGatewayAgent,
+		NormalizedLabels: normalizedAIGatewayAgentLabels(*resp.AIGatewayAgent),
+	}, nil
+}
+
+// GetAIGatewayAgentByName finds an AI Gateway Agent by name within a gateway.
+func (c *Client) GetAIGatewayAgentByName(
+	ctx context.Context,
+	gatewayID string,
+	name string,
+) (*AIGatewayAgent, error) {
+	agents, err := c.ListAIGatewayAgents(ctx, gatewayID)
+	if err != nil {
+		return nil, WrapAPIError(err, "list AI Gateway Agents to find by name", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeAIGatewayAgent),
+			ResourceName: name,
+			UseEnhanced:  true,
+		})
+	}
+
+	for i := range agents {
+		if agents[i].Name == name {
+			return &agents[i], nil
+		}
+	}
+
+	return nil, nil
+}
+
+// CreateAIGatewayAgent creates a new Agent under an AI Gateway.
+func (c *Client) CreateAIGatewayAgent(
+	ctx context.Context,
+	gatewayID string,
+	req kkComps.CreateAIGatewayAgentRequest,
+	namespace string,
+) (string, error) {
+	if err := ValidateAPIClient(c.aiGatewayAgentsAPI, "AI Gateway Agents API"); err != nil {
+		return "", err
+	}
+
+	resp, err := c.aiGatewayAgentsAPI.CreateAiGatewayAgent(ctx, gatewayID, req)
+	if err != nil {
+		return "", WrapAPIError(err, "create AI Gateway Agent", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeAIGatewayAgent),
+			ResourceName: req.Name,
+			Namespace:    namespace,
+			UseEnhanced:  true,
+		})
+	}
+
+	if resp == nil || resp.AIGatewayAgent == nil {
+		return "", fmt.Errorf("create AI Gateway Agent response missing data")
+	}
+
+	return resp.AIGatewayAgent.ID, nil
+}
+
+// UpdateAIGatewayAgent updates an existing Agent under an AI Gateway.
+func (c *Client) UpdateAIGatewayAgent(
+	ctx context.Context,
+	gatewayID string,
+	agentID string,
+	req kkComps.UpdateAIGatewayAgentRequest,
+	namespace string,
+) (string, error) {
+	if err := ValidateAPIClient(c.aiGatewayAgentsAPI, "AI Gateway Agents API"); err != nil {
+		return "", err
+	}
+
+	resp, err := c.aiGatewayAgentsAPI.UpdateAiGatewayAgent(ctx, kkOps.UpdateAiGatewayAgentRequest{
+		GatewayID:                   gatewayID,
+		AgentID:                     agentID,
+		UpdateAIGatewayAgentRequest: req,
+	})
+	if err != nil {
+		return "", WrapAPIError(err, "update AI Gateway Agent", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeAIGatewayAgent),
+			ResourceName: req.Name,
+			Namespace:    namespace,
+			UseEnhanced:  true,
+		})
+	}
+
+	if resp == nil || resp.AIGatewayAgent == nil {
+		return "", fmt.Errorf("update AI Gateway Agent response missing data")
+	}
+
+	return resp.AIGatewayAgent.ID, nil
+}
+
+// DeleteAIGatewayAgent deletes an AI Gateway Agent by ID.
+func (c *Client) DeleteAIGatewayAgent(ctx context.Context, gatewayID string, agentID string) error {
+	if err := ValidateAPIClient(c.aiGatewayAgentsAPI, "AI Gateway Agents API"); err != nil {
+		return err
+	}
+
+	_, err := c.aiGatewayAgentsAPI.DeleteAiGatewayAgent(ctx, gatewayID, agentID)
+	if err != nil {
+		return WrapAPIError(err, "delete AI Gateway Agent", nil)
+	}
+
+	return nil
+}
+
+func normalizedAIGatewayAgentLabels(agent kkComps.AIGatewayAgent) map[string]string {
+	normalized := agent.Labels
+	if normalized == nil {
+		normalized = make(map[string]string)
+	}
+	return normalized
+}

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -38,6 +38,7 @@ type ClientConfig struct {
 	AIGatewayAPI               helpers.AIGatewayAPI
 	AIGatewayProvidersAPI      helpers.AIGatewayProvidersAPI
 	AIGatewayPoliciesAPI       helpers.AIGatewayPoliciesAPI
+	AIGatewayAgentsAPI         helpers.AIGatewayAgentsAPI
 	AIGatewayConsumersAPI      helpers.AIGatewayConsumersAPI
 	AIGatewayConsumerGroupsAPI helpers.AIGatewayConsumerGroupsAPI
 	AIGatewayModelAPI          helpers.AIGatewayModelAPI
@@ -108,6 +109,7 @@ type Client struct {
 	aiGatewayAPI               helpers.AIGatewayAPI
 	aiGatewayProvidersAPI      helpers.AIGatewayProvidersAPI
 	aiGatewayPoliciesAPI       helpers.AIGatewayPoliciesAPI
+	aiGatewayAgentsAPI         helpers.AIGatewayAgentsAPI
 	aiGatewayConsumersAPI      helpers.AIGatewayConsumersAPI
 	aiGatewayConsumerGroupsAPI helpers.AIGatewayConsumerGroupsAPI
 	aiGatewayModelAPI          helpers.AIGatewayModelAPI
@@ -179,6 +181,7 @@ func NewClient(config ClientConfig) *Client {
 		aiGatewayAPI:               config.AIGatewayAPI,
 		aiGatewayProvidersAPI:      config.AIGatewayProvidersAPI,
 		aiGatewayPoliciesAPI:       config.AIGatewayPoliciesAPI,
+		aiGatewayAgentsAPI:         config.AIGatewayAgentsAPI,
 		aiGatewayConsumersAPI:      config.AIGatewayConsumersAPI,
 		aiGatewayConsumerGroupsAPI: config.AIGatewayConsumerGroupsAPI,
 		aiGatewayModelAPI:          config.AIGatewayModelAPI,
@@ -290,6 +293,12 @@ type AIGatewayProvider struct {
 // AIGatewayPolicy represents a Konnect AI Gateway Policy for internal use.
 type AIGatewayPolicy struct {
 	kkComps.AIGatewayPolicy
+	NormalizedLabels map[string]string
+}
+
+// AIGatewayAgent represents a Konnect AI Gateway Agent for internal use.
+type AIGatewayAgent struct {
+	kkComps.AIGatewayAgent
 	NormalizedLabels map[string]string
 }
 

--- a/internal/konnect/helpers/ai_gateway_agents.go
+++ b/internal/konnect/helpers/ai_gateway_agents.go
@@ -1,0 +1,89 @@
+package helpers
+
+import (
+	"context"
+
+	kkSDK "github.com/Kong/sdk-konnect-go"
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+)
+
+// AIGatewayAgentsAPI defines the interface for AI Gateway Agent operations needed by kongctl.
+type AIGatewayAgentsAPI interface {
+	ListAiGatewayAgents(
+		ctx context.Context,
+		request kkOps.ListAiGatewayAgentsRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.ListAiGatewayAgentsResponse, error)
+	CreateAiGatewayAgent(
+		ctx context.Context,
+		gatewayID string,
+		request kkComps.CreateAIGatewayAgentRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.CreateAiGatewayAgentResponse, error)
+	GetAiGatewayAgent(
+		ctx context.Context,
+		gatewayID string,
+		agentID string,
+		opts ...kkOps.Option,
+	) (*kkOps.GetAiGatewayAgentResponse, error)
+	UpdateAiGatewayAgent(
+		ctx context.Context,
+		request kkOps.UpdateAiGatewayAgentRequest,
+		opts ...kkOps.Option,
+	) (*kkOps.UpdateAiGatewayAgentResponse, error)
+	DeleteAiGatewayAgent(
+		ctx context.Context,
+		gatewayID string,
+		agentID string,
+		opts ...kkOps.Option,
+	) (*kkOps.DeleteAiGatewayAgentResponse, error)
+}
+
+// AIGatewayAgentsAPIImpl provides the real SDK implementation.
+type AIGatewayAgentsAPIImpl struct {
+	SDK *kkSDK.SDK
+}
+
+func (a *AIGatewayAgentsAPIImpl) ListAiGatewayAgents(
+	ctx context.Context,
+	request kkOps.ListAiGatewayAgentsRequest,
+	opts ...kkOps.Option,
+) (*kkOps.ListAiGatewayAgentsResponse, error) {
+	return a.SDK.AIGatewayAgents.ListAiGatewayAgents(ctx, request, opts...)
+}
+
+func (a *AIGatewayAgentsAPIImpl) CreateAiGatewayAgent(
+	ctx context.Context,
+	gatewayID string,
+	request kkComps.CreateAIGatewayAgentRequest,
+	opts ...kkOps.Option,
+) (*kkOps.CreateAiGatewayAgentResponse, error) {
+	return a.SDK.AIGatewayAgents.CreateAiGatewayAgent(ctx, gatewayID, request, opts...)
+}
+
+func (a *AIGatewayAgentsAPIImpl) GetAiGatewayAgent(
+	ctx context.Context,
+	gatewayID string,
+	agentID string,
+	opts ...kkOps.Option,
+) (*kkOps.GetAiGatewayAgentResponse, error) {
+	return a.SDK.AIGatewayAgents.GetAiGatewayAgent(ctx, gatewayID, agentID, opts...)
+}
+
+func (a *AIGatewayAgentsAPIImpl) UpdateAiGatewayAgent(
+	ctx context.Context,
+	request kkOps.UpdateAiGatewayAgentRequest,
+	opts ...kkOps.Option,
+) (*kkOps.UpdateAiGatewayAgentResponse, error) {
+	return a.SDK.AIGatewayAgents.UpdateAiGatewayAgent(ctx, request, opts...)
+}
+
+func (a *AIGatewayAgentsAPIImpl) DeleteAiGatewayAgent(
+	ctx context.Context,
+	gatewayID string,
+	agentID string,
+	opts ...kkOps.Option,
+) (*kkOps.DeleteAiGatewayAgentResponse, error) {
+	return a.SDK.AIGatewayAgents.DeleteAiGatewayAgent(ctx, gatewayID, agentID, opts...)
+}

--- a/internal/konnect/helpers/sdk.go
+++ b/internal/konnect/helpers/sdk.go
@@ -25,6 +25,7 @@ type SDKAPI interface {
 	GetAIGatewayAPI() AIGatewayAPI
 	GetAIGatewayProvidersAPI() AIGatewayProvidersAPI
 	GetAIGatewayPoliciesAPI() AIGatewayPoliciesAPI
+	GetAIGatewayAgentsAPI() AIGatewayAgentsAPI
 	GetAIGatewayConsumersAPI() AIGatewayConsumersAPI
 	GetAIGatewayConsumerGroupsAPI() AIGatewayConsumerGroupsAPI
 	GetAIGatewayModelAPI() AIGatewayModelAPI
@@ -162,6 +163,15 @@ func (k *KonnectSDK) GetAIGatewayConsumersAPI() AIGatewayConsumersAPI {
 	}
 
 	return &AIGatewayConsumersAPIImpl{SDK: k.SDK}
+}
+
+// Returns the implementation of the AIGatewayAgentsAPI interface.
+func (k *KonnectSDK) GetAIGatewayAgentsAPI() AIGatewayAgentsAPI {
+	if k.SDK == nil || k.SDK.AIGatewayAgents == nil {
+		return nil
+	}
+
+	return &AIGatewayAgentsAPIImpl{SDK: k.SDK}
 }
 
 // Returns the implementation of the AIGatewayConsumerGroupsAPI interface.

--- a/internal/konnect/helpers/sdk_mock.go
+++ b/internal/konnect/helpers/sdk_mock.go
@@ -13,6 +13,7 @@ type MockKonnectSDK struct {
 	AIGatewayFactory                   func() AIGatewayAPI
 	AIGatewayProvidersFactory          func() AIGatewayProvidersAPI
 	AIGatewayPoliciesFactory           func() AIGatewayPoliciesAPI
+	AIGatewayAgentsFactory             func() AIGatewayAgentsAPI
 	AIGatewayConsumersFactory          func() AIGatewayConsumersAPI
 	AIGatewayConsumerGroupsFactory     func() AIGatewayConsumerGroupsAPI
 	AIGatewayModelFactory              func() AIGatewayModelAPI
@@ -130,6 +131,14 @@ func (m *MockKonnectSDK) GetAIGatewayPoliciesAPI() AIGatewayPoliciesAPI {
 func (m *MockKonnectSDK) GetAIGatewayConsumersAPI() AIGatewayConsumersAPI {
 	if m.AIGatewayConsumersFactory != nil {
 		return m.AIGatewayConsumersFactory()
+	}
+	return nil
+}
+
+// Returns a mock instance of the AIGatewayAgentsAPI.
+func (m *MockKonnectSDK) GetAIGatewayAgentsAPI() AIGatewayAgentsAPI {
+	if m.AIGatewayAgentsFactory != nil {
+		return m.AIGatewayAgentsFactory()
 	}
 	return nil
 }

--- a/test/e2e/scenarios/ai-gateway/agent/overlays/001-update/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/agent/overlays/001-update/config.yaml
@@ -39,4 +39,4 @@ ai_gateways:
           logging:
             max_payload_size: 524288
         policies:
-          - !ref mask-sensitive-data
+          - !ref mask-sensitive-data#name

--- a/test/e2e/scenarios/ai-gateway/agent/overlays/001-update/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/agent/overlays/001-update/config.yaml
@@ -1,0 +1,42 @@
+ai_gateways:
+  - ref: ai-gateway-agent-e2e
+    display_name: "AI Gateway Agent E2E"
+    description: "AI Gateway Agent e2e"
+    proxy_urls:
+      - host: ai-gateway-agent-e2e.example.com
+        port: 443
+        protocol: https
+    labels:
+      owner: platform
+      lifecycle: dev
+    policies:
+      - ref: mask-sensitive-data
+        name: mask-sensitive-data
+        type: ai-sanitizer
+        display_name: "Mask Sensitive Data"
+        enabled: true
+        global: false
+        labels:
+          team: support
+          phase: create
+        config:
+          anonymize:
+            - email
+    agents:
+      - ref: booking-agent
+        name: booking-agent
+        type: a2a
+        display_name: "Booking Agent Updated"
+        enabled: true
+        labels:
+          team: support
+          phase: update
+        config:
+          url: https://booking-agent-v2.example.com
+          route:
+            paths:
+              - /booking
+          logging:
+            max_payload_size: 524288
+        policies:
+          - !ref mask-sensitive-data

--- a/test/e2e/scenarios/ai-gateway/agent/overlays/002-sync-delete-agent/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/agent/overlays/002-sync-delete-agent/config.yaml
@@ -1,0 +1,25 @@
+ai_gateways:
+  - ref: ai-gateway-agent-e2e
+    display_name: "AI Gateway Agent E2E"
+    description: "AI Gateway Agent e2e"
+    proxy_urls:
+      - host: ai-gateway-agent-e2e.example.com
+        port: 443
+        protocol: https
+    labels:
+      owner: platform
+      lifecycle: dev
+    policies:
+      - ref: mask-sensitive-data
+        name: mask-sensitive-data
+        type: ai-sanitizer
+        display_name: "Mask Sensitive Data"
+        enabled: true
+        global: false
+        labels:
+          team: support
+          phase: create
+        config:
+          anonymize:
+            - email
+    agents: []

--- a/test/e2e/scenarios/ai-gateway/agent/overlays/003-sync-delete-policy/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/agent/overlays/003-sync-delete-policy/config.yaml
@@ -1,0 +1,13 @@
+ai_gateways:
+  - ref: ai-gateway-agent-e2e
+    display_name: "AI Gateway Agent E2E"
+    description: "AI Gateway Agent e2e"
+    proxy_urls:
+      - host: ai-gateway-agent-e2e.example.com
+        port: 443
+        protocol: https
+    labels:
+      owner: platform
+      lifecycle: dev
+    policies: []
+    agents: []

--- a/test/e2e/scenarios/ai-gateway/agent/overlays/004-sync-delete-gateway/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/agent/overlays/004-sync-delete-gateway/config.yaml
@@ -1,0 +1,1 @@
+ai_gateways: []

--- a/test/e2e/scenarios/ai-gateway/agent/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/agent/scenario.yaml
@@ -1,0 +1,446 @@
+baseInputsPath: testdata
+
+env:
+  KONGCTL_LOG_LEVEL: info
+
+vars:
+  namespace: "ai-gateway-agent-e2e"
+  gateway_name: "AI Gateway Agent E2E"
+  gateway_ref: "ai-gateway-agent-e2e"
+  policy_ref: "mask-sensitive-data"
+  policy_name: "mask-sensitive-data"
+  policy_display_name: "Mask Sensitive Data"
+  agent_ref: "booking-agent"
+  agent_name: "booking-agent"
+  agent_display_name: "Booking Agent"
+  agent_updated_display_name: "Booking Agent Updated"
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - created_at
+      - updated_at
+      - config_hash
+      - endpoints
+      - resource_id
+      - change_id
+      - generated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-explain-and-scaffold
+    skipInputs: true
+    commands:
+      - name: 000-explain-ai-gateway-agent-json
+        run:
+          - explain
+          - ai_gateway_agent
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                type: object
+                '"x-kongctl-root-key"': ai_gateway_agents
+          - select: "contains(keys(properties), 'ai_gateway')"
+            expect:
+              fields:
+                "@": true
+          - select: "contains(keys(properties), 'config')"
+            expect:
+              fields:
+                "@": true
+      - name: 001-scaffold-ai-gateway-agent
+        run:
+          - scaffold
+          - ai_gateway_agent
+        outputFormat: disable
+        parseAs: raw
+        assertions:
+          - expect:
+              fields:
+                "contains(stdout, 'ai_gateway_agents:')": true
+                "contains(stdout, 'ai_gateway: !ref')": true
+                "contains(stdout, 'type: a2a')": true
+                "contains(stdout, 'config:')": true
+                "contains(stdout, 'policies:')": true
+      - name: 002-explain-ai-gateway-agents-nested-json
+        run:
+          - explain
+          - ai_gateway.agents
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                type: object
+                '"x-kongctl-resource"': ai_gateway_agent
+                '"x-kongctl-root-key"': ai_gateway_agents
+
+  - name: 002-plan-apply-create
+    commands:
+      - name: 000-plan-create
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-create.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+          - select: summary
+            expect:
+              fields:
+                total_changes: 3
+                by_action.CREATE: 3
+          - select: >-
+              changes[?resource_type=='ai_gateway_agent' && resource_ref=='{{ .vars.agent_ref }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                fields.name: "{{ .vars.agent_name }}"
+                fields.type: a2a
+                fields.display_name: "{{ .vars.agent_display_name }}"
+                fields.enabled: true
+                fields.config.url: https://booking-agent.example.com
+                fields.labels.phase: create
+                fields.policies[0]: "__REF__:{{ .vars.policy_ref }}#id"
+                references."policies.0".ref: "__REF__:{{ .vars.policy_ref }}#id"
+      - name: 001-apply-create
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-create.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 3
+                failed: 0
+                status: success
+      - name: 002-list-agents
+        run:
+          - get
+          - ai-gateway
+          - agents
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - -o
+          - json
+        recordVar:
+          name: agent_id
+          responsePath: "[?name=='{{ .vars.agent_name }}'] | [0].id"
+        assertions:
+          - select: "[?name=='{{ .vars.agent_name }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.agent_name }}"
+                type: a2a
+                display_name: "{{ .vars.agent_display_name }}"
+                enabled: true
+                labels.phase: create
+                "length(policies)": 1
+      - name: 003-get-agent-by-name
+        run:
+          - get
+          - ai-gateway
+          - agent
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - "{{ .vars.agent_name }}"
+          - -o
+          - json
+        assertions:
+          - select: name
+            expect:
+              fields:
+                "@": "{{ .vars.agent_name }}"
+          - select: type
+            expect:
+              fields:
+                "@": a2a
+      - name: 004-get-agent-by-id
+        run:
+          - get
+          - ai-gateway
+          - agents
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - "{{ .vars.agent_id }}"
+          - -o
+          - json
+        assertions:
+          - select: name
+            expect:
+              fields:
+                "@": "{{ .vars.agent_name }}"
+
+  - name: 003-plan-apply-update
+    inputOverlayDirs:
+      - overlays/001-update
+    commands:
+      - name: 000-plan-update
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-update.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+          - select: >-
+              changes[?resource_type=='ai_gateway_agent' && resource_ref=='{{ .vars.agent_ref }}'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                fields.display_name: "{{ .vars.agent_updated_display_name }}"
+                fields.config.url: https://booking-agent-v2.example.com
+                fields.labels.phase: update
+      - name: 001-apply-update
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-update.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 002-verify-update
+        run:
+          - get
+          - ai-gateway
+          - agents
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - "{{ .vars.agent_name }}"
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                display_name: "{{ .vars.agent_updated_display_name }}"
+                config.url: https://booking-agent-v2.example.com
+                labels.phase: update
+      - name: 003-diff-no-changes
+        outputFormat: text
+        parseAs: raw
+        run:
+          - diff
+          - -f
+          - "{{ .workdir }}/config.yaml"
+        assertions:
+          - select: stdout
+            expect:
+              fields:
+                "contains(@, 'No changes detected. Konnect is up to date.')": true
+
+  - name: 004-dump-round-trip
+    skipInputs: true
+    commands:
+      - name: 000-dump-ai-gateway-with-children
+        run:
+          - dump
+          - declarative
+          - "--resources=ai_gateways"
+          - "--include-child-resources"
+          - "--default-namespace={{ .vars.namespace }}"
+        outputFormat: none
+        parseAs: yaml
+        stdoutFile: "{{ .workdir }}/dump-ai-gateway.yaml"
+        assertions:
+          - select: >-
+              ai_gateways[?display_name=='{{ .vars.gateway_name }}'] | [0].agents[?name=='{{ .vars.agent_name }}'] | [0]
+            expect:
+              fields:
+                name: "{{ .vars.agent_name }}"
+                type: a2a
+                display_name: "{{ .vars.agent_updated_display_name }}"
+                config.url: https://booking-agent-v2.example.com
+                "length(policies)": 1
+          - select: >-
+              ai_gateways[?display_name=='{{ .vars.gateway_name }}'] | [0].policies[?name=='{{ .vars.policy_name }}'] | [0]
+            expect:
+              fields:
+                name: "{{ .vars.policy_name }}"
+                display_name: "{{ .vars.policy_display_name }}"
+                type: ai-sanitizer
+                config.anonymize[0]: email
+      - name: 001-plan-from-ai-gateway-dump
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/dump-ai-gateway.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+      - name: 002-dump-root-agents
+        run:
+          - dump
+          - declarative
+          - "--resources=ai_gateway_agents"
+          - "--filter-name={{ .vars.agent_name }}"
+          - "--default-namespace={{ .vars.namespace }}"
+        outputFormat: none
+        parseAs: yaml
+        assertions:
+          - select: "ai_gateway_agents[0]"
+            expect:
+              fields:
+                name: "{{ .vars.agent_name }}"
+                type: a2a
+                display_name: "{{ .vars.agent_updated_display_name }}"
+          - select: "ai_gateway_agents[0].ai_gateway != ''"
+            expect:
+              fields:
+                "@": true
+
+  - name: 005-sync-delete-agent
+    inputOverlayDirs:
+      - overlays/002-sync-delete-agent
+    commands:
+      - name: 000-sync-delete-agent
+        outputFormat: json
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: >-
+              plan.changes[?resource_type=='ai_gateway_agent' && action=='DELETE'] | [0]
+            expect:
+              fields:
+                resource_ref: "{{ .vars.agent_name }}"
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+                status: success
+      - name: 001-list-agents-empty
+        run:
+          - get
+          - ai-gateway
+          - agents
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 0
+
+  - name: 006-sync-delete-policy
+    inputOverlayDirs:
+      - overlays/003-sync-delete-policy
+    commands:
+      - name: 000-sync-delete-policy
+        outputFormat: json
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: >-
+              plan.changes[?resource_type=='ai_gateway_policy' && action=='DELETE'] | [0]
+            expect:
+              fields:
+                resource_ref: "{{ .vars.policy_name }}"
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+                status: success
+      - name: 001-list-policies-empty
+        run:
+          - get
+          - ai-gateway
+          - policies
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 0
+
+  - name: 007-sync-delete-gateway
+    inputOverlayDirs:
+      - overlays/004-sync-delete-gateway
+    commands:
+      - name: 000-sync-delete-gateway
+        outputFormat: json
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+                status: success
+      - name: 001-get-ai-gateways
+        run:
+          - get
+          - ai-gateways
+          - -o
+          - json
+        assertions:
+          - select: "[?display_name=='{{ .vars.gateway_name }}']"
+            expect:
+              fields:
+                "length(@)": 0

--- a/test/e2e/scenarios/ai-gateway/agent/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/agent/scenario.yaml
@@ -116,8 +116,7 @@ steps:
                 fields.enabled: true
                 fields.config.url: https://booking-agent.example.com
                 fields.labels.phase: create
-                fields.policies[0]: "__REF__:{{ .vars.policy_ref }}#id"
-                references."policies.0".ref: "__REF__:{{ .vars.policy_ref }}#id"
+                fields.policies[0]: "{{ .vars.policy_name }}"
       - name: 001-apply-create
         outputFormat: json
         run:

--- a/test/e2e/scenarios/ai-gateway/agent/testdata/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/agent/testdata/config.yaml
@@ -43,4 +43,4 @@ ai_gateways:
           logging:
             max_payload_size: 524288
         policies:
-          - !ref mask-sensitive-data
+          - !ref mask-sensitive-data#name

--- a/test/e2e/scenarios/ai-gateway/agent/testdata/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/agent/testdata/config.yaml
@@ -1,0 +1,46 @@
+_defaults:
+  kongctl:
+    namespace: ai-gateway-agent-e2e
+
+ai_gateways:
+  - ref: ai-gateway-agent-e2e
+    display_name: "AI Gateway Agent E2E"
+    description: "AI Gateway Agent e2e"
+    proxy_urls:
+      - host: ai-gateway-agent-e2e.example.com
+        port: 443
+        protocol: https
+    labels:
+      owner: platform
+      lifecycle: dev
+    policies:
+      - ref: mask-sensitive-data
+        name: mask-sensitive-data
+        type: ai-sanitizer
+        display_name: "Mask Sensitive Data"
+        enabled: true
+        global: false
+        labels:
+          team: support
+          phase: create
+        config:
+          anonymize:
+            - email
+    agents:
+      - ref: booking-agent
+        name: booking-agent
+        type: a2a
+        display_name: "Booking Agent"
+        enabled: true
+        labels:
+          team: support
+          phase: create
+        config:
+          url: https://booking-agent.example.com
+          route:
+            paths:
+              - /booking
+          logging:
+            max_payload_size: 524288
+        policies:
+          - !ref mask-sensitive-data


### PR DESCRIPTION
Refs #741

Summary:
- Add declarative AI Gateway Agent resources, including nested/root schemas, loader validation, sync scope, planner, executor, state, dump, and SDK helper wiring.
- Add get/list ai-gateway agents CLI commands and tableview child loading consistent with the other AI Gateway child resources.
- Add unit tests, an e2e scenario, and declarative docs/examples for nested and root-level agent declarations.

Validation:
- go fix ./...
- make format
- make build
- make test
- golangci-lint run ./internal/declarative/loader ./internal/declarative/executor ./internal/declarative/planner ./internal/declarative/resources ./internal/cmd/root/products/konnect/aigateway ./internal/cmd/root/verbs/dump
- KONGCTL_E2E_BIN=/home/rspurgeon/.local/share/worktrees/kong/kongctl/gh-741-aigw-agents/kongctl KONGCTL_E2E_ARTIFACTS_DIR=/home/rspurgeon/go/tmp/kongctl-e2e make test-e2e-scenarios SCENARIO=ai-gateway/agent LATEST_E2E_LINK=/home/rspurgeon/go/tmp/kongctl-e2e-latest (loaded and skipped without PAT)

Notes:
- Full make lint is still blocked by existing generated/mock lint findings in internal/konnect/helpers/controlplaneapi_mock.go, test/e2e/harness/portalclient/portal_api.gen.go, and internal/cmd/helper_mock.go, plus a sibling worktree permission warning.
- Authenticated targeted e2e execution reached the scenario but resetOrg returned Konnect 403 Permission denied in this environment.