### PR TITLE
fix(declarative): add top_n and platform_usage to dashboard schema

### DIFF
--- a/internal/declarative/loader/dashboard_test.go
+++ b/internal/declarative/loader/dashboard_test.go
@@ -152,9 +152,11 @@ analytics:
               query:
                 datasource: platform_usage
                 metrics:
-                  - request_count
+                  - service_count
                 dimensions:
                   - time
+                granularity: daily
+                limit: 10
               chart:
                 type: timeseries_line
                 chart_title: Platform Usage
@@ -164,6 +166,14 @@ analytics:
 	require.NoError(t, err)
 	require.Len(t, rs.Dashboards, 1)
 	require.Len(t, rs.Dashboards[0].Definition.Tiles, 2)
+
+	// platform_usage carries a limit; confirm it decodes and is preserved.
+	platformTile := rs.Dashboards[0].Definition.Tiles[1]
+	require.NotNil(t, platformTile.ChartTile)
+	platformQuery := platformTile.ChartTile.Definition.Query.PlatformQuery
+	require.NotNil(t, platformQuery)
+	require.NotNil(t, platformQuery.Limit)
+	assert.InEpsilon(t, 10, *platformQuery.Limit, 0)
 }
 
 func TestLoaderDashboardDefinitionPresenceFromYAML(t *testing.T) {

--- a/internal/declarative/loader/dashboard_test.go
+++ b/internal/declarative/loader/dashboard_test.go
@@ -117,7 +117,53 @@ analytics:
 	_, err := New().LoadFile(configPath)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid analytics dashboard tile query.datasource")
-	assert.Contains(t, err.Error(), "expected one of api_usage, llm_usage, agentic_usage")
+	assert.Contains(t, err.Error(), "expected one of api_usage, llm_usage, agentic_usage, platform_usage")
+}
+
+func TestLoaderLoadsTopNChartAndPlatformDatasource(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+analytics:
+  dashboards:
+    - ref: mcp-servers
+      name: MCP Servers
+      definition:
+        tiles:
+          - layout:
+              position: { col: 0, row: 0 }
+              size: { cols: 4, rows: 2 }
+            type: chart
+            definition:
+              query:
+                datasource: api_usage
+                metrics:
+                  - request_count
+                dimensions:
+                  - gateway_service
+              chart:
+                type: top_n
+                chart_title: Top Services
+          - layout:
+              position: { col: 4, row: 0 }
+              size: { cols: 4, rows: 2 }
+            type: chart
+            definition:
+              query:
+                datasource: platform_usage
+                metrics:
+                  - request_count
+                dimensions:
+                  - time
+              chart:
+                type: timeseries_line
+                chart_title: Platform Usage
+`), 0o600))
+
+	rs, err := New().LoadFile(configPath)
+	require.NoError(t, err)
+	require.Len(t, rs.Dashboards, 1)
+	require.Len(t, rs.Dashboards[0].Definition.Tiles, 2)
 }
 
 func TestLoaderDashboardDefinitionPresenceFromYAML(t *testing.T) {

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -397,14 +397,14 @@ func dashboardUnionParseError(sourcePath string, errMsg string) string {
 	case strings.Contains(errMsg, "into any supported union types for Query"):
 		return fmt.Sprintf(
 			"failed to parse YAML in %s: invalid analytics dashboard tile query.datasource; "+
-				"expected one of api_usage, llm_usage, agentic_usage",
+				"expected one of api_usage, llm_usage, agentic_usage, platform_usage",
 			sourcePath,
 		)
 	case strings.Contains(errMsg, "into any supported union types for Chart"):
 		return fmt.Sprintf(
 			"failed to parse YAML in %s: invalid analytics dashboard tile chart.type; "+
 				"expected one of donut, timeseries_line, timeseries_bar, horizontal_bar, vertical_bar, "+
-				"single_value, choropleth_map",
+				"single_value, choropleth_map, top_n",
 			sourcePath,
 		)
 	case strings.Contains(errMsg, "into any supported union types for TimeRange"):

--- a/internal/declarative/resources/explain_test.go
+++ b/internal/declarative/resources/explain_test.go
@@ -250,15 +250,17 @@ func TestRenderExplainSchema_AnalyticsDashboardDiscriminators(t *testing.T) {
 	assert.Equal(t, "chart", tile.Properties["type"].Const)
 
 	query := tile.Properties["definition"].Properties["query"]
-	require.Len(t, query.OneOf, 3)
+	require.Len(t, query.OneOf, 4)
 	assert.Equal(t, "api_usage", query.OneOf[0].Properties["datasource"].Const)
 	assert.Equal(t, "llm_usage", query.OneOf[1].Properties["datasource"].Const)
 	assert.Equal(t, "agentic_usage", query.OneOf[2].Properties["datasource"].Const)
+	assert.Equal(t, "platform_usage", query.OneOf[3].Properties["datasource"].Const)
 
 	chart := tile.Properties["definition"].Properties["chart"]
-	require.Len(t, chart.OneOf, 7)
+	require.Len(t, chart.OneOf, 8)
 	assert.Equal(t, "timeseries_line", chart.OneOf[0].Properties["type"].Const)
 	assert.Equal(t, "horizontal_bar", chart.OneOf[2].Properties["type"].Const)
+	assert.Equal(t, "top_n", chart.OneOf[7].Properties["type"].Const)
 }
 
 func TestRenderExplainSchema_APIImplementationServiceShape(t *testing.T) {
@@ -300,7 +302,7 @@ func TestRenderExplainText_AnalyticsDashboardAllowedValues(t *testing.T) {
 
 	text := RenderExplainText(subject, false)
 
-	assert.Contains(t, text, "ALLOWED: api_usage|llm_usage|agentic_usage")
+	assert.Contains(t, text, "ALLOWED: api_usage|llm_usage|agentic_usage|platform_usage")
 }
 
 func TestRenderExplainText_ResourceSubject(t *testing.T) {

--- a/internal/declarative/resources/explain_union_schemas.go
+++ b/internal/declarative/resources/explain_union_schemas.go
@@ -429,6 +429,7 @@ func dashboardQueryExplainNode() *ExplainNode {
 		dashboardQueryBranch("api_usage", "request_count"),
 		dashboardQueryBranch("llm_usage", "total_tokens"),
 		dashboardQueryBranch("agentic_usage", "request_count"),
+		dashboardQueryBranch("platform_usage", "request_count"),
 	)
 }
 
@@ -457,6 +458,7 @@ func dashboardChartExplainNode() *ExplainNode {
 		dashboardChartBranch("single_value", false, true),
 		dashboardChartBranch("donut", false, false),
 		dashboardChartBranch("choropleth_map", false, false),
+		dashboardChartBranch("top_n", false, false),
 	)
 }
 

--- a/internal/declarative/resources/explain_union_schemas.go
+++ b/internal/declarative/resources/explain_union_schemas.go
@@ -429,7 +429,32 @@ func dashboardQueryExplainNode() *ExplainNode {
 		dashboardQueryBranch("api_usage", "request_count"),
 		dashboardQueryBranch("llm_usage", "total_tokens"),
 		dashboardQueryBranch("agentic_usage", "request_count"),
-		dashboardQueryBranch("platform_usage", "request_count"),
+		dashboardPlatformQueryBranch(),
+	)
+}
+
+// dashboardPlatformQueryBranch describes the platform_usage query. Its metrics,
+// granularity, and limit differ from the other datasources, so it does not reuse
+// dashboardQueryBranch.
+func dashboardPlatformQueryBranch() *ExplainNode {
+	return explainObject(
+		explainField("datasource", explainConstStringNode("platform_usage"), true, true),
+		explainField("metrics", explainArrayOf(explainStringNode("service_count")), false, true),
+		explainField("dimensions", explainArrayOf(explainStringNode("time")), false, true),
+		explainField("filters", explainArrayOf(dashboardFilterExplainNode()), false, false),
+		explainField(
+			"granularity",
+			&ExplainNode{Kind: explainKindString, Nullable: true, Literal: "daily"},
+			false,
+			false,
+		),
+		explainField("time_range", dashboardTimeRangeExplainNode(), false, false),
+		explainField(
+			"limit",
+			&ExplainNode{Kind: "integer", Nullable: true, Literal: "10"},
+			false,
+			false,
+		),
 	)
 }
 


### PR DESCRIPTION
Reproduced on main first since this was filed on v1.3.0. 
Turns out `top_n` already loads (an SDK bump added it) but the schema hints and that "expected one of…" error never caught up, so it's basically invisible and the error lies to you. The `platform` datasource is the same  almost except the SDK calls it `platform_usage`.

so this just wires both into the chart/datasource branches and the two messages

One thing I am not sure about: does the real API send `platform` or `platform_usage`? 
If it's plain `platform`, the SDK doesn't have that yet (v0.41.0 only knows `platform_usage`)- so that's its own fix. 
I only checked `top_n` loads.

Part of #1444.