### PR TITLE
fix(declarative): support external event gateways

### DIFF
--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -800,9 +800,18 @@ func (l *Loader) applyNamespaceDefaults(rs *resources.ResourceSet, fileDefaults 
 	}
 
 	for i := range rs.EventGatewayControlPlanes {
+		if rs.EventGatewayControlPlanes[i].IsExternal() {
+			if rs.EventGatewayControlPlanes[i].Kongctl != nil {
+				return fmt.Errorf(
+					"event_gateway '%s' is marked as external and cannot use kongctl metadata",
+					rs.EventGatewayControlPlanes[i].Ref,
+				)
+			}
+			continue
+		}
 		if err := assignNamespace(
 			&rs.EventGatewayControlPlanes[i].Kongctl,
-			"control_plane",
+			"event_gateway",
 			rs.EventGatewayControlPlanes[i].Ref,
 		); err != nil {
 			return err

--- a/internal/declarative/planner/egw_control_plane_planner.go
+++ b/internal/declarative/planner/egw_control_plane_planner.go
@@ -129,10 +129,7 @@ func (p *Planner) planEGWControlPlaneChanges(
 		if desiredEGWCP.IsExternal() {
 			gatewayID = desiredEGWCP.GetKonnectID()
 			if gatewayID == "" {
-				plan.AddWarning("", fmt.Sprintf(
-					"external event_gateway %q has no resolved ID; child diffs may be incomplete",
-					desiredEGWCP.GetRef(),
-				))
+				return fmt.Errorf("external event_gateway %q has no resolved Konnect ID", desiredEGWCP.GetRef())
 			}
 		} else {
 			current, exists := currentByName[desiredEGWCP.Name]

--- a/internal/declarative/planner/egw_control_plane_planner.go
+++ b/internal/declarative/planner/egw_control_plane_planner.go
@@ -61,14 +61,18 @@ func (p *Planner) planEGWControlPlaneChanges(
 	namespace := plannerCtx.Namespace
 
 	// Fetch current managed Event Gateway Control Planes from the specific namespace
-	namespaceFilter := []string{namespace}
-	currentEGWControlPlanes, err := p.listManagedEventGatewayControlPlanes(ctx, namespaceFilter)
-	if err != nil {
-		// If API client is not configured, skip Event Gateway Control Plane planning
-		if state.IsAPIClientError(err) {
-			return nil
+	var currentEGWControlPlanes []state.EventGatewayControlPlane
+	if namespace != resources.NamespaceExternal {
+		namespaceFilter := []string{namespace}
+		var err error
+		currentEGWControlPlanes, err = p.listManagedEventGatewayControlPlanes(ctx, namespaceFilter)
+		if err != nil {
+			// If API client is not configured, skip Event Gateway Control Plane planning
+			if state.IsAPIClientError(err) {
+				return nil
+			}
+			return fmt.Errorf("failed to list current Event Gateway Control Planes: %w", err)
 		}
-		return fmt.Errorf("failed to list current Event Gateway Control Planes: %w", err)
 	}
 
 	// Index current Event Gateway Control Planes by name
@@ -83,6 +87,14 @@ func (p *Planner) planEGWControlPlaneChanges(
 	// Handle delete mode - plan DELETE for desired resources that exist in Konnect
 	if plan.Metadata.Mode == PlanModeDelete {
 		for _, desiredEGWCP := range desired {
+			if desiredEGWCP.IsExternal() {
+				plan.AddWarning("", fmt.Sprintf(
+					"event_gateway_control_plane %q is external, skipping delete",
+					desiredEGWCP.GetRef(),
+				))
+				continue
+			}
+
 			current, exists := currentByName[desiredEGWCP.Name]
 			if !exists {
 				plan.AddWarning("", fmt.Sprintf(
@@ -110,68 +122,83 @@ func (p *Planner) planEGWControlPlaneChanges(
 
 	// Compare each desired Event Gateway Control Plane
 	for _, desiredEGWCP := range desired {
-		current, exists := currentByName[desiredEGWCP.Name]
-
 		// Track the gateway change ID for dependency resolution
 		var gatewayChangeID string
+		var gatewayID string
 
-		if !exists {
-			// CREATE action
-			gatewayChangeID = p.planEGWControlPlaneCreate(desiredEGWCP, plan)
-		} else {
-			// Check if update needed
-			isProtected := labels.IsProtectedResource(current.NormalizedLabels)
-
-			// Get protection status from desired configuration
-			shouldProtect := false
-			if desiredEGWCP.Kongctl != nil && desiredEGWCP.Kongctl.Protected != nil && *desiredEGWCP.Kongctl.Protected {
-				shouldProtect = true
+		if desiredEGWCP.IsExternal() {
+			gatewayID = desiredEGWCP.GetKonnectID()
+			if gatewayID == "" {
+				plan.AddWarning("", fmt.Sprintf(
+					"external event_gateway %q has no resolved ID; child diffs may be incomplete",
+					desiredEGWCP.GetRef(),
+				))
 			}
+		} else {
+			current, exists := currentByName[desiredEGWCP.Name]
 
-			// Handle protection changes
-			if isProtected != shouldProtect {
-				// When changing protection status, include any other field updates too
-				needsUpdate, updateFields, changedFields := p.shouldUpdateEGWControlPlaneResource(current, desiredEGWCP)
-
-				// Create protection change object
-				protectionChange := &ProtectionChange{
-					Old: isProtected,
-					New: shouldProtect,
-				}
-
-				// Validate protection change
-				err := p.validateProtectionWithChange(
-					ResourceTypeEventGatewayControlPlane,
-					desiredEGWCP.Name,
-					isProtected,
-					ActionUpdate,
-					protectionChange,
-					needsUpdate,
-				)
-				if err != nil {
-					protectionErrors.Add(err)
-				} else {
-					p.planEGWControlPlaneProtectionChangeWithFields(
-						current,
-						desiredEGWCP,
-						isProtected,
-						shouldProtect,
-						updateFields,
-						changedFields,
-						plan,
-					)
-				}
+			if !exists {
+				// CREATE action
+				gatewayChangeID = p.planEGWControlPlaneCreate(desiredEGWCP, plan)
 			} else {
-				// Check if update needed based on configuration
-				needsUpdate, updateFields, changedFields := p.shouldUpdateEGWControlPlaneResource(current, desiredEGWCP)
-				if needsUpdate {
-					// Regular update - check protection
-					if err := p.validateProtection(
-						ResourceTypeEventGatewayControlPlane, desiredEGWCP.Name, isProtected, ActionUpdate,
-					); err != nil {
+				gatewayID = current.ID
+
+				// Check if update needed
+				isProtected := labels.IsProtectedResource(current.NormalizedLabels)
+
+				// Get protection status from desired configuration
+				shouldProtect := false
+				if desiredEGWCP.Kongctl != nil &&
+					desiredEGWCP.Kongctl.Protected != nil &&
+					*desiredEGWCP.Kongctl.Protected {
+					shouldProtect = true
+				}
+
+				// Handle protection changes
+				if isProtected != shouldProtect {
+					// When changing protection status, include any other field updates too
+					needsUpdate, updateFields, changedFields := p.shouldUpdateEGWControlPlaneResource(current, desiredEGWCP)
+
+					// Create protection change object
+					protectionChange := &ProtectionChange{
+						Old: isProtected,
+						New: shouldProtect,
+					}
+
+					// Validate protection change
+					err := p.validateProtectionWithChange(
+						ResourceTypeEventGatewayControlPlane,
+						desiredEGWCP.Name,
+						isProtected,
+						ActionUpdate,
+						protectionChange,
+						needsUpdate,
+					)
+					if err != nil {
 						protectionErrors.Add(err)
 					} else {
-						p.planEGWControlPlaneUpdateWithFields(current, desiredEGWCP, updateFields, changedFields, plan)
+						p.planEGWControlPlaneProtectionChangeWithFields(
+							current,
+							desiredEGWCP,
+							isProtected,
+							shouldProtect,
+							updateFields,
+							changedFields,
+							plan,
+						)
+					}
+				} else {
+					// Check if update needed based on configuration
+					needsUpdate, updateFields, changedFields := p.shouldUpdateEGWControlPlaneResource(current, desiredEGWCP)
+					if needsUpdate {
+						// Regular update - check protection
+						if err := p.validateProtection(
+							ResourceTypeEventGatewayControlPlane, desiredEGWCP.Name, isProtected, ActionUpdate,
+						); err != nil {
+							protectionErrors.Add(err)
+						} else {
+							p.planEGWControlPlaneUpdateWithFields(current, desiredEGWCP, updateFields, changedFields, plan)
+						}
 					}
 				}
 			}
@@ -179,10 +206,6 @@ func (p *Planner) planEGWControlPlaneChanges(
 
 		// Plan backend clusters for this gateway (whether it exists or is being created)
 		backendClusters := p.resources.GetBackendClustersForGateway(desiredEGWCP.Ref)
-		gatewayID := ""
-		if exists {
-			gatewayID = current.ID
-		}
 
 		if p.shouldPlanChild(
 			plan,

--- a/internal/declarative/planner/event_gateway_backend_cluster_planner.go
+++ b/internal/declarative/planner/event_gateway_backend_cluster_planner.go
@@ -128,7 +128,7 @@ func (p *Planner) planBackendClusterChangesForExistingGateway(
 	}
 
 	// 4. SYNC MODE: Delete unmanaged clusters
-	if plan.Metadata.Mode == PlanModeSync {
+	if plan.Metadata.Mode == PlanModeSync && !p.isEventGatewayExternal(gatewayRef) {
 		for name, current := range currentByName {
 			if !desiredNames[name] {
 				p.logger.Debug(

--- a/internal/declarative/planner/event_gateway_cluster_policy_planner.go
+++ b/internal/declarative/planner/event_gateway_cluster_policy_planner.go
@@ -136,7 +136,7 @@ func (p *Planner) planClusterPolicyChangesForExistingVirtualCluster(
 	}
 
 	// 4. SYNC MODE: Delete unmanaged policies
-	if plan.Metadata.Mode == PlanModeSync {
+	if plan.Metadata.Mode == PlanModeSync && !p.isEventGatewayVirtualClusterExternal(virtualClusterRef) {
 		for name, current := range currentByName {
 			if !desiredNames[name] {
 				p.logger.Debug(

--- a/internal/declarative/planner/event_gateway_consume_policy_planner.go
+++ b/internal/declarative/planner/event_gateway_consume_policy_planner.go
@@ -155,7 +155,7 @@ func (p *Planner) planConsumePolicyChangesForExistingVirtualCluster(
 	}
 
 	// 4. SYNC MODE: Delete policies no longer in desired state
-	if plan.Metadata.Mode == PlanModeSync {
+	if plan.Metadata.Mode == PlanModeSync && !p.isEventGatewayVirtualClusterExternal(virtualClusterRef) {
 		for name, current := range currentByName {
 			if !desiredNames[name] {
 				p.logger.Debug(

--- a/internal/declarative/planner/event_gateway_data_plane_certificate_planner.go
+++ b/internal/declarative/planner/event_gateway_data_plane_certificate_planner.go
@@ -124,7 +124,7 @@ func (p *Planner) planDataPlaneCertificateChangesForExistingGateway(
 	}
 
 	// 4. SYNC MODE: Delete unmanaged certificates
-	if plan.Metadata.Mode == PlanModeSync {
+	if plan.Metadata.Mode == PlanModeSync && !p.isEventGatewayExternal(gatewayRef) {
 		for name, current := range currentByName {
 			if !desiredNames[name] {
 				p.logger.Debug(

--- a/internal/declarative/planner/event_gateway_external.go
+++ b/internal/declarative/planner/event_gateway_external.go
@@ -1,0 +1,77 @@
+package planner
+
+import (
+	"fmt"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+)
+
+func (p *Planner) isEventGatewayExternal(gatewayRef string) bool {
+	if p == nil || p.resources == nil {
+		return false
+	}
+	eventGateway := p.resources.GetEventGatewayControlPlaneByRef(gatewayRef)
+	return eventGateway != nil && eventGateway.IsExternal()
+}
+
+func (p *Planner) isEventGatewayVirtualClusterExternal(virtualClusterRef string) bool {
+	if p == nil || p.resources == nil {
+		return false
+	}
+	virtualCluster := p.resources.GetVirtualClusterByRef(virtualClusterRef)
+	return virtualCluster != nil && virtualCluster.IsExternal()
+}
+
+func matchExternalEventGatewayVirtualCluster(
+	virtualCluster *resources.EventGatewayVirtualClusterResource,
+	available []state.EventGatewayVirtualCluster,
+) (*state.EventGatewayVirtualCluster, error) {
+	if virtualCluster == nil || virtualCluster.External == nil {
+		return nil, fmt.Errorf("event_gateway_virtual_cluster requires _external")
+	}
+
+	if virtualCluster.External.ID != "" {
+		for i := range available {
+			if available[i].ID == virtualCluster.External.ID {
+				return &available[i], nil
+			}
+		}
+		return nil, fmt.Errorf(
+			"external event_gateway_virtual_cluster %s: not found with id %s",
+			virtualCluster.GetRef(),
+			virtualCluster.External.ID,
+		)
+	}
+
+	if virtualCluster.External.Selector == nil {
+		return nil, fmt.Errorf(
+			"external event_gateway_virtual_cluster %s: invalid _external configuration",
+			virtualCluster.GetRef(),
+		)
+	}
+
+	matchFields := virtualCluster.External.Selector.MatchFields
+	var match *state.EventGatewayVirtualCluster
+	for i := range available {
+		if virtualCluster.External.Selector.Match(available[i]) {
+			if match != nil {
+				return nil, fmt.Errorf(
+					"external event_gateway_virtual_cluster %s: selector %v matched multiple virtual clusters",
+					virtualCluster.GetRef(),
+					matchFields,
+				)
+			}
+			match = &available[i]
+		}
+	}
+	if match == nil {
+		return nil, fmt.Errorf(
+			"external event_gateway_virtual_cluster %s: selector %v did not match any virtual cluster",
+			virtualCluster.GetRef(),
+			matchFields,
+		)
+	}
+
+	return match, nil
+}

--- a/internal/declarative/planner/event_gateway_external_test.go
+++ b/internal/declarative/planner/event_gateway_external_test.go
@@ -1,0 +1,467 @@
+package planner
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/konnect/helpers"
+	"github.com/stretchr/testify/require"
+)
+
+type stubExternalEventGatewayControlPlaneAPI struct {
+	gateways []kkComps.EventGatewayInfo
+}
+
+func (s *stubExternalEventGatewayControlPlaneAPI) ListEGWControlPlanes(
+	_ context.Context,
+	_ kkOps.ListEventGatewaysRequest,
+	_ ...kkOps.Option,
+) (*kkOps.ListEventGatewaysResponse, error) {
+	return &kkOps.ListEventGatewaysResponse{
+		StatusCode: 200,
+		ListEventGatewaysResponse: &kkComps.ListEventGatewaysResponse{
+			Meta: *eventGatewayExternalCursorMeta(),
+			Data: s.gateways,
+		},
+	}, nil
+}
+
+func (s *stubExternalEventGatewayControlPlaneAPI) FetchEGWControlPlane(
+	_ context.Context,
+	gatewayID string,
+	_ ...kkOps.Option,
+) (*kkOps.GetEventGatewayResponse, error) {
+	for _, gateway := range s.gateways {
+		if gateway.ID == gatewayID {
+			return &kkOps.GetEventGatewayResponse{StatusCode: 200, EventGatewayInfo: &gateway}, nil
+		}
+	}
+	return &kkOps.GetEventGatewayResponse{StatusCode: 404}, nil
+}
+
+func (s *stubExternalEventGatewayControlPlaneAPI) CreateEGWControlPlane(
+	_ context.Context,
+	_ kkComps.CreateGatewayRequest,
+	_ ...kkOps.Option,
+) (*kkOps.CreateEventGatewayResponse, error) {
+	return nil, errors.New("unexpected create event gateway")
+}
+
+func (s *stubExternalEventGatewayControlPlaneAPI) UpdateEGWControlPlane(
+	_ context.Context,
+	_ string,
+	_ kkComps.UpdateGatewayRequest,
+	_ ...kkOps.Option,
+) (*kkOps.UpdateEventGatewayResponse, error) {
+	return nil, errors.New("unexpected update event gateway")
+}
+
+func (s *stubExternalEventGatewayControlPlaneAPI) DeleteEGWControlPlane(
+	_ context.Context,
+	_ string,
+	_ ...kkOps.Option,
+) (*kkOps.DeleteEventGatewayResponse, error) {
+	return nil, errors.New("unexpected delete event gateway")
+}
+
+type stubExternalEventGatewayBackendClusterAPI struct {
+	clusters []kkComps.BackendCluster
+}
+
+func (s *stubExternalEventGatewayBackendClusterAPI) ListEventGatewayBackendClusters(
+	_ context.Context,
+	_ kkOps.ListEventGatewayBackendClustersRequest,
+	_ ...kkOps.Option,
+) (*kkOps.ListEventGatewayBackendClustersResponse, error) {
+	return &kkOps.ListEventGatewayBackendClustersResponse{
+		StatusCode: 200,
+		ListBackendClustersResponse: &kkComps.ListBackendClustersResponse{
+			Meta: eventGatewayExternalCursorMeta(),
+			Data: s.clusters,
+		},
+	}, nil
+}
+
+func (s *stubExternalEventGatewayBackendClusterAPI) FetchEventGatewayBackendCluster(
+	_ context.Context,
+	_ string,
+	clusterID string,
+	_ ...kkOps.Option,
+) (*kkOps.GetEventGatewayBackendClusterResponse, error) {
+	for _, cluster := range s.clusters {
+		if cluster.ID == clusterID {
+			return &kkOps.GetEventGatewayBackendClusterResponse{StatusCode: 200, BackendCluster: &cluster}, nil
+		}
+	}
+	return &kkOps.GetEventGatewayBackendClusterResponse{StatusCode: 404}, nil
+}
+
+func (s *stubExternalEventGatewayBackendClusterAPI) CreateEventGatewayBackendCluster(
+	_ context.Context,
+	_ string,
+	_ kkComps.CreateBackendClusterRequest,
+	_ ...kkOps.Option,
+) (*kkOps.CreateEventGatewayBackendClusterResponse, error) {
+	return nil, errors.New("unexpected create backend cluster")
+}
+
+func (s *stubExternalEventGatewayBackendClusterAPI) UpdateEventGatewayBackendCluster(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ kkComps.UpdateBackendClusterRequest,
+	_ ...kkOps.Option,
+) (*kkOps.UpdateEventGatewayBackendClusterResponse, error) {
+	return nil, errors.New("unexpected update backend cluster")
+}
+
+func (s *stubExternalEventGatewayBackendClusterAPI) DeleteEventGatewayBackendCluster(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ ...kkOps.Option,
+) (*kkOps.DeleteEventGatewayBackendClusterResponse, error) {
+	return nil, errors.New("unexpected delete backend cluster")
+}
+
+type stubExternalEventGatewayVirtualClusterAPI struct {
+	clusters []kkComps.VirtualCluster
+}
+
+func (s *stubExternalEventGatewayVirtualClusterAPI) ListEventGatewayVirtualClusters(
+	_ context.Context,
+	_ kkOps.ListEventGatewayVirtualClustersRequest,
+	_ ...kkOps.Option,
+) (*kkOps.ListEventGatewayVirtualClustersResponse, error) {
+	return &kkOps.ListEventGatewayVirtualClustersResponse{
+		StatusCode: 200,
+		ListVirtualClustersResponse: &kkComps.ListVirtualClustersResponse{
+			Meta: eventGatewayExternalCursorMeta(),
+			Data: s.clusters,
+		},
+	}, nil
+}
+
+func (s *stubExternalEventGatewayVirtualClusterAPI) FetchEventGatewayVirtualCluster(
+	_ context.Context,
+	_ string,
+	clusterID string,
+	_ ...kkOps.Option,
+) (*kkOps.GetEventGatewayVirtualClusterResponse, error) {
+	for _, cluster := range s.clusters {
+		if cluster.ID == clusterID {
+			return &kkOps.GetEventGatewayVirtualClusterResponse{StatusCode: 200, VirtualCluster: &cluster}, nil
+		}
+	}
+	return &kkOps.GetEventGatewayVirtualClusterResponse{StatusCode: 404}, nil
+}
+
+func (s *stubExternalEventGatewayVirtualClusterAPI) CreateEventGatewayVirtualCluster(
+	_ context.Context,
+	_ string,
+	_ kkComps.CreateVirtualClusterRequest,
+	_ ...kkOps.Option,
+) (*kkOps.CreateEventGatewayVirtualClusterResponse, error) {
+	return nil, errors.New("unexpected create virtual cluster")
+}
+
+func (s *stubExternalEventGatewayVirtualClusterAPI) UpdateEventGatewayVirtualCluster(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ kkComps.UpdateVirtualClusterRequest,
+	_ ...kkOps.Option,
+) (*kkOps.UpdateEventGatewayVirtualClusterResponse, error) {
+	return nil, errors.New("unexpected update virtual cluster")
+}
+
+func (s *stubExternalEventGatewayVirtualClusterAPI) DeleteEventGatewayVirtualCluster(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ ...kkOps.Option,
+) (*kkOps.DeleteEventGatewayVirtualClusterResponse, error) {
+	return nil, errors.New("unexpected delete virtual cluster")
+}
+
+type stubExternalEventGatewayClusterPolicyAPI struct {
+	policies []kkComps.EventGatewayPolicy
+}
+
+func (s *stubExternalEventGatewayClusterPolicyAPI) ListEventGatewayVirtualClusterClusterLevelPolicies(
+	_ context.Context,
+	_ kkOps.ListEventGatewayVirtualClusterClusterLevelPoliciesRequest,
+	_ ...kkOps.Option,
+) (*kkOps.ListEventGatewayVirtualClusterClusterLevelPoliciesResponse, error) {
+	return &kkOps.ListEventGatewayVirtualClusterClusterLevelPoliciesResponse{
+		StatusCode:                  200,
+		ListClusterPoliciesResponse: s.policies,
+	}, nil
+}
+
+func (s *stubExternalEventGatewayClusterPolicyAPI) GetEventGatewayVirtualClusterClusterLevelPolicy(
+	_ context.Context,
+	_ kkOps.GetEventGatewayVirtualClusterClusterLevelPolicyRequest,
+	_ ...kkOps.Option,
+) (*kkOps.GetEventGatewayVirtualClusterClusterLevelPolicyResponse, error) {
+	return nil, errors.New("unexpected get cluster policy")
+}
+
+func (s *stubExternalEventGatewayClusterPolicyAPI) CreateEventGatewayVirtualClusterClusterLevelPolicy(
+	_ context.Context,
+	_ kkOps.CreateEventGatewayVirtualClusterClusterLevelPolicyRequest,
+	_ ...kkOps.Option,
+) (*kkOps.CreateEventGatewayVirtualClusterClusterLevelPolicyResponse, error) {
+	return nil, errors.New("unexpected create cluster policy")
+}
+
+func (s *stubExternalEventGatewayClusterPolicyAPI) UpdateEventGatewayVirtualClusterClusterLevelPolicy(
+	_ context.Context,
+	_ kkOps.UpdateEventGatewayVirtualClusterClusterLevelPolicyRequest,
+	_ ...kkOps.Option,
+) (*kkOps.UpdateEventGatewayVirtualClusterClusterLevelPolicyResponse, error) {
+	return nil, errors.New("unexpected update cluster policy")
+}
+
+func (s *stubExternalEventGatewayClusterPolicyAPI) DeleteEventGatewayVirtualClusterClusterLevelPolicy(
+	_ context.Context,
+	_ kkOps.DeleteEventGatewayVirtualClusterClusterLevelPolicyRequest,
+	_ ...kkOps.Option,
+) (*kkOps.DeleteEventGatewayVirtualClusterClusterLevelPolicyResponse, error) {
+	return nil, errors.New("unexpected delete cluster policy")
+}
+
+var (
+	_ helpers.EGWControlPlaneAPI            = (*stubExternalEventGatewayControlPlaneAPI)(nil)
+	_ helpers.EventGatewayBackendClusterAPI = (*stubExternalEventGatewayBackendClusterAPI)(nil)
+	_ helpers.EventGatewayVirtualClusterAPI = (*stubExternalEventGatewayVirtualClusterAPI)(nil)
+	_ helpers.EventGatewayClusterPolicyAPI  = (*stubExternalEventGatewayClusterPolicyAPI)(nil)
+)
+
+func TestPlanner_ExternalEventGateway_PlansExternalVirtualClusterChildren(t *testing.T) {
+	ctx := context.Background()
+	gatewayID := "gateway-123"
+	virtualClusterID := "vc-123"
+
+	client := state.NewClient(state.ClientConfig{
+		EGWControlPlaneAPI: &stubExternalEventGatewayControlPlaneAPI{
+			gateways: []kkComps.EventGatewayInfo{
+				{ID: gatewayID, Name: "external-egw"},
+			},
+		},
+		EventGatewayBackendClusterAPI: &stubExternalEventGatewayBackendClusterAPI{},
+		EventGatewayVirtualClusterAPI: &stubExternalEventGatewayVirtualClusterAPI{
+			clusters: []kkComps.VirtualCluster{
+				{ID: virtualClusterID, Name: "external-vc"},
+			},
+		},
+		EventGatewayClusterPolicyAPI: &stubExternalEventGatewayClusterPolicyAPI{},
+	})
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(ctx, externalEventGatewayResourceSet(), Options{
+		Mode: PlanModeApply,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, plan.Changes, 1)
+	change := plan.Changes[0]
+	require.Equal(t, ActionCreate, change.Action)
+	require.Equal(t, ResourceTypeEventGatewayClusterPolicy, change.ResourceType)
+	require.Equal(t, "cluster-policy-ref", change.ResourceRef)
+	require.Equal(t, resources.NamespaceExternal, change.Namespace)
+	require.NotNil(t, change.Parent)
+	require.Equal(t, "virtual-cluster-ref", change.Parent.Ref)
+	require.Equal(t, virtualClusterID, change.Parent.ID)
+	require.Equal(t, gatewayID, change.References[FieldEventGatewayID].ID)
+	require.Equal(t, virtualClusterID, change.References[FieldEventGatewayVirtualClusterID].ID)
+}
+
+func TestPlanner_ExternalEventGateway_SyncDoesNotDeleteExistingBackendClusters(t *testing.T) {
+	t.Parallel()
+
+	planner := &Planner{
+		client: state.NewClient(state.ClientConfig{
+			EventGatewayBackendClusterAPI: &stubExternalEventGatewayBackendClusterAPI{
+				clusters: []kkComps.BackendCluster{{ID: "backend-123", Name: "backend"}},
+			},
+		}),
+		logger: slog.Default(),
+		resources: &resources.ResourceSet{
+			EventGatewayControlPlanes: []resources.EventGatewayControlPlaneResource{
+				externalEventGatewayResource(),
+			},
+		},
+	}
+
+	plan := NewPlan("1.0", "test", PlanModeSync)
+	err := planner.planEventGatewayBackendClusterChanges(
+		context.Background(),
+		nil,
+		resources.NamespaceExternal,
+		"external-egw",
+		"gateway-123",
+		"event-gateway-ref",
+		"",
+		nil,
+		plan,
+	)
+	require.NoError(t, err)
+	requireNoDeleteChange(t, plan, ResourceTypeEventGatewayBackendCluster)
+}
+
+func TestPlanner_ExternalEventGateway_SyncDoesNotDeleteExistingVirtualClusters(t *testing.T) {
+	t.Parallel()
+
+	planner := &Planner{
+		client: state.NewClient(state.ClientConfig{
+			EventGatewayVirtualClusterAPI: &stubExternalEventGatewayVirtualClusterAPI{
+				clusters: []kkComps.VirtualCluster{{ID: "vc-123", Name: "virtual-cluster"}},
+			},
+		}),
+		logger: slog.Default(),
+		resources: &resources.ResourceSet{
+			EventGatewayControlPlanes: []resources.EventGatewayControlPlaneResource{
+				externalEventGatewayResource(),
+			},
+		},
+	}
+
+	plan := NewPlan("1.0", "test", PlanModeSync)
+	err := planner.planEventGatewayVirtualClusterChanges(
+		context.Background(),
+		nil,
+		resources.NamespaceExternal,
+		"external-egw",
+		"gateway-123",
+		"event-gateway-ref",
+		"",
+		nil,
+		plan,
+	)
+	require.NoError(t, err)
+	requireNoDeleteChange(t, plan, ResourceTypeEventGatewayVirtualCluster)
+}
+
+func TestPlanner_ExternalEventGatewayVirtualCluster_SyncDoesNotDeleteExistingClusterPolicies(t *testing.T) {
+	t.Parallel()
+
+	policyName := "external-policy"
+	planner := &Planner{
+		client: state.NewClient(state.ClientConfig{
+			EventGatewayClusterPolicyAPI: &stubExternalEventGatewayClusterPolicyAPI{
+				policies: []kkComps.EventGatewayPolicy{
+					{ID: "policy-123", Name: &policyName, Type: "acls"},
+				},
+			},
+		}),
+		logger: slog.Default(),
+		resources: &resources.ResourceSet{
+			EventGatewayControlPlanes: []resources.EventGatewayControlPlaneResource{
+				externalEventGatewayResourceWithVirtualCluster(),
+			},
+			EventGatewayVirtualClusters: []resources.EventGatewayVirtualClusterResource{
+				externalEventGatewayVirtualClusterResource(),
+			},
+		},
+	}
+
+	plan := NewPlan("1.0", "test", PlanModeSync)
+	err := planner.planEventGatewayClusterPolicyChanges(
+		context.Background(),
+		nil,
+		resources.NamespaceExternal,
+		"gateway-123",
+		"event-gateway-ref",
+		"external-vc",
+		"vc-123",
+		"virtual-cluster-ref",
+		"",
+		nil,
+		plan,
+	)
+	require.NoError(t, err)
+	requireNoDeleteChange(t, plan, ResourceTypeEventGatewayClusterPolicy)
+}
+
+func externalEventGatewayResourceSet() *resources.ResourceSet {
+	name := "cluster-policy"
+	enabled := true
+	return &resources.ResourceSet{
+		EventGatewayControlPlanes: []resources.EventGatewayControlPlaneResource{
+			{
+				BaseResource:         resources.BaseResource{Ref: "event-gateway-ref"},
+				CreateGatewayRequest: kkComps.CreateGatewayRequest{Name: "external-egw"},
+				External: &resources.ExternalBlock{
+					Selector: &resources.ExternalSelector{MatchFields: map[string]string{"name": "external-egw"}},
+				},
+				VirtualClusters: []resources.EventGatewayVirtualClusterResource{
+					{
+						Ref:                         "virtual-cluster-ref",
+						CreateVirtualClusterRequest: kkComps.CreateVirtualClusterRequest{Name: "external-vc"},
+						External: &resources.ExternalBlock{
+							Selector: &resources.ExternalSelector{MatchFields: map[string]string{"name": "external-vc"}},
+						},
+						ClusterPolicies: []resources.EventGatewayClusterPolicyResource{
+							{
+								Ref: "cluster-policy-ref",
+								EventGatewayClusterPolicyModify: kkComps.CreateEventGatewayClusterPolicyModifyAcls(
+									kkComps.EventGatewayACLsPolicy{
+										Name:    &name,
+										Enabled: &enabled,
+										Config:  kkComps.EventGatewayACLPolicyConfig{},
+									},
+								),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func externalEventGatewayResource() resources.EventGatewayControlPlaneResource {
+	return resources.EventGatewayControlPlaneResource{
+		BaseResource:         resources.BaseResource{Ref: "event-gateway-ref"},
+		CreateGatewayRequest: kkComps.CreateGatewayRequest{Name: "external-egw"},
+		External:             &resources.ExternalBlock{ID: "gateway-123"},
+	}
+}
+
+func externalEventGatewayResourceWithVirtualCluster() resources.EventGatewayControlPlaneResource {
+	gateway := externalEventGatewayResource()
+	gateway.VirtualClusters = []resources.EventGatewayVirtualClusterResource{
+		externalEventGatewayVirtualClusterResource(),
+	}
+	return gateway
+}
+
+func externalEventGatewayVirtualClusterResource() resources.EventGatewayVirtualClusterResource {
+	return resources.EventGatewayVirtualClusterResource{
+		Ref:                         "virtual-cluster-ref",
+		CreateVirtualClusterRequest: kkComps.CreateVirtualClusterRequest{Name: "external-vc"},
+		External:                    &resources.ExternalBlock{ID: "vc-123"},
+	}
+}
+
+func requireNoDeleteChange(t *testing.T, plan *Plan, resourceType string) {
+	t.Helper()
+
+	for _, change := range plan.Changes {
+		if change.ResourceType == resourceType && change.Action == ActionDelete {
+			t.Fatalf("unexpected %s delete planned for external event gateway: %+v", resourceType, change)
+		}
+	}
+}
+
+func eventGatewayExternalCursorMeta() *kkComps.CursorMeta {
+	return &kkComps.CursorMeta{
+		Page: kkComps.CursorMetaPage{},
+	}
+}

--- a/internal/declarative/planner/event_gateway_external_test.go
+++ b/internal/declarative/planner/event_gateway_external_test.go
@@ -282,6 +282,24 @@ func TestPlanner_ExternalEventGateway_PlansExternalVirtualClusterChildren(t *tes
 	require.Equal(t, virtualClusterID, change.References[FieldEventGatewayVirtualClusterID].ID)
 }
 
+func TestPlanner_ExternalEventGateway_MissingResolvedIDFailsBeforeChildPlanning(t *testing.T) {
+	t.Parallel()
+
+	rs := externalEventGatewayResourceSet()
+	planner := NewPlanner(state.NewClient(state.ClientConfig{}), slog.Default())
+	planner.resources = rs
+
+	plan := NewPlan("1.0", "test", PlanModeApply)
+	err := planner.planEGWControlPlaneChanges(
+		context.Background(),
+		NewConfig(resources.NamespaceExternal),
+		rs.GetEventGatewayControlPlanesByNamespace(resources.NamespaceExternal),
+		plan,
+	)
+	require.ErrorContains(t, err, `external event_gateway "event-gateway-ref" has no resolved Konnect ID`)
+	require.Empty(t, plan.Changes)
+}
+
 func TestPlanner_ExternalEventGateway_SyncDoesNotDeleteExistingBackendClusters(t *testing.T) {
 	t.Parallel()
 

--- a/internal/declarative/planner/event_gateway_listener_planner.go
+++ b/internal/declarative/planner/event_gateway_listener_planner.go
@@ -160,7 +160,7 @@ func (p *Planner) planListenerChangesForExistingGateway(
 	}
 
 	// 4. SYNC MODE: Delete unmanaged listeners
-	if plan.Metadata.Mode == PlanModeSync {
+	if plan.Metadata.Mode == PlanModeSync && !p.isEventGatewayExternal(gatewayRef) {
 		for name, current := range currentByName {
 			if !desiredNames[name] {
 				p.logger.Debug(

--- a/internal/declarative/planner/event_gateway_listener_policy_planner.go
+++ b/internal/declarative/planner/event_gateway_listener_policy_planner.go
@@ -136,7 +136,7 @@ func (p *Planner) planListenerPolicyChangesForExistingListener(
 	}
 
 	// 4. SYNC MODE: Delete unmanaged policies
-	if plan.Metadata.Mode == PlanModeSync {
+	if plan.Metadata.Mode == PlanModeSync && !p.isEventGatewayExternal(gatewayRef) {
 		for name, current := range currentByName {
 			if !desiredNames[name] {
 				p.logger.Debug(

--- a/internal/declarative/planner/event_gateway_produce_policy_planner.go
+++ b/internal/declarative/planner/event_gateway_produce_policy_planner.go
@@ -139,7 +139,7 @@ func (p *Planner) planProducePolicyChangesForExistingVirtualCluster(
 		}
 	}
 
-	if plan.Metadata.Mode == PlanModeSync {
+	if plan.Metadata.Mode == PlanModeSync && !p.isEventGatewayVirtualClusterExternal(virtualClusterRef) {
 		for name, current := range currentByName {
 			if !desiredNames[name] {
 				p.logger.Debug(

--- a/internal/declarative/planner/event_gateway_schema_registry_planner.go
+++ b/internal/declarative/planner/event_gateway_schema_registry_planner.go
@@ -118,7 +118,7 @@ func (p *Planner) planSchemaRegistryChangesForExistingGateway(
 	}
 
 	// SYNC MODE: Delete unmanaged registries
-	if plan.Metadata.Mode == PlanModeSync {
+	if plan.Metadata.Mode == PlanModeSync && !p.isEventGatewayExternal(gatewayRef) {
 		for name, current := range currentByName {
 			if !desiredNames[name] {
 				p.logger.Debug(

--- a/internal/declarative/planner/event_gateway_static_key_planner.go
+++ b/internal/declarative/planner/event_gateway_static_key_planner.go
@@ -116,7 +116,7 @@ func (p *Planner) planStaticKeyChangesForExistingGateway(
 	}
 
 	// 4. SYNC MODE: Delete unmanaged static keys
-	if plan.Metadata.Mode == PlanModeSync {
+	if plan.Metadata.Mode == PlanModeSync && !p.isEventGatewayExternal(gatewayRef) {
 		for name, current := range currentByName {
 			if !desiredNames[name] {
 				p.logger.Debug(

--- a/internal/declarative/planner/event_gateway_tls_trust_bundle_planner.go
+++ b/internal/declarative/planner/event_gateway_tls_trust_bundle_planner.go
@@ -117,7 +117,7 @@ func (p *Planner) planTrustBundleChangesForExistingGateway(
 	}
 
 	// SYNC MODE: Delete unmanaged trust bundles
-	if plan.Metadata.Mode == PlanModeSync {
+	if plan.Metadata.Mode == PlanModeSync && !p.isEventGatewayExternal(gatewayRef) {
 		for name, current := range currentByName {
 			if !desiredNames[name] {
 				p.logger.Debug(

--- a/internal/declarative/planner/event_gateway_virtual_cluster_planner.go
+++ b/internal/declarative/planner/event_gateway_virtual_cluster_planner.go
@@ -85,6 +85,75 @@ func (p *Planner) planVirtualClusterChangesForExistingGateway(
 	// 3. Compare desired vs current
 	desiredNames := make(map[string]bool)
 	for _, desiredCluster := range desired {
+		if desiredCluster.IsExternal() {
+			current, err := matchExternalEventGatewayVirtualCluster(&desiredCluster, currentClusters)
+			if err != nil {
+				return err
+			}
+			if !desiredCluster.TryMatchKonnectResource(current) {
+				return fmt.Errorf(
+					"external event_gateway_virtual_cluster %s: failed to bind Konnect resource",
+					desiredCluster.GetRef(),
+				)
+			}
+			if current.Name != "" {
+				desiredCluster.Name = current.Name
+			}
+			desiredNames[current.Name] = true
+
+			// Plan child resources for this existing external virtual cluster, but never update
+			// the virtual cluster itself.
+			clusterPolicies := p.resources.GetClusterPoliciesForVirtualCluster(desiredCluster.Ref)
+			if p.shouldPlanChild(
+				plan,
+				resources.ResourceTypeEventGatewayVirtualCluster,
+				desiredCluster.Ref,
+				resources.ResourceTypeEventGatewayClusterPolicy,
+			) && (len(clusterPolicies) > 0 || plan.Metadata.Mode == PlanModeSync) {
+				if err := p.planEventGatewayClusterPolicyChanges(
+					ctx, nil, namespace, gatewayID, gatewayRef,
+					desiredCluster.Name, current.ID, desiredCluster.Ref,
+					"", clusterPolicies, plan,
+				); err != nil {
+					return err
+				}
+			}
+
+			producePolicies := p.resources.GetProducePoliciesForVirtualCluster(desiredCluster.Ref)
+			if p.shouldPlanChild(
+				plan,
+				resources.ResourceTypeEventGatewayVirtualCluster,
+				desiredCluster.Ref,
+				resources.ResourceTypeEventGatewayProducePolicy,
+			) && (len(producePolicies) > 0 || plan.Metadata.Mode == PlanModeSync) {
+				if err := p.planEventGatewayVirtualClusterProducePolicyChanges(
+					ctx, nil, namespace, gatewayID, gatewayRef,
+					desiredCluster.Name, current.ID, desiredCluster.Ref,
+					"", producePolicies, plan,
+				); err != nil {
+					return err
+				}
+			}
+
+			consumePolicies := p.resources.GetConsumePoliciesForVirtualCluster(desiredCluster.Ref)
+			if p.shouldPlanChild(
+				plan,
+				resources.ResourceTypeEventGatewayVirtualCluster,
+				desiredCluster.Ref,
+				resources.ResourceTypeEventGatewayConsumePolicy,
+			) && (len(consumePolicies) > 0 || plan.Metadata.Mode == PlanModeSync) {
+				if err := p.planEventGatewayConsumePolicyChanges(
+					ctx, nil, namespace, gatewayID, gatewayRef,
+					desiredCluster.Name, current.ID, desiredCluster.Ref,
+					"", consumePolicies, plan,
+				); err != nil {
+					return err
+				}
+			}
+
+			continue
+		}
+
 		desiredNames[desiredCluster.Name] = true
 		current, exists := currentByName[desiredCluster.Name]
 		if !exists {
@@ -229,7 +298,7 @@ func (p *Planner) planVirtualClusterChangesForExistingGateway(
 	}
 
 	// 4. SYNC MODE: Delete unmanaged clusters
-	if plan.Metadata.Mode == PlanModeSync {
+	if plan.Metadata.Mode == PlanModeSync && !p.isEventGatewayExternal(gatewayRef) {
 		for name, current := range currentByName {
 			if !desiredNames[name] {
 				p.logger.Debug(

--- a/internal/declarative/planner/planner.go
+++ b/internal/declarative/planner/planner.go
@@ -885,6 +885,10 @@ func (p *Planner) resolveResourceIdentities(ctx context.Context, rs *resources.R
 		return fmt.Errorf("failed to resolve control plane identities: %w", err)
 	}
 
+	if err := p.resolveEventGatewayControlPlaneIdentities(ctx, rs.EventGatewayControlPlanes); err != nil {
+		return fmt.Errorf("failed to resolve Event Gateway identities: %w", err)
+	}
+
 	if err := p.resolveGatewayServiceIdentities(ctx, rs.GatewayServices, rs.ControlPlanes); err != nil {
 		return fmt.Errorf("failed to resolve gateway service identities: %w", err)
 	}
@@ -1188,6 +1192,106 @@ func (p *Planner) resolveControlPlaneIdentities(
 	}
 
 	return nil
+}
+
+func (p *Planner) resolveEventGatewayControlPlaneIdentities(
+	ctx context.Context,
+	eventGateways []resources.EventGatewayControlPlaneResource,
+) error {
+	var (
+		allGateways []state.EventGatewayControlPlane
+		loaded      bool
+	)
+
+	loadAll := func() error {
+		if loaded {
+			return nil
+		}
+		gateways, err := p.client.ListAllEventGatewayControlPlanes(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to list Event Gateways for external lookup: %w", err)
+		}
+		allGateways = gateways
+		loaded = true
+		return nil
+	}
+
+	for i := range eventGateways {
+		eventGateway := &eventGateways[i]
+		if eventGateway.GetKonnectID() != "" || !eventGateway.IsExternal() {
+			continue
+		}
+		if err := loadAll(); err != nil {
+			return err
+		}
+
+		match, err := matchExternalEventGatewayControlPlane(eventGateway, allGateways)
+		if err != nil {
+			return err
+		}
+		if !eventGateway.TryMatchKonnectResource(match) {
+			return fmt.Errorf("external event_gateway %s: failed to bind Konnect resource", eventGateway.GetRef())
+		}
+		if match.Name != "" {
+			eventGateway.Name = match.Name
+		}
+
+		p.logger.Debug(
+			"Resolved external Event Gateway",
+			slog.String("ref", eventGateway.GetRef()),
+			slog.String("id", eventGateway.GetKonnectID()),
+			slog.String("name", eventGateway.Name),
+		)
+	}
+
+	return nil
+}
+
+func matchExternalEventGatewayControlPlane(
+	eventGateway *resources.EventGatewayControlPlaneResource,
+	available []state.EventGatewayControlPlane,
+) (*state.EventGatewayControlPlane, error) {
+	if eventGateway == nil || eventGateway.External == nil {
+		return nil, fmt.Errorf("event_gateway requires _external")
+	}
+
+	if eventGateway.External.ID != "" {
+		for i := range available {
+			if available[i].ID == eventGateway.External.ID {
+				return &available[i], nil
+			}
+		}
+		return nil, fmt.Errorf("external event_gateway %s: not found with id %s",
+			eventGateway.GetRef(), eventGateway.External.ID)
+	}
+
+	if eventGateway.External.Selector == nil {
+		return nil, fmt.Errorf("external event_gateway %s: invalid _external configuration", eventGateway.GetRef())
+	}
+
+	matchFields := eventGateway.External.Selector.MatchFields
+	var match *state.EventGatewayControlPlane
+	for i := range available {
+		if eventGateway.External.Selector.Match(available[i]) {
+			if match != nil {
+				return nil, fmt.Errorf(
+					"external event_gateway %s: selector %v matched multiple Event Gateways",
+					eventGateway.GetRef(),
+					matchFields,
+				)
+			}
+			match = &available[i]
+		}
+	}
+	if match == nil {
+		return nil, fmt.Errorf(
+			"external event_gateway %s: selector %v did not match any Event Gateway",
+			eventGateway.GetRef(),
+			matchFields,
+		)
+	}
+
+	return match, nil
 }
 
 func (p *Planner) resolveGatewayServiceIdentities(
@@ -2174,6 +2278,7 @@ func (p *Planner) resolveAuthStrategyIdentities(
 func (p *Planner) getResourceNamespaces(rs *resources.ResourceSet) []string {
 	namespaceSet := make(map[string]bool)
 	hasExternalPortals := false
+	hasExternalEventGateways := false
 	hasExternalOrganizationTeams := false
 
 	// Extract namespaces from parent resources
@@ -2217,6 +2322,10 @@ func (p *Planner) getResourceNamespaces(rs *resources.ResourceSet) []string {
 	}
 
 	for _, cp := range rs.EventGatewayControlPlanes {
+		if cp.IsExternal() {
+			hasExternalEventGateways = true
+			continue
+		}
 		ns := resources.GetNamespace(cp.Kongctl)
 		namespaceSet[ns] = true
 	}
@@ -2249,7 +2358,7 @@ func (p *Planner) getResourceNamespaces(rs *resources.ResourceSet) []string {
 	// Sort for consistent processing order
 	sort.Strings(namespaces)
 
-	if hasExternalPortals || hasExternalOrganizationTeams {
+	if hasExternalPortals || hasExternalEventGateways || hasExternalOrganizationTeams {
 		namespaces = append(namespaces, resources.NamespaceExternal)
 	}
 

--- a/internal/declarative/planner/sync_scope.go
+++ b/internal/declarative/planner/sync_scope.go
@@ -305,6 +305,7 @@ func syncParentTypeSupportsExternal(rt resources.ResourceType) bool {
 	switch rt {
 	case resources.ResourceTypePortal,
 		resources.ResourceTypeControlPlane,
+		resources.ResourceTypeEventGatewayControlPlane,
 		resources.ResourceTypeOrganizationTeam:
 		return true
 	default:

--- a/internal/declarative/resources/event_gateway_control_plane.go
+++ b/internal/declarative/resources/event_gateway_control_plane.go
@@ -28,6 +28,9 @@ type EventGatewayControlPlaneResource struct {
 	SchemaRegistries      []EventGatewaySchemaRegistryResource       `yaml:"schema_registries,omitempty"       json:"schema_registries,omitempty"`       //nolint:lll
 	StaticKeys            []EventGatewayStaticKeyResource            `yaml:"static_keys,omitempty"             json:"static_keys,omitempty"`             //nolint:lll
 	TrustBundles          []EventGatewayTLSTrustBundleResource       `yaml:"tls_trust_bundles,omitempty"       json:"tls_trust_bundles,omitempty"`       //nolint:lll
+
+	// External resource marker
+	External *ExternalBlock `yaml:"_external,omitempty" json:"_external,omitempty"`
 }
 
 func (e EventGatewayControlPlaneResource) GetType() ResourceType {
@@ -54,6 +57,12 @@ func (e *EventGatewayControlPlaneResource) SetLabels(labels map[string]string) {
 func (e EventGatewayControlPlaneResource) Validate() error {
 	if err := ValidateRef(e.Ref); err != nil {
 		return fmt.Errorf("invalid Event Gateway Control Plane ref: %w", err)
+	}
+
+	if e.External != nil {
+		if err := e.External.Validate(); err != nil {
+			return fmt.Errorf("invalid _external block: %w", err)
+		}
 	}
 
 	// Validate backend clusters
@@ -183,5 +192,19 @@ func (e EventGatewayControlPlaneResource) GetKonnectMonikerFilter() string {
 
 // TryMatchKonnectResource attempts to match this resource with a Konnect resource.
 func (e *EventGatewayControlPlaneResource) TryMatchKonnectResource(konnectResource any) bool {
-	return e.TryMatchByName(e.Name, konnectResource, matchOptions{sdkType: "EventGatewayInfo"})
+	id, ok := tryMatchByNameWithExternal(
+		e.Name,
+		konnectResource,
+		matchOptions{sdkType: "EventGatewayInfo"},
+		e.External,
+	)
+	if ok {
+		e.SetKonnectID(id)
+	}
+	return ok
+}
+
+// IsExternal returns true if this Event Gateway is externally managed.
+func (e *EventGatewayControlPlaneResource) IsExternal() bool {
+	return e.External != nil && e.External.IsExternal()
 }

--- a/internal/declarative/resources/event_gateway_virtual_cluster.go
+++ b/internal/declarative/resources/event_gateway_virtual_cluster.go
@@ -23,6 +23,9 @@ type EventGatewayVirtualClusterResource struct {
 	// Parent Event Gateway reference (for root-level definitions)
 	EventGateway string `yaml:"event_gateway,omitempty" json:"event_gateway,omitempty"`
 
+	// External resource marker
+	External *ExternalBlock `yaml:"_external,omitempty" json:"_external,omitempty"`
+
 	// Nested child resources
 	ClusterPolicies []EventGatewayClusterPolicyResource `yaml:"cluster_policies,omitempty" json:"cluster_policies,omitempty"`  //nolint:lll
 	ProducePolicies []EventGatewayProducePolicyResource `yaml:"produce_policies,omitempty" json:"produce_policies,omitempty"`  //nolint:lll
@@ -60,6 +63,12 @@ func (e EventGatewayVirtualClusterResource) GetKonnectID() string {
 func (e EventGatewayVirtualClusterResource) Validate() error {
 	if err := ValidateRef(e.Ref); err != nil {
 		return fmt.Errorf("invalid child ref: %w", err)
+	}
+
+	if e.External != nil {
+		if err := e.External.Validate(); err != nil {
+			return fmt.Errorf("invalid _external block: %w", err)
+		}
 	}
 
 	// Validate cluster policies
@@ -126,11 +135,20 @@ func (e EventGatewayVirtualClusterResource) GetKonnectMonikerFilter() string {
 }
 
 func (e *EventGatewayVirtualClusterResource) TryMatchKonnectResource(konnectResource any) bool {
-	if id := tryMatchByField(konnectResource, "Name", e.Name); id != "" {
-		e.konnectID = id
-		return true
+	id, ok := tryMatchByNameWithExternal(e.Name, konnectResource, matchOptions{}, e.External)
+	if ok {
+		e.SetKonnectID(id)
 	}
-	return false
+	return ok
+}
+
+func (e *EventGatewayVirtualClusterResource) SetKonnectID(id string) {
+	e.konnectID = id
+}
+
+// IsExternal returns true if this virtual cluster is externally managed.
+func (e *EventGatewayVirtualClusterResource) IsExternal() bool {
+	return e.External != nil && e.External.IsExternal()
 }
 
 // REQUIRED: Implement ResourceWithParent
@@ -145,8 +163,9 @@ func (e EventGatewayVirtualClusterResource) GetParentRef() *ResourceRef {
 // Without this, the embedded CreateVirtualClusterRequest's MarshalJSON is promoted and drops metadata fields.
 func (e EventGatewayVirtualClusterResource) MarshalJSON() ([]byte, error) {
 	type alias struct {
-		Ref          string `json:"ref"`
-		EventGateway string `json:"event_gateway,omitempty"`
+		Ref          string         `json:"ref"`
+		EventGateway string         `json:"event_gateway,omitempty"`
+		External     *ExternalBlock `json:"_external,omitempty"`
 
 		// Fields from kkComps.CreateVirtualClusterRequest
 		Name           string                                       `json:"name"`
@@ -168,6 +187,7 @@ func (e EventGatewayVirtualClusterResource) MarshalJSON() ([]byte, error) {
 	payload := alias{
 		Ref:             e.Ref,
 		EventGateway:    e.EventGateway,
+		External:        e.External,
 		Name:            e.Name,
 		Description:     e.Description,
 		Destination:     e.Destination,
@@ -190,9 +210,10 @@ func (e *EventGatewayVirtualClusterResource) UnmarshalJSON(data []byte) error {
 	// Temporary structure for unmarshaling resource metadata together with
 	// the CreateVirtualClusterRequest fields from the SDK.
 	var temp struct {
-		Ref          string `json:"ref"`
-		EventGateway string `json:"event_gateway,omitempty"`
-		Kongctl      any    `json:"kongctl,omitempty"`
+		Ref          string         `json:"ref"`
+		EventGateway string         `json:"event_gateway,omitempty"`
+		External     *ExternalBlock `json:"_external,omitempty"`
+		Kongctl      any            `json:"kongctl,omitempty"`
 
 		// Fields from kkComps.CreateVirtualClusterRequest
 		Name           string                                       `json:"name"`
@@ -222,6 +243,7 @@ func (e *EventGatewayVirtualClusterResource) UnmarshalJSON(data []byte) error {
 	// Populate resource metadata
 	e.Ref = temp.Ref
 	e.EventGateway = temp.EventGateway
+	e.External = temp.External
 
 	// Populate embedded CreateVirtualClusterRequest fields
 	e.Name = temp.Name

--- a/internal/declarative/resources/resources_test.go
+++ b/internal/declarative/resources/resources_test.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"testing"
 
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 )
@@ -51,6 +52,45 @@ func TestGetPortalsByNamespaceIncludesExternalsWhenRequested(t *testing.T) {
 	externalPages := rs.GetPortalPagesByNamespace(NamespaceExternal)
 	require.Len(t, externalPages, 1)
 	require.Equal(t, "page-2", externalPages[0].Ref)
+}
+
+func TestGetEventGatewayControlPlanesByNamespaceIncludesExternalsWhenRequested(t *testing.T) {
+	team := "team-one"
+	rs := &ResourceSet{
+		EventGatewayControlPlanes: []EventGatewayControlPlaneResource{
+			{
+				BaseResource: BaseResource{
+					Ref:     "managed",
+					Kongctl: namespaceMeta(team),
+				},
+				CreateGatewayRequest: kkComps.CreateGatewayRequest{Name: "managed"},
+			},
+			{
+				BaseResource:         BaseResource{Ref: "external"},
+				CreateGatewayRequest: kkComps.CreateGatewayRequest{Name: "external"},
+				External:             &ExternalBlock{ID: "gateway-123"},
+				VirtualClusters: []EventGatewayVirtualClusterResource{
+					{
+						Ref:                         "external-vc",
+						CreateVirtualClusterRequest: kkComps.CreateVirtualClusterRequest{Name: "external-vc"},
+						External:                    &ExternalBlock{ID: "vc-123"},
+					},
+				},
+			},
+		},
+	}
+
+	managed := rs.GetEventGatewayControlPlanesByNamespace(team)
+	require.Len(t, managed, 1)
+	require.Equal(t, "managed", managed[0].Ref)
+
+	external := rs.GetEventGatewayControlPlanesByNamespace(NamespaceExternal)
+	require.Len(t, external, 1)
+	require.Equal(t, "external", external[0].Ref)
+
+	require.Equal(t, "external", rs.GetEventGatewayControlPlaneByRef("external").Ref)
+	require.Equal(t, "external-vc", rs.GetVirtualClusterByRef("external-vc").Ref)
+	require.Equal(t, "vc-123", rs.GetVirtualClusterByRef("external-vc").External.ID)
 }
 
 func TestGetOrganizationUserTeamMembershipsByNamespaceUsesTeamNamespace(t *testing.T) {

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -733,6 +733,12 @@ func (rs *ResourceSet) GetPortalTeamRolesByNamespace(namespace string) []PortalT
 func (rs *ResourceSet) GetEventGatewayControlPlanesByNamespace(namespace string) []EventGatewayControlPlaneResource {
 	var filtered []EventGatewayControlPlaneResource
 	for _, cp := range rs.EventGatewayControlPlanes {
+		if cp.IsExternal() {
+			if namespace == NamespaceExternal {
+				filtered = append(filtered, cp)
+			}
+			continue
+		}
 		if GetNamespace(cp.Kongctl) == namespace {
 			filtered = append(filtered, cp)
 		}
@@ -750,8 +756,25 @@ func (rs *ResourceSet) GetBackendClusterByRef(ref string) *EventGatewayBackendCl
 	return nil
 }
 
+// GetEventGatewayControlPlaneByRef returns an Event Gateway resource by its ref from any namespace.
+func (rs *ResourceSet) GetEventGatewayControlPlaneByRef(ref string) *EventGatewayControlPlaneResource {
+	for i := range rs.EventGatewayControlPlanes {
+		if rs.EventGatewayControlPlanes[i].GetRef() == ref {
+			return &rs.EventGatewayControlPlanes[i]
+		}
+	}
+	return nil
+}
+
 // GetVirtualClusterByRef returns a virtual cluster resource by its ref from any namespace
 func (rs *ResourceSet) GetVirtualClusterByRef(ref string) *EventGatewayVirtualClusterResource {
+	for gatewayIdx := range rs.EventGatewayControlPlanes {
+		for clusterIdx := range rs.EventGatewayControlPlanes[gatewayIdx].VirtualClusters {
+			if rs.EventGatewayControlPlanes[gatewayIdx].VirtualClusters[clusterIdx].GetRef() == ref {
+				return &rs.EventGatewayControlPlanes[gatewayIdx].VirtualClusters[clusterIdx]
+			}
+		}
+	}
 	for i := range rs.EventGatewayVirtualClusters {
 		if rs.EventGatewayVirtualClusters[i].GetRef() == ref {
 			return &rs.EventGatewayVirtualClusters[i]

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -5225,6 +5225,53 @@ func (c *Client) ListManagedEventGatewayControlPlanes(
 	return filteredEGWControlPlanes, nil
 }
 
+// ListAllEventGatewayControlPlanes returns all Event Gateways, including non-managed ones.
+func (c *Client) ListAllEventGatewayControlPlanes(ctx context.Context) ([]EventGatewayControlPlane, error) {
+	if err := ValidateAPIClient(c.egwControlPlaneAPI, "event gateway control plane API"); err != nil {
+		return nil, err
+	}
+
+	var allData []kkComps.EventGatewayInfo
+	var pageAfter *string
+
+	for {
+		req := kkOps.ListEventGatewaysRequest{}
+		if pageAfter != nil {
+			req.PageAfter = pageAfter
+		}
+
+		res, err := c.egwControlPlaneAPI.ListEGWControlPlanes(ctx, req)
+		if err != nil {
+			return nil, WrapAPIError(err, "list all event gateway control planes", nil)
+		}
+		if res.ListEventGatewaysResponse == nil {
+			return []EventGatewayControlPlane{}, nil
+		}
+
+		allData = append(allData, res.ListEventGatewaysResponse.Data...)
+
+		nextCursor := pagination.ExtractPageAfterCursor(res.ListEventGatewaysResponse.Meta.Page.Next)
+		if nextCursor == "" {
+			break
+		}
+		pageAfter = &nextCursor
+	}
+
+	gateways := make([]EventGatewayControlPlane, 0, len(allData))
+	for _, gateway := range allData {
+		normalized := gateway.Labels
+		if normalized == nil {
+			normalized = make(map[string]string)
+		}
+		gateways = append(gateways, EventGatewayControlPlane{
+			EventGatewayInfo: gateway,
+			NormalizedLabels: normalized,
+		})
+	}
+
+	return gateways, nil
+}
+
 func (c *Client) CreateEventGatewayControlPlane(
 	ctx context.Context,
 	req kkComps.CreateGatewayRequest,

--- a/internal/declarative/validator/namespace_validator.go
+++ b/internal/declarative/validator/namespace_validator.go
@@ -214,13 +214,21 @@ func (v *NamespaceValidator) ValidateNamespaceRequirement(
 		managedOrganizationTeams = append(managedOrganizationTeams, team)
 	}
 
+	managedEventGateways := make([]resources.EventGatewayControlPlaneResource, 0, len(rs.EventGatewayControlPlanes))
+	for _, eventGateway := range rs.EventGatewayControlPlanes {
+		if eventGateway.IsExternal() {
+			continue
+		}
+		managedEventGateways = append(managedEventGateways, eventGateway)
+	}
+
 	totalParents := len(managedPortals) +
 		len(rs.ApplicationAuthStrategies) +
 		len(rs.DCRProviders) +
 		len(managedControlPlanes) +
 		len(rs.CatalogServices) +
 		len(rs.APIs) +
-		len(rs.EventGatewayControlPlanes) +
+		len(managedEventGateways) +
 		len(rs.Dashboards) +
 		len(managedOrganizationTeams)
 	if rs.Organization != nil {

--- a/test/e2e/harness/step.go
+++ b/test/e2e/harness/step.go
@@ -369,6 +369,36 @@ var createResourceEndpoints = map[string]resourceEndpoint{
 	"event-gateway":      {Method: http.MethodPost, Path: "/v1/event-gateways"},
 	"event_gateway":      {Method: http.MethodPost, Path: "/v1/event-gateways"},
 	"eventgateway":       {Method: http.MethodPost, Path: "/v1/event-gateways"},
+	"event-gateway-backend-cluster": {
+		Method:    http.MethodPost,
+		Path:      "/v1/event-gateways/{gatewayId}/backend-clusters",
+		ParamKeys: []string{"gatewayId"},
+	},
+	"event_gateway_backend_cluster": {
+		Method:    http.MethodPost,
+		Path:      "/v1/event-gateways/{gatewayId}/backend-clusters",
+		ParamKeys: []string{"gatewayId"},
+	},
+	"eventgatewaybackendcluster": {
+		Method:    http.MethodPost,
+		Path:      "/v1/event-gateways/{gatewayId}/backend-clusters",
+		ParamKeys: []string{"gatewayId"},
+	},
+	"event-gateway-virtual-cluster": {
+		Method:    http.MethodPost,
+		Path:      "/v1/event-gateways/{gatewayId}/virtual-clusters",
+		ParamKeys: []string{"gatewayId"},
+	},
+	"event_gateway_virtual_cluster": {
+		Method:    http.MethodPost,
+		Path:      "/v1/event-gateways/{gatewayId}/virtual-clusters",
+		ParamKeys: []string{"gatewayId"},
+	},
+	"eventgatewayvirtualcluster": {
+		Method:    http.MethodPost,
+		Path:      "/v1/event-gateways/{gatewayId}/virtual-clusters",
+		ParamKeys: []string{"gatewayId"},
+	},
 	"audit-log-destination": {
 		Method:    http.MethodPost,
 		Path:      "/v3/audit-log-destinations",

--- a/test/e2e/harness/step_test.go
+++ b/test/e2e/harness/step_test.go
@@ -28,6 +28,43 @@ func TestSystemAccountAccessTokenEndpointExpansion(t *testing.T) {
 	}
 }
 
+func TestEventGatewayChildEndpointExpansion(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource string
+		want     string
+	}{
+		{
+			name:     "backend cluster",
+			resource: "event-gateway-backend-cluster",
+			want:     "/v1/event-gateways/gateway%2F123/backend-clusters",
+		},
+		{
+			name:     "virtual cluster",
+			resource: "event-gateway-virtual-cluster",
+			want:     "/v1/event-gateways/gateway%2F123/virtual-clusters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoint, ok := createResourceEndpoints[tt.resource]
+			if !ok {
+				t.Fatalf("%s endpoint missing", tt.resource)
+			}
+
+			path, err := endpoint.expandPath(map[string]string{"gatewayId": "gateway/123"})
+			if err != nil {
+				t.Fatalf("expandPath() error = %v", err)
+			}
+
+			if path != tt.want {
+				t.Fatalf("path = %q, want %q", path, tt.want)
+			}
+		})
+	}
+}
+
 func TestRedactSensitiveJSONRedactsTokenFields(t *testing.T) {
 	body := []byte(`{"id":"token-id","token":"secret-token","nested":{"api_token":"nested-secret"},"items":[{"secret":"value"}]}`)
 

--- a/test/e2e/scenarios/event-gateway/external-sync/overlays/002-add-cluster-policy/external-event-gateway.yaml
+++ b/test/e2e/scenarios/event-gateway/external-sync/overlays/002-add-cluster-policy/external-event-gateway.yaml
@@ -1,0 +1,26 @@
+event_gateways:
+  - ref: external-sync-event-gateway
+    _external:
+      selector:
+        matchFields:
+          name: "external-sync-event-gateway"
+    virtual_clusters:
+      - ref: external-sync-virtual-cluster
+        _external:
+          selector:
+            matchFields:
+              name: "external-sync-virtual-cluster"
+        cluster_policies:
+          - ref: external-sync-cluster-policy
+            name: external-sync-cluster-policy
+            description: "External sync cluster policy"
+            type: acls
+            enabled: true
+            config:
+              rules:
+                - action: allow
+                  operations:
+                    - name: describe_configs
+                  resource_names:
+                    - match: "*"
+                  resource_type: transactional_id

--- a/test/e2e/scenarios/event-gateway/external-sync/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/external-sync/scenario.yaml
@@ -1,0 +1,212 @@
+baseInputsPath: ./testdata
+
+env:
+  KONGCTL_LOG_LEVEL: info
+
+vars:
+  egw_name: external-sync-event-gateway
+  backend_cluster_name: external-sync-backend-cluster
+  virtual_cluster_name: external-sync-virtual-cluster
+  cluster_policy_ref: external-sync-cluster-policy
+  cluster_policy_name: external-sync-cluster-policy
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - created_at
+      - updated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-bootstrap-out-of-band-event-gateway
+    skipInputs: true
+    commands:
+      - name: 000-create-event-gateway
+        create:
+          resource: event_gateway
+          payload:
+            inline:
+              name: "{{ .vars.egw_name }}"
+              description: "External sync event gateway"
+          recordVar:
+            name: egw_id
+            responsePath: id
+
+      - name: 001-create-backend-cluster
+        create:
+          resource: event-gateway-backend-cluster
+          endpointParams:
+            gatewayId: "{{ .vars.egw_id }}"
+          payload:
+            inline:
+              name: "{{ .vars.backend_cluster_name }}"
+              description: "External sync backend cluster"
+              authentication:
+                type: anonymous
+              insecure_allow_anonymous_virtual_cluster_auth: true
+              bootstrap_servers:
+                - "external-sync-backend-1.example.com:9092"
+                - "external-sync-backend-2.example.com:9092"
+              tls:
+                enabled: true
+                skip_verify: false
+                tls_versions:
+                  - tls12
+                  - tls13
+          recordVar:
+            name: backend_cluster_id
+            responsePath: id
+
+      - name: 002-create-virtual-cluster
+        create:
+          resource: event-gateway-virtual-cluster
+          endpointParams:
+            gatewayId: "{{ .vars.egw_id }}"
+          payload:
+            inline:
+              name: "{{ .vars.virtual_cluster_name }}"
+              description: "External sync virtual cluster"
+              destination:
+                id: "{{ .vars.backend_cluster_id }}"
+              authentication:
+                - type: anonymous
+              acl_mode: enforce_on_gateway
+              dns_label: external-sync-vc
+          recordVar:
+            name: virtual_cluster_id
+            responsePath: id
+
+  - name: 002-sync-external-reference
+    commands:
+      - name: 000-sync-dry-run
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/external-event-gateway.yaml"
+          - --dry-run
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: sync
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 0
+          - select: plan.changes[?resource_type=='event_gateway_backend_cluster' && action=='DELETE']
+            expect:
+              fields:
+                "length(@)": 0
+          - select: plan.changes[?resource_type=='event_gateway_virtual_cluster' && action=='DELETE']
+            expect:
+              fields:
+                "length(@)": 0
+
+  - name: 003-sync-with-declarative-cluster-policy
+    inputOverlayDirs:
+      - overlays/002-add-cluster-policy
+    commands:
+      - name: 000-sync-add-cluster-policy
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/external-event-gateway.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.CREATE: 1
+          - select: >-
+              plan.changes[?resource_type=='event_gateway_virtual_cluster_cluster_policy' &&
+              resource_ref=='{{ .vars.cluster_policy_ref }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.cluster_policy_ref }}"
+          - select: plan.changes[?resource_type=='event_gateway_virtual_cluster' && action=='DELETE']
+            expect:
+              fields:
+                "length(@)": 0
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+
+      - name: 001-get-cluster-policies
+        run:
+          - get
+          - event-gateway
+          - virtual-cluster
+          - cluster-policies
+          - --gateway-name
+          - "{{ .vars.egw_name }}"
+          - --virtual-cluster-name
+          - "{{ .vars.virtual_cluster_name }}"
+          - -o
+          - json
+        assertions:
+          - select: "[?name=='{{ .vars.cluster_policy_name }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.cluster_policy_name }}"
+                description: "External sync cluster policy"
+
+  - name: 004-sync-idempotency
+    inputOverlayDirs:
+      - overlays/002-add-cluster-policy
+    commands:
+      - name: 000-sync-no-changes
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/external-event-gateway.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 0
+
+  - name: 005-sync-remove-declarative-cluster-policy
+    commands:
+      - name: 000-sync-no-deletions
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/external-event-gateway.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 0
+          - select: plan.changes[?resource_type=='event_gateway_virtual_cluster_cluster_policy' && action=='DELETE']
+            expect:
+              fields:
+                "length(@)": 0
+
+      - name: 001-get-cluster-policies-after-sync
+        run:
+          - get
+          - event-gateway
+          - virtual-cluster
+          - cluster-policies
+          - --gateway-name
+          - "{{ .vars.egw_name }}"
+          - --virtual-cluster-name
+          - "{{ .vars.virtual_cluster_name }}"
+          - -o
+          - json
+        assertions:
+          - select: "[?name=='{{ .vars.cluster_policy_name }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.cluster_policy_name }}"

--- a/test/e2e/scenarios/event-gateway/external-sync/testdata/external-event-gateway.yaml
+++ b/test/e2e/scenarios/event-gateway/external-sync/testdata/external-event-gateway.yaml
@@ -1,0 +1,12 @@
+event_gateways:
+  - ref: external-sync-event-gateway
+    _external:
+      selector:
+        matchFields:
+          name: "external-sync-event-gateway"
+    virtual_clusters:
+      - ref: external-sync-virtual-cluster
+        _external:
+          selector:
+            matchFields:
+              name: "external-sync-virtual-cluster"


### PR DESCRIPTION
## Summary
- Add `_external` support for event gateways and nested event gateway virtual clusters.
- Resolve external event gateway identities and allow child planning without managing external parents.
- Suppress sync deletes under external event gateway and virtual cluster parents.
- Add focused planner/resource tests and an e2e scenario for external event gateway sync.

Fixes #1488

## Tests
- `go fix ./...`
- `make format`
- `make build`
- `make test`
- `make test-e2e-scenarios SCENARIO=event-gateway/external-sync`
- `git diff --check`
- `make lint` fails on existing untouched generated/baseline files: `test/e2e/harness/portalclient/portal_api.gen.go`, `internal/cmd/helper_mock.go`, and `internal/konnect/helpers/controlplaneapi_mock.go`.