### PR TITLE
fix(declarative): enforce saved plan execution modes

### DIFF
--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -30,8 +30,8 @@ simple YAML declaration files and a simple state free CLI tool.
 1. **Configuration manifests**: Configuration is expressed as simple YAML files that describe the desired state of your Konnect resources. 
    Configuration files can be split into multiple files and directories for modularity and reuse.
 1. **Plan-Based**: Plans are objects that represent required changes to move a set of resources from one state to another, desired, state. 
-   In `kongctl`, plan artifacts are first class concepts that can be created, stored, reviewed, and applied. Plans are represented as JSON objects
-   and can be generated and stored as files for later application. When running declarative commands, if plans are not provided
+   In `kongctl`, plan artifacts are first class concepts that can be created, stored, reviewed, and executed. Plans are represented as JSON objects
+   and can be generated and stored as files for later execution. When running declarative commands, if plans are not provided
    they are generated implicitly and executed immediately.
 1. **State-Free**: `kongctl` does not use a state file or database to store the current state. The system relies on querying of the 
    online Konnect state in order to calculate plans and apply changes.
@@ -195,7 +195,7 @@ portals:
 
 Plans are central to how `kongctl` manages resource state. Plans are objects which
 define the required steps to move a set of resources from their current state to a
-desired state. Plans can be created, stored, reviewed, and applied at a later time
+desired state. Plans can be created, stored, reviewed, and executed at a later time
 and are stored as JSON files. Plans are not required to be used, 
 but can enable advanced workflows.
 
@@ -220,6 +220,10 @@ kongctl plan --mode apply -f config.yaml --output-file plan.json
 # Phase 2: Execute plan artifact (can be done later)
 kongctl apply --plan plan.json
 ```
+
+Saved plans have strict execution ownership. `apply --plan`, `sync --plan`, and
+`delete --plan` accept only plans generated in `apply`, `sync`, and `delete`
+mode, respectively. `diff --plan` can inspect a plan generated in any mode.
 
 #### Why Use Plan Artifacts?
 
@@ -748,10 +752,10 @@ command usage, flags and options.
 ### plan
 
 Create a plan - a JSON file containing the set of planned changes to a set of resources.
-Plans are generated with either `--mode apply` or `--mode sync`. Apply mode
-creates and updates configured resources only. Sync mode also deletes managed
-resources, but only for resource collections that are explicitly present in the
-input configuration.
+Plans are generated with `--mode apply`, `--mode sync`, or `--mode delete`.
+Apply mode creates and updates configured resources only. Sync mode also deletes
+managed resources, but only for resource collections that are explicitly present
+in the input configuration. Delete mode targets matching resources for deletion.
 
 Generate an apply plan and output to STDOUT:
 
@@ -781,6 +785,7 @@ kongctl apply -f config.yaml
 Apply from saved plan:
 
 ```shell
+kongctl plan --mode apply -f config.yaml --output-file plan.json
 kongctl apply --plan plan.json
 ```
 
@@ -868,7 +873,27 @@ kongctl sync -f config.yaml --auto-approve
 Sync from a plan artifact:
 
 ```shell
+kongctl plan --mode sync -f config.yaml --output-file plan.json
 kongctl sync --plan plan.json
+```
+
+### delete
+
+`delete` removes the resources selected by the supplied declarative
+configuration. Saved delete plans must be generated in delete mode.
+
+Delete directly from config:
+
+```shell
+kongctl delete -f config.yaml
+```
+
+Generate, review, and execute a delete plan:
+
+```shell
+kongctl plan --mode delete -f config.yaml --output-file delete-plan.json
+kongctl diff --plan delete-plan.json
+kongctl delete --plan delete-plan.json
 ```
 
 ### diff
@@ -900,7 +925,8 @@ kongctl diff --plan plan.json
 ```
 
 > Note: `--mode` cannot be used with `--plan` because mode is stored in the
-> plan artifact metadata.
+> plan artifact metadata. Unlike execution commands, `diff --plan` accepts
+> apply-, sync-, and delete-mode plans.
 
 For `UPDATE` actions, text diff shows only the fields that would be
 changed. JSON and YAML outputs expose the same detail in each change's
@@ -1093,7 +1119,7 @@ Review what the previous state included:
 kongctl diff --plan plans/last-known-good.json
 ```
 
-Revert to previous state:
+Execute the previously approved sync-mode plan:
 
 ```shell
 kongctl sync --plan plans/last-known-good.json --auto-approve

--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -1067,7 +1067,7 @@ kongctl apply --plan proposed-changes.json
 
 ```shell
 # CI/CD Pipeline Stage 1: Plan Generation
-kongctl plan --mode apply -f production-config.yaml \
+kongctl plan --mode sync -f production-config.yaml \
   --output-file plan-$(date +%Y%m%d-%H%M%S).json
 
 # Stage 2: Manual approval gate

--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -215,7 +215,7 @@ kongctl apply -f config.yaml
 
 ```shell
 # Phase 1: Generate plan artifact
-kongctl plan -f config.yaml --output-file plan.json
+kongctl plan --mode apply -f config.yaml --output-file plan.json
 
 # Phase 2: Execute plan artifact (can be done later)
 kongctl apply --plan plan.json
@@ -1040,7 +1040,8 @@ kongctl apply -f config.yaml --profile prod
 Developer creates plan:
 
 ```shell
-kongctl plan -f config.yaml --output-file proposed-changes.json
+kongctl plan --mode apply -f config.yaml \
+  --output-file proposed-changes.json
 ```
 
 Review changes visually:
@@ -1066,7 +1067,7 @@ kongctl apply --plan proposed-changes.json
 
 ```shell
 # CI/CD Pipeline Stage 1: Plan Generation
-kongctl plan -f production-config.yaml \
+kongctl plan --mode apply -f production-config.yaml \
   --output-file plan-$(date +%Y%m%d-%H%M%S).json
 
 # Stage 2: Manual approval gate

--- a/docs/examples/declarative/plan-artifacts/README.md
+++ b/docs/examples/declarative/plan-artifacts/README.md
@@ -110,7 +110,7 @@ TIMESTAMP=$(date +%Y-%m-%d-%H%M%S)
 PLAN_FILE="plans/plan-${TIMESTAMP}.json"
 
 echo "Generating plan artifact..."
-kongctl plan -f config/ --output-file "$PLAN_FILE"
+kongctl plan --mode apply -f config/ --output-file "$PLAN_FILE"
 
 echo "Plan created: $PLAN_FILE"
 echo ""
@@ -180,7 +180,7 @@ jobs:
       
       - name: Generate Plan
         run: |
-          kongctl plan -f config/ --output-file plan.json
+          kongctl plan --mode apply -f config/ --output-file plan.json
           
       - name: Comment PR
         uses: actions/github-script@v6
@@ -220,7 +220,7 @@ jobs:
 
 Regenerate the plan with current state:
 ```bash
