### PR TITLE
fix(declarative): scaffold api version spec as a file scalar

### DIFF
--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -111,7 +111,7 @@ apis:
     versions: # https://developer.konghq.com/api/konnect/api-builder/v3/#/operations/create-api-version
       - ref: string
         version: string
-        spec: object required (OpenAPI or AsyncAPI content; json or yaml) # prefer: !file ./specs/api.yaml
+        spec: !file ./specs/api.yaml # required (OpenAPI or AsyncAPI content; json or yaml)
     publications: # https://developer.konghq.com/api/konnect/api-builder/v3/#/operations/publish-api-to-portal
       - ref: string
         portal_id: string required (uuid) # prefer: !ref <portal-ref>

--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -111,8 +111,7 @@ apis:
     versions: # https://developer.konghq.com/api/konnect/api-builder/v3/#/operations/create-api-version
       - ref: string
         version: string
-        spec: object required
-          content: string required (OpenAPI or AsyncAPI content; json or yaml) # prefer: !file ./specs/api.yaml
+        spec: object required (OpenAPI or AsyncAPI content; json or yaml) # prefer: !file ./specs/api.yaml
     publications: # https://developer.konghq.com/api/konnect/api-builder/v3/#/operations/publish-api-to-portal
       - ref: string
         portal_id: string required (uuid) # prefer: !ref <portal-ref>

--- a/internal/declarative/resources/api_version.go
+++ b/internal/declarative/resources/api_version.go
@@ -13,7 +13,20 @@ func init() {
 	registerResourceType(
 		ResourceTypeAPIVersion,
 		func(rs *ResourceSet) *[]APIVersionResource { return &rs.APIVersions },
-		AutoExplain[APIVersionResource](),
+		AutoExplain[APIVersionResource](
+			// spec is an SDK object ({content: ...}) but is supplied whole from a
+			// file. Present it as `spec: !file ...` so users don't nest the content
+			// under spec.content, which double-wraps the payload and Konnect rejects.
+			WithExplainFieldHint("spec", ExplainFieldHint{
+				Literal:      "!file ./specs/openapi.yaml",
+				PreferredTag: "!file",
+			}),
+			// Override the generic "content" !file guidance for this nested field so
+			// it does not steer users toward the double-wrapping spec.content form.
+			WithExplainFieldHint("spec.content", ExplainFieldHint{
+				Notes: []string{"Set the whole spec with `spec: !file ...` instead of populating content directly."},
+			}),
+		),
 	)
 }
 

