### PR TITLE
fix(e2e): prevent trusted comment failures

### DIFF
--- a/.github/workflows/e2e-required-status.yaml
+++ b/.github/workflows/e2e-required-status.yaml
@@ -95,6 +95,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      pull-requests: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -136,30 +137,34 @@ jobs:
               'This trusted E2E result will apply only to the exact reviewed SHA above. Re-run trusted E2E if the contributor pushes another commit.',
             ].join('\n');
 
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              per_page: 100,
-            });
-            const existing = comments.find((comment) =>
-              comment.body?.includes(trustedCommentMarker) &&
-              comment.user?.login === 'github-actions[bot]'
-            );
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: prNumber,
-                body,
+                per_page: 100,
               });
+              const existing = comments.find((comment) =>
+                comment.body?.includes(trustedCommentMarker) &&
+                comment.user?.login === 'github-actions[bot]'
+              );
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  body,
+                });
+              }
+            } catch (error) {
+              core.warning(`Unable to create or update trusted E2E PR comment: ${error.message}`);
             }
 
             await core.summary

--- a/.github/workflows/e2e-required-status.yaml
+++ b/.github/workflows/e2e-required-status.yaml
@@ -164,7 +164,8 @@ jobs:
                 });
               }
             } catch (error) {
-              core.warning(`Unable to create or update trusted E2E PR comment: ${error.message}`);
+              const errorMessage = error?.message ?? String(error);
+              core.warning(`Unable to create or update trusted E2E PR comment: ${errorMessage}`);
             }
 
             await core.summary

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1158,7 +1158,8 @@ jobs:
                 });
               }
             } catch (error) {
-              core.warning(`Unable to create or update trusted E2E PR comment: ${error.message}`);
+              const errorMessage = error?.message ?? String(error);
+              core.warning(`Unable to create or update trusted E2E PR comment: ${errorMessage}`);
             }
 
             await core.summary

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1087,6 +1087,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      pull-requests: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -1130,30 +1131,34 @@ jobs:
               'This trusted E2E result applies only to the exact reviewed SHA above. Re-run trusted E2E if the contributor pushes another commit.',
             ].join('\n');
 
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: trustedPRNumber,
-              per_page: 100,
-            });
-            const existing = comments.find((comment) =>
-              comment.body?.includes(trustedCommentMarker) &&
-              comment.user?.login === 'github-actions[bot]'
-            );
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: trustedPRNumber,
-                body,
+                per_page: 100,
               });
+              const existing = comments.find((comment) =>
+                comment.body?.includes(trustedCommentMarker) &&
+                comment.user?.login === 'github-actions[bot]'
+              );
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: trustedPRNumber,
+                  body,
+                });
+              }
+            } catch (error) {
+              core.warning(`Unable to create or update trusted E2E PR comment: ${error.message}`);
             }
 
             await core.summary


### PR DESCRIPTION
## Summary
- add `pull-requests: write` to the trusted E2E comment-only jobs
- make trusted E2E PR comment creation/update best-effort so a GitHub API comment rejection logs a warning instead of failing the gate job
- preserve the existing bot-authored marker restriction when updating comments

## Validation
- actionlint .github/workflows/e2e.yaml .github/workflows/e2e-required-status.yaml
- git diff --check

## Context
PR #1537 hit `403 Resource not accessible by integration` while `E2E Gate: Request Trusted Run` tried to create the informational trusted E2E comment. The commit status had already been initialized correctly; only the comment failed.