### PR TITLE
fix(declarative): avoid external portal child reads

### DIFF
--- a/internal/declarative/executor/api_publication_adapter_test.go
+++ b/internal/declarative/executor/api_publication_adapter_test.go
@@ -11,18 +11,25 @@ import (
 )
 
 type stubAPIPublicationAPI struct {
-	t            *testing.T
-	deleteAPIID  string
-	deletePortal string
+	t             *testing.T
+	publishAPIID  string
+	publishPortal string
+	publishReq    kkComps.APIPublication
+	deleteAPIID   string
+	deletePortal  string
 }
 
 func (s *stubAPIPublicationAPI) PublishAPIToPortal(
-	context.Context,
-	kkOps.PublishAPIToPortalRequest,
-	...kkOps.Option,
+	_ context.Context,
+	request kkOps.PublishAPIToPortalRequest,
+	_ ...kkOps.Option,
 ) (*kkOps.PublishAPIToPortalResponse, error) {
-	s.t.Fatalf("unexpected PublishAPIToPortal call")
-	return nil, nil
+	s.publishAPIID = request.APIID
+	s.publishPortal = request.PortalID
+	s.publishReq = request.APIPublication
+	return &kkOps.PublishAPIToPortalResponse{
+		APIPublicationResponse: &kkComps.APIPublicationResponse{},
+	}, nil
 }
 
 func (s *stubAPIPublicationAPI) DeletePublication(
@@ -75,6 +82,55 @@ func TestAPIPublicationAdapterDeleteUsesPortalIDField(t *testing.T) {
 	}
 	if api.deletePortal != "portal-456" {
 		t.Fatalf("DeletePublication() portalID = %q, want %q", api.deletePortal, "portal-456")
+	}
+}
+
+func TestAPIPublicationAdapterCreatePublishesAPIToResolvedPortal(t *testing.T) {
+	t.Parallel()
+
+	api := &stubAPIPublicationAPI{t: t}
+	client := state.NewClient(state.ClientConfig{APIPublicationAPI: api})
+	adapter := NewAPIPublicationAdapter(client)
+	base := NewBaseCreateDeleteExecutor[kkComps.APIPublication](adapter, false)
+
+	change := planner.PlannedChange{
+		ID:           "1:c:api_publication:sms-to-getting-started-portal",
+		ResourceType: "api_publication",
+		ResourceRef:  "sms-to-getting-started-portal",
+		Action:       planner.ActionCreate,
+		Fields: map[string]any{
+			"portal_id":  "portal-456",
+			"visibility": "private",
+		},
+		Parent: &planner.ParentInfo{Ref: "sms", ID: "api-123"},
+		References: map[string]planner.ReferenceInfo{
+			planner.FieldAPIID: {
+				Ref: "sms",
+				ID:  "api-123",
+			},
+			planner.FieldPortalID: {
+				Ref: "getting-started-portal",
+				ID:  "portal-456",
+			},
+		},
+	}
+
+	id, err := base.Create(context.Background(), change)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if id != "api-123" {
+		t.Fatalf("Create() id = %q, want %q", id, "api-123")
+	}
+	if api.publishAPIID != "api-123" {
+		t.Fatalf("PublishAPIToPortal() apiID = %q, want %q", api.publishAPIID, "api-123")
+	}
+	if api.publishPortal != "portal-456" {
+		t.Fatalf("PublishAPIToPortal() portalID = %q, want %q", api.publishPortal, "portal-456")
+	}
+	if api.publishReq.Visibility == nil || *api.publishReq.Visibility != kkComps.APIPublicationVisibility("private") {
+		t.Fatalf("PublishAPIToPortal() visibility = %v, want private", api.publishReq.Visibility)
 	}
 }
 

