### PR TITLE
task(ci): disable feature user agent schedule

### DIFF
--- a/.github/workflows/kongctl-feature-user-agent.lock.yml
+++ b/.github/workflows/kongctl-feature-user-agent.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"487d7437ef3b0bd5ed325ffe99ea940b483ff08c1f9c5e8f66b8c7918f1a06d8","body_hash":"b970da64ff874fd5bc77a876adecf1eb36ff185c2a1afbfa8d84c66350988f00","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"af54b51ea8ac55b8f25d4ab1e4c6b5141f09d56dc555ac90ca963e624f8a86a1","body_hash":"b970da64ff874fd5bc77a876adecf1eb36ff185c2a1afbfa8d84c66350988f00","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN","KONGCTL_FEATURE_USER_AGENT_KONNECT_PAT"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58","digest":"sha256:a316a2c021accba8a9ea194c75466b0c4a166be6ac783bf8c2d0afd73373dec2","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58@sha256:a316a2c021accba8a9ea194c75466b0c4a166be6ac783bf8c2d0afd73373dec2"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58","digest":"sha256:43a5cdbe4e1156920dcdaab26d6c6761777d5c6bdc572d7d07b11739fb34c749","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58@sha256:43a5cdbe4e1156920dcdaab26d6c6761777d5c6bdc572d7d07b11739fb34c749"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58","digest":"sha256:558682b7b6313a5443cbb3d702899823bd732f991c8b52db6b5b8066abefe7a1","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58@sha256:558682b7b6313a5443cbb3d702899823bd732f991c8b52db6b5b8066abefe7a1"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22","digest":"sha256:ce5c6f5461b077af0d8e8eb1763436e85153f8e9531117d58a7bdb23de71f00a","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.22@sha256:ce5c6f5461b077af0d8e8eb1763436e85153f8e9531117d58a7bdb23de71f00a"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0","digest":"sha256:71b07d9abecb83b4a2595bcd8ccb35f9a0166361a12335f9e16da1ef07172029","pinned_image":"ghcr.io/github/github-mcp-server:v1.1.0@sha256:71b07d9abecb83b4a2595bcd8ccb35f9a0166361a12335f9e16da1ef07172029"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -22,7 +22,7 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Runs a scheduled or manual feature-user evaluation of one advertised kongctl
+# Runs a manual feature-user evaluation of one advertised kongctl
 # workflow against a disposable Konnect org, filing actionable friction or
 # publishing successful evaluations as expiring discussions.
 #
@@ -54,9 +54,6 @@
 
 name: "User Agent Eval"
 on:
-  schedule:
-  - cron: "0 13 * * 1-5"
-  - cron: "0 1 * * 2-6"
   workflow_dispatch:
     inputs:
       aw_context:
@@ -189,21 +186,21 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_0fc5989a11e84bdb_EOF'
+          cat << 'GH_AW_PROMPT_50f867e382b0e9cc_EOF'
           <system>
-          GH_AW_PROMPT_0fc5989a11e84bdb_EOF
+          GH_AW_PROMPT_50f867e382b0e9cc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/cache_memory_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_0fc5989a11e84bdb_EOF'
+          cat << 'GH_AW_PROMPT_50f867e382b0e9cc_EOF'
           <safe-output-tools>
           Tools: create_issue, create_discussion, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_0fc5989a11e84bdb_EOF
+          GH_AW_PROMPT_50f867e382b0e9cc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_0fc5989a11e84bdb_EOF'
+          cat << 'GH_AW_PROMPT_50f867e382b0e9cc_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -235,12 +232,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_0fc5989a11e84bdb_EOF
+          GH_AW_PROMPT_50f867e382b0e9cc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_0fc5989a11e84bdb_EOF'
+          cat << 'GH_AW_PROMPT_50f867e382b0e9cc_EOF'
           </system>
           {{#runtime-import .github/workflows/kongctl-feature-user-agent.md}}
-          GH_AW_PROMPT_0fc5989a11e84bdb_EOF
+          GH_AW_PROMPT_50f867e382b0e9cc_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -336,9 +333,6 @@ jobs:
     permissions:
       contents: read
       issues: read
-    concurrency:
-      group: "gh-aw-copilot-${{ github.workflow }}"
-      queue: max
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""
@@ -487,9 +481,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_078cbceaad5706c1_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_2c4b452b61371f41_EOF'
           {"create_discussion":{"category":"general","expires":720,"fallback_to_issue":false,"labels":["automation","agentic-workflows","konnect"],"max":1,"title_prefix":"[agent-eval] "},"create_issue":{"expires":720,"labels":["automation","agentic-workflows","konnect"],"max":1,"title_prefix":"[agent-eval] "},"create_report_incomplete_issue":{},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_078cbceaad5706c1_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_2c4b452b61371f41_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -725,7 +719,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_7c855f5e9196a84d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_61e91cb3cd276d6b_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -766,7 +760,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_7c855f5e9196a84d_EOF
+          GH_AW_MCP_CONFIG_61e91cb3cd276d6b_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1318,7 +1312,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           WORKFLOW_NAME: "User Agent Eval"
-          WORKFLOW_DESCRIPTION: "Runs a scheduled or manual feature-user evaluation of one advertised kongctl\nworkflow against a disposable Konnect org, filing actionable friction or\npublishing successful evaluations as expiring discussions."
+          WORKFLOW_DESCRIPTION: "Runs a manual feature-user evaluation of one advertised kongctl\nworkflow against a disposable Konnect org, filing actionable friction or\npublishing successful evaluations as expiring discussions."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |

--- a/.github/workflows/kongctl-feature-user-agent.md
+++ b/.github/workflows/kongctl-feature-user-agent.md
@@ -1,17 +1,11 @@
 ---
 name: User Agent Eval
 description: |
-  Runs a scheduled or manual feature-user evaluation of one advertised kongctl
+  Runs a manual feature-user evaluation of one advertised kongctl
   workflow against a disposable Konnect org, filing actionable friction or
   publishing successful evaluations as expiring discussions.
 on:
-  schedule:
-    # GitHub schedules are UTC-only. Together these run twice on each
-    # Monday-Friday US/Central day: 13:00 UTC maps to 8 AM during daylight
-    # time and 7 AM during standard time; 01:00 UTC Tuesday-Saturday maps to
-    # the prior Monday-Friday evening at 8 PM/7 PM.
-    - cron: "0 13 * * 1-5"
-    - cron: "0 1 * * 2-6"
+  # Scheduled runs are disabled while this evaluation workflow is flaky.
   workflow_dispatch:
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Remove scheduled triggers from the User Agent Eval agentic workflow while it is flaky
- Keep manual workflow_dispatch available for explicit debugging runs
- Regenerate the matching gh-aw lock file

## Validation
- gh aw compile --validate --verbose
- gh aw validate .github/workflows/kongctl-feature-user-agent.md --verbose
- git diff --check