### PR TITLE
fix(declarative): correct API implementation explain schema

### DIFF
--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -121,14 +121,10 @@ apis:
         visibility: One of (public | private)
     implementations: # https://developer.konghq.com/api/konnect/api-builder/v3/#/operations/create-api-implementation
       - ref: string
-        type: string required
-        service_reference:
-          service:
-            id: string required (uuid) # prefer: !ref <gateway-service-ref>
-            control_plane_id: string required (uuid) # prefer: !ref <control-plane-ref>
-        control_plane_reference:
-          control_plane:
-            control_plane_id: string required (uuid) # prefer: !ref <control-plane-ref>
+        type: service
+        service:
+          id: string required (uuid) # prefer: !ref <gateway-service-ref>
+          control_plane_id: string required (uuid) # prefer: !ref <control-plane-ref>
     documents: # https://developer.konghq.com/api/konnect/api-builder/v3/#/operations/create-api-document
       - ref: string
         content: string required (markdown) # prefer: !file ./docs/page.md

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -1279,6 +1279,7 @@ func (l *Loader) suggestFieldName(fieldName string) string {
 		"versions":        {"version", "api_versions", "api-versions"},
 		"publications":    {"publication", "publish", "published"},
 		"implementations": {"implementation", "impl", "service"},
+		"service":         {"service_reference", "service-reference"},
 
 		// Auth strategy fields
 		"strategy_type": {"type", "auth_type", "strategy-type", "strategytype"},

--- a/internal/declarative/loader/loader_test.go
+++ b/internal/declarative/loader/loader_test.go
@@ -876,6 +876,80 @@ func TestLoader_LoadFile_APIWithChildren(t *testing.T) {
 	assert.Equal(t, "my-api", rs.APIImplementations[0].API) // Parent reference
 }
 
+func TestLoader_LoadFile_APIImplementationServiceShape(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(`
+apis:
+  - ref: users-api
+    name: Users API
+    implementations:
+      - ref: users-api-impl
+        type: service
+        service:
+          id: users-service
+          control_plane_id: users-control-plane
+`), 0o600)
+	require.NoError(t, err)
+
+	rs, err := New().LoadFile(path)
+	require.NoError(t, err)
+	require.Len(t, rs.APIImplementations, 1)
+
+	implementation := rs.APIImplementations[0]
+	assert.Equal(t, "users-api-impl", implementation.GetRef())
+	assert.Equal(t, "users-api", implementation.API)
+	require.NotNil(t, implementation.ServiceReference)
+	service := implementation.ServiceReference.GetService()
+	require.NotNil(t, service)
+	assert.Equal(t, "users-service", service.ID)
+	assert.Equal(t, "users-control-plane", service.ControlPlaneID)
+}
+
+func TestLoader_LoadFile_APIImplementationRejectsServiceReference(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(`
+apis:
+  - ref: users-api
+    name: Users API
+    implementations:
+      - ref: users-api-impl
+        type: service
+        service_reference:
+          service:
+            id: users-service
+            control_plane_id: users-control-plane
+`), 0o600)
+	require.NoError(t, err)
+
+	_, err = New().LoadFile(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown field 'service_reference'")
+	assert.Contains(t, err.Error(), "Did you mean 'service'?")
+}
+
+func TestLoader_LoadFile_APIImplementationRejectsUnsupportedType(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(`
+apis:
+  - ref: users-api
+    name: Users API
+    implementations:
+      - ref: users-api-impl
+        type: control_plane
+        service:
+          id: users-service
+          control_plane_id: users-control-plane
+`), 0o600)
+	require.NoError(t, err)
+
+	_, err = New().LoadFile(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API implementation type must be service")
+}
+
 func TestLoader_LoadFile_RejectsAPISpecContent(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")

--- a/internal/declarative/resources/api_implementation.go
+++ b/internal/declarative/resources/api_implementation.go
@@ -15,7 +15,9 @@ func init() {
 	registerResourceType(
 		ResourceTypeAPIImplementation,
 		func(rs *ResourceSet) *[]APIImplementationResource { return &rs.APIImplementations },
-		AutoExplain[APIImplementationResource](),
+		AutoExplain[APIImplementationResource](
+			WithExplainSchemaBuilder(apiImplementationExplainNode),
+		),
 	)
 }
 
@@ -229,6 +231,7 @@ func (i *APIImplementationResource) UnmarshalJSON(data []byte) error {
 	var temp struct {
 		Ref               string `json:"ref"`
 		API               string `json:"api,omitempty"`
+		Type              string `json:"type,omitempty"`
 		ImplementationURL string `json:"implementation_url,omitempty"`
 		Service           *struct {
 			ID             string `json:"id"`
@@ -248,6 +251,10 @@ func (i *APIImplementationResource) UnmarshalJSON(data []byte) error {
 	// Set our custom fields
 	i.Ref = temp.Ref
 	i.API = temp.API
+
+	if temp.Type != "" && temp.Type != "service" {
+		return fmt.Errorf("API implementation type must be service")
+	}
 
 	// Check if kongctl field was provided and reject it
 	if temp.Kongctl != nil {

--- a/internal/declarative/resources/api_implementation.go
+++ b/internal/declarative/resources/api_implementation.go
@@ -253,7 +253,7 @@ func (i *APIImplementationResource) UnmarshalJSON(data []byte) error {
 	i.API = temp.API
 
 	if temp.Type != "" && temp.Type != "service" {
-		return fmt.Errorf("API implementation type must be service")
+		return fmt.Errorf("API implementation type must be service (got %q)", temp.Type)
 	}
 
 	// Check if kongctl field was provided and reject it

--- a/internal/declarative/resources/explain.go
+++ b/internal/declarative/resources/explain.go
@@ -842,6 +842,7 @@ func autoExplainNode(
 			Properties: []*ExplainField{},
 			propIndex:  make(map[string]*ExplainField),
 		}
+		inlineUnions := []*ExplainNode{}
 
 		for field := range typ.Fields() {
 			if !field.IsExported() {
@@ -854,6 +855,16 @@ func autoExplainNode(
 			}
 			jsonName, _, jsonOmit, _ := explainFieldName(field, "json")
 			if field.Anonymous && (yamlInline || jsonName == ",inline" || (yamlName == "" && jsonName == "")) {
+				if union, ok, err := autoExplainSDKUnionNode(field.Type, path, hints, stack); err != nil {
+					return nil, err
+				} else if ok {
+					for _, embeddedField := range union.Properties {
+						node.addField(embeddedField)
+					}
+					inlineUnions = append(inlineUnions, union)
+					continue
+				}
+
 				embedded, err := autoExplainNode(field.Type, path, hints, stack)
 				if err != nil {
 					return nil, err
@@ -893,11 +904,52 @@ func autoExplainNode(
 			}
 			node.addField(fieldNode)
 		}
+		applyInlineUnionBranches(node, inlineUnions)
 
 		return node, nil
 	}
 
 	return autoExplainValueNode(typ, path, hints, stack)
+}
+
+func applyInlineUnionBranches(node *ExplainNode, inlineUnions []*ExplainNode) {
+	if node == nil || len(inlineUnions) == 0 {
+		return
+	}
+
+	for _, union := range inlineUnions {
+		if union == nil || len(union.OneOf) == 0 {
+			continue
+		}
+		unionFieldNames := explainFieldNameSet(union.Properties)
+		for _, branch := range union.OneOf {
+			if branch == nil {
+				continue
+			}
+			composed := branch.clone()
+			for _, field := range node.Properties {
+				if _, ok := unionFieldNames[field.Name]; ok {
+					continue
+				}
+				if composed.propertyExists(field.Name) {
+					continue
+				}
+				composed.addField(field.clone())
+			}
+			node.OneOf = append(node.OneOf, composed)
+		}
+	}
+}
+
+func explainFieldNameSet(fields []*ExplainField) map[string]struct{} {
+	names := make(map[string]struct{}, len(fields))
+	for _, field := range fields {
+		if field == nil {
+			continue
+		}
+		names[field.Name] = struct{}{}
+	}
+	return names
 }
 
 func autoExplainValueNode(
@@ -1799,6 +1851,18 @@ func (n *ExplainNode) lookup(path []string) (*ExplainNode, bool) {
 	return current, true
 }
 
+func (f *ExplainField) clone() *ExplainField {
+	if f == nil {
+		return nil
+	}
+	return &ExplainField{
+		Name:        f.Name,
+		Node:        f.Node.clone(),
+		Required:    f.Required,
+		Recommended: f.Recommended,
+	}
+}
+
 func (n *ExplainNode) clone() *ExplainNode {
 	if n == nil {
 		return nil
@@ -1821,13 +1885,7 @@ func (n *ExplainNode) clone() *ExplainNode {
 		propIndex:    make(map[string]*ExplainField),
 	}
 	for _, child := range n.Properties {
-		clonedField := &ExplainField{
-			Name:        child.Name,
-			Node:        child.Node.clone(),
-			Required:    child.Required,
-			Recommended: child.Recommended,
-		}
-		cloned.addField(clonedField)
+		cloned.addField(child.clone())
 	}
 	for _, branch := range n.OneOf {
 		cloned.OneOf = append(cloned.OneOf, branch.clone())

--- a/internal/declarative/resources/explain_test.go
+++ b/internal/declarative/resources/explain_test.go
@@ -7,6 +7,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type explainInlineUnionResource struct {
+	ExplainInlineUnion `yaml:",inline" json:",inline"`
+	Ref                string `yaml:"ref"     json:"ref"`
+}
+
+type ExplainInlineUnion struct {
+	ServiceReference *ExplainServiceReference `queryParam:"inline" union:"member"`
+}
+
+type ExplainServiceReference struct {
+	Service *ExplainService `json:"service,omitempty"`
+}
+
+type ExplainService struct {
+	ID string `json:"id"`
+}
+
 func TestResolveExplainSubject_Resource(t *testing.T) {
 	subject, err := ResolveExplainSubject("api")
 	require.NoError(t, err)
@@ -244,6 +261,39 @@ func TestRenderExplainSchema_AnalyticsDashboardDiscriminators(t *testing.T) {
 	assert.Equal(t, "horizontal_bar", chart.OneOf[2].Properties["type"].Const)
 }
 
+func TestRenderExplainSchema_APIImplementationServiceShape(t *testing.T) {
+	subject, err := ResolveExplainSubject("api.implementations")
+	require.NoError(t, err)
+
+	schema := RenderExplainSchema(subject)
+	require.NotNil(t, schema)
+
+	assert.Contains(t, schema.Properties, "service")
+	assert.Contains(t, schema.Properties, "type")
+	assert.NotContains(t, schema.Properties, "service_reference")
+	assert.NotContains(t, schema.Properties, "control_plane_reference")
+
+	service := schema.Properties["service"]
+	require.NotNil(t, service)
+	require.NotNil(t, service.Properties["id"])
+	require.NotNil(t, service.Properties["control_plane_id"])
+	assert.Equal(t, "gateway_service", service.Properties["id"].XRefKind)
+	assert.Equal(t, "control_plane", service.Properties["control_plane_id"].XRefKind)
+}
+
+func TestAutoExplainInlineSDKUnionUsesPayloadFields(t *testing.T) {
+	node, err := autoExplainConcreteNode[explainInlineUnionResource](nil)
+	require.NoError(t, err)
+
+	assert.True(t, node.propertyExists("service"))
+	assert.True(t, node.propertyExists("ref"))
+	assert.False(t, node.propertyExists("service_reference"))
+	require.Len(t, node.OneOf, 1)
+	assert.True(t, node.OneOf[0].propertyExists("service"))
+	assert.True(t, node.OneOf[0].propertyExists("ref"))
+	assert.False(t, node.OneOf[0].propertyExists("service_reference"))
+}
+
 func TestRenderExplainText_AnalyticsDashboardAllowedValues(t *testing.T) {
 	subject, err := ResolveExplainSubject("analytics.dashboards.definition.tiles.definition.query.datasource")
 	require.NoError(t, err)
@@ -390,6 +440,10 @@ func TestRenderScaffoldYAML_RootResource(t *testing.T) {
 	assert.Contains(t, scaffold, "- ref: my-resource")
 	assert.Contains(t, scaffold, "name: my-resource")
 	assert.Contains(t, scaffold, "# versions:")
+	assert.Contains(t, scaffold, "# type: service")
+	assert.Contains(t, scaffold, "# service:")
+	assert.NotContains(t, scaffold, "service_reference")
+	assert.NotContains(t, scaffold, "control_plane_reference")
 	assert.NotContains(t, scaffold, "spec_content")
 }
 

--- a/internal/declarative/resources/explain_union_schemas.go
+++ b/internal/declarative/resources/explain_union_schemas.go
@@ -365,6 +365,18 @@ func apiExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
 	return node, nil
 }
 
+func apiImplementationExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
+	return explainObject(
+		explainField(SchemaFieldRef, explainStringNode("my-resource"), true, true),
+		explainField("api", explainStringNode("my-api"), false, false),
+		explainField("type", explainConstStringNode("service"), false, true),
+		explainField("service", explainObject(
+			explainRefField("id", ResourceTypeGatewayService, true),
+			explainRefField("control_plane_id", ResourceTypeControlPlane, true),
+		), true, true),
+	), nil
+}
+
 func dashboardExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
 	hints := defaultExplainHints(ResourceTypeDashboard)
 	hints["name"] = ExplainFieldHint{DefaultFrom: SchemaFieldRef, Literal: "my-resource", Recommended: new(true)}


### PR DESCRIPTION
## Summary
- Fix API implementation explain/scaffold output to show the supported declarative `service` shape instead of SDK wrapper fields like `service_reference`.
- Accept optional `type: service` while rejecting unsupported API implementation types.
- Add generic explain handling for embedded inline SDK unions so payload fields are exposed instead of Go union member names.
- Update the checked-in declarative resource reference and loader suggestion for `service_reference`.

## Rationale
`kongctl explain api --extended` and generated docs pointed users toward `service_reference`, but the declarative loader rejects that field. The declarative contract should match the shape that kongctl can load, plan, and execute.

Closes #1531
Related #1534

## Testing
- `go test ./internal/declarative/resources ./internal/declarative/loader`
- `go fix ./...`
- `make format`
- `make build`
- `make test`
- `make lint`
- `./kongctl explain api --extended --output text`
- `./kongctl scaffold api`