### PR TITLE
task(ci): clarify E2E workflow and check naming

### DIFF
--- a/.github/workflows/e2e-main-debounce.yaml
+++ b/.github/workflows/e2e-main-debounce.yaml
@@ -1,5 +1,5 @@
-name: E2E Main Debounce
-run-name: E2E Main Debounce, sha:${{ github.sha }}
+name: E2E / Main Scheduler
+run-name: main · schedule scenarios · ${{ github.sha }}
 
 on:
   push:
@@ -31,7 +31,7 @@ concurrency:
 
 jobs:
   dispatch:
-    name: Dispatch E2E After Quiet Period
+    name: Schedule latest-main scenario run
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -40,10 +40,10 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Wait for quiet period
+      - name: Wait 15 minutes for main to settle
         run: sleep 900
 
-      - name: Dispatch E2E for latest main
+      - name: Dispatch latest-main scenario run
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/e2e-main-debounce.yaml
+++ b/.github/workflows/e2e-main-debounce.yaml
@@ -61,7 +61,7 @@ jobs:
             -f status=queued \
             -f branch="${GITHUB_REF_NAME}" \
             -f per_page=100 \
-            --jq '.workflow_runs[] | select(.display_title | startswith("E2E main debounce ")) | .id' |
+            --jq '.workflow_runs[] | select(.display_title | startswith("main · scenarios · debounced · ")) | .id' |
             while IFS= read -r run_id; do
               if [ -n "${run_id}" ]; then
                 echo "Canceling older queued debounced E2E run ${run_id}."

--- a/.github/workflows/e2e-required-status.yaml
+++ b/.github/workflows/e2e-required-status.yaml
@@ -1,4 +1,5 @@
-name: E2E Gate
+name: E2E / Required Status
+run-name: "PR #${{ github.event.pull_request.number }} · required status · ${{ github.event.action }}"
 
 on:
   pull_request_target:
@@ -23,7 +24,7 @@ concurrency:
 
 jobs:
   e2e-required-status:
-    name: "E2E Gate: Initialize Status"
+    name: Initialize “E2E Required”
     runs-on: ubuntu-latest
     outputs:
       required: ${{ steps.status.outputs.required }}
@@ -36,7 +37,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Initialize E2E Required status
+      - name: Initialize “E2E Required” status
         id: status
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
@@ -83,7 +84,7 @@ jobs:
             core.info(description);
 
   trusted-e2e-required-comment:
-    name: "E2E Gate: Request Trusted Run"
+    name: Request trusted run for fork PR
     needs:
       - e2e-required-status
     if: >-
@@ -102,7 +103,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Request trusted E2E run
+      - name: Post trusted-run instructions
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ needs.e2e-required-status.outputs.pr_number }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,13 +1,17 @@
-name: E2E
+name: E2E / Scenario Suite
 run-name: >-
