### PR TITLE
Feat: Adds external and lookup yaml tag functionality and refactors external processing

### DIFF
--- a/docs/contributor/declarative-resource-implementation-guide.md
+++ b/docs/contributor/declarative-resource-implementation-guide.md
@@ -1736,6 +1736,33 @@ application_auth_strategies:
 3. Planner materializes unresolved placeholders into change references.
 4. Executor resolves references to actual IDs before SDK calls.
 
+### EXTERNAL LOOKUP CONTRACTS
+
+`!external` and `!lookup` are exact aliases. The loader validates their scalar
+or mapping syntax and serializes an opaque placeholder; it never performs
+network access. The planner resolves the placeholder before managed identity
+matching and writes only the resulting ID into the resource and plan.
+
+Resource types that support `_external` or inline lookup targets must:
+
+1. Implement `ExternallyResolvableResource`.
+2. Use `registerExternalResourceType` (or its slice-accessor variant) so the
+   capability is enforced by the generic registration constraint.
+3. Register supported selectors and any parent resource type.
+4. Provide exactly one planner lookup adapter.
+5. Add unit, integration, and E2E coverage for selector, ambiguity, missing
+   scope, caching, and unmanaged lifecycle behavior.
+
+Cross-resource YAML fields use static `RelationshipDescriptor` metadata. Mark
+API schema IDs as `api_foreign_key` and kongctl-added root parent fields as
+`kongctl_parent_selector`. Include the target type, scope field, and root-only
+placement. This metadata drives planner inference and `kongctl explain`; do not
+add field-name switches to individual planners.
+
+Keep execution dependencies separate from relationship metadata. Dependencies
+control operation ordering, while relationship descriptors define the YAML
+field contract and supported reference forms.
+
 ### FIELD COMPARISON
 - **Sparse updates**: Only include changed fields in update request
 - **Nil handling**: Distinguish between "not set" and "empty string"

--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -45,12 +45,17 @@ Use YAML tags in field values to load files or reference other resources.
   `VAR#extract.path` and `var`/`extract` map form.
 - `!ref`: Reference another declarative resource by `ref`.
   `resource-ref#field` is supported; the default field is `id`.
+- `!external`: Resolve an existing Konnect resource directly in a relationship
+  field. Supports `field:value` and flat mapping forms.
+- `!lookup`: A friendlier exact alias for `!external`; both use the same
+  planner-time resolver and cache.
 - `!ref` is intended for string fields.
 - `string (uuid)` and `array[string(uuid)]` annotations in this document
   describe API value types. In declarative config, prefer `!ref` and avoid
   literal UUID values.
-- For unmanaged/external resources, prefer `_external.selector` and then
-  reference that resource by `!ref` from other fields.
+- For a one-off unmanaged relationship, use `!external`. Use an `_external`
+  declaration plus `!ref` when the resource needs a reusable declarative ref
+  or owns managed child resources.
 - Large text/spec fields are commonly loaded with `!file`.
 - `!file` paths are resolved relative to the config file and must remain
   within the configured base directory boundary.
@@ -69,6 +74,25 @@ apis:
       - ref: billing-publication
         portal_id: !ref docs-portal
 ```
+
+The target resource type is inferred from the field. Scalar values use
+`field:value` syntax and mapping selectors use AND semantics:
+
+```yaml
+portal_id: !external name:Docs Portal
+ai_gateway: !lookup {name: shared-ai-gateway}
+```
+
+API-native foreign keys such as `portal_id` and kongctl-added root parent
+selectors such as `ai_gateway` retain their established names. They share the
+same relationship resolution behavior. Parent selectors are omitted when the
+child is nested and the parent can be inferred.
+
+Initially, inline lookup targets are the resource types that already support
+`_external`: portals, control planes, gateway services, AI gateways, audit-log
+webhook destinations, organization teams, Event Gateway control planes, and
+Event Gateway virtual clusters. Run `kongctl explain` to see selectors and
+scope requirements for a specific field.
 
 ## Audit Logs
 

--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -45,15 +45,15 @@ Use YAML tags in field values to load files or reference other resources.
   `VAR#extract.path` and `var`/`extract` map form.
 - `!ref`: Reference another declarative resource by `ref`.
   `resource-ref#field` is supported; the default field is `id`.
-- `!external`: Resolve an existing Konnect resource directly in a relationship
+- `!lookup`: Resolve an existing Konnect resource directly in a relationship
   field. Supports `field:value` and flat mapping forms.
-- `!lookup`: A friendlier exact alias for `!external`; both use the same
-  planner-time resolver and cache.
+- `!external`: An exact alias for `!lookup`; both use the same planner-time
+  resolver and cache.
 - `!ref` is intended for string fields.
 - `string (uuid)` and `array[string(uuid)]` annotations in this document
   describe API value types. In declarative config, prefer `!ref` and avoid
   literal UUID values.
-- For a one-off unmanaged relationship, use `!external`. Use an `_external`
+- For a one-off unmanaged relationship, use `!lookup`. Use an `_external`
   declaration plus `!ref` when the resource needs a reusable declarative ref
   or owns managed child resources.
 - Large text/spec fields are commonly loaded with `!file`.
@@ -79,7 +79,7 @@ The target resource type is inferred from the field. Scalar values use
 `field:value` syntax and mapping selectors use AND semantics:
 
 ```yaml
-portal_id: !external name:Docs Portal
+portal_id: !lookup {name: Docs Portal}
 ai_gateway: !lookup {name: shared-ai-gateway}
 ```
 

--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -428,8 +428,8 @@ These flags help prevent accidentally operating on unexpected namespaces, especi
 External resources are Konnect objects managed elsewhere but selected by the
 `kongctl` declarative engine for use by managed resources. Use `_external` when
 the object needs a reusable declarative `ref` or managed children. Use the
-`!external` tag to resolve an existing object directly in a relationship field.
-`!lookup` is an equivalent, friendlier alias for `!external`.
+`!lookup` tag to resolve an existing object directly in a relationship field.
+`!external` is an exact alias for `!lookup`.
 
 ```yaml
 # External portal definition - this tells kongctl that this portal
@@ -460,7 +460,7 @@ apis:
     name: Products
     publications:
       - ref: products-publication
-        portal_id: !external name:Shared Developer Portal
+        portal_id: !lookup {name: Shared Developer Portal}
 
 ai_gateway_model_providers:
   - ref: shared-provider
@@ -471,7 +471,7 @@ ai_gateway_model_providers:
     config: {}
 ```
 
-`!external` and `!lookup` are exact aliases. A mapping can contain multiple
+`!lookup` and `!external` are exact aliases. A mapping can contain multiple
 selectors, all of which must match. `id:<uuid>` and `{id: <uuid>}` bind a known
 ID directly and cannot be combined with other selectors. Selector lookups must
 match exactly one resource.
@@ -580,8 +580,8 @@ use cases.
 The supported relationship tags are:
 
 - `!ref`: reference a resource declared in the same configuration.
-- `!external`: resolve an existing remote resource during planning.
-- `!lookup`: exact, friendlier alias for `!external`.
+- `!lookup`: resolve an existing remote resource during planning.
+- `!external`: exact alias for `!lookup`.
 
 `kongctl explain <resource>.<field>` reports the relationship target, whether
 the field is an API foreign key or a kongctl parent selector, supported tags,

--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -425,8 +425,11 @@ These flags help prevent accidentally operating on unexpected namespaces, especi
 
 ## External Resources and Namespaces
 
-External resources (`_external` pseudo-resource) are references to Konnect objects that are managed elsewhere
-but are "selected" by the `kongctl` declarative engine so they can be referenced by other resources under management.
+External resources are Konnect objects managed elsewhere but selected by the
+`kongctl` declarative engine for use by managed resources. Use `_external` when
+the object needs a reusable declarative `ref` or managed children. Use the
+`!external` tag to resolve an existing object directly in a relationship field.
+`!lookup` is an equivalent, friendlier alias for `!external`.
 
 ```yaml
 # External portal definition - this tells kongctl that this portal
@@ -445,8 +448,44 @@ Because kongctl does not own those resources:
 - External references do **not** add their namespaces to sync planning. Only namespaces from managed parent
   resources are considered when sync mode calculates deletes.
 - Child resources (portal pages, customizations, etc.) are still planned by resolving the external parent's Konnect ID.
-  Ensure the owning team labels the parent (for example via `kongctl adopt`) so the ID can be resolved, but you do not
-  need to (and cannot) assign a namespace to the external definition itself.
+  You do not need to (and cannot) assign a namespace to the external
+  definition itself.
+
+Inline lookups use either a `field:value` scalar or a mapping. The target type
+is inferred from the relationship field:
+
+```yaml
+apis:
+  - ref: products
+    name: Products
+    publications:
+      - ref: products-publication
+        portal_id: !external name:Shared Developer Portal
+
+ai_gateway_model_providers:
+  - ref: shared-provider
+    ai_gateway: !lookup {name: shared-ai-gateway}
+    name: openai
+    type: openai
+    display_name: OpenAI
+    config: {}
+```
+
+`!external` and `!lookup` are exact aliases. A mapping can contain multiple
+selectors, all of which must match. `id:<uuid>` and `{id: <uuid>}` bind a known
+ID directly and cannot be combined with other selectors. Selector lookups must
+match exactly one resource.
+
+Some relationship fields, such as `portal_id`, are fields from the Konnect API
+schema. Others, such as `ai_gateway`, are parent selectors added by kongctl for
+root-level child declarations. Their names remain different for compatibility,
+but both accept literal IDs, `!ref`, `!external`, and `!lookup` where supported.
+When a child is nested under its parent, the kongctl parent selector is omitted
+and inferred from the nesting.
+
+Lookups run during planning with the active Konnect profile. Equivalent
+lookups, including `_external` declarations, are cached for that plan. Saved
+plans contain resolved IDs rather than tag placeholders.
 
 ## Resources managed by decK
 
@@ -537,6 +576,16 @@ load content from external files, reference across resources, load values
 from environment variables, and extract specific values from structured
 data. Over time more tags may be added to support various functions and
 use cases.
+
+The supported relationship tags are:
+
+- `!ref`: reference a resource declared in the same configuration.
+- `!external`: resolve an existing remote resource during planning.
+- `!lookup`: exact, friendlier alias for `!external`.
+
+`kongctl explain <resource>.<field>` reports the relationship target, whether
+the field is an API foreign key or a kongctl parent selector, supported tags,
+selectors, and any required scope field.
 
 ### Loading File Content to YAML Fields
 

--- a/docs/examples/declarative/external/README.md
+++ b/docs/examples/declarative/external/README.md
@@ -14,6 +14,9 @@ in your configuration files.
 
 ```
 external/
+├── yaml-tags/         # Inline !external and !lookup examples
+│   ├── external-tags.yaml
+│   └── README.md
 ├── platform/          # Platform team manages the shared portal
 │   ├── portal.yaml     # Portal definition with pages and customization
 │   ├── api.yaml        # Platform API published to their portal
@@ -31,6 +34,11 @@ external/
 │   └── docs/           # API documentation
 └── README.md           # This file
 ```
+
+For a smaller example that resolves existing resources directly in
+relationship fields, see [`yaml-tags/`](yaml-tags/). It demonstrates both
+`!external` and its equivalent `!lookup` alias without declaring a reusable
+`_external` resource.
 
 ## Key Concepts
 

--- a/docs/examples/declarative/external/README.md
+++ b/docs/examples/declarative/external/README.md
@@ -14,7 +14,7 @@ in your configuration files.
 
 ```
 external/
-├── yaml-tags/         # Inline !external and !lookup examples
+├── yaml-tags/         # Inline !lookup examples
 │   ├── external-tags.yaml
 │   └── README.md
 ├── platform/          # Platform team manages the shared portal
@@ -36,9 +36,8 @@ external/
 ```
 
 For a smaller example that resolves existing resources directly in
-relationship fields, see [`yaml-tags/`](yaml-tags/). It demonstrates both
-`!external` and its equivalent `!lookup` alias without declaring a reusable
-`_external` resource.
+relationship fields, see [`yaml-tags/`](yaml-tags/). It uses the standard
+`!lookup` spelling without declaring a reusable `_external` resource.
 
 ## Key Concepts
 

--- a/docs/examples/declarative/external/yaml-tags/README.md
+++ b/docs/examples/declarative/external/yaml-tags/README.md
@@ -1,0 +1,39 @@
+# Inline External Lookup Tags
+
+This example uses YAML tags to resolve an existing Konnect resource directly
+in a relationship field during planning.
+
+The manifest demonstrates both kinds of relationship field:
+
+- `portal_id` is a foreign-key field from the Konnect API schema.
+- `portal` is a root-level parent selector added by kongctl.
+
+Both fields use the same planner-time lookup mechanism. `!external` is the
+canonical spelling, while `!lookup` is an equivalent, friendlier alias.
+
+```yaml
+portal_id: !external name:Shared Developer Portal
+portal: !lookup {name: Shared Developer Portal}
+```
+
+Scalar lookups use `field:value` syntax. Mapping lookups can contain multiple
+selectors, all of which must match. A known Konnect ID can be bound directly:
+
+```yaml
+portal_id: !external {id: 00000000-0000-0000-0000-000000000000}
+```
+
+The target resource must already exist. It remains externally managed;
+kongctl only manages the API publication and portal page declared in this
+example.
+
+Preview or apply the example with:
+
+```bash
+kongctl plan -f external-tags.yaml --mode apply
+kongctl apply -f external-tags.yaml
+```
+
+Use an `_external` resource declaration plus `!ref` instead when the external
+resource needs a reusable declarative `ref` or managed children spread across
+multiple files.

--- a/docs/examples/declarative/external/yaml-tags/README.md
+++ b/docs/examples/declarative/external/yaml-tags/README.md
@@ -8,11 +8,11 @@ The manifest demonstrates both kinds of relationship field:
 - `portal_id` is a foreign-key field from the Konnect API schema.
 - `portal` is a root-level parent selector added by kongctl.
 
-Both fields use the same planner-time lookup mechanism. `!external` is the
-canonical spelling, while `!lookup` is an equivalent, friendlier alias.
+Both fields use the same planner-time lookup mechanism. Examples use `!lookup`
+consistently. `!external` is also supported as an exact alias.
 
 ```yaml
-portal_id: !external name:Shared Developer Portal
+portal_id: !lookup {name: Shared Developer Portal}
 portal: !lookup {name: Shared Developer Portal}
 ```
 
@@ -20,7 +20,7 @@ Scalar lookups use `field:value` syntax. Mapping lookups can contain multiple
 selectors, all of which must match. A known Konnect ID can be bound directly:
 
 ```yaml
