### PR TITLE
fix(ci): point pending E2E status at PR checks

### DIFF
--- a/.github/workflows/e2e-required-status.yaml
+++ b/.github/workflows/e2e-required-status.yaml
@@ -49,6 +49,9 @@ jobs:
             const description = required
               ? 'E2E required for this PR and waiting for E2E workflow.'
               : 'E2E not required for this PR.';
+            const targetUrl = required
+              ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/pull/${pr.number}/checks`
+              : `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
 
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
@@ -57,7 +60,7 @@ jobs:
               context: statusContext,
               state,
               description,
-              target_url: `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+              target_url: targetUrl,
             });
 
             core.info(description);


### PR DESCRIPTION
Summary: Updates the E2E Required Status preflight so pending E2E Required statuses link to the PR checks page instead of the green preflight workflow run. Non-required statuses still link to the preflight run that made the decision, and the real E2E finalizer continues to replace the status URL with the E2E run when it completes. Tests: actionlint .github/workflows/e2e-required-status.yaml .github/workflows/e2e.yaml; ruby YAML parse; git diff --check.