### PR TITLE
fix(declarative): preserve namespace on child deletes

### DIFF
--- a/internal/declarative/planner/api_planner.go
+++ b/internal/declarative/planner/api_planner.go
@@ -858,7 +858,7 @@ func (p *Planner) planAPIVersionChanges(
 					slog.String("version", versionStr),
 					slog.String("version_id", current.ID),
 				)
-				p.planAPIVersionDelete(apiRef, apiID, current.ID, versionStr, plan)
+				p.planAPIVersionDelete(parentNamespace, apiRef, apiID, current.ID, versionStr, plan)
 			}
 		}
 	}
@@ -919,7 +919,9 @@ func (p *Planner) planAPIVersionCreate(
 	plan.AddChange(change)
 }
 
-func (p *Planner) planAPIVersionDelete(apiRef string, apiID string, versionID string, versionStr string, plan *Plan) {
+func (p *Planner) planAPIVersionDelete(
+	parentNamespace string, apiRef string, apiID string, versionID string, versionStr string, plan *Plan,
+) {
 	change := PlannedChange{
 		ID:           p.nextChangeID(ActionDelete, ResourceTypeAPIVersion, versionID),
 		ResourceType: ResourceTypeAPIVersion,
@@ -933,6 +935,7 @@ func (p *Planner) planAPIVersionDelete(apiRef string, apiID string, versionID st
 		Action:    ActionDelete,
 		Fields:    map[string]any{FieldVersion: versionStr},
 		DependsOn: []string{},
+		Namespace: parentNamespace,
 	}
 
 	plan.AddChange(change)
@@ -1148,7 +1151,7 @@ func (p *Planner) planAPIPublicationChanges(
 					portalRef = portalID // Fallback to ID if ref not found
 				}
 				current := currentByPortal[portalID]
-				p.planAPIPublicationDelete(apiRef, apiID, portalID, portalRef, current, plan)
+				p.planAPIPublicationDelete(parentNamespace, apiRef, apiID, portalID, portalRef, current, plan)
 			}
 		}
 	}
