### PR TITLE
test(e2e): assert org user list headers

### DIFF
--- a/test/e2e/scenarios/org/users/get/scenario.yaml
+++ b/test/e2e/scenarios/org/users/get/scenario.yaml
@@ -134,6 +134,14 @@ steps:
           - name: user-1-in-output
             expect:
               fields:
+                "contains(stdout, 'ID')": true
+                "contains(stdout, 'EMAIL')": true
+                "contains(stdout, 'FULL NAME')": true
+                "contains(stdout, 'PREFERRED NAME')": true
+                "contains(stdout, 'ACTIVE')": true
+                "contains(stdout, 'INFERRED REGION')": true
+                "contains(stdout, 'CREATED AT')": true
+                "contains(stdout, 'UPDATED AT')": true
                 "contains(stdout, '{{ .env.KONGCTL_E2E_ORG_USER_EMAIL_1 }}')": true
           - name: user-2-in-output
             expect:
@@ -155,6 +163,14 @@ steps:
           - name: user-1-in-output
             expect:
               fields:
+                "contains(stdout, 'ID')": true
+                "contains(stdout, 'EMAIL')": true
+                "contains(stdout, 'FULL NAME')": true
+                "contains(stdout, 'PREFERRED NAME')": true
+                "contains(stdout, 'ACTIVE')": true
+                "contains(stdout, 'INFERRED REGION')": true
+                "contains(stdout, 'CREATED AT')": true
+                "contains(stdout, 'UPDATED AT')": true
                 "contains(stdout, '{{ .env.KONGCTL_E2E_ORG_USER_EMAIL_1 }}')": true
           - name: user-2-not-in-output
             expect:


### PR DESCRIPTION
## Summary

- add text table header assertions for org user list output
- cover filtered user text output with the same header checks
- keep existing user email presence and absence assertions intact

Closes #1503.

## Testing

- git diff --check
- go test -tags=e2e ./test/e2e/harness/scenario