### PR TITLE
fix(release): reduce GoReleaser build parallelism

### DIFF
--- a/.github/workflows/release.lock.yml
+++ b/.github/workflows/release.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"b13de3eaf9a3d2090bb85200bc0d39b3fe1e8bf2f877a7be46264841a1fb9d1f","body_hash":"feaf419f8ae06a2764f9d89b57c60fc5ae78214f649d6c9b4d998046b8127976","compiler_version":"v0.77.5","agent_id":"copilot","agent_model":"gpt-5-mini"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"9a007f52c478da3c24dbce2567274bb95d841a27d9d2e86cf65e73b00da9e24b","body_hash":"feaf419f8ae06a2764f9d89b57c60fc5ae78214f649d6c9b4d998046b8127976","compiler_version":"v0.77.5","agent_id":"copilot","agent_model":"gpt-5-mini"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","DOCKER_TOKEN","DOCKER_USERNAME","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_TOKEN_PRIVATE_READ","GITHUB_TOKEN","TAP_GITHUB_TOKEN"],"actions":[{"repo":"Homebrew/actions/setup-homebrew","sha":"cced187498280712e078aaba62dc13a3e9cd80bf","version":"cced187498280712e078aaba62dc13a3e9cd80bf"},{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"ed597411d8f924073f98dfc5c65a23a2325f34cd","version":"v8"},{"repo":"actions/setup-go","sha":"4a3601121dd01d1626a1e23e37211e3254c1c06c","version":"v6.4.0 (source v6)"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"docker/login-action","sha":"c94ce9fb468520275223c153574b00df6fe4bcc9","version":"c94ce9fb468520275223c153574b00df6fe4bcc9"},{"repo":"docker/setup-buildx-action","sha":"8d2750c68a42422c14e847fe6c8ac0403b4cbd6f","version":"8d2750c68a42422c14e847fe6c8ac0403b4cbd6f"},{"repo":"docker/setup-qemu-action","sha":"c7c53464625b32c7a7e944ae62b3e17d2b600130","version":"c7c53464625b32c7a7e944ae62b3e17d2b600130"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"},{"repo":"goreleaser/goreleaser-action","sha":"e435ccd777264be153ace6237001ef4d979d3a7a","version":"e435ccd777264be153ace6237001ef4d979d3a7a"},{"repo":"step-security/harden-runner","sha":"6c3c2f2c1c457b00c10c4848d6f5491db3b629df","version":"6c3c2f2c1c457b00c10c4848d6f5491db3b629df"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58","digest":"sha256:a316a2c021accba8a9ea194c75466b0c4a166be6ac783bf8c2d0afd73373dec2","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58@sha256:a316a2c021accba8a9ea194c75466b0c4a166be6ac783bf8c2d0afd73373dec2"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58","digest":"sha256:43a5cdbe4e1156920dcdaab26d6c6761777d5c6bdc572d7d07b11739fb34c749","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58@sha256:43a5cdbe4e1156920dcdaab26d6c6761777d5c6bdc572d7d07b11739fb34c749"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58","digest":"sha256:558682b7b6313a5443cbb3d702899823bd732f991c8b52db6b5b8066abefe7a1","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58@sha256:558682b7b6313a5443cbb3d702899823bd732f991c8b52db6b5b8066abefe7a1"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22","digest":"sha256:ce5c6f5461b077af0d8e8eb1763436e85153f8e9531117d58a7bdb23de71f00a","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.22@sha256:ce5c6f5461b077af0d8e8eb1763436e85153f8e9531117d58a7bdb23de71f00a"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0","digest":"sha256:71b07d9abecb83b4a2595bcd8ccb35f9a0166361a12335f9e16da1ef07172029","pinned_image":"ghcr.io/github/github-mcp-server:v1.1.0@sha256:71b07d9abecb83b4a2595bcd8ccb35f9a0166361a12335f9e16da1ef07172029"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -222,20 +222,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_6a7c972eb8ff040c_EOF'
+          cat << 'GH_AW_PROMPT_0e66f5155ccdcb6a_EOF'
           <system>
-          GH_AW_PROMPT_6a7c972eb8ff040c_EOF
+          GH_AW_PROMPT_0e66f5155ccdcb6a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_6a7c972eb8ff040c_EOF'
+          cat << 'GH_AW_PROMPT_0e66f5155ccdcb6a_EOF'
           <safe-output-tools>
           Tools: update_release, missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_6a7c972eb8ff040c_EOF
+          GH_AW_PROMPT_0e66f5155ccdcb6a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_6a7c972eb8ff040c_EOF'
+          cat << 'GH_AW_PROMPT_0e66f5155ccdcb6a_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -264,12 +264,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_6a7c972eb8ff040c_EOF
+          GH_AW_PROMPT_0e66f5155ccdcb6a_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_6a7c972eb8ff040c_EOF'
+          cat << 'GH_AW_PROMPT_0e66f5155ccdcb6a_EOF'
           </system>
           {{#runtime-import .github/workflows/release.md}}
-          GH_AW_PROMPT_6a7c972eb8ff040c_EOF
+          GH_AW_PROMPT_0e66f5155ccdcb6a_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -493,9 +493,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_bbf7e0c0d8e67d8c_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_252207ac41813fa7_EOF'
           {"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_release":{"max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_bbf7e0c0d8e67d8c_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_252207ac41813fa7_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -692,7 +692,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_152b243924b9eb6e_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_a42a936bcd6a41db_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -733,7 +733,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_152b243924b9eb6e_EOF
+          GH_AW_MCP_CONFIG_a42a936bcd6a41db_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1639,7 +1639,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
         with:
-          args: release --clean
+          args: release --clean --parallelism=1
           distribution: goreleaser
           version: v2.13.3
       - name: Set up Homebrew

--- a/.github/workflows/release.md
+++ b/.github/workflows/release.md
@@ -293,7 +293,7 @@ jobs:
         with:
           distribution: goreleaser
           version: v2.13.3
-          args: release --clean
+          args: release --clean --parallelism=1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- limit GoReleaser to one internal task at a time during full releases
- regenerate the compiled agentic release workflow

## Rationale

The v1.5.0 release exhausted the standard GitHub-hosted runner's disk while
GoReleaser compiled multiple platform targets concurrently. Serializing those
tasks reduces peak Go build cache and temporary-directory usage while keeping
the existing release outputs and runner configuration.

Failed run: https://github.com/Kong/kongctl/actions/runs/29519014976

## Validation

- `gh aw compile release --no-check-update`
- `gh aw compile release --no-check-update --no-emit --actionlint`
- `git diff --check`

## Follow-up

Recovery of the orphaned `v1.5.0` tag is intentionally outside this focused
change.