### PR TITLE
fix(e2e): handle fork PR status without unsafe fallbacks

### DIFF
--- a/.github/workflows/e2e-required-status.yaml
+++ b/.github/workflows/e2e-required-status.yaml
@@ -45,13 +45,18 @@ jobs:
             });
             const e2ePattern = /^(go\.mod|go\.sum|main\.go|[^/]+\.go|internal\/.*|test\/e2e\/.*|Makefile|\.goreleaser\.yml|\.github\/workflows\/e2e\.yaml|\.github\/workflows\/e2e-main-debounce\.yaml)$/;
             const required = files.some((file) => e2ePattern.test(file.filename));
+            const forkPullRequest = pr.head.repo.full_name !== pr.base.repo.full_name;
             const state = required ? 'pending' : 'success';
-            const description = required
-              ? 'E2E required for this PR and waiting for E2E workflow.'
-              : 'E2E not required for this PR.';
-            const targetUrl = required
-              ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/pull/${pr.number}/checks`
-              : `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            let description = 'E2E not required for this PR.';
+            let targetUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+
+            if (required && forkPullRequest) {
+              description = 'Fork PR requires trusted maintainer E2E for reviewed SHA.';
+              targetUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/workflows/e2e.yaml`;
+            } else if (required) {
+              description = 'E2E required for this PR and waiting for E2E workflow.';
+              targetUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/pull/${pr.number}/checks`;
+            }
 
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -99,14 +99,9 @@ jobs:
           TECH_ORGS_JSON: ${{ vars.KONGCTL_E2E_TECH_ORGS_JSON || '' }}
           DISABLE_DEFAULT_ORG_FALLBACK: >-
             ${{
-              ((
-                  github.event_name == 'pull_request' &&
-                  github.event.pull_request.head.repo.full_name != github.repository
-                ) ||
-                (
-                  github.event_name == 'workflow_dispatch' &&
-                  inputs.trusted_pr_number != ''
-                )
+              (
+                github.event_name == 'pull_request' &&
+                github.event.pull_request.head.repo.full_name != github.repository
               ) &&
               'true' ||
               'false'
@@ -183,11 +178,11 @@ jobs:
           checkout_ref="${GITHUB_SHA}"
           is_fork=false
 
-          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ] && \
-            [ -n "${PULL_REQUEST_HEAD_REPO}" ] && \
-            [ "${PULL_REQUEST_HEAD_REPO}" != "${GITHUB_REPOSITORY}" ]; then
-            is_fork=true
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ] && [ -n "${PULL_REQUEST_HEAD_SHA}" ]; then
             status_sha="${PULL_REQUEST_HEAD_SHA}"
+            if [ -n "${PULL_REQUEST_HEAD_REPO}" ] && [ "${PULL_REQUEST_HEAD_REPO}" != "${GITHUB_REPOSITORY}" ]; then
+              is_fork=true
+            fi
           fi
 
           emit_outputs() {

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,6 +2,9 @@ name: E2E
 run-name: >-
   E2E ${{
     github.event_name == 'workflow_dispatch' &&
+    inputs.trusted_pr_number != '' &&
+    format('trusted PR {0} {1}', inputs.trusted_pr_number, inputs.trusted_head_sha) ||
+    github.event_name == 'workflow_dispatch' &&
     inputs.dispatch_source == 'main-debounce' &&
     format('main debounce {0}', inputs.main_sha) ||
     github.ref_name
@@ -22,6 +25,14 @@ on:
         default: ""
       main_sha:
         description: Main branch SHA selected by the debounce workflow
+        type: string
+        default: ""
+      trusted_pr_number:
+        description: Fork PR number approved for trusted E2E
+        type: string
+        default: ""
+      trusted_head_sha:
+        description: Exact reviewed fork PR head SHA approved for trusted E2E
         type: string
         default: ""
       konnect_environment:
@@ -53,10 +64,19 @@ jobs:
   e2e-needed:
     name: E2E Needed
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       required: ${{ steps.detect.outputs.required }}
+      is_fork: ${{ steps.detect.outputs.is_fork }}
+      trusted_e2e_required: ${{ steps.detect.outputs.trusted_e2e_required }}
+      run_shards: ${{ steps.detect.outputs.run_shards }}
       konnect_environment: ${{ steps.target.outputs.konnect_environment }}
       orgs_json: ${{ steps.target.outputs.orgs_json }}
+      status_sha: ${{ steps.detect.outputs.status_sha }}
+      checkout_repository: ${{ steps.detect.outputs.checkout_repository }}
+      checkout_ref: ${{ steps.detect.outputs.checkout_ref }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -77,6 +97,20 @@ jobs:
           DEFAULT_ORGS_JSON: ${{ vars.KONGCTL_E2E_ORGS_JSON || '' }}
           PRODUCTION_ORGS_JSON: ${{ vars.KONGCTL_E2E_PRODUCTION_ORGS_JSON || '' }}
           TECH_ORGS_JSON: ${{ vars.KONGCTL_E2E_TECH_ORGS_JSON || '' }}
+          DISABLE_DEFAULT_ORG_FALLBACK: >-
+            ${{
+              ((
+                  github.event_name == 'pull_request' &&
+                  github.event.pull_request.head.repo.full_name != github.repository
+                ) ||
+                (
+                  github.event_name == 'workflow_dispatch' &&
+                  inputs.trusted_pr_number != ''
+                )
+              ) &&
+              'true' ||
+              'false'
+            }}
         run: |
           set -euo pipefail
 
@@ -104,7 +138,11 @@ jobs:
             orgs_json="${DEFAULT_ORGS_JSON:-}"
           fi
           if [ -z "${orgs_json}" ]; then
-            orgs_json='[{"org_name":"default"}]'
+            if [ "${DISABLE_DEFAULT_ORG_FALLBACK}" = "true" ]; then
+              orgs_json='[]'
+            else
+              orgs_json='[{"org_name":"default"}]'
+            fi
           fi
 
           orgs_json="$(ORGS_JSON="${orgs_json}" python3 - <<'PY'
@@ -132,9 +170,82 @@ jobs:
           BASE_REF: ${{ github.base_ref || '' }}
           DISPATCH_SOURCE: ${{ github.event_name == 'workflow_dispatch' && inputs.dispatch_source || '' }}
           MAIN_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.main_sha || '' }}
+          TRUSTED_PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.trusted_pr_number || '' }}
+          TRUSTED_HEAD_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.trusted_head_sha || '' }}
+          PULL_REQUEST_HEAD_REPO: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || '' }}
+          PULL_REQUEST_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+
+          status_sha="${GITHUB_SHA}"
+          checkout_repository="${GITHUB_REPOSITORY}"
+          checkout_ref="${GITHUB_SHA}"
+          is_fork=false
+
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ] && \
+            [ -n "${PULL_REQUEST_HEAD_REPO}" ] && \
+            [ "${PULL_REQUEST_HEAD_REPO}" != "${GITHUB_REPOSITORY}" ]; then
+            is_fork=true
+            status_sha="${PULL_REQUEST_HEAD_SHA}"
+          fi
+
+          emit_outputs() {
+            local required="$1"
+            local run_shards="$2"
+            local trusted_e2e_required="$3"
+
+            {
+              echo "required=${required}"
+              echo "run_shards=${run_shards}"
+              echo "is_fork=${is_fork}"
+              echo "trusted_e2e_required=${trusted_e2e_required}"
+              echo "status_sha=${status_sha}"
+              echo "checkout_repository=${checkout_repository}"
+              echo "checkout_ref=${checkout_ref}"
+            } >> "${GITHUB_OUTPUT}"
+          }
+
+          if [ -n "${TRUSTED_PR_NUMBER}" ] || [ -n "${TRUSTED_HEAD_SHA}" ]; then
+            if [ "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ]; then
+              echo "::error::Trusted E2E inputs are only valid for workflow_dispatch."
+              exit 1
+            fi
+            if [ -z "${TRUSTED_PR_NUMBER}" ] || [ -z "${TRUSTED_HEAD_SHA}" ]; then
+              echo "::error::trusted_pr_number and trusted_head_sha must both be provided."
+              exit 1
+            fi
+            if ! [[ "${TRUSTED_PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+              echo "::error::trusted_pr_number must be a pull request number."
+              exit 1
+            fi
+            if ! [[ "${TRUSTED_HEAD_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+              echo "::error::trusted_head_sha must be a full 40-character Git SHA."
+              exit 1
+            fi
+
+            pr_api="/repos/${GITHUB_REPOSITORY}/pulls/${TRUSTED_PR_NUMBER}"
+            head_sha="$(gh api "${pr_api}" --jq '.head.sha')"
+            head_repo="$(gh api "${pr_api}" --jq '.head.repo.full_name')"
+            base_repo="$(gh api "${pr_api}" --jq '.base.repo.full_name')"
+
+            if [ "${head_repo}" = "${base_repo}" ]; then
+              echo "::error::Trusted fork E2E only accepts fork pull requests. Use the normal E2E workflow for same-repo PRs."
+              exit 1
+            fi
+            if [ "${TRUSTED_HEAD_SHA}" != "${head_sha}" ]; then
+              echo "::error::Trusted SHA ${TRUSTED_HEAD_SHA} does not match current PR head ${head_sha}."
+              exit 1
+            fi
+
+            is_fork=true
+            status_sha="${TRUSTED_HEAD_SHA}"
+            checkout_repository="${head_repo}"
+            checkout_ref="${TRUSTED_HEAD_SHA}"
+            emit_outputs true true false
+            echo "Trusted E2E required for fork PR #${TRUSTED_PR_NUMBER} at ${TRUSTED_HEAD_SHA}."
+            exit 0
+          fi
 
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && [ "${DISPATCH_SOURCE}" = "main-debounce" ]; then
             if [ -z "${MAIN_SHA}" ]; then
@@ -146,18 +257,18 @@ jobs:
               gh api "/repos/${GITHUB_REPOSITORY}/git/ref/heads/${DEFAULT_BRANCH}" --jq '.object.sha'
             )"
             if [ "${MAIN_SHA}" != "${current_main_sha}" ]; then
-              echo "required=false" >> "${GITHUB_OUTPUT}"
+              emit_outputs false false false
               echo "Skipping stale debounced E2E for ${MAIN_SHA}; current ${DEFAULT_BRANCH} is ${current_main_sha}."
               exit 0
             fi
 
-            echo "required=true" >> "${GITHUB_OUTPUT}"
+            emit_outputs true true false
             echo "E2E required for debounced ${DEFAULT_BRANCH} dispatch at ${MAIN_SHA}."
             exit 0
           fi
 
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            echo "required=true" >> "${GITHUB_OUTPUT}"
+            emit_outputs true true false
             echo "E2E required for ${GITHUB_EVENT_NAME}."
             exit 0
           fi
@@ -193,19 +304,33 @@ jobs:
           )"
 
           if grep -Eq "${e2e_pattern}" "${changed_files}"; then
-            echo "required=true" >> "${GITHUB_OUTPUT}"
-            echo "E2E required for this change set."
+            if [ "${is_fork}" = "true" ]; then
+              emit_outputs true false true
+              echo "E2E requires maintainer-triggered trusted run for fork PR."
+              if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+                {
+                  echo "## E2E"
+                  echo
+                  echo "- Status: waiting for trusted maintainer run"
+                  echo "- Reason: fork PR code cannot receive E2E secrets automatically"
+                  echo "- Reviewed SHA required: ${status_sha}"
+                } >> "${GITHUB_STEP_SUMMARY}"
+              fi
+            else
+              emit_outputs true true false
+              echo "E2E required for this change set."
+            fi
             exit 0
           fi
 
-          echo "required=false" >> "${GITHUB_OUTPUT}"
+          emit_outputs false false false
           echo "E2E not required for this change set."
 
   e2e-harness:
     name: E2E Harness
     needs:
       - e2e-needed
-    if: needs.e2e-needed.outputs.required == 'true'
+    if: needs.e2e-needed.outputs.run_shards == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -215,6 +340,9 @@ jobs:
           egress-policy: audit
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ needs.e2e-needed.outputs.checkout_repository }}
+          ref: ${{ needs.e2e-needed.outputs.checkout_ref }}
 
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
@@ -230,7 +358,7 @@ jobs:
     name: E2E Build
     needs:
       - e2e-needed
-    if: needs.e2e-needed.outputs.required == 'true'
+    if: needs.e2e-needed.outputs.run_shards == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -240,6 +368,9 @@ jobs:
           egress-policy: audit
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ needs.e2e-needed.outputs.checkout_repository }}
+          ref: ${{ needs.e2e-needed.outputs.checkout_ref }}
 
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
@@ -267,7 +398,7 @@ jobs:
       - e2e-needed
       - e2e-harness
       - e2e-build
