### PR TITLE
fix(e2e): clarify trusted fork validation results

### DIFF
--- a/.github/workflows/e2e-required-status.yaml
+++ b/.github/workflows/e2e-required-status.yaml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
   pull-requests: read
   statuses: write
 
@@ -26,6 +25,11 @@ jobs:
   e2e-required-status:
     name: "E2E Gate: Initialize Status"
     runs-on: ubuntu-latest
+    outputs:
+      required: ${{ steps.status.outputs.required }}
+      fork_pull_request: ${{ steps.status.outputs.fork_pull_request }}
+      pr_number: ${{ steps.status.outputs.pr_number }}
+      pr_head_sha: ${{ steps.status.outputs.pr_head_sha }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -33,11 +37,11 @@ jobs:
           egress-policy: audit
 
       - name: Initialize E2E Required status
+        id: status
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const statusContext = 'E2E Required';
-            const trustedCommentMarker = '<!-- kongctl-trusted-e2e-status -->';
             const pr = context.payload.pull_request;
             const runURL = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
             const files = await github.paginate(github.rest.pulls.listFiles, {
@@ -50,6 +54,11 @@ jobs:
             const required = files.some((file) => e2ePattern.test(file.filename));
             const forkPullRequest = pr.head.repo.full_name !== pr.base.repo.full_name;
             const state = required ? 'pending' : 'success';
+            core.setOutput('required', String(required));
+            core.setOutput('fork_pull_request', String(forkPullRequest));
+            core.setOutput('pr_number', String(pr.number));
+            core.setOutput('pr_head_sha', pr.head.sha);
+
             let description = 'E2E not required for this PR.';
             let targetUrl = runURL;
 
@@ -71,64 +80,94 @@ jobs:
               target_url: targetUrl,
             });
 
-            if (required && forkPullRequest) {
-              const defaultBranch = context.payload.repository.default_branch;
-              const trustedCommand = [
-                `gh workflow run e2e.yaml --repo ${process.env.GITHUB_REPOSITORY}`,
-                `--ref ${defaultBranch}`,
-                `-f trusted_pr_number=${pr.number}`,
-                `-f trusted_head_sha=${pr.head.sha}`,
-              ].join(' ');
-              const body = [
-                trustedCommentMarker,
-                'Trusted E2E is required for this fork PR.',
-                '',
-                `- PR: #${pr.number}`,
-                `- Reviewed SHA: \`${pr.head.sha}\``,
-                '- Status: `pending`',
-                '- Trusted run: not started',
-                '',
-                'After maintainer review, run trusted E2E from the base repository:',
-                '',
-                '```bash',
-                trustedCommand,
-                '```',
-                '',
-                'This trusted E2E result will apply only to the exact reviewed SHA above. Re-run trusted E2E if the contributor pushes another commit.',
-              ].join('\n');
+            core.info(description);
 
-              const comments = await github.paginate(github.rest.issues.listComments, {
+  trusted-e2e-required-comment:
+    name: "E2E Gate: Request Trusted Run"
+    needs:
+      - e2e-required-status
+    if: >-
+      ${{
+        needs.e2e-required-status.outputs.required == 'true' &&
+        needs.e2e-required-status.outputs.fork_pull_request == 'true'
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Request trusted E2E run
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ needs.e2e-required-status.outputs.pr_number }}
+          PR_HEAD_SHA: ${{ needs.e2e-required-status.outputs.pr_head_sha }}
+        with:
+          script: |
+            const trustedCommentMarker = '<!-- kongctl-trusted-e2e-status -->';
+            const prNumber = Number(process.env.PR_NUMBER);
+            const prHeadSHA = process.env.PR_HEAD_SHA;
+            const defaultBranch = context.payload.repository.default_branch;
+            const trustedCommand = [
+              `gh workflow run e2e.yaml --repo ${process.env.GITHUB_REPOSITORY}`,
+              `--ref ${defaultBranch}`,
+              `-f trusted_pr_number=${prNumber}`,
+              `-f trusted_head_sha=${prHeadSHA}`,
+            ].join(' ');
+            const body = [
+              trustedCommentMarker,
+              'Trusted E2E is required for this fork PR.',
+              '',
+              `- PR: #${prNumber}`,
+              `- Reviewed SHA: \`${prHeadSHA}\``,
+              '- Status: `pending`',
+              '- Trusted run: not started',
+              '',
+              'After maintainer review, run trusted E2E from the base repository:',
+              '',
+              '```bash',
+              trustedCommand,
+              '```',
+              '',
+              'This trusted E2E result will apply only to the exact reviewed SHA above. Re-run trusted E2E if the contributor pushes another commit.',
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) =>
+              comment.body?.includes(trustedCommentMarker) &&
+              comment.user?.login === 'github-actions[bot]'
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: pr.number,
-                per_page: 100,
+                comment_id: existing.id,
+                body,
               });
-              const existing = comments.find((comment) => comment.body?.includes(trustedCommentMarker));
-              if (existing) {
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: existing.id,
-                  body,
-                });
-              } else {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: pr.number,
-                  body,
-                });
-              }
-
-              await core.summary
-                .addHeading('Trusted Fork E2E')
-                .addList([
-                  `Status: ${state}`,
-                  `PR: #${pr.number}`,
-                  `Reviewed SHA: ${pr.head.sha}`,
-                  'Trusted run: not started',
-                ])
-                .write();
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
             }
 