-kongctl plan -f config/ --output-file new-plan.json
+kongctl plan --mode apply -f config/ --output-file new-plan.json
 ```
 
 ### Viewing plan details

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -719,7 +719,8 @@ kongctl get portals
 
 Generate plan with debug:
 ```bash
-kongctl plan -f config.yaml --log-level debug --output-file plan.json
+kongctl plan --mode apply -f config.yaml --log-level debug \
+  --output-file plan.json
 ```
 
 Review plan:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -511,8 +511,11 @@ Error: plan is out of date - resource already exists
 
 Regenerate the plan:
 ```bash
-kongctl plan -f config.yaml --output-file new-plan.json
+kongctl plan --mode apply -f config.yaml --output-file new-plan.json
 ```
+
+Use `--mode sync` or `--mode delete` instead when the plan will be executed by
+`kongctl sync --plan` or `kongctl delete --plan`.
 
 Compare old and new plans:
 ```bash

--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -778,7 +778,8 @@ func declarativeSyncExamples() string {
   # Synchronize using the explicit Konnect target form
   %[1]s sync konnect -f api.yaml
 
-  # Execute a reviewed plan without prompting
+  # Generate and execute a reviewed sync plan without prompting
+  %[1]s plan --mode sync -f config.yaml --output-file plan.json
   %[1]s sync --plan plan.json --auto-approve`, meta.CLIName))
 }
 
@@ -817,7 +818,8 @@ func declarativeApplyExamples() string {
     -f https://get.konghq.com/api.yaml \
     -s ./kongctl-example
 
-  # Apply from a pre-generated plan
+  # Generate and apply a reviewed apply plan
+  %[1]s plan --mode apply -f config.yaml --output-file plan.json
   %[1]s apply --plan plan.json`, meta.CLIName))
 }
 
