### PR TITLE
test(e2e): add maturity-aware beta handling

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -80,6 +80,7 @@ jobs:
       is_fork: ${{ steps.detect.outputs.is_fork }}
       trusted_e2e_required: ${{ steps.detect.outputs.trusted_e2e_required }}
       run_shards: ${{ steps.detect.outputs.run_shards }}
+      beta_mode: ${{ steps.detect.outputs.beta_mode }}
       konnect_environment: ${{ steps.target.outputs.konnect_environment }}
       konnect_base_url: ${{ steps.target.outputs.konnect_base_url }}
       konnect_base_auth_url: ${{ steps.target.outputs.konnect_base_auth_url }}
@@ -246,6 +247,13 @@ jobs:
           checkout_repository="${GITHUB_REPOSITORY}"
           checkout_ref="${GITHUB_SHA}"
           is_fork=false
+          beta_mode=warn
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && \
+            [ "${DISPATCH_SOURCE}" != "main-debounce" ] && \
+            [ -z "${TRUSTED_PR_NUMBER}" ] && \
+            [ -z "${TRUSTED_HEAD_SHA}" ]; then
+            beta_mode=fail
+          fi
 
           if [ "${GITHUB_EVENT_NAME}" = "pull_request" ] && [ -n "${PULL_REQUEST_HEAD_SHA}" ]; then
             status_sha="${PULL_REQUEST_HEAD_SHA}"