-    if: needs.e2e-needed.outputs.required == 'true'
+    if: needs.e2e-needed.outputs.run_shards == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     # Backstop serialization per target org if workflow-level serialization is
@@ -343,6 +474,9 @@ jobs:
           egress-policy: audit
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ needs.e2e-needed.outputs.checkout_repository }}
+          ref: ${{ needs.e2e-needed.outputs.checkout_ref }}
 
       # Optional: Un-comment if you need private module access
       # - name: Configure private module access
@@ -538,7 +672,7 @@ jobs:
     needs:
       - e2e-needed
       - e2e
-    if: ${{ always() && !cancelled() && needs.e2e-needed.outputs.required == 'true' }}
+    if: ${{ always() && !cancelled() && needs.e2e-needed.outputs.run_shards == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -548,6 +682,9 @@ jobs:
           egress-policy: audit
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ needs.e2e-needed.outputs.checkout_repository }}
+          ref: ${{ needs.e2e-needed.outputs.checkout_ref }}
 
       - name: Download workflow artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -842,15 +979,33 @@ jobs:
         env:
           E2E_NEEDED_RESULT: ${{ needs.e2e-needed.result }}
           E2E_REQUIRED: ${{ needs.e2e-needed.outputs.required }}
+          E2E_RUN_SHARDS: ${{ needs.e2e-needed.outputs.run_shards }}
+          E2E_TRUSTED_REQUIRED: ${{ needs.e2e-needed.outputs.trusted_e2e_required }}
           E2E_VERIFY_RESULT: ${{ needs.e2e-verify.result }}