@@ -828,7 +830,8 @@ func declarativeDeleteExamples() string {
   # Preview deletions before executing them
   %[1]s delete -f config.yaml --dry-run
 
-  # Execute a reviewed delete plan without prompting
+  # Generate and execute a reviewed delete plan without prompting
+  %[1]s plan --mode delete -f config.yaml --output-file delete-plan.json
   %[1]s delete --plan delete-plan.json --auto-approve`, meta.CLIName))
 }
 
@@ -1766,7 +1769,7 @@ Konnect is the default target for this command, so "kongctl sync" and
 	addSaveDirFlag(cmd)
 	addRemoteFileAuthFlag(cmd)
 	addBaseDirFlag(cmd)
-	cmd.Flags().String("plan", "", "Path to existing plan file")
+	cmd.Flags().String("plan", "", "Path to existing sync-mode plan file")
 	cmd.Flags().Bool("dry-run", false, "Preview changes without applying them")
 	cmd.Flags().Bool("auto-approve", false, "Skip confirmation prompt")
 	cmd.Flags().StringP("output", "o", textOutputFormat, "Output format (text|json|yaml)")
@@ -2074,36 +2077,150 @@ func runApply(command *cobra.Command, args []string) error {
 	return nil
 }
 
-func validateDeletePlan(plan *planner.Plan) error {
-	if plan.Metadata.Mode != planner.PlanModeDelete {
-		return fmt.Errorf(
-			"delete command requires a plan generated in delete mode, got %q mode. "+
-				"Generate a delete plan with: kongctl plan --mode delete -f <files>",
-			plan.Metadata.Mode,
-		)
-	}
-	return nil
+func validateApplyPlan(plan *planner.Plan, planFile string) error {
+	return validateExecutionPlan(
+		plan,
+		planFile,
+		"apply",
+		planner.PlanModeApply,
+		allowedActionsForPlanMode(planner.PlanModeApply),
+	)
 }
 
-func validateApplyPlan(plan *planner.Plan, planFile string) error {
-	if plan.Metadata.Mode != planner.PlanModeApply {
-		return fmt.Errorf(
-			"plan %q was generated in %q mode and cannot be loaded into the apply command. "+
-				"Generate an apply plan with: kongctl plan --mode apply -f <files> "+
-				"--output-file <plan-file>",
-			planFile,
-			plan.Metadata.Mode,
-		)
+func validateSyncPlan(plan *planner.Plan, planFile string) error {
+	return validateExecutionPlan(
+		plan,
+		planFile,
+		"sync",
+		planner.PlanModeSync,
+		allowedActionsForPlanMode(planner.PlanModeSync),
+	)
+}
+
+func validateDeletePlan(plan *planner.Plan, planFile string) error {
+	return validateExecutionPlan(
+		plan,
+		planFile,
+		"delete",
+		planner.PlanModeDelete,
+		allowedActionsForPlanMode(planner.PlanModeDelete),
+	)
+}
+
+func validateExecutionPlan(
+	plan *planner.Plan,
+	planFile string,
+	commandName string,
+	requiredMode planner.PlanMode,
+	allowedActions []planner.ActionType,
+) error {
+	planDescription := describePlanSource(planFile)
+	if plan == nil {
+		return fmt.Errorf("%s could not be loaded for the %s command", planDescription, commandName)
 	}
 
-	// Check if plan contains DELETE operations
+	if plan.Metadata.Mode != requiredMode {
+		err := fmt.Errorf(
+			"%s was generated in %q mode and cannot be loaded into the %s command, which requires %q mode. "+
+				"Regenerate it with: kongctl plan --mode %s -f <files> --output-file <plan-file>",
+			planDescription,
+			plan.Metadata.Mode,
+			commandName,
+			requiredMode,
+			requiredMode,
+		)
+		if executionCommand := executionCommandForPlan(plan); executionCommand != "" {
+			return fmt.Errorf(
+				"%w. To execute this plan unchanged, use: kongctl %s --plan %s",
+				err,
+				executionCommand,
+				planArgumentForSource(planFile),
+			)
+		}
+		return err
+	}
+
 	for _, change := range plan.Changes {
-		if change.Action == planner.ActionDelete {
-			return fmt.Errorf("apply command cannot execute plans with DELETE operations. Use 'sync' command instead")
+		if !slices.Contains(allowedActions, change.Action) {
+			return fmt.Errorf(
+				"%s contains %q action, which cannot be executed by the %s command. "+
+					"Allowed actions for %s plans: %s. "+
+					"Regenerate it with: kongctl plan --mode %s -f <files> --output-file <plan-file>",
+				planDescription,
+				change.Action,
+				commandName,
+				requiredMode,
+				formatPlanActions(allowedActions),
+				requiredMode,
+			)
 		}
 	}
 
 	return nil
+}
+
+func describePlanSource(planFile string) string {
+	switch planFile {
+	case "":
+		return "generated plan"
+	case "-":
+		return "plan from stdin"
+	default:
+		return fmt.Sprintf("plan %q", planFile)
+	}
+}
+
+func planArgumentForSource(planFile string) string {
+	if planFile == "-" {
+		return "-"
+	}
+	return "<plan-file>"
+}
+
+func allowedActionsForPlanMode(mode planner.PlanMode) []planner.ActionType {
+	switch mode {
+	case planner.PlanModeApply:
+		return []planner.ActionType{
+			planner.ActionCreate,
+			planner.ActionUpdate,
+			planner.ActionExternalTool,
+		}
+	case planner.PlanModeSync:
+		return []planner.ActionType{
+			planner.ActionCreate,
+			planner.ActionUpdate,
+			planner.ActionDelete,
+			planner.ActionExternalTool,
+		}
+	case planner.PlanModeDelete:
+		return []planner.ActionType{planner.ActionDelete}
+	default:
+		return nil
+	}
+}
+
+func executionCommandForPlan(plan *planner.Plan) string {
+	if plan == nil {
+		return ""
+	}
+	allowedActions := allowedActionsForPlanMode(plan.Metadata.Mode)
+	if allowedActions == nil {
+		return ""
+	}
+	for _, change := range plan.Changes {
+		if !slices.Contains(allowedActions, change.Action) {
+			return ""
+		}
+	}
+	return string(plan.Metadata.Mode)
+}
+
+func formatPlanActions(actions []planner.ActionType) string {
+	formatted := make([]string, 0, len(actions))
+	for _, action := range actions {
+		formatted = append(formatted, string(action))
+	}
+	return strings.Join(formatted, ", ")
 }
 
 // Displays an output for the execution of an apply or sync command.
@@ -2284,7 +2401,7 @@ Konnect is the default target for this command, so "kongctl apply" and
 	addSaveDirFlag(cmd)
 	addRemoteFileAuthFlag(cmd)
 	addBaseDirFlag(cmd)
-	cmd.Flags().String("plan", "", "Path to existing plan file")
+	cmd.Flags().String("plan", "", "Path to existing apply-mode plan file")
 	cmd.Flags().Bool("dry-run", false, "Preview changes without applying")
 	cmd.Flags().Bool("auto-approve", false, "Skip confirmation prompt")
 	cmd.Flags().StringP("output", "o", textOutputFormat, "Output format (text|json|yaml)")
@@ -2308,7 +2425,7 @@ in Konnect are skipped with a warning. Child resources are removed via
 cascade deletion.
 
 This is equivalent to running:
-  kongctl plan --mode delete -f <files> | kongctl sync --plan -`,
+  kongctl plan --mode delete -f <files> | kongctl delete --plan -`,
 		RunE: runDelete,
 	}
 
@@ -2320,7 +2437,7 @@ This is equivalent to running:
 	addSaveDirFlag(cmd)
 	addRemoteFileAuthFlag(cmd)
 	addBaseDirFlag(cmd)
-	cmd.Flags().String("plan", "", "Path to existing delete plan file")
+	cmd.Flags().String("plan", "", "Path to existing delete-mode plan file")
 	cmd.Flags().Bool("dry-run", false, "Preview deletions without executing them")
 	cmd.Flags().Bool("auto-approve", false, "Skip confirmation prompt")
 	cmd.Flags().StringP("output", "o", textOutputFormat, "Output format (text|json|yaml)")
@@ -2468,7 +2585,7 @@ func runDelete(command *cobra.Command, args []string) error {
 	command.SetContext(ctx)
 
 	// Validate that the plan was generated in delete mode
-	if err := validateDeletePlan(plan); err != nil {
+	if err := validateDeletePlan(plan, planFile); err != nil {
 		return err
 	}
 
@@ -2717,6 +2834,11 @@ func runSync(command *cobra.Command, args []string) error {
 		ctx = context.WithValue(ctx, planFileKey, planFile)
 	}
 	command.SetContext(ctx)
+
+	// Validate plan mode and actions before handling an empty plan or executing changes.
+	if err := validateSyncPlan(plan, planFile); err != nil {
+		return err
+	}
 
 	// Check if plan is empty (no changes needed)
 	if plan.IsEmpty() {

--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -2121,18 +2121,22 @@ func validateExecutionPlan(
 
 	if plan.Metadata.Mode != requiredMode {
 		err := fmt.Errorf(
-			"%s was generated in %q mode and cannot be loaded into the %s command, which requires %q mode. "+
-				"Regenerate it with: kongctl plan --mode %s -f <files> --output-file <plan-file>",
+			"%s was generated in %q mode and cannot be loaded into the %s command, which requires %q mode.\n"+
+				"To use the %s command, regenerate the plan with:\n"+
+				"> kongctl plan --mode %s -f <files> --output-file <plan-file>",
 			planDescription,
 			plan.Metadata.Mode,
 			commandName,
 			requiredMode,
+			commandName,
 			requiredMode,
 		)
 		if executionCommand := executionCommandForPlan(plan); executionCommand != "" {
 			return fmt.Errorf(
-				"%w. To execute this plan unchanged, use: kongctl %s --plan %s",
+				"%w\nTo execute this plan, use the %s command:\n"+
+					"> kongctl %s --plan %s",
 				err,
+				executionCommand,
 				executionCommand,
 				planArgumentForSource(planFile),
 			)
@@ -2144,13 +2148,15 @@ func validateExecutionPlan(
 		if !slices.Contains(allowedActions, change.Action) {
 			return fmt.Errorf(
 				"%s contains %q action, which cannot be executed by the %s command. "+
-					"Allowed actions for %s plans: %s. "+
-					"Regenerate it with: kongctl plan --mode %s -f <files> --output-file <plan-file>",
+					"Allowed actions for %s plans: %s.\n"+
+					"To use the %s command, regenerate the plan with:\n"+
+					"> kongctl plan --mode %s -f <files> --output-file <plan-file>",
 				planDescription,
 				change.Action,
 				commandName,
 				requiredMode,
 				formatPlanActions(allowedActions),
+				commandName,
 				requiredMode,
 			)
 		}

--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -767,8 +767,8 @@ func declarativePlanExamples() string {
   # Generate a plan using the explicit Konnect target form
   %[1]s plan konnect -f api.yaml
 
-  # Save a plan artifact for review or later execution
-  %[1]s plan -f config.yaml --output-file plan.json`, meta.CLIName))
+  # Save an apply-mode plan artifact for review or later execution
+  %[1]s plan --mode apply -f config.yaml --output-file plan.json`, meta.CLIName))
 }
 
 func declarativeSyncExamples() string {
@@ -840,7 +840,7 @@ func newDeclarativePlanCmd() *cobra.Command {
 		Long: `Generate a plan artifact from declarative configuration files for Konnect.
 
 The plan artifact represents the desired state of Konnect resources and can be used