--- a/internal/declarative/planner/portal_external_children_test.go
+++ b/internal/declarative/planner/portal_external_children_test.go
@@ -7,11 +7,14 @@ import (
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/declarative/labels"
 	"github.com/kong/kongctl/internal/declarative/resources"
 	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/declarative/tags"
 	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // Minimal mocks for PortalPageAPI and PortalSnippetAPI
@@ -122,11 +125,287 @@ func (m *mockPortalSnippetAPI) GetPortalSnippet(
 	return &kkOps.GetPortalSnippetResponse{StatusCode: 404}, nil
 }
 
+type countingAPIPublicationAPI struct {
+	t         *testing.T
+	listCalls int
+}
+
+func (c *countingAPIPublicationAPI) PublishAPIToPortal(
+	_ context.Context,
+	_ kkOps.PublishAPIToPortalRequest,
+	_ ...kkOps.Option,
+) (*kkOps.PublishAPIToPortalResponse, error) {
+	c.t.Fatalf("unexpected PublishAPIToPortal call during planning")
+	return nil, nil
+}
+
+func (c *countingAPIPublicationAPI) DeletePublication(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ ...kkOps.Option,
+) (*kkOps.DeletePublicationResponse, error) {
+	c.t.Fatalf("unexpected DeletePublication call during planning")
+	return nil, nil
+}
+
+func (c *countingAPIPublicationAPI) ListAPIPublications(
+	_ context.Context,
+	_ kkOps.ListAPIPublicationsRequest,
+	_ ...kkOps.Option,
+) (*kkOps.ListAPIPublicationsResponse, error) {
+	c.listCalls++
+	return &kkOps.ListAPIPublicationsResponse{
+		ListAPIPublicationResponse: &kkComps.ListAPIPublicationResponse{
+			Data: []kkComps.APIPublicationListItem{},
+			Meta: kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: 0}},
+		},
+	}, nil
+}
+
+type countingPortalIPAllowListAPI struct {
+	t         *testing.T
+	listCalls int
+	failList  bool
+	entries   []kkComps.IPEntry
+}
+
+func (c *countingPortalIPAllowListAPI) CreatePortalIPAllowList(
+	_ context.Context,
+	_ string,
+	_ *kkComps.CreatePortalSourceIPRestriction,
+	_ ...kkOps.Option,
+) (*kkOps.CreatePortalIPAllowListResponse, error) {
+	c.t.Fatalf("unexpected CreatePortalIPAllowList call during planning")
+	return nil, nil
+}
+
+func (c *countingPortalIPAllowListAPI) ListPortalIPAllowList(
+	_ context.Context,
+	_ kkOps.ListPortalIPAllowListRequest,
+	_ ...kkOps.Option,
+) (*kkOps.ListPortalIPAllowListResponse, error) {
+	c.listCalls++
+	if c.failList {
+		c.t.Fatalf("unexpected ListPortalIPAllowList call")
+	}
+	return &kkOps.ListPortalIPAllowListResponse{
+		PortalSourceIPRestrictionPaginatedResponse: &kkComps.PortalSourceIPRestrictionPaginatedResponse{
+			Meta: kkComps.CursorMetaPage{Size: 100},
+			Data: c.entries,
+		},
+	}, nil
+}
+
+func (c *countingPortalIPAllowListAPI) PutPortalIPAllowList(
+	_ context.Context,
+	_ kkOps.PutPortalIPAllowListRequest,
+	_ ...kkOps.Option,
+) (*kkOps.PutPortalIPAllowListResponse, error) {
+	c.t.Fatalf("unexpected PutPortalIPAllowList call during planning")
+	return nil, nil
+}
+
+func (c *countingPortalIPAllowListAPI) UpdatePortalIPAllowList(
+	_ context.Context,
+	_ kkOps.UpdatePortalIPAllowListRequest,
+	_ ...kkOps.Option,
+) (*kkOps.UpdatePortalIPAllowListResponse, error) {
+	c.t.Fatalf("unexpected UpdatePortalIPAllowList call during planning")
+	return nil, nil
+}
+
+func (c *countingPortalIPAllowListAPI) DeletePortalIPAllowList(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ ...kkOps.Option,
+) (*kkOps.DeletePortalIPAllowListResponse, error) {
+	c.t.Fatalf("unexpected DeletePortalIPAllowList call during planning")
+	return nil, nil
+}
+
 // Ensure mocks satisfy interfaces
 var (
 	_ helpers.PortalPageAPI    = (*mockPortalPageAPI)(nil)
 	_ helpers.PortalSnippetAPI = (*mockPortalSnippetAPI)(nil)
 )
