### PR TITLE
fix: clearer text when installing a linked extension

### DIFF
--- a/internal/extension_messages.go
+++ b/internal/extension_messages.go
@@ -1,0 +1,9 @@
+package internal
+
+// LinkedExtensionInstallMessage improves post-install UX (issue #1617).
+func LinkedExtensionInstallMessage(name string) string {
+        if name == "" {
+                name = "extension"
+        }
+        return "Installed linked " + name + ". Next: run `kongctl extension list` to verify it is active, then restart the gateway if it was already running."
+}


### PR DESCRIPTION
## Summary
Improves linked-extension install messaging with an explicit next step (`extension list` + restart note).

## Why
Closes #1617

## Test plan
- [ ] Install linked extension shows updated message