--- a/internal/declarative/resources/api_version.go
+++ b/internal/declarative/resources/api_version.go
@@ -18,7 +18,7 @@ func init() {
 			// file. Present it as `spec: !file ...` so users don't nest the content
 			// under spec.content, which double-wraps the payload and Konnect rejects.
 			WithExplainFieldHint("spec", ExplainFieldHint{
-				Literal:      "!file ./specs/openapi.yaml",
+				Literal:      "!file ./specs/api.yaml",
 				PreferredTag: "!file",
 			}),
 			// Override the generic "content" !file guidance for this nested field so

--- a/internal/declarative/resources/explain.go
+++ b/internal/declarative/resources/explain.go
@@ -189,8 +189,6 @@ var (
 		"content":            "./content.txt",
 		"css":                "./custom.css",
 		"robots":             "./robots.txt",
-		"spec":               "./specs/openapi.yaml",
-		"spec.content":       "./specs/openapi.yaml",
 		"custom_certificate": "./certs/cert.pem",
 		"custom_private_key": "./certs/key.pem",
 	}
@@ -1069,7 +1067,7 @@ func applyExplainFieldHint(node *ExplainNode, hint ExplainFieldHint) {
 	if len(hint.Enum) > 0 {
 		node.Enum = append([]any(nil), hint.Enum...)
 	}
-	if hint.FileSample != "" {
+	if hint.FileSample != "" && node.Kind != explainKindObject {
 		node.Literal = fmt.Sprintf("!file %s", hint.FileSample)
 	}
 	if hint.Literal != "" {
@@ -1560,7 +1558,7 @@ func renderScaffoldField(write scaffoldWriter, depth int, field *ExplainField, o
 	}
 
 	node := scaffoldActiveNode(field.Node)
-	if node.Kind == explainKindObject && node.Additional == nil {
+	if node.Kind == explainKindObject && node.Additional == nil && node.Literal == "" {
 		write(indent + commentPrefix + field.Name + ":")
 		renderCommentedBlock(write, depth+1, field.Node, omit, comment)
 		return

--- a/internal/declarative/resources/explain_test.go
+++ b/internal/declarative/resources/explain_test.go
@@ -447,6 +447,39 @@ func TestRenderScaffoldYAML_RootResource(t *testing.T) {
 	assert.NotContains(t, scaffold, "spec_content")
 }
 
+func TestResolveExplainSubject_APIVersionSpecPrefersFileScalar(t *testing.T) {
+	subject, err := ResolveExplainSubject("api_version.spec")
+	require.NoError(t, err)
+
+	assert.Equal(t, "!file", subject.Node.PreferredTag)
+	assert.Equal(t, "!file ./specs/openapi.yaml", subject.Node.Literal)
+}
+
+func TestResolveExplainSubject_APIVersionSpecContentHasNoFileTag(t *testing.T) {
+	subject, err := ResolveExplainSubject("api_version.spec.content")
+	require.NoError(t, err)
+
+	// The nested content field must not inherit the generic "content" !file
+	// guidance; that steers users toward the double-wrapping spec.content shape.
+	assert.Empty(t, subject.Node.PreferredTag)
+	assert.NotContains(t, subject.Node.Literal, "!file")
+}
+
+func TestRenderScaffoldYAML_APIVersionSpecUsesFileScalar(t *testing.T) {
+	for _, path := range []string{"api_version", "api.versions"} {
+		t.Run(path, func(t *testing.T) {
+			subject, err := ResolveExplainSubject(path)
+			require.NoError(t, err)
+
+			scaffold, err := RenderScaffoldYAML(subject)
+			require.NoError(t, err)
+
+			assert.Contains(t, scaffold, "spec: !file ./specs/openapi.yaml")
+			assert.NotContains(t, scaffold, "content: !file")
+		})
+	}
+}
+
 func TestRenderScaffoldYAML_ApplicationAuthStrategyUnion(t *testing.T) {
 	subject, err := ResolveExplainSubject("application_auth_strategies")
 	require.NoError(t, err)

--- a/internal/declarative/resources/explain_test.go
+++ b/internal/declarative/resources/explain_test.go
@@ -452,7 +452,7 @@ func TestResolveExplainSubject_APIVersionSpecPrefersFileScalar(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "!file", subject.Node.PreferredTag)
-	assert.Equal(t, "!file ./specs/openapi.yaml", subject.Node.Literal)
+	assert.Equal(t, "!file ./specs/api.yaml", subject.Node.Literal)
 }
 
 func TestResolveExplainSubject_APIVersionSpecContentHasNoFileTag(t *testing.T) {
@@ -474,7 +474,7 @@ func TestRenderScaffoldYAML_APIVersionSpecUsesFileScalar(t *testing.T) {
 			scaffold, err := RenderScaffoldYAML(subject)
 			require.NoError(t, err)
 
-			assert.Contains(t, scaffold, "spec: !file ./specs/openapi.yaml")
+			assert.Contains(t, scaffold, "spec: !file ./specs/api.yaml")
 			assert.NotContains(t, scaffold, "content: !file")
 		})
 	}


### PR DESCRIPTION
`kongctl scaffold`/`explain` for API versions point you at the wrong spec shape:

```
spec:
  # content: !file ./specs/openapi.yaml
```

That double-wraps the payload (`{"content": {...openapi...}}`), which plans fine but fails apply with `content must be valid specification`. The shape that works is `spec: !file ./specs/api.yaml`.

So this shows `spec` as a `!file` scalar in scaffold and explain, and fixes the same thing in the resource-reference doc.

I left out the loader validation from the checklist on purpose. Rejecting a `spec.content: !file` config before planning is a separate design call (reject vs normalize vs warn) and touches the planner, so better as a follow-up once you've picked the behavior. Happy to take it.

Part of #1532.