### PR TITLE
test(e2e): cover catalog service lookup paths

### DIFF
--- a/test/e2e/scenarios/all/scenario.yaml
+++ b/test/e2e/scenarios/all/scenario.yaml
@@ -82,10 +82,6 @@ steps:
               fields:
                 failed: 0
                 status: success
-          - select: "plan.changes[?resource_type=='portal' && resource_ref=='all-portal'] | [0]"
-            expect:
-              fields:
-                action: CREATE
           - select: "plan.changes[?resource_type=='application_auth_strategy' && resource_ref=='all-key-auth'] | [0]"
             expect:
               fields:

--- a/test/e2e/scenarios/catalog/service/scenario.yaml
+++ b/test/e2e/scenarios/catalog/service/scenario.yaml
@@ -84,6 +84,9 @@ steps:
           - services
           - -o
           - json
+        recordVar:
+          name: serviceID
+          responsePath: "[0].id"
         assertions:
           - select: "length(@)"
             expect:
@@ -94,6 +97,40 @@ steps:
               fields:
                 name: "{{ .vars.serviceName }}"
                 display_name: "Payments Service"
+
+      - name: 003-get-service-by-id
+        run:
+          - get
+          - catalog
+          - service
+          - "{{ .vars.serviceID }}"
+          - -o
+          - json
+        assertions:
+          - select: id
+            expect:
+              fields:
+                "@": "{{ .vars.serviceID }}"
+          - select: "@"
+            expect:
+              fields:
+                name: "{{ .vars.serviceName }}"
+                display_name: "Payments Service"
+
+      - name: 004-get-service-not-found
+        parseAs: raw
+        run:
+          - get
+          - catalog
+          - service
+          - nonexistent-catalog-service-xyz
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                "contains(stdout, 'No catalog service found')": true
 
   - name: 002-update-catalog-service
     inputOverlayDirs:


### PR DESCRIPTION
## Summary

- record the created catalog service ID from the list response
- add get-by-ID assertions for catalog service detail output
- add not-found lookup coverage for the current success-with-message behavior

Closes #1410.

## Testing

- git diff --check
- go test -tags=e2e ./test/e2e/harness/scenario