### PR TITLE
fix(extensions): download release assets via the asset API URL

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -276,9 +276,11 @@ Release artifact installs fetch GitHub release metadata and assets over HTTPS.
 Source fallback uses `git clone` over HTTPS.
 
 For the most predictable install experience, publish public release artifacts.
-Private repositories may work through source-clone fallback when local Git
-credentials are configured, but release artifact discovery uses GitHub HTTP
-metadata and should be treated as public-repository oriented for v1.
+Set `GITHUB_TOKEN` or `GH_TOKEN` to install from private repositories: release
+metadata and asset content are then fetched with the token through the GitHub
+release-asset API. Public installs still work without a token, and a
+rate-limited asset API request falls back to the public download URL.
+Source-clone fallback also works when local Git credentials are configured.
 
 Remote installs show a trust warning with the selected source, extension name,
 release or source ref, asset, executable, command paths, and package hashes.

--- a/internal/extensions/github.go
+++ b/internal/extensions/github.go
@@ -183,7 +183,7 @@ func fetchGitHubReleaseAsset(ctx context.Context, source GitHubSource, tempRoot 
 	}
 
 	archivePath := filepath.Join(workDir, "release-asset")
-	if err := downloadGitHubAsset(ctx, asset.downloadEndpoint(), archivePath); err != nil {
+	if err := downloadReleaseAsset(ctx, asset, archivePath); err != nil {
 		cleanup()
 		return FetchedGitHubSource{}, err
 	}
@@ -446,6 +446,23 @@ func githubAssetNames(assets []githubReleaseAsset) string {
 		names = append(names, asset.Name)
 	}
 	return strings.Join(names, ", ")
+}
+
+// downloadReleaseAsset fetches the asset, preferring the asset API URL. If that
+// fails (for example a public download that hits an API rate limit), it retries
+// the distinct browser_download_url, which stays usable without the API.
+func downloadReleaseAsset(ctx context.Context, asset githubReleaseAsset, target string) error {
+	primary := asset.downloadEndpoint()
+	err := downloadGitHubAsset(ctx, primary, target)
+	if err == nil {
+		return nil
+	}
+	if asset.DownloadURL != "" && asset.DownloadURL != primary {
+		if fallbackErr := downloadGitHubAsset(ctx, asset.DownloadURL, target); fallbackErr == nil {
+			return nil
+		}
+	}
+	return err
 }
 
 func downloadGitHubAsset(ctx context.Context, downloadURL, target string) error {

--- a/internal/extensions/github.go
+++ b/internal/extensions/github.go
@@ -183,7 +183,7 @@ func fetchGitHubReleaseAsset(ctx context.Context, source GitHubSource, tempRoot 
 	}
 
 	archivePath := filepath.Join(workDir, "release-asset")
-	if err := downloadGitHubAsset(ctx, asset.DownloadURL, archivePath); err != nil {
+	if err := downloadGitHubAsset(ctx, asset.downloadEndpoint(), archivePath); err != nil {
 		cleanup()
 		return FetchedGitHubSource{}, err
 	}
@@ -301,6 +301,18 @@ type githubRelease struct {
 type githubReleaseAsset struct {
 	Name        string `json:"name"`
 	DownloadURL string `json:"browser_download_url"`
+	// APIURL is the release asset API endpoint. Unlike browser_download_url it
+	// serves authenticated downloads reliably (with Accept: application/octet-stream).
+	APIURL string `json:"url"`
+}
+
+// downloadEndpoint returns the URL to fetch the asset content from, preferring
+// the asset API URL and falling back to browser_download_url.
+func (a githubReleaseAsset) downloadEndpoint() string {
+	if a.APIURL != "" {
+		return a.APIURL
+	}
+	return a.DownloadURL
 }
 
 func getGitHubRelease(ctx context.Context, source GitHubSource) (githubRelease, error) {
@@ -352,7 +364,8 @@ func selectGitHubReleaseAsset(assets []githubReleaseAsset) (githubReleaseAsset, 
 	for _, asset := range assets {
 		asset.Name = strings.TrimSpace(asset.Name)
 		asset.DownloadURL = strings.TrimSpace(asset.DownloadURL)
-		if asset.Name == "" || asset.DownloadURL == "" {
+		asset.APIURL = strings.TrimSpace(asset.APIURL)
+		if asset.Name == "" || asset.downloadEndpoint() == "" {
 			continue
 		}
 		if releaseArchiveKind(asset.Name) == "" {

--- a/internal/extensions/github_test.go
+++ b/internal/extensions/github_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -233,6 +234,166 @@ func TestFetchGitHubReleaseAssetUsesAPIURL(t *testing.T) {
 			require.FileExists(t, filepath.Join(fetched.Dir, ManifestFileName))
 		})
 	}
+}
+
+func TestFetchGitHubReleaseAssetWithholdsTokenFromRedirectHost(t *testing.T) {
+	archive := testReleaseTarGzip(t)
+	t.Setenv("GITHUB_TOKEN", "test-token")
+
+	blob := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Empty(t, r.Header.Get("Authorization"), "token must not be sent to the redirect storage host")
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write(archive)
+		require.NoError(t, err)
+	}))
+	t.Cleanup(blob.Close)
+	// Redirect to a different hostname (localhost vs 127.0.0.1) so the client
+	// strips Authorization, matching a real api.github.com -> storage redirect.
+	blobURL := strings.Replace(blob.URL, "127.0.0.1", "localhost", 1)
+
+	var api *httptest.Server
+	api = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/kong/kongctl-ext-foo/releases/latest":
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(githubRelease{
+				TagName: "v1.2.3",
+				Assets: []githubReleaseAsset{
+					{Name: "kongctl-ext-foo.tar.gz", APIURL: api.URL + "/api/assets/1"},
+				},
+			}))
+		case "/api/assets/1":
+			require.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+			http.Redirect(w, r, blobURL+"/blob/kongctl-ext-foo.tar.gz", http.StatusFound)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(api.Close)
+
+	previousAPIBaseURL := githubAPIBaseURL
+	previousHTTPClient := githubHTTPClient
+	githubAPIBaseURL = api.URL
+	githubHTTPClient = api.Client()
+	t.Cleanup(func() {
+		githubAPIBaseURL = previousAPIBaseURL
+		githubHTTPClient = previousHTTPClient
+	})
+
+	fetched, err := FetchGitHubSource(context.Background(), GitHubSource{
+		Owner: "kong",
+		Repo:  "kongctl-ext-foo",
+	}, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(fetched.Cleanup)
+	require.FileExists(t, filepath.Join(fetched.Dir, ManifestFileName))
+}
+
+func TestFetchGitHubReleaseAssetPublicAPIDownload(t *testing.T) {
+	archive := testReleaseTarGzip(t)
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/kong/kongctl-ext-foo/releases/latest":
+			require.Empty(t, r.Header.Get("Authorization"))
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(githubRelease{
+				TagName: "v1.2.3",
+				Assets: []githubReleaseAsset{
+					{
+						Name:        "kongctl-ext-foo.tar.gz",
+						DownloadURL: server.URL + "/downloads/kongctl-ext-foo.tar.gz",
+						APIURL:      server.URL + "/api/assets/1",
+					},
+				},
+			}))
+		case "/api/assets/1":
+			require.Empty(t, r.Header.Get("Authorization"))
+			require.Equal(t, "application/octet-stream", r.Header.Get("Accept"))
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write(archive)
+			require.NoError(t, err)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	previousAPIBaseURL := githubAPIBaseURL
+	previousHTTPClient := githubHTTPClient
+	githubAPIBaseURL = server.URL
+	githubHTTPClient = server.Client()
+	t.Cleanup(func() {
+		githubAPIBaseURL = previousAPIBaseURL
+		githubHTTPClient = previousHTTPClient
+	})
+
+	fetched, err := FetchGitHubSource(context.Background(), GitHubSource{
+		Owner: "kong",
+		Repo:  "kongctl-ext-foo",
+	}, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(fetched.Cleanup)
+	require.FileExists(t, filepath.Join(fetched.Dir, ManifestFileName))
+}
+
+func TestFetchGitHubReleaseAssetFallsBackToBrowserURLOnAPIFailure(t *testing.T) {
+	archive := testReleaseTarGzip(t)
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+
+	var apiHit, browserHit bool
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/kong/kongctl-ext-foo/releases/latest":
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(githubRelease{
+				TagName: "v1.2.3",
+				Assets: []githubReleaseAsset{
+					{
+						Name:        "kongctl-ext-foo.tar.gz",
+						DownloadURL: server.URL + "/downloads/kongctl-ext-foo.tar.gz",
+						APIURL:      server.URL + "/api/assets/1",
+					},
+				},
+			}))
+		case "/api/assets/1":
+			apiHit = true
+			w.WriteHeader(http.StatusTooManyRequests)
+		case "/downloads/kongctl-ext-foo.tar.gz":
+			browserHit = true
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write(archive)
+			require.NoError(t, err)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	previousAPIBaseURL := githubAPIBaseURL
+	previousHTTPClient := githubHTTPClient
+	githubAPIBaseURL = server.URL
+	githubHTTPClient = server.Client()
+	t.Cleanup(func() {
+		githubAPIBaseURL = previousAPIBaseURL
+		githubHTTPClient = previousHTTPClient
+	})
+
+	fetched, err := FetchGitHubSource(context.Background(), GitHubSource{
+		Owner: "kong",
+		Repo:  "kongctl-ext-foo",
+	}, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(fetched.Cleanup)
+
+	require.True(t, apiHit, "should try the asset API URL first")
+	require.True(t, browserHit, "should fall back to browser_download_url after the API rate limit")
+	require.FileExists(t, filepath.Join(fetched.Dir, ManifestFileName))
 }
 
 func TestFetchGitHubReleaseAssetFallsBackToVPrefixedTag(t *testing.T) {

--- a/internal/extensions/github_test.go
+++ b/internal/extensions/github_test.go
@@ -162,55 +162,77 @@ func TestFetchGitHubSourcePrefersReleaseAsset(t *testing.T) {
 func TestFetchGitHubReleaseAssetUsesAPIURL(t *testing.T) {
 	archive := testReleaseTarGzip(t)
 
-	var server *httptest.Server
-	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/repos/kong/kongctl-ext-foo/releases/latest":
-			w.Header().Set("Content-Type", "application/json")
-			require.NoError(t, json.NewEncoder(w).Encode(githubRelease{
-				TagName: "v1.2.3",
-				Assets: []githubReleaseAsset{
-					{
-						Name:        "kongctl-ext-foo.tar.gz",
-						DownloadURL: server.URL + "/downloads/kongctl-ext-foo.tar.gz",
-						APIURL:      server.URL + "/api/assets/1",
-					},
-				},
+	// The GitHub asset API answers either with a 200 stream or a 302 redirect to
+	// storage; both must work.
+	for _, tc := range []struct {
+		name     string
+		redirect bool
+	}{
+		{name: "direct 200 stream", redirect: false},
+		{name: "302 redirect", redirect: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GITHUB_TOKEN", "test-token")
+
+			var server *httptest.Server
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/repos/kong/kongctl-ext-foo/releases/latest":
+					require.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+					w.Header().Set("Content-Type", "application/json")
+					require.NoError(t, json.NewEncoder(w).Encode(githubRelease{
+						TagName: "v1.2.3",
+						Assets: []githubReleaseAsset{
+							{
+								Name:        "kongctl-ext-foo.tar.gz",
+								DownloadURL: server.URL + "/downloads/kongctl-ext-foo.tar.gz",
+								APIURL:      server.URL + "/api/assets/1",
+							},
+						},
+					}))
+				case "/api/assets/1":
+					require.Equal(t, "application/octet-stream", r.Header.Get("Accept"))
+					require.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+					if tc.redirect {
+						http.Redirect(w, r, server.URL+"/blob/kongctl-ext-foo.tar.gz", http.StatusFound)
+						return
+					}
+					w.WriteHeader(http.StatusOK)
+					_, err := w.Write(archive)
+					require.NoError(t, err)
+				case "/blob/kongctl-ext-foo.tar.gz":
+					w.WriteHeader(http.StatusOK)
+					_, err := w.Write(archive)
+					require.NoError(t, err)
+				case "/downloads/kongctl-ext-foo.tar.gz":
+					t.Error("download used browser_download_url instead of the asset API URL")
+					http.NotFound(w, r)
+				default:
+					http.NotFound(w, r)
+				}
 			}))
-		case "/api/assets/1":
-			require.Equal(t, "application/octet-stream", r.Header.Get("Accept"))
-			http.Redirect(w, r, server.URL+"/blob/kongctl-ext-foo.tar.gz", http.StatusFound)
-		case "/blob/kongctl-ext-foo.tar.gz":
-			w.WriteHeader(http.StatusOK)
-			_, err := w.Write(archive)
+			t.Cleanup(server.Close)
+
+			previousAPIBaseURL := githubAPIBaseURL
+			previousHTTPClient := githubHTTPClient
+			githubAPIBaseURL = server.URL
+			githubHTTPClient = server.Client()
+			t.Cleanup(func() {
+				githubAPIBaseURL = previousAPIBaseURL
+				githubHTTPClient = previousHTTPClient
+			})
+
+			fetched, err := FetchGitHubSource(context.Background(), GitHubSource{
+				Owner: "kong",
+				Repo:  "kongctl-ext-foo",
+			}, t.TempDir())
 			require.NoError(t, err)
-		case "/downloads/kongctl-ext-foo.tar.gz":
-			t.Error("download used browser_download_url instead of the asset API URL")
-			http.NotFound(w, r)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	t.Cleanup(server.Close)
+			t.Cleanup(fetched.Cleanup)
 
-	previousAPIBaseURL := githubAPIBaseURL
-	previousHTTPClient := githubHTTPClient
-	githubAPIBaseURL = server.URL
-	githubHTTPClient = server.Client()
-	t.Cleanup(func() {
-		githubAPIBaseURL = previousAPIBaseURL
-		githubHTTPClient = previousHTTPClient
-	})
-
-	fetched, err := FetchGitHubSource(context.Background(), GitHubSource{
-		Owner: "kong",
-		Repo:  "kongctl-ext-foo",
-	}, t.TempDir())
-	require.NoError(t, err)
-	t.Cleanup(fetched.Cleanup)
-
-	require.Equal(t, SourceTypeGitHubReleaseAsset, fetched.SourceType)
-	require.FileExists(t, filepath.Join(fetched.Dir, ManifestFileName))
+			require.Equal(t, SourceTypeGitHubReleaseAsset, fetched.SourceType)
+			require.FileExists(t, filepath.Join(fetched.Dir, ManifestFileName))
+		})
+	}
 }
 
 func TestFetchGitHubReleaseAssetFallsBackToVPrefixedTag(t *testing.T) {

--- a/internal/extensions/github_test.go
+++ b/internal/extensions/github_test.go
@@ -159,6 +159,60 @@ func TestFetchGitHubSourcePrefersReleaseAsset(t *testing.T) {
 	require.NotZero(t, runtimeInfo.Mode().Perm()&0o111)
 }
 
+func TestFetchGitHubReleaseAssetUsesAPIURL(t *testing.T) {
+	archive := testReleaseTarGzip(t)
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/kong/kongctl-ext-foo/releases/latest":
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(githubRelease{
+				TagName: "v1.2.3",
+				Assets: []githubReleaseAsset{
+					{
+						Name:        "kongctl-ext-foo.tar.gz",
+						DownloadURL: server.URL + "/downloads/kongctl-ext-foo.tar.gz",
+						APIURL:      server.URL + "/api/assets/1",
+					},
+				},
+			}))
+		case "/api/assets/1":
+			require.Equal(t, "application/octet-stream", r.Header.Get("Accept"))
+			http.Redirect(w, r, server.URL+"/blob/kongctl-ext-foo.tar.gz", http.StatusFound)
+		case "/blob/kongctl-ext-foo.tar.gz":
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write(archive)
+			require.NoError(t, err)
+		case "/downloads/kongctl-ext-foo.tar.gz":
+			t.Error("download used browser_download_url instead of the asset API URL")
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	previousAPIBaseURL := githubAPIBaseURL
+	previousHTTPClient := githubHTTPClient
+	githubAPIBaseURL = server.URL
+	githubHTTPClient = server.Client()
+	t.Cleanup(func() {
+		githubAPIBaseURL = previousAPIBaseURL
+		githubHTTPClient = previousHTTPClient
+	})
+
+	fetched, err := FetchGitHubSource(context.Background(), GitHubSource{
+		Owner: "kong",
+		Repo:  "kongctl-ext-foo",
+	}, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(fetched.Cleanup)
+
+	require.Equal(t, SourceTypeGitHubReleaseAsset, fetched.SourceType)
+	require.FileExists(t, filepath.Join(fetched.Dir, ManifestFileName))
+}
+
 func TestFetchGitHubReleaseAssetFallsBackToVPrefixedTag(t *testing.T) {
 	archive := testReleaseTarGzip(t)
 


### PR DESCRIPTION
`kongctl install extension` pulls the release asset from its `browser_download_url`, which is flaky for private/authenticated assets. The API `url` field is the documented way, with `Accept: application/octet-stream` — and we were already sending that header and the token, just hitting the wrong URL.

So now it downloads from the asset `url`, falling back to `browser_download_url` if there isn't one. It redirects to storage, but Go drops the auth header on a cross-host redirect, so nothing extra to do. Added a test that serves via the API URL (302 and all) and fails if the browser URL gets used.

Closes #1529.