-for review, approval workflows, or as input to sync operations.
+for review, approval workflows, or as input to the matching execution command.
 
 Konnect is the default target for this command, so "kongctl plan" and
 "kongctl plan konnect" are equivalent.`,
@@ -1980,7 +1980,7 @@ func runApply(command *cobra.Command, args []string) error {
 	command.SetContext(ctx)
 
 	// Validate plan for apply
-	if err := validateApplyPlan(plan, command); err != nil {
+	if err := validateApplyPlan(plan, planFile); err != nil {
 		return err
 	}
 
@@ -2085,20 +2085,22 @@ func validateDeletePlan(plan *planner.Plan) error {
 	return nil
 }
 
-func validateApplyPlan(plan *planner.Plan, command *cobra.Command) error {
+func validateApplyPlan(plan *planner.Plan, planFile string) error {
+	if plan.Metadata.Mode != planner.PlanModeApply {
+		return fmt.Errorf(
+			"plan %q was generated in %q mode and cannot be loaded into the apply command. "+
+				"Generate an apply plan with: kongctl plan --mode apply -f <files> "+
+				"--output-file <plan-file>",
+			planFile,
+			plan.Metadata.Mode,
+		)
+	}
+
 	// Check if plan contains DELETE operations
 	for _, change := range plan.Changes {
 		if change.Action == planner.ActionDelete {
 			return fmt.Errorf("apply command cannot execute plans with DELETE operations. Use 'sync' command instead")
 		}
-	}
-
-	// Warn if plan was generated in sync mode
-	if plan.Metadata.Mode == planner.PlanModeSync {
-		fmt.Fprintf(
-			command.OutOrStderr(),
-			"Warning: Plan was generated in sync mode but apply will skip DELETE operations\n",
-		)
 	}
 
 	return nil

--- a/internal/cmd/root/products/konnect/declarative/declarative_test.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative_test.go
@@ -232,29 +232,173 @@ func TestMaxConcurrencyFromCmd(t *testing.T) {
 	})
 }
 
-func Test_validateDeletePlan(t *testing.T) {
+func Test_validateExecutionPlans(t *testing.T) {
 	tests := []struct {
-		name    string
-		mode    planner.PlanMode
-		wantErr bool
-		errMsg  string
+		name      string
+		validate  func(*planner.Plan, string) error
+		mode      planner.PlanMode
+		actions   []planner.ActionType
+		wantError []string
 	}{
 		{
-			name:    "delete mode is accepted",
-			mode:    planner.PlanModeDelete,
-			wantErr: false,
+			name:     "apply accepts create update and external tool actions",
+			validate: validateApplyPlan,
+			mode:     planner.PlanModeApply,
+			actions: []planner.ActionType{
+				planner.ActionCreate,
+				planner.ActionUpdate,
+				planner.ActionExternalTool,
+			},
 		},
 		{
-			name:    "apply mode is rejected",
-			mode:    planner.PlanModeApply,
-			wantErr: true,
-			errMsg:  `delete command requires a plan generated in delete mode, got "apply" mode`,
+			name:     "apply rejects sync mode",
+			validate: validateApplyPlan,
+			mode:     planner.PlanModeSync,
+			wantError: []string{
+				`plan "test-plan.json" was generated in "sync" mode`,
+				`apply command, which requires "apply" mode`,
+				`kongctl plan --mode apply -f <files> --output-file <plan-file>`,
+				`kongctl sync --plan <plan-file>`,
+			},
 		},
 		{
-			name:    "sync mode is rejected",
-			mode:    planner.PlanModeSync,
-			wantErr: true,
-			errMsg:  `delete command requires a plan generated in delete mode, got "sync" mode`,
+			name:     "apply rejects delete mode",
+			validate: validateApplyPlan,
+			mode:     planner.PlanModeDelete,
+			wantError: []string{
+				`plan "test-plan.json" was generated in "delete" mode`,
+				`apply command, which requires "apply" mode`,
+				`kongctl delete --plan <plan-file>`,
+			},
+		},
+		{
+			name:     "apply rejects delete actions",
+			validate: validateApplyPlan,
+			mode:     planner.PlanModeApply,
+			actions:  []planner.ActionType{planner.ActionDelete},
+			wantError: []string{
+				`contains "DELETE" action`,
+				`cannot be executed by the apply command`,
+				`Allowed actions for apply plans: CREATE, UPDATE, EXTERNAL_TOOL`,
+				`kongctl plan --mode apply`,
+			},
+		},
+		{
+			name:     "apply rejects unknown actions",
+			validate: validateApplyPlan,
+			mode:     planner.PlanModeApply,
+			actions:  []planner.ActionType{"REPLACE"},
+			wantError: []string{
+				`contains "REPLACE" action`,
+				`Allowed actions for apply plans: CREATE, UPDATE, EXTERNAL_TOOL`,
+			},
+		},
+		{
+			name:     "sync accepts all supported actions",
+			validate: validateSyncPlan,
+			mode:     planner.PlanModeSync,
+			actions: []planner.ActionType{
+				planner.ActionCreate,
+				planner.ActionUpdate,
+				planner.ActionDelete,
+				planner.ActionExternalTool,
+			},
+		},
+		{
+			name:     "sync rejects apply mode",
+			validate: validateSyncPlan,
+			mode:     planner.PlanModeApply,
+			wantError: []string{
+				`plan "test-plan.json" was generated in "apply" mode`,
+				`sync command, which requires "sync" mode`,
+				`kongctl apply --plan <plan-file>`,
+			},
+		},
+		{
+			name:     "sync rejects delete mode",
+			validate: validateSyncPlan,
+			mode:     planner.PlanModeDelete,
+			wantError: []string{
+				`plan "test-plan.json" was generated in "delete" mode`,
+				`sync command, which requires "sync" mode`,
+				`kongctl delete --plan <plan-file>`,
+			},
+		},
+		{
+			name:     "sync rejects unknown actions",
+			validate: validateSyncPlan,
+			mode:     planner.PlanModeSync,
+			actions:  []planner.ActionType{"REPLACE"},
+			wantError: []string{
+				`contains "REPLACE" action`,
+				`Allowed actions for sync plans: CREATE, UPDATE, DELETE, EXTERNAL_TOOL`,
+			},
+		},
+		{
+			name:     "delete accepts delete actions",
+			validate: validateDeletePlan,
+			mode:     planner.PlanModeDelete,
+			actions:  []planner.ActionType{planner.ActionDelete},
+		},
+		{
+			name:     "delete rejects apply mode",
+			validate: validateDeletePlan,
+			mode:     planner.PlanModeApply,
+			wantError: []string{
+				`plan "test-plan.json" was generated in "apply" mode`,
+				`delete command, which requires "delete" mode`,
+				`kongctl apply --plan <plan-file>`,
+			},
+		},
+		{
+			name:     "delete rejects sync mode",
+			validate: validateDeletePlan,
+			mode:     planner.PlanModeSync,
+			wantError: []string{
+				`plan "test-plan.json" was generated in "sync" mode`,
+				`delete command, which requires "delete" mode`,
+				`kongctl sync --plan <plan-file>`,
+			},
+		},
+		{
+			name:     "delete rejects create actions",
+			validate: validateDeletePlan,
+			mode:     planner.PlanModeDelete,
+			actions:  []planner.ActionType{planner.ActionCreate},
+			wantError: []string{
+				`contains "CREATE" action`,
+				`Allowed actions for delete plans: DELETE`,
+			},
+		},
+		{
+			name:     "delete rejects update actions",
+			validate: validateDeletePlan,
+			mode:     planner.PlanModeDelete,
+			actions:  []planner.ActionType{planner.ActionUpdate},
+			wantError: []string{
+				`contains "UPDATE" action`,
+				`Allowed actions for delete plans: DELETE`,
+			},
+		},
+		{
+			name:     "delete rejects external tool actions",
+			validate: validateDeletePlan,
+			mode:     planner.PlanModeDelete,
+			actions:  []planner.ActionType{planner.ActionExternalTool},
+			wantError: []string{
+				`contains "EXTERNAL_TOOL" action`,
+				`Allowed actions for delete plans: DELETE`,
+			},
+		},
+		{
+			name:     "delete rejects unknown actions",
+			validate: validateDeletePlan,
+			mode:     planner.PlanModeDelete,
+			actions:  []planner.ActionType{"REPLACE"},
+			wantError: []string{
+				`contains "REPLACE" action`,
+				`Allowed actions for delete plans: DELETE`,
+			},
 		},
 	}
 
@@ -262,65 +406,52 @@ func Test_validateDeletePlan(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			plan := &planner.Plan{
 				Metadata: planner.PlanMetadata{Mode: tt.mode},
+				Changes:  make([]planner.PlannedChange, 0, len(tt.actions)),
 			}
-			err := validateDeletePlan(plan)
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.errMsg)
-			} else {
+			for _, action := range tt.actions {
+				plan.Changes = append(plan.Changes, planner.PlannedChange{Action: action})
+			}
+
+			err := tt.validate(plan, "test-plan.json")
+			if len(tt.wantError) == 0 {
 				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			for _, expected := range tt.wantError {
+				assert.Contains(t, err.Error(), expected)
 			}
 		})
 	}
 }
 
-func Test_validateApplyPlan(t *testing.T) {
-	tests := []struct {
-		name    string
-		mode    planner.PlanMode
-		changes []planner.PlannedChange
-		wantErr string
-	}{
-		{
-			name: "apply mode is accepted",
-			mode: planner.PlanModeApply,
-		},
-		{
-			name: "sync mode is rejected",
-			mode: planner.PlanModeSync,
-			wantErr: `plan "sync-plan.json" was generated in "sync" mode and cannot be loaded into the apply command. ` +
-				"Generate an apply plan with: kongctl plan --mode apply -f <files> --output-file <plan-file>",
-		},
-		{
-			name: "delete mode is rejected",
-			mode: planner.PlanModeDelete,
-			wantErr: `plan "sync-plan.json" was generated in "delete" mode and cannot be loaded into the apply command. ` +
-				"Generate an apply plan with: kongctl plan --mode apply -f <files> --output-file <plan-file>",
-		},
-		{
-			name: "apply mode with delete operations is rejected",
-			mode: planner.PlanModeApply,
-			changes: []planner.PlannedChange{
-				{Action: planner.ActionDelete},
-			},
-			wantErr: "apply command cannot execute plans with DELETE operations. Use 'sync' command instead",
+func Test_validateExecutionPlanDescribesStdin(t *testing.T) {
+	plan := &planner.Plan{
+		Metadata: planner.PlanMetadata{Mode: planner.PlanModeDelete},
+	}
+
+	err := validateApplyPlan(plan, "-")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `plan from stdin was generated in "delete" mode`)
+	assert.Contains(t, err.Error(), "kongctl delete --plan -")
+}
+
+func Test_validateExecutionPlanDoesNotRecommendInvalidPlanModeCommand(t *testing.T) {
+	plan := &planner.Plan{
+		Metadata: planner.PlanMetadata{Mode: planner.PlanModeApply},
+		Changes: []planner.PlannedChange{
+			{Action: planner.ActionDelete},
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			plan := &planner.Plan{
-				Metadata: planner.PlanMetadata{Mode: tt.mode},
-				Changes:  tt.changes,
-			}
-			err := validateApplyPlan(plan, "sync-plan.json")
-			if tt.wantErr != "" {
-				require.EqualError(t, err, tt.wantErr)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
+	err := validateSyncPlan(plan, "edited-plan.json")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `sync command, which requires "sync" mode`)
+	assert.NotContains(t, err.Error(), "To execute this plan unchanged")
+	assert.NotContains(t, err.Error(), "kongctl apply --plan")
 }
 
 func Test_parsePlanMode(t *testing.T) {

--- a/internal/cmd/root/products/konnect/declarative/declarative_test.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative_test.go
@@ -257,8 +257,10 @@ func Test_validateExecutionPlans(t *testing.T) {
 			wantError: []string{
 				`plan "test-plan.json" was generated in "sync" mode`,
 				`apply command, which requires "apply" mode`,
-				`kongctl plan --mode apply -f <files> --output-file <plan-file>`,
-				`kongctl sync --plan <plan-file>`,
+				"To use the apply command, regenerate the plan with:\n" +
+					"> kongctl plan --mode apply -f <files> --output-file <plan-file>",
+				"To execute this plan, use the sync command:\n" +
+					"> kongctl sync --plan <plan-file>",
 			},
 		},
 		{
@@ -280,7 +282,8 @@ func Test_validateExecutionPlans(t *testing.T) {
 				`contains "DELETE" action`,
 				`cannot be executed by the apply command`,
 				`Allowed actions for apply plans: CREATE, UPDATE, EXTERNAL_TOOL`,
-				`kongctl plan --mode apply`,
+				"To use the apply command, regenerate the plan with:\n" +
+					"> kongctl plan --mode apply",
 			},
 		},
 		{
@@ -435,7 +438,18 @@ func Test_validateExecutionPlanDescribesStdin(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `plan from stdin was generated in "delete" mode`)
-	assert.Contains(t, err.Error(), "kongctl delete --plan -")
+	assert.Contains(
+		t,
+		err.Error(),
+		"To use the apply command, regenerate the plan with:\n"+
+			"> kongctl plan --mode apply -f <files> --output-file <plan-file>",
+	)
+	assert.Contains(
+		t,
+		err.Error(),
+		"To execute this plan, use the delete command:\n"+
+			"> kongctl delete --plan -",
+	)
 }
 
 func Test_validateExecutionPlanDoesNotRecommendInvalidPlanModeCommand(t *testing.T) {
@@ -450,7 +464,7 @@ func Test_validateExecutionPlanDoesNotRecommendInvalidPlanModeCommand(t *testing
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `sync command, which requires "sync" mode`)
-	assert.NotContains(t, err.Error(), "To execute this plan unchanged")
+	assert.NotContains(t, err.Error(), "To execute this plan, use the ")
 	assert.NotContains(t, err.Error(), "kongctl apply --plan")
 }
 

--- a/internal/cmd/root/products/konnect/declarative/declarative_test.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative_test.go
@@ -274,6 +274,55 @@ func Test_validateDeletePlan(t *testing.T) {
 	}
 }
 
+func Test_validateApplyPlan(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    planner.PlanMode
+		changes []planner.PlannedChange
+		wantErr string
+	}{
+		{
+			name: "apply mode is accepted",
+			mode: planner.PlanModeApply,
+		},
+		{
+			name: "sync mode is rejected",
+			mode: planner.PlanModeSync,
+			wantErr: `plan "sync-plan.json" was generated in "sync" mode and cannot be loaded into the apply command. ` +
+				"Generate an apply plan with: kongctl plan --mode apply -f <files> --output-file <plan-file>",
+		},
+		{
+			name: "delete mode is rejected",
+			mode: planner.PlanModeDelete,
+			wantErr: `plan "sync-plan.json" was generated in "delete" mode and cannot be loaded into the apply command. ` +
+				"Generate an apply plan with: kongctl plan --mode apply -f <files> --output-file <plan-file>",
+		},
+		{
+			name: "apply mode with delete operations is rejected",
+			mode: planner.PlanModeApply,
+			changes: []planner.PlannedChange{
+				{Action: planner.ActionDelete},
+			},
+			wantErr: "apply command cannot execute plans with DELETE operations. Use 'sync' command instead",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := &planner.Plan{
+				Metadata: planner.PlanMetadata{Mode: tt.mode},
+				Changes:  tt.changes,
+			}
+			err := validateApplyPlan(plan, "sync-plan.json")
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func Test_parsePlanMode(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -291,7 +291,8 @@ func TestDeleteHelpUsesDeclarativeExamples(t *testing.T) {
 		"kongctl delete -f config.yaml",
 		"# Preview deletions before executing them",
 		"kongctl delete -f config.yaml --dry-run",
-		"# Execute a reviewed delete plan without prompting",
+		"# Generate and execute a reviewed delete plan without prompting",
+		"kongctl plan --mode delete -f config.yaml --output-file delete-plan.json",
 		"kongctl delete --plan delete-plan.json --auto-approve",
 	} {
 		if !strings.Contains(examples, want) {

--- a/internal/cmd/root/verbs/apply/apply_test.go
+++ b/internal/cmd/root/verbs/apply/apply_test.go
@@ -188,7 +188,7 @@ func TestApplyCmd_Flags(t *testing.T) {
 	// Test flags on konnect subcommand
 	planFlag := konnectCmd.Flags().Lookup("plan")
 	assert.NotNil(t, planFlag, "Should have --plan flag")
-	assert.Equal(t, "Path to existing plan file", planFlag.Usage)
+	assert.Equal(t, "Path to existing apply-mode plan file", planFlag.Usage)
 	assert.Equal(t, "", planFlag.DefValue)
 
 	autoApproveFlag := konnectCmd.Flags().Lookup("auto-approve")

--- a/internal/cmd/root/verbs/del/del.go
+++ b/internal/cmd/root/verbs/del/del.go
@@ -33,7 +33,7 @@ var (
 
 Deletes all resources defined in the declarative configuration files from Konnect.
 This is equivalent to running:
-  kongctl plan --mode delete -f <files> | kongctl sync --plan -`))
+  kongctl plan --mode delete -f <files> | kongctl delete --plan -`))
 )
 
 func NewDeleteCmd() (*cobra.Command, error) {

--- a/internal/cmd/root/verbs/del/del_test.go
+++ b/internal/cmd/root/verbs/del/del_test.go
@@ -1,0 +1,16 @@
+package del
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteHelpUsesDeleteForDeleteModePlans(t *testing.T) {
+	cmd, err := NewDeleteCmd()
+	require.NoError(t, err)
+
+	assert.Contains(t, cmd.Long, "kongctl plan --mode delete -f <files> | kongctl delete --plan -")
+	assert.NotContains(t, cmd.Long, "kongctl sync --plan -")
+}

--- a/internal/cmd/root/verbs/help/templates/apply.md
+++ b/internal/cmd/root/verbs/help/templates/apply.md
@@ -76,7 +76,7 @@ kongctl apply -f config.yaml --auto-approve
 
 ```bash
 # Generate plan first