-portal_id: !external {id: 00000000-0000-0000-0000-000000000000}
+portal_id: !lookup {id: 00000000-0000-0000-0000-000000000000}
 ```
 
 The target resource must already exist. It remains externally managed;

--- a/docs/examples/declarative/external/yaml-tags/external-tags.yaml
+++ b/docs/examples/declarative/external/yaml-tags/external-tags.yaml
@@ -1,0 +1,22 @@
+# Resolve an existing portal in an API-native foreign-key field.
+apis:
+  - ref: external-tag-example-api
+    name: External Tag Example API
+    publications:
+      - ref: external-tag-example-publication
+        portal_id: !external name:Shared Developer Portal
+        visibility: public
+
+# Resolve the same portal through a kongctl-added root parent selector.
+portal_pages:
+  - ref: external-tag-example-page
+    portal: !lookup name:Shared Developer Portal
+    slug: external-tag-example
+    title: External Tag Example
+    description: Page attached to an externally managed portal
+    visibility: public
+    status: published
+    content: |
+      # External lookup tags
+
+      This page was attached to an existing portal using `!lookup`.

--- a/docs/examples/declarative/external/yaml-tags/external-tags.yaml
+++ b/docs/examples/declarative/external/yaml-tags/external-tags.yaml
@@ -4,7 +4,7 @@ apis:
     name: External Tag Example API
     publications:
       - ref: external-tag-example-publication
-        portal_id: !external name:Shared Developer Portal
+        portal_id: !lookup {name: Shared Developer Portal}
         visibility: public
 
 # Resolve the same portal through a kongctl-added root parent selector.

--- a/docs/examples/declarative/external/yaml-tags/external-tags.yaml
+++ b/docs/examples/declarative/external/yaml-tags/external-tags.yaml
@@ -4,7 +4,7 @@ apis:
     name: External Tag Example API
     publications:
       - ref: external-tag-example-publication
-        portal_id: !lookup {name: Shared Developer Portal}
+        portal_id: !lookup name:Shared Developer Portal
         visibility: public
 
 # Resolve the same portal through a kongctl-added root parent selector.

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -277,6 +277,8 @@ func (l *Loader) parseYAML(r io.Reader, sourcePath string, rootDir string) (*res
 	refResolver := tags.NewRefTagResolver(baseDir)
 	registry.Register(fileResolver)
 	registry.Register(refResolver)
+	registry.Register(tags.NewExternalTagResolver("!external"))
+	registry.Register(tags.NewExternalTagResolver("!lookup"))
 	registry.Register(tags.NewEnvTagResolver(tags.EnvTagModeResolve))
 
 	if registry.HasResolvers() {
@@ -290,6 +292,8 @@ func (l *Loader) parseYAML(r io.Reader, sourcePath string, rootDir string) (*res
 	placeholderRegistry := tags.NewResolverRegistry()
 	placeholderRegistry.Register(fileResolver)
 	placeholderRegistry.Register(refResolver)
+	placeholderRegistry.Register(tags.NewExternalTagResolver("!external"))
+	placeholderRegistry.Register(tags.NewExternalTagResolver("!lookup"))
 	placeholderRegistry.Register(tags.NewEnvTagResolver(tags.EnvTagModePlaceholder))
 
 	placeholderContent, err := placeholderRegistry.Process(rawContent)

--- a/internal/declarative/loader/tag_integration_test.go
+++ b/internal/declarative/loader/tag_integration_test.go
@@ -57,6 +57,76 @@ apis:
 	require.ErrorContains(t, err, "portal_id")
 }
 
+func TestLoader_NormalizesOrganizationTeamRefSelectors(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+organization:
+  teams:
+    - ref: platform-team
+      name: Platform Team
+  users:
+    - ref: alice
+      email: alice@example.com
+  system-accounts:
+    - ref: ci-bot
+      name: ci-bot
+organization_user_team_memberships:
+  - ref: alice-platform
+    user: alice
+    team: !ref platform-team#id
+organization_system_account_team_memberships:
+  - ref: ci-bot-platform
+    system_account: ci-bot
+    team: !ref platform-team#id
+organization_team_roles:
+  - ref: platform-api-viewer
+    team: !ref platform-team#id
+    role_name: Viewer
+    entity_id: "*"
+    entity_type_name: APIs
+    entity_region: us
+`), 0o600))
+
+	rs, err := NewWithBaseDir(tmpDir).LoadFile(configFile)
+	require.NoError(t, err)
+	require.Equal(t, "platform-team", rs.OrganizationUserTeamMemberships[0].Team)
+	require.Equal(t, "platform-team", rs.OrganizationSystemAccountTeamMemberships[0].Team)
+	require.Equal(t, "platform-team", rs.OrganizationTeamRoles[0].Team)
+	require.True(t, rs.SyncScope.ChildInScope(
+		resources.ResourceTypeOrganizationTeam,
+		"platform-team",
+		resources.ResourceTypeOrganizationTeamRole,
+	))
+}
+
+func TestLoader_RejectsMalformedAIGatewayParentLookup(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+ai_gateway_model_providers:
+  - ref: external-openai-provider
+    ai_gateway: "__EXTERNAL__:not-valid-base64"
+    name: external-openai-provider
+    type: openai
+    display_name: External OpenAI Provider
+    config:
+      auth:
+        type: basic
+        headers:
+          - name: Authorization
+            value: Bearer fake-openai-api-key
+`), 0o600))
+
+	_, err := NewWithBaseDir(tmpDir).LoadFile(configFile)
+	require.ErrorContains(t, err, "invalid external lookup placeholder")
+	require.ErrorContains(t, err, "ai_gateway")
+}
+
 func TestLoader_TagProcessing(t *testing.T) {
 	// Create test directory
 	tmpDir, err := os.MkdirTemp("", "loader-test-*")

--- a/internal/declarative/loader/tag_integration_test.go
+++ b/internal/declarative/loader/tag_integration_test.go
@@ -38,6 +38,25 @@ apis:
 	require.Equal(t, external.MatchFields, lookup.MatchFields)
 }
 
+func TestLoader_RejectsMalformedExternalLookupPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+apis:
+  - ref: products
+    name: Products
+    publications:
+      - ref: products-publication
+        portal_id: "__EXTERNAL__:not-valid-base64"
+`), 0o600))
+
+	_, err := NewWithBaseDir(tmpDir).LoadFile(configFile)
+	require.ErrorContains(t, err, "invalid external lookup placeholder")
+	require.ErrorContains(t, err, "portal_id")
+}
+
 func TestLoader_TagProcessing(t *testing.T) {
 	// Create test directory
 	tmpDir, err := os.MkdirTemp("", "loader-test-*")

--- a/internal/declarative/loader/tag_integration_test.go
+++ b/internal/declarative/loader/tag_integration_test.go
@@ -6,9 +6,37 @@ import (
 	"testing"
 
 	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/tags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestLoader_ExternalLookupTagAliases(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+apis:
+  - ref: products
+    name: Products
+    publications:
+      - ref: external-publication
+        portal_id: !external name:Shared Portal
+      - ref: lookup-publication
+        portal_id: !lookup {name: Shared Portal}
+`), 0o600))
+
+	rs, err := NewWithBaseDir(tmpDir).LoadFile(configFile)
+	require.NoError(t, err)
+	require.Len(t, rs.APIPublications, 2)
+
+	external, ok := tags.ParseExternalPlaceholder(rs.APIPublications[0].PortalID)
+	require.True(t, ok)
+	lookup, ok := tags.ParseExternalPlaceholder(rs.APIPublications[1].PortalID)
+	require.True(t, ok)
+	require.Equal(t, external.MatchFields, lookup.MatchFields)
+}
 
 func TestLoader_TagProcessing(t *testing.T) {
 	// Create test directory

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -14,6 +14,8 @@ import (
 
 // validateResourceSet validates all resources and checks for ref uniqueness
 func (l *Loader) validateResourceSet(rs *resources.ResourceSet) error {
+	normalizeOrganizationTeamSelectors(rs)
+
 	// Validate portals
 	if err := l.validatePortals(rs.Portals, rs); err != nil {
 		return err
@@ -138,6 +140,30 @@ func (l *Loader) validateResourceSet(rs *resources.ResourceSet) error {
 	}
 
 	return nil
+}
+
+func normalizeOrganizationTeamSelectors(rs *resources.ResourceSet) {
+	if rs == nil {
+		return
+	}
+	for i := range rs.OrganizationUserTeamMemberships {
+		rs.OrganizationUserTeamMemberships[i].Team = resources.NormalizeResourceRef(
+			rs.OrganizationUserTeamMemberships[i].Team,
+		)
+	}
+	for i := range rs.OrganizationSystemAccountTeamMemberships {
+		rs.OrganizationSystemAccountTeamMemberships[i].Team = resources.NormalizeResourceRef(
+			rs.OrganizationSystemAccountTeamMemberships[i].Team,
+		)
+	}
+	for i := range rs.OrganizationTeamRoles {
+		role := &rs.OrganizationTeamRoles[i]
+		original := role.Team
+		role.Team = resources.NormalizeResourceRef(role.Team)
+		if rs.SyncScope != nil {
+			rs.SyncScope.RebindChildParent(resources.ResourceTypeOrganizationTeam, original, role.Team)
+		}
+	}
 }
 
 func (l *Loader) validateOrganizationUsers(rs *resources.ResourceSet) error {
@@ -834,7 +860,15 @@ func validateAIGatewayChildren[T any, P aiGatewayChildResource[T]](
 		}
 
 		gatewayRef := resources.NormalizeResourceRef(parentRef.Ref)
-		if lookup, external := tags.ParseExternalPlaceholder(parentRef.Ref); external {
+		if tags.IsExternalPlaceholder(parentRef.Ref) {
+			lookup, ok := tags.ParseExternalPlaceholder(parentRef.Ref)
+			if !ok {
+				return fmt.Errorf(
+					"%s %q has invalid external lookup placeholder in ai_gateway",
+					resourceLabel,
+					child.GetRef(),
+				)
+			}
 			gatewayRef = "external:" + tags.ExternalLookupKey(lookup.MatchFields)
 		} else {
 			gateway, found := rs.GetResourceByRef(gatewayRef)

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -181,6 +181,9 @@ func (l *Loader) validateOrganizationUsers(rs *resources.ResourceSet) error {
 				membership.User,
 			)
 		}
+		if tags.IsExternalPlaceholder(membership.Team) {
+			continue
+		}
 		if resource, found := rs.GetResourceByRef(membership.Team); !found {
 			return fmt.Errorf("organization_user_team_membership %q references unknown organization_team: %s",
 				membership.GetRef(), membership.Team)
@@ -283,6 +286,9 @@ func (l *Loader) validateOrganizationSystemAccounts(rs *resources.ResourceSet) e
 				membership.SystemAccount,
 			)
 		}
+		if tags.IsExternalPlaceholder(membership.Team) {
+			continue
+		}
 		if resource, found := rs.GetResourceByRef(membership.Team); !found {
 			return fmt.Errorf("organization_system_account_team_membership %q references unknown organization_team: %s",
 				membership.GetRef(), membership.Team)
@@ -369,12 +375,14 @@ func (l *Loader) validateOrganizationTeamRoleReferences(
 	role *resources.OrganizationTeamRoleResource,
 	rs *resources.ResourceSet,
 ) error {
-	if resource, found := rs.GetResourceByRef(role.Team); !found {
-		return fmt.Errorf("organization_team_role %q references unknown organization_team: %s",
-			role.GetRef(), role.Team)
-	} else if resource.GetType() != resources.ResourceTypeOrganizationTeam {
-		return fmt.Errorf("organization_team_role %q references %s but expected organization_team: %s",
-			role.GetRef(), resource.GetType(), role.Team)
+	if !tags.IsExternalPlaceholder(role.Team) {
+		if resource, found := rs.GetResourceByRef(role.Team); !found {
+			return fmt.Errorf("organization_team_role %q references unknown organization_team: %s",
+				role.GetRef(), role.Team)
+		} else if resource.GetType() != resources.ResourceTypeOrganizationTeam {
+			return fmt.Errorf("organization_team_role %q references %s but expected organization_team: %s",
+				role.GetRef(), resource.GetType(), role.Team)
+		}
 	}
 
 	if !tags.IsRefPlaceholder(role.EntityID) {
@@ -534,6 +542,10 @@ func (l *Loader) validateControlPlaneDataPlaneCertificates(
 				return fmt.Errorf("duplicate ref '%s' (already defined as %s)",
 					cert.GetRef(), existing.GetType())
 			}
+		}
+
+		if tags.IsExternalPlaceholder(cert.ControlPlane) {
+			continue
 		}
 
 		if !rs.HasRef(cert.ControlPlane) {
@@ -822,23 +834,27 @@ func validateAIGatewayChildren[T any, P aiGatewayChildResource[T]](
 		}
 
 		gatewayRef := resources.NormalizeResourceRef(parentRef.Ref)
-		gateway, found := rs.GetResourceByRef(gatewayRef)
-		if !found {
-			return fmt.Errorf(
-				"%s %q references unknown ai_gateway %q",
-				resourceLabel,
-				child.GetRef(),
-				parentRef.Ref,
-			)
-		}
-		if gateway.GetType() != resources.ResourceTypeAIGateway {
-			return fmt.Errorf(
-				"%s %q references %q which is %s, not ai_gateway",
-				resourceLabel,
-				child.GetRef(),
-				parentRef.Ref,
-				gateway.GetType(),
-			)
+		if lookup, external := tags.ParseExternalPlaceholder(parentRef.Ref); external {
+			gatewayRef = "external:" + tags.ExternalLookupKey(lookup.MatchFields)
+		} else {
+			gateway, found := rs.GetResourceByRef(gatewayRef)
+			if !found {
+				return fmt.Errorf(
+					"%s %q references unknown ai_gateway %q",
+					resourceLabel,
+					child.GetRef(),
+					parentRef.Ref,
+				)
+			}
+			if gateway.GetType() != resources.ResourceTypeAIGateway {
+				return fmt.Errorf(
+					"%s %q references %q which is %s, not ai_gateway",
+					resourceLabel,
+					child.GetRef(),
+					parentRef.Ref,
+					gateway.GetType(),
+				)
+			}
 		}
 
 		value := uniqueValue(childPtr)
@@ -1636,6 +1652,11 @@ func (l *Loader) validateResourceReferences(resource any, rs *resources.Resource
 		// Skip validation for unresolved reference placeholders
 		if strings.HasPrefix(fieldValue, tags.RefPlaceholderPrefix) {
 			// This will be resolved during planning/execution phase
+			continue
+		}
+		if tags.IsExternalPlaceholder(fieldValue) {
+			// External lookups are validated and resolved by the planner once the
+			// target type and any parent scope are available.
 			continue
 		}
 

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -1655,6 +1655,13 @@ func (l *Loader) validateResourceReferences(resource any, rs *resources.Resource
 			continue
 		}
 		if tags.IsExternalPlaceholder(fieldValue) {
+			if _, ok := tags.ParseExternalPlaceholder(fieldValue); !ok {
+				return fmt.Errorf(
+					"resource %q has invalid external lookup placeholder (field: %s)",
+					refResource.GetRef(),
+					fieldPath,
+				)
+			}
 			// External lookups are validated and resolved by the planner once the
 			// target type and any parent scope are available.
 			continue

--- a/internal/declarative/planner/ai_gateway_planner.go
+++ b/internal/declarative/planner/ai_gateway_planner.go
@@ -70,7 +70,12 @@ func (p *Planner) planAIGatewayChanges(
 			if desiredGateway.IsExternal() {
 				continue
 			}
-			current, exists, err := matchCurrentAIGateway(desiredGateway, currentByID, currentByName, currentByDisplayName)
+			current, exists, err := matchCurrentAIGateway(
+				desiredGateway,
+				currentByID,
+				currentByName,
+				currentByDisplayName,
+			)
 			if err != nil {
 				return err
 			}

--- a/internal/declarative/planner/control_plane_api_implementation_dependencies_test.go
+++ b/internal/declarative/planner/control_plane_api_implementation_dependencies_test.go
@@ -1,0 +1,80 @@
+package planner
+
+import (
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdjustControlPlaneAPIImplementationDeleteDependencies(t *testing.T) {
+	t.Parallel()
+
+	t.Run("API delete removes declared implementation relationship", func(t *testing.T) {
+		t.Parallel()
+
+		const controlPlaneID = "3285a0db-a0e6-4c18-8620-c9753c6b96ad"
+		changes := []PlannedChange{
+			{
+				ID:           "control-plane-delete",
+				ResourceType: ResourceTypeControlPlane,
+				ResourceRef:  "control-plane",
+				ResourceID:   controlPlaneID,
+				Action:       ActionDelete,
+			},
+			{
+				ID:           "api-delete",
+				ResourceType: ResourceTypeAPI,
+				ResourceRef:  "api",
+				Action:       ActionDelete,
+			},
+		}
+		rs := &resources.ResourceSet{
+			APIImplementations: []resources.APIImplementationResource{{
+				Ref: "implementation",
+				API: "api",
+				APIImplementation: kkComps.APIImplementation{
+					Type: kkComps.APIImplementationTypeServiceReference,
+					ServiceReference: &kkComps.ServiceReference{
+						Service: &kkComps.APIImplementationService{
+							ID:             "service-id",
+							ControlPlaneID: controlPlaneID,
+						},
+					},
+				},
+			}},
+		}
+
+		adjustControlPlaneAPIImplementationDeleteDependencies(changes, rs)
+		require.Equal(t, []string{"api-delete"}, changes[0].DependsOn)
+	})
+
+	t.Run("implementation delete precedes control plane delete", func(t *testing.T) {
+		t.Parallel()
+
+		const controlPlaneID = "3285a0db-a0e6-4c18-8620-c9753c6b96ad"
+		changes := []PlannedChange{
+			{
+				ID:           "implementation-delete",
+				ResourceType: ResourceTypeAPIImplementation,
+				Action:       ActionDelete,
+				Fields: map[string]any{
+					FieldService: map[string]any{
+						FieldControlPlaneID: controlPlaneID,
+					},
+				},
+			},
+			{
+				ID:           "control-plane-delete",
+				ResourceType: ResourceTypeControlPlane,
+				ResourceRef:  "control-plane",
+				ResourceID:   controlPlaneID,
+				Action:       ActionDelete,
+			},
+		}
+
+		adjustControlPlaneAPIImplementationDeleteDependencies(changes, nil)
+		require.Equal(t, []string{"implementation-delete"}, changes[1].DependsOn)
+	})
+}

--- a/internal/declarative/planner/control_plane_planner.go
+++ b/internal/declarative/planner/control_plane_planner.go
@@ -36,12 +36,16 @@ func (p *controlPlanePlannerImpl) PlanChanges(ctx context.Context, plannerCtx *C
 		return nil
 	}
 
-	currentControlPlanes, err := p.planner.listManagedControlPlanes(ctx, []string{namespace})
-	if err != nil {
-		if state.IsAPIClientError(err) {
-			return nil
+	var currentControlPlanes []state.ControlPlane
+	if namespace != resources.NamespaceExternal {
+		var err error
+		currentControlPlanes, err = p.planner.listManagedControlPlanes(ctx, []string{namespace})
+		if err != nil {
+			if state.IsAPIClientError(err) {
+				return nil
+			}
+			return fmt.Errorf("failed to list current control planes in namespace %s: %w", namespace, err)
 		}
-		return fmt.Errorf("failed to list current control planes in namespace %s: %w", namespace, err)
 	}
 
 	currentByName := make(map[string]state.ControlPlane)

--- a/internal/declarative/planner/control_plane_planner_test.go
+++ b/internal/declarative/planner/control_plane_planner_test.go
@@ -339,6 +339,29 @@ func TestControlPlanePlanner_PlanDeleteSync(t *testing.T) {
 	assert.Equal(t, "cp-delete", plan.Changes[0].ResourceRef)
 }
 
+func TestControlPlanePlanner_ExternalNamespaceDoesNotListOrReconcile(t *testing.T) {
+	t.Parallel()
+
+	mockAPI := helpers.NewMockControlPlaneAPI(t)
+	planner := &Planner{
+		client: state.NewClient(state.ClientConfig{ControlPlaneAPI: mockAPI}),
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		resources: &resources.ResourceSet{
+			ControlPlanes: []resources.ControlPlaneResource{{
+				BaseResource: resources.BaseResource{Ref: "external"},
+				External:     &resources.ExternalBlock{ID: "control-plane-123"},
+			}},
+		},
+	}
+	planner.genericPlanner = NewGenericPlanner(planner)
+
+	plan := NewPlan("1.0", "test", PlanModeSync)
+	err := NewControlPlanePlanner(NewBasePlanner(planner)).
+		PlanChanges(t.Context(), NewConfig(resources.NamespaceExternal), plan)
+	require.NoError(t, err)
+	require.Empty(t, plan.Changes)
+}
+
 func TestControlPlanePlanner_PlanDeleteMembersDependOnGroupDelete(t *testing.T) {
 	planner := &Planner{
 		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),

--- a/internal/declarative/planner/event_gateway_external_test.go
+++ b/internal/declarative/planner/event_gateway_external_test.go
@@ -282,6 +282,34 @@ func TestPlanner_ExternalEventGateway_PlansExternalVirtualClusterChildren(t *tes
 	require.Equal(t, virtualClusterID, change.References[FieldEventGatewayVirtualClusterID].ID)
 }
 
+func TestPlanner_PreResolvedExternalVirtualClusterPlansChildren(t *testing.T) {
+	t.Parallel()
+
+	const (
+		gatewayID        = "gateway-123"
+		virtualClusterID = "vc-123"
+	)
+	client := state.NewClient(state.ClientConfig{
+		EGWControlPlaneAPI: &stubExternalEventGatewayControlPlaneAPI{
+			gateways: []kkComps.EventGatewayInfo{{ID: gatewayID, Name: "external-egw"}},
+		},
+		EventGatewayBackendClusterAPI: &stubExternalEventGatewayBackendClusterAPI{},
+		EventGatewayVirtualClusterAPI: &stubExternalEventGatewayVirtualClusterAPI{
+			clusters: []kkComps.VirtualCluster{{ID: virtualClusterID, Name: "external-vc"}},
+		},
+		EventGatewayClusterPolicyAPI: &stubExternalEventGatewayClusterPolicyAPI{},
+	})
+	rs := externalEventGatewayResourceSet()
+	rs.EventGatewayControlPlanes[0].SetKonnectID(gatewayID)
+	rs.EventGatewayControlPlanes[0].VirtualClusters[0].SetKonnectID(virtualClusterID)
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	require.Equal(t, ResourceTypeEventGatewayClusterPolicy, plan.Changes[0].ResourceType)
+	require.Equal(t, virtualClusterID, plan.Changes[0].Parent.ID)
+}
+
 func TestPlanner_ExternalEventGateway_MissingResolvedIDFailsBeforeChildPlanning(t *testing.T) {
 	t.Parallel()
 

--- a/internal/declarative/planner/event_gateway_virtual_cluster_planner.go
+++ b/internal/declarative/planner/event_gateway_virtual_cluster_planner.go
@@ -86,6 +86,15 @@ func (p *Planner) planVirtualClusterChangesForExistingGateway(
 	desiredNames := make(map[string]bool)
 	for _, desiredCluster := range desired {
 		if desiredCluster.IsExternal() {
+			if desiredCluster.GetKonnectID() != "" {
+				for _, current := range currentClusters {
+					if current.ID == desiredCluster.GetKonnectID() {
+						desiredNames[current.Name] = true
+						break
+					}
+				}
+				continue
+			}
 			current, err := matchExternalEventGatewayVirtualCluster(&desiredCluster, currentClusters)
 			if err != nil {
 				return err

--- a/internal/declarative/planner/event_gateway_virtual_cluster_planner.go
+++ b/internal/declarative/planner/event_gateway_virtual_cluster_planner.go
@@ -86,24 +86,35 @@ func (p *Planner) planVirtualClusterChangesForExistingGateway(
 	desiredNames := make(map[string]bool)
 	for _, desiredCluster := range desired {
 		if desiredCluster.IsExternal() {
+			var current state.EventGatewayVirtualCluster
 			if desiredCluster.GetKonnectID() != "" {
-				for _, current := range currentClusters {
-					if current.ID == desiredCluster.GetKonnectID() {
-						desiredNames[current.Name] = true
+				found := false
+				for _, candidate := range currentClusters {
+					if candidate.ID == desiredCluster.GetKonnectID() {
+						current = candidate
+						found = true
 						break
 					}
 				}
-				continue
-			}
-			current, err := matchExternalEventGatewayVirtualCluster(&desiredCluster, currentClusters)
-			if err != nil {
-				return err
-			}
-			if !desiredCluster.TryMatchKonnectResource(current) {
-				return fmt.Errorf(
-					"external event_gateway_virtual_cluster %s: failed to bind Konnect resource",
-					desiredCluster.GetRef(),
-				)
+				if !found {
+					return fmt.Errorf(
+						"external event_gateway_virtual_cluster %s: resolved Konnect resource %s not found",
+						desiredCluster.GetRef(),
+						desiredCluster.GetKonnectID(),
+					)
+				}
+			} else {
+				matched, err := matchExternalEventGatewayVirtualCluster(&desiredCluster, currentClusters)
+				if err != nil {
+					return err
+				}
+				current = *matched
+				if !desiredCluster.TryMatchKonnectResource(current) {
+					return fmt.Errorf(
+						"external event_gateway_virtual_cluster %s: failed to bind Konnect resource",
+						desiredCluster.GetRef(),
+					)
+				}
 			}
 			if current.Name != "" {
 				desiredCluster.Name = current.Name

--- a/internal/declarative/planner/external_lookup.go
+++ b/internal/declarative/planner/external_lookup.go
@@ -212,9 +212,9 @@ func (r *externalLookupResolver) resolveScopedDeclarations(ctx context.Context, 
 		if !service.IsExternal() || service.GetKonnectID() != "" {
 			continue
 		}
-		parentID, err := resolveScopedParentID(service.ControlPlane, controlPlaneByRef)
+		parentID, err := r.planner.resolveGatewayServiceControlPlaneID(service, controlPlaneByRef)
 		if err != nil {
-			return fmt.Errorf("gateway_service %q: %w", service.GetRef(), err)
+			return err
 		}
 		usesDeck := controlPlaneHasDeck(service, deckControlPlanes)
 		if parentID == "" && usesDeck {

--- a/internal/declarative/planner/external_lookup.go
+++ b/internal/declarative/planner/external_lookup.go
@@ -1,0 +1,729 @@
+package planner
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/declarative/tags"
+	"github.com/kong/kongctl/internal/util"
+)
+
+type externalLookupRequest struct {
+	ResourceType resources.ResourceType
+	MatchFields  map[string]string
+	ParentID     string
+	Source       string
+}
+
+type externalLookupCacheEntry struct {
+	id  string
+	err error
+}
+
+type externalLookupAdapter func(context.Context, externalLookupRequest) (string, error)
+
+type inlineExternalParent struct {
+	resourceType resources.ResourceType
+	id           string
+	parentID     string
+}
+
+// externalLookupResolver owns all remote identity lookups for one plan generation.
+type externalLookupResolver struct {
+	planner          *Planner
+	cache            map[string]externalLookupCacheEntry
+	adapters         map[resources.ResourceType]externalLookupAdapter
+	hasInlineParents bool
+}
+
+func newExternalLookupResolver(planner *Planner) *externalLookupResolver {
+	r := &externalLookupResolver{
+		planner: planner,
+		cache:   make(map[string]externalLookupCacheEntry),
+	}
+	r.adapters = map[resources.ResourceType]externalLookupAdapter{
+		resources.ResourceTypePortal:                     r.lookupPortal,
+		resources.ResourceTypeControlPlane:               r.lookupControlPlane,
+		resources.ResourceTypeGatewayService:             r.lookupGatewayService,
+		resources.ResourceTypeAIGateway:                  r.lookupAIGateway,
+		resources.ResourceTypeAuditLogWebhookDestination: r.lookupAuditLogWebhookDestination,
+		resources.ResourceTypeOrganizationTeam:           r.lookupOrganizationTeam,
+		resources.ResourceTypeEventGatewayControlPlane:   r.lookupEventGatewayControlPlane,
+		resources.ResourceTypeEventGatewayVirtualCluster: r.lookupEventGatewayVirtualCluster,
+	}
+	return r
+}
+
+func (r *externalLookupResolver) validateRegistry() error {
+	for _, resourceType := range resources.ExternalResolvableTypes() {
+		if r.adapters[resourceType] == nil {
+			return fmt.Errorf("externally resolvable resource type %s has no planner lookup adapter", resourceType)
+		}
+	}
+	for resourceType := range r.adapters {
+		if _, ok := resources.ExternalResolutionFor(resourceType); !ok {
+			return fmt.Errorf(
+				"external lookup adapter registered for resource type %s without capability",
+				resourceType,
+			)
+		}
+	}
+	return nil
+}
+
+func (r *externalLookupResolver) resolve(ctx context.Context, req externalLookupRequest) (string, error) {
+	capability, ok := resources.ExternalResolutionFor(req.ResourceType)
+	if !ok {
+		return "", fmt.Errorf("%s: resource type %s does not support external lookup", req.Source, req.ResourceType)
+	}
+	if len(req.MatchFields) == 0 {
+		return "", fmt.Errorf("%s: external lookup requires at least one selector", req.Source)
+	}
+	if id, hasID := req.MatchFields[FieldID]; hasID {
+		if len(req.MatchFields) != 1 {
+			return "", fmt.Errorf("%s: external lookup id cannot be combined with other selectors", req.Source)
+		}
+		if strings.TrimSpace(id) == "" {
+			return "", fmt.Errorf("%s: external lookup id cannot be empty", req.Source)
+		}
+		return id, nil
+	}
+	for field := range req.MatchFields {
+		if !capability.AllowAnyStringSelector && !slices.Contains(capability.Selectors, field) {
+			return "", fmt.Errorf(
+				"%s: external %s lookup does not support selector %q (supported: %s)",
+				req.Source,
+				req.ResourceType,
+				field,
+				strings.Join(capability.Selectors, ", "),
+			)
+		}
+	}
+	if capability.ParentType != "" && req.ParentID == "" {
+		return "", fmt.Errorf(
+			"%s: external %s lookup requires resolved %s scope",
+			req.Source,
+			req.ResourceType,
+			capability.ParentType,
+		)
+	}
+
+	key := string(req.ResourceType) + "|" + req.ParentID + "|" + tags.ExternalLookupKey(req.MatchFields)
+	if cached, ok := r.cache[key]; ok {
+		return cached.id, cached.err
+	}
+
+	adapter := r.adapters[req.ResourceType]
+	if adapter == nil {
+		return "", fmt.Errorf("%s: no external lookup adapter for %s", req.Source, req.ResourceType)
+	}
+	id, err := adapter(ctx, req)
+	r.cache[key] = externalLookupCacheEntry{id: id, err: err}
+	return id, err
+}
+
+func externalRequest(
+	resourceType resources.ResourceType,
+	external *resources.ExternalBlock,
+	parentID string,
+	source string,
+) externalLookupRequest {
+	matchFields := make(map[string]string)
+	if external != nil {
+		if external.ID != "" {
+			matchFields[FieldID] = external.ID
+		} else if external.Selector != nil {
+			maps.Copy(matchFields, external.Selector.MatchFields)
+		}
+	}
+	return externalLookupRequest{
+		ResourceType: resourceType,
+		MatchFields:  matchFields,
+		ParentID:     parentID,
+		Source:       source,
+	}
+}
+
+func (r *externalLookupResolver) resolveDeclarations(ctx context.Context, rs *resources.ResourceSet) error {
+	if err := r.validateRegistry(); err != nil {
+		return err
+	}
+
+	// Resolve unscoped resources first so scoped resources can consume their IDs.
+	for _, resourceType := range []resources.ResourceType{
+		resources.ResourceTypeControlPlane,
+		resources.ResourceTypeEventGatewayControlPlane,
+		resources.ResourceTypePortal,
+		resources.ResourceTypeAIGateway,
+		resources.ResourceTypeOrganizationTeam,
+	} {
+		for _, item := range rs.AllResourcesByType(resourceType) {
+			external, ok := item.(resources.ExternallyResolvableResource)
+			if !ok || external.GetExternalBlock() == nil || item.GetKonnectID() != "" {
+				continue
+			}
+			id, err := r.resolve(ctx, externalRequest(
+				item.GetType(), external.GetExternalBlock(), "", externalDeclarationSource(item),
+			))
+			if err != nil {
+				return err
+			}
+			external.SetKonnectID(id)
+		}
+	}
+
+	if rs.AuditLogs != nil {
+		for i := range rs.AuditLogs.Destinations {
+			destination := &rs.AuditLogs.Destinations[i]
+			if destination.GetKonnectID() != "" {
+				continue
+			}
+			id, err := r.resolve(ctx, externalRequest(
+				destination.GetType(), destination.External, "", externalDeclarationSource(destination),
+			))
+			if err != nil {
+				return err
+			}
+			destination.SetKonnectID(id)
+		}
+	}
+
+	return nil
+}
+
+func externalDeclarationSource(resource resources.Resource) string {
+	return fmt.Sprintf("%s %q _external", resource.GetType(), resource.GetRef())
+}
+
+func (r *externalLookupResolver) resolveScopedDeclarations(ctx context.Context, rs *resources.ResourceSet) error {
+	controlPlaneByRef := make(map[string]*resources.ControlPlaneResource, len(rs.ControlPlanes))
+	for i := range rs.ControlPlanes {
+		controlPlaneByRef[rs.ControlPlanes[i].GetRef()] = &rs.ControlPlanes[i]
+	}
+	for i := range rs.GatewayServices {
+		service := &rs.GatewayServices[i]
+		if !service.IsExternal() || service.GetKonnectID() != "" {
+			continue
+		}
+		parentID, err := resolveScopedParentID(service.ControlPlane, controlPlaneByRef)
+		if err != nil {
+			return fmt.Errorf("gateway_service %q: %w", service.GetRef(), err)
+		}
+		if parentID == "" && controlPlaneHasDeck(service, deckControlPlaneRefs(rs.ControlPlanes)) {
+			continue
+		}
+		id, err := r.resolve(ctx, externalRequest(
+			service.GetType(), service.External, parentID, externalDeclarationSource(service),
+		))
+		if err != nil {
+			if controlPlaneHasDeck(service, deckControlPlaneRefs(rs.ControlPlanes)) {
+				continue
+			}
+			return err
+		}
+		service.SetKonnectID(id)
+		service.SetResolvedControlPlaneID(parentID)
+	}
+
+	eventGatewayByRef := make(map[string]*resources.EventGatewayControlPlaneResource, len(rs.EventGatewayControlPlanes))
+	for i := range rs.EventGatewayControlPlanes {
+		eventGatewayByRef[rs.EventGatewayControlPlanes[i].GetRef()] = &rs.EventGatewayControlPlanes[i]
+	}
+	for i := range rs.EventGatewayVirtualClusters {
+		cluster := &rs.EventGatewayVirtualClusters[i]
+		if !cluster.IsExternal() || cluster.GetKonnectID() != "" {
+			continue
+		}
+		parentID, err := resolveScopedParentID(cluster.EventGateway, eventGatewayByRef)
+		if err != nil {
+			return fmt.Errorf("event_gateway_virtual_cluster %q: %w", cluster.GetRef(), err)
+		}
+		id, err := r.resolve(ctx, externalRequest(
+			cluster.GetType(), cluster.External, parentID, externalDeclarationSource(cluster),
+		))
+		if err != nil {
+			return err
+		}
+		cluster.SetKonnectID(id)
+	}
+	return nil
+}
+
+func (r *externalLookupResolver) resolveInlineLookups(
+	ctx context.Context,
+	rs *resources.ResourceSet,
+	targetTypes ...resources.ResourceType,
+) error {
+	targetSet := make(map[resources.ResourceType]struct{}, len(targetTypes))
+	for _, targetType := range targetTypes {
+		targetSet[targetType] = struct{}{}
+	}
+
+	var resolutionErr error
+	inlineParents := make(map[string]inlineExternalParent)
+	rs.ForEachResource(func(resource resources.Resource) bool {
+		for _, relationship := range resources.RelationshipDescriptorsFor(resource) {
+			fieldPath := relationship.FieldPath
+			targetType := relationship.TargetType
+			if _, selected := targetSet[targetType]; !selected {
+				continue
+			}
+			value, err := stringFieldByPath(resource, fieldPath)
+			if err != nil {
+				resolutionErr = fmt.Errorf("%s %q field %s: %w", resource.GetType(), resource.GetRef(), fieldPath, err)
+				return false
+			}
+			lookup, isLookup := tags.ParseExternalPlaceholder(value)
+			if !isLookup {
+				continue
+			}
+
+			parentID, err := r.inlineLookupParentID(rs, resource, relationship)
+			if err != nil {
+				resolutionErr = fmt.Errorf("%s %q field %s: %w", resource.GetType(), resource.GetRef(), fieldPath, err)
+				return false
+			}
+			source := fmt.Sprintf("%s %q field %s", resource.GetType(), resource.GetRef(), fieldPath)
+			if lookup.Line > 0 {
+				source += fmt.Sprintf(" (line %d, column %d)", lookup.Line, lookup.Column)
+			}
+			id, err := r.resolve(ctx, externalLookupRequest{
+				ResourceType: targetType,
+				MatchFields:  lookup.MatchFields,
+				ParentID:     parentID,
+				Source:       source,
+			})
+			if err != nil {
+				resolutionErr = err
+				return false
+			}
+			if err := setStringFieldByPath(resource, fieldPath, id); err != nil {
+				resolutionErr = fmt.Errorf("%s: bind resolved ID: %w", source, err)
+				return false
+			}
+			if relationship.Kind == resources.RelationshipKindKongctlParentSelector {
+				r.hasInlineParents = true
+				if rs.SyncScope != nil {
+					rs.SyncScope.RebindChildParent(targetType, value, id)
+				}
+				key := string(targetType) + "|" + id
+				inlineParents[key] = inlineExternalParent{
+					resourceType: targetType,
+					id:           id,
+					parentID:     parentID,
+				}
+			}
+		}
+		return true
+	})
+	if resolutionErr != nil {
+		return resolutionErr
+	}
+	for _, parent := range inlineParents {
+		if err := ensureInlineExternalParent(rs, parent); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ensureInlineExternalParent(rs *resources.ResourceSet, parent inlineExternalParent) error {
+	if existing, ok := rs.GetResourceByRef(parent.id); ok {
+		if existing.GetType() != parent.resourceType {
+			return fmt.Errorf(
+				"resolved external ID %q is already used as ref by %s, expected %s",
+				parent.id,
+				existing.GetType(),
+				parent.resourceType,
+			)
+		}
+		return nil
+	}
+
+	external := &resources.ExternalBlock{ID: parent.id}
+	// Only registered parent-capable external types can reach this switch.
+	//nolint:exhaustive
+	switch parent.resourceType {
+	case resources.ResourceTypePortal:
+		rs.Portals = append(rs.Portals, resources.PortalResource{
+			BaseResource: resources.BaseResource{Ref: parent.id},
+			External:     external,
+		})
+		rs.Portals[len(rs.Portals)-1].SetKonnectID(parent.id)
+	case resources.ResourceTypeControlPlane:
+		rs.ControlPlanes = append(rs.ControlPlanes, resources.ControlPlaneResource{
+			BaseResource: resources.BaseResource{Ref: parent.id},
+			External:     external,
+		})
+		rs.ControlPlanes[len(rs.ControlPlanes)-1].SetKonnectID(parent.id)
+	case resources.ResourceTypeAIGateway:
+		rs.AIGateways = append(rs.AIGateways, resources.AIGatewayResource{
+			BaseResource: resources.BaseResource{Ref: parent.id},
+			External:     external,
+		})
+		rs.AIGateways[len(rs.AIGateways)-1].SetKonnectID(parent.id)
+	case resources.ResourceTypeOrganizationTeam:
+		rs.OrganizationTeams = append(rs.OrganizationTeams, resources.OrganizationTeamResource{
+			BaseResource: resources.BaseResource{Ref: parent.id},
+			External:     external,
+		})
+		rs.OrganizationTeams[len(rs.OrganizationTeams)-1].SetKonnectID(parent.id)
+	case resources.ResourceTypeEventGatewayControlPlane:
+		rs.EventGatewayControlPlanes = append(
+			rs.EventGatewayControlPlanes,
+			resources.EventGatewayControlPlaneResource{
+				BaseResource: resources.BaseResource{Ref: parent.id},
+				External:     external,
+			},
+		)
+		rs.EventGatewayControlPlanes[len(rs.EventGatewayControlPlanes)-1].SetKonnectID(parent.id)
+	case resources.ResourceTypeEventGatewayVirtualCluster:
+		rs.EventGatewayVirtualClusters = append(
+			rs.EventGatewayVirtualClusters,
+			resources.EventGatewayVirtualClusterResource{
+				Ref:          parent.id,
+				EventGateway: parent.parentID,
+				External:     external,
+			},
+		)
+		rs.EventGatewayVirtualClusters[len(rs.EventGatewayVirtualClusters)-1].SetKonnectID(parent.id)
+	default:
+		return fmt.Errorf("cannot materialize inline external parent for %s", parent.resourceType)
+	}
+	return nil
+}
+
+func (r *externalLookupResolver) inlineLookupParentID(
+	rs *resources.ResourceSet,
+	resource resources.Resource,
+	relationship resources.RelationshipDescriptor,
+) (string, error) {
+	targetType := relationship.TargetType
+	capability, _ := resources.ExternalResolutionFor(targetType)
+	if capability.ParentType == "" {
+		return "", nil
+	}
+
+	if relationship.ScopeFieldPath == "" {
+		return "", fmt.Errorf("no parent-scope field registered for %s", targetType)
+	}
+	parentValue, err := stringFieldByPath(resource, relationship.ScopeFieldPath)
+	if err != nil {
+		return "", fmt.Errorf("lookup requires companion %s: %w", relationship.ScopeFieldPath, err)
+	}
+
+	if tags.IsExternalPlaceholder(parentValue) {
+		return "", fmt.Errorf("parent lookup must be resolved before child lookup")
+	}
+	if util.IsValidUUID(parentValue) {
+		return parentValue, nil
+	}
+	parentRef := parentValue
+	if tags.IsRefPlaceholder(parentValue) {
+		ref, field, ok := tags.ParseRefPlaceholder(parentValue)
+		if !ok || field != FieldID {
+			return "", fmt.Errorf("invalid parent reference %q", parentValue)
+		}
+		parentRef = ref
+	}
+	parent, ok := rs.GetResourceByRef(parentRef)
+	if !ok {
+		return "", fmt.Errorf("parent resource %q not found", parentValue)
+	}
+	if parent.GetType() != capability.ParentType {
+		return "", fmt.Errorf("parent %q is %s, expected %s", parentValue, parent.GetType(), capability.ParentType)
+	}
+	if parent.GetKonnectID() == "" {
+		return "", fmt.Errorf("parent resource %q does not have a resolved Konnect ID", parentValue)
+	}
+	return parent.GetKonnectID(), nil
+}
+
+func deckControlPlaneRefs(controlPlanes []resources.ControlPlaneResource) map[string]bool {
+	result := make(map[string]bool)
+	for i := range controlPlanes {
+		if controlPlanes[i].HasDeckConfig() {
+			result[controlPlanes[i].GetRef()] = true
+		}
+	}
+	return result
+}
+
+func resolveScopedParentID[T resources.Resource](value string, byRef map[string]T) (string, error) {
+	if tags.IsRefPlaceholder(value) {
+		ref, field, ok := tags.ParseRefPlaceholder(value)
+		if !ok || field != FieldID {
+			return "", fmt.Errorf("invalid parent reference %q", value)
+		}
+		value = ref
+	}
+	if util.IsValidUUID(value) {
+		return value, nil
+	}
+	parent, ok := byRef[value]
+	if !ok {
+		return "", fmt.Errorf("parent resource %q not found", value)
+	}
+	if parent.GetKonnectID() == "" {
+		return "", fmt.Errorf("parent resource %q does not have a resolved Konnect ID", value)
+	}
+	return parent.GetKonnectID(), nil
+}
+
+func matchExternalCandidates[T any](
+	req externalLookupRequest,
+	candidates []T,
+	id func(T) string,
+) (string, error) {
+	selector := &resources.ExternalSelector{MatchFields: req.MatchFields}
+	matches := make([]string, 0, 1)
+	for _, candidate := range candidates {
+		if selector.Match(candidate) {
+			matches = append(matches, id(candidate))
+		}
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf(
+			"%s: no %s matched selector {%s}", req.Source, req.ResourceType, tags.ExternalLookupKey(req.MatchFields),
+		)
+	}
+	if len(matches) > 1 {
+		return "", fmt.Errorf(
+			"%s: selector {%s} matched %d %s resources",
+			req.Source, tags.ExternalLookupKey(req.MatchFields), len(matches), req.ResourceType,
+		)
+	}
+	return matches[0], nil
+}
+
+func (r *externalLookupResolver) lookupPortal(ctx context.Context, req externalLookupRequest) (string, error) {
+	items, err := r.planner.client.ListAllPortals(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%s: list portals: %w", req.Source, err)
+	}
+	return matchExternalCandidates(req, items, func(item state.Portal) string { return item.ID })
+}
+
+func (r *externalLookupResolver) lookupControlPlane(ctx context.Context, req externalLookupRequest) (string, error) {
+	items, err := r.planner.client.ListAllControlPlanes(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%s: list control planes: %w", req.Source, err)
+	}
+	return matchExternalCandidates(req, items, func(item state.ControlPlane) string { return item.ID })
+}
+
+func (r *externalLookupResolver) lookupGatewayService(ctx context.Context, req externalLookupRequest) (string, error) {
+	items, err := r.planner.client.ListGatewayServices(ctx, req.ParentID)
+	if err != nil {
+		return "", fmt.Errorf("%s: list gateway services: %w", req.Source, err)
+	}
+	return matchExternalCandidates(req, items, func(item state.GatewayService) string { return item.ID })
+}
+
+func (r *externalLookupResolver) lookupAIGateway(ctx context.Context, req externalLookupRequest) (string, error) {
+	items, err := r.planner.client.ListAllAIGateways(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%s: list AI Gateways: %w", req.Source, err)
+	}
+	matches := make([]string, 0, 1)
+	for _, item := range items {
+		matched := true
+		for field, value := range req.MatchFields {
+			switch field {
+			case FieldName:
+				matched = matched && item.Name == value
+			case FieldDisplayName:
+				matched = matched && item.DisplayName == value
+			}
+		}
+		if matched {
+			matches = append(matches, item.ID)
+		}
+	}
+	return singleExternalID(req, matches)
+}
+
+func (r *externalLookupResolver) lookupAuditLogWebhookDestination(
+	ctx context.Context,
+	req externalLookupRequest,
+) (string, error) {
+	items, err := r.planner.client.ListAuditLogWebhookDestinations(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%s: list audit-log webhook destinations: %w", req.Source, err)
+	}
+	return matchExternalCandidates(req, items, func(item state.AuditLogWebhookDestination) string { return item.ID })
+}
+
+func (r *externalLookupResolver) lookupOrganizationTeam(
+	ctx context.Context,
+	req externalLookupRequest,
+) (string, error) {
+	teams, err := r.planner.client.ListAllOrganizationTeams(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%s: list organization teams: %w", req.Source, err)
+	}
+	matches := make([]string, 0, 1)
+	for _, team := range teams {
+		if team.Name != nil && *team.Name == req.MatchFields[FieldName] && team.ID != nil && *team.ID != "" {
+			matches = append(matches, *team.ID)
+		}
+	}
+	return singleExternalID(req, matches)
+}
+
+func (r *externalLookupResolver) lookupEventGatewayControlPlane(
+	ctx context.Context,
+	req externalLookupRequest,
+) (string, error) {
+	items, err := r.planner.client.ListAllEventGatewayControlPlanes(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%s: list Event Gateways: %w", req.Source, err)
+	}
+	return matchExternalCandidates(req, items, func(item state.EventGatewayControlPlane) string { return item.ID })
+}
+
+func (r *externalLookupResolver) lookupEventGatewayVirtualCluster(
+	ctx context.Context,
+	req externalLookupRequest,
+) (string, error) {
+	items, err := r.planner.client.ListEventGatewayVirtualClusters(ctx, req.ParentID)
+	if err != nil {
+		return "", fmt.Errorf("%s: list Event Gateway virtual clusters: %w", req.Source, err)
+	}
+	return matchExternalCandidates(req, items, func(item state.EventGatewayVirtualCluster) string { return item.ID })
+}
+
+func singleExternalID(req externalLookupRequest, matches []string) (string, error) {
+	if len(matches) == 0 {
+		return "", fmt.Errorf(
+			"%s: no %s matched selector {%s}", req.Source, req.ResourceType, tags.ExternalLookupKey(req.MatchFields),
+		)
+	}
+	if len(matches) > 1 {
+		return "", fmt.Errorf(
+			"%s: selector {%s} matched %d %s resources",
+			req.Source, tags.ExternalLookupKey(req.MatchFields), len(matches), req.ResourceType,
+		)
+	}
+	return matches[0], nil
+}
+
+func setStringFieldByPath(resource resources.Resource, path, value string) error {
+	if implementation, ok := resource.(*resources.APIImplementationResource); ok {
+		if implementation.ServiceReference == nil {
+			return fmt.Errorf("service is not configured")
+		}
+		service := implementation.ServiceReference.GetService()
+		if service == nil {
+			return fmt.Errorf("service is not configured")
+		}
+		switch path {
+		case "service.id":
+			service.ID = value
+			return nil
+		case "service.control_plane_id":
+			service.ControlPlaneID = value
+			return nil
+		}
+	}
+
+	current := reflect.ValueOf(resource)
+	for part := range strings.SplitSeq(path, ".") {
+		for current.Kind() == reflect.Pointer {
+			if current.IsNil() {
+				return fmt.Errorf("field %s is nil", path)
+			}
+			current = current.Elem()
+		}
+		current = findSettableTaggedField(current, part)
+		if !current.IsValid() {
+			return fmt.Errorf("field %s not found", path)
+		}
+	}
+	for current.Kind() == reflect.Pointer {
+		if current.IsNil() {
+			return fmt.Errorf("field %s is nil", path)
+		}
+		current = current.Elem()
+	}
+	if current.Kind() != reflect.String || !current.CanSet() {
+		return fmt.Errorf("field %s is not a settable string", path)
+	}
+	current.SetString(value)
+	return nil
+}
+
+func stringFieldByPath(resource resources.Resource, path string) (string, error) {
+	if implementation, ok := resource.(*resources.APIImplementationResource); ok {
+		if implementation.ServiceReference == nil || implementation.ServiceReference.GetService() == nil {
+			return "", fmt.Errorf("service is not configured")
+		}
+		service := implementation.ServiceReference.GetService()
+		switch path {
+		case "service.id":
+			return service.ID, nil
+		case "service.control_plane_id":
+			return service.ControlPlaneID, nil
+		}
+	}
+
+	current := reflect.ValueOf(resource)
+	for part := range strings.SplitSeq(path, ".") {
+		for current.Kind() == reflect.Pointer {
+			if current.IsNil() {
+				return "", fmt.Errorf("field %s is nil", path)
+			}
+			current = current.Elem()
+		}
+		current = findSettableTaggedField(current, part)
+		if !current.IsValid() {
+			return "", fmt.Errorf("field %s not found", path)
+		}
+	}
+	for current.Kind() == reflect.Pointer {
+		if current.IsNil() {
+			return "", fmt.Errorf("field %s is nil", path)
+		}
+		current = current.Elem()
+	}
+	if current.Kind() != reflect.String {
+		return "", fmt.Errorf("field %s is not a string", path)
+	}
+	return current.String(), nil
+}
+
+func findSettableTaggedField(value reflect.Value, name string) reflect.Value {
+	if value.Kind() != reflect.Struct {
+		return reflect.Value{}
+	}
+	typeOfValue := value.Type()
+	for i := 0; i < value.NumField(); i++ {
+		fieldInfo := typeOfValue.Field(i)
+		for _, tagName := range []string{"yaml", "json"} {
+			tag := strings.Split(fieldInfo.Tag.Get(tagName), ",")[0]
+			if tag == name {
+				return value.Field(i)
+			}
+		}
+	}
+	for i := 0; i < value.NumField(); i++ {
+		fieldInfo := typeOfValue.Field(i)
+		if !fieldInfo.Anonymous {
+			continue
+		}
+		field := value.Field(i)
+		for field.Kind() == reflect.Pointer && !field.IsNil() {
+			field = field.Elem()
+		}
+		if result := findSettableTaggedField(field, name); result.IsValid() {
+			return result
+		}
+	}
+	return reflect.Value{}
+}

--- a/internal/declarative/planner/external_lookup.go
+++ b/internal/declarative/planner/external_lookup.go
@@ -206,6 +206,7 @@ func (r *externalLookupResolver) resolveScopedDeclarations(ctx context.Context, 
 	for i := range rs.ControlPlanes {
 		controlPlaneByRef[rs.ControlPlanes[i].GetRef()] = &rs.ControlPlanes[i]
 	}
+	deckControlPlanes := deckControlPlaneRefs(rs.ControlPlanes)
 	for i := range rs.GatewayServices {
 		service := &rs.GatewayServices[i]
 		if !service.IsExternal() || service.GetKonnectID() != "" {
@@ -215,14 +216,15 @@ func (r *externalLookupResolver) resolveScopedDeclarations(ctx context.Context, 
 		if err != nil {
 			return fmt.Errorf("gateway_service %q: %w", service.GetRef(), err)
 		}
-		if parentID == "" && controlPlaneHasDeck(service, deckControlPlaneRefs(rs.ControlPlanes)) {
+		usesDeck := controlPlaneHasDeck(service, deckControlPlanes)
+		if parentID == "" && usesDeck {
 			continue
 		}
 		id, err := r.resolve(ctx, externalRequest(
 			service.GetType(), service.External, parentID, externalDeclarationSource(service),
 		))
 		if err != nil {
-			if controlPlaneHasDeck(service, deckControlPlaneRefs(rs.ControlPlanes)) {
+			if usesDeck {
 				continue
 			}
 			return err

--- a/internal/declarative/planner/external_lookup.go
+++ b/internal/declarative/planner/external_lookup.go
@@ -663,14 +663,18 @@ func setStringFieldByPath(resource resources.Resource, path, value string) error
 
 func stringFieldByPath(resource resources.Resource, path string) (string, error) {
 	if implementation, ok := resource.(*resources.APIImplementationResource); ok {
-		if implementation.ServiceReference == nil || implementation.ServiceReference.GetService() == nil {
-			return "", fmt.Errorf("service is not configured")
-		}
-		service := implementation.ServiceReference.GetService()
 		switch path {
 		case "service.id":
+			if implementation.ServiceReference == nil || implementation.ServiceReference.GetService() == nil {
+				return "", nil
+			}
+			service := implementation.ServiceReference.GetService()
 			return service.ID, nil
 		case "service.control_plane_id":
+			if implementation.ServiceReference == nil || implementation.ServiceReference.GetService() == nil {
+				return "", nil
+			}
+			service := implementation.ServiceReference.GetService()
 			return service.ControlPlaneID, nil
 		}
 	}

--- a/internal/declarative/planner/external_lookup_test.go
+++ b/internal/declarative/planner/external_lookup_test.go
@@ -94,6 +94,20 @@ func TestExternalLookupResolverDefersDeckServiceForNewControlPlane(t *testing.T)
 	require.Empty(t, rs.GatewayServices[0].GetKonnectID())
 }
 
+func TestExternalControlPlaneContributesOnlyExternalNamespace(t *testing.T) {
+	t.Parallel()
+
+	planner := &Planner{}
+	rs := &resources.ResourceSet{
+		ControlPlanes: []resources.ControlPlaneResource{{
+			BaseResource: resources.BaseResource{Ref: "external-control-plane"},
+			External:     &resources.ExternalBlock{ID: "control-plane-123"},
+		}},
+	}
+
+	require.Equal(t, []string{resources.NamespaceExternal}, planner.getResourceNamespaces(rs))
+}
+
 func externalPlaceholder(t *testing.T, tag string) string {
 	t.Helper()
 	value, err := tags.NewExternalTagResolver(tag).Resolve(&yaml.Node{

--- a/internal/declarative/planner/external_lookup_test.go
+++ b/internal/declarative/planner/external_lookup_test.go
@@ -1,0 +1,85 @@
+package planner
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/declarative/tags"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3" //nolint:gomodguard_v2 // yaml.v3 required to build tagged test nodes
+)
+
+func TestExternalLookupResolverInlineAliasesShareCache(t *testing.T) {
+	t.Parallel()
+
+	portalAPI := &MockPortalAPI{}
+	portalAPI.On("ListPortals", mock.Anything, mock.Anything).Return(&kkOps.ListPortalsResponse{
+		ListPortalsResponse: &kkComps.ListPortalsResponse{
+			Data: []kkComps.ListPortalsResponsePortal{newListPortal("portal-id", "Shared Portal", nil)},
+			Meta: kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: 1}},
+		},
+	}, nil).Once()
+
+	client := state.NewClient(state.ClientConfig{PortalAPI: portalAPI})
+	planner := NewPlanner(client, slog.Default())
+	resolver := newExternalLookupResolver(planner)
+	planner.externalResolver = resolver
+	rs := &resources.ResourceSet{APIPublications: []resources.APIPublicationResource{
+		{Ref: "external", PortalID: externalPlaceholder(t, "!external")},
+		{Ref: "lookup", PortalID: externalPlaceholder(t, "!lookup")},
+	}}
+
+	require.NoError(t, resolver.resolveInlineLookups(t.Context(), rs, resources.ResourceTypePortal))
+	require.Equal(t, "portal-id", rs.APIPublications[0].PortalID)
+	require.Equal(t, "portal-id", rs.APIPublications[1].PortalID)
+	require.NotContains(t, planner.getResourceNamespaces(rs), resources.NamespaceExternal)
+	portalAPI.AssertExpectations(t)
+}
+
+func TestExternalLookupResolverRejectsUnsupportedPlacement(t *testing.T) {
+	t.Parallel()
+
+	resolver := newExternalLookupResolver(NewPlanner(state.NewClient(state.ClientConfig{}), slog.Default()))
+	_, err := resolver.resolve(context.Background(), externalLookupRequest{
+		ResourceType: resources.ResourceTypeAPI,
+		MatchFields:  map[string]string{"name": "products"},
+		Source:       "api_publication products field portal_id",
+	})
+	require.ErrorContains(t, err, "does not support external lookup")
+}
+
+func TestEnsureInlineExternalParentBridgesRootChildPlanning(t *testing.T) {
+	t.Parallel()
+
+	rs := &resources.ResourceSet{AIGatewayProviders: []resources.AIGatewayProviderResource{{
+		BaseResource: resources.BaseResource{Ref: "provider"},
+		AIGateway:    "gateway-id",
+	}}}
+	require.NoError(t, ensureInlineExternalParent(rs, inlineExternalParent{
+		resourceType: resources.ResourceTypeAIGateway,
+		id:           "gateway-id",
+	}))
+	require.Len(t, rs.AIGateways, 1)
+	require.True(t, rs.AIGateways[0].IsExternal())
+	require.Equal(t, "gateway-id", rs.AIGateways[0].GetKonnectID())
+	require.Len(t, rs.GetAIGatewayProvidersForGateway("gateway-id"), 1)
+}
+
+func externalPlaceholder(t *testing.T, tag string) string {
+	t.Helper()
+	value, err := tags.NewExternalTagResolver(tag).Resolve(&yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Value: "name"},
+			{Kind: yaml.ScalarNode, Value: "Shared Portal"},
+		},
+	})
+	require.NoError(t, err)
+	return value.(string)
+}

--- a/internal/declarative/planner/external_lookup_test.go
+++ b/internal/declarative/planner/external_lookup_test.go
@@ -54,6 +54,22 @@ func TestExternalLookupResolverRejectsUnsupportedPlacement(t *testing.T) {
 	require.ErrorContains(t, err, "does not support external lookup")
 }
 
+func TestExternalLookupResolverSkipsAPIImplementationWithoutService(t *testing.T) {
+	t.Parallel()
+
+	resolver := newExternalLookupResolver(NewPlanner(state.NewClient(state.ClientConfig{}), slog.Default()))
+	rs := &resources.ResourceSet{APIImplementations: []resources.APIImplementationResource{{
+		Ref: "implementation",
+	}}}
+
+	require.NoError(t, resolver.resolveInlineLookups(
+		t.Context(),
+		rs,
+		resources.ResourceTypeControlPlane,
+		resources.ResourceTypeGatewayService,
+	))
+}
+
 func TestEnsureInlineExternalParentBridgesRootChildPlanning(t *testing.T) {
 	t.Parallel()
 

--- a/internal/declarative/planner/external_lookup_test.go
+++ b/internal/declarative/planner/external_lookup_test.go
@@ -71,6 +71,29 @@ func TestEnsureInlineExternalParentBridgesRootChildPlanning(t *testing.T) {
 	require.Len(t, rs.GetAIGatewayProvidersForGateway("gateway-id"), 1)
 }
 
+func TestExternalLookupResolverDefersDeckServiceForNewControlPlane(t *testing.T) {
+	t.Parallel()
+
+	rs := &resources.ResourceSet{
+		ControlPlanes: []resources.ControlPlaneResource{{
+			BaseResource: resources.BaseResource{Ref: "control-plane"},
+			Deck:         &resources.DeckConfig{Files: []string{"kong.yaml"}},
+		}},
+		GatewayServices: []resources.GatewayServiceResource{{
+			Ref:          "gateway-service",
+			ControlPlane: "control-plane",
+			External: &resources.ExternalBlock{Selector: &resources.ExternalSelector{
+				MatchFields: map[string]string{"name": "gateway-service"},
+			}},
+		}},
+	}
+
+	planner := NewPlanner(state.NewClient(state.ClientConfig{}), slog.Default())
+	resolver := newExternalLookupResolver(planner)
+	require.NoError(t, resolver.resolveScopedDeclarations(t.Context(), rs))
+	require.Empty(t, rs.GatewayServices[0].GetKonnectID())
+}
+
 func externalPlaceholder(t *testing.T, tag string) string {
 	t.Helper()
 	value, err := tags.NewExternalTagResolver(tag).Resolve(&yaml.Node{

--- a/internal/declarative/planner/planner.go
+++ b/internal/declarative/planner/planner.go
@@ -152,6 +152,7 @@ func (p *Planner) GeneratePlan(ctx context.Context, rs *resources.ResourceSet, o
 
 	if opts.Mode == PlanModeSync {
 		ensurePlanningSyncScope(rs)
+		excludeExternalOnlyControlPlaneSyncScope(rs)
 		if err := validateSyncScope(rs.SyncScope); err != nil {
 			return nil, err
 		}
@@ -2523,6 +2524,7 @@ func (p *Planner) resolveAuthStrategyIdentities(
 func (p *Planner) getResourceNamespaces(rs *resources.ResourceSet) []string {
 	namespaceSet := make(map[string]bool)
 	hasExternalPortals := false
+	hasExternalControlPlanes := false
 	hasExternalEventGateways := false
 	hasExternalAIGateways := false
 	hasExternalOrganizationTeams := false
@@ -2538,6 +2540,10 @@ func (p *Planner) getResourceNamespaces(rs *resources.ResourceSet) []string {
 	}
 
 	for _, cp := range rs.ControlPlanes {
+		if cp.IsExternal() {
+			hasExternalControlPlanes = true
+			continue
+		}
 		ns := resources.GetNamespace(cp.Kongctl)
 		namespaceSet[ns] = true
 	}
@@ -2614,6 +2620,7 @@ func (p *Planner) getResourceNamespaces(rs *resources.ResourceSet) []string {
 	sort.Strings(namespaces)
 
 	if hasExternalPortals ||
+		hasExternalControlPlanes ||
 		hasExternalEventGateways ||
 		hasExternalAIGateways ||
 		hasExternalOrganizationTeams ||

--- a/internal/declarative/planner/planner.go
+++ b/internal/declarative/planner/planner.go
@@ -57,7 +57,8 @@ type Planner struct {
 	changeCount int
 
 	// Cache for managed resources fetched during a single GeneratePlan run.
-	resourceCache *planningResourceCache
+	resourceCache    *planningResourceCache
+	externalResolver *externalLookupResolver
 
 	// For multi-namespace runs, prefer one all-namespace read per resource type
 	// and filter in-memory per namespace to reduce API calls.
@@ -151,7 +152,6 @@ func (p *Planner) GeneratePlan(ctx context.Context, rs *resources.ResourceSet, o
 
 	if opts.Mode == PlanModeSync {
 		ensurePlanningSyncScope(rs)
-		basePlan.Metadata.SyncScope = syncScopeMetadata(rs.SyncScope)
 		if err := validateSyncScope(rs.SyncScope); err != nil {
 			return nil, err
 		}
@@ -163,6 +163,9 @@ func (p *Planner) GeneratePlan(ctx context.Context, rs *resources.ResourceSet, o
 		rs,
 	); err != nil {
 		return nil, fmt.Errorf("failed to resolve resource identities: %w", err)
+	}
+	if opts.Mode == PlanModeSync {
+		basePlan.Metadata.SyncScope = syncScopeMetadata(rs.SyncScope)
 	}
 
 	// Initialize resolver with populated ResourceSet
@@ -893,6 +896,23 @@ func (p *Planner) GetDesiredPortalSnippets() []resources.PortalSnippetResource {
 
 // resolveResourceIdentities pre-resolves Konnect IDs for all resources
 func (p *Planner) resolveResourceIdentities(ctx context.Context, rs *resources.ResourceSet) error {
+	p.externalResolver = newExternalLookupResolver(p)
+	if err := p.externalResolver.resolveDeclarations(ctx, rs); err != nil {
+		return fmt.Errorf("failed to resolve external declarations: %w", err)
+	}
+	if err := p.externalResolver.resolveInlineLookups(
+		ctx,
+		rs,
+		resources.ResourceTypeControlPlane,
+		resources.ResourceTypeEventGatewayControlPlane,
+		resources.ResourceTypePortal,
+		resources.ResourceTypeAIGateway,
+		resources.ResourceTypeAuditLogWebhookDestination,
+		resources.ResourceTypeOrganizationTeam,
+	); err != nil {
+		return fmt.Errorf("failed to resolve inline external lookups: %w", err)
+	}
+
 	// Resolve Control Plane identities
 	if err := p.resolveControlPlaneIdentities(ctx, rs.ControlPlanes); err != nil {
 		return fmt.Errorf("failed to resolve control plane identities: %w", err)
@@ -900,6 +920,18 @@ func (p *Planner) resolveResourceIdentities(ctx context.Context, rs *resources.R
 
 	if err := p.resolveEventGatewayControlPlaneIdentities(ctx, rs.EventGatewayControlPlanes); err != nil {
 		return fmt.Errorf("failed to resolve Event Gateway identities: %w", err)
+	}
+
+	if err := p.externalResolver.resolveScopedDeclarations(ctx, rs); err != nil {
+		return fmt.Errorf("failed to resolve scoped external declarations: %w", err)
+	}
+	if err := p.externalResolver.resolveInlineLookups(
+		ctx,
+		rs,
+		resources.ResourceTypeGatewayService,
+		resources.ResourceTypeEventGatewayVirtualCluster,
+	); err != nil {
+		return fmt.Errorf("failed to resolve scoped inline external lookups: %w", err)
 	}
 
 	if err := p.resolveGatewayServiceIdentities(ctx, rs.GatewayServices, rs.ControlPlanes); err != nil {
@@ -1114,7 +1146,11 @@ func matchExternalAIGateway(
 	if gateway.External.ID != "" {
 		match := gatewayByID[gateway.External.ID]
 		if match == nil {
-			return nil, fmt.Errorf("external ai_gateway %s: not found with id %s", gateway.GetRef(), gateway.External.ID)
+			return nil, fmt.Errorf(
+				"external ai_gateway %s: not found with id %s",
+				gateway.GetRef(),
+				gateway.External.ID,
+			)
 		}
 		return match, nil
 	}
@@ -1136,7 +1172,10 @@ func matchExternalAIGateway(
 		return singleExternalAIGatewayMatch(gateway.GetRef(), FieldName, name, gatewayByName[name])
 	}
 
-	return nil, fmt.Errorf("external ai_gateway %s: selector supports 'display_name' or 'name' fields", gateway.GetRef())
+	return nil, fmt.Errorf(
+		"external ai_gateway %s: selector supports 'display_name' or 'name' fields",
+		gateway.GetRef(),
+	)
 }
 
 func singleExternalAIGatewayMatch(
@@ -1517,6 +1556,9 @@ func (p *Planner) resolveGatewayServiceIdentities(
 		}
 
 		service.SetResolvedControlPlaneID(cpID)
+		if service.GetKonnectID() != "" {
+			continue
+		}
 
 		if !service.IsExternal() {
 			// Managed services will be resolved when supported; for now record CP ID only.
@@ -1607,6 +1649,16 @@ func (p *Planner) resolveAuditLogWebhookDestinationIdentities(
 	destinations []resources.AuditLogWebhookDestinationResource,
 ) error {
 	if len(destinations) == 0 {
+		return nil
+	}
+	needsLookup := false
+	for i := range destinations {
+		if destinations[i].GetKonnectID() == "" {
+			needsLookup = true
+			break
+		}
+	}
+	if !needsLookup {
 		return nil
 	}
 
@@ -2564,7 +2616,8 @@ func (p *Planner) getResourceNamespaces(rs *resources.ResourceSet) []string {
 	if hasExternalPortals ||
 		hasExternalEventGateways ||
 		hasExternalAIGateways ||
-		hasExternalOrganizationTeams {
+		hasExternalOrganizationTeams ||
+		(p.externalResolver != nil && p.externalResolver.hasInlineParents) {
 		namespaces = append(namespaces, resources.NamespaceExternal)
 	}
 

--- a/internal/declarative/planner/planner.go
+++ b/internal/declarative/planner/planner.go
@@ -455,6 +455,7 @@ func (p *Planner) GeneratePlan(ctx context.Context, rs *resources.ResourceSet, o
 	// Resolve dependencies and calculate execution order.
 	// Inject additional dependency constraints that span resource planners.
 	adjustControlPlaneGroupDeleteDependencies(basePlan.Changes)
+	adjustControlPlaneAPIImplementationDeleteDependencies(basePlan.Changes, rs)
 	adjustAuthStrategyDeleteDependencies(basePlan.Changes)
 	adjustDCRProviderDeleteDependencies(basePlan.Changes)
 
@@ -597,6 +598,67 @@ func adjustControlPlaneGroupDeleteDependencies(changes []PlannedChange) {
 				memberChange := &changes[memberIdx]
 				memberChange.DependsOn = appendDependsOn(memberChange.DependsOn, groupChange.ID)
 			}
+		}
+	}
+}
+
+// adjustControlPlaneAPIImplementationDeleteDependencies ensures control plane
+// DELETE changes execute after API implementation relationships are removed.
+func adjustControlPlaneAPIImplementationDeleteDependencies(changes []PlannedChange, rs *resources.ResourceSet) {
+	controlPlaneDeletes := make(map[string]*PlannedChange)
+	apiDeletes := make(map[string]*PlannedChange)
+
+	for i := range changes {
+		change := &changes[i]
+		if change.Action != ActionDelete {
+			continue
+		}
+		switch change.ResourceType {
+		case ResourceTypeControlPlane:
+			if change.ResourceID != "" {
+				controlPlaneDeletes[change.ResourceID] = change
+			}
+			if change.ResourceRef != "" {
+				controlPlaneDeletes[change.ResourceRef] = change
+			}
+		case ResourceTypeAPI:
+			if change.ResourceRef != "" {
+				apiDeletes[change.ResourceRef] = change
+			}
+		}
+	}
+
+	for i := range changes {
+		change := &changes[i]
+		if change.Action != ActionDelete || change.ResourceType != ResourceTypeAPIImplementation {
+			continue
+		}
+		service, ok := change.Fields[FieldService].(map[string]any)
+		if !ok {
+			continue
+		}
+		controlPlaneID, _ := service[FieldControlPlaneID].(string)
+		if controlPlaneDelete := controlPlaneDeletes[controlPlaneID]; controlPlaneDelete != nil {
+			controlPlaneDelete.DependsOn = appendDependsOn(controlPlaneDelete.DependsOn, change.ID)
+		}
+	}
+
+	if rs == nil {
+		return
+	}
+	for i := range rs.APIImplementations {
+		implementation := &rs.APIImplementations[i]
+		if implementation.ServiceReference == nil {
+			continue
+		}
+		service := implementation.ServiceReference.GetService()
+		if service == nil {
+			continue
+		}
+		controlPlaneDelete := controlPlaneDeletes[normalizeControlPlaneRef(service.ControlPlaneID)]
+		apiDelete := apiDeletes[resources.NormalizeResourceRef(implementation.API)]
+		if controlPlaneDelete != nil && apiDelete != nil {
+			controlPlaneDelete.DependsOn = appendDependsOn(controlPlaneDelete.DependsOn, apiDelete.ID)
 		}
 	}
 }

--- a/internal/declarative/planner/sync_scope.go
+++ b/internal/declarative/planner/sync_scope.go
@@ -85,6 +85,18 @@ func ensurePlanningSyncScope(rs *resources.ResourceSet) {
 	addOrganizationChildScopes(scope, rs)
 }
 
+func excludeExternalOnlyControlPlaneSyncScope(rs *resources.ResourceSet) {
+	if rs == nil || rs.SyncScope == nil || len(rs.ControlPlanes) == 0 {
+		return
+	}
+	for i := range rs.ControlPlanes {
+		if !rs.ControlPlanes[i].IsExternal() {
+			return
+		}
+	}
+	rs.SyncScope.RemoveRoot(resources.ResourceTypeControlPlane)
+}
+
 func hasOrganizationAssignmentSelectors(rs *resources.ResourceSet) bool {
 	return rs != nil && rs.Organization != nil &&
 		(len(rs.Organization.Users) > 0 || len(rs.Organization.SystemAccounts) > 0)

--- a/internal/declarative/planner/sync_scope.go
+++ b/internal/declarative/planner/sync_scope.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/tags"
 )
 
 func syncScopeMetadata(scope *resources.SyncScope) *PlanSyncScope {
@@ -348,6 +349,9 @@ func validateParentScopes(scope *resources.SyncScope) error {
 	}
 	for _, child := range scope.ChildScopes() {
 		if !syncRootParentType(child.ParentType) || scope.RootInScope(child.ParentType) {
+			continue
+		}
+		if tags.IsExternalPlaceholder(child.ParentRef) {
 			continue
 		}
 		guidance := "add the parent resource collection or move the child collection under that parent"

--- a/internal/declarative/planner/sync_scope.go
+++ b/internal/declarative/planner/sync_scope.go
@@ -403,6 +403,7 @@ func syncParentTypeSupportsExternal(rt resources.ResourceType) bool {
 	switch rt {
 	case resources.ResourceTypePortal,
 		resources.ResourceTypeControlPlane,
+		resources.ResourceTypeAIGateway,
 		resources.ResourceTypeEventGatewayControlPlane,
 		resources.ResourceTypeOrganizationTeam:
 		return true
@@ -431,7 +432,7 @@ func (p *Planner) shouldPlanRoot(plan *Plan, rt resources.ResourceType) bool {
 	if planAll {
 		return true
 	}
-	return scope.RootInScope(rt)
+	return scope.RootInScope(rt) || scope.ParentHasChildScope(rt)
 }
 
 func (p *Planner) shouldPlanChild(

--- a/internal/declarative/planner/sync_scope_test.go
+++ b/internal/declarative/planner/sync_scope_test.go
@@ -38,6 +38,58 @@ func TestGeneratePlan_SyncWithNoScopeDoesNotListResources(t *testing.T) {
 	mockAppAuthAPI.AssertNotCalled(t, "ListAppAuthStrategies", mock.Anything, mock.Anything)
 }
 
+func TestExcludeExternalOnlyControlPlaneSyncScope(t *testing.T) {
+	t.Parallel()
+
+	t.Run("external only", func(t *testing.T) {
+		t.Parallel()
+
+		scope := resources.NewSyncScope()
+		scope.AddRoot(resources.ResourceTypeControlPlane)
+		rs := &resources.ResourceSet{
+			ControlPlanes: []resources.ControlPlaneResource{{
+				BaseResource: resources.BaseResource{Ref: "external"},
+				External:     &resources.ExternalBlock{ID: "control-plane-123"},
+			}},
+			SyncScope: scope,
+		}
+
+		excludeExternalOnlyControlPlaneSyncScope(rs)
+		require.False(t, scope.RootInScope(resources.ResourceTypeControlPlane))
+	})
+
+	t.Run("managed and external", func(t *testing.T) {
+		t.Parallel()
+
+		scope := resources.NewSyncScope()
+		scope.AddRoot(resources.ResourceTypeControlPlane)
+		rs := &resources.ResourceSet{
+			ControlPlanes: []resources.ControlPlaneResource{
+				{BaseResource: resources.BaseResource{Ref: "managed"}},
+				{
+					BaseResource: resources.BaseResource{Ref: "external"},
+					External:     &resources.ExternalBlock{ID: "control-plane-123"},
+				},
+			},
+			SyncScope: scope,
+		}
+
+		excludeExternalOnlyControlPlaneSyncScope(rs)
+		require.True(t, scope.RootInScope(resources.ResourceTypeControlPlane))
+	})
+
+	t.Run("explicit empty collection", func(t *testing.T) {
+		t.Parallel()
+
+		scope := resources.NewSyncScope()
+		scope.AddRoot(resources.ResourceTypeControlPlane)
+		rs := &resources.ResourceSet{SyncScope: scope}
+
+		excludeExternalOnlyControlPlaneSyncScope(rs)
+		require.True(t, scope.RootInScope(resources.ResourceTypeControlPlane))
+	})
+}
+
 func TestValidateParentScopesAllowsInlineExternalParent(t *testing.T) {
 	t.Parallel()
 

--- a/internal/declarative/planner/sync_scope_test.go
+++ b/internal/declarative/planner/sync_scope_test.go
@@ -111,6 +111,24 @@ func TestValidateParentScopesAllowsInlineExternalParent(t *testing.T) {
 	))
 }
 
+func TestShouldPlanRootForScopedInlineExternalChildren(t *testing.T) {
+	t.Parallel()
+
+	scope := resources.NewSyncScope()
+	scope.AddChild(
+		resources.ResourceTypeAIGateway,
+		"gateway-id",
+		resources.ResourceTypeAIGatewayProvider,
+	)
+	planner := &Planner{
+		resources: &resources.ResourceSet{SyncScope: scope},
+	}
+	plan := NewPlan("1.0", "test", PlanModeSync)
+
+	require.True(t, planner.shouldPlanRoot(plan, resources.ResourceTypeAIGateway))
+	require.False(t, planner.shouldPlanRoot(plan, resources.ResourceTypePortal))
+}
+
 func TestGeneratePlan_SyncPortalScopeDoesNotListUnscopedRoots(t *testing.T) {
 	ctx := context.Background()
 	mockPortalAPI := new(MockPortalAPI)

--- a/internal/declarative/planner/sync_scope_test.go
+++ b/internal/declarative/planner/sync_scope_test.go
@@ -38,6 +38,27 @@ func TestGeneratePlan_SyncWithNoScopeDoesNotListResources(t *testing.T) {
 	mockAppAuthAPI.AssertNotCalled(t, "ListAppAuthStrategies", mock.Anything, mock.Anything)
 }
 
+func TestValidateParentScopesAllowsInlineExternalParent(t *testing.T) {
+	t.Parallel()
+
+	placeholder := externalPlaceholder(t, "!external")
+	scope := resources.NewSyncScope()
+	scope.AddChild(resources.ResourceTypeAIGateway, placeholder, resources.ResourceTypeAIGatewayProvider)
+	require.NoError(t, validateParentScopes(scope))
+
+	scope.RebindChildParent(resources.ResourceTypeAIGateway, placeholder, "gateway-id")
+	require.True(t, scope.ChildInScope(
+		resources.ResourceTypeAIGateway,
+		"gateway-id",
+		resources.ResourceTypeAIGatewayProvider,
+	))
+	require.False(t, scope.ChildInScope(
+		resources.ResourceTypeAIGateway,
+		placeholder,
+		resources.ResourceTypeAIGatewayProvider,
+	))
+}
+
 func TestGeneratePlan_SyncPortalScopeDoesNotListUnscopedRoots(t *testing.T) {
 	ctx := context.Background()
 	mockPortalAPI := new(MockPortalAPI)

--- a/internal/declarative/resources/ai_gateway.go
+++ b/internal/declarative/resources/ai_gateway.go
@@ -16,7 +16,7 @@ const (
 var aiGatewayMaturity = maturity.Metadata{Level: maturity.LevelBeta}
 
 func init() {
-	registerResourceType(
+	registerExternalResourceType(
 		ResourceTypeAIGateway,
 		func(rs *ResourceSet) *[]AIGatewayResource { return &rs.AIGateways },
 		AutoExplain[AIGatewayResource](
@@ -24,9 +24,12 @@ func init() {
 			WithExplainRecommendedFields("ref", "name", "display_name"),
 			WithExplainSchemaBuilder(aiGatewayExplainNode),
 		),
+		ExternalResolutionRegistration{Selectors: []string{SchemaFieldName, "display_name"}},
 		WithMaturity(aiGatewayMaturity),
 	)
 }
+
+func (a *AIGatewayResource) GetExternalBlock() *ExternalBlock { return a.External }
 
 // AIGatewayResource represents a Konnect AI Gateway in declarative configuration.
 type AIGatewayResource struct {

--- a/internal/declarative/resources/ai_gateway_provider.go
+++ b/internal/declarative/resources/ai_gateway_provider.go
@@ -6,7 +6,6 @@ import (
 )
 
 const (
-	aiGatewayProviderFieldName        = "name"
 	aiGatewayProviderFieldType        = "type"
 	aiGatewayProviderFieldDisplayName = "display_name"
 	aiGatewayProviderFieldLabels      = "labels"
@@ -154,7 +153,7 @@ func (a AIGatewayProviderResource) GetReferenceFieldMappings() map[string]string
 
 func (a AIGatewayProviderResource) PayloadMap() (map[string]any, error) {
 	payload := map[string]any{
-		aiGatewayProviderFieldName:        a.Name,
+		SchemaFieldName:                   a.Name,
 		aiGatewayProviderFieldType:        a.Type,
 		aiGatewayProviderFieldDisplayName: a.DisplayName,
 		aiGatewayProviderFieldConfig:      a.Config,

--- a/internal/declarative/resources/audit_log_webhook_destination.go
+++ b/internal/declarative/resources/audit_log_webhook_destination.go
@@ -3,7 +3,7 @@ package resources
 import "fmt"
 
 func init() {
-	registerResourceTypeWithSliceAccessors(
+	registerExternalResourceTypeWithSliceAccessors(
 		ResourceTypeAuditLogWebhookDestination,
 		auditLogWebhookDestinationSlice,
 		ensureAuditLogWebhookDestinationSlice,
@@ -11,8 +11,11 @@ func init() {
 			WithExplainAliases("audit-logs.destinations"),
 			WithExplainRecommendedFields("ref", "_external"),
 		),
+		ExternalResolutionRegistration{Selectors: []string{SchemaFieldName}},
 	)
 }
+
+func (d *AuditLogWebhookDestinationResource) GetExternalBlock() *ExternalBlock { return d.External }
 
 func auditLogWebhookDestinationSlice(rs *ResourceSet) *[]AuditLogWebhookDestinationResource {
 	if rs == nil || rs.AuditLogs == nil {

--- a/internal/declarative/resources/control_plane.go
+++ b/internal/declarative/resources/control_plane.go
@@ -8,12 +8,15 @@ import (
 )
 
 func init() {
-	registerResourceType(
+	registerExternalResourceType(
 		ResourceTypeControlPlane,
 		func(rs *ResourceSet) *[]ControlPlaneResource { return &rs.ControlPlanes },
 		AutoExplain[ControlPlaneResource](),
+		ExternalResolutionRegistration{Selectors: []string{SchemaFieldName}},
 	)
 }
+
+func (c *ControlPlaneResource) GetExternalBlock() *ExternalBlock { return c.External }
 
 // ControlPlaneGroupMember represents a member entry for a control plane group.
 type ControlPlaneGroupMember struct {

--- a/internal/declarative/resources/dcr_provider.go
+++ b/internal/declarative/resources/dcr_provider.go
@@ -119,7 +119,7 @@ func (d *DCRProviderResource) TryMatchKonnectResource(konnectResource any) bool 
 
 func (d DCRProviderResource) ToCreatePayload() map[string]any {
 	payload := map[string]any{
-		"name":          d.Name,
+		SchemaFieldName: d.Name,
 		"provider_type": d.ProviderType,
 		"issuer":        NormalizeDCRProviderIssuer(d.Issuer),
 		"dcr_config":    d.DCRConfig,

--- a/internal/declarative/resources/event_gateway_control_plane.go
+++ b/internal/declarative/resources/event_gateway_control_plane.go
@@ -7,14 +7,17 @@ import (
 )
 
 func init() {
-	registerResourceType(
+	registerExternalResourceType(
 		ResourceTypeEventGatewayControlPlane,
 		func(rs *ResourceSet) *[]EventGatewayControlPlaneResource { return &rs.EventGatewayControlPlanes },
 		AutoExplain[EventGatewayControlPlaneResource](
 			WithExplainAliases("egw"),
 		),
+		ExternalResolutionRegistration{AllowAnyStringSelector: true},
 	)
 }
+
+func (e *EventGatewayControlPlaneResource) GetExternalBlock() *ExternalBlock { return e.External }
 
 type EventGatewayControlPlaneResource struct {
 	BaseResource

--- a/internal/declarative/resources/event_gateway_virtual_cluster.go
+++ b/internal/declarative/resources/event_gateway_virtual_cluster.go
@@ -8,14 +8,19 @@ import (
 )
 
 func init() {
-	registerResourceType(
+	registerExternalResourceType(
 		ResourceTypeEventGatewayVirtualCluster,
 		func(rs *ResourceSet) *[]EventGatewayVirtualClusterResource { return &rs.EventGatewayVirtualClusters },
 		AutoExplain[EventGatewayVirtualClusterResource](
 			WithExplainSchemaBuilder(eventGatewayVirtualClusterExplainNode),
 		),
+		ExternalResolutionRegistration{
+			ParentType: ResourceTypeEventGatewayControlPlane, AllowAnyStringSelector: true,
+		},
 	)
 }
+
+func (e *EventGatewayVirtualClusterResource) GetExternalBlock() *ExternalBlock { return e.External }
 
 type EventGatewayVirtualClusterResource struct {
 	kkComps.CreateVirtualClusterRequest `       yaml:",inline"                 json:",inline"`

--- a/internal/declarative/resources/explain.go
+++ b/internal/declarative/resources/explain.go
@@ -1003,7 +1003,8 @@ func applyRelationshipHints(rt ResourceType, node *ExplainNode) {
 			ScopeField: relationship.ScopeFieldPath,
 			RootOnly:   relationship.RootOnly,
 		}
-		if capability, supported := ExternalResolutionFor(relationship.TargetType); supported {
+		capability, supportsExternal := ExternalResolutionFor(relationship.TargetType)
+		if supportsExternal {
 			metadata.AcceptedTags = []string{"!ref", "!external", "!lookup"}
 			metadata.Selectors = append([]string(nil), capability.Selectors...)
 			if capability.AllowAnyStringSelector {
@@ -1019,10 +1020,19 @@ func applyRelationshipHints(rt ResourceType, node *ExplainNode) {
 		}
 		fieldNode.Notes = append(
 			fieldNode.Notes,
-			fmt.Sprintf("Relationship field (%s); use !external or the equivalent !lookup for an existing remote resource.",
-				relationship.Kind),
+			relationshipExplainNote(relationship.Kind, supportsExternal),
 		)
 	}
+}
+
+func relationshipExplainNote(kind RelationshipKind, supportsExternal bool) string {
+	if supportsExternal {
+		return fmt.Sprintf(
+			"Relationship field (%s); use !lookup or its !external alias for an existing remote resource.",
+			kind,
+		)
+	}
+	return fmt.Sprintf("Relationship field (%s); use !ref to reference a declarative resource.", kind)
 }
 
 func defaultExplainHints(rt ResourceType) map[string]ExplainFieldHint {

--- a/internal/declarative/resources/explain.go
+++ b/internal/declarative/resources/explain.go
@@ -113,6 +113,7 @@ type ExplainNode struct {
 	Recommended  bool
 	PreferredTag string
 	RefKind      string
+	Relationship *ExplainRelationship
 	Notes        []string
 	Literal      string
 	Properties   []*ExplainField
@@ -130,32 +131,43 @@ type ExplainField struct {
 }
 
 type JSONSchema struct {
-	Schema      string                  `json:"$schema,omitempty" yaml:"$schema,omitempty"`
-	ID          string                  `json:"$id,omitempty" yaml:"$id,omitempty"`
-	Title       string                  `json:"title,omitempty" yaml:"title,omitempty"`
-	Description string                  `json:"description,omitempty" yaml:"description,omitempty"`
-	Type        any                     `json:"type,omitempty" yaml:"type,omitempty"`
-	Properties  map[string]*JSONSchema  `json:"properties,omitempty" yaml:"properties,omitempty"`
-	Required    []string                `json:"required,omitempty" yaml:"required,omitempty"`
-	Items       *JSONSchema             `json:"items,omitempty" yaml:"items,omitempty"`
-	Additional  any                     `json:"additionalProperties,omitempty" yaml:"additionalProperties,omitempty"`
-	OneOf       []*JSONSchema           `json:"oneOf,omitempty" yaml:"oneOf,omitempty"`
-	Const       any                     `json:"const,omitempty" yaml:"const,omitempty"`
-	Enum        []any                   `json:"enum,omitempty" yaml:"enum,omitempty"`
-	Default     any                     `json:"default,omitempty" yaml:"default,omitempty"`
-	XResource   any                     `json:"x-kongctl-resource,omitempty" yaml:"x-kongctl-resource,omitempty"`
-	XPath       string                  `json:"x-kongctl-path,omitempty" yaml:"x-kongctl-path,omitempty"`
-	XRootKey    string                  `json:"x-kongctl-root-key,omitempty" yaml:"x-kongctl-root-key,omitempty"`
-	XClass      string                  `json:"x-kongctl-resource-class,omitempty" yaml:"x-kongctl-resource-class,omitempty"` //nolint:lll
-	XRefKind    string                  `json:"x-kongctl-ref-kind,omitempty" yaml:"x-kongctl-ref-kind,omitempty"`
-	XTag        string                  `json:"x-kongctl-preferred-tag,omitempty" yaml:"x-kongctl-preferred-tag,omitempty"`
-	XDefault    string                  `json:"x-kongctl-default-from,omitempty" yaml:"x-kongctl-default-from,omitempty"`
-	XNotes      []string                `json:"x-kongctl-notes,omitempty" yaml:"x-kongctl-notes,omitempty"`
-	XSubject    *ExplainSchemaSubject   `json:"x-kongctl-subject,omitempty" yaml:"x-kongctl-subject,omitempty"`
-	XPlacement  *ExplainSchemaPlacement `json:"x-kongctl-placement,omitempty" yaml:"x-kongctl-placement,omitempty"`
-	XRoot       *bool                   `json:"x-kongctl-supports-root,omitempty" yaml:"x-kongctl-supports-root,omitempty"`
-	XNestedDecl *bool                   `json:"x-kongctl-supports-nested-declaration,omitempty" yaml:"x-kongctl-supports-nested-declaration,omitempty"` //nolint:lll
-	XMaturity   *ExplainMaturity        `json:"x-kongctl-maturity,omitempty" yaml:"x-kongctl-maturity,omitempty"`
+	Schema        string                  `json:"$schema,omitempty" yaml:"$schema,omitempty"`
+	ID            string                  `json:"$id,omitempty" yaml:"$id,omitempty"`
+	Title         string                  `json:"title,omitempty" yaml:"title,omitempty"`
+	Description   string                  `json:"description,omitempty" yaml:"description,omitempty"`
+	Type          any                     `json:"type,omitempty" yaml:"type,omitempty"`
+	Properties    map[string]*JSONSchema  `json:"properties,omitempty" yaml:"properties,omitempty"`
+	Required      []string                `json:"required,omitempty" yaml:"required,omitempty"`
+	Items         *JSONSchema             `json:"items,omitempty" yaml:"items,omitempty"`
+	Additional    any                     `json:"additionalProperties,omitempty" yaml:"additionalProperties,omitempty"`
+	OneOf         []*JSONSchema           `json:"oneOf,omitempty" yaml:"oneOf,omitempty"`
+	Const         any                     `json:"const,omitempty" yaml:"const,omitempty"`
+	Enum          []any                   `json:"enum,omitempty" yaml:"enum,omitempty"`
+	Default       any                     `json:"default,omitempty" yaml:"default,omitempty"`
+	XResource     any                     `json:"x-kongctl-resource,omitempty" yaml:"x-kongctl-resource,omitempty"`
+	XPath         string                  `json:"x-kongctl-path,omitempty" yaml:"x-kongctl-path,omitempty"`
+	XRootKey      string                  `json:"x-kongctl-root-key,omitempty" yaml:"x-kongctl-root-key,omitempty"`
+	XClass        string                  `json:"x-kongctl-resource-class,omitempty" yaml:"x-kongctl-resource-class,omitempty"` //nolint:lll
+	XRefKind      string                  `json:"x-kongctl-ref-kind,omitempty" yaml:"x-kongctl-ref-kind,omitempty"`
+	XRelationship *ExplainRelationship    `json:"x-kongctl-relationship,omitempty" yaml:"x-kongctl-relationship,omitempty"`
+	XTag          string                  `json:"x-kongctl-preferred-tag,omitempty" yaml:"x-kongctl-preferred-tag,omitempty"` //nolint:lll
+	XDefault      string                  `json:"x-kongctl-default-from,omitempty" yaml:"x-kongctl-default-from,omitempty"`
+	XNotes        []string                `json:"x-kongctl-notes,omitempty" yaml:"x-kongctl-notes,omitempty"`
+	XSubject      *ExplainSchemaSubject   `json:"x-kongctl-subject,omitempty" yaml:"x-kongctl-subject,omitempty"`
+	XPlacement    *ExplainSchemaPlacement `json:"x-kongctl-placement,omitempty" yaml:"x-kongctl-placement,omitempty"`
+	XRoot         *bool                   `json:"x-kongctl-supports-root,omitempty" yaml:"x-kongctl-supports-root,omitempty"`                             //nolint:lll
+	XNestedDecl   *bool                   `json:"x-kongctl-supports-nested-declaration,omitempty" yaml:"x-kongctl-supports-nested-declaration,omitempty"` //nolint:lll
+	XMaturity     *ExplainMaturity        `json:"x-kongctl-maturity,omitempty" yaml:"x-kongctl-maturity,omitempty"`
+}
+
+// ExplainRelationship describes the user-visible contract of a resource relationship field.
+type ExplainRelationship struct {
+	Target       ResourceType     `json:"target" yaml:"target"`
+	Kind         RelationshipKind `json:"kind" yaml:"kind"`
+	AcceptedTags []string         `json:"accepted_tags,omitempty" yaml:"accepted_tags,omitempty"`
+	Selectors    []string         `json:"selectors,omitempty" yaml:"selectors,omitempty"`
+	ScopeField   string           `json:"scope_field,omitempty" yaml:"scope_field,omitempty"`
+	RootOnly     bool             `json:"root_only,omitempty" yaml:"root_only,omitempty"`
 }
 
 type ExplainSchemaSubject struct {
@@ -182,13 +194,13 @@ var (
 	explainDocCacheMu sync.RWMutex
 
 	recommendedFieldNames = map[string]struct{}{
-		SchemaFieldRef: {},
-		"name":         {},
-		"display_name": {},
-		"description":  {},
-		"version":      {},
-		"slug":         {},
-		"spec":         {},
+		SchemaFieldRef:  {},
+		SchemaFieldName: {},
+		"display_name":  {},
+		"description":   {},
+		"version":       {},
+		"slug":          {},
+		"spec":          {},
 	}
 	fileFieldSamples = map[string]string{
 		"content":            "./content.txt",
@@ -959,6 +971,8 @@ func buildExplainSchema(rt ResourceType, reg ExplainRegistration) (*ExplainNode,
 			return nil, err
 		}
 		if node != nil {
+			applyReferenceHints(rt, node)
+			applyRelationshipHints(rt, node)
 			return node, nil
 		}
 	}
@@ -972,8 +986,43 @@ func buildExplainSchema(rt ResourceType, reg ExplainRegistration) (*ExplainNode,
 	}
 
 	applyReferenceHints(rt, node)
+	applyRelationshipHints(rt, node)
 
 	return node, nil
+}
+
+func applyRelationshipHints(rt ResourceType, node *ExplainNode) {
+	for _, relationship := range RelationshipDescriptorsForType(rt) {
+		fieldNode, ok := node.lookup(strings.Split(relationship.FieldPath, "."))
+		if !ok {
+			continue
+		}
+		metadata := &ExplainRelationship{
+			Target:     relationship.TargetType,
+			Kind:       relationship.Kind,
+			ScopeField: relationship.ScopeFieldPath,
+			RootOnly:   relationship.RootOnly,
+		}
+		if capability, supported := ExternalResolutionFor(relationship.TargetType); supported {
+			metadata.AcceptedTags = []string{"!ref", "!external", "!lookup"}
+			metadata.Selectors = append([]string(nil), capability.Selectors...)
+			if capability.AllowAnyStringSelector {
+				metadata.Selectors = []string{"<string field>"}
+			}
+		} else {
+			metadata.AcceptedTags = []string{"!ref"}
+		}
+		fieldNode.Relationship = metadata
+		fieldNode.RefKind = string(relationship.TargetType)
+		if fieldNode.PreferredTag == "" {
+			fieldNode.PreferredTag = "!ref"
+		}
+		fieldNode.Notes = append(
+			fieldNode.Notes,
+			fmt.Sprintf("Relationship field (%s); use !external or the equivalent !lookup for an existing remote resource.",
+				relationship.Kind),
+		)
+	}
 }
 
 func defaultExplainHints(rt ResourceType) map[string]ExplainFieldHint {
@@ -2097,6 +2146,12 @@ func (n *ExplainNode) clone() *ExplainNode {
 		Additional:   n.Additional.clone(),
 		propIndex:    make(map[string]*ExplainField),
 	}
+	if n.Relationship != nil {
+		relationship := *n.Relationship
+		relationship.AcceptedTags = append([]string(nil), n.Relationship.AcceptedTags...)
+		relationship.Selectors = append([]string(nil), n.Relationship.Selectors...)
+		cloned.Relationship = &relationship
+	}
 	for _, child := range n.Properties {
 		cloned.addField(child.clone())
 	}
@@ -2112,14 +2167,15 @@ func (n *ExplainNode) toJSONSchema() *JSONSchema {
 	}
 
 	schema := &JSONSchema{
-		Description: n.Description,
-		Default:     n.Default,
-		Const:       n.Const,
-		Enum:        append([]any(nil), n.Enum...),
-		XRefKind:    n.RefKind,
-		XTag:        n.PreferredTag,
-		XDefault:    n.DefaultFrom,
-		XNotes:      append([]string(nil), n.Notes...),
+		Description:   n.Description,
+		Default:       n.Default,
+		Const:         n.Const,
+		Enum:          append([]any(nil), n.Enum...),
+		XRefKind:      n.RefKind,
+		XRelationship: n.Relationship,
+		XTag:          n.PreferredTag,
+		XDefault:      n.DefaultFrom,
+		XNotes:        append([]string(nil), n.Notes...),
 	}
 
 	schema.Type = schemaTypeValue(n.Kind, n.Nullable)

--- a/internal/declarative/resources/external.go
+++ b/internal/declarative/resources/external.go
@@ -3,7 +3,7 @@ package resources
 import (
 	"fmt"
 	"reflect"
-	"unicode"
+	"strings"
 )
 
 // ExternalBlock marks a resource as externally managed
@@ -47,16 +47,6 @@ func (e *ExternalBlock) Validate() error {
 	return nil
 }
 
-// capitalizeFirst capitalizes the first character of a string
-func capitalizeFirst(s string) string {
-	if len(s) == 0 {
-		return s
-	}
-	runes := []rune(s)
-	runes[0] = unicode.ToUpper(runes[0])
-	return string(runes)
-}
-
 // Match checks if the given Konnect resource matches this selector
 func (s *ExternalSelector) Match(konnectResource any) bool {
 	if s == nil || len(s.MatchFields) == 0 {
@@ -64,32 +54,68 @@ func (s *ExternalSelector) Match(konnectResource any) bool {
 	}
 
 	v := reflect.ValueOf(konnectResource)
-	if v.Kind() == reflect.Pointer {
-		v = v.Elem()
-	}
-
-	if v.Kind() != reflect.Struct {
-		return false
-	}
-
-	// Check all match fields
 	for fieldName, expectedValue := range s.MatchFields {
-		// Convert field name to title case for reflection (e.g., "name" -> "Name")
-		titleFieldName := capitalizeFirst(fieldName)
-		field := v.FieldByName(titleFieldName)
-
-		// Try embedded structs if direct field not found
-		if !field.IsValid() {
-			// Look in embedded Portal struct
-			if portalField := v.FieldByName("Portal"); portalField.IsValid() && portalField.Kind() == reflect.Struct {
-				field = portalField.FieldByName(titleFieldName)
-			}
-		}
-
-		if !field.IsValid() || field.Kind() != reflect.String || field.String() != expectedValue {
+		field, ok := externalSelectorStringField(v, fieldName)
+		if !ok || field != expectedValue {
 			return false
 		}
 	}
 
 	return true
+}
+
+func externalSelectorStringField(value reflect.Value, selectorName string) (string, bool) {
+	for value.IsValid() && (value.Kind() == reflect.Pointer || value.Kind() == reflect.Interface) {
+		if value.IsNil() {
+			return "", false
+		}
+		value = value.Elem()
+	}
+	if !value.IsValid() || value.Kind() != reflect.Struct {
+		return "", false
+	}
+
+	valueType := value.Type()
+	for i := range value.NumField() {
+		structField := valueType.Field(i)
+		if structField.PkgPath != "" {
+			continue
+		}
+		fieldValue := value.Field(i)
+		if externalSelectorFieldMatches(structField, selectorName) {
+			return externalSelectorStringValue(fieldValue)
+		}
+		if structField.Anonymous {
+			if result, ok := externalSelectorStringField(fieldValue, selectorName); ok {
+				return result, true
+			}
+		}
+	}
+	return "", false
+}
+
+func externalSelectorStringValue(value reflect.Value) (string, bool) {
+	for value.IsValid() && (value.Kind() == reflect.Pointer || value.Kind() == reflect.Interface) {
+		if value.IsNil() {
+			return "", false
+		}
+		value = value.Elem()
+	}
+	if !value.IsValid() || value.Kind() != reflect.String {
+		return "", false
+	}
+	return value.String(), true
+}
+
+func externalSelectorFieldMatches(field reflect.StructField, selectorName string) bool {
+	if strings.EqualFold(field.Name, selectorName) {
+		return true
+	}
+	for _, tagName := range []string{"json", "yaml"} {
+		name, _, _ := strings.Cut(field.Tag.Get(tagName), ",")
+		if name != "" && name != "-" && name == selectorName {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/declarative/resources/external_test.go
+++ b/internal/declarative/resources/external_test.go
@@ -1,0 +1,33 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExternalSelectorMatchUsesSerializedFieldNames(t *testing.T) {
+	t.Parallel()
+
+	type EmbeddedCandidate struct {
+		Name        string  `json:"name"`
+		DisplayName *string `json:"display_name,omitempty"`
+	}
+	type candidate struct {
+		EmbeddedCandidate
+	}
+
+	displayName := "Shared Gateway"
+	value := candidate{EmbeddedCandidate: EmbeddedCandidate{
+		Name:        "shared-gateway",
+		DisplayName: &displayName,
+	}}
+
+	require.True(t, (&ExternalSelector{MatchFields: map[string]string{
+		"name":         "shared-gateway",
+		"display_name": "Shared Gateway",
+	}}).Match(value))
+	require.False(t, (&ExternalSelector{MatchFields: map[string]string{
+		"display_name": "Other Gateway",
+	}}).Match(value))
+}

--- a/internal/declarative/resources/gateway_service.go
+++ b/internal/declarative/resources/gateway_service.go
@@ -11,10 +11,11 @@ import (
 )
 
 func init() {
-	registerResourceType(
+	registerExternalResourceType(
 		ResourceTypeGatewayService,
 		func(rs *ResourceSet) *[]GatewayServiceResource { return &rs.GatewayServices },
 		AutoExplain[GatewayServiceResource](),
+		ExternalResolutionRegistration{Selectors: []string{SchemaFieldName}, ParentType: ResourceTypeControlPlane},
 	)
 }
 
@@ -163,6 +164,11 @@ func (s *GatewayServiceResource) SetDefaults() {
 func (s GatewayServiceResource) GetKonnectID() string {
 	return s.konnectID
 }
+
+// SetKonnectID binds a resolved external or managed service identity.
+func (s *GatewayServiceResource) SetKonnectID(id string) { s.konnectID = id }
+
+func (s *GatewayServiceResource) GetExternalBlock() *ExternalBlock { return s.External }
 
 // GetKonnectMonikerFilter returns the filter string for Konnect lookups.
 func (s GatewayServiceResource) GetKonnectMonikerFilter() string {

--- a/internal/declarative/resources/interfaces.go
+++ b/internal/declarative/resources/interfaces.go
@@ -44,6 +44,14 @@ type ReferenceMapping interface {
 	GetReferenceFieldMappings() map[string]string
 }
 
+// ExternallyResolvableResource is the compile-time contract for resource types
+// that may bind an existing Konnect object through _external or an inline lookup.
+type ExternallyResolvableResource interface {
+	Resource
+	GetExternalBlock() *ExternalBlock
+	SetKonnectID(string)
+}
+
 // ResourceWithParent represents resources that have a parent
 type ResourceWithParent interface {
 	Resource

--- a/internal/declarative/resources/organization_team.go
+++ b/internal/declarative/resources/organization_team.go
@@ -8,12 +8,15 @@ import (
 )
 
 func init() {
-	registerResourceType(
+	registerExternalResourceType(
 		ResourceTypeOrganizationTeam,
 		func(rs *ResourceSet) *[]OrganizationTeamResource { return &rs.OrganizationTeams },
 		AutoExplain[OrganizationTeamResource](),
+		ExternalResolutionRegistration{Selectors: []string{SchemaFieldName}},
 	)
 }
+
+func (t *OrganizationTeamResource) GetExternalBlock() *ExternalBlock { return t.External }
 
 // OrganizationTeamResource represents a team in declarative configuration
 type OrganizationTeamResource struct {

--- a/internal/declarative/resources/portal.go
+++ b/internal/declarative/resources/portal.go
@@ -10,12 +10,15 @@ import (
 )
 
 func init() {
-	registerResourceType(
+	registerExternalResourceType(
 		ResourceTypePortal,
 		func(rs *ResourceSet) *[]PortalResource { return &rs.Portals },
 		AutoExplain[PortalResource](),
+		ExternalResolutionRegistration{Selectors: []string{SchemaFieldName}},
 	)
 }
+
+func (p *PortalResource) GetExternalBlock() *ExternalBlock { return p.External }
 
 // PortalResource represents a portal in declarative configuration
 type PortalResource struct {

--- a/internal/declarative/resources/registry.go
+++ b/internal/declarative/resources/registry.go
@@ -20,6 +20,15 @@ type resourceOps struct {
 	explain           ExplainRegistration
 	maturity          *maturity.Metadata
 	operationMaturity map[Operation]maturity.Metadata
+	external          *ExternalResolutionRegistration
+}
+
+// ExternalResolutionRegistration describes the selectors and scope supported
+// by a resource type's external lookup adapter.
+type ExternalResolutionRegistration struct {
+	Selectors              []string
+	ParentType             ResourceType
+	AllowAnyStringSelector bool
 }
 
 // registry maps resource types to their operations.
@@ -49,6 +58,37 @@ func registerResourceType[R any, RPtr interface {
 	options ...ResourceRegistrationOption,
 ) {
 	registerResourceTypeWithSliceAccessors[R, RPtr](rt, getSlicePtr, getSlicePtr, explain, options...)
+}
+
+func registerExternalResourceType[R any, RPtr interface {
+	*R
+	ExternallyResolvableResource
+}](rt ResourceType,
+	getSlicePtr func(*ResourceSet) *[]R,
+	explain ExplainRegistration,
+	external ExternalResolutionRegistration,
+	options ...ResourceRegistrationOption,
+) {
+	registerResourceTypeWithSliceAccessors[R, RPtr](rt, getSlicePtr, getSlicePtr, explain, options...)
+	ops := registry[rt]
+	ops.external = &external
+	registry[rt] = ops
+}
+
+func registerExternalResourceTypeWithSliceAccessors[R any, RPtr interface {
+	*R
+	ExternallyResolvableResource
+}](rt ResourceType,
+	getSlicePtr func(*ResourceSet) *[]R,
+	ensureSlicePtr func(*ResourceSet) *[]R,
+	explain ExplainRegistration,
+	external ExternalResolutionRegistration,
+	options ...ResourceRegistrationOption,
+) {
+	registerResourceTypeWithSliceAccessors[R, RPtr](rt, getSlicePtr, ensureSlicePtr, explain, options...)
+	ops := registry[rt]
+	ops.external = &external
+	registry[rt] = ops
 }
 
 func registerResourceTypeWithSliceAccessors[R any, RPtr interface {
@@ -208,4 +248,26 @@ func RegisteredTypes() []ResourceType {
 		types = append(types, rt)
 	}
 	return types
+}
+
+// ExternalResolutionFor returns external lookup capability metadata.
+func ExternalResolutionFor(rt ResourceType) (ExternalResolutionRegistration, bool) {
+	ops, ok := registry[rt]
+	if !ok || ops.external == nil {
+		return ExternalResolutionRegistration{}, false
+	}
+	result := *ops.external
+	result.Selectors = append([]string(nil), result.Selectors...)
+	return result, true
+}
+
+// ExternalResolvableTypes returns all resource types with the external capability contract.
+func ExternalResolvableTypes() []ResourceType {
+	result := make([]ResourceType, 0)
+	for rt, ops := range registry {
+		if ops.external != nil {
+			result = append(result, rt)
+		}
+	}
+	return result
 }

--- a/internal/declarative/resources/relationships.go
+++ b/internal/declarative/resources/relationships.go
@@ -1,0 +1,209 @@
+package resources
+
+import "strings"
+
+// RelationshipKind distinguishes API schema foreign keys from kongctl-added
+// root-level parent selectors while giving both the same reference semantics.
+type RelationshipKind string
+
+const (
+	RelationshipKindAPIForeignKey         RelationshipKind = "api_foreign_key"
+	RelationshipKindKongctlParentSelector RelationshipKind = "kongctl_parent_selector"
+)
+
+// RelationshipDescriptor is static schema metadata for a cross-resource field.
+type RelationshipDescriptor struct {
+	FieldPath      string
+	TargetType     ResourceType
+	Kind           RelationshipKind
+	ScopeFieldPath string
+	RootOnly       bool
+}
+
+var relationshipDescriptors = map[ResourceType][]RelationshipDescriptor{
+	ResourceTypeAPIPublication: {
+		{FieldPath: "portal_id", TargetType: ResourceTypePortal, Kind: RelationshipKindAPIForeignKey},
+	},
+	ResourceTypeAPIImplementation: {
+		{
+			FieldPath:  "service.control_plane_id",
+			TargetType: ResourceTypeControlPlane,
+			Kind:       RelationshipKindAPIForeignKey,
+		},
+		{
+			FieldPath: "service.id", TargetType: ResourceTypeGatewayService, Kind: RelationshipKindAPIForeignKey,
+			ScopeFieldPath: "service.control_plane_id",
+		},
+	},
+	ResourceTypeGatewayService: {
+		{
+			FieldPath: "control_plane", TargetType: ResourceTypeControlPlane,
+			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
+		},
+	},
+	ResourceTypeControlPlaneDataPlaneCertificate: {
+		{
+			FieldPath: "control_plane", TargetType: ResourceTypeControlPlane,
+			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
+		},
+	},
+	ResourceTypePortalAuditLogWebhook: {
+		{
+			FieldPath: "portal", TargetType: ResourceTypePortal,
+			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
+		},
+		{
+			FieldPath: "audit_log_destination_id", TargetType: ResourceTypeAuditLogWebhookDestination,
+			Kind: RelationshipKindAPIForeignKey,
+		},
+	},
+	ResourceTypeOrganizationTeamRole: {
+		{
+			FieldPath: "team", TargetType: ResourceTypeOrganizationTeam,
+			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
+		},
+	},
+	ResourceTypeOrganizationUserTeamMembership: {
+		{
+			FieldPath: "team", TargetType: ResourceTypeOrganizationTeam,
+			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
+		},
+	},
+	ResourceTypeOrganizationSystemAccountTeamMembership: {
+		{
+			FieldPath: "team", TargetType: ResourceTypeOrganizationTeam,
+			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
+		},
+	},
+	ResourceTypeEventGatewayVirtualCluster: {
+		{
+			FieldPath: "event_gateway", TargetType: ResourceTypeEventGatewayControlPlane,
+			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
+		},
+	},
+	ResourceTypeEventGatewayClusterPolicy: {
+		{
+			FieldPath: "event_gateway", TargetType: ResourceTypeEventGatewayControlPlane,
+			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
+		},
+		{
+			FieldPath: "virtual_cluster", TargetType: ResourceTypeEventGatewayVirtualCluster,
+			Kind: RelationshipKindKongctlParentSelector, ScopeFieldPath: "event_gateway", RootOnly: true,
+		},
+	},
+	ResourceTypeEventGatewayProducePolicy: {
+		{
+			FieldPath: "event_gateway", TargetType: ResourceTypeEventGatewayControlPlane,
+			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
+		},
+		{
+			FieldPath: "virtual_cluster", TargetType: ResourceTypeEventGatewayVirtualCluster,
+			Kind: RelationshipKindKongctlParentSelector, ScopeFieldPath: "event_gateway", RootOnly: true,
+		},
+	},
+	ResourceTypeEventGatewayConsumePolicy: {
+		{
+			FieldPath: "event_gateway", TargetType: ResourceTypeEventGatewayControlPlane,
+			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
+		},
+		{
+			FieldPath: "virtual_cluster", TargetType: ResourceTypeEventGatewayVirtualCluster,
+			Kind: RelationshipKindKongctlParentSelector, ScopeFieldPath: "event_gateway", RootOnly: true,
+		},
+	},
+}
+
+var aiGatewayChildTypes = []ResourceType{
+	ResourceTypeAIGatewayProvider,
+	ResourceTypeAIGatewayIdentityProvider,
+	ResourceTypeAIGatewayPolicy,
+	ResourceTypeAIGatewayAgent,
+	ResourceTypeAIGatewayConsumer,
+	ResourceTypeAIGatewayConsumerGroup,
+	ResourceTypeAIGatewayModel,
+	ResourceTypeAIGatewayMCPServer,
+	ResourceTypeAIGatewayVault,
+	ResourceTypeAIGatewayDataPlaneCertificate,
+}
+
+var portalChildTypes = []ResourceType{
+	ResourceTypePortalCustomization,
+	ResourceTypePortalCustomDomain,
+	ResourceTypePortalAuthSettings,
+	ResourceTypePortalIPAllowList,
+	ResourceTypePortalIntegration,
+	ResourceTypePortalIdentityProvider,
+	ResourceTypePortalTeamGroupMapping,
+	ResourceTypePortalPage,
+	ResourceTypePortalSnippet,
+	ResourceTypePortalTeam,
+	ResourceTypePortalTeamRole,
+	ResourceTypePortalAssetLogo,
+	ResourceTypePortalAssetFavicon,
+	ResourceTypePortalEmailConfig,
+	ResourceTypePortalEmailTemplate,
+}
+
+var eventGatewayChildTypes = []ResourceType{
+	ResourceTypeEventGatewayBackendCluster,
+	ResourceTypeEventGatewayListener,
+	ResourceTypeEventGatewayDataPlaneCertificate,
+	ResourceTypeEventGatewaySchemaRegistry,
+	ResourceTypeEventGatewayStaticKey,
+	ResourceTypeEventGatewayTLSTrustBundle,
+}
+
+func init() {
+	for _, resourceType := range aiGatewayChildTypes {
+		relationshipDescriptors[resourceType] = []RelationshipDescriptor{{
+			FieldPath: SchemaFieldAIGateway, TargetType: ResourceTypeAIGateway,
+			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
+		}}
+	}
+	for _, resourceType := range portalChildTypes {
+		relationshipDescriptors[resourceType] = []RelationshipDescriptor{{
+			FieldPath: SchemaFieldPortal, TargetType: ResourceTypePortal,
+			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
+		}}
+	}
+	for _, resourceType := range eventGatewayChildTypes {
+		relationshipDescriptors[resourceType] = []RelationshipDescriptor{{
+			FieldPath: "event_gateway", TargetType: ResourceTypeEventGatewayControlPlane,
+			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
+		}}
+	}
+}
+
+// RelationshipDescriptorsForType returns static relationship schema metadata.
+func RelationshipDescriptorsForType(resourceType ResourceType) []RelationshipDescriptor {
+	return append([]RelationshipDescriptor(nil), relationshipDescriptors[resourceType]...)
+}
+
+// RelationshipDescriptorsFor returns static descriptors plus compatibility
+// mappings for fields not yet backfilled into the static schema registry.
+func RelationshipDescriptorsFor(resource Resource) []RelationshipDescriptor {
+	result := RelationshipDescriptorsForType(resource.GetType())
+	seen := make(map[string]struct{}, len(result))
+	for _, descriptor := range result {
+		seen[descriptor.FieldPath] = struct{}{}
+	}
+	mapping, ok := resource.(ReferenceMapping)
+	if !ok {
+		return result
+	}
+	for fieldPath, target := range mapping.GetReferenceFieldMappings() {
+		if _, exists := seen[fieldPath]; exists {
+			continue
+		}
+		kind := RelationshipKindKongctlParentSelector
+		if strings.HasSuffix(fieldPath, "_id") || strings.Contains(fieldPath, ".id") {
+			kind = RelationshipKindAPIForeignKey
+		}
+		result = append(result, RelationshipDescriptor{
+			FieldPath:  fieldPath,
+			TargetType: ResourceType(target),
+			Kind:       kind,
+		})
+	}
+	return result
+}

--- a/internal/declarative/resources/relationships_test.go
+++ b/internal/declarative/resources/relationships_test.go
@@ -1,0 +1,35 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelationshipDescriptorsDistinguishFieldOrigins(t *testing.T) {
+	t.Parallel()
+
+	publication := RelationshipDescriptorsForType(ResourceTypeAPIPublication)
+	require.Contains(t, publication, RelationshipDescriptor{
+		FieldPath: "portal_id", TargetType: ResourceTypePortal, Kind: RelationshipKindAPIForeignKey,
+	})
+
+	model := RelationshipDescriptorsForType(ResourceTypeAIGatewayModel)
+	require.Contains(t, model, RelationshipDescriptor{
+		FieldPath: SchemaFieldAIGateway, TargetType: ResourceTypeAIGateway,
+		Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
+	})
+}
+
+func TestExplainSchemaIncludesRelationshipContract(t *testing.T) {
+	t.Parallel()
+
+	subject, err := ResolveExplainSubject("api_publication.portal_id")
+	require.NoError(t, err)
+	schema := RenderExplainSchema(subject)
+	require.NotNil(t, schema.XRelationship)
+	require.Equal(t, ResourceTypePortal, schema.XRelationship.Target)
+	require.Equal(t, RelationshipKindAPIForeignKey, schema.XRelationship.Kind)
+	require.Equal(t, []string{"!ref", "!external", "!lookup"}, schema.XRelationship.AcceptedTags)
+	require.Equal(t, []string{"name"}, schema.XRelationship.Selectors)
+}

--- a/internal/declarative/resources/relationships_test.go
+++ b/internal/declarative/resources/relationships_test.go
@@ -33,3 +33,17 @@ func TestExplainSchemaIncludesRelationshipContract(t *testing.T) {
 	require.Equal(t, []string{"!ref", "!external", "!lookup"}, schema.XRelationship.AcceptedTags)
 	require.Equal(t, []string{"name"}, schema.XRelationship.Selectors)
 }
+
+func TestRelationshipExplainNoteMatchesExternalCapability(t *testing.T) {
+	t.Parallel()
+
+	require.Contains(
+		t,
+		relationshipExplainNote(RelationshipKindAPIForeignKey, true),
+		"use !lookup",
+	)
+	note := relationshipExplainNote(RelationshipKindAPIForeignKey, false)
+	require.Contains(t, note, "use !ref")
+	require.NotContains(t, note, "!lookup")
+	require.NotContains(t, note, "!external")
+}

--- a/internal/declarative/resources/resources_test.go
+++ b/internal/declarative/resources/resources_test.go
@@ -54,6 +54,31 @@ func TestGetPortalsByNamespaceIncludesExternalsWhenRequested(t *testing.T) {
 	require.Equal(t, "page-2", externalPages[0].Ref)
 }
 
+func TestGetControlPlanesByNamespaceIncludesExternalsWhenRequested(t *testing.T) {
+	t.Parallel()
+
+	team := "team-one"
+	rs := &ResourceSet{
+		ControlPlanes: []ControlPlaneResource{
+			{
+				BaseResource: BaseResource{Ref: "managed", Kongctl: namespaceMeta(team)},
+			},
+			{
+				BaseResource: BaseResource{Ref: "external"},
+				External:     &ExternalBlock{ID: "control-plane-123"},
+			},
+		},
+	}
+
+	managed := rs.GetControlPlanesByNamespace(team)
+	require.Len(t, managed, 1)
+	require.Equal(t, "managed", managed[0].Ref)
+
+	external := rs.GetControlPlanesByNamespace(NamespaceExternal)
+	require.Len(t, external, 1)
+	require.Equal(t, "external", external[0].Ref)
+}
+
 func TestGetEventGatewayControlPlanesByNamespaceIncludesExternalsWhenRequested(t *testing.T) {
 	team := "team-one"
 	rs := &ResourceSet{

--- a/internal/declarative/resources/sync_scope.go
+++ b/internal/declarative/resources/sync_scope.go
@@ -103,6 +103,29 @@ func (s *SyncScope) ChildInScope(parentType ResourceType, parentRef string, rt R
 	return ok
 }
 
+// RebindChildParent moves child sync scope from a declarative selector value to
+// its planner-resolved parent ID.
+func (s *SyncScope) RebindChildParent(parentType ResourceType, oldRef, newRef string) {
+	if s == nil || oldRef == "" || newRef == "" || oldRef == newRef {
+		return
+	}
+	byParentRef := s.ChildResourceTypes[parentType]
+	if byParentRef == nil {
+		return
+	}
+	childTypes := byParentRef[oldRef]
+	if childTypes == nil {
+		return
+	}
+	if byParentRef[newRef] == nil {
+		byParentRef[newRef] = make(map[ResourceType]struct{})
+	}
+	for childType := range childTypes {
+		byParentRef[newRef][childType] = struct{}{}
+	}
+	delete(byParentRef, oldRef)
+}
+
 // AddRootChildCollection records an explicit root-level empty child collection.
 // This cannot express a parent and is rejected by sync planning with guidance.
 func (s *SyncScope) AddRootChildCollection(rt ResourceType) {

--- a/internal/declarative/resources/sync_scope.go
+++ b/internal/declarative/resources/sync_scope.go
@@ -111,6 +111,14 @@ func (s *SyncScope) ChildInScope(parentType ResourceType, parentRef string, rt R
 	return ok
 }
 
+// ParentHasChildScope reports whether any child collection is in scope for a parent resource type.
+func (s *SyncScope) ParentHasChildScope(parentType ResourceType) bool {
+	if s == nil {
+		return false
+	}
+	return len(s.ChildResourceTypes[parentType]) > 0
+}
+
 // RebindChildParent moves child sync scope from a declarative selector value to
 // its planner-resolved parent ID.
 func (s *SyncScope) RebindChildParent(parentType ResourceType, oldRef, newRef string) {

--- a/internal/declarative/resources/sync_scope.go
+++ b/internal/declarative/resources/sync_scope.go
@@ -68,6 +68,14 @@ func (s *SyncScope) RootInScope(rt ResourceType) bool {
 	return ok
 }
 
+// RemoveRoot removes a top-level resource collection from sync scope.
+func (s *SyncScope) RemoveRoot(rt ResourceType) {
+	if s == nil {
+		return
+	}
+	delete(s.RootResourceTypes, rt)
+}
+
 // AddChild marks a child resource collection as in scope for one parent ref.
 func (s *SyncScope) AddChild(parentType ResourceType, parentRef string, rt ResourceType) {
 	parentRef = NormalizeResourceRef(parentRef)

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -84,6 +84,7 @@ const (
 
 const (
 	SchemaFieldRef               = "ref"
+	SchemaFieldName              = "name"
 	SchemaFieldPortal            = "portal"
 	SchemaFieldOrganization      = "organization"
 	SchemaFieldTeams             = "teams"

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -523,6 +523,12 @@ func (rs *ResourceSet) GetPortalsByNamespace(namespace string) []PortalResource 
 func (rs *ResourceSet) GetControlPlanesByNamespace(namespace string) []ControlPlaneResource {
 	var filtered []ControlPlaneResource
 	for _, cp := range rs.ControlPlanes {
+		if cp.IsExternal() {
+			if namespace == NamespaceExternal {
+				filtered = append(filtered, cp)
+			}
+			continue
+		}
 		if GetNamespace(cp.Kongctl) == namespace {
 			filtered = append(filtered, cp)
 		}

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -6118,8 +6118,8 @@ func (c *Client) ListManagedOrganizationTeams(ctx context.Context, namespaces []
 	return PaginateAll(ctx, lister)
 }
 
-// GetOrganizationTeamByNameUnfiltered finds an organization team by name without requiring kongctl-managed labels.
-func (c *Client) GetOrganizationTeamByNameUnfiltered(ctx context.Context, name string) (*OrganizationTeam, error) {
+// ListAllOrganizationTeams returns organization teams without requiring kongctl-managed labels.
+func (c *Client) ListAllOrganizationTeams(ctx context.Context) ([]OrganizationTeam, error) {
 	if err := ValidateAPIClient(c.organizationTeamAPI, "organization team API"); err != nil {
 		return nil, err
 	}
@@ -6160,7 +6160,12 @@ func (c *Client) GetOrganizationTeamByNameUnfiltered(ctx context.Context, name s
 		return teams, &PageMeta{Total: total}, nil
 	}
 
-	teams, err := PaginateAll(ctx, lister)
+	return PaginateAll(ctx, lister)
+}
+
+// GetOrganizationTeamByNameUnfiltered finds an organization team by name without requiring kongctl-managed labels.
+func (c *Client) GetOrganizationTeamByNameUnfiltered(ctx context.Context, name string) (*OrganizationTeam, error) {
+	teams, err := c.ListAllOrganizationTeams(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/declarative/tags/external.go
+++ b/internal/declarative/tags/external.go
@@ -74,6 +74,8 @@ func (r *ExternalTagResolver) Resolve(node *yaml.Node) (any, error) {
 		}
 	case yaml.DocumentNode, yaml.SequenceNode, yaml.AliasNode:
 		return nil, fmt.Errorf("%s must be used with a field:value scalar or mapping", r.tag)
+	default:
+		return nil, fmt.Errorf("%s cannot resolve unsupported YAML node kind %d", r.tag, node.Kind)
 	}
 
 	if _, hasID := lookup.MatchFields["id"]; hasID && len(lookup.MatchFields) != 1 {
@@ -120,7 +122,7 @@ func ExternalLookupKey(matchFields map[string]string) string {
 		if i > 0 {
 			b.WriteByte(',')
 		}
-		fmt.Fprintf(&b, "%s=%s", field, matchFields[field])
+		fmt.Fprintf(&b, "%q=%q", field, matchFields[field])
 	}
 	return b.String()
 }

--- a/internal/declarative/tags/external.go
+++ b/internal/declarative/tags/external.go
@@ -1,0 +1,126 @@
+package tags
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3" //nolint:gomodguard_v2 // yaml.v3 required for custom tag processing
+)
+
+// ExternalPlaceholderPrefix identifies planner-time external lookup placeholders.
+const ExternalPlaceholderPrefix = "__EXTERNAL__:"
+
+// ExternalLookup describes a lookup parsed from !external or !lookup.
+type ExternalLookup struct {
+	MatchFields map[string]string `json:"match_fields"`
+	Line        int               `json:"line,omitempty"`
+	Column      int               `json:"column,omitempty"`
+}
+
+// ExternalTagResolver converts external lookup tags into planner-time placeholders.
+type ExternalTagResolver struct {
+	tag string
+}
+
+// NewExternalTagResolver creates a resolver for !external or its !lookup alias.
+func NewExternalTagResolver(tag string) *ExternalTagResolver {
+	return &ExternalTagResolver{tag: tag}
+}
+
+// Tag returns the YAML tag handled by this resolver.
+func (r *ExternalTagResolver) Tag() string {
+	return r.tag
+}
+
+// Resolve validates and serializes an external lookup without performing network access.
+func (r *ExternalTagResolver) Resolve(node *yaml.Node) (any, error) {
+	lookup := ExternalLookup{Line: node.Line, Column: node.Column}
+
+	switch node.Kind {
+	case yaml.ScalarNode:
+		field, value, ok := strings.Cut(node.Value, ":")
+		field = strings.TrimSpace(field)
+		value = strings.TrimSpace(value)
+		if !ok || field == "" || value == "" {
+			return nil, fmt.Errorf("%s scalar must use field:value syntax", r.tag)
+		}
+		lookup.MatchFields = map[string]string{field: value}
+	case yaml.MappingNode:
+		lookup.MatchFields = make(map[string]string, len(node.Content)/2)
+		for i := 0; i < len(node.Content); i += 2 {
+			if i+1 >= len(node.Content) {
+				return nil, fmt.Errorf("%s mapping is malformed", r.tag)
+			}
+			key := node.Content[i]
+			value := node.Content[i+1]
+			if key.Kind != yaml.ScalarNode || value.Kind != yaml.ScalarNode {
+				return nil, fmt.Errorf("%s mapping keys and values must be strings", r.tag)
+			}
+			if (key.Tag != "" && key.Tag != "!!str") || (value.Tag != "" && value.Tag != "!!str") {
+				return nil, fmt.Errorf("%s mapping keys and values must be strings", r.tag)
+			}
+			field := strings.TrimSpace(key.Value)
+			match := strings.TrimSpace(value.Value)
+			if field == "" || match == "" {
+				return nil, fmt.Errorf("%s mapping keys and values cannot be empty", r.tag)
+			}
+			lookup.MatchFields[field] = match
+		}
+		if len(lookup.MatchFields) == 0 {
+			return nil, fmt.Errorf("%s mapping must contain at least one selector", r.tag)
+		}
+	case yaml.DocumentNode, yaml.SequenceNode, yaml.AliasNode:
+		return nil, fmt.Errorf("%s must be used with a field:value scalar or mapping", r.tag)
+	}
+
+	if _, hasID := lookup.MatchFields["id"]; hasID && len(lookup.MatchFields) != 1 {
+		return nil, fmt.Errorf("%s id cannot be combined with other selectors", r.tag)
+	}
+
+	payload, err := json.Marshal(lookup)
+	if err != nil {
+		return nil, fmt.Errorf("encode external lookup: %w", err)
+	}
+	return ExternalPlaceholderPrefix + base64.RawURLEncoding.EncodeToString(payload), nil
+}
+
+// IsExternalPlaceholder reports whether a string contains a planner-time lookup.
+func IsExternalPlaceholder(value string) bool {
+	return strings.HasPrefix(value, ExternalPlaceholderPrefix)
+}
+
+// ParseExternalPlaceholder decodes a planner-time external lookup placeholder.
+func ParseExternalPlaceholder(value string) (ExternalLookup, bool) {
+	if !IsExternalPlaceholder(value) {
+		return ExternalLookup{}, false
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(value, ExternalPlaceholderPrefix))
+	if err != nil {
+		return ExternalLookup{}, false
+	}
+	var lookup ExternalLookup
+	if err := json.Unmarshal(payload, &lookup); err != nil || len(lookup.MatchFields) == 0 {
+		return ExternalLookup{}, false
+	}
+	return lookup, true
+}
+
+// ExternalLookupKey returns a stable selector representation for caching and diagnostics.
+func ExternalLookupKey(matchFields map[string]string) string {
+	fields := make([]string, 0, len(matchFields))
+	for field := range matchFields {
+		fields = append(fields, field)
+	}
+	sort.Strings(fields)
+	var b strings.Builder
+	for i, field := range fields {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, "%s=%s", field, matchFields[field])
+	}
+	return b.String()
+}

--- a/internal/declarative/tags/external_test.go
+++ b/internal/declarative/tags/external_test.go
@@ -1,0 +1,73 @@
+package tags
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3" //nolint:gomodguard_v2 // yaml.v3 required for custom tag tests
+)
+
+func TestExternalTagResolverAliases(t *testing.T) {
+	t.Parallel()
+
+	for _, tag := range []string{"!external", "!lookup"} {
+		t.Run(tag, func(t *testing.T) {
+			t.Parallel()
+			resolver := NewExternalTagResolver(tag)
+			value, err := resolver.Resolve(&yaml.Node{Kind: yaml.ScalarNode, Value: "name:Shared: Portal"})
+			require.NoError(t, err)
+			lookup, ok := ParseExternalPlaceholder(value.(string))
+			require.True(t, ok)
+			require.Equal(t, map[string]string{"name": "Shared: Portal"}, lookup.MatchFields)
+		})
+	}
+}
+
+func TestExternalTagResolverMapping(t *testing.T) {
+	t.Parallel()
+
+	resolver := NewExternalTagResolver("!external")
+	value, err := resolver.Resolve(&yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Value: "name"},
+			{Kind: yaml.ScalarNode, Value: "shared"},
+			{Kind: yaml.ScalarNode, Value: "display_name"},
+			{Kind: yaml.ScalarNode, Value: "Shared Gateway"},
+		},
+	})
+	require.NoError(t, err)
+	lookup, ok := ParseExternalPlaceholder(value.(string))
+	require.True(t, ok)
+	require.Equal(t, map[string]string{"name": "shared", "display_name": "Shared Gateway"}, lookup.MatchFields)
+}
+
+func TestExternalTagResolverRejectsInvalidValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		node *yaml.Node
+	}{
+		{name: "missing delimiter", node: &yaml.Node{Kind: yaml.ScalarNode, Value: "shared"}},
+		{name: "empty selector", node: &yaml.Node{Kind: yaml.MappingNode}},
+		{name: "id combined", node: &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Value: "id"},
+			{Kind: yaml.ScalarNode, Value: "123"},
+			{Kind: yaml.ScalarNode, Value: "name"},
+			{Kind: yaml.ScalarNode, Value: "shared"},
+		}}},
+		{name: "non-string value", node: &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Tag: "!!str", Value: "id"},
+			{Kind: yaml.ScalarNode, Tag: "!!int", Value: "123"},
+		}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewExternalTagResolver("!external").Resolve(tt.node)
+			require.Error(t, err)
+		})
+	}
+}

--- a/internal/declarative/tags/external_test.go
+++ b/internal/declarative/tags/external_test.go
@@ -42,6 +42,15 @@ func TestExternalTagResolverMapping(t *testing.T) {
 	require.Equal(t, map[string]string{"name": "shared", "display_name": "Shared Gateway"}, lookup.MatchFields)
 }
 
+func TestExternalLookupKeyIsUnambiguous(t *testing.T) {
+	t.Parallel()
+
+	separateSelectors := ExternalLookupKey(map[string]string{"a": "b", "c": "d"})
+	delimitersInValue := ExternalLookupKey(map[string]string{"a": "b,c=d"})
+	require.NotEqual(t, separateSelectors, delimitersInValue)
+	require.Equal(t, separateSelectors, ExternalLookupKey(map[string]string{"c": "d", "a": "b"}))
+}
+
 func TestExternalTagResolverRejectsInvalidValues(t *testing.T) {
 	t.Parallel()
 
@@ -50,6 +59,7 @@ func TestExternalTagResolverRejectsInvalidValues(t *testing.T) {
 		node *yaml.Node
 	}{
 		{name: "missing delimiter", node: &yaml.Node{Kind: yaml.ScalarNode, Value: "shared"}},
+		{name: "invalid node kind", node: &yaml.Node{}},
 		{name: "empty selector", node: &yaml.Node{Kind: yaml.MappingNode}},
 		{name: "id combined", node: &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
 			{Kind: yaml.ScalarNode, Value: "id"},

--- a/test/e2e/scenarios/external/ai-gateway-parent/overlays/001-retain-one-provider/providers.yaml
+++ b/test/e2e/scenarios/external/ai-gateway-parent/overlays/001-retain-one-provider/providers.yaml
@@ -1,0 +1,12 @@
+ai_gateway_model_providers:
+  - ref: external-openai-provider
+    ai_gateway: !external name:external-ai-gateway
+    name: external-openai-provider
+    type: openai
+    display_name: External OpenAI Provider
+    config:
+      auth:
+        type: basic
+        headers:
+          - name: Authorization
+            value: Bearer fake-openai-api-key

--- a/test/e2e/scenarios/external/ai-gateway-parent/scenario.yaml
+++ b/test/e2e/scenarios/external/ai-gateway-parent/scenario.yaml
@@ -1,0 +1,104 @@
+baseInputsPath: testdata
+
+vars:
+  gatewayName: External AI Gateway
+  gatewaySlug: external-ai-gateway
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-create-unmanaged-ai-gateway
+    skipInputs: true
+    commands:
+      - name: 000-create-ai-gateway
+        create:
+          resource: ai_gateway
+          payload:
+            inline:
+              display_name: "{{ .vars.gatewayName }}"
+              name: "{{ .vars.gatewaySlug }}"
+              description: Created outside kongctl declarative management
+          recordVar:
+            name: gatewayID
+            responsePath: id
+
+  - name: 002-apply-external-children
+    commands:
+      - name: 000-apply-providers
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/providers.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 2
+                by_action.CREATE: 2
+          - select: "length(plan.changes[?resource_type=='ai_gateway'])"
+            expect:
+              fields:
+                "@": 0
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success
+
+  - name: 003-verify-children-and-idempotency
+    commands:
+      - name: 000-get-providers
+        run:
+          - get
+          - ai-gateway
+          - model-providers
+          - --gateway-name
+          - "{{ .vars.gatewayName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 2
+      - name: 001-plan-again
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/providers.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+
+  - name: 004-verify-external-gateway-remains
+    skipInputs: true
+    commands:
+      - name: 000-verify-external-gateway-remains
+        run:
+          - get
+          - ai-gateways
+          - -o
+          - json
+        assertions:
+          - select: "[?id=='{{ .vars.gatewayID }}']"
+            expect:
+              fields:
+                "length(@)": 1
+
+  - name: 005-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 005-cleanup
+    skipInputs: true
+    commands:
+      - resetOrg: true

--- a/test/e2e/scenarios/external/ai-gateway-parent/scenario.yaml
+++ b/test/e2e/scenarios/external/ai-gateway-parent/scenario.yaml
@@ -24,12 +24,25 @@ steps:
           recordVar:
             name: gatewayID
             responsePath: id
-
-  - name: 002-apply-external-children
-    commands:
-      - name: 000-apply-providers
+      - name: 001-adopt-ai-gateway
         run:
-          - apply
+          - adopt
+          - ai-gateway
+          - "{{ .vars.gatewayID }}"
+          - --namespace
+          - default
+        assertions:
+          - expect:
+              fields:
+                id: "{{ .vars.gatewayID }}"
+                namespace: default
+                resource_type: ai_gateway
+
+  - name: 002-sync-external-children
+    commands:
+      - name: 000-sync-providers
+        run:
+          - sync
           - -f
           - "{{ .workdir }}/providers.yaml"
           - --auto-approve
@@ -43,6 +56,10 @@ steps:
             expect:
               fields:
                 "@": 0
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: sync
           - select: summary
             expect:
               fields:
@@ -71,14 +88,55 @@ steps:
           - -f
           - "{{ .workdir }}/providers.yaml"
           - --mode
-          - apply
+          - sync
         assertions:
           - select: summary
             expect:
               fields:
                 total_changes: 0
+          - select: "length(changes[?resource_type=='ai_gateway'])"
+            expect:
+              fields:
+                "@": 0
 
-  - name: 004-verify-external-gateway-remains
+  - name: 004-sync-does-not-prune-external-children
+    inputOverlayDirs:
+      - overlays/001-retain-one-provider
+    commands:
+      - name: 000-sync-one-provider
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/providers.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 0
+          - select: >-
+              plan.changes[?resource_type=='ai_gateway' ||
+                           resource_type=='ai_gateway_model_provider']
+            expect:
+              fields:
+                "length(@)": 0
+
+      - name: 001-get-providers
+        run:
+          - get
+          - ai-gateway
+          - model-providers
+          - --gateway-name
+          - "{{ .vars.gatewayName }}"
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 2
+
+  - name: 005-verify-external-gateway-remains
     skipInputs: true
     commands:
       - name: 000-verify-external-gateway-remains
@@ -93,12 +151,7 @@ steps:
               fields:
                 "length(@)": 1
 
-  - name: 005-reset-org
-    skipInputs: true
-    commands:
-      - resetOrg: true
-
-  - name: 005-cleanup
+  - name: 006-cleanup
     skipInputs: true
     commands:
       - resetOrg: true

--- a/test/e2e/scenarios/external/ai-gateway-parent/testdata/providers.yaml
+++ b/test/e2e/scenarios/external/ai-gateway-parent/testdata/providers.yaml
@@ -1,0 +1,24 @@
+ai_gateway_model_providers:
+  - ref: external-openai-provider
+    ai_gateway: !external name:external-ai-gateway
+    name: external-openai-provider
+    type: openai
+    display_name: External OpenAI Provider
+    config:
+      auth:
+        type: basic
+        headers:
+          - name: Authorization
+            value: Bearer fake-openai-api-key
+
+  - ref: lookup-openai-provider
+    ai_gateway: !lookup {name: external-ai-gateway}
+    name: lookup-openai-provider
+    type: openai
+    display_name: Lookup OpenAI Provider
+    config:
+      auth:
+        type: basic
+        headers:
+          - name: Authorization
+            value: Bearer fake-openai-api-key

--- a/test/e2e/scenarios/external/api-impl/scenario.yaml
+++ b/test/e2e/scenarios/external/api-impl/scenario.yaml
@@ -33,12 +33,25 @@ steps:
           recordVar:
             name: gw_svc_id
             responsePath: id
-
-  - name: 002-apply
-    commands:
-      - name: 000-apply
+      - name: 002-adopt-cp
         run:
-          - apply
+          - adopt
+          - control-plane
+          - "{{ .vars.cp_id }}"
+          - --namespace
+          - default
+        assertions:
+          - expect:
+              fields:
+                id: "{{ .vars.cp_id }}"
+                namespace: default
+                resource_type: control_plane
+
+  - name: 002-sync-external-references
+    commands:
+      - name: 000-sync
+        run:
+          - sync
           - -f
           - "{{ .workdir }}/api.yaml"
           - -f
@@ -48,13 +61,20 @@ steps:
           - select: "plan.metadata"
             expect:
               fields:
-                mode: apply
+                mode: sync
           - select: >-
               plan.changes[?resource_type=='api_implementation' && 
                             resource_ref=='e2e-api-implementation'] | [0]
             expect:
              fields:
                 action: CREATE
+          - select: >-
+              plan.changes[?resource_type=='control_plane' ||
+                           resource_type=='gateway_service' ||
+                           resource_type=='_deck']
+            expect:
+              fields:
+                "length(@)": 0
 
   - name: 003-get-implementations
     skipInputs: true
@@ -74,6 +94,39 @@ steps:
               fields:
                 service.control_plane_id: "{{ .vars.cp_id }}"
                 service.id: "{{ .vars.gw_svc_id }}"
+      - name: 001-get-control-plane
+        run:
+          - get
+          - gateway
+          - control-plane
+          - "{{ .vars.cp_id }}"
+          - -o
+          - json
+        assertions:
+          - select: id
+            expect:
+              fields:
+                "@": "{{ .vars.cp_id }}"
+          - select: name
+            expect:
+              fields:
+                "@": e2e-cp
+      - name: 002-get-gateway-service
+        run:
+          - get
+          - gateway
+          - control-plane
+          - services
+          - --control-plane-name
+          - e2e-cp
+          - -o
+          - json
+        assertions:
+          - select: "[?id=='{{ .vars.gw_svc_id }}'] | [0]"
+            expect:
+              fields:
+                id: "{{ .vars.gw_svc_id }}"
+                name: e2e-gw-svc
 
   - name: 004-get-implementation-by-id
     skipInputs: true

--- a/test/e2e/scenarios/external/api-impl/testdata/api.yaml
+++ b/test/e2e/scenarios/external/api-impl/testdata/api.yaml
@@ -5,6 +5,5 @@ apis:
     implementations:
       - ref: e2e-api-implementation
         service:
-          control_plane_id: !ref e2e-cp#id
-          id: !ref e2e-gw-svc#id
-
+          control_plane_id: !external name:e2e-cp
+          id: !lookup {name: e2e-gw-svc}

--- a/test/e2e/scenarios/external/portal-publication/testdata/team-a/api.yaml
+++ b/test/e2e/scenarios/external/portal-publication/testdata/team-a/api.yaml
@@ -44,5 +44,5 @@ apis:
 
     publications:
       - ref: test-api-publication
-        portal_id: !ref shared-portal#id
+        portal_id: !external name:Platform Shared Portal
         visibility: "public"

--- a/test/integration/declarative/external_lookup_test.go
+++ b/test/integration/declarative/external_lookup_test.go
@@ -1,0 +1,45 @@
+//go:build integration
+
+package declarative_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kong/kongctl/internal/declarative/loader"
+	"github.com/kong/kongctl/internal/declarative/tags"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExternalLookupTagsAcrossRelationshipKinds(t *testing.T) {
+	t.Parallel()
+
+	configFile := filepath.Join(t.TempDir(), "external-lookups.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+apis:
+  - ref: products
+    name: Products
+    publications:
+      - ref: products-publication
+        portal_id: !external name:Shared Portal
+
+gateway_services:
+  - ref: billing-service
+    control_plane: !lookup {name: Shared Control Plane}
+    _external:
+      id: service-id
+`), 0o600))
+
+	rs, err := loader.New().LoadFile(configFile)
+	require.NoError(t, err)
+	require.Len(t, rs.APIPublications, 1)
+	require.Len(t, rs.GatewayServices, 1)
+
+	publicationLookup, ok := tags.ParseExternalPlaceholder(rs.APIPublications[0].PortalID)
+	require.True(t, ok)
+	parentLookup, ok := tags.ParseExternalPlaceholder(rs.GatewayServices[0].ControlPlane)
+	require.True(t, ok)
+	require.Equal(t, map[string]string{"name": "Shared Portal"}, publicationLookup.MatchFields)
+	require.Equal(t, map[string]string{"name": "Shared Control Plane"}, parentLookup.MatchFields)
+}


### PR DESCRIPTION
Adds planner-time external resource lookup with the `!lookup` YAML tag and its `!external` alias. Centralizes existing `_external` resolution, documents relationship behavior and examples, and adds unit, integration, and E2E coverage.

Closes #1675
Related to #1674