### PR TITLE
task(ci): add ad-hoc prerelease expiration

### DIFF
--- a/.github/workflows/adhoc-prerelease-cleanup.yml
+++ b/.github/workflows/adhoc-prerelease-cleanup.yml
@@ -1,0 +1,115 @@
+name: Ad-hoc prerelease cleanup
+
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Preview expired prereleases without deleting them
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: adhoc-prerelease-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Delete expired prereleases
+    runs-on: ubuntu-latest
+    env:
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+      GH_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Configure GH_HOST for enterprise compatibility
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh_host="${GITHUB_SERVER_URL#https://}"
+          gh_host="${gh_host#http://}"
+          echo "GH_HOST=${gh_host}" >> "$GITHUB_ENV"
+
+      - name: Delete expired ad-hoc prereleases
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          marker="<!-- kongctl-adhoc-prerelease: true -->"
+          expiry_prefix="<!-- kongctl-adhoc-prerelease-expires-at: "
+          now_epoch="$(date -u +%s)"
+          deleted_count=0
+          expired_count=0
+          skipped_count=0
+          releases_file="${RUNNER_TEMP}/adhoc-prereleases.jsonl"
+          summary="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+          echo "## Ad-hoc prerelease cleanup" >> "${summary}"
+          echo "" >> "${summary}"
+
+          gh api --paginate "/repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+            --jq '.[] | @base64' > "${releases_file}"
+
+          while IFS= read -r encoded_release; do
+            release_json="$(printf '%s' "${encoded_release}" | base64 -d)"
+            tag="$(jq -r '.tag_name' <<< "${release_json}")"
+            is_draft="$(jq -r '.draft' <<< "${release_json}")"
+            is_prerelease="$(jq -r '.prerelease' <<< "${release_json}")"
+            body="$(jq -r '.body // ""' <<< "${release_json}")"
+
+            if [ "${is_draft}" != "false" ] || [ "${is_prerelease}" != "true" ]; then
+              continue
+            fi
+
+            if [[ "${tag}" != prerelease-* ]]; then
+              continue
+            fi
+
+            if [[ "${body}" != *"${marker}"* ]]; then
+              continue
+            fi
+
+            expires_at="$(jq -r --arg prefix "${expiry_prefix}" '
+              (.body // "") as $body
+              | ($body | split($prefix) | .[1] // "")
+              | split(" -->") | .[0] // ""
+            ' <<< "${release_json}")"
+
+            if [ -z "${expires_at}" ]; then
+              continue
+            fi
+
+            if ! expires_at_epoch="$(date -u -d "${expires_at}" +%s 2>/dev/null)"; then
+              skipped_count="$((skipped_count + 1))"
+              echo "::warning::Skipping ${tag}; invalid expiration marker: ${expires_at}"
+              continue
+            fi
+
+            if [ "${expires_at_epoch}" -gt "${now_epoch}" ]; then
+              continue
+            fi
+
+            expired_count="$((expired_count + 1))"
+            if [ "${DRY_RUN}" = "true" ]; then
+              echo "::notice::Would delete expired ad-hoc prerelease ${tag} (expired ${expires_at})"
+              echo "- Would delete \`${tag}\` (expired \`${expires_at}\`)" >> "${summary}"
+              continue
+            fi
+
+            gh release delete "${tag}" --cleanup-tag --yes
+            deleted_count="$((deleted_count + 1))"
+            echo "- Deleted \`${tag}\` (expired \`${expires_at}\`)" >> "${summary}"
+          done < "${releases_file}"
+
+          if [ "${expired_count}" -eq 0 ]; then
+            echo "No expired ad-hoc prereleases found." >> "${summary}"
+          fi
+
+          echo "" >> "${summary}"
+          echo "- Expired matches: ${expired_count}" >> "${summary}"
+          echo "- Deleted: ${deleted_count}" >> "${summary}"
+          echo "- Skipped: ${skipped_count}" >> "${summary}"

--- a/.github/workflows/adhoc-prerelease.yml
+++ b/.github/workflows/adhoc-prerelease.yml
@@ -15,6 +15,15 @@ on:
         description: Optional stable prerelease channel tag to create or update
         required: false
         type: string
+      retention_days:
+        description: Days before cleanup deletes this prerelease; use 0 to disable
+        required: false
+        default: "60"
+        type: string
+      expires_at:
+        description: Optional expiration date or RFC3339 timestamp; overrides retention_days
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -76,7 +85,9 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ env.RELEASE_GITHUB_TOKEN }}
+          EXPIRES_AT_INPUT: ${{ inputs.expires_at }}
           RELEASE_TAG_INPUT: ${{ inputs.release_tag }}
+          RETENTION_DAYS_INPUT: ${{ inputs.retention_days }}
           STABLE_RELEASE_TAG_INPUT: ${{ inputs.stable_release_tag }}
           SOURCE_REF: ${{ inputs.source_ref }}
         run: |
