### PR TITLE
fix(ci): keep required E2E status visible for conflicted PRs

### DIFF
--- a/.github/workflows/e2e-required-status.yaml
+++ b/.github/workflows/e2e-required-status.yaml
@@ -1,0 +1,63 @@
+name: E2E Required Status
+
+on:
+  pull_request_target:
+    branches: ['**']
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+env:
+  DO_NOT_TRACK: "1"
+
+concurrency:
+  group: e2e-required-status-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-required-status:
+    name: E2E Required Status
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Set E2E Required status
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const statusContext = 'E2E Required';
+            const pr = context.payload.pull_request;
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            const e2ePattern = /^(go\.mod|go\.sum|main\.go|[^/]+\.go|internal\/.*|test\/e2e\/.*|Makefile|\.goreleaser\.yml|\.github\/workflows\/e2e\.yaml|\.github\/workflows\/e2e-main-debounce\.yaml)$/;
+            const required = files.some((file) => e2ePattern.test(file.filename));
+            const state = required ? 'pending' : 'success';
+            const description = required
+              ? 'E2E required for this PR and waiting for E2E workflow.'
+              : 'E2E not required for this PR.';
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: pr.head.sha,
+              context: statusContext,
+              state,
+              description,
+              target_url: `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+            });
+
+            core.info(description);

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,7 +8,6 @@ run-name: >-
   }}
 permissions:
   contents: read
-  statuses: write
 
 on:
   pull_request:
@@ -830,6 +829,9 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      statuses: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -849,6 +851,9 @@ jobs:
             const neededResult = process.env.E2E_NEEDED_RESULT;
             const required = process.env.E2E_REQUIRED === 'true';
             const verifyResult = process.env.E2E_VERIFY_RESULT;
+            const pullRequest = context.payload.pull_request;
+            const forkPullRequest = eventName === 'pull_request' &&
+              pullRequest?.head?.repo?.full_name !== pullRequest?.base?.repo?.full_name;
 
             let state = 'success';
             let description = 'E2E not required for this change.';
@@ -866,7 +871,9 @@ jobs:
               description = 'E2E required and E2E Verify succeeded.';
             }
 
-            if (eventName === 'pull_request' || eventName === 'merge_group') {
+            if (forkPullRequest) {
+              core.warning('Skipping E2E Required status update for fork pull request.');
+            } else if (eventName === 'pull_request' || eventName === 'merge_group') {
               await github.rest.repos.createCommitStatus({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,6 +8,7 @@ run-name: >-
   }}
 permissions:
   contents: read
+  statuses: write
 
 on:
   pull_request:
@@ -822,7 +823,7 @@ jobs:
           echo "Verified ${scenario_count} scenarios across ${total} shards."
 
   e2e-required:
-    name: E2E Required
+    name: E2E Required Status
     needs:
       - e2e-needed
       - e2e-verify
@@ -835,23 +836,51 @@ jobs:
         with:
           egress-policy: audit
       - name: Check requirement outcome
-        shell: bash
-        run: |
-          set -euo pipefail
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          E2E_NEEDED_RESULT: ${{ needs.e2e-needed.result }}
+          E2E_REQUIRED: ${{ needs.e2e-needed.outputs.required }}
+          E2E_VERIFY_RESULT: ${{ needs.e2e-verify.result }}
+          STATUS_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        with:
+          script: |
+            const statusContext = 'E2E Required';
+            const eventName = process.env.GITHUB_EVENT_NAME;
+            const neededResult = process.env.E2E_NEEDED_RESULT;
+            const required = process.env.E2E_REQUIRED === 'true';
+            const verifyResult = process.env.E2E_VERIFY_RESULT;
 
-          if [ "${{ needs.e2e-needed.result }}" != "success" ]; then
-            echo "::error::E2E Needed concluded ${{ needs.e2e-needed.result }}."
-            exit 1
-          fi
+            let state = 'success';
+            let description = 'E2E not required for this change.';
+            let failureMessage = '';
 
-          if [ "${{ needs.e2e-needed.outputs.required }}" != "true" ]; then
-            echo "E2E not required for this change."
-            exit 0
-          fi
+            if (neededResult !== 'success') {
+              state = 'failure';
+              description = `E2E Needed concluded ${neededResult}.`;
+              failureMessage = description;
+            } else if (required && verifyResult !== 'success') {
+              state = 'failure';
+              description = `E2E required but E2E Verify concluded ${verifyResult}.`;
+              failureMessage = description;
+            } else if (required) {
+              description = 'E2E required and E2E Verify succeeded.';
+            }
 
-          if [ "${{ needs.e2e-verify.result }}" != "success" ]; then
-            echo "::error::E2E required but E2E Verify concluded ${{ needs.e2e-verify.result }}."
-            exit 1
-          fi
+            if (eventName === 'pull_request' || eventName === 'merge_group') {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha: process.env.STATUS_SHA,
+                context: statusContext,
+                state,
+                description,
+                target_url: `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+              });
+            }
 
-          echo "E2E required and E2E Verify succeeded."
+            if (failureMessage) {
+              core.setFailed(failureMessage);
+              return;
+            }
+
+            core.info(description);


### PR DESCRIPTION
Summary: Adds a pull_request_target status preflight for E2E Required and has the E2E finalizer update that status so conflicted PRs do not appear green. Tests: actionlint .github/workflows/e2e.yaml .github/workflows/e2e-required-status.yaml; ruby YAML parse; git diff --check.