-            core.info(description);
+            await core.summary
+              .addHeading('Trusted Fork E2E')
+              .addList([
+                'Status: pending',
+                `PR: #${prNumber}`,
+                `Reviewed SHA: ${prHeadSHA}`,
+                'Trusted run: not started',
+              ])
+              .write();

--- a/.github/workflows/e2e-required-status.yaml
+++ b/.github/workflows/e2e-required-status.yaml
@@ -1,4 +1,4 @@
-name: E2E Required Status
+name: E2E Gate
 
 on:
   pull_request_target:
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: read
   statuses: write
 
@@ -23,7 +24,7 @@ concurrency:
 
 jobs:
   e2e-required-status:
-    name: E2E Required Status
+    name: "E2E Gate: Initialize Status"
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -31,12 +32,14 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Set E2E Required status
+      - name: Initialize E2E Required status
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const statusContext = 'E2E Required';
+            const trustedCommentMarker = '<!-- kongctl-trusted-e2e-status -->';
             const pr = context.payload.pull_request;
+            const runURL = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -48,7 +51,7 @@ jobs:
             const forkPullRequest = pr.head.repo.full_name !== pr.base.repo.full_name;
             const state = required ? 'pending' : 'success';
             let description = 'E2E not required for this PR.';
-            let targetUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            let targetUrl = runURL;
 
             if (required && forkPullRequest) {
               description = 'Fork PR requires trusted maintainer E2E for reviewed SHA.';
@@ -67,5 +70,65 @@ jobs:
               description,
               target_url: targetUrl,
             });
+
+            if (required && forkPullRequest) {
+              const defaultBranch = context.payload.repository.default_branch;
+              const trustedCommand = [
+                `gh workflow run e2e.yaml --repo ${process.env.GITHUB_REPOSITORY}`,
+                `--ref ${defaultBranch}`,
+                `-f trusted_pr_number=${pr.number}`,
+                `-f trusted_head_sha=${pr.head.sha}`,
+              ].join(' ');
+              const body = [
+                trustedCommentMarker,
+                'Trusted E2E is required for this fork PR.',
+                '',
+                `- PR: #${pr.number}`,
+                `- Reviewed SHA: \`${pr.head.sha}\``,
+                '- Status: `pending`',
+                '- Trusted run: not started',
+                '',
+                'After maintainer review, run trusted E2E from the base repository:',
+                '',
+                '```bash',
+                trustedCommand,
+                '```',
+                '',
+                'This trusted E2E result will apply only to the exact reviewed SHA above. Re-run trusted E2E if the contributor pushes another commit.',
+              ].join('\n');
+
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 100,
+              });
+              const existing = comments.find((comment) => comment.body?.includes(trustedCommentMarker));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body,
+                });
+              }
+
+              await core.summary
+                .addHeading('Trusted Fork E2E')
+                .addList([
+                  `Status: ${state}`,
+                  `PR: #${pr.number}`,
+                  `Reviewed SHA: ${pr.head.sha}`,
+                  'Trusted run: not started',
+                ])
+                .write();
+            }
 
             core.info(description);

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -77,6 +77,7 @@ jobs:
       status_sha: ${{ steps.detect.outputs.status_sha }}
       checkout_repository: ${{ steps.detect.outputs.checkout_repository }}
       checkout_ref: ${{ steps.detect.outputs.checkout_ref }}
