### PR TITLE
fix(konnect): report all missing token create flags at once

### DIFF
--- a/internal/cmd/helper.go
+++ b/internal/cmd/helper.go
@@ -175,6 +175,12 @@ func (e *ConfigurationError) Error() string {
 	return e.Err.Error()
 }
 
+// Unwrap exposes the wrapped error so callers (and the top-level error
+// renderer) can inspect a joined set of validation errors.
+func (e *ConfigurationError) Unwrap() error {
+	return e.Err
+}
+
 func (e *ExecutionError) Error() string {
 	return e.Err.Error()
 }

--- a/internal/cmd/root/products/konnect/token/token.go
+++ b/internal/cmd/root/products/konnect/token/token.go
@@ -1,6 +1,7 @@
 package token
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -275,8 +276,8 @@ func runCreatePAT(c *cobra.Command, args []string, opts *patOptions) error {
 	if err := applyCreateJQExpressionArg(c, args); err != nil {
 		return err
 	}
-	if strings.TrimSpace(opts.name) == "" {
-		return &cmdpkg.ConfigurationError{Err: fmt.Errorf("--%s is required", flagName)}
+	if err := validateCreatePATFlags(opts); err != nil {
+		return err
 	}
 
 	exp, err := parseCreateTokenExpiration(opts.expiresIn, opts.expiresAt)
@@ -405,10 +406,7 @@ func runCreateSPAT(c *cobra.Command, args []string, opts *spatOptions) error {
 	if err := applyCreateJQExpressionArg(c, args); err != nil {
 		return err
 	}
-	if strings.TrimSpace(opts.name) == "" {
-		return &cmdpkg.ConfigurationError{Err: fmt.Errorf("--%s is required", flagName)}
-	}
-	if err := validateSystemAccountSelector(opts.systemAccountID, opts.systemAccountName); err != nil {
+	if err := validateCreateSPATFlags(opts); err != nil {
 		return err
 	}
 
@@ -658,13 +656,63 @@ func resolvePAT(
 	return &matches[0], nil
 }
 
-func validateSystemAccountSelector(id, name string) error {
+// validateCreatePATFlags reports every missing required flag at once so the user
+// doesn't have to rerun the command to discover them one by one.
+func validateCreatePATFlags(opts *patOptions) error {
+	var errs []error
+	if strings.TrimSpace(opts.name) == "" {
+		errs = append(errs, fmt.Errorf("--%s is required", flagName))
+	}
+	if err := expirationRequiredError(opts.expiresIn, opts.expiresAt); err != nil {
+		errs = append(errs, err)
+	}
+	return bundleConfigErrors(errs)
+}
+
+// validateCreateSPATFlags mirrors validateCreatePATFlags and adds the system
+// account selector requirement.
+func validateCreateSPATFlags(opts *spatOptions) error {
+	var errs []error
+	if strings.TrimSpace(opts.name) == "" {
+		errs = append(errs, fmt.Errorf("--%s is required", flagName))
+	}
+	if err := systemAccountSelectorError(opts.systemAccountID, opts.systemAccountName); err != nil {
+		errs = append(errs, err)
+	}
+	if err := expirationRequiredError(opts.expiresIn, opts.expiresAt); err != nil {
+		errs = append(errs, err)
+	}
+	return bundleConfigErrors(errs)
+}
+
+// expirationRequiredError returns an error when neither expiry flag is set. The
+// mutually-exclusive case (both set) is left to expiration parsing.
+func expirationRequiredError(expiresIn, expiresAt string) error {
+	if strings.TrimSpace(expiresIn) == "" && strings.TrimSpace(expiresAt) == "" {
+		return fmt.Errorf("exactly one of --%s or --%s is required", flagExpiresIn, flagExpiresAt)
+	}
+	return nil
+}
+
+func bundleConfigErrors(errs []error) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	return &cmdpkg.ConfigurationError{Err: errors.Join(errs...)}
+}
+
+func systemAccountSelectorError(id, name string) error {
 	hasID := strings.TrimSpace(id) != ""
 	hasName := strings.TrimSpace(name) != ""
 	if hasID == hasName {
-		return &cmdpkg.ConfigurationError{
-			Err: fmt.Errorf("exactly one of --%s or --%s is required", flagSystemAccountID, flagSystemAccountName),
-		}
+		return fmt.Errorf("exactly one of --%s or --%s is required", flagSystemAccountID, flagSystemAccountName)
+	}
+	return nil
+}
+
+func validateSystemAccountSelector(id, name string) error {
+	if err := systemAccountSelectorError(id, name); err != nil {
+		return &cmdpkg.ConfigurationError{Err: err}
 	}
 	return nil
 }

--- a/internal/cmd/root/products/konnect/token/token_test.go
+++ b/internal/cmd/root/products/konnect/token/token_test.go
@@ -275,3 +275,57 @@ func TestValidateSystemAccountSelectorRequiresExactlyOneSelector(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateCreatePATFlagsBundlesMissingRequired(t *testing.T) {
+	err := validateCreatePATFlags(&patOptions{})
+	var cfgErr *cmdpkg.ConfigurationError
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("expected ConfigurationError, got %T: %v", err, err)
+	}
+	for _, want := range []string{
+		"--name is required",
+		"exactly one of --expires-in or --expires-at is required",
+	} {
+		if !strings.Contains(cfgErr.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %q", want, cfgErr.Error())
+		}
+	}
+	if lines := strings.Count(cfgErr.Error(), "\n") + 1; lines != 2 {
+		t.Fatalf("expected 2 bundled errors, got %d: %q", lines, cfgErr.Error())
+	}
+}
+
+func TestValidateCreatePATFlagsReportsOnlyMissing(t *testing.T) {
+	err := validateCreatePATFlags(&patOptions{name: "ci"})
+	var cfgErr *cmdpkg.ConfigurationError
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("expected ConfigurationError, got %T: %v", err, err)
+	}
+	if strings.Contains(cfgErr.Error(), "--name is required") {
+		t.Fatalf("did not expect name error, got %q", cfgErr.Error())
+	}
+	if !strings.Contains(cfgErr.Error(), "exactly one of --expires-in or --expires-at is required") {
+		t.Fatalf("expected expiry error, got %q", cfgErr.Error())
+	}
+
+	if err := validateCreatePATFlags(&patOptions{name: "ci", expiresIn: "30d"}); err != nil {
+		t.Fatalf("expected no error when required flags are set, got %v", err)
+	}
+}
+
+func TestValidateCreateSPATFlagsBundlesAllMissing(t *testing.T) {
+	err := validateCreateSPATFlags(&spatOptions{})
+	var cfgErr *cmdpkg.ConfigurationError
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("expected ConfigurationError, got %T: %v", err, err)
+	}
+	for _, want := range []string{
+		"--name is required",
+		"exactly one of --system-account-id or --system-account-name is required",
+		"exactly one of --expires-in or --expires-at is required",
+	} {
+		if !strings.Contains(cfgErr.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %q", want, cfgErr.Error())
+		}
+	}
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -828,17 +828,51 @@ func renderPlainCommandError(w io.Writer, err error) {
 	fmt.Fprintf(w, "Error: %s\n", errorText)
 }
 
+// flattenJoinedErrors expands an error into the individual errors of an
+// errors.Join, reached through single-error wrappers such as ConfigurationError.
+// It returns nil for a plain single error so it renders unchanged.
+func flattenJoinedErrors(err error) []error {
+	for err != nil {
+		if joined, ok := err.(interface{ Unwrap() []error }); ok {
+			var out []error
+			for _, e := range joined.Unwrap() {
+				if sub := flattenJoinedErrors(e); sub != nil {
+					out = append(out, sub...)
+				} else {
+					out = append(out, e)
+				}
+			}
+			return out
+		}
+		u, ok := err.(interface{ Unwrap() error })
+		if !ok {
+			return nil
+		}
+		err = u.Unwrap()
+	}
+	return nil
+}
+
 func renderCommandUsageError(w io.Writer, command *cobra.Command, err error) {
 	if w == nil || err == nil {
 		return
 	}
 
-	errorText := strings.TrimSpace(stripCobraSuggestion(err.Error()))
-	if errorText == "" {
-		errorText = "invalid command usage"
+	if leaves := flattenJoinedErrors(err); len(leaves) > 1 {
+		for _, leaf := range leaves {
+			text := strings.TrimSpace(stripCobraSuggestion(leaf.Error()))
+			if text == "" {
+				text = "invalid command usage"
+			}
+			fmt.Fprintf(w, "- Error: %s\n", text)
+		}
+	} else {
+		errorText := strings.TrimSpace(stripCobraSuggestion(err.Error()))
+		if errorText == "" {
+			errorText = "invalid command usage"
+		}
+		fmt.Fprintf(w, "Error: %s\n", errorText)
 	}
-
-	fmt.Fprintf(w, "Error: %s\n", errorText)
 
 	suggestion := cmdpkg.SuggestionForError(command, err)
 	if len(suggestion.Values) > 0 {

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -723,6 +723,50 @@ func TestCreatePATRejectsExpiresAtOutsideBounds(t *testing.T) {
 	}
 }
 
+func TestCreatePATBundlesMissingRequiredFlags(t *testing.T) {
+	result := executeRootForTest(t, "create", "pat")
+	if result.exitCode == 0 {
+		t.Fatalf("expected create pat without flags to fail\nstdout:\n%s", result.stdout)
+	}
+	for _, want := range []string{
+		"- Error: --name is required",
+		"- Error: exactly one of --expires-in or --expires-at is required",
+	} {
+		if !strings.Contains(result.stderr, want) {
+			t.Fatalf("expected stderr to contain %q\nstderr:\n%s", want, result.stderr)
+		}
+	}
+}
+
+func TestCreateSPATBundlesMissingRequiredFlags(t *testing.T) {
+	result := executeRootForTest(t, "create", "spat")
+	if result.exitCode == 0 {
+		t.Fatalf("expected create spat without flags to fail\nstdout:\n%s", result.stdout)
+	}
+	for _, want := range []string{
+		"- Error: --name is required",
+		"- Error: exactly one of --system-account-id or --system-account-name is required",
+		"- Error: exactly one of --expires-in or --expires-at is required",
+	} {
+		if !strings.Contains(result.stderr, want) {
+			t.Fatalf("expected stderr to contain %q\nstderr:\n%s", want, result.stderr)
+		}
+	}
+}
+
+func TestCreatePATSingleMissingFlagRendersPlainError(t *testing.T) {
+	result := executeRootForTest(t, "create", "pat", "--name", "ci")
+	if result.exitCode == 0 {
+		t.Fatalf("expected create pat without expiry to fail\nstdout:\n%s", result.stdout)
+	}
+	if strings.Contains(result.stderr, "- Error:") {
+		t.Fatalf("single error should not use the bundled list format\nstderr:\n%s", result.stderr)
+	}
+	if !strings.Contains(result.stderr, "Error: exactly one of --expires-in or --expires-at is required") {
+		t.Fatalf("expected plain expiry error\nstderr:\n%s", result.stderr)
+	}
+}
+
 func TestCreatePATTokenOutputAndJQ(t *testing.T) {
 	patAPI := &rootTestPATAPI{token: "kpat_123", id: "pat-id"}
 	installRootTokenSDK(t, &helpers.MockKonnectSDK{


### PR DESCRIPTION
`create pat` checks required flags one at a time, so you rerun it just to find the next missing one. Now it collects them with `errors.Join` and reports all at once (same for `create spat`).

The list rendering lives in the shared usage-error path (`renderCommandUsageError`), so any command that returns an `errors.Join` wrapped in a `ConfigurationError` gets one `- Error:` line per failure. Single errors render exactly as before. `ConfigurationError` now has `Unwrap`, so the joined set stays inspectable.

Closes #1155.