-  E2E ${{
+  ${{
     github.event_name == 'workflow_dispatch' &&
     inputs.trusted_pr_number != '' &&
-    format('trusted PR {0} {1}', inputs.trusted_pr_number, inputs.trusted_head_sha) ||
+    format('PR #{0} · trusted scenarios · {1}', inputs.trusted_pr_number, inputs.trusted_head_sha) ||
     github.event_name == 'workflow_dispatch' &&
     inputs.dispatch_source == 'main-debounce' &&
-    format('main debounce {0}', inputs.main_sha) ||
-    github.ref_name
+    format('main · scenarios · debounced · {0}', inputs.main_sha) ||
+    github.event_name == 'pull_request' &&
+    format('PR #{0} · scenarios · {1}', github.event.pull_request.number, github.event.action) ||
+    github.event_name == 'merge_group' &&
+    format('Merge queue · scenarios · {0}', github.ref_name) ||
+    format('Manual · scenarios · {0}', inputs.konnect_environment)
   }}
 permissions:
   contents: read
@@ -71,7 +75,7 @@ concurrency:
 
 jobs:
   e2e-needed:
-    name: "E2E Gate: Decide"
+    name: Determine scenario requirement
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -104,7 +108,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Resolve Konnect target
+      - name: Select Konnect environment and organizations
         id: target
         shell: bash
         env:
@@ -230,7 +234,7 @@ jobs:
           echo "konnect_machine_client_id=${konnect_machine_client_id}" >> "${GITHUB_OUTPUT}"
           echo "orgs_json=${orgs_json}" >> "${GITHUB_OUTPUT}"
 
-      - name: Detect whether E2E is required
+      - name: Decide whether scenario suite is required
         id: detect
         shell: bash
         env:
@@ -469,7 +473,7 @@ jobs:
           echo "E2E not required for this change set."
 
   e2e-harness:
-    name: E2E Harness
+    name: Test scenario harness
     needs:
       - e2e-needed
     if: needs.e2e-needed.outputs.run_shards == 'true'
@@ -534,12 +538,12 @@ jobs:
             go mod edit -replace=github.com/Kong/sdk-konnect-go=./.private/sdk-konnect-go-internal
           fi
 
-      - name: Run E2E harness tests
+      - name: Test scenario harness
         run: |
           go test -count=1 -tags=e2e ./test/e2e/harness/...
 
   e2e-build:
-    name: E2E Build
+    name: Build scenario executables
     needs:
       - e2e-needed
     if: needs.e2e-needed.outputs.run_shards == 'true'
@@ -607,10 +611,10 @@ jobs:
       - name: Build kongctl
         run: make build-ci
 
-      - name: Build E2E test binary
+      - name: Build scenario test binary
         run: go test -c -tags=e2e -o e2e.test ./test/e2e
 
-      - name: Upload E2E binaries
+      - name: Upload scenario executables
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-binaries-${{ github.run_id }}
@@ -619,7 +623,7 @@ jobs:
             ${{ github.workspace }}/e2e.test
 
   e2e:
-    name: E2E (${{ matrix.org_name }})
+    name: Run scenarios — ${{ matrix.org_name }}
     needs:
       - e2e-needed
       - e2e-harness
@@ -708,7 +712,7 @@ jobs:
       - name: Setup deck
         uses: kong/setup-deck@6ea0a466ee5826ddb531cbe851ba8e5a77a0e041 # v1.7.1
 
-      - name: Download E2E binaries
+      - name: Download scenario executables
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: e2e-binaries-${{ github.run_id }}
@@ -798,7 +802,7 @@ jobs:
       #   run: |
       #     echo "Skipping E2E (no 'run-e2e' label)." && exit 0
 
-      - name: Run E2E scenario tests (Konnect)
+      - name: Run assigned Konnect scenarios
         run: |
           set -euo pipefail
 
@@ -884,7 +888,7 @@ jobs:
           sudo chown -R "${USER}:${USER}" "${CAP_DIR}" 2>/dev/null || true
           ls -lh "${CAP_DIR}" || true
 
-      - name: Upload E2E artifacts
+      - name: Upload scenario results and diagnostics
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -892,7 +896,7 @@ jobs:
           path: ${{ env.KONGCTL_E2E_ARTIFACTS_DIR }}
 
   e2e-verify:
-    name: E2E Shard Verification
+    name: Verify scenario results and coverage
     needs:
       - e2e-needed
       - e2e
@@ -913,7 +917,7 @@ jobs:
           repository: ${{ needs.e2e-needed.outputs.checkout_repository }}
           ref: ${{ needs.e2e-needed.outputs.checkout_ref }}
 
-      - name: Download workflow artifacts
+      - name: Download shard results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           github-token: ${{ github.token }}
@@ -922,7 +926,7 @@ jobs:
           pattern: e2e-artifacts-${{ github.run_id }}-*
           path: ${{ github.workspace }}/.downloaded-artifacts
 
-      - name: Verify shard coverage
+      - name: Verify scenario coverage and results
         shell: bash
         run: |
           set -euo pipefail
@@ -1249,7 +1253,7 @@ jobs:
           echo "Verified ${scenario_count} scenarios across ${total} shards."
 
   e2e-required:
-    name: "E2E Gate: Report Result"
+    name: Publish “E2E Required”
     needs:
       - e2e-needed
       - e2e-verify
@@ -1269,7 +1273,7 @@ jobs:
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
-      - name: Report E2E Required outcome
+      - name: Publish “E2E Required” status
         id: report
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -1377,7 +1381,7 @@ jobs:
             core.info(description);
 
   trusted-e2e-result-comment:
-    name: "E2E Gate: Update Trusted PR Comment"
+    name: Update trusted-run PR comment
     needs:
       - e2e-required
     if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.trusted_pr_number != '' }}
@@ -1393,7 +1397,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Update trusted E2E comment
+      - name: Update trusted-run PR comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           E2E_REQUIRED_STATE: ${{ needs.e2e-required.outputs.state || 'failure' }}

--- a/docs/contributor/forked-pr-e2e.md
+++ b/docs/contributor/forked-pr-e2e.md
@@ -14,10 +14,10 @@ after the PR is out of draft and review comments are resolved.
 2. Approve the pending fork workflows in the PR.
 
    This lets the normal unprivileged `Checks` and `CI Test` workflows run. The
-   fork-triggered `E2E` workflow may also start, but it should only run the
-   gate path. It should not expand the secret-backed E2E shard jobs, should not
-   use the `default` org fallback, and should not receive Konnect or Gmail
-   secrets.
+   fork-triggered `E2E / Scenario Suite` workflow may also start, but it
+   should only run the gate path. It should not expand the secret-backed E2E
+   shard jobs, should not use the `default` org fallback, and should not
+   receive Konnect or Gmail secrets.
 
 3. Confirm the exact PR head SHA that was reviewed.
 
