### PR TITLE
fix(declarative): enforce event gateway dependency order

### DIFF
--- a/internal/declarative/executor/event_gateway_listener_policy_adapter.go
+++ b/internal/declarative/executor/event_gateway_listener_policy_adapter.go
@@ -106,22 +106,23 @@ func resolveVirtualClusterDestination(fields map[string]any, execCtx *ExecutionC
 		return
 	}
 
-	id, hasID := destMap[planner.FieldID]
-	if !hasID {
-		return
-	}
-
-	idStr, ok := id.(string)
-	if !ok || !tags.IsRefPlaceholder(idStr) {
-		return
-	}
-
-	// Get the resolved virtual cluster ID from execution context
 	change := *execCtx.PlannedChange
-	if virtualClusterRef, refOK := change.References[planner.FieldEventGatewayVirtualClusterID]; refOK &&
-		virtualClusterRef.HasResolvedID() {
-		destMap[planner.FieldID] = virtualClusterRef.ID
+	virtualClusterRef, refOK := change.References[planner.FieldEventGatewayVirtualClusterID]
+	if !refOK || !virtualClusterRef.HasResolvedID() {
+		return
 	}
+
+	if id, hasID := destMap[planner.FieldID]; hasID {
+		idStr, ok := id.(string)
+		if !ok || !tags.IsRefPlaceholder(idStr) {
+			return
+		}
+	} else if _, hasName := destMap[planner.FieldName]; !hasName {
+		return
+	}
+
+	destMap[planner.FieldID] = virtualClusterRef.ID
+	delete(destMap, planner.FieldName)
 }
 
 // Create creates a new listener policy

--- a/internal/declarative/executor/event_gateway_listener_policy_adapter_test.go
+++ b/internal/declarative/executor/event_gateway_listener_policy_adapter_test.go
@@ -1,0 +1,53 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveVirtualClusterDestinationPrefersHydratedDependencyID(t *testing.T) {
+	fields := listenerPolicyFieldsWithDestination(map[string]any{planner.FieldName: "virtual-name"})
+	execCtx := &ExecutionContext{PlannedChange: &planner.PlannedChange{
+		References: map[string]planner.ReferenceInfo{
+			planner.FieldEventGatewayVirtualClusterID: {
+				Ref: "virtual-ref",
+				ID:  "virtual-id",
+			},
+		},
+	}}
+
+	resolveVirtualClusterDestination(fields, execCtx)
+
+	destination := listenerPolicyDestination(t, fields)
+	require.Equal(t, "virtual-id", destination[planner.FieldID])
+	require.NotContains(t, destination, planner.FieldName)
+}
+
+func TestResolveVirtualClusterDestinationKeepsNameWithoutPlannedDependency(t *testing.T) {
+	fields := listenerPolicyFieldsWithDestination(map[string]any{planner.FieldName: "virtual-name"})
+
+	resolveVirtualClusterDestination(fields, nil)
+
+	destination := listenerPolicyDestination(t, fields)
+	require.Equal(t, "virtual-name", destination[planner.FieldName])
+	require.NotContains(t, destination, planner.FieldID)
+}
+
+func listenerPolicyFieldsWithDestination(destination map[string]any) map[string]any {
+	return map[string]any{
+		planner.FieldConfig: map[string]any{
+			planner.FieldDestination: destination,
+		},
+	}
+}
+
+func listenerPolicyDestination(t *testing.T, fields map[string]any) map[string]any {
+	t.Helper()
+	config, ok := fields[planner.FieldConfig].(map[string]any)
+	require.True(t, ok)
+	destination, ok := config[planner.FieldDestination].(map[string]any)
+	require.True(t, ok)
+	return destination
+}