@@ -208,8 +219,52 @@ jobs:
             fi
           }
 
+          resolve_expiration() {
+            local expires_at_input="$1"
+            local retention_days_input="$2"
+            local now_epoch
+            local expires_at_epoch
+
+            now_epoch="$(date -u +%s)"
+
+            if [ -n "${expires_at_input}" ]; then
+              if ! expires_at_epoch="$(date -u -d "${expires_at_input}" +%s 2>/dev/null)"; then
+                echo "::error::expires_at must be a valid date or RFC3339 timestamp: ${expires_at_input}"
+                exit 1
+              fi
+            else
+              retention_days_input="${retention_days_input:-60}"
+
+              if ! [[ "${retention_days_input}" =~ ^[0-9]+$ ]]; then
+                echo "::error::retention_days must be a non-negative integer: ${retention_days_input}"
+                exit 1
+              fi
+
+              local retention_days_num
+              retention_days_num="$((10#${retention_days_input}))"
+              if [ "${retention_days_num}" -eq 0 ]; then
+                return 0
+              fi
+
+              if [ "${retention_days_num}" -gt 365 ]; then
+                echo "::error::retention_days must be 365 or less for ad-hoc prereleases"
+                exit 1
+              fi
+
+              expires_at_epoch="$((now_epoch + retention_days_num * 86400))"
+            fi
+
+            if [ "${expires_at_epoch}" -le "${now_epoch}" ]; then
+              echo "::error::expiration must be in the future"
+              exit 1
+            fi
+
+            date -u -d "@${expires_at_epoch}" +"%Y-%m-%dT%H:%M:%SZ"
+          }
+
           source_sha="$(git rev-parse HEAD)"
           short_sha="$(git rev-parse --short=7 HEAD)"
+          expires_at="$(resolve_expiration "${EXPIRES_AT_INPUT}" "${RETENTION_DAYS_INPUT}")"
           safe_ref="$(sanitize_ref "${SOURCE_REF}")"
           stable_release_tag="${STABLE_RELEASE_TAG_INPUT}"
 
@@ -248,6 +303,7 @@ jobs:
           {
             echo "release_tag=${release_tag}"
             echo "stable_release_tag=${stable_release_tag}"
+            echo "expires_at=${expires_at}"
             echo "safe_ref=${safe_ref}"
             echo "short_sha=${short_sha}"
             echo "source_sha=${source_sha}"
@@ -388,6 +444,7 @@ jobs:
           SDK_MODE: ${{ steps.private_sdk.outputs.sdk_mode }}
           SDK_VERSION: ${{ steps.private_sdk.outputs.sdk_version }}
           STABLE_RELEASE_TAG: ${{ steps.release.outputs.stable_release_tag }}
+          EXPIRES_AT: ${{ steps.release.outputs.expires_at }}
           SOURCE_REF: ${{ inputs.source_ref }}
           SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
         run: |
@@ -397,11 +454,21 @@ jobs:
           {
             echo "## Ad-hoc prerelease"
             echo ""
+            echo "<!-- kongctl-adhoc-prerelease: true -->"
+            if [ -n "${EXPIRES_AT}" ]; then
+              echo "<!-- kongctl-adhoc-prerelease-expires-at: ${EXPIRES_AT} -->"
+            fi
+            echo ""
             echo "- Source ref: \`${SOURCE_REF}\`"
             echo "- Source SHA: \`${SOURCE_SHA}\`"
             echo "- Binary version: \`dev\`"
             if [ -n "${STABLE_RELEASE_TAG}" ]; then
               echo "- Stable channel: \`${STABLE_RELEASE_TAG}\`"
+            fi
+            if [ -n "${EXPIRES_AT}" ]; then
+              echo "- Expires at: \`${EXPIRES_AT}\`"
+            else
+              echo "- Expires at: disabled"
             fi
             echo "- SDK mode: \`${SDK_MODE:-public}\`"
             if [ -n "${SDK_VERSION}" ]; then

--- a/.github/workflows/adhoc-prerelease.yml
+++ b/.github/workflows/adhoc-prerelease.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
       retention_days:
-        description: Days before cleanup deletes this prerelease; use 0 to disable
+        description: Days before cleanup deletes this prerelease (0 to disable; max 365)
         required: false
         default: "60"
         type: string


### PR DESCRIPTION
## Summary
- add optional expiration metadata to ad-hoc prereleases with a 60-day default retention
- add a scheduled cleanup workflow with manual dry-run support
- limit cleanup to marked prerelease tags whose expiration has passed

## Tests
- actionlint .github/workflows/adhoc-prerelease.yml .github/workflows/adhoc-prerelease-cleanup.yml
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/adhoc-prerelease.yml .github/workflows/adhoc-prerelease-cleanup.yml