### PR TITLE
test(e2e): enable event gateway 1.2 scenarios

### DIFF
--- a/test/e2e/scenarios/event-gateway/principal-metadata/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/principal-metadata/scenario.yaml
@@ -1,12 +1,10 @@
 test:
-  enabledByEnvVar: KONGCTL_E2E_RUN_EGW_PRINCIPAL_METADATA
   requiredEnvVars:
     - KONGCTL_E2E_KONG_IDENTITY_DIRECTORY
   info: >-
-    Requires a Konnect environment with Event Gateway runtime 1.2 principal
-    metadata support and a Kong Identity directory. Set
-    KONGCTL_E2E_RUN_EGW_PRINCIPAL_METADATA=1 and
-    KONGCTL_E2E_KONG_IDENTITY_DIRECTORY to include it.
+    Covers Event Gateway runtime 1.2 principal metadata support and requires a
+    Kong Identity directory. Set KONGCTL_E2E_KONG_IDENTITY_DIRECTORY to include
+    it.
 
 baseInputsPath: ./testdata
 

--- a/test/e2e/scenarios/event-gateway/topic-aliases/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/topic-aliases/scenario.yaml
@@ -1,8 +1,6 @@
 test:
-  enabledByEnvVar: KONGCTL_E2E_RUN_EGW_TOPIC_ALIASES
   info: >-
-    Requires a Konnect environment with Event Gateway runtime 1.2 topic_aliases
-    support. Set KONGCTL_E2E_RUN_EGW_TOPIC_ALIASES=1 to include it.
+    Covers Event Gateway runtime 1.2 topic_aliases support.
 
 baseInputsPath: ./testdata
 


### PR DESCRIPTION
## Summary
- Remove stale preview opt-in gates from Event Gateway 1.2 topic alias and principal metadata e2e scenarios
- Keep the Kong Identity directory requirement for principal metadata because the scenario injects it through `KONGCTL_E2E_KONG_IDENTITY_DIRECTORY`

## Rationale
Event Gateway runtime 1.2 is GA, so the 1.2 e2e coverage should run by default in supported e2e organizations instead of requiring the old `KONGCTL_E2E_RUN_EGW_*` flags.

## Testing
- `git diff --check -- test/e2e/scenarios/event-gateway/topic-aliases/scenario.yaml test/e2e/scenarios/event-gateway/principal-metadata/scenario.yaml`
- `GOCACHE=/home/rspurgeon/dev/kong/kongctl/.codex-tmp/gocache GOTMPDIR=/home/rspurgeon/dev/kong/kongctl/.codex-tmp/gotmp go test -mod=readonly -tags=e2e ./test/e2e/harness/scenario`