+      trusted_pr_number: ${{ steps.detect.outputs.trusted_pr_number }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -198,6 +199,7 @@ jobs:
               echo "status_sha=${status_sha}"
               echo "checkout_repository=${checkout_repository}"
               echo "checkout_ref=${checkout_ref}"
+              echo "trusted_pr_number=${TRUSTED_PR_NUMBER}"
             } >> "${GITHUB_OUTPUT}"
           }
 
@@ -963,6 +965,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      issues: write
       statuses: write
     steps:
       - name: Harden Runner
@@ -978,6 +981,7 @@ jobs:
           E2E_TRUSTED_REQUIRED: ${{ needs.e2e-needed.outputs.trusted_e2e_required }}
           E2E_VERIFY_RESULT: ${{ needs.e2e-verify.result }}
           TRUSTED_DISPATCH: ${{ github.event_name == 'workflow_dispatch' && inputs.trusted_pr_number != '' && 'true' || 'false' }}
+          TRUSTED_PR_NUMBER: ${{ needs.e2e-needed.outputs.trusted_pr_number || inputs.trusted_pr_number }}
           STATUS_SHA: >-
             ${{
               needs.e2e-needed.outputs.status_sha ||
@@ -994,6 +998,7 @@ jobs:
         with:
           script: |
             const statusContext = 'E2E Required';
+            const trustedCommentMarker = '<!-- kongctl-trusted-e2e-status -->';
             const eventName = process.env.GITHUB_EVENT_NAME;
             const neededResult = process.env.E2E_NEEDED_RESULT;
             const required = process.env.E2E_REQUIRED === 'true';
@@ -1001,6 +1006,9 @@ jobs:
             const trustedE2ERequired = process.env.E2E_TRUSTED_REQUIRED === 'true';
             const verifyResult = process.env.E2E_VERIFY_RESULT;
             const trustedDispatch = process.env.TRUSTED_DISPATCH === 'true';
+            const trustedPRNumber = process.env.TRUSTED_PR_NUMBER;
+            const statusSha = process.env.STATUS_SHA;
+            const runURL = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
             const pullRequest = context.payload.pull_request;
             const forkPullRequest = eventName === 'pull_request' &&
               pullRequest?.head?.repo?.full_name !== pullRequest?.base?.repo?.full_name;
@@ -1021,7 +1029,9 @@ jobs:
               state = 'pending';
               description = 'Fork PR requires trusted maintainer E2E for reviewed SHA.';
             } else if (required && runShards) {
-              description = 'E2E required and E2E Verify succeeded.';
+              description = trustedDispatch
+                ? 'Trusted E2E passed for reviewed fork SHA.'
+                : 'E2E required and E2E Verify succeeded.';
             }
 
             if (forkPullRequest) {
@@ -1030,12 +1040,54 @@ jobs:
               await github.rest.repos.createCommitStatus({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                sha: process.env.STATUS_SHA,
+                sha: statusSha,
                 context: statusContext,
                 state,
                 description,
-                target_url: `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+                target_url: runURL,
               });
+            }
+
+            if (trustedDispatch && trustedPRNumber) {
+              const statusLabel = state === 'success'
+                ? 'passed'
+                : state === 'failure' || state === 'error'
+                  ? 'failed'
+                  : state;
+              const body = [
+                trustedCommentMarker,
+                `Trusted E2E ${statusLabel} for reviewed fork SHA.`,
+                '',
+                `- PR: #${trustedPRNumber}`,
+                `- Reviewed SHA: \`${statusSha}\``,
+                `- Trusted run: ${runURL}`,
+                `- Status: \`${state}\``,
+                '',
+                'This trusted E2E result applies only to the exact reviewed SHA above. Re-run trusted E2E if the contributor pushes another commit.',
+              ].join('\n');
+
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: Number(trustedPRNumber),
+                per_page: 100,
+              });
+              const existing = comments.find((comment) => comment.body?.includes(trustedCommentMarker));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: Number(trustedPRNumber),
+                  body,
+                });
+              }
             }
 
             if (failureMessage) {

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -62,7 +62,7 @@ concurrency:
 
 jobs:
   e2e-needed:
-    name: E2E Needed
+    name: "E2E Gate: Decide"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -665,7 +665,7 @@ jobs:
           path: ${{ env.KONGCTL_E2E_ARTIFACTS_DIR }}
 
   e2e-verify:
-    name: E2E Verify
+    name: E2E Shard Verification
     needs:
       - e2e-needed
       - e2e
@@ -956,7 +956,7 @@ jobs:
           echo "Verified ${scenario_count} scenarios across ${total} shards."
 
   e2e-required:
-    name: E2E Required Status
+    name: "E2E Gate: Report Result"
     needs:
       - e2e-needed
       - e2e-verify
@@ -972,7 +972,7 @@ jobs:
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
-      - name: Check requirement outcome
+      - name: Report E2E Required outcome
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           E2E_NEEDED_RESULT: ${{ needs.e2e-needed.result }}
@@ -1062,6 +1062,7 @@ jobs:
                 `- Reviewed SHA: \`${statusSha}\``,
                 `- Trusted run: ${runURL}`,
                 `- Status: \`${state}\``,
+                `- Description: ${description}`,
                 '',
                 'This trusted E2E result applies only to the exact reviewed SHA above. Re-run trusted E2E if the contributor pushes another commit.',
               ].join('\n');