-          STATUS_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          TRUSTED_DISPATCH: ${{ github.event_name == 'workflow_dispatch' && inputs.trusted_pr_number != '' && 'true' || 'false' }}
+          STATUS_SHA: >-
+            ${{
+              needs.e2e-needed.outputs.status_sha ||
+              (
+                github.event_name == 'workflow_dispatch' &&
+                inputs.trusted_head_sha
+              ) ||
+              (
+                github.event_name == 'pull_request' &&
+                github.event.pull_request.head.sha
+              ) ||
+              github.sha
+            }}
         with:
           script: |
             const statusContext = 'E2E Required';
             const eventName = process.env.GITHUB_EVENT_NAME;
             const neededResult = process.env.E2E_NEEDED_RESULT;
             const required = process.env.E2E_REQUIRED === 'true';
+            const runShards = process.env.E2E_RUN_SHARDS === 'true';
+            const trustedE2ERequired = process.env.E2E_TRUSTED_REQUIRED === 'true';
             const verifyResult = process.env.E2E_VERIFY_RESULT;
+            const trustedDispatch = process.env.TRUSTED_DISPATCH === 'true';
             const pullRequest = context.payload.pull_request;
             const forkPullRequest = eventName === 'pull_request' &&
               pullRequest?.head?.repo?.full_name !== pullRequest?.base?.repo?.full_name;