--- a/internal/declarative/executor/event_gateway_virtual_cluster_adapter.go
+++ b/internal/declarative/executor/event_gateway_virtual_cluster_adapter.go
@@ -333,6 +333,12 @@ func (e *EventGatewayVirtualClusterResourceInfo) GetNormalizedLabels() map[strin
 
 // buildBackendClusterReference constructs BackendClusterReferenceModify from a map or SDK type
 func buildBackendClusterReference(field any, execCtx *ExecutionContext) (kkComps.BackendClusterReferenceModify, error) {
+	if id := resolvedBackendClusterID(execCtx); id != "" {
+		return kkComps.CreateBackendClusterReferenceModifyBackendClusterReferenceByID(
+			kkComps.BackendClusterReferenceByID{ID: id},
+		), nil
+	}
+
 	// If it's already the SDK type, return it directly
 	if bcRef, ok := field.(kkComps.BackendClusterReferenceModify); ok {
 		if bcRef.BackendClusterReferenceByID != nil && util.IsValidUUID(bcRef.BackendClusterReferenceByID.ID) {
@@ -398,6 +404,17 @@ func buildBackendClusterReference(field any, execCtx *ExecutionContext) (kkComps
 
 	return kkComps.BackendClusterReferenceModify{},
 		fmt.Errorf("destination must have either 'id' or 'name' field")
+}
+
+func resolvedBackendClusterID(execCtx *ExecutionContext) string {
+	if execCtx == nil || execCtx.PlannedChange == nil {
+		return ""
+	}
+	backendClusterRef, ok := execCtx.PlannedChange.References[planner.FieldEventGatewayBackendClusterID]
+	if !ok || !backendClusterRef.HasResolvedID() {
+		return ""
+	}
+	return backendClusterRef.ID
 }
 
 // getBackendClusterIDFromExecutionContext extracts the backend cluster ID from ExecutionContext parameter

--- a/internal/declarative/executor/event_gateway_virtual_cluster_adapter_test.go
+++ b/internal/declarative/executor/event_gateway_virtual_cluster_adapter_test.go
@@ -24,6 +24,38 @@ func TestBuildVirtualClusterAuthentication_ClientCertificate(t *testing.T) {
 	assert.NotNil(t, result[0].VirtualClusterAuthenticationClientCertificate)
 }
 
+func TestBuildBackendClusterReferencePrefersHydratedDependencyID(t *testing.T) {
+	destination := kkComps.CreateBackendClusterReferenceModifyBackendClusterReferenceByName(
+		kkComps.BackendClusterReferenceByName{Name: "backend-name"},
+	)
+	execCtx := &ExecutionContext{PlannedChange: &planner.PlannedChange{
+		References: map[string]planner.ReferenceInfo{
+			planner.FieldEventGatewayBackendClusterID: {
+				Ref: "backend-ref",
+				ID:  "backend-id",
+			},
+		},
+	}}
+
+	result, err := buildBackendClusterReference(destination, execCtx)
+	require.NoError(t, err)
+	require.NotNil(t, result.BackendClusterReferenceByID)
+	assert.Equal(t, "backend-id", result.BackendClusterReferenceByID.ID)
+	assert.Nil(t, result.BackendClusterReferenceByName)
+}
+
+func TestBuildBackendClusterReferenceKeepsNameWithoutPlannedDependency(t *testing.T) {
+	destination := kkComps.CreateBackendClusterReferenceModifyBackendClusterReferenceByName(
+		kkComps.BackendClusterReferenceByName{Name: "backend-name"},
+	)
+
+	result, err := buildBackendClusterReference(destination, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result.BackendClusterReferenceByName)
+	assert.Equal(t, "backend-name", result.BackendClusterReferenceByName.Name)
+	assert.Nil(t, result.BackendClusterReferenceByID)
+}
+
 func TestBuildVirtualClusterAuthentication_FetchKongIdentityPrincipal(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -3113,7 +3113,7 @@ func (e *Executor) updateResource(ctx context.Context, change *planner.PlannedCh
 		}
 		// Resolve event gateway backend cluster reference if needed
 		if backendClusterRef, ok := change.References[planner.FieldEventGatewayBackendClusterID]; ok &&
-			backendClusterRef.ID == "" {
+			unresolvedReferenceID(backendClusterRef.ID) {
 			backendClusterID, err := e.resolveEventGatewayBackendClusterRef(ctx, change.Parent.ID, backendClusterRef)
 			if err != nil {
 				return "", fmt.Errorf("failed to resolve event gateway backend cluster reference: %w", err)

--- a/internal/declarative/planner/event_gateway_dependencies_test.go
+++ b/internal/declarative/planner/event_gateway_dependencies_test.go
@@ -1,0 +1,244 @@
+package planner
+
+import (
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventGatewayByNameDependenciesProduceSafeExecutionGroups(t *testing.T) {
+	backendCluster := resources.EventGatewayBackendClusterResource{
+		Ref: "backend",
+		CreateBackendClusterRequest: components.CreateBackendClusterRequest{
+			Name: "backend-name",
+		},
+	}
+	virtualCluster := resources.EventGatewayVirtualClusterResource{
+		Ref: "virtual",
+		CreateVirtualClusterRequest: components.CreateVirtualClusterRequest{
+			Name: "virtual-name",
+			Destination: components.CreateBackendClusterReferenceModifyBackendClusterReferenceByName(
+				components.BackendClusterReferenceByName{Name: backendCluster.Name},
+			),
+		},
+	}
+	resourceSet := &resources.ResourceSet{
+		EventGatewayControlPlanes: []resources.EventGatewayControlPlaneResource{{
+			BaseResource:    resources.BaseResource{Ref: "gateway"},
+			BackendClusters: []resources.EventGatewayBackendClusterResource{backendCluster},
+			VirtualClusters: []resources.EventGatewayVirtualClusterResource{virtualCluster},
+		}},
+	}
+	planner := &Planner{logger: slog.Default(), resources: resourceSet}
+	plan := NewPlan("1.0", "test", PlanModeApply)
+
+	gatewayID := "gateway-create"
+	plan.AddChange(PlannedChange{
+		ID:           gatewayID,
+		ResourceType: ResourceTypeEventGatewayControlPlane,
+		ResourceRef:  "gateway",
+		Action:       ActionCreate,
+		Fields:       map[string]any{FieldName: "gateway-name"},
+	})
+	planner.planBackendClusterCreate(
+		"default", "gateway", "gateway-name", "", backendCluster, []string{gatewayID}, plan,
+	)
+	listenerID := planner.planListenerCreate(
+		"default",
+		"gateway",
+		"gateway-name",
+		"",
+		resources.EventGatewayListenerResource{Ref: "listener"},
+		[]string{gatewayID},
+		plan,
+	)
+	virtualClusterID := planner.planVirtualClusterCreate(
+		"default", "gateway", "gateway-name", "", virtualCluster, []string{gatewayID}, plan,
+	)
+
+	var policy resources.EventGatewayListenerPolicyResource
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"ref":"policy",
+		"name":"policy-name",
+		"type":"forward_to_virtual_cluster",
+		"config":{
+			"type":"port_mapping",
+			"advertised_host":"example.com",
+			"destination":{"name":"virtual-name"}
+		}
+	}`), &policy))
+	planner.planListenerPolicyCreate(
+		"default", "", "gateway", "", "listener", "listener-name", policy, []string{listenerID}, plan,
+	)
+
+	backendClusterID := plannedChangeID(t, plan, ResourceTypeEventGatewayBackendCluster, "backend")
+	policyID := plannedChangeID(t, plan, ResourceTypeEventGatewayListenerPolicy, "policy")
+
+	result, err := NewDependencyResolver().ResolveDependenciesWithGroups(plan.Changes)
+	require.NoError(t, err)
+	require.Equal(t, [][]string{
+		{gatewayID},
+		{backendClusterID, listenerID},
+		{virtualClusterID},
+		{policyID},
+	}, result.ExecutionGroups)
+	require.ElementsMatch(t, []string{gatewayID, backendClusterID}, result.FullDepsMap[virtualClusterID])
+	require.ElementsMatch(t, []string{gatewayID, listenerID, virtualClusterID}, result.FullDepsMap[policyID])
+
+	backendRef := planChange(t, plan, virtualClusterID).References[FieldEventGatewayBackendClusterID]
+	require.Equal(t, "backend", backendRef.Ref)
+	require.Equal(t, resources.UnknownReferenceID, backendRef.ID)
+	virtualRef := planChange(t, plan, policyID).References[FieldEventGatewayVirtualClusterID]
+	require.Equal(t, "virtual", virtualRef.Ref)
+	require.Equal(t, resources.UnknownReferenceID, virtualRef.ID)
+}
+
+func TestEventGatewayByNameDependenciesAreScopedToGateway(t *testing.T) {
+	resourceSet := &resources.ResourceSet{
+		EventGatewayControlPlanes: []resources.EventGatewayControlPlaneResource{
+			{
+				BaseResource: resources.BaseResource{Ref: "gateway-a"},
+				VirtualClusters: []resources.EventGatewayVirtualClusterResource{{
+					Ref: "virtual-a",
+				}},
+			},
+			{
+				BaseResource: resources.BaseResource{Ref: "gateway-b"},
+				BackendClusters: []resources.EventGatewayBackendClusterResource{{
+					Ref: "backend-b",
+					CreateBackendClusterRequest: components.CreateBackendClusterRequest{
+						Name: "shared-name",
+					},
+				}},
+				VirtualClusters: []resources.EventGatewayVirtualClusterResource{{
+					Ref: "virtual-b",
+					CreateVirtualClusterRequest: components.CreateVirtualClusterRequest{
+						Name: "shared-virtual-name",
+					},
+				}},
+			},
+		},
+	}
+	planner := &Planner{logger: slog.Default(), resources: resourceSet}
+	plan := NewPlan("1.0", "test", PlanModeApply)
+	plan.AddChange(PlannedChange{
+		ID:           "backend-create",
+		ResourceType: ResourceTypeEventGatewayBackendCluster,
+		ResourceRef:  "backend-b",
+		Action:       ActionCreate,
+	})
+	plan.AddChange(PlannedChange{
+		ID:           "virtual-create",
+		ResourceType: ResourceTypeEventGatewayVirtualCluster,
+		ResourceRef:  "virtual-b",
+		Action:       ActionCreate,
+	})
+
+	virtualClusterID := planner.planVirtualClusterCreate(
+		"default",
+		"gateway-a",
+		"gateway-a-name",
+		"gateway-a-id",
+		resources.EventGatewayVirtualClusterResource{
+			Ref: "virtual-a",
+			CreateVirtualClusterRequest: components.CreateVirtualClusterRequest{
+				Name: "virtual-a",
+				Destination: components.CreateBackendClusterReferenceModifyBackendClusterReferenceByName(
+					components.BackendClusterReferenceByName{Name: "shared-name"},
+				),
+			},
+		},
+		nil,
+		plan,
+	)
+
+	require.NotContains(
+		t,
+		planChange(t, plan, virtualClusterID).References,
+		FieldEventGatewayBackendClusterID,
+	)
+
+	var policy resources.EventGatewayListenerPolicyResource
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"ref":"policy-a",
+		"name":"policy-a",
+		"type":"forward_to_virtual_cluster",
+		"config":{
+			"type":"port_mapping",
+			"advertised_host":"example.com",
+			"destination":{"name":"shared-virtual-name"}
+		}
+	}`), &policy))
+	planner.planListenerPolicyCreate(
+		"default", "gateway-a-id", "gateway-a", "listener-id", "listener", "listener", policy, nil, plan,
+	)
+	policyID := plannedChangeID(t, plan, ResourceTypeEventGatewayListenerPolicy, "policy-a")
+	require.NotContains(t, planChange(t, plan, policyID).References, FieldEventGatewayVirtualClusterID)
+}
+
+func TestEventGatewayExplicitRefsRemainDependencies(t *testing.T) {
+	backendCluster := resources.EventGatewayBackendClusterResource{
+		Ref: "backend",
+		CreateBackendClusterRequest: components.CreateBackendClusterRequest{
+			Name: "backend-name",
+		},
+	}
+	resourceSet := &resources.ResourceSet{
+		EventGatewayControlPlanes: []resources.EventGatewayControlPlaneResource{{
+			BaseResource:    resources.BaseResource{Ref: "gateway"},
+			BackendClusters: []resources.EventGatewayBackendClusterResource{backendCluster},
+		}},
+	}
+	planner := &Planner{logger: slog.Default(), resources: resourceSet}
+	plan := NewPlan("1.0", "test", PlanModeApply)
+	planner.planBackendClusterCreate("default", "gateway", "gateway", "gateway-id", backendCluster, nil, plan)
+
+	virtualClusterID := planner.planVirtualClusterCreate(
+		"default",
+		"gateway",
+		"gateway",
+		"gateway-id",
+		resources.EventGatewayVirtualClusterResource{
+			Ref: "virtual",
+			CreateVirtualClusterRequest: components.CreateVirtualClusterRequest{
+				Name: "virtual",
+				Destination: components.CreateBackendClusterReferenceModifyBackendClusterReferenceByID(
+					components.BackendClusterReferenceByID{ID: "__REF__:backend#id"},
+				),
+			},
+		},
+		nil,
+		plan,
+	)
+
+	backendRef := planChange(t, plan, virtualClusterID).References[FieldEventGatewayBackendClusterID]
+	require.Equal(t, "__REF__:backend#id", backendRef.Ref)
+	require.Equal(t, resources.UnknownReferenceID, backendRef.ID)
+	require.Equal(t, "backend-name", backendRef.LookupFields[FieldName])
+}
+
+func plannedChangeID(t *testing.T, plan *Plan, resourceType, resourceRef string) string {
+	t.Helper()
+	for _, change := range plan.Changes {
+		if change.ResourceType == resourceType && change.ResourceRef == resourceRef {
+			return change.ID
+		}
+	}
+	t.Fatalf("planned change not found: %s %s", resourceType, resourceRef)
+	return ""
+}
+
+func planChange(t *testing.T, plan *Plan, id string) PlannedChange {
+	t.Helper()
+	for _, change := range plan.Changes {
+		if change.ID == id {
+			return change
+		}
+	}
+	t.Fatalf("planned change not found: %s", id)
+	return PlannedChange{}
+}

--- a/internal/declarative/planner/event_gateway_listener_policy_planner.go
+++ b/internal/declarative/planner/event_gateway_listener_policy_planner.go
@@ -236,8 +236,8 @@ func (p *Planner) planListenerPolicyCreate(
 		},
 	}
 
-	// Add virtual cluster reference if policy config has a destination with ref placeholder
-	p.addVirtualClusterReference(&change, fields)
+	// Add a virtual cluster reference for explicit refs and same-plan by-name destinations.
+	p.addVirtualClusterReference(&change, gatewayRef, fields, plan)
 
 	p.logger.Debug(
 		"Enqueuing listener policy CREATE",
@@ -291,8 +291,8 @@ func (p *Planner) planListenerPolicyUpdate(
 		},
 	}
 
-	// Add virtual cluster reference if policy config has a destination with ref placeholder
-	p.addVirtualClusterReference(&change, updateFields)
+	// Add a virtual cluster reference for explicit refs and same-plan by-name destinations.
+	p.addVirtualClusterReference(&change, gatewayRef, updateFields, plan)
 
 	p.logger.Debug(
 		"Enqueuing listener policy UPDATE",
@@ -760,10 +760,14 @@ func getBoolFromNestedMap(m map[string]any, keys ...string) bool {
 	return false
 }
 
-// addVirtualClusterReference checks if the policy has a virtual cluster destination with a ref placeholder
-// and adds the appropriate reference to the change for runtime resolution.
-func (p *Planner) addVirtualClusterReference(change *PlannedChange, fields map[string]any) {
-	// Check if the policy has a config.destination.id that is a ref placeholder
+// addVirtualClusterReference records explicit refs and dependencies on virtual clusters
+// created by name in the same gateway plan.
+func (p *Planner) addVirtualClusterReference(
+	change *PlannedChange,
+	gatewayRef string,
+	fields map[string]any,
+	plan *Plan,
+) {
 	config, hasConfig := fields[FieldConfig]
 	if !hasConfig {
 		return
@@ -784,34 +788,46 @@ func (p *Planner) addVirtualClusterReference(change *PlannedChange, fields map[s
 		return
 	}
 
-	// Check for id field with ref placeholder
-	id, hasID := destMap[FieldID]
-	if !hasID {
-		return
-	}
+	var (
+		virtualClusterRef  string
+		virtualClusterName string
+	)
 
-	idStr, ok := id.(string)
-	if !ok || !tags.IsRefPlaceholder(idStr) {
-		return
-	}
-
-	// Extract the ref and look up the virtual cluster name
-	var virtualClusterName string
-	if parsedRef, _, parseOK := tags.ParseRefPlaceholder(idStr); parseOK && parsedRef != "" {
-		virtualCluster := p.resources.GetVirtualClusterByRef(parsedRef)
-		if virtualCluster != nil {
-			virtualClusterName = virtualCluster.Name
+	if id, hasID := destMap[FieldID]; hasID {
+		idStr, ok := id.(string)
+		if !ok || !tags.IsRefPlaceholder(idStr) {
+			return
 		}
+		virtualClusterRef = idStr
+		if parsedRef, _, parseOK := tags.ParseRefPlaceholder(idStr); parseOK && parsedRef != "" {
+			virtualCluster := p.resources.GetVirtualClusterByRef(parsedRef)
+			if virtualCluster != nil {
+				virtualClusterName = virtualCluster.Name
+			}
+		}
+	} else if name, hasName := destMap[FieldName].(string); hasName {
+		virtualClusterName = name
+		for _, virtualCluster := range p.resources.GetVirtualClustersForGateway(gatewayRef) {
+			if virtualCluster.Name == name &&
+				planHasCreate(plan, ResourceTypeEventGatewayVirtualCluster, virtualCluster.Ref) {
+				virtualClusterRef = virtualCluster.Ref
+				break
+			}
+		}
+	}
+
+	if virtualClusterRef == "" {
+		return
 	}
 
 	p.logger.Debug(
 		"Adding virtual cluster reference to listener policy",
-		"virtual_cluster_ref", idStr,
+		"virtual_cluster_ref", virtualClusterRef,
 		"virtual_cluster_name", virtualClusterName,
 	)
 
 	change.References[FieldEventGatewayVirtualClusterID] = ReferenceInfo{
-		Ref: idStr,
+		Ref: virtualClusterRef,
 		ID:  resources.UnknownReferenceID,
 		LookupFields: map[string]string{
 			FieldName: virtualClusterName,

--- a/internal/declarative/planner/event_gateway_virtual_cluster_planner.go
+++ b/internal/declarative/planner/event_gateway_virtual_cluster_planner.go
@@ -459,19 +459,7 @@ func (p *Planner) planVirtualClusterCreate(
 		change.References = make(map[string]ReferenceInfo)
 	}
 
-	// Set backend cluster reference
-	if cluster.Destination.BackendClusterReferenceByID != nil &&
-		tags.IsRefPlaceholder(cluster.Destination.BackendClusterReferenceByID.ID) {
-		var backendClusterName string
-
-		change.References[FieldEventGatewayBackendClusterID] = ReferenceInfo{
-			Ref: cluster.Destination.BackendClusterReferenceByID.ID,
-			ID:  resources.UnknownReferenceID,
-			LookupFields: map[string]string{
-				FieldName: backendClusterName,
-			},
-		}
-	}
+	p.addBackendClusterReference(&change, gatewayRef, cluster.Destination, plan)
 
 	p.logger.Debug(
 		"Enqueuing virtual cluster CREATE",
@@ -515,28 +503,7 @@ func (p *Planner) planVirtualClusterUpdate(
 		},
 	}
 
-	// Set backend cluster reference if destination uses a ref placeholder
-	if cluster.Destination.BackendClusterReferenceByID != nil &&
-		tags.IsRefPlaceholder(cluster.Destination.BackendClusterReferenceByID.ID) {
-		var backendClusterName string
-		backendClusterRef, _, ok := tags.ParseRefPlaceholder(cluster.Destination.BackendClusterReferenceByID.ID)
-		if ok {
-			backendCluster := p.resources.GetBackendClusterByRef(backendClusterRef)
-			if backendCluster != nil {
-				backendClusterName = backendCluster.Name
-			}
-		}
-
-		if change.References == nil {
-			change.References = make(map[string]ReferenceInfo)
-		}
-		change.References[FieldEventGatewayBackendClusterID] = ReferenceInfo{
-			Ref: cluster.Destination.BackendClusterReferenceByID.ID,
-			LookupFields: map[string]string{
-				FieldName: backendClusterName,
-			},
-		}
-	}
+	p.addBackendClusterReference(&change, gatewayRef, cluster.Destination, plan)
 
 	p.logger.Debug(
 		"Enqueuing virtual cluster UPDATE",
@@ -546,6 +513,73 @@ func (p *Planner) planVirtualClusterUpdate(
 		"fields", updateFields,
 	)
 	plan.AddChange(change)
+}
+
+// addBackendClusterReference records dependencies on backend clusters created in the same gateway plan.
+// Explicit !ref destinations are always recorded; by-name destinations are recorded only when the named
+// backend cluster is being created in this plan.
+func (p *Planner) addBackendClusterReference(
+	change *PlannedChange,
+	gatewayRef string,
+	destination components.BackendClusterReferenceModify,
+	plan *Plan,
+) {
+	if change == nil || plan == nil || p.resources == nil {
+		return
+	}
+
+	var (
+		ref  string
+		name string
+	)
+
+	if destination.BackendClusterReferenceByID != nil &&
+		tags.IsRefPlaceholder(destination.BackendClusterReferenceByID.ID) {
+		ref = destination.BackendClusterReferenceByID.ID
+		parsedRef, _, ok := tags.ParseRefPlaceholder(ref)
+		if ok {
+			for _, backendCluster := range p.resources.GetBackendClustersForGateway(gatewayRef) {
+				if backendCluster.Ref == parsedRef {
+					name = backendCluster.Name
+					break
+				}
+			}
+		}
+	} else if destination.BackendClusterReferenceByName != nil {
+		name = destination.BackendClusterReferenceByName.Name
+		for _, backendCluster := range p.resources.GetBackendClustersForGateway(gatewayRef) {
+			if backendCluster.Name == name && planHasCreate(plan, ResourceTypeEventGatewayBackendCluster, backendCluster.Ref) {
+				ref = backendCluster.Ref
+				break
+			}
+		}
+	}
+
+	if ref == "" {
+		return
+	}
+	if change.References == nil {
+		change.References = make(map[string]ReferenceInfo)
+	}
+	change.References[FieldEventGatewayBackendClusterID] = ReferenceInfo{
+		Ref: ref,
+		ID:  resources.UnknownReferenceID,
+		LookupFields: map[string]string{
+			FieldName: name,
+		},
+	}
+}
+
+func planHasCreate(plan *Plan, resourceType, resourceRef string) bool {
+	if plan == nil {
+		return false
+	}
+	for _, change := range plan.Changes {
+		if change.Action == ActionCreate && change.ResourceType == resourceType && change.ResourceRef == resourceRef {
+			return true
+		}
+	}
+	return false
 }
 
 // planVirtualClusterDelete plans a DELETE change for a virtual cluster

--- a/test/e2e/scenarios/event-gateway/dependency-order/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/dependency-order/scenario.yaml
@@ -1,0 +1,32 @@
+baseInputsPath: testdata
+
+env:
+  KONGCTL_LOG_LEVEL: trace
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-apply-dependent-resources
+    commands:
+      - name: 000-apply
+        outputFormat: json
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 5
+                by_action.CREATE: 5
+          - select: summary
+            expect:
+              fields:
+                applied: 5
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/event-gateway/dependency-order/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/dependency-order/testdata/config.yaml
@@ -1,0 +1,49 @@
+_defaults:
+  kongctl:
+    namespace: event-gateway-dependency-order-test
+
+event_gateways:
+  - ref: event-gateway-dependency-order-test
+    name: event-gateway-dependency-order-test
+
+    backend_clusters:
+      - ref: retail-kafka-cluster
+        name: retail-kafka-cluster
+        bootstrap_servers:
+          - kafka1:9092
+          - kafka2:9092
+          - kafka3:9092
+        authentication:
+          type: anonymous
+        insecure_allow_anonymous_virtual_cluster_auth: true
+        tls:
+          enabled: false
+
+    virtual_clusters:
+      - ref: storefront
+        name: storefront
+        destination:
+          name: retail-kafka-cluster
+        dns_label: storefront
+        acl_mode: enforce_on_gateway
+        authentication:
+          - type: anonymous
+
+    listeners:
+      - ref: storefront-listener
+        name: storefront-listener
+        addresses:
+          - 0.0.0.0
+        ports:
+          - "19092-19095"
+        policies:
+          - ref: storefront-forward
+            type: forward_to_virtual_cluster
+            name: storefront-forward
+            config:
+              type: port_mapping
+              advertised_host: host.docker.internal
+              bootstrap_port: at_start
+              min_broker_id: 0
+              destination:
+                name: storefront


### PR DESCRIPTION
## Summary

- infer same-gateway dependencies when Event Gateway virtual clusters and listener policies target resources by name
- execute dependent creates with IDs hydrated from earlier create results
- preserve existing by-name behavior for resources outside the current plan
- add deterministic planner and executor regression coverage

## Rationale

Event Gateway resources could be placed in the same execution group even though virtual clusters depend on backend clusters and listener policies depend on virtual clusters. Konnect sometimes resolved those names quickly enough, making apply nondeterministic. The planner now records those semantic dependencies and the executor uses the newly created IDs.

## Testing

- go fix ./...
- make format
- make build
- make lint
- make test
- make test-integration
- make test-e2e-scenarios SCENARIO=event-gateway/dependency-order (5 consecutive passes)

Latest E2E artifacts: /home/rspurgeon/go/e2e-artifacts/20260714-175015

Closes #1607