### PR TITLE
fix(e2e): support shard reruns across attempts

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -818,6 +818,9 @@ jobs:
     if: ${{ always() && !cancelled() && needs.e2e-needed.outputs.run_shards == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -832,6 +835,10 @@ jobs:
       - name: Download workflow artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.run_id }}
+          pattern: e2e-artifacts-${{ github.run_id }}-*
           path: ${{ github.workspace }}/.downloaded-artifacts
 
       - name: Verify shard coverage


### PR DESCRIPTION
## Summary

- authenticate the E2E shard verification artifact download so it uses GitHub's API-backed cross-run path
- grant the verification job least-privilege `actions: read` access
- download only shard artifacts, excluding the unrelated E2E binary artifact

## Rationale

A partial rerun retains artifacts from successful shards in the previous attempt and uploads a replacement artifact for the rerun shard. The verification job could list that mixed-attempt artifact set, but the action's attempt-local signed URL lookup failed with `404 Not Found: workflow run not found` before verification ran.

Passing `github-token`, `repository`, and `run-id` makes `actions/download-artifact` use the authenticated REST path, which can download retained artifacts from previous attempts. The existing verification logic already selects the newest result for each shard.

Observed in https://github.com/Kong/kongctl/actions/runs/29977078703.

## Testing

- `actionlint .github/workflows/e2e.yaml`
- `git diff --check`