-kongctl plan -f config.yaml -o my-plan.json
+kongctl plan --mode apply -f config.yaml --output-file my-plan.json
 
 # Review plan
 cat my-plan.json | jq '.summary'
@@ -214,7 +214,8 @@ kongctl apply -f base/ -f overlays/dev/ --profile dev
 kongctl apply -f base/ -f overlays/staging/ --profile staging
 
 # Production (with plan review)
-kongctl plan -f base/ -f overlays/prod/ -o prod-plan.json
+kongctl plan --mode apply -f base/ -f overlays/prod/ \
+  --output-file prod-plan.json
 # ... review plan ...
 kongctl apply --plan prod-plan.json --profile prod
 ```
@@ -227,7 +228,7 @@ kongctl apply --plan prod-plan.json --profile prod
 set -e
 
 # Generate plan
-kongctl plan -f ./configs/ -o plan.json
+kongctl plan --mode apply -f ./configs/ --output-file plan.json
 
 # Validate plan meets policies
 ./scripts/validate-plan.sh plan.json

--- a/internal/cmd/root/verbs/help/templates/apply.md
+++ b/internal/cmd/root/verbs/help/templates/apply.md
@@ -19,7 +19,7 @@ kongctl apply [flags]
 - `-s, --remote-file-save-dir` (string): Save remote URL sources into a local directory before loading
 - `-F, --remote-file-save-force`: Overwrite existing files when saving with `--remote-file-save-dir`
 - `--remote-file-auth` (string): Remote URL authentication mode: `auto` or `none`
-- `--plan` (string): Path to a pre-generated plan file
+- `--plan` (string): Path to a pre-generated apply-mode plan file
 - `-r, --recursive`: Process directories recursively
 
 ### Execution Flags

--- a/internal/cmd/root/verbs/help/templates/plan.md
+++ b/internal/cmd/root/verbs/help/templates/plan.md
@@ -57,7 +57,7 @@ kongctl plan -f ./configs/ --recursive
 
 ```bash
 # Save plan to file for review
