### PR TITLE
fix(declarative): resolve parent_policy_id ref for modify_headers and skip_record policies

### DIFF
--- a/internal/declarative/planner/event_gateway_consume_policy_planner.go
+++ b/internal/declarative/planner/event_gateway_consume_policy_planner.go
@@ -575,22 +575,33 @@ func consumePolicyIsSchemaValidation(policy resources.EventGatewayConsumePolicyR
 }
 
 func consumePolicyParentPolicyID(policy resources.EventGatewayConsumePolicyResource) string {
-	if policy.EventGatewayParsedRecordDecryptFieldsPolicyCreate == nil {
+	switch {
+	case policy.EventGatewaySkipRecordPolicyCreate != nil:
+		if id := policy.EventGatewaySkipRecordPolicyCreate.ParentPolicyID; id != nil {
+			return *id
+		}
+		return ""
+	case policy.EventGatewayParsedRecordDecryptFieldsPolicyCreate != nil:
+		return policy.EventGatewayParsedRecordDecryptFieldsPolicyCreate.ParentPolicyID
+	default:
 		return ""
 	}
-	return policy.EventGatewayParsedRecordDecryptFieldsPolicyCreate.ParentPolicyID
 }
 
 func consumePolicyWithParentPolicyID(
 	policy resources.EventGatewayConsumePolicyResource,
 	parentPolicyID string,
 ) resources.EventGatewayConsumePolicyResource {
-	if policy.EventGatewayParsedRecordDecryptFieldsPolicyCreate == nil {
-		return policy
+	switch {
+	case policy.EventGatewaySkipRecordPolicyCreate != nil:
+		variant := *policy.EventGatewaySkipRecordPolicyCreate
+		variant.ParentPolicyID = &parentPolicyID
+		policy.EventGatewaySkipRecordPolicyCreate = &variant
+	case policy.EventGatewayParsedRecordDecryptFieldsPolicyCreate != nil:
+		variant := *policy.EventGatewayParsedRecordDecryptFieldsPolicyCreate
+		variant.ParentPolicyID = parentPolicyID
+		policy.EventGatewayParsedRecordDecryptFieldsPolicyCreate = &variant
 	}
-	variant := *policy.EventGatewayParsedRecordDecryptFieldsPolicyCreate
-	variant.ParentPolicyID = parentPolicyID
-	policy.EventGatewayParsedRecordDecryptFieldsPolicyCreate = &variant
 	return policy
 }
 

--- a/internal/declarative/planner/event_gateway_consume_policy_planner.go
+++ b/internal/declarative/planner/event_gateway_consume_policy_planner.go
@@ -576,6 +576,11 @@ func consumePolicyIsSchemaValidation(policy resources.EventGatewayConsumePolicyR
 
 func consumePolicyParentPolicyID(policy resources.EventGatewayConsumePolicyResource) string {
 	switch {
+	case policy.EventGatewayModifyHeadersPolicyCreate != nil:
+		if id := policy.EventGatewayModifyHeadersPolicyCreate.ParentPolicyID; id != nil {
+			return *id
+		}
+		return ""
 	case policy.EventGatewaySkipRecordPolicyCreate != nil:
 		if id := policy.EventGatewaySkipRecordPolicyCreate.ParentPolicyID; id != nil {
 			return *id
@@ -593,6 +598,10 @@ func consumePolicyWithParentPolicyID(
 	parentPolicyID string,
 ) resources.EventGatewayConsumePolicyResource {
 	switch {
+	case policy.EventGatewayModifyHeadersPolicyCreate != nil:
+		variant := *policy.EventGatewayModifyHeadersPolicyCreate
+		variant.ParentPolicyID = &parentPolicyID
+		policy.EventGatewayModifyHeadersPolicyCreate = &variant
 	case policy.EventGatewaySkipRecordPolicyCreate != nil:
 		variant := *policy.EventGatewaySkipRecordPolicyCreate
 		variant.ParentPolicyID = &parentPolicyID

--- a/internal/declarative/planner/event_gateway_consume_policy_planner_test.go
+++ b/internal/declarative/planner/event_gateway_consume_policy_planner_test.go
@@ -399,3 +399,53 @@ func TestPrepareConsumePolicyParentRefsResolvesSkipRecordParent(t *testing.T) {
 		*prepared[1].EventGatewaySkipRecordPolicyCreate.ParentPolicyID,
 	)
 }
+
+func TestPrepareConsumePolicyParentRefsResolvesModifyHeadersParent(t *testing.T) {
+	parent := consumePolicyResourceFromJSON(t, `{
+		"ref": "schema-validation",
+		"type": "schema_validation",
+		"name": "schema-validation",
+		"config": {
+			"type": "json"
+		}
+	}`)
+	child := consumePolicyResourceFromJSON(t, `{
+		"ref": "modify-headers",
+		"type": "modify_headers",
+		"name": "modify-headers",
+		"parent_policy_id": "__REF__:schema-validation#id",
+		"condition": "record.value != null",
+		"config": {
+			"actions": [
+				{"op": "set", "key": "x-tenant", "value": "acme"}
+			]
+		}
+	}`)
+
+	parentName := "schema-validation"
+	currentByName := map[string]state.EventGatewayConsumePolicyInfo{
+		parentName: {
+			EventGatewayPolicy: kkComps.EventGatewayPolicy{
+				ID:   "schema-validation-id",
+				Name: &parentName,
+				Type: "schema_validation",
+			},
+		},
+	}
+
+	p := &Planner{}
+	prepared, err := p.prepareConsumePolicyParentRefs(
+		[]resources.EventGatewayConsumePolicyResource{parent, child},
+		currentByName,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, prepared, 2)
+	require.NotNil(t, prepared[1].EventGatewayModifyHeadersPolicyCreate)
+	require.NotNil(t, prepared[1].EventGatewayModifyHeadersPolicyCreate.ParentPolicyID)
+	require.Equal(
+		t,
+		"schema-validation-id",
+		*prepared[1].EventGatewayModifyHeadersPolicyCreate.ParentPolicyID,
+	)
+}

--- a/internal/declarative/planner/event_gateway_consume_policy_planner_test.go
+++ b/internal/declarative/planner/event_gateway_consume_policy_planner_test.go
@@ -354,3 +354,48 @@ func TestPrepareConsumePolicyParentRefsResolvesExistingSchemaValidationParent(t 
 		prepared[1].EventGatewayParsedRecordDecryptFieldsPolicyCreate.ParentPolicyID,
 	)
 }
+
+func TestPrepareConsumePolicyParentRefsResolvesSkipRecordParent(t *testing.T) {
+	parent := consumePolicyResourceFromJSON(t, `{
+		"ref": "schema-validation",
+		"type": "schema_validation",
+		"name": "schema-validation",
+		"config": {
+			"type": "json"
+		}
+	}`)
+	child := consumePolicyResourceFromJSON(t, `{
+		"ref": "skip-record",
+		"type": "skip_record",
+		"name": "skip-record",
+		"parent_policy_id": "__REF__:schema-validation#id",
+		"condition": "record.value != null"
+	}`)
+
+	parentName := "schema-validation"
+	currentByName := map[string]state.EventGatewayConsumePolicyInfo{
+		parentName: {
+			EventGatewayPolicy: kkComps.EventGatewayPolicy{
+				ID:   "schema-validation-id",
+				Name: &parentName,
+				Type: "schema_validation",
+			},
+		},
+	}
+
+	p := &Planner{}
+	prepared, err := p.prepareConsumePolicyParentRefs(
+		[]resources.EventGatewayConsumePolicyResource{parent, child},
+		currentByName,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, prepared, 2)
+	require.NotNil(t, prepared[1].EventGatewaySkipRecordPolicyCreate)
+	require.NotNil(t, prepared[1].EventGatewaySkipRecordPolicyCreate.ParentPolicyID)
+	require.Equal(
+		t,
+		"schema-validation-id",
+		*prepared[1].EventGatewaySkipRecordPolicyCreate.ParentPolicyID,
+	)
+}

--- a/internal/declarative/planner/event_gateway_produce_policy_planner.go
+++ b/internal/declarative/planner/event_gateway_produce_policy_planner.go
@@ -593,22 +593,33 @@ func producePolicyIsSchemaValidation(policy resources.EventGatewayProducePolicyR
 }
 
 func producePolicyParentPolicyID(policy resources.EventGatewayProducePolicyResource) string {
-	if policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate == nil {
+	switch {
+	case policy.EventGatewayModifyHeadersPolicyCreate != nil:
+		if id := policy.EventGatewayModifyHeadersPolicyCreate.ParentPolicyID; id != nil {
+			return *id
+		}
+		return ""
+	case policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate != nil:
+		return policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate.ParentPolicyID
+	default:
 		return ""
 	}
-	return policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate.ParentPolicyID
 }
 
 func producePolicyWithParentPolicyID(
 	policy resources.EventGatewayProducePolicyResource,
 	parentPolicyID string,
 ) resources.EventGatewayProducePolicyResource {
-	if policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate == nil {
-		return policy
+	switch {
+	case policy.EventGatewayModifyHeadersPolicyCreate != nil:
+		variant := *policy.EventGatewayModifyHeadersPolicyCreate
+		variant.ParentPolicyID = &parentPolicyID
+		policy.EventGatewayModifyHeadersPolicyCreate = &variant
+	case policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate != nil:
+		variant := *policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate
+		variant.ParentPolicyID = parentPolicyID
+		policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate = &variant
 	}
-	variant := *policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate
-	variant.ParentPolicyID = parentPolicyID
-	policy.EventGatewayParsedRecordEncryptFieldsPolicyCreate = &variant
 	return policy
 }
 

--- a/internal/declarative/planner/event_gateway_produce_policy_planner_test.go
+++ b/internal/declarative/planner/event_gateway_produce_policy_planner_test.go
@@ -481,3 +481,51 @@ func TestPrepareProducePolicyParentRefsResolvesExistingSchemaValidationParent(t 
 		prepared[1].EventGatewayParsedRecordEncryptFieldsPolicyCreate.ParentPolicyID,
 	)
 }
+
+func TestPrepareProducePolicyParentRefsResolvesModifyHeadersParent(t *testing.T) {
+	parent := producePolicyResourceFromJSON(t, `{
+		"ref": "schema-validation",
+		"type": "schema_validation",
+		"name": "schema-validation",
+		"config": {
+			"type": "json"
+		}
+	}`)
+	child := producePolicyResourceFromJSON(t, `{
+		"ref": "modify-headers",
+		"type": "modify_headers",
+		"name": "modify-headers",
+		"parent_policy_id": "__REF__:schema-validation#id",
+		"config": {
+			"actions": [
+				{"op": "set", "key": "x-tenant", "value": "acme"}
+			]
+		}
+	}`)
+
+	currentByName := map[string]state.EventGatewayVirtualClusterProducePolicyInfo{
+		"schema-validation": {
+			EventGatewayPolicy: kkComps.EventGatewayPolicy{
+				ID:   "schema-validation-id",
+				Name: new("schema-validation"),
+				Type: "schema_validation",
+			},
+		},
+	}
+
+	p := newTestPlanner()
+	prepared, err := p.prepareProducePolicyParentRefs(
+		[]resources.EventGatewayProducePolicyResource{parent, child},
+		currentByName,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, prepared, 2)
+	require.NotNil(t, prepared[1].EventGatewayModifyHeadersPolicyCreate)
+	require.NotNil(t, prepared[1].EventGatewayModifyHeadersPolicyCreate.ParentPolicyID)
+	require.Equal(
+		t,
+		"schema-validation-id",
+		*prepared[1].EventGatewayModifyHeadersPolicyCreate.ParentPolicyID,
+	)
+}


### PR DESCRIPTION
`modify_headers` (produce) and `skip_record` (consume) child policies with `parent_policy_id: !ref` ship the raw `__REF__:...` placeholder to Konnect, which 500s.

The planner's parent-policy helpers only pulled the ID off the `encrypt_fields`/`decrypt_fields` variants, so `prepareProducePolicyParentRefs`/`prepareConsumePolicyParentRefs` skipped those two types and never swapped the placeholder for the resolved parent ID. Both variants carry `parent_policy_id` in the SDK, so this just teaches the helpers to read and write it the same way the encrypt/decrypt ones already do.

Unit tests on both `prepare*ParentRefs` cover the `modify_headers`/`skip_record` case with the parent already in current state. They fail on main (placeholder leaks through) and pass with the fix.

closes #1606