@@ -1088,6 +1089,17 @@ jobs:
                   body,
                 });
               }
+
+              await core.summary
+                .addHeading('Trusted Fork E2E')
+                .addList([
+                  `Status: ${state}`,
+                  `Description: ${description}`,
+                  `PR: #${trustedPRNumber}`,
+                  `Reviewed SHA: ${statusSha}`,
+                  `Trusted run: ${runURL}`,
+                ])
+                .write();
             }
 
             if (failureMessage) {

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -965,14 +965,19 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      issues: write
       statuses: write
+    outputs:
+      state: ${{ steps.report.outputs.state }}
+      description: ${{ steps.report.outputs.description }}
+      status_sha: ${{ steps.report.outputs.status_sha }}
+      trusted_pr_number: ${{ steps.report.outputs.trusted_pr_number }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
       - name: Report E2E Required outcome
+        id: report
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           E2E_NEEDED_RESULT: ${{ needs.e2e-needed.result }}
@@ -998,7 +1003,6 @@ jobs:
         with:
           script: |
             const statusContext = 'E2E Required';
-            const trustedCommentMarker = '<!-- kongctl-trusted-e2e-status -->';
             const eventName = process.env.GITHUB_EVENT_NAME;
             const neededResult = process.env.E2E_NEEDED_RESULT;
             const required = process.env.E2E_REQUIRED === 'true';
@@ -1034,6 +1038,11 @@ jobs:
                 : 'E2E required and E2E Verify succeeded.';
             }
 
+            core.setOutput('state', state);
+            core.setOutput('description', description);
+            core.setOutput('status_sha', statusSha);
+            core.setOutput('trusted_pr_number', trustedPRNumber || '');
+
             if (forkPullRequest) {
               core.warning('Skipping E2E Required status update for fork pull request.');
             } else if (eventName === 'pull_request' || eventName === 'merge_group' || trustedDispatch) {
@@ -1049,47 +1058,6 @@ jobs:
             }
 
             if (trustedDispatch && trustedPRNumber) {
-              const statusLabel = state === 'success'
-                ? 'passed'
-                : state === 'failure' || state === 'error'
-                  ? 'failed'
-                  : state;
-              const body = [
-                trustedCommentMarker,
-                `Trusted E2E ${statusLabel} for reviewed fork SHA.`,
-                '',
-                `- PR: #${trustedPRNumber}`,
-                `- Reviewed SHA: \`${statusSha}\``,
-                `- Trusted run: ${runURL}`,
-                `- Status: \`${state}\``,
-                `- Description: ${description}`,
-                '',
-                'This trusted E2E result applies only to the exact reviewed SHA above. Re-run trusted E2E if the contributor pushes another commit.',
-              ].join('\n');
-
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: Number(trustedPRNumber),
-                per_page: 100,
-              });
-              const existing = comments.find((comment) => comment.body?.includes(trustedCommentMarker));
-              if (existing) {
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: existing.id,
-                  body,
-                });
-              } else {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: Number(trustedPRNumber),
-                  body,
-                });
-              }
-
               await core.summary
                 .addHeading('Trusted Fork E2E')
                 .addList([
@@ -1108,3 +1076,93 @@ jobs:
             }
 
             core.info(description);
+
+  trusted-e2e-result-comment:
+    name: "E2E Gate: Update Trusted PR Comment"
+    needs:
+      - e2e-required
+    if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.trusted_pr_number != '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Update trusted E2E comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          E2E_REQUIRED_STATE: ${{ needs.e2e-required.outputs.state || 'failure' }}
+          E2E_REQUIRED_DESCRIPTION: >-
+            ${{
+              needs.e2e-required.outputs.description ||
+              format('E2E gate result job concluded {0}.', needs.e2e-required.result)
+            }}
+          TRUSTED_PR_NUMBER: ${{ needs.e2e-required.outputs.trusted_pr_number || inputs.trusted_pr_number }}
+          STATUS_SHA: ${{ needs.e2e-required.outputs.status_sha || inputs.trusted_head_sha }}
+        with:
+          script: |
+            const trustedCommentMarker = '<!-- kongctl-trusted-e2e-status -->';
+            const state = process.env.E2E_REQUIRED_STATE;
+            const description = process.env.E2E_REQUIRED_DESCRIPTION;
+            const trustedPRNumber = Number(process.env.TRUSTED_PR_NUMBER);
+            const statusSha = process.env.STATUS_SHA;
+            const runURL = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const statusLabel = state === 'success'
+              ? 'passed'
+              : state === 'failure' || state === 'error'
+                ? 'failed'
+                : state;
+            const body = [
+              trustedCommentMarker,
+              `Trusted E2E ${statusLabel} for reviewed fork SHA.`,
+              '',
+              `- PR: #${trustedPRNumber}`,
+              `- Reviewed SHA: \`${statusSha}\``,
+              `- Trusted run: ${runURL}`,
+              `- Status: \`${state}\``,
+              `- Description: ${description}`,
+              '',
+              'This trusted E2E result applies only to the exact reviewed SHA above. Re-run trusted E2E if the contributor pushes another commit.',
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: trustedPRNumber,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) =>
+              comment.body?.includes(trustedCommentMarker) &&
+              comment.user?.login === 'github-actions[bot]'
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: trustedPRNumber,
+                body,
+              });
+            }
+
+            await core.summary
+              .addHeading('Trusted Fork E2E')
+              .addList([
+                `Status: ${state}`,
+                `Description: ${description}`,
+                `PR: #${trustedPRNumber}`,
+                `Reviewed SHA: ${statusSha}`,
+                `Trusted run: ${runURL}`,
+              ])
+              .write();

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -398,7 +398,8 @@ To run trusted E2E for a fork PR:
 
 The workflow verifies that `trusted_head_sha` still matches the PR head before
 checking out or running the fork code. The trusted run writes the final