-kongctl plan -f config.yaml --output-file plan.json
+kongctl plan --mode apply -f config.yaml --output-file plan.json
 
 # Use saved plan with apply
 kongctl apply --plan plan.json
@@ -150,14 +150,15 @@ kongctl plan -f api-config.yaml
 kongctl apply -f api-config.yaml
 
 # 4. Or save plan for team review
-kongctl plan -f api-config.yaml --output-file proposed-changes.json
+kongctl plan --mode apply -f api-config.yaml \
+  --output-file proposed-changes.json
 ```
 
 ### CI/CD Workflow
 
 ```bash
 # In CI pipeline
-kongctl plan -f ./configs/ --output-file plan.json
+kongctl plan --mode apply -f ./configs/ --output-file plan.json
 
 # Review plan (automated checks)
 ./scripts/validate-plan.sh plan.json

--- a/internal/cmd/root/verbs/help/templates/sync.md
+++ b/internal/cmd/root/verbs/help/templates/sync.md
@@ -23,7 +23,7 @@ kongctl sync [flags]
 - `-s, --remote-file-save-dir` (string): Save remote URL sources into a local directory before loading
 - `-F, --remote-file-save-force`: Overwrite existing files when saving with `--remote-file-save-dir`
 - `--remote-file-auth` (string): Remote URL authentication mode: `auto` or `none`