@@ -262,6 +270,7 @@ jobs:
             {
               echo "required=${required}"
               echo "run_shards=${run_shards}"
+              echo "beta_mode=${beta_mode}"
               echo "is_fork=${is_fork}"
               echo "trusted_e2e_required=${trusted_e2e_required}"
               echo "status_sha=${status_sha}"
@@ -566,6 +575,7 @@ jobs:
       KONGCTL_E2E_BIN: ${{ github.workspace }}/kongctl
       KONGCTL_E2E_TEST_BIN: ${{ github.workspace }}/e2e.test
       KONGCTL_E2E_TEST_TIMEOUT: ${{ vars.KONGCTL_E2E_TEST_TIMEOUT || '55m' }}
+      KONGCTL_E2E_BETA_MODE: ${{ needs.e2e-needed.outputs.beta_mode }}
       KONGCTL_E2E_KONNECT_PAT: ${{ secrets.KONGCTL_E2E_KONNECT_PAT }}
       KONGCTL_E2E_KONNECT_ENV: ${{ needs.e2e-needed.outputs.konnect_environment }}
       KONGCTL_E2E_KONNECT_BASE_URL: ${{ needs.e2e-needed.outputs.konnect_base_url }}
@@ -728,13 +738,7 @@ jobs:
           mkdir -p "${ART_DIR}"
           export KONGCTL_E2E_ARTIFACTS_DIR="${ART_DIR}"
 
-          extract_results() {
-            local status="$1"
-            local output_file="$2"
-
-            sed -n "s/^[[:space:]]*--- ${status}: Test_Scenarios\/\(.*\) (.*/\1/p" "${ART_DIR}/run.log" | \
-              sed 's#^test/e2e/scenarios/##' | sort > "${output_file}"
-          }
+          source "${GITHUB_WORKSPACE}/test/e2e/harness/ci/results.sh"
 
           run_started_at="$(date +%s)"
           set +e
@@ -745,17 +749,23 @@ jobs:
           run_finished_at="$(date +%s)"
 
           passed_file="$(mktemp)"
+          passed_raw_file="$(mktemp)"
           failed_file="$(mktemp)"
           skipped_file="$(mktemp)"
+          beta_failed_file="$(mktemp)"
 
-          extract_results "PASS" "${passed_file}"
-          extract_results "FAIL" "${failed_file}"
-          extract_results "SKIP" "${skipped_file}"
+          e2e_extract_go_results "${ART_DIR}/run.log" "PASS" "${passed_raw_file}"
+          e2e_extract_go_results "${ART_DIR}/run.log" "FAIL" "${failed_file}"
+          e2e_extract_go_results "${ART_DIR}/run.log" "SKIP" "${skipped_file}"
+          e2e_extract_beta_failures "${ART_DIR}" "${beta_failed_file}"
+          e2e_subtract_results "${passed_raw_file}" "${beta_failed_file}" "${passed_file}"
+          e2e_emit_beta_annotations "${ART_DIR}"
 
           passed_count="$(wc -l < "${passed_file}" | tr -d ' ')"
           failed_count="$(wc -l < "${failed_file}" | tr -d ' ')"
           skipped_count="$(wc -l < "${skipped_file}" | tr -d ' ')"
-          observed_count="$((passed_count + failed_count + skipped_count))"
+          beta_failed_count="$(wc -l < "${beta_failed_file}" | tr -d ' ')"
+          observed_count="$((passed_count + failed_count + skipped_count + beta_failed_count))"
           duration_seconds="$((run_finished_at - run_started_at))"
 
           {
@@ -768,6 +778,7 @@ jobs:
             printf 'passed_count=%s\n' "${passed_count}"
             printf 'failed_count=%s\n' "${failed_count}"
             printf 'skipped_count=%s\n' "${skipped_count}"
+            printf 'beta_failed_count=%s\n' "${beta_failed_count}"
             printf 'observed_count=%s\n' "${observed_count}"
             printf '\n[passed]\n'
             cat "${passed_file}"
@@ -775,6 +786,8 @@ jobs:
             cat "${failed_file}"
             printf '\n[skipped]\n'
             cat "${skipped_file}"
+            printf '\n[beta_failed]\n'
+            cat "${beta_failed_file}"
           } > "${ART_DIR}/scenario-results.txt"
 
           echo "E2E artifacts: ${ART_DIR}"
@@ -847,11 +860,14 @@ jobs:
           set -euo pipefail
 
           summary_file="${GITHUB_STEP_SUMMARY:-}"
+          source "${GITHUB_WORKSPACE}/test/e2e/harness/ci/results.sh"
           summary_rows="$(mktemp)"
           failed_rows="$(mktemp)"
+          beta_failed_rows="$(mktemp)"
           nonzero_exit_rows="$(mktemp)"
           expected="$(mktemp)"
           actual="$(mktemp)"
+          observed_scenarios="$(mktemp)"
           excluded="$(mktemp)"
           indices="$(mktemp)"
           records="$(mktemp)"
@@ -861,6 +877,7 @@ jobs:
           passed_total=0
           failed_total=0
           skipped_total=0
+          beta_failed_total=0
           observed_total=0
           duration_total=0
           nonzero_exit_total=0
@@ -888,6 +905,7 @@ jobs:
           fi
 
           : > "${actual}"
+          : > "${observed_scenarios}"
           : > "${excluded}"
           : > "${indices}"
           : > "${records}"
@@ -896,6 +914,7 @@ jobs:
           : > "${latest_totals}"
           : > "${summary_rows}"
           : > "${failed_rows}"
+          : > "${beta_failed_rows}"
           : > "${nonzero_exit_rows}"
 
           for manifest in "${manifests[@]}"; do
@@ -930,13 +949,15 @@ jobs:
             passed_count="$(sed -n 's/^passed_count=//p' "${results}")"
             failed_count="$(sed -n 's/^failed_count=//p' "${results}")"
             skipped_count="$(sed -n 's/^skipped_count=//p' "${results}")"
+            beta_failed_count="$(sed -n 's/^beta_failed_count=//p' "${results}")"
             observed_count="$(sed -n 's/^observed_count=//p' "${results}")"
             if [ -z "${exit_code}" ] || [ -z "${duration_seconds}" ] || [ -z "${passed_count}" ] || \
-              [ -z "${failed_count}" ] || [ -z "${skipped_count}" ] || [ -z "${observed_count}" ]; then
+              [ -z "${failed_count}" ] || [ -z "${skipped_count}" ] || \
+              [ -z "${beta_failed_count}" ] || [ -z "${observed_count}" ]; then
               fail "Malformed scenario results: ${results}"
             fi
 
-            printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
               "${run_attempt}" \
               "${index}" \
               "${total}" \
@@ -945,6 +966,7 @@ jobs:
               "${passed_count}" \
               "${failed_count}" \
               "${skipped_count}" \
+              "${beta_failed_count}" \
               "${observed_count}" \
               "${exit_code}" \
               "${duration_seconds}" \
@@ -966,7 +988,8 @@ jobs:
             awk -F'\t' -v total="${total}" '$3 == total && !seen[$2]++ { print }' > "${selected_records}"
 
           while IFS=$'\t' read -r run_attempt index shard_total org_name scenario_rows \
-            passed_count failed_count skipped_count observed_count exit_code duration_seconds manifest results; do
+            passed_count failed_count skipped_count beta_failed_count observed_count exit_code duration_seconds \
+            manifest results; do
             if [ -z "${index}" ]; then
               continue
             fi
@@ -974,7 +997,7 @@ jobs:
             printf '%s\n' "${index}" >> "${indices}"
             tail -n +4 "${manifest}" | sed '/^$/d' >> "${actual}"
 
-            printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
               "${index}" \
               "${run_attempt}" \
               "${org_name}" \
@@ -982,12 +1005,14 @@ jobs:
               "${passed_count}" \
               "${failed_count}" \
               "${skipped_count}" \
+              "${beta_failed_count}" \
               "${exit_code}" \
               "${duration_seconds}" >> "${summary_rows}"
 
             passed_total="$((passed_total + passed_count))"
             failed_total="$((failed_total + failed_count))"
             skipped_total="$((skipped_total + skipped_count))"
+            beta_failed_total="$((beta_failed_total + beta_failed_count))"
             observed_total="$((observed_total + observed_count))"
             duration_total="$((duration_total + duration_seconds))"
             if [ "${exit_code}" -ne 0 ]; then
@@ -1006,6 +1031,18 @@ jobs:
             ' "${results}" | while IFS= read -r scenario_name; do
               printf '%s\t%s\n' "${org_name}" "${scenario_name}" >> "${failed_rows}"
             done
+            awk '
+              /^\[beta_failed\]$/ { section="beta_failed"; next }
+              /^\[/ { section=""; next }
+              section == "beta_failed" && NF { print }
+            ' "${results}" | while IFS= read -r scenario_name; do
+              printf '%s\t%s\n' "${org_name}" "${scenario_name}" >> "${beta_failed_rows}"
+            done
+            awk '
+              /^\[(passed|failed|skipped|beta_failed)\]$/ { section="result"; next }
+              /^\[/ { section=""; next }
+              section == "result" && NF { print }
+            ' "${results}" >> "${observed_scenarios}"
           done < "${selected_records}"
 
           sort -u "${excluded}" -o "${excluded}"
@@ -1045,27 +1082,45 @@ jobs:
             fail "Scenario coverage mismatch across shard manifests."
           fi
 
+          result_coverage_error="$(e2e_result_coverage_error "${actual}" "${observed_scenarios}")"
+          if [ -n "${result_coverage_error}" ]; then
+            fail "${result_coverage_error}"
+          fi
+
           scenario_count="$(wc -l < "${actual}" | tr -d ' ')"
+          if [ "${observed_total}" -ne "${scenario_count}" ]; then
+            fail "Observed result count ${observed_total} does not match assigned scenario count ${scenario_count}."
+          fi
+
+          result_status="passed"
+          if [ "${failed_total}" -gt 0 ] || [ "${nonzero_exit_total}" -gt 0 ]; then
+            result_status="failed"
+          elif [ "${beta_failed_total}" -gt 0 ]; then
+            result_status="passed with beta warnings"
+          fi
+
           if [ -n "${summary_file}" ]; then
             {
               echo "## E2E Results"
               echo
-              echo "- Status: $([ "${failed_total}" -eq 0 ] && [ "${nonzero_exit_total}" -eq 0 ] && echo passed || echo failed)"
+              echo "- Status: ${result_status}"
               echo "- Selected shard layout attempt: ${latest_attempt}"
               echo "- Shards: ${total}"
               echo "- Assigned scenarios: ${scenario_count}"
               echo "- Passed: ${passed_total}"
               echo "- Failed: ${failed_total}"
               echo "- Skipped: ${skipped_total}"
+              echo "- Beta failed: ${beta_failed_total}"
               echo "- Shards with non-zero exit: ${nonzero_exit_total}"
               echo "- Observed results: ${observed_total}"
               echo "- Total shard runtime: ${duration_total}s"
               echo
-              echo "| Shard | Attempt | Org | Assigned | Passed | Failed | Skipped | Exit | Duration |"
-              echo "| --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: |"
+              echo "| Shard | Attempt | Org | Assigned | Passed | Failed | Skipped | Beta failed | Exit | Duration |"
+              echo "| --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |"
             } >> "${summary_file}"
-            while IFS=$'\t' read -r index run_attempt org_name assigned_count passed_count failed_count skipped_count exit_code duration_seconds; do
-              printf '| %s | %s | %s | %s | %s | %s | %s | %s | %ss |\n' \
+            while IFS=$'\t' read -r index run_attempt org_name assigned_count passed_count failed_count \
+              skipped_count beta_failed_count exit_code duration_seconds; do
+              printf '| %s | %s | %s | %s | %s | %s | %s | %s | %s | %ss |\n' \
                 "${index}" \
                 "${run_attempt}" \
                 "${org_name}" \
@@ -1073,6 +1128,7 @@ jobs:
                 "${passed_count}" \
                 "${failed_count}" \
                 "${skipped_count}" \
+                "${beta_failed_count}" \
                 "${exit_code}" \
                 "${duration_seconds}" >> "${summary_file}"
             done < <(sort -n "${summary_rows}")
@@ -1087,6 +1143,18 @@ jobs:
               while IFS=$'\t' read -r org_name scenario_name; do
                 printf '| %s | %s |\n' "${org_name}" "${scenario_name}" >> "${summary_file}"
               done < "${failed_rows}"
+            fi
+            if [ "${beta_failed_total}" -gt 0 ]; then
+              {
+                echo
+                echo "### Beta Failures"
+                echo
+                echo "| Org | Scenario |"
+                echo "| --- | --- |"
+              } >> "${summary_file}"
+              while IFS=$'\t' read -r org_name scenario_name; do
+                printf '| %s | %s |\n' "${org_name}" "${scenario_name}" >> "${summary_file}"
+              done < "${beta_failed_rows}"
             fi
             if [ "${nonzero_exit_total}" -gt 0 ]; then
               {
@@ -1106,16 +1174,7 @@ jobs:
             fi
           fi
 
-          failure_reason=""
-          if [ "${failed_total}" -gt 0 ]; then
-            failure_reason="${failed_total} scenario(s) failed"
-          fi
-          if [ "${nonzero_exit_total}" -gt 0 ]; then
-            if [ -n "${failure_reason}" ]; then
-              failure_reason="${failure_reason}; "
-            fi
-            failure_reason="${failure_reason}${nonzero_exit_total} shard(s) exited non-zero"
-          fi
+          failure_reason="$(e2e_blocking_failure_reason "${failed_total}" "${nonzero_exit_total}")"
           if [ -n "${failure_reason}" ]; then
             fail "E2E verification failed: ${failure_reason}."
           fi

--- a/test/e2e/harness/builder.go
+++ b/test/e2e/harness/builder.go
@@ -144,12 +144,6 @@ func ensureRunDir() (string, error) {
 
 // ArtifactsDir returns the shared E2E run artifact directory.
 func ArtifactsDir() (string, error) {
-	if base := os.Getenv("KONGCTL_E2E_ARTIFACTS_DIR"); base != "" {
-		if err := os.MkdirAll(base, 0o755); err != nil {
-			return "", err
-		}
-		return base, nil
-	}
 	return ensureRunDir()
 }
 

--- a/test/e2e/harness/builder.go
+++ b/test/e2e/harness/builder.go
@@ -142,6 +142,17 @@ func ensureRunDir() (string, error) {
 	return d, nil
 }
 
+// ArtifactsDir returns the shared E2E run artifact directory.
+func ArtifactsDir() (string, error) {
+	if base := os.Getenv("KONGCTL_E2E_ARTIFACTS_DIR"); base != "" {
+		if err := os.MkdirAll(base, 0o755); err != nil {
+			return "", err
+		}
+		return base, nil
+	}
+	return ensureRunDir()
+}
+
 func copyFile(src, dst string) error {
 	fi, err := os.Stat(src)
 	if err != nil {

--- a/test/e2e/harness/ci/results.sh
+++ b/test/e2e/harness/ci/results.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+e2e_extract_go_results() {
+  local run_log="$1"
+  local status="$2"
+  local output_file="$3"
+
+  sed -n "s/^[[:space:]]*--- ${status}: Test_Scenarios\/\(.*\) (.*/\1/p" "${run_log}" |
+    sed 's#^test/e2e/scenarios/##' |
+    sed 's#^scenarios/##' |
+    sort -u >"${output_file}"
+}
+
+e2e_extract_beta_failures() {
+  local artifacts_dir="$1"
+  local output_file="$2"
+  local failures_dir="${artifacts_dir}/beta-failures"
+  local record
+
+  : >"${output_file}"
+  if [ ! -d "${failures_dir}" ]; then
+    return 0
+  fi
+
+  while IFS= read -r record; do
+    jq -er '
+      select(
+        (.scenario | type == "string" and length > 0) and
+        .maturity == "beta" and
+        .mode == "warn" and
+        (.error | type == "string" and length > 0)
+      ) |
+      .scenario
+    ' "${record}" >>"${output_file}"
+  done < <(find "${failures_dir}" -name failure.json -type f | sort)
+
+  sort -u "${output_file}" -o "${output_file}"
+}
+
+e2e_subtract_results() {
+  local input_file="$1"
+  local excluded_file="$2"
+  local output_file="$3"
+
+  comm -23 <(sort -u "${input_file}") <(sort -u "${excluded_file}") >"${output_file}"
+}
+
+e2e_escape_workflow_command() {
+  local value="$1"
+  value="${value//'%'/'%25'}"
+  value="${value//$'\r'/'%0D'}"
+  value="${value//$'\n'/'%0A'}"
+  printf '%s' "${value}"
+}
+
+e2e_emit_beta_annotations() {
+  local artifacts_dir="$1"
+  local failures_dir="${artifacts_dir}/beta-failures"
+  local record scenario message cleanup_message
+
+  if [ ! -d "${failures_dir}" ]; then
+    return 0
+  fi
+
+  while IFS= read -r record; do
+    scenario="$(jq -er '.scenario' "${record}")"
+    message="$(jq -er '.error' "${record}")"
+    printf '::warning file=test/e2e/scenarios/%s,title=Beta E2E failure::%s\n' \
+      "${scenario}" \
+      "$(e2e_escape_workflow_command "${message}")"
+
+    cleanup_message="$(jq -r '.cleanup_error // empty' "${record}")"
+    if [ -n "${cleanup_message}" ]; then
+      printf '::warning file=test/e2e/scenarios/%s,title=Beta E2E cleanup failure::%s\n' \
+        "${scenario}" \
+        "$(e2e_escape_workflow_command "${cleanup_message}")"
+    fi
+  done < <(find "${failures_dir}" -name failure.json -type f | sort)
+}
+
+e2e_blocking_failure_reason() {
+  local failed_total="$1"
+  local nonzero_exit_total="$2"
+  local failure_reason=""
+
+  if [ "${failed_total}" -gt 0 ]; then
+    failure_reason="${failed_total} scenario(s) failed"
+  fi
+  if [ "${nonzero_exit_total}" -gt 0 ]; then
+    if [ -n "${failure_reason}" ]; then
+      failure_reason="${failure_reason}; "
+    fi
+    failure_reason="${failure_reason}${nonzero_exit_total} shard(s) exited non-zero"
+  fi
+
+  printf '%s' "${failure_reason}"
+}
+
+e2e_result_coverage_error() {
+  local assigned_file="$1"
+  local observed_file="$2"
+  local assigned_sorted observed_sorted duplicate_results
+
+  assigned_sorted="$(mktemp)"
+  observed_sorted="$(mktemp)"
+  sort "${assigned_file}" >"${assigned_sorted}"
+  sort "${observed_file}" >"${observed_sorted}"
+
+  duplicate_results="$(uniq -d "${observed_sorted}" || true)"
+  if [ -n "${duplicate_results}" ]; then
+    printf 'Scenarios appeared in multiple result categories: %s' "${duplicate_results}"
+    rm -f "${assigned_sorted}" "${observed_sorted}"
+    return 0
+  fi
+  if ! diff -q "${assigned_sorted}" "${observed_sorted}" >/dev/null; then
+    printf 'Scenario result coverage does not match shard assignments.'
+  fi
+
+  rm -f "${assigned_sorted}" "${observed_sorted}"
+}

--- a/test/e2e/harness/ci/results_test.go
+++ b/test/e2e/harness/ci/results_test.go
@@ -19,8 +19,8 @@ func TestAIGatewayScenariosAreBeta(t *testing.T) {
 	if err != nil {
 		t.Fatalf("glob AI Gateway scenarios: %v", err)
 	}
-	if len(paths) != 15 {
-		t.Fatalf("AI Gateway scenario count = %d, want 15", len(paths))
+	if len(paths) == 0 {
+		t.Fatal("no AI Gateway scenarios found")
 	}
 
 	for _, path := range paths {

--- a/test/e2e/harness/ci/results_test.go
+++ b/test/e2e/harness/ci/results_test.go
@@ -1,0 +1,191 @@
+//go:build e2e
+
+package ci
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+func TestAIGatewayScenariosAreBeta(t *testing.T) {
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(resultsScriptPath(t)), "..", "..", "..", ".."))
+	paths, err := filepath.Glob(filepath.Join(repoRoot, "test", "e2e", "scenarios", "ai-gateway", "*", "scenario.yaml"))
+	if err != nil {
+		t.Fatalf("glob AI Gateway scenarios: %v", err)
+	}
+	if len(paths) != 15 {
+		t.Fatalf("AI Gateway scenario count = %d, want 15", len(paths))
+	}
+
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		var metadata struct {
+			Test struct {
+				Maturity string `yaml:"maturity"`
+			} `yaml:"test"`
+		}
+		if err := yaml.Unmarshal(data, &metadata); err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		if metadata.Test.Maturity != "beta" {
+			t.Errorf("%s maturity = %q, want beta", path, metadata.Test.Maturity)
+		}
+	}
+}
+
+func TestResultAccountingSeparatesBetaFailures(t *testing.T) {
+	dir := t.TempDir()
+	runLog := filepath.Join(dir, "run.log")
+	if err := os.WriteFile(runLog, []byte(strings.Join([]string{
+		"--- PASS: Test_Scenarios/test/e2e/scenarios/portal/pages/scenario.yaml (1.00s)",
+		"--- PASS: Test_Scenarios/scenarios/ai-gateway/model/scenario.yaml (2.00s)",
+		"--- FAIL: Test_Scenarios/test/e2e/scenarios/portal/assets/scenario.yaml (3.00s)",
+		"--- SKIP: Test_Scenarios/test/e2e/scenarios/portal/email/scenario.yaml (0.00s)",
+	}, "\n")), 0o600); err != nil {
+		t.Fatalf("write run log: %v", err)
+	}
+
+	failureDir := filepath.Join(dir, "beta-failures", "ai-gateway", "model")
+	if err := os.MkdirAll(failureDir, 0o755); err != nil {
+		t.Fatalf("create beta failure dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(failureDir, "failure.json"), []byte(`{
+  "scenario": "ai-gateway/model/scenario.yaml",
+  "maturity": "beta",
+  "mode": "warn",
+  "error": "model failed",
+  "cleanup_error": "reset failed"
+}`), 0o600); err != nil {
+		t.Fatalf("write beta failure: %v", err)
+	}
+
+	script := resultsScriptPath(t)
+	command := `
+source "$1"
+e2e_extract_go_results "$2/run.log" PASS "$2/passed.raw"
+e2e_extract_go_results "$2/run.log" FAIL "$2/failed"
+e2e_extract_go_results "$2/run.log" SKIP "$2/skipped"
+e2e_extract_beta_failures "$2" "$2/beta"
+e2e_subtract_results "$2/passed.raw" "$2/beta" "$2/passed"
+e2e_emit_beta_annotations "$2"
+`
+	output, err := exec.Command("bash", "-c", command, "bash", script, dir).CombinedOutput()
+	if err != nil {
+		t.Fatalf("result accounting failed: %v\n%s", err, output)
+	}
+
+	assertFileContents(t, filepath.Join(dir, "passed"), "portal/pages/scenario.yaml\n")
+	assertFileContents(t, filepath.Join(dir, "failed"), "portal/assets/scenario.yaml\n")
+	assertFileContents(t, filepath.Join(dir, "skipped"), "portal/email/scenario.yaml\n")
+	assertFileContents(t, filepath.Join(dir, "beta"), "ai-gateway/model/scenario.yaml\n")
+	annotations := string(output)
+	if !strings.Contains(annotations, "title=Beta E2E failure::model failed") {
+		t.Fatalf("annotations missing beta failure: %s", annotations)
+	}
+	if !strings.Contains(annotations, "title=Beta E2E cleanup failure::reset failed") {
+		t.Fatalf("annotations missing cleanup failure: %s", annotations)
+	}
+}
+
+func TestBlockingFailureReasonIgnoresAdvisoryFailures(t *testing.T) {
+	script := resultsScriptPath(t)
+	command := `
+source "$1"
+printf 'advisory=%s\n' "$(e2e_blocking_failure_reason 0 0)"
+printf 'stable=%s\n' "$(e2e_blocking_failure_reason 2 0)"
+printf 'shard=%s\n' "$(e2e_blocking_failure_reason 0 1)"
+printf 'both=%s\n' "$(e2e_blocking_failure_reason 2 1)"
+`
+	output, err := exec.Command("bash", "-c", command, "bash", script).CombinedOutput()
+	if err != nil {
+		t.Fatalf("failure gating failed: %v\n%s", err, output)
+	}
+	got := string(output)
+	for _, want := range []string{
+		"advisory=\n",
+		"stable=2 scenario(s) failed\n",
+		"shard=1 shard(s) exited non-zero\n",
+		"both=2 scenario(s) failed; 1 shard(s) exited non-zero\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("gating output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestResultCoverageIncludesAllFourCategories(t *testing.T) {
+	dir := t.TempDir()
+	assigned := filepath.Join(dir, "assigned")
+	observed := filepath.Join(dir, "observed")
+	if err := os.WriteFile(assigned, []byte(strings.Join([]string{
+		"portal/pages/scenario.yaml",
+		"portal/assets/scenario.yaml",
+		"portal/email/scenario.yaml",
+		"ai-gateway/model/scenario.yaml",
+	}, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("write assigned scenarios: %v", err)
+	}
+	if err := os.WriteFile(observed, []byte(strings.Join([]string{
+		"portal/pages/scenario.yaml",
+		"portal/assets/scenario.yaml",
+		"portal/email/scenario.yaml",
+		"ai-gateway/model/scenario.yaml",
+	}, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("write observed scenarios: %v", err)
+	}
+
+	script := resultsScriptPath(t)
+	command := `source "$1"; e2e_result_coverage_error "$2" "$3"`
+	output, err := exec.Command("bash", "-c", command, "bash", script, assigned, observed).CombinedOutput()
+	if err != nil {
+		t.Fatalf("result coverage failed: %v\n%s", err, output)
+	}
+	if len(output) != 0 {
+		t.Fatalf("complete result coverage error = %q, want empty", output)
+	}
+
+	if err := os.WriteFile(observed, []byte(strings.Join([]string{
+		"portal/pages/scenario.yaml",
+		"portal/pages/scenario.yaml",
+		"portal/email/scenario.yaml",
+		"ai-gateway/model/scenario.yaml",
+	}, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("write duplicate observed scenarios: %v", err)
+	}
+	output, err = exec.Command("bash", "-c", command, "bash", script, assigned, observed).CombinedOutput()
+	if err != nil {
+		t.Fatalf("duplicate result coverage failed: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "multiple result categories") {
+		t.Fatalf("duplicate result coverage error = %q", output)
+	}
+}
+
+func resultsScriptPath(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test source path")
+	}
+	return filepath.Join(filepath.Dir(filename), "results.sh")
+}
+
+func assertFileContents(t *testing.T, path, want string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(data) != want {
+		t.Fatalf("%s = %q, want %q", path, data, want)
+	}
+}

--- a/test/e2e/harness/scenario/advisory.go
+++ b/test/e2e/harness/scenario/advisory.go
@@ -27,17 +27,34 @@ func RecordAdvisoryFailure(
 	scenarioErr error,
 	cleanupErr error,
 ) (string, error) {
-	if scenarioErr == nil {
-		return "", fmt.Errorf("scenario error is required")
-	}
-
-	scenarioName, err := advisoryScenarioName(scenarioPath)
-	if err != nil {
-		return "", err
-	}
 	artifactsDir, err := harness.ArtifactsDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve artifacts directory: %w", err)
+	}
+	return recordAdvisoryFailureAt(
+		artifactsDir,
+		scenarioPath,
+		maturity,
+		mode,
+		scenarioErr,
+		cleanupErr,
+	)
+}
+
+func recordAdvisoryFailureAt(
+	artifactsDir string,
+	scenarioPath string,
+	maturity Maturity,
+	mode BetaMode,
+	scenarioErr error,
+	cleanupErr error,
+) (string, error) {
+	if scenarioErr == nil {
+		return "", fmt.Errorf("scenario error is required")
+	}
+	scenarioName, err := advisoryScenarioName(scenarioPath)
+	if err != nil {
+		return "", err
 	}
 
 	record := AdvisoryFailure{

--- a/test/e2e/harness/scenario/advisory.go
+++ b/test/e2e/harness/scenario/advisory.go
@@ -1,0 +1,104 @@
+//go:build e2e
+
+package scenario
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/kong/kongctl/test/e2e/harness"
+)
+
+type AdvisoryFailure struct {
+	Scenario     string   `json:"scenario"`
+	Maturity     Maturity `json:"maturity"`
+	Mode         BetaMode `json:"mode"`
+	Error        string   `json:"error"`
+	CleanupError string   `json:"cleanup_error,omitempty"`
+}
+
+func RecordAdvisoryFailure(
+	scenarioPath string,
+	maturity Maturity,
+	mode BetaMode,
+	scenarioErr error,
+	cleanupErr error,
+) (string, error) {
+	if scenarioErr == nil {
+		return "", fmt.Errorf("scenario error is required")
+	}
+
+	scenarioName, err := advisoryScenarioName(scenarioPath)
+	if err != nil {
+		return "", err
+	}
+	artifactsDir, err := harness.ArtifactsDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve artifacts directory: %w", err)
+	}
+
+	record := AdvisoryFailure{
+		Scenario: scenarioName,
+		Maturity: maturity,
+		Mode:     mode,
+		Error:    scenarioErr.Error(),
+	}
+	if cleanupErr != nil {
+		record.CleanupError = cleanupErr.Error()
+	}
+
+	data, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal advisory failure: %w", err)
+	}
+	data = append(data, '\n')
+
+	scenarioDir := strings.TrimSuffix(scenarioName, "/scenario.yaml")
+	path := filepath.Join(artifactsDir, "beta-failures", filepath.FromSlash(scenarioDir), "failure.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", fmt.Errorf("create advisory artifact directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".failure-*.json")
+	if err != nil {
+		return "", fmt.Errorf("create advisory artifact: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		_ = os.Remove(tmpPath)
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return "", fmt.Errorf("set advisory artifact permissions: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return "", fmt.Errorf("write advisory artifact: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return "", fmt.Errorf("close advisory artifact: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return "", fmt.Errorf("publish advisory artifact: %w", err)
+	}
+
+	return path, nil
+}
+
+func advisoryScenarioName(path string) (string, error) {
+	name := filepath.ToSlash(strings.TrimSpace(path))
+	name = strings.TrimPrefix(name, "scenarios/")
+	name = strings.TrimPrefix(name, "test/e2e/scenarios/")
+	name = strings.TrimSuffix(name, "/")
+	name = filepath.ToSlash(filepath.Clean(name))
+
+	if name == "" || name == "." || filepath.IsAbs(name) || name == ".." || strings.HasPrefix(name, "../") {
+		return "", fmt.Errorf("invalid advisory scenario path %q", path)
+	}
+	if !strings.HasSuffix(name, "/scenario.yaml") {
+		return "", fmt.Errorf("invalid advisory scenario path %q: expected scenario.yaml", path)
+	}
+	return name, nil
+}

--- a/test/e2e/harness/scenario/advisory_test.go
+++ b/test/e2e/harness/scenario/advisory_test.go
@@ -1,0 +1,100 @@
+//go:build e2e
+
+package scenario
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRecordAdvisoryFailure(t *testing.T) {
+	artifactsDir := t.TempDir()
+	t.Setenv("KONGCTL_E2E_ARTIFACTS_DIR", artifactsDir)
+
+	path, err := RecordAdvisoryFailure(
+		"test/e2e/scenarios/ai-gateway/model/scenario.yaml",
+		MaturityBeta,
+		BetaModeWarn,
+		errors.New("model scenario failed"),
+		errors.New("reset failed"),
+	)
+	if err != nil {
+		t.Fatalf("RecordAdvisoryFailure() error = %v", err)
+	}
+
+	wantPath := filepath.Join(artifactsDir, "beta-failures", "ai-gateway", "model", "failure.json")
+	if path != wantPath {
+		t.Fatalf("RecordAdvisoryFailure() path = %q, want %q", path, wantPath)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read advisory artifact: %v", err)
+	}
+	var got AdvisoryFailure
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse advisory artifact: %v", err)
+	}
+	if got.Scenario != "ai-gateway/model/scenario.yaml" {
+		t.Fatalf("scenario = %q, want ai-gateway/model/scenario.yaml", got.Scenario)
+	}
+	if got.Maturity != MaturityBeta || got.Mode != BetaModeWarn {
+		t.Fatalf("policy = %q/%q, want beta/warn", got.Maturity, got.Mode)
+	}
+	if got.Error != "model scenario failed" || got.CleanupError != "reset failed" {
+		t.Fatalf("errors = %q/%q, want scenario and cleanup errors", got.Error, got.CleanupError)
+	}
+}
+
+func TestRecordAdvisoryFailureOverwritesInitialRecord(t *testing.T) {
+	artifactsDir := t.TempDir()
+	t.Setenv("KONGCTL_E2E_ARTIFACTS_DIR", artifactsDir)
+	scenarioErr := errors.New("scenario failed")
+	scenarioPath := "test/e2e/scenarios/ai-gateway/model/scenario.yaml"
+
+	path, err := RecordAdvisoryFailure(scenarioPath, MaturityBeta, BetaModeWarn, scenarioErr, nil)
+	if err != nil {
+		t.Fatalf("write initial advisory: %v", err)
+	}
+	if _, err := RecordAdvisoryFailure(
+		scenarioPath,
+		MaturityBeta,
+		BetaModeWarn,
+		scenarioErr,
+		errors.New("cleanup failed"),
+	); err != nil {
+		t.Fatalf("update advisory: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read advisory artifact: %v", err)
+	}
+	var got AdvisoryFailure
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parse advisory artifact: %v", err)
+	}
+	if got.Error != "scenario failed" || got.CleanupError != "cleanup failed" {
+		t.Fatalf("updated errors = %q/%q, want original and cleanup failures", got.Error, got.CleanupError)
+	}
+}
+
+func TestRecordAdvisoryFailureRejectsInvalidInputs(t *testing.T) {
+	t.Setenv("KONGCTL_E2E_ARTIFACTS_DIR", t.TempDir())
+
+	if _, err := RecordAdvisoryFailure("scenario.yaml", MaturityBeta, BetaModeWarn, nil, nil); err == nil {
+		t.Fatal("RecordAdvisoryFailure(nil error) error = nil, want error")
+	}
+	if _, err := RecordAdvisoryFailure(
+		"../../scenario.yaml",
+		MaturityBeta,
+		BetaModeWarn,
+		errors.New("failed"),
+		nil,
+	); err == nil {
+		t.Fatal("RecordAdvisoryFailure(invalid path) error = nil, want error")
+	}
+}

--- a/test/e2e/harness/scenario/advisory_test.go
+++ b/test/e2e/harness/scenario/advisory_test.go
@@ -12,9 +12,9 @@ import (
 
 func TestRecordAdvisoryFailure(t *testing.T) {
 	artifactsDir := t.TempDir()
-	t.Setenv("KONGCTL_E2E_ARTIFACTS_DIR", artifactsDir)
 
-	path, err := RecordAdvisoryFailure(
+	path, err := recordAdvisoryFailureAt(
+		artifactsDir,
 		"test/e2e/scenarios/ai-gateway/model/scenario.yaml",
 		MaturityBeta,
 		BetaModeWarn,
@@ -51,15 +51,22 @@ func TestRecordAdvisoryFailure(t *testing.T) {
 
 func TestRecordAdvisoryFailureOverwritesInitialRecord(t *testing.T) {
 	artifactsDir := t.TempDir()
-	t.Setenv("KONGCTL_E2E_ARTIFACTS_DIR", artifactsDir)
 	scenarioErr := errors.New("scenario failed")
 	scenarioPath := "test/e2e/scenarios/ai-gateway/model/scenario.yaml"
 
-	path, err := RecordAdvisoryFailure(scenarioPath, MaturityBeta, BetaModeWarn, scenarioErr, nil)
+	path, err := recordAdvisoryFailureAt(
+		artifactsDir,
+		scenarioPath,
+		MaturityBeta,
+		BetaModeWarn,
+		scenarioErr,
+		nil,
+	)
 	if err != nil {
 		t.Fatalf("write initial advisory: %v", err)
 	}
-	if _, err := RecordAdvisoryFailure(
+	if _, err := recordAdvisoryFailureAt(
+		artifactsDir,
 		scenarioPath,
 		MaturityBeta,
 		BetaModeWarn,
@@ -83,12 +90,20 @@ func TestRecordAdvisoryFailureOverwritesInitialRecord(t *testing.T) {
 }
 
 func TestRecordAdvisoryFailureRejectsInvalidInputs(t *testing.T) {
-	t.Setenv("KONGCTL_E2E_ARTIFACTS_DIR", t.TempDir())
+	artifactsDir := t.TempDir()
 
-	if _, err := RecordAdvisoryFailure("scenario.yaml", MaturityBeta, BetaModeWarn, nil, nil); err == nil {
+	if _, err := recordAdvisoryFailureAt(
+		artifactsDir,
+		"scenario.yaml",
+		MaturityBeta,
+		BetaModeWarn,
+		nil,
+		nil,
+	); err == nil {
 		t.Fatal("RecordAdvisoryFailure(nil error) error = nil, want error")
 	}
-	if _, err := RecordAdvisoryFailure(
+	if _, err := recordAdvisoryFailureAt(
+		artifactsDir,
 		"../../scenario.yaml",
 		MaturityBeta,
 		BetaModeWarn,

--- a/test/e2e/harness/scenario/preflight.go
+++ b/test/e2e/harness/scenario/preflight.go
@@ -8,6 +8,99 @@ import (
 	"strings"
 )
 
+const BetaModeEnvName = "KONGCTL_E2E_BETA_MODE"
+
+type Maturity string
+
+const (
+	MaturityStable Maturity = "stable"
+	MaturityBeta   Maturity = "beta"
+)
+
+type BetaMode string
+
+const (
+	BetaModeFail BetaMode = "fail"
+	BetaModeWarn BetaMode = "warn"
+	BetaModeSkip BetaMode = "skip"
+)
+
+type scenarioPreflight struct {
+	Maturity   Maturity
+	SkipReason string
+}
+
+func BetaModeFromEnv() (BetaMode, error) {
+	return parseBetaMode(os.Getenv(BetaModeEnvName))
+}
+
+func parseBetaMode(value string) (BetaMode, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return BetaModeFail, nil
+	}
+
+	mode := BetaMode(value)
+	switch mode {
+	case BetaModeFail, BetaModeWarn, BetaModeSkip:
+		return mode, nil
+	default:
+		return "", fmt.Errorf(
+			"invalid %s value %q: supported values are %q, %q, and %q",
+			BetaModeEnvName,
+			value,
+			BetaModeFail,
+			BetaModeWarn,
+			BetaModeSkip,
+		)
+	}
+}
+
+func scenarioMaturity(s Scenario) (Maturity, error) {
+	value := strings.TrimSpace(s.Test.Maturity)
+	if value == "" {
+		return MaturityStable, nil
+	}
+
+	maturity := Maturity(value)
+	switch maturity {
+	case MaturityStable, MaturityBeta:
+		return maturity, nil
+	default:
+		return "", fmt.Errorf(
+			"invalid scenario maturity %q: supported values are %q and %q",
+			value,
+			MaturityStable,
+			MaturityBeta,
+		)
+	}
+}
+
+func IsAdvisoryFailure(maturity Maturity, mode BetaMode) bool {
+	return maturity == MaturityBeta && mode == BetaModeWarn
+}
+
+func preflightScenario(s Scenario, mode BetaMode) (scenarioPreflight, error) {
+	maturity, err := scenarioMaturity(s)
+	if err != nil {
+		return scenarioPreflight{}, err
+	}
+	if _, err := parseBetaMode(string(mode)); err != nil {
+		return scenarioPreflight{}, err
+	}
+	if maturity == MaturityBeta && mode == BetaModeSkip {
+		return scenarioPreflight{
+			Maturity:   maturity,
+			SkipReason: "skipping: beta scenario disabled by KONGCTL_E2E_BETA_MODE=skip",
+		}, nil
+	}
+
+	return scenarioPreflight{
+		Maturity:   maturity,
+		SkipReason: skipScenarioReason(s),
+	}, nil
+}
+
 // skipScenarioReason applies scenario-level preflight checks declared in scenario.yaml.
 // This keeps optional, external-dependency scenarios (like Gmail-backed flows) from
 // running by default unless explicitly opted in and configured.

--- a/test/e2e/harness/scenario/preflight_test.go
+++ b/test/e2e/harness/scenario/preflight_test.go
@@ -2,7 +2,162 @@
 
 package scenario
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestScenarioMaturity(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    Maturity
+		wantErr bool
+	}{
+		{name: "omitted defaults stable", want: MaturityStable},
+		{name: "stable", value: "stable", want: MaturityStable},
+		{name: "beta", value: "beta", want: MaturityBeta},
+		{name: "whitespace trimmed", value: " beta ", want: MaturityBeta},
+		{name: "unknown", value: "experimental", wantErr: true},
+		{name: "case sensitive", value: "Beta", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := scenarioMaturity(Scenario{Test: ScenarioTest{Maturity: tt.value}})
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("scenarioMaturity() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("scenarioMaturity() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("scenarioMaturity() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseBetaMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		want    BetaMode
+		wantErr bool
+	}{
+		{name: "omitted defaults fail", want: BetaModeFail},
+		{name: "fail", value: "fail", want: BetaModeFail},
+		{name: "warn", value: "warn", want: BetaModeWarn},
+		{name: "skip", value: "skip", want: BetaModeSkip},
+		{name: "whitespace trimmed", value: " warn ", want: BetaModeWarn},
+		{name: "unknown", value: "ignore", wantErr: true},
+		{name: "case sensitive", value: "WARN", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseBetaMode(tt.value)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseBetaMode() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseBetaMode() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("parseBetaMode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPreflightScenarioBetaModes(t *testing.T) {
+	beta := Scenario{Test: ScenarioTest{Maturity: string(MaturityBeta)}}
+
+	for _, mode := range []BetaMode{BetaModeFail, BetaModeWarn} {
+		got, err := preflightScenario(beta, mode)
+		if err != nil {
+			t.Fatalf("preflightScenario(beta, %q) error = %v", mode, err)
+		}
+		if got.Maturity != MaturityBeta || got.SkipReason != "" {
+			t.Fatalf("preflightScenario(beta, %q) = %+v, want runnable beta", mode, got)
+		}
+	}
+
+	got, err := preflightScenario(beta, BetaModeSkip)
+	if err != nil {
+		t.Fatalf("preflightScenario(beta, skip) error = %v", err)
+	}
+	if got.Maturity != MaturityBeta || got.SkipReason == "" {
+		t.Fatalf("preflightScenario(beta, skip) = %+v, want skipped beta", got)
+	}
+
+	stable, err := preflightScenario(Scenario{}, BetaModeSkip)
+	if err != nil {
+		t.Fatalf("preflightScenario(stable, skip) error = %v", err)
+	}
+	if stable.Maturity != MaturityStable || stable.SkipReason != "" {
+		t.Fatalf("preflightScenario(stable, skip) = %+v, want runnable stable", stable)
+	}
+}
+
+func TestRunSkipsBetaBeforeHarnessInitialization(t *testing.T) {
+	scenarioPath := filepath.Join(t.TempDir(), "scenario.yaml")
+	if err := os.WriteFile(scenarioPath, []byte("test:\n  maturity: beta\n"), 0o600); err != nil {
+		t.Fatalf("write scenario: %v", err)
+	}
+	t.Setenv("KONGCTL_E2E_BIN", filepath.Join(t.TempDir(), "missing-kongctl"))
+
+	returned := false
+	t.Run("beta", func(t *testing.T) {
+		_, _ = Run(t, scenarioPath, BetaModeSkip)
+		returned = true
+	})
+	if returned {
+		t.Fatal("Run() returned normally, want beta scenario skipped before harness initialization")
+	}
+}
+
+func TestPreflightScenarioValidatesMaturityBeforeSkipGates(t *testing.T) {
+	disabled := false
+	_, err := preflightScenario(Scenario{
+		Test: ScenarioTest{
+			Enabled:  &disabled,
+			Maturity: "experimental",
+		},
+	}, BetaModeWarn)
+	if err == nil {
+		t.Fatal("preflightScenario() error = nil, want invalid maturity error")
+	}
+}
+
+func TestIsAdvisoryFailure(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		maturity Maturity
+		mode     BetaMode
+		want     bool
+	}{
+		{name: "stable fail", maturity: MaturityStable, mode: BetaModeFail},
+		{name: "stable warn", maturity: MaturityStable, mode: BetaModeWarn},
+		{name: "stable skip", maturity: MaturityStable, mode: BetaModeSkip},
+		{name: "beta fail", maturity: MaturityBeta, mode: BetaModeFail},
+		{name: "beta warn", maturity: MaturityBeta, mode: BetaModeWarn, want: true},
+		{name: "beta skip", maturity: MaturityBeta, mode: BetaModeSkip},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsAdvisoryFailure(tt.maturity, tt.mode); got != tt.want {
+				t.Fatalf("IsAdvisoryFailure(%q, %q) = %v, want %v", tt.maturity, tt.mode, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestMissingEnvVars(t *testing.T) {
 	t.Setenv("KONGCTL_TEST_ENV_A", "1")

--- a/test/e2e/harness/scenario/run.go
+++ b/test/e2e/harness/scenario/run.go
@@ -39,18 +39,26 @@ func checkAndStopAfter(stepName, cmdName, stopAfterSpec string, isLastCmdInStep 
 }
 
 // Run executes the scenario using the e2e harness.
-func Run(t *testing.T, scenarioPath string) error {
+func Run(t *testing.T, scenarioPath string, betaMode BetaMode) (Maturity, error) {
 	t.Helper()
 	s, err := Load(scenarioPath)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	if reason := skipScenarioReason(s); reason != "" {
-		t.Skip(reason)
-		return nil
+	preflight, err := preflightScenario(s, betaMode)
+	if err != nil {
+		return "", err
+	}
+	if preflight.SkipReason != "" {
+		t.Skip(preflight.SkipReason)
+		return preflight.Maturity, nil
 	}
 
+	return preflight.Maturity, runScenario(t, scenarioPath, s)
+}
+
+func runScenario(t *testing.T, scenarioPath string, s Scenario) error {
 	harness.RequireBinary(t)
 	if scenarioRequiresPAT(s) {
 		_ = harness.RequirePAT(t, "e2e")

--- a/test/e2e/harness/scenario/types.go
+++ b/test/e2e/harness/scenario/types.go
@@ -25,6 +25,7 @@ type ScenarioTest struct {
 	RequiredEnvVars     []string `yaml:"requiredEnvVars"`
 	RequiresPAT         *bool    `yaml:"requiresPAT"`
 	AssignedEnvironment string   `yaml:"assignedEnvironment"`
+	Maturity            string   `yaml:"maturity"`
 	Info                string   `yaml:"info"`
 }
 

--- a/test/e2e/scenarios/README.md
+++ b/test/e2e/scenarios/README.md
@@ -20,6 +20,44 @@ Quickstart
   - `KONGCTL_E2E_UPDATE_EXPECT=1 make test-e2e-scenarios SCENARIO=portal/visibility`
 - Artifacts: set `KONGCTL_E2E_ARTIFACTS_DIR=/tmp/kongctl-e2e` to choose a folder; otherwise a temp dir is created and printed at the end.
 
+Scenario Maturity
+
+Scenarios are stable by default. Use the `test.maturity` field for scenarios
+covering beta product areas:
+
+```yaml
+test:
+  maturity: beta
+```
+
+Supported values are `stable` and `beta`. Unknown values fail scenario
+preflight.
+
+`KONGCTL_E2E_BETA_MODE` controls beta scenario execution:
+
+- `fail` runs beta scenarios and treats failures as fatal. This is the default
+  for local and ordinary manually dispatched runs.
+- `warn` runs beta scenarios but reports their failures as advisory. Stable
+  failures remain fatal. Required pull request, merge queue, trusted fork, and
+  main-branch runs use this mode.
+- `skip` skips beta scenarios before executing their steps.
+
+Examples:
+
+```sh
+KONGCTL_E2E_BETA_MODE=warn make test-e2e-ai-gateway
+KONGCTL_E2E_BETA_MODE=skip make test-e2e-scenarios
+```
+
+Warned beta failures preserve normal command artifacts and add a structured
+record under `beta-failures/`. The harness then performs a best-effort captured
+organization reset before continuing. Cleanup failures are reported as
+additional warnings without replacing the original scenario error.
+
+CI continues to use `scenario-results.txt` as the shard result artifact. It
+adds `beta_failed_count` and a `[beta_failed]` section alongside the existing
+passed, failed, and skipped results.
+
 Key Concepts
 
 - Scenario: Top-level test definition. Sets defaults for masking and retries.
@@ -42,6 +80,7 @@ Schema (YAML)
 - env: map of environment variables to pass to kongctl
 - vars: free-form variables usable in templates (e.g., for selectors or overlay files)
 - test:
+  - maturity: optional stable|beta classification; defaults to stable
   - enabledByEnvVar: optional opt-in env gate for the scenario
   - assignedEnvironment: optional GitHub Actions environment / matrix org
     name. When set, CI runs the scenario only in the matching matrix job.

--- a/test/e2e/scenarios/ai-gateway/agent/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/agent/scenario.yaml
@@ -1,5 +1,8 @@
 baseInputsPath: testdata
 
+test:
+  maturity: beta
+
 env:
   KONGCTL_LOG_LEVEL: info
 

--- a/test/e2e/scenarios/ai-gateway/config-store/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/config-store/scenario.yaml
@@ -1,5 +1,8 @@
 baseInputsPath: testdata
 
+test:
+  maturity: beta
+
 vars:
   namespace: ai-gateway-config-store-e2e
   gateway_name: AI Gateway Config Store E2E

--- a/test/e2e/scenarios/ai-gateway/consumer-group/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/consumer-group/scenario.yaml
@@ -1,5 +1,8 @@
 baseInputsPath: testdata
 
+test:
+  maturity: beta
+
 env:
   KONGCTL_LOG_LEVEL: info
 

--- a/test/e2e/scenarios/ai-gateway/consumer/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/consumer/scenario.yaml
@@ -1,5 +1,8 @@
 baseInputsPath: testdata
 
+test:
+  maturity: beta
+
 env:
   KONGCTL_LOG_LEVEL: info
 

--- a/test/e2e/scenarios/ai-gateway/data-plane-certificate/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/data-plane-certificate/scenario.yaml
@@ -1,5 +1,8 @@
 baseInputsPath: testdata
 
+test:
+  maturity: beta
+
 env:
   KONGCTL_LOG_LEVEL: info
 

--- a/test/e2e/scenarios/ai-gateway/identity-provider/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/identity-provider/scenario.yaml
@@ -1,5 +1,8 @@
 baseInputsPath: testdata
 
+test:
+  maturity: beta
+
 env:
   KONGCTL_LOG_LEVEL: info
 

--- a/test/e2e/scenarios/ai-gateway/maturity/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/maturity/scenario.yaml
@@ -1,4 +1,5 @@
 test:
+  maturity: beta
   requiresPAT: false
 
 steps:

--- a/test/e2e/scenarios/ai-gateway/mcp-server/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/mcp-server/scenario.yaml
@@ -1,5 +1,8 @@
 baseInputsPath: testdata
 
+test:
+  maturity: beta
+
 env:
   KONGCTL_LOG_LEVEL: info
   KONGCTL_E2E_WEATHERAPI_API_KEY: fake-weather-api-key

--- a/test/e2e/scenarios/ai-gateway/model-matrix/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/model-matrix/scenario.yaml
@@ -1,5 +1,8 @@
 baseInputsPath: testdata
 
+test:
+  maturity: beta
+
 env:
   KONGCTL_LOG_LEVEL: info
 

--- a/test/e2e/scenarios/ai-gateway/model-provider/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/model-provider/scenario.yaml
@@ -1,5 +1,8 @@
 baseInputsPath: testdata
 
+test:
+  maturity: beta
+
 env:
   KONGCTL_LOG_LEVEL: info
 

--- a/test/e2e/scenarios/ai-gateway/model/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/model/scenario.yaml
@@ -1,5 +1,8 @@
 baseInputsPath: testdata
 
+test:
+  maturity: beta
+
 env:
   KONGCTL_LOG_LEVEL: info
 

--- a/test/e2e/scenarios/ai-gateway/policy-matrix/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/policy-matrix/scenario.yaml
@@ -1,5 +1,8 @@
 baseInputsPath: testdata
 
+test:
+  maturity: beta
+
 env:
   KONGCTL_LOG_LEVEL: info
 

--- a/test/e2e/scenarios/ai-gateway/policy/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/policy/scenario.yaml
@@ -1,5 +1,8 @@
 baseInputsPath: testdata
 
+test:
+  maturity: beta
+
 env:
   KONGCTL_LOG_LEVEL: info
 

--- a/test/e2e/scenarios/ai-gateway/root/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/root/scenario.yaml
@@ -1,5 +1,8 @@
 baseInputsPath: testdata
 
+test:
+  maturity: beta
+
 env:
   KONGCTL_LOG_LEVEL: info
 

--- a/test/e2e/scenarios/ai-gateway/vault/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/vault/scenario.yaml
@@ -1,5 +1,8 @@
 baseInputsPath: testdata
 
+test:
+  maturity: beta
+
 env:
   KONGCTL_LOG_LEVEL: info
 

--- a/test/e2e/scenarios_test.go
+++ b/test/e2e/scenarios_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kong/kongctl/test/e2e/harness"
 	"github.com/kong/kongctl/test/e2e/harness/scenario"
 )
 
@@ -96,11 +97,35 @@ func Test_Scenarios(t *testing.T) {
 		return
 	}
 
+	betaMode, err := scenario.BetaModeFromEnv()
+	if err != nil {
+		t.Fatalf("invalid beta scenario configuration: %v", err)
+	}
+
 	for _, p := range selected {
 		t.Run(p, func(t *testing.T) {
-			if err := scenario.Run(t, p); err != nil {
+			maturity, err := scenario.Run(t, p, betaMode)
+			if err == nil {
+				return
+			}
+			if !scenario.IsAdvisoryFailure(maturity, betaMode) {
 				t.Fatalf("scenario failed: %v", err)
 			}
+
+			harness.Warnf("Beta scenario failed: %s: %v", normalizeScenarioPath(p), err)
+			_, recordErr := scenario.RecordAdvisoryFailure(p, maturity, betaMode, err, nil)
+			cleanupErr := harness.ResetOrgWithCapture("after_beta_failure")
+			if cleanupErr != nil {
+				harness.Warnf("Beta scenario cleanup failed: %s: %v", normalizeScenarioPath(p), cleanupErr)
+			}
+			if recordErr != nil {
+				t.Fatalf("record beta scenario advisory failure: %v (original failure: %v)", recordErr, err)
+			}
+			artifactPath, recordErr := scenario.RecordAdvisoryFailure(p, maturity, betaMode, err, cleanupErr)
+			if recordErr != nil {
+				t.Fatalf("update beta scenario advisory failure: %v (original failure: %v)", recordErr, err)
+			}
+			t.Logf("beta scenario failure recorded at %s", artifactPath)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- add stable and beta maturity metadata with fail, warn, and skip policies
- preserve beta advisory failures and cleanup diagnostics in existing E2E artifacts
- extend shard accounting, warnings, and summaries without weakening stable failure gating
- mark AI Gateway scenarios beta and document local and CI behavior

Closes #1717

## Validation

- `go fix ./...`
- `make format`
- `GOFLAGS=-buildvcs=false make build`
- `make lint`
- `make test`
- `make test-integration`
- `make test-installer`
- `go test -count=1 -tags=e2e ./test/e2e/harness/...`
- E2E test binary compilation
- `actionlint .github/workflows/e2e.yaml`
- deterministic local beta warning smoke test with reset disabled; verified advisory error, captured cleanup, and result classification artifacts