### PR TITLE
fix(konnect): report unknown profile instead of loading an empty config

### DIFF
--- a/internal/cmd/root/products/konnect/common/common.go
+++ b/internal/cmd/root/products/konnect/common/common.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -540,11 +541,7 @@ func accessTokenUnavailableError(cfg config.Hook) error {
 	profile := cfg.GetProfile()
 
 	if !profileIsConfigured(cfg) {
-		return fmt.Errorf(
-			"profile %q is not configured. Run '%s get profiles' to list configured "+
-				"profiles, or '%s login --profile %s' to set it up",
-			profile, meta.CLIName, meta.CLIName, profile,
-		)
+		return unknownProfileError(cfg, profile)
 	}
 
 	envVar := fmt.Sprintf("KONGCTL_%s_KONNECT_PAT", strings.ToUpper(profile))
@@ -573,7 +570,7 @@ func profileIsConfigured(cfg config.Hook) bool {
 	if name == kprofile.DefaultProfile {
 		return true
 	}
-	if profileInConfigFile(cfg, name) {
+	if slices.Contains(configuredProfileNames(cfg), name) {
 		return true
 	}
 	if profileHasEnvVars(name) {
@@ -582,17 +579,38 @@ func profileIsConfigured(cfg config.Hook) bool {
 	return auth.HasStoredCredential(cfg)
 }
 
-func profileInConfigFile(cfg config.Hook, name string) bool {
+// unknownProfileError explains that the requested profile is unknown and lists
+// the profiles found in the config file so a mistyped name is easy to spot.
+func unknownProfileError(cfg config.Hook, profile string) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "profile %q is not configured.\n\n", profile)
+
+	available := configuredProfileNames(cfg)
+	if len(available) > 0 {
+		b.WriteString("Available profiles:\n")
+		for _, name := range available {
+			fmt.Fprintf(&b, "    %s\n", name)
+		}
+		fmt.Fprintf(&b, "\nUse one of these profiles or run '%s login --profile %s' "+
+			"to authenticate with this profile.", meta.CLIName, profile)
+	} else {
+		b.WriteString("No profiles are configured yet.\n\n")
+		fmt.Fprintf(&b, "Run '%s login --profile %s' to authenticate with this profile.",
+			meta.CLIName, profile)
+	}
+
+	return errors.New(b.String())
+}
+
+// configuredProfileNames returns the sorted profiles defined in the config file.
+func configuredProfileNames(cfg config.Hook) []string {
 	pc, ok := cfg.(*config.ProfiledConfig)
 	if !ok || pc.Viper == nil {
-		return false
+		return nil
 	}
-	for _, key := range pc.AllKeys() {
-		if top, _, _ := strings.Cut(key, "."); top == name {
-			return true
-		}
-	}
-	return false
+	names := kprofile.NewManager(pc.Viper).GetProfiles()
+	slices.Sort(names)
+	return names
 }
 
 func profileHasEnvVars(name string) bool {

--- a/internal/cmd/root/products/konnect/common/common.go
+++ b/internal/cmd/root/products/konnect/common/common.go
@@ -591,11 +591,11 @@ func unknownProfileError(cfg config.Hook, profile string) error {
 		for _, name := range available {
 			fmt.Fprintf(&b, "    %s\n", name)
 		}
-		fmt.Fprintf(&b, "\nUse one of these profiles or run '%s login --profile %s' "+
+		fmt.Fprintf(&b, "\nUse one of these profiles, or run %s login with --profile set to %q "+
 			"to authenticate with this profile.", meta.CLIName, profile)
 	} else {
 		b.WriteString("No profiles are configured yet.\n\n")
-		fmt.Fprintf(&b, "Run '%s login --profile %s' to authenticate with this profile.",
+		fmt.Fprintf(&b, "Run %s login with --profile set to %q to authenticate with this profile.",
 			meta.CLIName, profile)
 	}
 

--- a/internal/cmd/root/products/konnect/common/common.go
+++ b/internal/cmd/root/products/konnect/common/common.go
@@ -20,6 +20,8 @@ import (
 	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/konnect/httpclient"
 	"github.com/kong/kongctl/internal/meta"
+	kprofile "github.com/kong/kongctl/internal/profile"
+	viperutil "github.com/kong/kongctl/internal/util/viper"
 	"github.com/spf13/cobra"
 )
 
@@ -536,6 +538,15 @@ func GetAccessTokenSource(cfg config.Hook, logger *slog.Logger) (*auth.TokenSour
 
 func accessTokenUnavailableError(cfg config.Hook) error {
 	profile := cfg.GetProfile()
+
+	if !profileIsConfigured(cfg) {
+		return fmt.Errorf(
+			"profile %q is not configured. Run '%s get profiles' to list configured "+
+				"profiles, or '%s login --profile %s' to set it up",
+			profile, meta.CLIName, meta.CLIName, profile,
+		)
+	}
+
 	envVar := fmt.Sprintf("KONGCTL_%s_KONNECT_PAT", strings.ToUpper(profile))
 
 	return fmt.Errorf(
@@ -551,6 +562,47 @@ func accessTokenUnavailableError(cfg config.Hook) error {
 		profile,
 		PATConfigPath,
 	)
+}
+
+// profileIsConfigured reports whether the CLI has any prior knowledge of the
+// requested profile, via the config file, environment variables, or a stored
+// login credential. An unknown profile is almost always a mistyped --profile
+// value, which otherwise surfaces later as a confusing auth failure.
+func profileIsConfigured(cfg config.Hook) bool {
+	name := cfg.GetProfile()
+	if name == kprofile.DefaultProfile {
+		return true
+	}
+	if profileInConfigFile(cfg, name) {
+		return true
+	}
+	if profileHasEnvVars(name) {
+		return true
+	}
+	return auth.HasStoredCredential(cfg)
+}
+
+func profileInConfigFile(cfg config.Hook, name string) bool {
+	pc, ok := cfg.(*config.ProfiledConfig)
+	if !ok || pc.Viper == nil {
+		return false
+	}
+	for _, key := range pc.AllKeys() {
+		if top, _, _ := strings.Cut(key, "."); top == name {
+			return true
+		}
+	}
+	return false
+}
+
+func profileHasEnvVars(name string) bool {
+	prefix := viperutil.ProfileEnvPrefix(name) + "_"
+	for _, entry := range os.Environ() {
+		if strings.HasPrefix(entry, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func isDeclarativeRetryVerb(verb verbs.VerbValue) bool {

--- a/internal/cmd/root/products/konnect/common/common_test.go
+++ b/internal/cmd/root/products/konnect/common/common_test.go
@@ -699,7 +699,7 @@ func TestResolveAccessTokenUnknownProfileListsAvailableProfiles(t *testing.T) {
 	require.Contains(t, err.Error(), "Available profiles:")
 	require.Contains(t, err.Error(), "    default")
 	require.Contains(t, err.Error(), "    dev")
-	require.Contains(t, err.Error(), "kongctl login --profile tech")
+	require.Contains(t, err.Error(), `--profile set to "tech"`)
 	require.NotContains(t, err.Error(), "authentication token not available")
 }
 
@@ -711,8 +711,17 @@ func TestResolveAccessTokenUnknownProfileWithNoProfilesConfigured(t *testing.T) 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), `profile "tech" is not configured`)
 	require.Contains(t, err.Error(), "No profiles are configured yet.")
-	require.Contains(t, err.Error(), "kongctl login --profile tech")
+	require.Contains(t, err.Error(), `--profile set to "tech"`)
 	require.NotContains(t, err.Error(), "authentication token not available")
+}
+
+func TestResolveAccessTokenUnknownProfileEscapesProfileName(t *testing.T) {
+	cfg := newFileBackedConfig(t, t.TempDir(), "evil; rm -rf /", nil)
+
+	_, err := ResolveAccessToken(t.Context(), cfg, nil)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `--profile set to "evil; rm -rf /"`)
 }
 
 func TestResolveAccessTokenKnownProfilesReportAuthGuidance(t *testing.T) {

--- a/internal/cmd/root/products/konnect/common/common_test.go
+++ b/internal/cmd/root/products/konnect/common/common_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -16,6 +17,8 @@ import (
 	"github.com/kong/kongctl/internal/konnect/auth"
 	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/konnect/httpclient"
+	kprofile "github.com/kong/kongctl/internal/profile"
+	utilviper "github.com/kong/kongctl/internal/util/viper"
 	configtest "github.com/kong/kongctl/test/config"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
@@ -663,6 +666,63 @@ func TestResolveAccessTokenMapsMissingCredentialsToGuidance(t *testing.T) {
 	require.Contains(t, err.Error(), "kongctl login")
 	require.NotContains(t, err.Error(), dir)
 	require.NotContains(t, err.Error(), "stat ")
+}
+
+func newFileBackedConfig(t *testing.T, dir, profile string, fileKeys map[string]any) *config.ProfiledConfig {
+	t.Helper()
+	path := filepath.Join(dir, "config.yaml")
+	mainv := utilviper.NewViper(path)
+	for key, value := range fileKeys {
+		mainv.Set(key, value)
+	}
+	return config.BuildProfiledConfig(profile, path, mainv)
+}
+
+func requireAuthGuidance(t *testing.T, cfg config.Hook) {
+	t.Helper()
+	_, err := ResolveAccessToken(t.Context(), cfg, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "authentication token not available")
+	require.NotContains(t, err.Error(), "is not configured")
+}
+
+func TestResolveAccessTokenUnknownProfileReportsNotConfigured(t *testing.T) {
+	dir := t.TempDir()
+	cfg := newFileBackedConfig(t, dir, "tech", nil)
+
+	_, err := ResolveAccessToken(t.Context(), cfg, nil)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `profile "tech" is not configured`)
+	require.NotContains(t, err.Error(), "authentication token not available")
+}
+
+func TestResolveAccessTokenKnownProfilesReportAuthGuidance(t *testing.T) {
+	t.Run("default profile", func(t *testing.T) {
+		cfg := newFileBackedConfig(t, t.TempDir(), kprofile.DefaultProfile, nil)
+		requireAuthGuidance(t, cfg)
+	})
+
+	t.Run("profile in config file", func(t *testing.T) {
+		cfg := newFileBackedConfig(t, t.TempDir(), "dev", map[string]any{
+			"dev.konnect.base_url": BaseURLDefault,
+		})
+		requireAuthGuidance(t, cfg)
+	})
+
+	t.Run("profile with environment variables", func(t *testing.T) {
+		t.Setenv("KONGCTL_CI_HTTP_TIMEOUT", "13s")
+		cfg := newFileBackedConfig(t, t.TempDir(), "ci", nil)
+		requireAuthGuidance(t, cfg)
+	})
+
+	t.Run("profile with stored credential", func(t *testing.T) {
+		dir := t.TempDir()
+		credPath := filepath.Join(dir, ".work-konnect-token.json")
+		require.NoError(t, os.WriteFile(credPath, []byte("{}"), 0o600))
+		cfg := newFileBackedConfig(t, dir, "work", nil)
+		requireAuthGuidance(t, cfg)
+	})
 }
 
 func TestResolveAccessTokenPreservesContextErrors(t *testing.T) {

--- a/internal/cmd/root/products/konnect/common/common_test.go
+++ b/internal/cmd/root/products/konnect/common/common_test.go
@@ -686,14 +686,32 @@ func requireAuthGuidance(t *testing.T, cfg config.Hook) {
 	require.NotContains(t, err.Error(), "is not configured")
 }
 
-func TestResolveAccessTokenUnknownProfileReportsNotConfigured(t *testing.T) {
-	dir := t.TempDir()
-	cfg := newFileBackedConfig(t, dir, "tech", nil)
+func TestResolveAccessTokenUnknownProfileListsAvailableProfiles(t *testing.T) {
+	cfg := newFileBackedConfig(t, t.TempDir(), "tech", map[string]any{
+		"default.konnect.base_url": BaseURLDefault,
+		"dev.konnect.base_url":     BaseURLDefault,
+	})
 
 	_, err := ResolveAccessToken(t.Context(), cfg, nil)
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), `profile "tech" is not configured`)
+	require.Contains(t, err.Error(), "Available profiles:")
+	require.Contains(t, err.Error(), "    default")
+	require.Contains(t, err.Error(), "    dev")
+	require.Contains(t, err.Error(), "kongctl login --profile tech")
+	require.NotContains(t, err.Error(), "authentication token not available")
+}
+
+func TestResolveAccessTokenUnknownProfileWithNoProfilesConfigured(t *testing.T) {
+	cfg := newFileBackedConfig(t, t.TempDir(), "tech", nil)
+
+	_, err := ResolveAccessToken(t.Context(), cfg, nil)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `profile "tech" is not configured`)
+	require.Contains(t, err.Error(), "No profiles are configured yet.")
+	require.Contains(t, err.Error(), "kongctl login --profile tech")
 	require.NotContains(t, err.Error(), "authentication token not available")
 }
 

--- a/internal/konnect/auth/token_source.go
+++ b/internal/konnect/auth/token_source.go
@@ -190,10 +190,12 @@ func credentialFilePath(cfg config.Hook) string {
 }
 
 // HasStoredCredential reports whether a saved login credential file exists on
-// disk for the configured profile.
+// disk for the configured profile. A stat error other than "not found" (e.g. a
+// permission or IO error) is treated as present, so the profile is not wrongly
+// reported as unknown.
 func HasStoredCredential(cfg config.Hook) bool {
 	_, err := os.Stat(credentialFilePath(cfg))
-	return err == nil
+	return err == nil || !errors.Is(err, os.ErrNotExist)
 }
 
 func (t *AccessToken) expiresWithin(skew time.Duration) bool {

--- a/internal/konnect/auth/token_source.go
+++ b/internal/konnect/auth/token_source.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -186,6 +187,13 @@ func credentialFilePath(cfg config.Hook) string {
 	profile := cfg.GetProfile()
 	cfgPath := filepath.Dir(cfg.GetPath())
 	return filepath.Join(cfgPath, getCredentialFileName(profile))
+}
+
+// HasStoredCredential reports whether a saved login credential file exists on
+// disk for the configured profile.
+func HasStoredCredential(cfg config.Hook) bool {
+	_, err := os.Stat(credentialFilePath(cfg))
+	return err == nil
 }
 
 func (t *AccessToken) expiresWithin(skew time.Duration) bool {


### PR DESCRIPTION
Pass `--profile` a name that doesn't exist and kongctl says nothing. It loads an empty config, then later dies on a vague "authentication token not available" that never mentions the profile. A typo shouldn't send you debugging your creds.

Now it checks first: if the profile isn't one it knows (default, in your config, `KONGCTL_<PROFILE>_*` env vars, or a token from a past login), it just says `profile "tech" is not configured`. Test covers the unknown case and all four known ones.

One call I'd want your take on: I put the check on the auth path, not config load. Config load also runs for `login`/`--help`/completion, so checking there would break `login --profile new` on first setup. Trade-off is it only fires on auth commands. Easy to move if you'd rather.

Closes #1363