-`E2E Required` status to that exact SHA.
+`E2E Required` status to that exact SHA and posts an updatable PR comment
+with the reviewed SHA and trusted run URL.
 
 The workflow also exposes the Konnect target, test timeout, HTTP timeout, and
 retry knobs above as repository or organization variables of the same names,

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -385,6 +385,12 @@ message that trusted maintainer E2E is required. The normal fork-triggered E2E
 workflow does not expand shard jobs, does not use the `default` org fallback,
 and does not receive Konnect or Gmail secrets.
 
+The status named `E2E Required` is the merge gate. It is a commit status, not
+one of the workflow job names. For fork PRs, an `E2E Gate` workflow initializes
+that status and posts an updatable PR comment with the exact SHA and trusted
+workflow command. The trusted workflow dispatch later updates the same commit
+status and comment with the pass or fail result.
+
 To run trusted E2E for a fork PR:
 
 1. Review the PR for malicious changes, especially build scripts, tests,


### PR DESCRIPTION
## Summary
- make trusted fork E2E success status read as a trusted reviewed-SHA result
- post or update a PR comment when fork PRs need trusted E2E, then update it with the trusted run result
- restrict trusted E2E comment updates to comments authored by `github-actions[bot]`
- scope `issues: write` to dedicated trusted-comment jobs instead of normal E2E result jobs
- add trusted fork E2E summaries to the gate and trusted dispatch jobs
- clarify E2E gate/job naming while preserving the required `E2E Required` commit status context
- document the commit-status gate and trusted PR comment behavior in the E2E README

## Validation
- actionlint .github/workflows/e2e.yaml .github/workflows/e2e-required-status.yaml
- git diff --check