### PR TITLE
fix(declarative): prevent AI Gateway certificate churn

### DIFF
--- a/internal/declarative/planner/ai_gateway_data_plane_certificate_planner.go
+++ b/internal/declarative/planner/ai_gateway_data_plane_certificate_planner.go
@@ -203,7 +203,7 @@ func shouldReplaceAIGatewayDataPlaneCertificate(
 	if current.Cert != desired.Cert {
 		changedFields[FieldCert] = FieldChange{Old: current.Cert, New: desired.Cert}
 	}
-	if descriptionPlanValue(current.Description) != descriptionPlanValue(desired.Description) {
+	if getString(current.Description) != getString(desired.Description) {
 		changedFields[FieldDescription] = FieldChange{
 			Old: descriptionPlanValue(current.Description),
 			New: descriptionPlanValue(desired.Description),

--- a/internal/declarative/planner/ai_gateway_data_plane_certificate_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_data_plane_certificate_planner_test.go
@@ -44,7 +44,27 @@ func TestAIGatewayDataPlaneCertificatePlannerNoopsMatchingTitleCertAndDescriptio
 		},
 		AIGatewayDataPlaneCertificatesAPI: &testAIGatewayDataPlaneCertificateAPI{
 			certs: []kkComps.AIGatewayDataPlaneClientCertificate{
-				testAIGatewayDataPlaneCertificate("cert-id", "support-data-plane-cert", "first-cert", "Support cert"),
+				testAIGatewayDataPlaneCertificate("Support cert"),
+			},
+		},
+	})
+	rs := testAIGatewayDataPlaneCertificateResourceSet(cert, nil)
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+	require.NoError(t, err)
+	require.Empty(t, plan.Changes)
+}
+
+func TestAIGatewayDataPlaneCertificatePlannerNoopsEmptyRemoteDescriptionWhenDesiredOmitted(t *testing.T) {
+	cert := testAIGatewayDataPlaneCertificateResource()
+	cert.Description = nil
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{
+			gateways: []kkComps.AIGateway{testAIGateway()},
+		},
+		AIGatewayDataPlaneCertificatesAPI: &testAIGatewayDataPlaneCertificateAPI{
+			certs: []kkComps.AIGatewayDataPlaneClientCertificate{
+				testAIGatewayDataPlaneCertificate(""),
 			},
 		},
 	})
@@ -66,7 +86,7 @@ func TestAIGatewayDataPlaneCertificatePlannerReplacesChangedCertificate(t *testi
 		},
 		AIGatewayDataPlaneCertificatesAPI: &testAIGatewayDataPlaneCertificateAPI{
 			certs: []kkComps.AIGatewayDataPlaneClientCertificate{
-				testAIGatewayDataPlaneCertificate("cert-id", "support-data-plane-cert", "first-cert", "Support cert"),
+				testAIGatewayDataPlaneCertificate("Support cert"),
 			},
 		},
 	})
@@ -102,7 +122,7 @@ func TestAIGatewayDataPlaneCertificatePlannerSyncDeletesScopedCertificates(t *te
 		},
 		AIGatewayDataPlaneCertificatesAPI: &testAIGatewayDataPlaneCertificateAPI{
 			certs: []kkComps.AIGatewayDataPlaneClientCertificate{
-				testAIGatewayDataPlaneCertificate("cert-id", "support-data-plane-cert", "first-cert", "Support cert"),
+				testAIGatewayDataPlaneCertificate("Support cert"),
 			},
 		},
 	})
@@ -160,16 +180,11 @@ func testAIGatewayDataPlaneCertificateResource() resources.AIGatewayDataPlaneCer
 	}
 }
 
-func testAIGatewayDataPlaneCertificate(
-	id string,
-	title string,
-	cert string,
-	description string,
-) kkComps.AIGatewayDataPlaneClientCertificate {
+func testAIGatewayDataPlaneCertificate(description string) kkComps.AIGatewayDataPlaneClientCertificate {
 	return kkComps.AIGatewayDataPlaneClientCertificate{
-		ID:          id,
-		Title:       title,
-		Cert:        cert,
+		ID:          "cert-id",
+		Title:       "support-data-plane-cert",
+		Cert:        "first-cert",
 		Description: &description,
 	}
 }

--- a/test/e2e/scenarios/ai-gateway/data-plane-certificate/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/data-plane-certificate/scenario.yaml
@@ -12,7 +12,6 @@ vars:
   gateway_ref: "ai-gateway-data-plane-certificate-e2e"
   cert_ref: "support-data-plane-cert"
   cert_title: "support-data-plane-cert"
-  cert_description: "Support data plane certificate"
   cert_rotated_description: "Support data plane certificate rotated"
 
 defaults:
@@ -98,7 +97,6 @@ steps:
                 action: CREATE
                 references.ai_gateway_id.ref: "{{ .vars.gateway_ref }}"
                 fields.title: "{{ .vars.cert_title }}"
-                fields.description: "{{ .vars.cert_description }}"
                 "contains(fields.cert, 'MIIB4TCCAYug')": true
       - name: 001-apply-create
         outputFormat: json
@@ -131,7 +129,6 @@ steps:
             expect:
               fields:
                 title: "{{ .vars.cert_title }}"
-                description: "{{ .vars.cert_description }}"
                 "contains(cert, 'MIIB4TCCAYug')": true
       - name: 003-get-data-plane-certificate-by-title
         run:
@@ -149,10 +146,6 @@ steps:
             expect:
               fields:
                 "@": "{{ .vars.cert_title }}"
-          - select: description
-            expect:
-              fields:
-                "@": "{{ .vars.cert_description }}"
       - name: 004-get-data-plane-certificate-by-id
         run:
           - get
@@ -168,6 +161,19 @@ steps:
             expect:
               fields:
                 "@": "{{ .vars.cert_title }}"
+      - name: 005-plan-sync-no-changes
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
 
   - name: 003-plan-apply-replace
     inputOverlayDirs:

--- a/test/e2e/scenarios/ai-gateway/data-plane-certificate/testdata/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/data-plane-certificate/testdata/config.yaml
@@ -16,5 +16,4 @@ ai_gateways:
     data_plane_certificates:
       - ref: support-data-plane-cert
         title: support-data-plane-cert
-        description: "Support data plane certificate"
         cert: !file ./certs/first.pem


### PR DESCRIPTION
## Summary

- reproduce non-convergent AI Gateway data-plane certificate syncs in the existing E2E scenario
- treat omitted and empty certificate descriptions as equivalent during drift comparison
- add focused planner regression coverage

## Rationale

Konnect returns an omitted optional certificate description as an empty string. kongctl compared that value with the desired nil pointer and interpreted the representational difference as drift, causing a destructive DELETE and CREATE on every sync.

The comparison now normalizes both values while preserving replacement behavior for genuine certificate or description changes.

## Testing

- `go fix ./...`
- `make format`
- `make build`
- `make lint`
- `make test`
- `make test-integration`
- `make test-e2e-scenarios SCENARIO=ai-gateway/data-plane-certificate STOP_AFTER=002-plan-apply-create/005-plan-sync-no-changes`

Closes #1736