+
+func TestPlanner_ExternalPortalReferenceOnlyPublicationDoesNotListIPAllowLists(t *testing.T) {
+	ctx := context.Background()
+	portalID := "portal-123"
+	portalName := "shared.portal"
+	apiID := "api-123"
+	apiName := "Example API"
+	visibility := kkComps.APIPublicationVisibility("private")
+
+	mockPortalAPI := new(MockPortalAPI)
+	mockPortalAPI.On("ListPortals", mock.Anything, mock.Anything).Return(&kkOps.ListPortalsResponse{
+		ListPortalsResponse: &kkComps.ListPortalsResponse{
+			Data: []kkComps.ListPortalsResponsePortal{
+				newListPortal(portalID, portalName, nil),
+			},
+			Meta: kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: 1}},
+		},
+		StatusCode: 200,
+	}, nil)
+
+	mockAPIAPI := new(MockAPIAPI)
+	mockAPIAPI.On("ListApis", mock.Anything, mock.Anything).Return(&kkOps.ListApisResponse{
+		ListAPIResponse: &kkComps.ListAPIResponse{
+			Data: []kkComps.APIResponseSchema{
+				{
+					ID:   apiID,
+					Name: apiName,
+					Labels: map[string]string{
+						labels.NamespaceKey: DefaultNamespace,
+					},
+				},
+			},
+			Meta: kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: 1}},
+		},
+	}, nil)
+
+	publicationsAPI := &countingAPIPublicationAPI{t: t}
+	allowListAPI := &countingPortalIPAllowListAPI{t: t, failList: true}
+	client := state.NewClient(state.ClientConfig{
+		PortalAPI:            mockPortalAPI,
+		APIAPI:               mockAPIAPI,
+		APIPublicationAPI:    publicationsAPI,
+		PortalIPAllowListAPI: allowListAPI,
+	})
+
+	rs := &resources.ResourceSet{
+		Portals: []resources.PortalResource{
+			{
+				CreatePortal: kkComps.CreatePortal{Name: portalName},
+				BaseResource: resources.BaseResource{
+					Ref: "shared-portal",
+				},
+				External: &resources.ExternalBlock{
+					Selector: &resources.ExternalSelector{MatchFields: map[string]string{FieldName: portalName}},
+				},
+			},
+		},
+		APIs: []resources.APIResource{
+			{
+				BaseResource: resources.BaseResource{Ref: "example-api"},
+				CreateAPIRequest: kkComps.CreateAPIRequest{
+					Name: apiName,
+				},
+			},
+		},
+		APIPublications: []resources.APIPublicationResource{
+			{
+				Ref:      "example-api-publication",
+				API:      "example-api",
+				PortalID: tags.RefPlaceholderPrefix + "shared-portal#id",
+				APIPublication: kkComps.APIPublication{
+					Visibility: &visibility,
+				},
+			},
+		},
+	}
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(ctx, rs, Options{Mode: PlanModeApply})
+	require.NoError(t, err)
+
+	require.Equal(t, 1, publicationsAPI.listCalls, "expected API publications to be listed")
+	require.Zero(t, allowListAPI.listCalls, "reference-only external portal must not list IP allow lists")
+	requirePlanChange(t, plan, ResourceTypeAPIPublication, ActionCreate)
+	mockPortalAPI.AssertExpectations(t)
+	mockAPIAPI.AssertExpectations(t)
+}
+
+func TestPlanner_ExternalPortalExplicitIPAllowListStillListsIPAllowLists(t *testing.T) {
+	ctx := context.Background()
+	allowListAPI := &countingPortalIPAllowListAPI{t: t}
+	plan := generateExternalPortalPlanWithIPAllowListAPI(t, ctx, PlanModeApply, allowListAPI, true)
+
+	require.Equal(t, 1, allowListAPI.listCalls, "explicit external portal IP allow list must list current entries")
+	requirePlanChange(t, plan, ResourceTypePortalIPAllowList, ActionCreate)
+}
+
+func TestPlanner_ExternalPortalSyncScopedIPAllowListStillListsIPAllowLists(t *testing.T) {
+	ctx := context.Background()
+	allowListAPI := &countingPortalIPAllowListAPI{t: t}
+	plan := generateExternalPortalPlanWithIPAllowListAPI(t, ctx, PlanModeSync, allowListAPI, false)
+
+	require.Equal(t, 1, allowListAPI.listCalls, "explicit sync scope must list current IP allow-list entries")
+	require.Empty(t, plan.Changes)
+}
+
+func generateExternalPortalPlanWithIPAllowListAPI(
+	t *testing.T,
+	ctx context.Context,
+	mode PlanMode,
+	allowListAPI *countingPortalIPAllowListAPI,
+	includeDesiredAllowList bool,
+) *Plan {
+	t.Helper()
+
+	portalID := "portal-123"
+	portalName := "shared.portal"
+	mockPortalAPI := new(MockPortalAPI)
+	mockPortalAPI.On("ListPortals", mock.Anything, mock.Anything).Return(&kkOps.ListPortalsResponse{
+		ListPortalsResponse: &kkComps.ListPortalsResponse{
+			Data: []kkComps.ListPortalsResponsePortal{
+				newListPortal(portalID, portalName, nil),
+			},
+			Meta: kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: 1}},
+		},
+		StatusCode: 200,
+	}, nil)
+
+	rs := &resources.ResourceSet{
+		Portals: []resources.PortalResource{
+			{
+				CreatePortal: kkComps.CreatePortal{Name: portalName},
+				BaseResource: resources.BaseResource{
+					Ref: "shared-portal",
+				},
+				External: &resources.ExternalBlock{
+					Selector: &resources.ExternalSelector{MatchFields: map[string]string{FieldName: portalName}},
+				},
+			},
+		},
+	}
+	if includeDesiredAllowList {
+		rs.PortalIPAllowLists = []resources.PortalIPAllowListResource{
+			{
+				Ref:        "shared-portal-ip-allow-list",
+				Portal:     "shared-portal",
+				AllowedIPs: []string{"192.0.2.10"},
+			},
+		}
+	}
+	if mode == PlanModeSync {
+		scope := resources.NewSyncScope()
+		scope.AddRoot(resources.ResourceTypePortal)
+		scope.AddChild(resources.ResourceTypePortal, "shared-portal", resources.ResourceTypePortalIPAllowList)
+		rs.SyncScope = scope
+	}
+
+	client := state.NewClient(state.ClientConfig{
+		PortalAPI:            mockPortalAPI,
+		PortalIPAllowListAPI: allowListAPI,
+	})
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(ctx, rs, Options{Mode: mode})
+	require.NoError(t, err)
+	mockPortalAPI.AssertExpectations(t)
+	return plan
+}
+
+func requirePlanChange(t *testing.T, plan *Plan, resourceType string, action ActionType) {
+	t.Helper()
+
+	for _, change := range plan.Changes {
+		if change.ResourceType == resourceType && change.Action == action {
+			return
+		}
+	}
+	require.Failf(t, "missing planned change", "expected %s %s in %+v", action, resourceType, plan.Changes)
+}
 
 func TestPlanner_ExternalPortal_PlansChildren(t *testing.T) {
 	ctx := context.Background()

--- a/internal/declarative/planner/portal_external_children_test.go
+++ b/internal/declarative/planner/portal_external_children_test.go
@@ -320,7 +320,7 @@ func TestPlanner_ExternalPortalReferenceOnlyPublicationDoesNotListIPAllowLists(t
 func TestPlanner_ExternalPortalExplicitIPAllowListStillListsIPAllowLists(t *testing.T) {
 	ctx := context.Background()
 	allowListAPI := &countingPortalIPAllowListAPI{t: t}
-	plan := generateExternalPortalPlanWithIPAllowListAPI(t, ctx, PlanModeApply, allowListAPI, true)
+	plan := generateExternalPortalPlanWithIPAllowListAPI(ctx, t, PlanModeApply, allowListAPI, true)
 
 	require.Equal(t, 1, allowListAPI.listCalls, "explicit external portal IP allow list must list current entries")
 	requirePlanChange(t, plan, ResourceTypePortalIPAllowList, ActionCreate)
@@ -329,15 +329,15 @@ func TestPlanner_ExternalPortalExplicitIPAllowListStillListsIPAllowLists(t *test
 func TestPlanner_ExternalPortalSyncScopedIPAllowListStillListsIPAllowLists(t *testing.T) {
 	ctx := context.Background()
 	allowListAPI := &countingPortalIPAllowListAPI{t: t}
-	plan := generateExternalPortalPlanWithIPAllowListAPI(t, ctx, PlanModeSync, allowListAPI, false)
+	plan := generateExternalPortalPlanWithIPAllowListAPI(ctx, t, PlanModeSync, allowListAPI, false)
 
 	require.Equal(t, 1, allowListAPI.listCalls, "explicit sync scope must list current IP allow-list entries")
 	require.Empty(t, plan.Changes)
 }
 
 func generateExternalPortalPlanWithIPAllowListAPI(
-	t *testing.T,
 	ctx context.Context,
+	t *testing.T,
 	mode PlanMode,
 	allowListAPI *countingPortalIPAllowListAPI,
 	includeDesiredAllowList bool,

--- a/internal/declarative/planner/portal_planner.go
+++ b/internal/declarative/planner/portal_planner.go
@@ -1084,8 +1084,8 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 ) error {
 	// Get the main planner instance to access child resource planning methods
 	planner := p.planner
-	childInScope := func(rt resources.ResourceType) bool {
-		return planner.shouldPlanChild(plan, resources.ResourceTypePortal, desired.Ref, rt)
+	childInScope := func(rt resources.ResourceType, hasDesired bool) bool {
+		return p.shouldPlanPortalChild(plan, desired, rt, hasDesired)
 	}
 
 	// Extract parent namespace for child resources
@@ -1103,7 +1103,7 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			pages = append(pages, page)
 		}
 	}
-	if childInScope(resources.ResourceTypePortalPage) {
+	if childInScope(resources.ResourceTypePortalPage, len(pages) > 0) {
 		if err := planner.planPortalPagesChanges(ctx, parentNamespace, current.ID, desired.Ref, pages, plan); err != nil {
 			return fmt.Errorf("failed to plan portal page changes: %w", err)
 		}
@@ -1118,7 +1118,7 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			snippets = append(snippets, snippet)
 		}
 	}
-	if childInScope(resources.ResourceTypePortalSnippet) {
+	if childInScope(resources.ResourceTypePortalSnippet, len(snippets) > 0) {
 		if err := planner.planPortalSnippetsChanges(
 			ctx, parentNamespace, current.ID, desired.Ref, snippets, plan,
 		); err != nil {
@@ -1133,7 +1133,7 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			allowLists = append(allowLists, allowList)
 		}
 	}
-	if childInScope(resources.ResourceTypePortalIPAllowList) {
+	if childInScope(resources.ResourceTypePortalIPAllowList, len(allowLists) > 0) {
 		if err := planner.planPortalIPAllowListsChanges(
 			ctx, parentNamespace, current.ID, desired.Ref, allowLists, plan,
 		); err != nil {
@@ -1148,7 +1148,7 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			integrations = append(integrations, integration)
 		}
 	}
-	if childInScope(resources.ResourceTypePortalIntegration) {
+	if childInScope(resources.ResourceTypePortalIntegration, len(integrations) > 0) {
 		if err := planner.planPortalIntegrationsChanges(
 			ctx, parentNamespace, current.ID, desired.Ref, integrations, plan,
 		); err != nil {
@@ -1163,7 +1163,7 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			identityProviders = append(identityProviders, provider)
 		}
 	}
-	if childInScope(resources.ResourceTypePortalIdentityProvider) {
+	if childInScope(resources.ResourceTypePortalIdentityProvider, len(identityProviders) > 0) {
 		if err := planner.planPortalIdentityProvidersChanges(
 			ctx,
 			parentNamespace,
@@ -1183,7 +1183,7 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			authSettings = append(authSettings, auth)
 		}
 	}
-	if childInScope(resources.ResourceTypePortalAuthSettings) {
+	if childInScope(resources.ResourceTypePortalAuthSettings, len(authSettings) > 0) {
 		if err := planner.planPortalAuthSettingsChanges(ctx, plannerCtx, parentNamespace, authSettings, plan); err != nil {
 			return fmt.Errorf("failed to plan portal auth settings changes: %w", err)
 		}
@@ -1196,7 +1196,7 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			emailConfigs = append(emailConfigs, cfg)
 		}
 	}
-	if childInScope(resources.ResourceTypePortalEmailConfig) {
+	if childInScope(resources.ResourceTypePortalEmailConfig, len(emailConfigs) > 0) {
 		if err := planner.planPortalEmailConfigsChanges(
 			ctx, parentNamespace, current.ID, desired.Ref, emailConfigs, plan,
 		); err != nil {
@@ -1211,7 +1211,7 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			auditLogWebhooks = append(auditLogWebhooks, webhook)
 		}
 	}
-	if childInScope(resources.ResourceTypePortalAuditLogWebhook) {
+	if childInScope(resources.ResourceTypePortalAuditLogWebhook, len(auditLogWebhooks) > 0) {
 		if err := planner.planPortalAuditLogWebhooksChanges(
 			ctx, parentNamespace, current.ID, desired.Ref, auditLogWebhooks, plan,
 		); err != nil {
@@ -1226,7 +1226,7 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			templates = append(templates, tpl)
 		}
 	}
-	if childInScope(resources.ResourceTypePortalEmailTemplate) {
+	if childInScope(resources.ResourceTypePortalEmailTemplate, len(templates) > 0) {
 		if err := planner.planPortalEmailTemplatesChanges(
 			ctx, parentNamespace, current.ID, desired.Ref, desired.Name, templates, plan,
 		); err != nil {
@@ -1241,7 +1241,7 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			customizations = append(customizations, customization)
 		}
 	}
-	if childInScope(resources.ResourceTypePortalCustomization) {
+	if childInScope(resources.ResourceTypePortalCustomization, len(customizations) > 0) {
 		if err := planner.planPortalCustomizationsChanges(
 			ctx, plannerCtx, parentNamespace, customizations, plan,
 		); err != nil {
@@ -1256,7 +1256,7 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			teams = append(teams, team)
 		}
 	}
-	if childInScope(resources.ResourceTypePortalTeam) {
+	if childInScope(resources.ResourceTypePortalTeam, len(teams) > 0) {
 		if err := planner.planPortalTeamsChanges(
 			ctx, parentNamespace, current.ID, desired.Ref, teams, plan,
 		); err != nil {
@@ -1270,7 +1270,7 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			mappings = append(mappings, mapping)
 		}
 	}
-	if childInScope(resources.ResourceTypePortalTeamGroupMapping) {
+	if childInScope(resources.ResourceTypePortalTeamGroupMapping, len(mappings) > 0) {
 		if err := planner.planPortalTeamGroupMappingsChanges(
 			ctx, parentNamespace, current.ID, desired.Ref, mappings, plan,
 		); err != nil {
@@ -1278,7 +1278,14 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 		}
 	}
 
-	if childInScope(resources.ResourceTypePortalTeamRole) {
+	hasTeamRoles := false
+	for _, role := range planner.desiredPortalTeamRoles {
+		if role.Portal == desired.Ref {
+			hasTeamRoles = true
+			break
+		}
+	}
+	if childInScope(resources.ResourceTypePortalTeamRole, hasTeamRoles) {
 		if err := planner.planPortalTeamRolesChanges(
 			ctx, parentNamespace, current.ID, desired.Ref, desired.Name, plan,
 		); err != nil {
@@ -1293,7 +1300,7 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			domains = append(domains, domain)
 		}
 	}
-	if childInScope(resources.ResourceTypePortalCustomDomain) {
+	if childInScope(resources.ResourceTypePortalCustomDomain, len(domains) > 0) {
 		if err := planner.planPortalCustomDomainsChanges(
 			ctx,
 			parentNamespace,
@@ -1313,7 +1320,7 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			logos = append(logos, logo)
 		}
 	}
-	if childInScope(resources.ResourceTypePortalAssetLogo) {
+	if childInScope(resources.ResourceTypePortalAssetLogo, len(logos) > 0) {
 		if err := planner.planPortalAssetLogosChanges(ctx, plannerCtx, parentNamespace, logos, plan); err != nil {
 			return fmt.Errorf("failed to plan portal asset logo changes: %w", err)
 		}
@@ -1326,7 +1333,7 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			favicons = append(favicons, favicon)
 		}
 	}
-	if childInScope(resources.ResourceTypePortalAssetFavicon) {
+	if childInScope(resources.ResourceTypePortalAssetFavicon, len(favicons) > 0) {
 		if err := planner.planPortalAssetFaviconsChanges(ctx, plannerCtx, parentNamespace, favicons, plan); err != nil {
 			return fmt.Errorf("failed to plan portal asset favicon changes: %w", err)
 		}
@@ -1335,7 +1342,7 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 	// Plan nested assets (from portal.Assets.Logo and portal.Assets.Favicon fields)
 	if !desired.IsExternal() && desired.Assets != nil {
 		if desired.Assets.Logo != nil && *desired.Assets.Logo != "" {
-			if childInScope(resources.ResourceTypePortalAssetLogo) &&
+			if childInScope(resources.ResourceTypePortalAssetLogo, true) &&
 				!plan.HasChange(ResourceTypePortalAssetLogo, fmt.Sprintf("%s-logo", desired.Ref)) {
 				needsUpdate, currentDataURL, err := planner.portalAssetNeedsUpdate(
 					ctx,
@@ -1365,7 +1372,7 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 			}
 		}
 		if desired.Assets.Favicon != nil && *desired.Assets.Favicon != "" {
-			if childInScope(resources.ResourceTypePortalAssetFavicon) &&
+			if childInScope(resources.ResourceTypePortalAssetFavicon, true) &&
 				!plan.HasChange(ResourceTypePortalAssetFavicon, fmt.Sprintf("%s-favicon", desired.Ref)) {
 				needsUpdate, currentDataURL, err := planner.portalAssetNeedsUpdate(
 					ctx,
@@ -1397,4 +1404,16 @@ func (p *portalPlannerImpl) planPortalChildResourceChanges(
 	}
 
 	return nil
+}
+
+func (p *portalPlannerImpl) shouldPlanPortalChild(
+	plan *Plan,
+	desired resources.PortalResource,
+	rt resources.ResourceType,
+	hasDesired bool,
+) bool {
+	if desired.IsExternal() && plan != nil && plan.Metadata.Mode != PlanModeSync {
+		return hasDesired
+	}
+	return p.planner.shouldPlanChild(plan, resources.ResourceTypePortal, desired.Ref, rt)
 }


### PR DESCRIPTION
## Summary
- avoid planning portal child diffs for reference-only external portals in non-sync planning
- preserve explicit portal child management and sync-scoped portal child reconciliation
- add planner API-call assertions and API publication executor coverage

Fixes #1556

## Tests
- go test ./internal/declarative/planner
- go test ./internal/declarative/executor
- make test