@@ -1268,6 +1271,7 @@ func (p *Planner) getAuthStrategyName(strategy resources.ApplicationAuthStrategy
 }
 
 func (p *Planner) planAPIPublicationDelete(
+	parentNamespace string,
 	apiRef string,
 	apiID string,
 	portalID string,
@@ -1297,6 +1301,7 @@ func (p *Planner) planAPIPublicationDelete(
 			FieldPortalID: portalID,
 		},
 		DependsOn: []string{},
+		Namespace: parentNamespace,
 	}
 
 	if len(current.AuthStrategyIDs) > 0 {
@@ -1754,7 +1759,7 @@ func (p *Planner) planAPIDocumentChanges(
 	if plan.Metadata.Mode == PlanModeSync {
 		remaining := stateIndex.unprocessed()
 		for path, current := range remaining {
-			p.planAPIDocumentDelete(apiRef, apiID, current.ID, path, plan)
+			p.planAPIDocumentDelete(parentNamespace, apiRef, apiID, current.ID, path, plan)
 		}
 	}
 
@@ -2089,7 +2094,9 @@ func (p *Planner) planAPIDocumentUpdate(
 	plan.AddChange(change)
 }
 
-func (p *Planner) planAPIDocumentDelete(apiRef string, apiID string, documentID string, path string, plan *Plan) {
+func (p *Planner) planAPIDocumentDelete(
+	parentNamespace string, apiRef string, apiID string, documentID string, path string, plan *Plan,
+) {
 	change := PlannedChange{
 		ID:           p.nextChangeID(ActionDelete, ResourceTypeAPIDocument, documentID),
 		ResourceType: ResourceTypeAPIDocument,
@@ -2103,6 +2110,7 @@ func (p *Planner) planAPIDocumentDelete(apiRef string, apiID string, documentID 
 		Action:    ActionDelete,
 		Fields:    map[string]any{FieldSlug: path},
 		DependsOn: []string{},
+		Namespace: parentNamespace,
 	}
 
 	// Set API reference for executor

--- a/internal/declarative/planner/control_plane_data_plane_certificate_planner.go
+++ b/internal/declarative/planner/control_plane_data_plane_certificate_planner.go
@@ -117,6 +117,7 @@ func (p *Planner) planControlPlaneDataPlaneCertificateDiff(
 
 			certValue := getString(current.Cert)
 			p.planControlPlaneDataPlaneCertificateDelete(
+				namespace,
 				controlPlaneRef,
 				controlPlaneID,
 				getString(current.ID),
@@ -198,6 +199,7 @@ func (p *Planner) planControlPlaneDataPlaneCertificateCreate(
 }
 
 func (p *Planner) planControlPlaneDataPlaneCertificateDelete(
+	namespace string,
 	controlPlaneRef string,
 	controlPlaneID string,
 	certID string,
@@ -212,6 +214,7 @@ func (p *Planner) planControlPlaneDataPlaneCertificateDelete(
 		ResourceID:   certID,
 		Action:       ActionDelete,
 		DependsOn:    dependsOn,
+		Namespace:    namespace,
 		Parent: &ParentInfo{
 			Ref: controlPlaneRef,
 			ID:  controlPlaneID,

--- a/internal/declarative/planner/delete_namespace_test.go
+++ b/internal/declarative/planner/delete_namespace_test.go
@@ -1,0 +1,156 @@
+package planner
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteBuildersSetNamespace(t *testing.T) {
+	t.Parallel()
+
+	const namespace = "team-a"
+
+	testCases := []struct {
+		name         string
+		resourceType string
+		planDelete   func(*Planner, *Plan)
+	}{
+		{
+			name:         "api version",
+			resourceType: ResourceTypeAPIVersion,
+			planDelete: func(p *Planner, plan *Plan) {
+				p.planAPIVersionDelete(namespace, "api", "api-id", "version-id", "v1", plan)
+			},
+		},
+		{
+			name:         "api publication",
+			resourceType: ResourceTypeAPIPublication,
+			planDelete: func(p *Planner, plan *Plan) {
+				p.planAPIPublicationDelete(namespace, "api", "api-id", "portal-id", "portal", state.APIPublication{}, plan)
+			},
+		},
+		{
+			name:         "api document",
+			resourceType: ResourceTypeAPIDocument,
+			planDelete: func(p *Planner, plan *Plan) {
+				p.planAPIDocumentDelete(namespace, "api", "api-id", "document-id", "overview", plan)
+			},
+		},
+		{
+			name:         "control plane data plane certificate",
+			resourceType: ResourceTypeControlPlaneDataPlaneCertificate,
+			planDelete: func(p *Planner, plan *Plan) {
+				p.planControlPlaneDataPlaneCertificateDelete(namespace, "cp", "cp-id", "cert-id", "cert-fp", nil, plan)
+			},
+		},
+		{
+			name:         "event gateway backend cluster",
+			resourceType: ResourceTypeEventGatewayBackendCluster,
+			planDelete: func(p *Planner, plan *Plan) {
+				p.planBackendClusterDelete(namespace, "gateway", "Gateway", "gateway-id", "cluster-id", "cluster", plan)
+			},
+		},
+		{
+			name:         "event gateway cluster policy",
+			resourceType: ResourceTypeEventGatewayClusterPolicy,
+			planDelete: func(p *Planner, plan *Plan) {
+				p.planClusterPolicyDelete(namespace, "gateway-id", "gateway", "cluster-id", "cluster", "policy-id", "policy", plan)
+			},
+		},
+		{
+			name:         "event gateway consume policy",
+			resourceType: ResourceTypeEventGatewayConsumePolicy,
+			planDelete: func(p *Planner, plan *Plan) {
+				p.planConsumePolicyDelete(namespace, "gateway-id", "gateway", "cluster-id", "cluster", "policy-id", "policy", plan)
+			},
+		},
+		{
+			name:         "event gateway data plane certificate",
+			resourceType: ResourceTypeEventGatewayDataPlaneCertificate,
+			planDelete: func(p *Planner, plan *Plan) {
+				p.planDataPlaneCertificateDelete(namespace, "gateway", "Gateway", "gateway-id", "cert-id", "cert", plan)
+			},
+		},
+		{
+			name:         "event gateway listener",
+			resourceType: ResourceTypeEventGatewayListener,
+			planDelete: func(p *Planner, plan *Plan) {
+				p.planListenerDelete(namespace, "gateway", "Gateway", "gateway-id", "listener-id", "listener", plan)
+			},
+		},
+		{
+			name:         "event gateway listener policy",
+			resourceType: ResourceTypeEventGatewayListenerPolicy,
+			planDelete: func(p *Planner, plan *Plan) {
+				p.planListenerPolicyDelete(
+					namespace, "gateway-id", "gateway", "listener-id", "listener", "policy-id", "policy", plan,
+				)
+			},
+		},
+		{
+			name:         "event gateway produce policy",
+			resourceType: ResourceTypeEventGatewayProducePolicy,
+			planDelete: func(p *Planner, plan *Plan) {
+				p.planProducePolicyDelete(namespace, "gateway-id", "gateway", "cluster-id", "cluster", "policy-id", "policy", plan)
+			},
+		},
+		{
+			name:         "event gateway schema registry",
+			resourceType: ResourceTypeEventGatewaySchemaRegistry,
+			planDelete: func(p *Planner, plan *Plan) {
+				p.planSchemaRegistryDelete(namespace, "gateway", "gateway-id", "registry-id", "registry", plan)
+			},
+		},
+		{
+			name:         "event gateway static key",
+			resourceType: ResourceTypeEventGatewayStaticKey,
+			planDelete: func(p *Planner, plan *Plan) {
+				p.planStaticKeyDelete(namespace, "gateway", "Gateway", "gateway-id", "key-id", "key", plan)
+			},
+		},
+		{
+			name:         "event gateway TLS trust bundle",
+			resourceType: ResourceTypeEventGatewayTLSTrustBundle,
+			planDelete: func(p *Planner, plan *Plan) {
+				p.planTrustBundleDelete(namespace, "gateway", "gateway-id", "bundle-id", "bundle", plan)
+			},
+		},
+		{
+			name:         "event gateway virtual cluster",
+			resourceType: ResourceTypeEventGatewayVirtualCluster,
+			planDelete: func(p *Planner, plan *Plan) {
+				p.planVirtualClusterDelete(namespace, "gateway", "Gateway", "gateway-id", "cluster-id", "cluster", plan)
+			},
+		},
+		{
+			name:         "portal page",
+			resourceType: ResourceTypePortalPage,
+			planDelete: func(p *Planner, plan *Plan) {
+				p.planPortalPageDelete(namespace, "portal", "portal-id", "page-id", "overview", plan)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			planner := NewPlanner(nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+			planner.resources = &resources.ResourceSet{}
+			plan := NewPlan("1.0", "test", PlanModeSync)
+
+			tc.planDelete(planner, plan)
+
+			require.Len(t, plan.Changes, 1)
+			assert.Equal(t, tc.resourceType, plan.Changes[0].ResourceType)
+			assert.Equal(t, ActionDelete, plan.Changes[0].Action)
+			assert.Equal(t, namespace, plan.Changes[0].Namespace)
+		})
+	}
+}

--- a/internal/declarative/planner/event_gateway_backend_cluster_planner.go
+++ b/internal/declarative/planner/event_gateway_backend_cluster_planner.go
@@ -136,7 +136,7 @@ func (p *Planner) planBackendClusterChangesForExistingGateway(
 					"cluster_name", name,
 					"cluster_id", current.ID,
 				)
-				p.planBackendClusterDelete(gatewayRef, gatewayName, gatewayID, current.ID, name, plan)
+				p.planBackendClusterDelete(namespace, gatewayRef, gatewayName, gatewayID, current.ID, name, plan)
 			}
 		}
 	}
@@ -288,6 +288,7 @@ func (p *Planner) planBackendClusterUpdate(
 
 // planBackendClusterDelete plans a DELETE change for a backend cluster
 func (p *Planner) planBackendClusterDelete(
+	namespace string,
 	gatewayRef string,
 	_ string, // gatewayName - unused but kept for API consistency
 	gatewayID string,
@@ -302,6 +303,7 @@ func (p *Planner) planBackendClusterDelete(
 		ResourceID:   clusterID,
 		Action:       ActionDelete,
 		Fields:       map[string]any{},
+		Namespace:    namespace,
 	}
 
 	change.Parent = &ParentInfo{

--- a/internal/declarative/planner/event_gateway_cluster_policy_planner.go
+++ b/internal/declarative/planner/event_gateway_cluster_policy_planner.go
@@ -145,7 +145,7 @@ func (p *Planner) planClusterPolicyChangesForExistingVirtualCluster(
 					"policy_id", current.ID,
 				)
 				p.planClusterPolicyDelete(
-					gatewayID, gatewayRef, virtualClusterID, virtualClusterRef,
+					namespace, gatewayID, gatewayRef, virtualClusterID, virtualClusterRef,
 					current.ID, name, plan,
 				)
 			}
@@ -299,6 +299,7 @@ func (p *Planner) planClusterPolicyUpdate(
 
 // planClusterPolicyDelete plans a DELETE change for a cluster policy
 func (p *Planner) planClusterPolicyDelete(
+	namespace string,
 	gatewayID string,
 	gatewayRef string,
 	virtualClusterID string,
@@ -313,6 +314,7 @@ func (p *Planner) planClusterPolicyDelete(
 		ResourceRef:  policyName,
 		ResourceID:   policyID,
 		Action:       ActionDelete,
+		Namespace:    namespace,
 		Parent: &ParentInfo{
 			Ref: virtualClusterRef,
 			ID:  virtualClusterID,

--- a/internal/declarative/planner/event_gateway_consume_policy_planner.go
+++ b/internal/declarative/planner/event_gateway_consume_policy_planner.go
@@ -131,7 +131,7 @@ func (p *Planner) planConsumePolicyChangesForExistingVirtualCluster(
 						"changed_fields", changedFields,
 					)
 					deleteID := p.planConsumePolicyDelete(
-						gatewayID, gatewayRef, virtualClusterID, virtualClusterRef,
+						namespace, gatewayID, gatewayRef, virtualClusterID, virtualClusterRef,
 						current.ID, policyName, plan,
 					)
 					p.planConsumePolicyCreate(
@@ -164,7 +164,7 @@ func (p *Planner) planConsumePolicyChangesForExistingVirtualCluster(
 					"policy_id", current.ID,
 				)
 				p.planConsumePolicyDelete(
-					gatewayID, gatewayRef, virtualClusterID, virtualClusterRef,
+					namespace, gatewayID, gatewayRef, virtualClusterID, virtualClusterRef,
 					current.ID, name, plan,
 				)
 			}
@@ -408,6 +408,7 @@ func (p *Planner) addConsumePolicyParentPolicyReference(change *PlannedChange) {
 
 // planConsumePolicyDelete plans a DELETE change for a consume policy.
 func (p *Planner) planConsumePolicyDelete(
+	namespace string,
 	gatewayID string,
 	gatewayRef string,
 	virtualClusterID string,
@@ -422,6 +423,7 @@ func (p *Planner) planConsumePolicyDelete(
 		ResourceRef:  policyName,
 		ResourceID:   policyID,
 		Action:       ActionDelete,
+		Namespace:    namespace,
 		Parent: &ParentInfo{
 			Ref: virtualClusterRef,
 			ID:  virtualClusterID,

--- a/internal/declarative/planner/event_gateway_data_plane_certificate_planner.go
+++ b/internal/declarative/planner/event_gateway_data_plane_certificate_planner.go
@@ -132,7 +132,7 @@ func (p *Planner) planDataPlaneCertificateChangesForExistingGateway(
 					"cert_name", name,
 					"cert_id", current.ID,
 				)
-				p.planDataPlaneCertificateDelete(gatewayRef, gatewayName, gatewayID, current.ID, name, plan)
+				p.planDataPlaneCertificateDelete(namespace, gatewayRef, gatewayName, gatewayID, current.ID, name, plan)
 			}
 		}
 	}
@@ -261,6 +261,7 @@ func (p *Planner) planDataPlaneCertificateUpdate(
 
 // planDataPlaneCertificateDelete plans a DELETE change for a data plane certificate
 func (p *Planner) planDataPlaneCertificateDelete(
+	namespace string,
 	gatewayRef string,
 	_ string, // gatewayName - unused but kept for API consistency
 	gatewayID string,
@@ -274,6 +275,7 @@ func (p *Planner) planDataPlaneCertificateDelete(
 		ResourceRef:  certName,
 		ResourceID:   certID,
 		Action:       ActionDelete,
+		Namespace:    namespace,
 		Parent: &ParentInfo{
 			Ref: gatewayRef,
 			ID:  gatewayID,

--- a/internal/declarative/planner/event_gateway_listener_planner.go
+++ b/internal/declarative/planner/event_gateway_listener_planner.go
@@ -168,7 +168,7 @@ func (p *Planner) planListenerChangesForExistingGateway(
 					"listener_name", name,
 					"listener_id", current.ID,
 				)
-				p.planListenerDelete(gatewayRef, gatewayName, gatewayID, current.ID, name, plan)
+				p.planListenerDelete(namespace, gatewayRef, gatewayName, gatewayID, current.ID, name, plan)
 			}
 		}
 	}
@@ -323,6 +323,7 @@ func (p *Planner) planListenerUpdate(
 
 // planListenerDelete plans a DELETE change for a listener
 func (p *Planner) planListenerDelete(
+	namespace string,
 	gatewayRef string,
 	_ string, // gatewayName - unused but kept for API consistency
 	gatewayID string,
@@ -336,6 +337,7 @@ func (p *Planner) planListenerDelete(
 		ResourceRef:  listenerName,
 		ResourceID:   listenerID,
 		Action:       ActionDelete,
+		Namespace:    namespace,
 		Parent: &ParentInfo{
 			Ref: gatewayRef,
 			ID:  gatewayID,

--- a/internal/declarative/planner/event_gateway_listener_policy_planner.go
+++ b/internal/declarative/planner/event_gateway_listener_policy_planner.go
@@ -145,7 +145,7 @@ func (p *Planner) planListenerPolicyChangesForExistingListener(
 					"policy_id", current.ID,
 				)
 				p.planListenerPolicyDelete(
-					gatewayID, gatewayRef, listenerID, listenerRef,
+					namespace, gatewayID, gatewayRef, listenerID, listenerRef,
 					current.ID, name, plan,
 				)
 			}
@@ -305,6 +305,7 @@ func (p *Planner) planListenerPolicyUpdate(
 
 // planListenerPolicyDelete plans a DELETE change for a listener policy
 func (p *Planner) planListenerPolicyDelete(
+	namespace string,
 	gatewayID string,
 	gatewayRef string,
 	listenerID string,
@@ -319,6 +320,7 @@ func (p *Planner) planListenerPolicyDelete(
 		ResourceRef:  policyName,
 		ResourceID:   policyID,
 		Action:       ActionDelete,
+		Namespace:    namespace,
 		Parent: &ParentInfo{
 			Ref: listenerRef,
 			ID:  listenerID,

--- a/internal/declarative/planner/event_gateway_produce_policy_planner.go
+++ b/internal/declarative/planner/event_gateway_produce_policy_planner.go
@@ -116,7 +116,7 @@ func (p *Planner) planProducePolicyChangesForExistingVirtualCluster(
 						"policy_id", current.ID,
 					)
 					deleteID := p.planProducePolicyDelete(
-						gatewayID, gatewayRef, virtualClusterID, virtualClusterRef,
+						namespace, gatewayID, gatewayRef, virtualClusterID, virtualClusterRef,
 						current.ID, policyName, plan,
 					)
 					p.planProducePolicyCreate(
@@ -148,7 +148,7 @@ func (p *Planner) planProducePolicyChangesForExistingVirtualCluster(
 					"policy_id", current.ID,
 				)
 				p.planProducePolicyDelete(
-					gatewayID, gatewayRef, virtualClusterID, virtualClusterRef,
+					namespace, gatewayID, gatewayRef, virtualClusterID, virtualClusterRef,
 					current.ID, name, plan,
 				)
 			}
@@ -490,6 +490,7 @@ func stringValueAtFieldPath(fields map[string]any, fieldPath string) (string, bo
 }
 
 func (p *Planner) planProducePolicyDelete(
+	namespace string,
 	gatewayID string,
 	gatewayRef string,
 	virtualClusterID string,
@@ -504,6 +505,7 @@ func (p *Planner) planProducePolicyDelete(
 		ResourceRef:  policyName,
 		ResourceID:   policyID,
 		Action:       ActionDelete,
+		Namespace:    namespace,
 		Parent: &ParentInfo{
 			Ref: virtualClusterRef,
 			ID:  virtualClusterID,

--- a/internal/declarative/planner/event_gateway_schema_registry_planner.go
+++ b/internal/declarative/planner/event_gateway_schema_registry_planner.go
@@ -126,7 +126,7 @@ func (p *Planner) planSchemaRegistryChangesForExistingGateway(
 					"registry_name", name,
 					"registry_id", current.ID,
 				)
-				p.planSchemaRegistryDelete(gatewayRef, gatewayID, current.ID, name, plan)
+				p.planSchemaRegistryDelete(namespace, gatewayRef, gatewayID, current.ID, name, plan)
 			}
 		}
 	}
@@ -236,6 +236,7 @@ func (p *Planner) planSchemaRegistryUpdate(
 
 // planSchemaRegistryDelete plans a DELETE change for a schema registry.
 func (p *Planner) planSchemaRegistryDelete(
+	namespace string,
 	gatewayRef string,
 	gatewayID string,
 	registryID string,
@@ -248,7 +249,7 @@ func (p *Planner) planSchemaRegistryDelete(
 		ResourceRef:  registryName,
 		ResourceID:   registryID,
 		Action:       ActionDelete,
-		Namespace:    "",
+		Namespace:    namespace,
 		Parent: &ParentInfo{
 			Ref: gatewayRef,
 			ID:  gatewayID,

--- a/internal/declarative/planner/event_gateway_static_key_planner.go
+++ b/internal/declarative/planner/event_gateway_static_key_planner.go
@@ -105,7 +105,9 @@ func (p *Planner) planStaticKeyChangesForExistingGateway(
 					"key_id", current.ID,
 					"gateway_ref", gatewayRef,
 				)
-				deleteChangeID := p.planStaticKeyDelete(gatewayRef, gatewayName, gatewayID, current.ID, desiredKey.Name, plan)
+				deleteChangeID := p.planStaticKeyDelete(
+					namespace, gatewayRef, gatewayName, gatewayID, current.ID, desiredKey.Name, plan,
+				)
 				// CREATE depends on the DELETE being applied first
 				p.planStaticKeyCreate(namespace, gatewayRef, gatewayName, gatewayID, desiredKey,
 					[]string{deleteChangeID}, plan)
@@ -122,7 +124,7 @@ func (p *Planner) planStaticKeyChangesForExistingGateway(
 					"key_name", name,
 					"key_id", current.ID,
 				)
-				p.planStaticKeyDelete(gatewayRef, gatewayName, gatewayID, current.ID, name, plan)
+				p.planStaticKeyDelete(namespace, gatewayRef, gatewayName, gatewayID, current.ID, name, plan)
 			}
 		}
 	}
@@ -218,6 +220,7 @@ func (p *Planner) planStaticKeyCreate(
 
 // planStaticKeyDelete plans a DELETE change for a static key and returns the change ID.
 func (p *Planner) planStaticKeyDelete(
+	namespace string,
 	gatewayRef string,
 	_ string, // gatewayName - unused but kept for API consistency
 	gatewayID string,
@@ -234,6 +237,7 @@ func (p *Planner) planStaticKeyDelete(
 		ResourceID:   keyID,
 		Action:       ActionDelete,
 		Fields:       map[string]any{},
+		Namespace:    namespace,
 		Parent: &ParentInfo{
 			Ref: gatewayRef,
 			ID:  gatewayID,

--- a/internal/declarative/planner/event_gateway_tls_trust_bundle_planner.go
+++ b/internal/declarative/planner/event_gateway_tls_trust_bundle_planner.go
@@ -125,7 +125,7 @@ func (p *Planner) planTrustBundleChangesForExistingGateway(
 					"bundle_name", name,
 					"bundle_id", current.ID,
 				)
-				p.planTrustBundleDelete(gatewayRef, gatewayID, current.ID, name, plan)
+				p.planTrustBundleDelete(namespace, gatewayRef, gatewayID, current.ID, name, plan)
 			}
 		}
 	}
@@ -234,6 +234,7 @@ func (p *Planner) planTrustBundleUpdate(
 
 // planTrustBundleDelete plans a DELETE change for a TLS trust bundle.
 func (p *Planner) planTrustBundleDelete(
+	namespace string,
 	gatewayRef string,
 	gatewayID string,
 	bundleID string,
@@ -246,7 +247,7 @@ func (p *Planner) planTrustBundleDelete(
 		ResourceRef:  bundleName,
 		ResourceID:   bundleID,
 		Action:       ActionDelete,
-		Namespace:    "",
+		Namespace:    namespace,
 		Parent: &ParentInfo{
 			Ref: gatewayRef,
 			ID:  gatewayID,

--- a/internal/declarative/planner/event_gateway_virtual_cluster_planner.go
+++ b/internal/declarative/planner/event_gateway_virtual_cluster_planner.go
@@ -237,7 +237,7 @@ func (p *Planner) planVirtualClusterChangesForExistingGateway(
 					"cluster_name", name,
 					"cluster_id", current.ID,
 				)
-				p.planVirtualClusterDelete(gatewayRef, gatewayName, gatewayID, current.ID, name, plan)
+				p.planVirtualClusterDelete(namespace, gatewayRef, gatewayName, gatewayID, current.ID, name, plan)
 			}
 		}
 	}
@@ -481,6 +481,7 @@ func (p *Planner) planVirtualClusterUpdate(
 
 // planVirtualClusterDelete plans a DELETE change for a virtual cluster
 func (p *Planner) planVirtualClusterDelete(
+	namespace string,
 	gatewayRef string,
 	_ string, // gatewayName - unused but kept for API consistency
 	gatewayID string,
@@ -494,6 +495,7 @@ func (p *Planner) planVirtualClusterDelete(
 		ResourceRef:  clusterName,
 		ResourceID:   clusterID,
 		Action:       ActionDelete,
+		Namespace:    namespace,
 		Parent: &ParentInfo{
 			Ref: gatewayRef,
 			ID:  gatewayID,

--- a/internal/declarative/planner/planner_test.go
+++ b/internal/declarative/planner/planner_test.go
@@ -109,7 +109,9 @@ func (s *stubAPIPublicationAPI) ListAPIPublications(
 	}, nil
 }
 
-type stubAPIVersionAPI struct{}
+type stubAPIVersionAPI struct {
+	response *kkOps.ListAPIVersionsResponse
+}
 
 func (s *stubAPIVersionAPI) CreateAPIVersion(
 	_ context.Context,
@@ -125,6 +127,9 @@ func (s *stubAPIVersionAPI) ListAPIVersions(
 	_ kkOps.ListAPIVersionsRequest,
 	_ ...kkOps.Option,
 ) (*kkOps.ListAPIVersionsResponse, error) {
+	if s.response != nil {
+		return s.response, nil
+	}
 	return &kkOps.ListAPIVersionsResponse{
 		ListAPIVersionResponse: &kkComps.ListAPIVersionResponse{
 			Data: []kkComps.ListAPIVersionResponseAPIVersionSummary{},
@@ -196,7 +201,9 @@ func (s *stubAPIImplementationAPI) DeleteAPIImplementation(
 	return nil, fmt.Errorf("DeleteAPIImplementation not implemented")
 }
 
-type stubAPIDocumentAPI struct{}
+type stubAPIDocumentAPI struct {
+	response *kkOps.ListAPIDocumentsResponse
+}
 
 func (s *stubAPIDocumentAPI) CreateAPIDocument(
 	_ context.Context,
@@ -232,6 +239,9 @@ func (s *stubAPIDocumentAPI) ListAPIDocuments(
 	_ *kkComps.APIDocumentFilterParameters,
 	_ ...kkOps.Option,
 ) (*kkOps.ListAPIDocumentsResponse, error) {
+	if s.response != nil {
+		return s.response, nil
+	}
 	return &kkOps.ListAPIDocumentsResponse{
 		ListAPIDocumentResponse: &kkComps.ListAPIDocumentResponse{
 			Data: []kkComps.APIDocumentSummaryWithChildren{},
@@ -1358,5 +1368,152 @@ func TestGeneratePlan_SyncDeletesRespectAuthStrategyDependencies(t *testing.T) {
 
 	mockPortalAPI.AssertExpectations(t)
 	mockAPIAPI.AssertExpectations(t)
+	mockAppAuthAPI.AssertExpectations(t)
+}
+
+func TestGeneratePlan_APIChildDeleteChangesUseParentNamespace(t *testing.T) {
+	ctx := context.Background()
+	namespace := "team-a"
+	apiID := "api-123"
+	apiName := "orders-api"
+	apiRef := "orders"
+	portalID := "portal-123"
+	portalName := "docs"
+
+	mockPortalAPI := new(MockPortalAPI)
+	mockAPIAPI := new(MockAPIAPI)
+	mockAppAuthAPI := new(MockAppAuthStrategiesAPI)
+
+	mockAPIAPI.On("ListApis", mock.Anything, mock.Anything).Return(&kkOps.ListApisResponse{
+		ListAPIResponse: &kkComps.ListAPIResponse{
+			Data: []kkComps.APIResponseSchema{
+				{
+					ID:   apiID,
+					Name: apiName,
+					Labels: map[string]string{
+						labels.NamespaceKey: namespace,
+					},
+				},
+			},
+			Meta: kkComps.PaginatedMeta{
+				Page: kkComps.PageMeta{Total: 1},
+			},
+		},
+	}, nil)
+	mockPortalAPI.On("ListPortals", mock.Anything, mock.Anything).Return(&kkOps.ListPortalsResponse{
+		ListPortalsResponse: &kkComps.ListPortalsResponse{
+			Data: []kkComps.ListPortalsResponsePortal{
+				newListPortal(portalID, portalName, map[string]string{labels.NamespaceKey: namespace}),
+			},
+			Meta: kkComps.PaginatedMeta{
+				Page: kkComps.PageMeta{Total: 1},
+			},
+		},
+	}, nil).Maybe()
+	mockAppAuthAPI.On("ListAppAuthStrategies", mock.Anything, mock.Anything).
+		Return(&kkOps.ListAppAuthStrategiesResponse{
+			ListAppAuthStrategiesResponse: &kkComps.ListAppAuthStrategiesResponse{
+				Data: []kkComps.AppAuthStrategy{},
+				Meta: kkComps.PaginatedMeta{
+					Page: kkComps.PageMeta{Total: 0},
+				},
+			},
+		}, nil).Maybe()
+
+	client := state.NewClient(state.ClientConfig{
+		PortalAPI:  mockPortalAPI,
+		APIAPI:     mockAPIAPI,
+		AppAuthAPI: mockAppAuthAPI,
+		APIVersionAPI: &stubAPIVersionAPI{
+			response: &kkOps.ListAPIVersionsResponse{
+				ListAPIVersionResponse: &kkComps.ListAPIVersionResponse{
+					Data: []kkComps.ListAPIVersionResponseAPIVersionSummary{
+						{
+							ID:      "version-123",
+							Version: "v1",
+						},
+					},
+					Meta: kkComps.PaginatedMeta{
+						Page: kkComps.PageMeta{Total: 1},
+					},
+				},
+			},
+		},
+		APIPublicationAPI: &stubAPIPublicationAPI{
+			response: &kkOps.ListAPIPublicationsResponse{
+				ListAPIPublicationResponse: &kkComps.ListAPIPublicationResponse{
+					Data: []kkComps.APIPublicationListItem{
+						{
+							APIID:    apiID,
+							PortalID: portalID,
+						},
+					},
+					Meta: kkComps.PaginatedMeta{
+						Page: kkComps.PageMeta{Total: 1},
+					},
+				},
+			},
+		},
+		APIImplementationAPI: &stubAPIImplementationAPI{},
+		APIDocumentAPI: &stubAPIDocumentAPI{
+			response: &kkOps.ListAPIDocumentsResponse{
+				ListAPIDocumentResponse: &kkComps.ListAPIDocumentResponse{
+					Data: []kkComps.APIDocumentSummaryWithChildren{
+						{
+							ID:    "document-123",
+							Title: "Overview",
+							Slug:  "overview",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	scope := resources.NewSyncScope()
+	scope.AddRoot(resources.ResourceTypeAPI)
+	scope.AddChild(resources.ResourceTypeAPI, apiRef, resources.ResourceTypeAPIVersion)
+	scope.AddChild(resources.ResourceTypeAPI, apiRef, resources.ResourceTypeAPIPublication)
+	scope.AddChild(resources.ResourceTypeAPI, apiRef, resources.ResourceTypeAPIDocument)
+
+	rs := &resources.ResourceSet{
+		APIs: []resources.APIResource{
+			{
+				BaseResource: resources.BaseResource{
+					Ref: apiRef,
+					Kongctl: &resources.KongctlMeta{
+						Namespace: &namespace,
+					},
+				},
+				CreateAPIRequest: kkComps.CreateAPIRequest{
+					Name: apiName,
+				},
+			},
+		},
+		SyncScope: scope,
+	}
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(ctx, rs, Options{Mode: PlanModeSync})
+	require.NoError(t, err)
+
+	deleteChanges := map[string]PlannedChange{}
+	for _, change := range plan.Changes {
+		if change.Action == ActionDelete {
+			deleteChanges[change.ResourceType] = change
+		}
+	}
+
+	for _, resourceType := range []string{
+		ResourceTypeAPIVersion,
+		ResourceTypeAPIPublication,
+		ResourceTypeAPIDocument,
+	} {
+		change, ok := deleteChanges[resourceType]
+		require.True(t, ok, "missing %s delete change", resourceType)
+		assert.Equal(t, namespace, change.Namespace, "%s delete should use parent namespace", resourceType)
+	}
+
+	mockAPIAPI.AssertExpectations(t)
+	mockPortalAPI.AssertExpectations(t)
 	mockAppAuthAPI.AssertExpectations(t)
 }

--- a/internal/declarative/planner/portal_child_planner.go
+++ b/internal/declarative/planner/portal_child_planner.go
@@ -3475,7 +3475,7 @@ func (p *Planner) planPortalPagesChanges(
 		// Find pages to delete
 		for path, existingPage := range existingByPath {
 			if !desiredPaths[path] {
-				p.planPortalPageDelete(portalRef, portalID, existingPage.ID, existingPage.Slug, plan)
+				p.planPortalPageDelete(parentNamespace, portalRef, portalID, existingPage.ID, existingPage.Slug, plan)
 			}
 		}
 	}
@@ -3742,7 +3742,7 @@ func (p *Planner) planPortalPageUpdate(
 
 // planPortalPageDelete creates a DELETE change for a portal page
 func (p *Planner) planPortalPageDelete(
-	portalRef string, portalID string, pageID string, slug string, plan *Plan,
+	parentNamespace string, portalRef string, portalID string, pageID string, slug string, plan *Plan,
 ) {
 	change := PlannedChange{
 		ID:           p.nextChangeID(ActionDelete, ResourceTypePortalPage, pageID),
@@ -3757,6 +3757,7 @@ func (p *Planner) planPortalPageDelete(
 		Action:    ActionDelete,
 		Fields:    map[string]any{FieldSlug: slug},
 		DependsOn: []string{},
+		Namespace: parentNamespace,
 	}
 
 	// Store parent portal reference

--- a/test/e2e/scenarios/apis/child-delete-namespace/overlays/002-remove-publication/config.yaml
+++ b/test/e2e/scenarios/apis/child-delete-namespace/overlays/002-remove-publication/config.yaml
@@ -1,0 +1,20 @@
+_defaults:
+  kongctl:
+    namespace: apis-child-delete-namespace
+
+portals:
+  - ref: api-child-delete-portal
+    name: api-child-delete-portal
+    display_name: "API Child Delete Portal"
+    description: "Portal used to verify child delete namespaces"
+    authentication_enabled: false
+    default_api_visibility: public
+    default_page_visibility: public
+
+apis:
+  - ref: api-child-delete-api
+    name: api-child-delete-api
+    description: "API used to verify child delete namespaces"
+    labels:
+      scenario: child-delete-namespace
+    publications: []

--- a/test/e2e/scenarios/apis/child-delete-namespace/scenario.yaml
+++ b/test/e2e/scenarios/apis/child-delete-namespace/scenario.yaml
@@ -1,0 +1,147 @@
+baseInputsPath: testdata
+
+env:
+  KONGCTL_LOG_LEVEL: info
+
+vars:
+  namespace: apis-child-delete-namespace
+  portalRef: api-child-delete-portal
+  apiRef: api-child-delete-api
+  publicationRef: api-child-delete-publication
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - created_at
+      - updated_at
+      - resource_id
+      - change_id
+      - generated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-bootstrap-state
+    commands:
+      - name: 000-sync-initial
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 3
+                by_action.CREATE: 3
+          - select: summary
+            expect:
+              fields:
+                applied: 3
+                failed: 0
+          - select: >-
+              plan.changes[?resource_type=='api_publication' &&
+                            resource_ref=='{{ .vars.publicationRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                namespace: "{{ .vars.namespace }}"
+
+  - name: 002-delete-child-in-sync-mode
+    inputOverlayDirs:
+      - overlays/002-remove-publication
+    commands:
+      - name: 000-diff-sync-delete-publication
+        run:
+          - diff
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+          - -o
+          - json
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: sync
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: >-
+              changes[?resource_type=='api_publication' &&
+                      action=='DELETE'] | [0]
+            expect:
+              fields:
+                action: DELETE
+                namespace: "{{ .vars.namespace }}"
+
+      - name: 001-diff-sync-delete-publication-text
+        outputFormat: text
+        parseAs: raw
+        run:
+          - diff
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: stdout
+            expect:
+              fields:
+                "contains(@, '=== Namespace: {{ .vars.namespace }} ===')": true
+                "contains(@, '=== Namespace: default ===')": false
+                "contains(@, 'api_publication')": true
+
+      - name: 002-sync-delete-publication
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: >-
+              plan.changes[?resource_type=='api_publication' &&
+                            action=='DELETE'] | [0]
+            expect:
+              fields:
+                action: DELETE
+                namespace: "{{ .vars.namespace }}"
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+                status: success
+
+      - name: 003-verify-publication-deleted
+        run:
+          - get
+          - api
+          - publications
+          - --api-name
+          - "{{ .vars.apiRef }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 0
+
+  - name: 003-final-reset
+    skipInputs: true
+    commands:
+      - resetOrg: true

--- a/test/e2e/scenarios/apis/child-delete-namespace/testdata/config.yaml
+++ b/test/e2e/scenarios/apis/child-delete-namespace/testdata/config.yaml
@@ -1,0 +1,23 @@
+_defaults:
+  kongctl:
+    namespace: apis-child-delete-namespace
+
+portals:
+  - ref: api-child-delete-portal
+    name: api-child-delete-portal
+    display_name: "API Child Delete Portal"
+    description: "Portal used to verify child delete namespaces"
+    authentication_enabled: false
+    default_api_visibility: public
+    default_page_visibility: public
+
+apis:
+  - ref: api-child-delete-api
+    name: api-child-delete-api
+    description: "API used to verify child delete namespaces"
+    labels:
+      scenario: child-delete-namespace
+    publications:
+      - ref: api-child-delete-publication
+        portal_id: !ref api-child-delete-portal#id
+        visibility: public

--- a/test/e2e/scenarios/event-gateway/backend-cluster/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/backend-cluster/scenario.yaml
@@ -7,6 +7,7 @@ env:
 vars:
   egwName: egw-cp-for-bc-test
   bcRef: default-backend-cluster
+  namespace: event-gateways-bc-comprehensive-test
 
 defaults:
   mask:
@@ -259,6 +260,7 @@ steps:
               fields:
                 action: DELETE
                 resource_ref: "{{ .vars.bcRef }}"
+                namespace: "{{ .vars.namespace }}"
       - name: 002-sync-delete
         outputFormat: json
         run:
@@ -380,6 +382,7 @@ steps:
               fields:
                 action: DELETE
                 resource_ref: "{{ .vars.bcRef }}"
+                namespace: "{{ .vars.namespace }}"
       - name: 002-sync-delete-root-level
         outputFormat: json
         run:


### PR DESCRIPTION
## Summary
- preserve the parent namespace on sync-mode DELETE changes for API children, portal pages, control-plane child certs, and Event Gateway child resources
- add planner regression coverage for API child deletes and direct delete-builder namespace invariants
- add e2e scenario coverage for API publication child deletes and extend Event Gateway backend-cluster DELETE assertions

Fixes #1474

## Verification
- go test ./internal/declarative/planner -count=1
- go test -tags=e2e ./test/e2e/harness/scenario -count=1
- env -u KONGCTL_E2E_KONNECT_PAT KONGCTL_E2E_SCENARIO=apis/child-delete-namespace go test -tags=e2e -run '^Test_Scenarios$' ./test/e2e -count=1
- env -u KONGCTL_E2E_KONNECT_PAT KONGCTL_E2E_SCENARIO=event-gateway/backend-cluster go test -tags=e2e -run '^Test_Scenarios$' ./test/e2e -count=1
- make format
- make lint
- make test
- make build

Note: selected e2e scenario checks were run with KONGCTL_E2E_KONNECT_PAT unset to verify scenario loading/compilation without resetting or mutating a Konnect org.