@@ -863,17 +1018,20 @@ jobs:
               state = 'failure';
               description = `E2E Needed concluded ${neededResult}.`;
               failureMessage = description;
-            } else if (required && verifyResult !== 'success') {
+            } else if (required && runShards && verifyResult !== 'success') {
               state = 'failure';
               description = `E2E required but E2E Verify concluded ${verifyResult}.`;
               failureMessage = description;
-            } else if (required) {
+            } else if (required && trustedE2ERequired) {
+              state = 'pending';
+              description = 'Fork PR requires trusted maintainer E2E for reviewed SHA.';
+            } else if (required && runShards) {
               description = 'E2E required and E2E Verify succeeded.';
             }
 
             if (forkPullRequest) {
               core.warning('Skipping E2E Required status update for fork pull request.');
-            } else if (eventName === 'pull_request' || eventName === 'merge_group') {
+            } else if (eventName === 'pull_request' || eventName === 'merge_group' || trustedDispatch) {
               await github.rest.repos.createCommitStatus({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -379,6 +379,27 @@ The workflow derives sharding directly from GitHub Actions strategy context:
 - `KONGCTL_E2E_MATRIX_ORG=${{ matrix.org_name }}`
 - `KONGCTL_E2E_ORGS_JSON` set to the selected org matrix
 
+Fork pull requests do not receive secret-backed E2E automatically. When a fork
+PR changes files that require E2E, the required status remains pending with a
+message that trusted maintainer E2E is required. The normal fork-triggered E2E
+workflow does not expand shard jobs, does not use the `default` org fallback,
+and does not receive Konnect or Gmail secrets.
+
+To run trusted E2E for a fork PR:
+
+1. Review the PR for malicious changes, especially build scripts, tests,
+   dependency updates, workflow-adjacent files, shell execution, and network
+   calls.
+2. Record the exact current PR head SHA from the reviewed commit.
+3. Run the `E2E` workflow manually with `trusted_pr_number` and
+   `trusted_head_sha`.
+4. Approve the protected E2E environment when prompted.
+5. Re-run trusted E2E if the contributor pushes another commit.
+
+The workflow verifies that `trusted_head_sha` still matches the PR head before
+checking out or running the fork code. The trusted run writes the final
+`E2E Required` status to that exact SHA.
+
 The workflow also exposes the Konnect target, test timeout, HTTP timeout, and
 retry knobs above as repository or organization variables of the same names,
 so CI can tune runtime behavior without changing Go code. Manual dispatch
@@ -440,7 +461,7 @@ override this with the `konnect_environment` input.
 If production and `.tech` need separate org pools, set
 `KONGCTL_E2E_PRODUCTION_ORGS_JSON` and `KONGCTL_E2E_TECH_ORGS_JSON` to
 environment names backed by matching PATs. The workflow selects an org matrix
-with this fallback order:
+with this fallback order for non-fork runs:
 
 1. `KONGCTL_E2E_TECH_ORGS_JSON` for `.tech`, or
    `KONGCTL_E2E_PRODUCTION_ORGS_JSON` for production.
@@ -453,9 +474,10 @@ Use `KONGCTL_E2E_KONNECT_BASE_URL`,
 tech defaults are not sufficient.
 
 If the org-pool variable is unset, the workflow falls back to a single-org
-matrix entry named `default`, which is useful during migration if you still
-have a `default` environment or a temporary repository-level
-`KONGCTL_E2E_KONNECT_PAT` secret in place.
+matrix entry named `default` for non-fork runs, which is useful during
+migration if you still have a `default` environment or a temporary
+repository-level `KONGCTL_E2E_KONNECT_PAT` secret in place. Fork PR runs do not
+use this fallback.
 
 ### SDK Prerelease Preview Automation
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -476,8 +476,8 @@ tech defaults are not sufficient.
 If the org-pool variable is unset, the workflow falls back to a single-org
 matrix entry named `default` for non-fork runs, which is useful during
 migration if you still have a `default` environment or a temporary
-repository-level `KONGCTL_E2E_KONNECT_PAT` secret in place. Fork PR runs do not
-use this fallback.
+repository-level `KONGCTL_E2E_KONNECT_PAT` secret in place.
+Untrusted fork-triggered PR runs do not use this fallback.
 
 ### SDK Prerelease Preview Automation
 


### PR DESCRIPTION
## Summary
- detect fork PRs in E2E and avoid secret-backed shard expansion for untrusted fork code
- add trusted maintainer workflow_dispatch inputs that verify PR number and exact reviewed SHA before checkout
- update E2E Required status messaging and document the maintainer runbook

Closes #1569

## Validation
- actionlint .github/workflows/e2e.yaml .github/workflows/e2e-required-status.yaml
- git diff --check