### PR TITLE
fix(declarative): allow periods in resource refs

### DIFF
--- a/internal/declarative/loader/ai_gateway_model_test.go
+++ b/internal/declarative/loader/ai_gateway_model_test.go
@@ -52,6 +52,33 @@ func TestLoaderExtractsNestedAIGatewayModels(t *testing.T) {
 	))
 }
 
+func TestLoaderAcceptsDottedAIGatewayModelRef(t *testing.T) {
+	input := `
+ai_gateways:
+  - ref: support-gateway
+    display_name: Support Gateway
+    models:
+      - ref: gpt-5.4
+        type: model
+        name: gpt-5.4
+        display_name: GPT 5.4
+        config: {route: {}, model: {}}
+        formats: [{type: openai}]
+        targets: [{name: gpt-4o, provider: support-openai, config: {type: openai}}]
+        policies: []
+        capabilities: [generate]
+`
+
+	rs, err := New().LoadFromSources(
+		[]Source{{Path: writeLoaderTestFile(t, input), Type: SourceTypeFile}},
+		false,
+	)
+	require.NoError(t, err)
+	require.Len(t, rs.AIGatewayModels, 1)
+	require.Equal(t, "gpt-5.4", rs.AIGatewayModels[0].Ref)
+	require.Equal(t, "gpt-5.4", rs.AIGatewayModels[0].Name())
+}
+
 func TestLoaderValidatesAIGatewayModelParentAndDuplicates(t *testing.T) {
 	rootOnly := `
 ai_gateway_models:

--- a/internal/declarative/resources/validation.go
+++ b/internal/declarative/resources/validation.go
@@ -7,9 +7,9 @@ import (
 )
 
 // refPattern defines the allowed pattern for resource refs
-// Allows alphanumeric characters, hyphens, and underscores
-// Must start with a letter or number, and can contain hyphens and underscores
-var refPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+// Allows alphanumeric characters, periods, hyphens, and underscores
+// Must start with a letter or number, and can contain periods, hyphens, and underscores
+var refPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
 
 const (
 	// MaxRefLength is the maximum allowed length for a ref
@@ -38,7 +38,7 @@ func ValidateRef(ref string) error {
 
 	if !refPattern.MatchString(ref) {
 		return fmt.Errorf("ref must start with a letter or number and " +
-			"contain only alphanumeric characters, hyphens, and underscores")
+			"contain only alphanumeric characters, periods, hyphens, and underscores")
 	}
 
 	return nil

--- a/internal/declarative/resources/validation_test.go
+++ b/internal/declarative/resources/validation_test.go
@@ -30,6 +30,11 @@ func TestValidateRef(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "valid ref with period",
+			ref:     "gpt-5.4",
+			wantErr: false,
+		},
+		{
 			name:    "valid ref starting with number",
 			ref:     "123resource",
 			wantErr: false,
@@ -95,8 +100,8 @@ func TestValidateRef(t *testing.T) {
 			errMsg:  "ref must start with a letter or number",
 		},
 		{
-			name:    "ref with dot",
-			ref:     "my.resource",
+			name:    "ref starting with period",
+			ref:     ".myresource",
 			wantErr: true,
 			errMsg:  "ref must start with a letter or number",
 		},


### PR DESCRIPTION
## Summary

- allow periods in declarative resource refs after the initial alphanumeric character
- preserve existing ref length and reserved-character validation
- cover dotted AI Gateway model refs through validator and loader tests

## Rationale

Konnect AI Gateway model names commonly use dotted version identifiers such as `gpt-5.4`. Allowing the same value as a kongctl ref removes the need to maintain a separate dot-free local identifier without loosening reserved delimiter handling.

Fixes #1647

## Testing

- `go fix ./...`
- `make format`
- `GOFLAGS=-buildvcs=false make build`
- `make lint`
- `make test-installer`
- `make test`
- `make test-integration`