-- `--plan` (string): Path to a pre-generated plan file
+- `--plan` (string): Path to a pre-generated sync-mode plan file
 - `-r, --recursive`: Process directories recursively
 
 ### Execution Flags

--- a/internal/cmd/root/verbs/help/templates/sync.md
+++ b/internal/cmd/root/verbs/help/templates/sync.md
@@ -162,7 +162,8 @@ Error: Cannot delete protected resources:
 kongctl sync -f environments/dev/ --recursive --auto-approve
 
 # Production - careful sync with review
-kongctl plan -f environments/prod/ --recursive -o prod-plan.json
+kongctl plan --mode sync -f environments/prod/ --recursive \
+  --output-file prod-plan.json
 # ... review plan carefully ...
 kongctl sync --plan prod-plan.json
 ```

--- a/test/e2e/scenarios/declarative/plan-mode-validation/scenario.yaml
+++ b/test/e2e/scenarios/declarative/plan-mode-validation/scenario.yaml
@@ -1,0 +1,111 @@
+test:
+  requiresPAT: false
+
+env:
+  KONGCTL_E2E_KONNECT_PAT: local-plan-mode-validation-token
+
+steps:
+  - name: 000-execution-mode-mismatches
+    skipInputs: true
+    commands:
+      - name: 000-apply-rejects-sync-plan
+        run:
+          - apply
+          - --plan
+          - "{{ .scenario_dir }}/testdata/sync-plan.json"
+          - --auto-approve
+        expectFailure:
+          exitCode: 1
+          contains: 'apply command, which requires "apply" mode'
+
+      - name: 001-apply-rejects-delete-plan
+        run:
+          - apply
+          - --plan
+          - "{{ .scenario_dir }}/testdata/delete-plan.json"
+          - --auto-approve
+        expectFailure:
+          exitCode: 1
+          contains: 'apply command, which requires "apply" mode'
+
+      - name: 002-sync-rejects-apply-plan
+        run:
+          - sync
+          - --plan
+          - "{{ .scenario_dir }}/testdata/apply-plan.json"
+          - --auto-approve
+        expectFailure:
+          exitCode: 1
+          contains: 'sync command, which requires "sync" mode'
+
+      - name: 003-sync-rejects-delete-plan
+        run:
+          - sync
+          - --plan
+          - "{{ .scenario_dir }}/testdata/delete-plan.json"
+          - --auto-approve
+        expectFailure:
+          exitCode: 1
+          contains: 'sync command, which requires "sync" mode'
+
+      - name: 004-delete-rejects-apply-plan
+        run:
+          - delete
+          - --plan
+          - "{{ .scenario_dir }}/testdata/apply-plan.json"
+          - --auto-approve
+        expectFailure:
+          exitCode: 1
+          contains: 'delete command, which requires "delete" mode'
+
+      - name: 005-delete-rejects-sync-plan
+        run:
+          - delete
+          - --plan
+          - "{{ .scenario_dir }}/testdata/sync-plan.json"
+          - --auto-approve
+        expectFailure:
+          exitCode: 1
+          contains: 'delete command, which requires "delete" mode'
+
+  - name: 001-diff-remains-mode-neutral
+    skipInputs: true
+    commands:
+      - name: 000-diff-apply-plan
+        run:
+          - diff
+          - --plan
+          - "{{ .scenario_dir }}/testdata/apply-plan.json"
+          - --output
+          - json
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: apply
+
+      - name: 001-diff-sync-plan
+        run:
+          - diff
+          - --plan
+          - "{{ .scenario_dir }}/testdata/sync-plan.json"
+          - --output
+          - json
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: sync
+
+      - name: 002-diff-delete-plan
+        run:
+          - diff
+          - --plan
+          - "{{ .scenario_dir }}/testdata/delete-plan.json"
+          - --output
+          - json
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: delete

--- a/test/e2e/scenarios/declarative/plan-mode-validation/testdata/apply-plan.json
+++ b/test/e2e/scenarios/declarative/plan-mode-validation/testdata/apply-plan.json
@@ -1,0 +1,15 @@
+{
+  "metadata": {
+    "version": "1.0",
+    "generated_at": "2026-07-22T00:00:00Z",
+    "generator": "kongctl/e2e",
+    "mode": "apply"
+  },
+  "changes": [],
+  "execution_order": [],
+  "summary": {
+    "total_changes": 0,
+    "by_action": {},
+    "by_resource": {}
+  }
+}

--- a/test/e2e/scenarios/declarative/plan-mode-validation/testdata/delete-plan.json
+++ b/test/e2e/scenarios/declarative/plan-mode-validation/testdata/delete-plan.json
@@ -1,0 +1,15 @@
+{
+  "metadata": {
+    "version": "1.0",
+    "generated_at": "2026-07-22T00:00:00Z",
+    "generator": "kongctl/e2e",
+    "mode": "delete"
+  },
+  "changes": [],
+  "execution_order": [],
+  "summary": {
+    "total_changes": 0,
+    "by_action": {},
+    "by_resource": {}
+  }
+}

--- a/test/e2e/scenarios/declarative/plan-mode-validation/testdata/sync-plan.json
+++ b/test/e2e/scenarios/declarative/plan-mode-validation/testdata/sync-plan.json
@@ -1,0 +1,15 @@
+{
+  "metadata": {
+    "version": "1.0",
+    "generated_at": "2026-07-22T00:00:00Z",
+    "generator": "kongctl/e2e",
+    "mode": "sync"
+  },
+  "changes": [],
+  "execution_order": [],
+  "summary": {
+    "total_changes": 0,
+    "by_action": {},
+    "by_resource": {}
+  }
+}

--- a/test/integration/declarative/apply_test.go
+++ b/test/integration/declarative/apply_test.go
@@ -133,7 +133,7 @@ func TestApplyCommand_RejectsDeletes(t *testing.T) {
 			Version:     "1.0",
 			GeneratedAt: time.Now(),
 			Generator:   "kongctl/test",
-			Mode:        planner.PlanModeSync, // Sync mode supports deletes
+			Mode:        planner.PlanModeApply,
 		},
 		Changes: []planner.PlannedChange{
 			{

--- a/test/integration/declarative/apply_test.go
+++ b/test/integration/declarative/apply_test.go
@@ -176,8 +176,9 @@ func TestApplyCommand_RejectsDeletes(t *testing.T) {
 
 	// Verify rejection of DELETE operations
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "apply command cannot execute plans with DELETE operations")
-	assert.Contains(t, err.Error(), "Use 'sync' command")
+	assert.Contains(t, err.Error(), `contains "DELETE" action`)
+	assert.Contains(t, err.Error(), "cannot be executed by the apply command")
+	assert.Contains(t, err.Error(), "Allowed actions for apply plans: CREATE, UPDATE, EXTERNAL_TOOL")
 }
 
 func TestApplyCommand_DryRun(t *testing.T) {

--- a/test/integration/declarative/plan_mode_validation_test.go
+++ b/test/integration/declarative/plan_mode_validation_test.go
@@ -1,0 +1,130 @@
+//go:build integration
+
+package declarative_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/declarative"
+	"github.com/kong/kongctl/internal/cmd/root/verbs"
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecutionCommandsRejectMismatchedPlanModes(t *testing.T) {
+	tests := []struct {
+		name         string
+		command      verbs.VerbValue
+		actualMode   planner.PlanMode
+		requiredMode planner.PlanMode
+	}{
+		{
+			name:         "apply rejects sync plan",
+			command:      "apply",
+			actualMode:   planner.PlanModeSync,
+			requiredMode: planner.PlanModeApply,
+		},
+		{
+			name:         "apply rejects delete plan",
+			command:      "apply",
+			actualMode:   planner.PlanModeDelete,
+			requiredMode: planner.PlanModeApply,
+		},
+		{
+			name:         "sync rejects apply plan",
+			command:      "sync",
+			actualMode:   planner.PlanModeApply,
+			requiredMode: planner.PlanModeSync,
+		},
+		{
+			name:         "sync rejects delete plan",
+			command:      "sync",
+			actualMode:   planner.PlanModeDelete,
+			requiredMode: planner.PlanModeSync,
+		},
+		{
+			name:         "delete rejects apply plan",
+			command:      "delete",
+			actualMode:   planner.PlanModeApply,
+			requiredMode: planner.PlanModeDelete,
+		},
+		{
+			name:         "delete rejects sync plan",
+			command:      "delete",
+			actualMode:   planner.PlanModeSync,
+			requiredMode: planner.PlanModeDelete,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			planFile := writePlanArtifact(t, tt.actualMode)
+			cmd, err := declarative.NewDeclarativeCmd(tt.command)
+			require.NoError(t, err)
+			cmd.SetContext(SetupTestContext(t))
+
+			var output bytes.Buffer
+			cmd.SetOut(&output)
+			cmd.SetErr(&output)
+			cmd.SetArgs([]string{"--plan", planFile, "--auto-approve"})
+
+			err = cmd.Execute()
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), `plan "`+planFile+`" was generated in "`+string(tt.actualMode)+`" mode`)
+			assert.Contains(
+				t,
+				err.Error(),
+				tt.command.String()+` command, which requires "`+string(tt.requiredMode)+`" mode`,
+			)
+			assert.Contains(
+				t,
+				err.Error(),
+				"kongctl plan --mode "+string(tt.requiredMode)+" -f <files> --output-file <plan-file>",
+			)
+			assert.Contains(t, err.Error(), "kongctl "+string(tt.actualMode)+" --plan <plan-file>")
+		})
+	}
+}
+
+func TestDiffAcceptsSavedPlansFromEveryMode(t *testing.T) {
+	for _, mode := range []planner.PlanMode{
+		planner.PlanModeApply,
+		planner.PlanModeSync,
+		planner.PlanModeDelete,
+	} {
+		t.Run(string(mode), func(t *testing.T) {
+			planFile := writePlanArtifact(t, mode)
+			cmd, err := declarative.NewDeclarativeCmd("diff")
+			require.NoError(t, err)
+			cmd.SetContext(SetupTestContext(t))
+
+			var output bytes.Buffer
+			cmd.SetOut(&output)
+			cmd.SetErr(&output)
+			cmd.SetArgs([]string{"--plan", planFile})
+
+			err = cmd.Execute()
+
+			require.NoError(t, err)
+			assert.Contains(t, output.String(), "No changes detected")
+		})
+	}
+}
+
+func writePlanArtifact(t *testing.T, mode planner.PlanMode) string {
+	t.Helper()
+
+	plan := planner.NewPlan("1.0", "kongctl/integration-test", mode)
+	planData, err := json.Marshal(plan)
+	require.NoError(t, err)
+
+	planFile := filepath.Join(t.TempDir(), string(mode)+"-plan.json")
+	require.NoError(t, os.WriteFile(planFile, planData, 0o600))
+	return planFile
+}


### PR DESCRIPTION
## Summary

- enforce strict saved-plan ownership for declarative execution commands:
  - `apply --plan` accepts only apply-mode plans
  - `sync --plan` accepts only sync-mode plans
  - `delete --plan` accepts only delete-mode plans
- keep `diff --plan` mode-neutral
- identify the plan source, actual mode, required mode, regeneration command, and safe execution command in mismatch errors
- retain defensive action validation for editable plan artifacts:
  - apply accepts `CREATE`, `UPDATE`, and `EXTERNAL_TOOL`
  - sync accepts `CREATE`, `UPDATE`, `DELETE`, and `EXTERNAL_TOOL`
  - delete accepts only `DELETE`
- correct delete help that routed delete-mode plans through `sync`
- make saved-plan examples generate the mode required by their execution command
- add unit, integration, root-command, and E2E coverage for the mode and action invariants

## Testing

- `go fix ./...`
- changed Go files formatted with `gofumpt` and `golines -m 120`
- `make build`
- `make build-ci`
- `make lint`
- `make test`
- `make test-integration`
- `KONGCTL_E2E_SCENARIO=declarative/plan-mode-validation go test -tags=e2e ./test/e2e -run '^Test_Scenarios$' -count=1 -v`

Closes #1653
