### PR TITLE
fix(ci): hide ad-hoc prerelease tags from GoReleaser

### DIFF
--- a/.github/workflows/adhoc-prerelease.yml
+++ b/.github/workflows/adhoc-prerelease.yml
@@ -357,6 +357,16 @@ jobs:
           PY
           echo "config=${config}" >> "$GITHUB_OUTPUT"
 
+      - name: Hide ad-hoc prerelease tags from GoReleaser
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mapfile -t prerelease_tags < <(git tag -l 'prerelease-*')
+          if [ "${#prerelease_tags[@]}" -gt 0 ]; then
+            git tag -d "${prerelease_tags[@]}"
+          fi
+
       - name: Build release binaries
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         env:


### PR DESCRIPTION
## Description
- delete local prerelease-* tag refs before the ad-hoc prerelease GoReleaser build
- keep remote immutable prerelease tags and stable channel releases unchanged

## Rationale
GoReleaser treats reachable prerelease channel tags, such as prerelease-aigw-2, as the current version tag during snapshot builds. Those tags are intentionally non-semver, which breaks the incpatch snapshot template before packaging can complete.

## Validation
- actionlint .github/workflows/adhoc-prerelease.yml
- git diff --check -- .github/workflows/adhoc-prerelease.yml