@@ -28,7 +28,7 @@ after the PR is out of draft and review comments are resolved.
      --jq .headRefOid
    ```
 
-4. Run the trusted E2E workflow from the base repository.
+4. Run the trusted `E2E / Scenario Suite` workflow from the base repository.
 
    ```shell
    gh workflow run e2e.yaml \
@@ -38,7 +38,7 @@ after the PR is out of draft and review comments are resolved.
      -f trusted_head_sha=<full-sha>
    ```
 
-5. Wait for the trusted E2E workflow to finish.
+5. Wait for the trusted `E2E / Scenario Suite` workflow to finish.
 
    The trusted run updates the `E2E Required` commit status on the reviewed
    SHA and updates the trusted E2E PR comment with the result and workflow
@@ -55,13 +55,20 @@ after the PR is out of draft and review comments are resolved.
 workflow job name.
 
 For fork PRs, the PR may still show fork workflows waiting for approval, or a
-fork-triggered `E2E` workflow that skipped the real shard jobs. Those are not
-the trusted E2E result. The canonical fork E2E result is the trusted
-`workflow_dispatch` run from `main`, reflected by:
+fork-triggered `E2E / Scenario Suite` workflow that skipped the real shard
+jobs. Those are not the trusted E2E result. The canonical fork E2E result is
+the trusted `workflow_dispatch` run from `main`, reflected by:
 
 - the `E2E Required` commit status on the reviewed SHA
 - the trusted E2E PR comment
 - the linked trusted E2E workflow run
+
+GitHub displays the workflow name as a checks-screen section, each job name as
+a row in that section, and each step name inside its opened job.
+`E2E Required` is separate: it is the protected commit-status context used as
+the merge gate. Multiple PR events can still create multiple workflow
+sections; the distinct names clarify those runs without changing trigger or
+deduplication behavior.
 
 If `E2E Required` becomes pending again after a trusted run, check whether the
 PR head SHA changed, or whether the PR was closed, reopened, or synchronized

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -369,8 +369,8 @@ steps:
 
 ### CI Notes
 
-The E2E GitHub Actions workflow scales wall-clock time by running one matrix
-job per Konnect org. Each job gets:
+The `E2E / Scenario Suite` GitHub Actions workflow scales wall-clock time by
+running one matrix job per Konnect org. Each job gets:
 
 - one environment-scoped PAT
 - the Konnect environment selector from workflow dispatch or repository
@@ -394,10 +394,24 @@ workflow does not expand shard jobs, does not use the `default` org fallback,
 and does not receive Konnect or Gmail secrets.
 
 The status named `E2E Required` is the merge gate. It is a commit status, not
-one of the workflow job names. For fork PRs, an `E2E Gate` workflow initializes
-that status and posts an updatable PR comment with the exact SHA and trusted
-workflow command. The trusted workflow dispatch later updates the same commit
-status and comment with the pass or fail result.
+one of the workflow job names. For fork PRs, the
+`E2E / Required Status` workflow initializes that status and posts an
+updatable PR comment with the exact SHA and trusted workflow command. The
+trusted `E2E / Scenario Suite` dispatch later updates the same commit status
+and comment with the pass or fail result.
+
+GitHub displays the E2E checks using this hierarchy:
+
+1. The workflow name is the section on the checks screen.
+2. The job name is a check row within that section.
+3. The step name is an operation visible after opening a job.
+4. `E2E Required` is the protected commit-status context used as the merge
+   gate.
+
+Multiple PR events can still create multiple workflow sections. The distinct
+workflow, run, job, and step names clarify those sections without changing
+trigger or deduplication behavior. Main-branch scheduling appears in Actions
+as `E2E / Main Scheduler`.
 
 For the maintainer runbook, see
 `docs/contributor/forked-pr-e2e.md`.


### PR DESCRIPTION
## Summary

- distinguish the required-status, scenario-suite, and main-scheduler workflows
- add event-aware workflow run names and descriptive job and step names
- document the GitHub checks hierarchy and preserve the protected `E2E Required` status

## Rationale

Repeated `E2E` labels made PR checks and Actions history difficult to interpret. These display-only changes clarify each workflow responsibility without changing triggers, permissions, identifiers, dependencies, artifacts, variables, dispatch paths, or execution behavior.

Closes #1731

## Validation

- `actionlint -config-file .github/actionlint.yaml .github/workflows/e2e.yaml .github/workflows/e2e-required-status.yaml .github/workflows/e2e-main-debounce.yaml`
- `go fix ./...`
- `make format`
- `GOFLAGS=-buildvcs=false make build`
- `make lint`
- `make test`
- verified the active `main` ruleset still requires exactly `E2E Required`

`GOFLAGS=-buildvcs=false` was needed locally because Go VCS stamping resolved this linked worktree from `/home/rspurgeon`; the build itself passed.