### PR TITLE
feat(cmd): add configurable text layouts and full IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,54 @@ Text cells are limited to 40 display characters and shrink further to fit the
 terminal. JSON and YAML output remain complete and are not affected by text
 column selection.
 
+### Text table layout and IDs
+
+Static text tables use a compact layout and abbreviated UUIDs by default. Both
+behaviors can be configured for each profile:
+
+```yaml
+default:
+  text:
+    layout: auto
+    id-format: full
+```
+
+`text.layout` accepts the following values:
+
+- `compact` keeps the default curated columns.
+- `auto` starts with the compact columns and adds safe display columns when
+  stdout is a TTY with enough room. Piped or redirected output remains compact.
+- `wide` includes all eligible display columns regardless of terminal width.
+
+Automatic and wide layouts keep the compact columns first. They do not add
+label maps, configuration fields, raw helper fields, log-file paths, or fields
+that may contain details, tokens, or secrets.
+
+`text.id-format` accepts `compact` or `full`. Full mode preserves complete UUIDs
+in semantic ID columns, such as `ID`, `OWNER UUID`, and `RESOURCE IDENTIFIER`.
+Other columns shrink first, so a table may exceed the terminal width rather
+than truncate a UUID.
+
+Override profile settings for one command with `--text-layout` and
+`--text-id-format`:
+
+```shell
+kongctl get apis --output text --text-layout wide --text-id-format full
+```
+
+The equivalent environment variables follow the normal profile convention:
+
+```shell
+KONGCTL_DEFAULT_TEXT_LAYOUT=auto \
+KONGCTL_DEFAULT_TEXT_ID_FORMAT=full \
+kongctl get apis
+```
+
+Explicit `--columns` definitions take precedence over both text settings, then
+command-line text flags take precedence over profile or environment values.
+JSON and YAML ignore profile text settings. Explicit text-formatting flags
+cannot be combined with JSON or YAML output.
+
 ## Configuration and Profiles
 
 `kongctl` configuration data is read from `$XDG_CONFIG_HOME/kongctl` and falls back to 

--- a/internal/cmd/output/columns/columns.go
+++ b/internal/cmd/output/columns/columns.go
@@ -32,6 +32,13 @@ type Column struct {
 	steps  []pathStep
 }
 
+// RenderOptions configures static table width allocation.
+type RenderOptions struct {
+	// MinimumWidths prevents selected columns from shrinking below the
+	// corresponding display width. Missing entries use the legacy minimum.
+	MinimumWidths []int
+}
+
 type pathStep struct {
 	key   *string
 	index *int
@@ -412,7 +419,16 @@ func singleLine(value string) string {
 // RenderAutoWidth detects the output terminal width and falls back to 120
 // columns when the output does not expose a terminal file descriptor.
 func RenderAutoWidth(out io.Writer, headers []string, rows [][]string) error {
-	return Render(out, headers, rows, terminalWidth(out))
+	return RenderAutoWidthWithOptions(out, headers, rows, RenderOptions{})
+}
+
+func RenderAutoWidthWithOptions(
+	out io.Writer,
+	headers []string,
+	rows [][]string,
+	options RenderOptions,
+) error {
+	return RenderWithOptions(out, headers, rows, terminalWidth(out), options)
 }
 
 func terminalWidth(out io.Writer) int {
@@ -435,6 +451,16 @@ func terminalWidth(out io.Writer) int {
 
 // Render writes a plain, aligned table with display-width-aware truncation.
 func Render(out io.Writer, headers []string, rows [][]string, availableWidth int) error {
+	return RenderWithOptions(out, headers, rows, availableWidth, RenderOptions{})
+}
+
+func RenderWithOptions(
+	out io.Writer,
+	headers []string,
+	rows [][]string,
+	availableWidth int,
+	options RenderOptions,
+) error {
 	if out == nil {
 		return errors.New("column output stream is unavailable")
 	}
@@ -444,7 +470,7 @@ func Render(out io.Writer, headers []string, rows [][]string, availableWidth int
 	if availableWidth <= 0 {
 		availableWidth = 120
 	}
-	widths := calculateWidths(headers, rows, availableWidth)
+	widths := calculateWidths(headers, rows, availableWidth, options.MinimumWidths)
 	if err := writeRow(out, headers, widths); err != nil {
 		return err
 	}
@@ -456,7 +482,7 @@ func Render(out io.Writer, headers []string, rows [][]string, availableWidth int
 	return nil
 }
 
-func calculateWidths(headers []string, rows [][]string, available int) []int {
+func calculateWidths(headers []string, rows [][]string, available int, configuredMinimums []int) []int {
 	widths := make([]int, len(headers))
 	minimums := make([]int, len(headers))
 	for i, header := range headers {
@@ -467,6 +493,13 @@ func calculateWidths(headers []string, rows [][]string, available int) []int {
 		for i := 0; i < len(headers) && i < len(row); i++ {
 			widths[i] = min(MaxColumnWidth, max(widths[i], runewidth.StringWidth(singleLine(row[i]))))
 		}
+	}
+	for i := range minimums {
+		if i >= len(configuredMinimums) || configuredMinimums[i] <= 0 {
+			continue
+		}
+		minimums[i] = min(MaxColumnWidth, configuredMinimums[i])
+		widths[i] = max(widths[i], minimums[i])
 	}
 	for tableWidth(widths) > available {
 		widest := -1

--- a/internal/cmd/output/columns/columns.go
+++ b/internal/cmd/output/columns/columns.go
@@ -498,7 +498,7 @@ func calculateWidths(headers []string, rows [][]string, available int, configure
 		if i >= len(configuredMinimums) || configuredMinimums[i] <= 0 {
 			continue
 		}
-		minimums[i] = min(MaxColumnWidth, configuredMinimums[i])
+		minimums[i] = max(minimums[i], min(MaxColumnWidth, configuredMinimums[i]))
 		widths[i] = max(widths[i], minimums[i])
 	}
 	for tableWidth(widths) > available {

--- a/internal/cmd/output/columns/columns_test.go
+++ b/internal/cmd/output/columns/columns_test.go
@@ -107,3 +107,13 @@ func TestRenderAutoWidthFallsBackForNonTerminalOutput(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "NAME\npayments\n", out.String())
 }
+
+func TestCalculateWidthsConfiguredMinimumCannotLowerLegacyFloor(t *testing.T) {
+	widths := calculateWidths(
+		[]string{"NAME", "DESCRIPTION"},
+		[][]string{{"payments", "Payment service"}},
+		1,
+		[]int{1, 1},
+	)
+	require.Equal(t, []int{3, 3}, widths)
+}

--- a/internal/cmd/output/tableview/tableview.go
+++ b/internal/cmd/output/tableview/tableview.go
@@ -33,11 +33,14 @@ import (
 	cmdCommon "github.com/kong/kongctl/internal/cmd/common"
 	columnoutput "github.com/kong/kongctl/internal/cmd/output/columns"
 	jqoutput "github.com/kong/kongctl/internal/cmd/output/jq"
+	textoutput "github.com/kong/kongctl/internal/cmd/output/text"
 	"github.com/kong/kongctl/internal/iostreams"
 	"github.com/kong/kongctl/internal/theme"
 	"github.com/muesli/termenv"
 	"github.com/segmentio/cli"
 )
+
+const defaultNameHeader = "NAME"
 
 type fdProvider interface {
 	Fd() uintptr
@@ -2293,6 +2296,10 @@ func RenderForFormat(
 	extraOpts ...Option,
 ) error {
 	var selectedColumns []columnoutput.Column
+	textSettings := textoutput.Settings{
+		Layout:   textoutput.DefaultLayout,
+		IDFormat: textoutput.DefaultIDFormat,
+	}
 	if helper != nil {
 		cfg, err := helper.GetConfig()
 		if err != nil {
@@ -2316,6 +2323,11 @@ func RenderForFormat(
 			return &cmdpkg.ConfigurationError{
 				Err: fmt.Errorf("--%s cannot be combined with --%s", columnoutput.FlagName, jqoutput.FlagName),
 			}
+		}
+
+		textSettings, err = textoutput.Resolve(helper.GetCmd(), cfg, outType.String())
+		if err != nil {
+			return &cmdpkg.ConfigurationError{Err: err}
 		}
 
 		if jqoutput.HasFilter(settings) {
@@ -2366,32 +2378,34 @@ func RenderForFormat(
 
 		var headers []string
 		var matrix [][]string
+		minimumWidths := []int(nil)
 		var err error
 		if len(selectedColumns) > 0 {
 			headers, matrix, err = columnoutput.Project(raw, selectedColumns)
 			if err != nil {
 				return cmdpkg.PrepareExecutionErrorWithHelper(helper, "custom column projection failed", err)
 			}
-		} else if len(cfg.customHeaders) > 0 {
-			headers = slices.Clone(cfg.customHeaders)
-			matrix = rowsToMatrix(cfg.customRows)
-			if !cfg.exactCustomTable {
-				headers, matrix = curateDefaultColumns(headers, matrix, cfg.includeDefaultDescription)
-			}
-			matrix = abbreviateMatrixIDs(headers, matrix)
 		} else {
-			headers, matrix, err = buildRows(display)
+			headers, matrix, minimumWidths, err = buildConfiguredStaticTable(
+				display,
+				cfg,
+				textSettings,
+				streams.Out,
+			)
 			if err != nil {
 				return err
 			}
-			headers, matrix = curateDefaultColumns(headers, matrix, cfg.includeDefaultDescription)
-			matrix = abbreviateMatrixIDs(headers, matrix)
 		}
 
 		if len(headers) == 0 {
 			return writeStaticMessage(streams.Out, "", "No resources found.")
 		}
-		return columnoutput.RenderAutoWidth(streams.Out, headers, matrix)
+		return columnoutput.RenderAutoWidthWithOptions(
+			streams.Out,
+			headers,
+			matrix,
+			columnoutput.RenderOptions{MinimumWidths: minimumWidths},
+		)
 	case cmdCommon.JSON, cmdCommon.YAML:
 		if printer != nil {
 			printer.Print(raw)
@@ -2400,6 +2414,223 @@ func RenderForFormat(
 	default:
 		return fmt.Errorf("tableview: unsupported output format %s", outType.String())
 	}
+}
+
+type staticTableSource struct {
+	headers []string
+	rows    [][]string
+}
+
+func buildConfiguredStaticTable(
+	display any,
+	cfg config,
+	settings textoutput.Settings,
+	out io.Writer,
+) ([]string, [][]string, []int, error) {
+	if cfg.exactCustomTable {
+		headers := slices.Clone(cfg.customHeaders)
+		matrix := formatMatrixIDs(headers, rowsToMatrix(cfg.customRows), settings.IDFormat)
+		return headers, matrix, fullIDMinimumWidths(headers, matrix, settings.IDFormat), nil
+	}
+
+	var displayHeaders []string
+	var displayRows [][]string
+	var err error
+	if display != nil {
+		displayHeaders, displayRows, err = buildRows(display)
+		if err != nil {
+			if len(cfg.customHeaders) == 0 {
+				return nil, nil, nil, err
+			}
+			displayHeaders = nil
+			displayRows = nil
+		}
+	}
+
+	var baseHeaders []string
+	var baseRows [][]string
+	if len(cfg.customHeaders) > 0 {
+		baseHeaders = slices.Clone(cfg.customHeaders)
+		baseRows = rowsToMatrix(cfg.customRows)
+	} else {
+		baseHeaders = slices.Clone(displayHeaders)
+		baseRows = cloneMatrix(displayRows)
+	}
+
+	compactHeaders, compactRows := curateDefaultColumns(
+		baseHeaders,
+		baseRows,
+		cfg.includeDefaultDescription,
+	)
+	sources := []staticTableSource{{headers: displayHeaders, rows: displayRows}}
+	if len(cfg.customHeaders) > 0 {
+		sources = append(sources, staticTableSource{headers: baseHeaders, rows: baseRows})
+	}
+
+	termWidth, _, isTTY := resolveTerminal(out)
+	headers, rows := selectLayoutColumns(
+		compactHeaders,
+		compactRows,
+		sources,
+		settings,
+		termWidth,
+		isTTY,
+	)
+	rows = formatMatrixIDs(headers, rows, settings.IDFormat)
+
+	minimums := fullIDMinimumWidths(headers, rows, settings.IDFormat)
+	if settings.Layout == textoutput.LayoutAuto && isTTY {
+		minimums = mergeMinimumWidths(minimums, readableMinimumWidths(headers))
+	}
+	return headers, rows, minimums, nil
+}
+
+func selectLayoutColumns(
+	compactHeaders []string,
+	compactRows [][]string,
+	sources []staticTableSource,
+	settings textoutput.Settings,
+	terminalWidth int,
+	isTTY bool,
+) ([]string, [][]string) {
+	headers := slices.Clone(compactHeaders)
+	rows := cloneMatrix(compactRows)
+	if settings.Layout == textoutput.LayoutCompact ||
+		(settings.Layout == textoutput.LayoutAuto && !isTTY) {
+		return headers, rows
+	}
+
+	seen := make(map[string]struct{}, len(headers))
+	for _, header := range headers {
+		seen[normalizeDefaultHeader(header)] = struct{}{}
+	}
+
+	for _, source := range sources {
+		if len(source.rows) != len(rows) {
+			continue
+		}
+		for columnIndex, sourceHeader := range source.headers {
+			header := canonicalDefaultHeader(sourceHeader)
+			key := normalizeDefaultHeader(header)
+			if !isEligibleWideHeader(key) {
+				continue
+			}
+			if _, exists := seen[key]; exists {
+				continue
+			}
+
+			candidateMinimum := readableColumnMinimum(header)
+			if settings.IDFormat == textoutput.IDFormatFull && isIDHeaderKey(normalizeHeaderKey(header)) {
+				candidateMinimum = max(candidateMinimum, sourceUUIDWidth(source.rows, columnIndex))
+			}
+			currentMinimums := readableMinimumWidths(headers)
+			if settings.IDFormat == textoutput.IDFormatFull {
+				currentMinimums = mergeMinimumWidths(
+					currentMinimums,
+					fullIDMinimumWidths(headers, rows, settings.IDFormat),
+				)
+			}
+			if settings.Layout == textoutput.LayoutAuto &&
+				staticTableWidth(append(currentMinimums, candidateMinimum)) > terminalWidth {
+				return headers, rows
+			}
+
+			headers = append(headers, header)
+			for rowIndex := range rows {
+				value := ""
+				if columnIndex < len(source.rows[rowIndex]) {
+					value = source.rows[rowIndex][columnIndex]
+				}
+				rows[rowIndex] = append(rows[rowIndex], value)
+			}
+			seen[key] = struct{}{}
+		}
+	}
+	return headers, rows
+}
+
+func staticTableWidth(widths []int) int {
+	return 2*max(0, len(widths)-1) + sum(widths)
+}
+
+func isEligibleWideHeader(header string) bool {
+	if header == "" || header == "LABEL" || header == "LABELS" ||
+		header == "CONFIG" || header == "LOG FILE" || strings.HasPrefix(header, "RAW ") {
+		return false
+	}
+	for field := range strings.FieldsSeq(header) {
+		switch field {
+		case "DETAIL", "TOKEN", "SECRET":
+			return false
+		}
+	}
+	return true
+}
+
+func readableMinimumWidths(headers []string) []int {
+	minimums := make([]int, len(headers))
+	for i, header := range headers {
+		minimums[i] = readableColumnMinimum(header)
+	}
+	return minimums
+}
+
+func readableColumnMinimum(header string) int {
+	return min(columnoutput.MaxColumnWidth, max(6, runewidth.StringWidth(header)))
+}
+
+func sourceUUIDWidth(rows [][]string, columnIndex int) int {
+	width := 0
+	for _, row := range rows {
+		if columnIndex >= len(row) {
+			continue
+		}
+		value := strings.TrimSpace(row[columnIndex])
+		if isLikelyUUID(value) {
+			width = max(width, runewidth.StringWidth(value))
+		}
+	}
+	return width
+}
+
+func formatMatrixIDs(headers []string, rows [][]string, idFormat textoutput.IDFormat) [][]string {
+	if idFormat == textoutput.IDFormatCompact {
+		return abbreviateMatrixIDs(headers, rows)
+	}
+	return cloneMatrix(rows)
+}
+
+func fullIDMinimumWidths(headers []string, rows [][]string, idFormat textoutput.IDFormat) []int {
+	minimums := make([]int, len(headers))
+	if idFormat != textoutput.IDFormatFull {
+		return minimums
+	}
+	for _, index := range identifyIDColumns(headers) {
+		minimums[index] = sourceUUIDWidth(rows, index)
+	}
+	return minimums
+}
+
+func mergeMinimumWidths(left, right []int) []int {
+	length := max(len(left), len(right))
+	merged := make([]int, length)
+	for i := range length {
+		if i < len(left) {
+			merged[i] = left[i]
+		}
+		if i < len(right) {
+			merged[i] = max(merged[i], right[i])
+		}
+	}
+	return merged
+}
+
+func cloneMatrix(rows [][]string) [][]string {
+	cloned := make([][]string, len(rows))
+	for i, row := range rows {
+		cloned[i] = slices.Clone(row)
+	}
+	return cloned
 }
 
 func curateDefaultColumns(
@@ -2412,7 +2643,7 @@ func curateDefaultColumns(
 	}
 
 	identityOrder := []string{
-		"NAME", "DISPLAY NAME", "TITLE", "EMAIL", "USERNAME", "VERSION", "DOMAIN", "FINGERPRINT", "PID", "KEY",
+		defaultNameHeader, "DISPLAY NAME", "TITLE", "EMAIL", "USERNAME", "VERSION", "DOMAIN", "FINGERPRINT", "PID", "KEY",
 		"FULL NAME", "IMPLEMENTATION", "PORTAL", "RESOURCE", "CATEGORY", "TEAM", "APPLICATION", "API",
 	}
 	byName := make(map[string]int, len(headers))
@@ -2447,7 +2678,7 @@ func curateDefaultColumns(
 	}
 
 	identityLimit := 1
-	if _, hasName := byName["NAME"]; hasName && len(headers) == 3 {
+	if _, hasName := byName[defaultNameHeader]; hasName && len(headers) == 3 {
 		if _, hasDisplayName := byName["DISPLAY NAME"]; hasDisplayName {
 			identityLimit = 2
 		}

--- a/internal/cmd/output/tableview/tableview_test.go
+++ b/internal/cmd/output/tableview/tableview_test.go
@@ -13,8 +13,13 @@ import (
 
 	cmd "github.com/kong/kongctl/internal/cmd"
 	cmdCommon "github.com/kong/kongctl/internal/cmd/common"
+	columnoutput "github.com/kong/kongctl/internal/cmd/output/columns"
+	textoutput "github.com/kong/kongctl/internal/cmd/output/text"
+	configpkg "github.com/kong/kongctl/internal/config"
 	"github.com/kong/kongctl/internal/iostreams"
 	"github.com/kong/kongctl/internal/theme"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 type sampleRecord struct {
@@ -552,6 +557,175 @@ func TestRenderForFormat_DefaultTextOmitsWideMetadataAndPutsIDLast(t *testing.T)
 	require.NotContains(t, outBuf.String(), "LABELS")
 	require.NotContains(t, outBuf.String(), "DESCRIPTION")
 	require.NotContains(t, outBuf.String(), "ENDPOINT")
+}
+
+func TestSelectLayoutColumns(t *testing.T) {
+	compactHeaders := []string{"NAME", "ID"}
+	compactRows := [][]string{{"payments", "12345678-1234-1234-1234-123456789012"}}
+	sources := []staticTableSource{{
+		headers: []string{"ID", "NAME", "DESCRIPTION", "LABELS", "CREATED AT", "STATUS"},
+		rows: [][]string{{
+			"12345678-1234-1234-1234-123456789012",
+			"payments",
+			"Payment API",
+			"team: platform",
+			"2026-07-31",
+			"active",
+		}},
+	}}
+
+	t.Run("compact", func(t *testing.T) {
+		headers, rows := selectLayoutColumns(
+			compactHeaders,
+			compactRows,
+			sources,
+			textoutput.Settings{Layout: textoutput.LayoutCompact, IDFormat: textoutput.IDFormatCompact},
+			200,
+			true,
+		)
+		require.Equal(t, compactHeaders, headers)
+		require.Equal(t, compactRows, rows)
+	})
+
+	t.Run("non tty auto falls back to compact", func(t *testing.T) {
+		headers, _ := selectLayoutColumns(
+			compactHeaders,
+			compactRows,
+			sources,
+			textoutput.Settings{Layout: textoutput.LayoutAuto, IDFormat: textoutput.IDFormatCompact},
+			200,
+			false,
+		)
+		require.Equal(t, compactHeaders, headers)
+	})
+
+	t.Run("auto adds a declaration order prefix at readable boundaries", func(t *testing.T) {
+		settings := textoutput.Settings{Layout: textoutput.LayoutAuto, IDFormat: textoutput.IDFormatCompact}
+		headers, _ := selectLayoutColumns(compactHeaders, compactRows, sources, settings, 26, true)
+		require.Equal(t, []string{"NAME", "ID"}, headers)
+
+		headers, _ = selectLayoutColumns(compactHeaders, compactRows, sources, settings, 27, true)
+		require.Equal(t, []string{"NAME", "ID", "DESCRIPTION"}, headers)
+
+		headers, _ = selectLayoutColumns(compactHeaders, compactRows, sources, settings, 39, true)
+		require.Equal(t, []string{"NAME", "ID", "DESCRIPTION", "CREATED AT"}, headers)
+	})
+
+	t.Run("wide includes every safe field with compact columns first", func(t *testing.T) {
+		headers, _ := selectLayoutColumns(
+			compactHeaders,
+			compactRows,
+			sources,
+			textoutput.Settings{Layout: textoutput.LayoutWide, IDFormat: textoutput.IDFormatCompact},
+			10,
+			false,
+		)
+		require.Equal(
+			t,
+			[]string{"NAME", "ID", "DESCRIPTION", "CREATED AT", "STATUS"},
+			headers,
+		)
+	})
+}
+
+func TestBuildConfiguredStaticTableFullIDsAreProtected(t *testing.T) {
+	uuid := "12345678-1234-1234-1234-123456789012"
+	display := []struct {
+		Name string
+		ID   string
+	}{{Name: "a very long resource name", ID: uuid}}
+
+	headers, rows, minimums, err := buildConfiguredStaticTable(
+		display,
+		config{},
+		textoutput.Settings{Layout: textoutput.LayoutCompact, IDFormat: textoutput.IDFormatFull},
+		&strings.Builder{},
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{"NAME", "ID"}, headers)
+	require.Equal(t, uuid, rows[0][1])
+	require.Equal(t, len(uuid), minimums[1])
+
+	var output strings.Builder
+	err = columnoutput.RenderWithOptions(
+		&output,
+		headers,
+		rows,
+		20,
+		columnoutput.RenderOptions{MinimumWidths: minimums},
+	)
+	require.NoError(t, err)
+	require.Contains(t, output.String(), uuid)
+	require.NotContains(t, output.String(), "1234…")
+}
+
+func TestBuildConfiguredStaticTableWideUsesSafeDisplayFields(t *testing.T) {
+	record := labeledRecord{
+		Name:        "payments",
+		Description: "Payment API",
+		Labels:      map[string]string{"team": "platform"},
+		Endpoint:    "https://example.test/payments",
+		ID:          "12345678-1234-1234-1234-123456789012",
+	}
+	cfg := config{
+		customHeaders: []string{"NAME", "ID"},
+		customRows:    []table.Row{{record.Name, record.ID}},
+	}
+
+	headers, rows, _, err := buildConfiguredStaticTable(
+		[]labeledRecord{record},
+		cfg,
+		textoutput.Settings{Layout: textoutput.LayoutWide, IDFormat: textoutput.IDFormatCompact},
+		&strings.Builder{},
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{"NAME", "ID", "DESCRIPTION", "ENDPOINT"}, headers)
+	require.Equal(t, "1234…", rows[0][1])
+}
+
+func TestFormatMatrixIDsRecognizesSemanticHeaders(t *testing.T) {
+	uuid := "12345678-1234-1234-1234-123456789012"
+	headers := []string{"ID", "OWNER UUID", "RESOURCE UID", "EXTERNAL IDENTIFIER", "CUSTOM ID"}
+	rows := [][]string{{uuid, uuid, uuid, uuid, "not-a-uuid"}}
+
+	compact := formatMatrixIDs(headers, rows, textoutput.IDFormatCompact)
+	require.Equal(t, []string{"1234…", "1234…", "1234…", "1234…", "not-a-uuid"}, compact[0])
+
+	full := formatMatrixIDs(headers, rows, textoutput.IDFormatFull)
+	require.Equal(t, rows, full)
+}
+
+func TestRenderForFormatCustomColumnSliceOverridesFullIDSetting(t *testing.T) {
+	mainConfig := viper.New()
+	mainConfig.Set("default", map[string]any{
+		"text": map[string]any{"layout": "wide", "id-format": "full"},
+	})
+	cfg := configpkg.BuildProfiledConfig("default", "config.yaml", mainConfig)
+	command := &cobra.Command{Use: "get"}
+	columnoutput.AddFlags(command.Flags())
+	require.NoError(t, command.Flags().Set(columnoutput.FlagName, "ID=.id[:8]"))
+	command.SetContext(context.WithValue(t.Context(), configpkg.ConfigKey, cfg))
+	helper := cmd.BuildHelper(command, nil)
+	streams, _, output, _ := iostreams.NewTestIOStreams()
+	raw := struct {
+		ID string `json:"id"`
+	}{ID: "12345678-1234-1234-1234-123456789012"}
+
+	err := RenderForFormat(helper, false, cmdCommon.TEXT, nil, streams, raw, raw, "")
+	require.NoError(t, err)
+	require.Equal(t, "ID\n12345678\n", output.String())
+}
+
+func TestRenderForFormatStructuredOutputRemainsRaw(t *testing.T) {
+	printer := &stubPrinter{}
+	streams := iostreams.NewTestIOStreamsOnly()
+	raw := struct {
+		ID string `json:"id"`
+	}{ID: "12345678-1234-1234-1234-123456789012"}
+
+	err := RenderForFormat(nil, false, cmdCommon.JSON, printer, streams, raw, raw, "")
+	require.NoError(t, err)
+	require.Equal(t, []any{raw}, printer.printed)
 }
 
 func TestRenderForFormat_ExplicitDefaultDescriptionIsTruncated(t *testing.T) {

--- a/internal/cmd/output/text/settings.go
+++ b/internal/cmd/output/text/settings.go
@@ -1,0 +1,134 @@
+package text
+
+import (
+	"fmt"
+	"strings"
+
+	cmdcommon "github.com/kong/kongctl/internal/cmd/common"
+	"github.com/kong/kongctl/internal/config"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const (
+	LayoutFlagName     = "text-layout"
+	LayoutConfigPath   = "text.layout"
+	IDFormatFlagName   = "text-id-format"
+	IDFormatConfigPath = "text.id-format"
+	DefaultLayout      = LayoutCompact
+	DefaultIDFormat    = IDFormatCompact
+)
+
+type Layout string
+
+const (
+	LayoutCompact Layout = "compact"
+	LayoutAuto    Layout = "auto"
+	LayoutWide    Layout = "wide"
+)
+
+type IDFormat string
+
+const (
+	IDFormatCompact IDFormat = "compact"
+	IDFormatFull    IDFormat = "full"
+)
+
+type Settings struct {
+	Layout   Layout
+	IDFormat IDFormat
+}
+
+func AddFlags(flags *pflag.FlagSet) {
+	if flags == nil {
+		return
+	}
+	if flags.Lookup(LayoutFlagName) == nil {
+		flags.String(LayoutFlagName, "", fmt.Sprintf(`Configure static text-table column selection.
+- Config path: [ %s ]
+- Allowed    : [ compact|auto|wide ]
+- Default    : [ compact ]`, LayoutConfigPath))
+	}
+	if flags.Lookup(IDFormatFlagName) == nil {
+		flags.String(IDFormatFlagName, "", fmt.Sprintf(`Configure UUID rendering in static text-table ID columns.
+- Config path: [ %s ]
+- Allowed    : [ compact|full ]
+- Default    : [ compact ]`, IDFormatConfigPath))
+	}
+}
+
+func BindFlags(cfg config.Hook, flags *pflag.FlagSet) error {
+	if cfg == nil || flags == nil {
+		return nil
+	}
+	bindings := []struct {
+		flag       string
+		configPath string
+	}{
+		{LayoutFlagName, LayoutConfigPath},
+		{IDFormatFlagName, IDFormatConfigPath},
+	}
+	for _, binding := range bindings {
+		if flag := flags.Lookup(binding.flag); flag != nil {
+			if err := cfg.BindFlag(binding.configPath, flag); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func Resolve(cmd *cobra.Command, cfg config.Hook, outputFormat string) (Settings, error) {
+	settings := Settings{Layout: DefaultLayout, IDFormat: DefaultIDFormat}
+	if outputFormat != cmdcommon.TEXT.String() {
+		if explicitlyConfigured(cmd) {
+			return settings, fmt.Errorf(
+				"--%s and --%s are only supported with --%s text",
+				LayoutFlagName,
+				IDFormatFlagName,
+				cmdcommon.OutputFlagName,
+			)
+		}
+		return settings, nil
+	}
+
+	if cfg == nil {
+		return settings, nil
+	}
+
+	layout := strings.ToLower(strings.TrimSpace(cfg.GetString(LayoutConfigPath)))
+	if layout != "" {
+		settings.Layout = Layout(layout)
+	}
+	idFormat := strings.ToLower(strings.TrimSpace(cfg.GetString(IDFormatConfigPath)))
+	if idFormat != "" {
+		settings.IDFormat = IDFormat(idFormat)
+	}
+	if err := settings.Validate(); err != nil {
+		return Settings{}, err
+	}
+	return settings, nil
+}
+
+func (s Settings) Validate() error {
+	switch s.Layout {
+	case LayoutCompact, LayoutAuto, LayoutWide:
+	default:
+		return fmt.Errorf("invalid %s value %q, must be one of [compact auto wide]", LayoutConfigPath, s.Layout)
+	}
+	switch s.IDFormat {
+	case IDFormatCompact, IDFormatFull:
+	default:
+		return fmt.Errorf("invalid %s value %q, must be one of [compact full]", IDFormatConfigPath, s.IDFormat)
+	}
+	return nil
+}
+
+func explicitlyConfigured(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return false
+	}
+	root := cmd.Root()
+	return cmdcommon.CommandTreeFlagChanged(root, LayoutFlagName) ||
+		cmdcommon.CommandTreeFlagChanged(root, IDFormatFlagName)
+}

--- a/internal/cmd/output/text/settings_test.go
+++ b/internal/cmd/output/text/settings_test.go
@@ -1,0 +1,110 @@
+package text
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kong/kongctl/internal/config"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlagUsageIncludesDefaults(t *testing.T) {
+	cmd, _ := configuredCommand(t, nil)
+	usage := cmd.PersistentFlags().FlagUsages()
+	require.Contains(t, usage, "- Allowed    : [ compact|auto|wide ]\n")
+	require.Contains(t, usage, "- Allowed    : [ compact|full ]\n")
+	require.Equal(t, 2, strings.Count(usage, "- Default    : [ compact ]"))
+}
+
+func TestResolvePrecedenceAndDefaults(t *testing.T) {
+	tests := []struct {
+		name         string
+		profile      map[string]any
+		layoutFlag   string
+		idFormatFlag string
+		want         Settings
+	}{
+		{
+			name: "defaults",
+			want: Settings{Layout: LayoutCompact, IDFormat: IDFormatCompact},
+		},
+		{
+			name: "profile values",
+			profile: map[string]any{
+				"text": map[string]any{"layout": "auto", "id-format": "full"},
+			},
+			want: Settings{Layout: LayoutAuto, IDFormat: IDFormatFull},
+		},
+		{
+			name: "flags override profile",
+			profile: map[string]any{
+				"text": map[string]any{"layout": "auto", "id-format": "full"},
+			},
+			layoutFlag:   "wide",
+			idFormatFlag: "compact",
+			want:         Settings{Layout: LayoutWide, IDFormat: IDFormatCompact},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, cfg := configuredCommand(t, tt.profile)
+			if tt.layoutFlag != "" {
+				require.NoError(t, cmd.PersistentFlags().Set(LayoutFlagName, tt.layoutFlag))
+			}
+			if tt.idFormatFlag != "" {
+				require.NoError(t, cmd.PersistentFlags().Set(IDFormatFlagName, tt.idFormatFlag))
+			}
+
+			got, err := Resolve(cmd, cfg, "text")
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveRejectsInvalidTextSettings(t *testing.T) {
+	cmd, cfg := configuredCommand(t, map[string]any{
+		"text": map[string]any{"layout": "panoramic"},
+	})
+
+	_, err := Resolve(cmd, cfg, "text")
+	require.EqualError(t, err, `invalid text.layout value "panoramic", must be one of [compact auto wide]`)
+}
+
+func TestResolveNonTextOutput(t *testing.T) {
+	t.Run("profile settings are ignored", func(t *testing.T) {
+		cmd, cfg := configuredCommand(t, map[string]any{
+			"text": map[string]any{"layout": "panoramic", "id-format": "invalid"},
+		})
+
+		got, err := Resolve(cmd, cfg, "json")
+		require.NoError(t, err)
+		require.Equal(t, Settings{Layout: LayoutCompact, IDFormat: IDFormatCompact}, got)
+	})
+
+	t.Run("explicit flag is rejected", func(t *testing.T) {
+		cmd, cfg := configuredCommand(t, nil)
+		require.NoError(t, cmd.PersistentFlags().Set(LayoutFlagName, "wide"))
+
+		_, err := Resolve(cmd, cfg, "yaml")
+		require.EqualError(
+			t,
+			err,
+			"--text-layout and --text-id-format are only supported with --output text",
+		)
+	})
+}
+
+func configuredCommand(t *testing.T, profile map[string]any) (*cobra.Command, config.Hook) {
+	t.Helper()
+	mainConfig := viper.New()
+	mainConfig.Set("default", profile)
+	cfg := config.BuildProfiledConfig("default", "config.yaml", mainConfig)
+	cmd := &cobra.Command{Use: "kongctl"}
+	AddFlags(cmd.PersistentFlags())
+	require.NoError(t, BindFlags(cfg, cmd.PersistentFlags()))
+	return cmd, cfg
+}

--- a/internal/cmd/root/products/konnect/aigateway/agents.go
+++ b/internal/cmd/root/products/konnect/aigateway/agents.go
@@ -18,7 +18,6 @@ import (
 	declresources "github.com/kong/kongctl/internal/declarative/resources"
 	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/meta"
-	"github.com/kong/kongctl/internal/util"
 	"github.com/kong/kongctl/internal/util/i18n"
 	"github.com/kong/kongctl/internal/util/normalizers"
 	"github.com/kong/kongctl/internal/util/pagination"
@@ -369,7 +368,7 @@ func aiGatewayAgentToRecord(agent kkComps.AIGatewayAgent) aiGatewayAgentRecord {
 		record.Enabled = fmt.Sprintf("%t", *enabled)
 	}
 	if id := declresources.AIGatewayAgentID(agent); id != "" {
-		record.ID = util.AbbreviateUUID(id)
+		record.ID = id
 	}
 	if updatedAt := declresources.AIGatewayAgentUpdatedAt(agent); !updatedAt.IsZero() {
 		record.LocalUpdatedTime = updatedAt.In(time.Local).Format("2006-01-02 15:04:05")

--- a/internal/cmd/root/products/konnect/aigateway/config_stores.go
+++ b/internal/cmd/root/products/konnect/aigateway/config_stores.go
@@ -16,7 +16,6 @@ import (
 	"github.com/kong/kongctl/internal/config"
 	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/meta"
-	"github.com/kong/kongctl/internal/util"
 	"github.com/kong/kongctl/internal/util/i18n"
 	"github.com/kong/kongctl/internal/util/normalizers"
 	"github.com/kong/kongctl/internal/util/pagination"
@@ -307,7 +306,7 @@ func fetchAIGatewayConfigStores(
 
 func aiGatewayConfigStoreToRecord(store kkComps.AIGatewayConfigStore) aiGatewayConfigStoreRecord {
 	record := aiGatewayConfigStoreRecord{
-		ID:               util.AbbreviateUUID(store.ID),
+		ID:               store.ID,
 		Name:             valueOrMissing(store.Name),
 		DisplayName:      aiGatewayMissingValue,
 		LocalUpdatedTime: aiGatewayMissingValue,

--- a/internal/cmd/root/products/konnect/aigateway/config_stores_test.go
+++ b/internal/cmd/root/products/konnect/aigateway/config_stores_test.go
@@ -20,7 +20,7 @@ func TestAIGatewayConfigStorePresentation(t *testing.T) {
 	}
 
 	record := aiGatewayConfigStoreToRecord(store)
-	require.Equal(t, "1111…", record.ID)
+	require.Equal(t, store.ID, record.ID)
 	require.Equal(t, "support-store", record.Name)
 	require.Equal(t, displayName, record.DisplayName)
 	require.Contains(t, aiGatewayConfigStoreDetailView(store), "display_name: Support-Store")

--- a/internal/cmd/root/products/konnect/aigateway/consumer_groups.go
+++ b/internal/cmd/root/products/konnect/aigateway/consumer_groups.go
@@ -18,7 +18,6 @@ import (
 	declresources "github.com/kong/kongctl/internal/declarative/resources"
 	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/meta"
-	"github.com/kong/kongctl/internal/util"
 	"github.com/kong/kongctl/internal/util/i18n"
 	"github.com/kong/kongctl/internal/util/normalizers"
 	"github.com/kong/kongctl/internal/util/pagination"
@@ -363,7 +362,7 @@ func aiGatewayConsumerGroupToRecord(group kkComps.AIGatewayConsumerGroup) aiGate
 		LocalUpdatedTime: aiGatewayMissingValue,
 	}
 	if id := declresources.AIGatewayConsumerGroupID(group); id != "" {
-		record.ID = util.AbbreviateUUID(id)
+		record.ID = id
 	}
 	if updatedAt := declresources.AIGatewayConsumerGroupUpdatedAt(group); !updatedAt.IsZero() {
 		record.LocalUpdatedTime = updatedAt.In(time.Local).Format("2006-01-02 15:04:05")

--- a/internal/cmd/root/products/konnect/aigateway/consumers.go
+++ b/internal/cmd/root/products/konnect/aigateway/consumers.go
@@ -18,7 +18,6 @@ import (
 	declresources "github.com/kong/kongctl/internal/declarative/resources"
 	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/meta"
-	"github.com/kong/kongctl/internal/util"
 	"github.com/kong/kongctl/internal/util/i18n"
 	"github.com/kong/kongctl/internal/util/normalizers"
 	"github.com/kong/kongctl/internal/util/pagination"
@@ -373,7 +372,7 @@ func aiGatewayConsumerToRecord(consumer kkComps.AIGatewayConsumer) aiGatewayCons
 		LocalUpdatedTime: aiGatewayMissingValue,
 	}
 	if id := declresources.AIGatewayConsumerID(consumer); id != "" {
-		record.ID = util.AbbreviateUUID(id)
+		record.ID = id
 	}
 	if updatedAt := declresources.AIGatewayConsumerUpdatedAt(consumer); !updatedAt.IsZero() {
 		record.LocalUpdatedTime = updatedAt.In(time.Local).Format("2006-01-02 15:04:05")

--- a/internal/cmd/root/products/konnect/aigateway/credentials.go
+++ b/internal/cmd/root/products/konnect/aigateway/credentials.go
@@ -467,7 +467,7 @@ func aiGatewayConsumerCredentialToRecord(
 		LocalUpdatedTime: aiGatewayMissingValue,
 	}
 	if id := declresources.AIGatewayConsumerCredentialID(credential); id != "" {
-		record.ID = util.AbbreviateUUID(id)
+		record.ID = id
 	}
 	if credential.TTL != nil {
 		record.TTL = fmt.Sprintf("%d", *credential.TTL)

--- a/internal/cmd/root/products/konnect/aigateway/data_plane_certificates.go
+++ b/internal/cmd/root/products/konnect/aigateway/data_plane_certificates.go
@@ -408,7 +408,7 @@ func aiGatewayDataPlaneCertificateToRecord(
 		LocalUpdatedTime: aiGatewayMissingValue,
 	}
 	if id := declresources.AIGatewayDataPlaneCertificateID(cert); id != "" {
-		record.ID = util.AbbreviateUUID(id)
+		record.ID = id
 	}
 	if cert.Description != nil {
 		record.Description = valueOrMissing(*cert.Description)

--- a/internal/cmd/root/products/konnect/aigateway/getAIGateway.go
+++ b/internal/cmd/root/products/konnect/aigateway/getAIGateway.go
@@ -71,7 +71,7 @@ func aiGatewayToDisplayRecord(gateway kkComps.AIGateway) aiGatewayDisplayRecord 
 	}
 
 	if strings.TrimSpace(gateway.ID) != "" {
-		record.ID = util.AbbreviateUUID(gateway.ID)
+		record.ID = gateway.ID
 	}
 	if strings.TrimSpace(gateway.DisplayName) != "" {
 		record.DisplayName = gateway.DisplayName

--- a/internal/cmd/root/products/konnect/aigateway/identity_providers.go
+++ b/internal/cmd/root/products/konnect/aigateway/identity_providers.go
@@ -389,7 +389,7 @@ func aiGatewayIdentityProviderToDisplayRecord(
 
 	id := aiGatewayIdentityProviderStringFieldFromRaw(raw, aiGatewayFieldID)
 	if id != "" {
-		id = util.AbbreviateUUID(id)
+		id = strings.TrimSpace(id)
 	} else {
 		id = aiGatewayMissingValue
 	}

--- a/internal/cmd/root/products/konnect/aigateway/mcp_servers.go
+++ b/internal/cmd/root/products/konnect/aigateway/mcp_servers.go
@@ -18,7 +18,6 @@ import (
 	declresources "github.com/kong/kongctl/internal/declarative/resources"
 	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/meta"
-	"github.com/kong/kongctl/internal/util"
 	"github.com/kong/kongctl/internal/util/i18n"
 	"github.com/kong/kongctl/internal/util/normalizers"
 	"github.com/kong/kongctl/internal/util/pagination"
@@ -362,7 +361,7 @@ func aiGatewayMCPServerToRecord(server kkComps.AIGatewayMCPServer) aiGatewayMCPS
 		LocalUpdatedTime: aiGatewayMissingValue,
 	}
 	if id := declresources.AIGatewayMCPServerID(server); id != "" {
-		record.ID = util.AbbreviateUUID(id)
+		record.ID = id
 	}
 	if enabled := declresources.AIGatewayMCPServerEnabled(server); enabled != nil {
 		record.Enabled = fmt.Sprintf("%t", *enabled)

--- a/internal/cmd/root/products/konnect/aigateway/models.go
+++ b/internal/cmd/root/products/konnect/aigateway/models.go
@@ -387,7 +387,7 @@ func aiGatewayModelToRecord(model kkComps.AIGatewayModel) aiGatewayModelRecord {
 		LocalUpdatedTime: aiGatewayMissingValue,
 	}
 	if id := declresources.AIGatewayModelID(model); id != "" {
-		record.ID = util.AbbreviateUUID(id)
+		record.ID = id
 	}
 	if enabled := declresources.AIGatewayModelEnabled(model); enabled != nil {
 		record.Enabled = fmt.Sprintf("%t", *enabled)

--- a/internal/cmd/root/products/konnect/aigateway/nodes.go
+++ b/internal/cmd/root/products/konnect/aigateway/nodes.go
@@ -17,7 +17,6 @@ import (
 	"github.com/kong/kongctl/internal/config"
 	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/meta"
-	"github.com/kong/kongctl/internal/util"
 	"github.com/kong/kongctl/internal/util/i18n"
 	"github.com/kong/kongctl/internal/util/normalizers"
 	"github.com/kong/kongctl/internal/util/pagination"
@@ -345,7 +344,7 @@ func aiGatewayNodeToRecord(node kkComps.AIGatewayDataPlaneNode) aiGatewayNodeRec
 		LocalUpdatedTime: aiGatewayMissingValue,
 	}
 	if id := aiGatewayNodeID(node); id != "" {
-		record.ID = util.AbbreviateUUID(id)
+		record.ID = id
 	}
 	if updatedAt := aiGatewayNodeUpdatedAt(node); !updatedAt.IsZero() {
 		record.LocalUpdatedTime = updatedAt.In(time.Local).Format("2006-01-02 15:04:05")

--- a/internal/cmd/root/products/konnect/aigateway/policies.go
+++ b/internal/cmd/root/products/konnect/aigateway/policies.go
@@ -18,7 +18,6 @@ import (
 	declresources "github.com/kong/kongctl/internal/declarative/resources"
 	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/meta"
-	"github.com/kong/kongctl/internal/util"
 	"github.com/kong/kongctl/internal/util/i18n"
 	"github.com/kong/kongctl/internal/util/normalizers"
 	"github.com/kong/kongctl/internal/util/pagination"
@@ -366,7 +365,7 @@ func aiGatewayPolicyToRecord(policy kkComps.AIGatewayPolicy) aiGatewayPolicyReco
 		LocalUpdatedTime: aiGatewayMissingValue,
 	}
 	if id := declresources.AIGatewayPolicyID(policy); id != "" {
-		record.ID = util.AbbreviateUUID(id)
+		record.ID = id
 	}
 	if enabled := declresources.AIGatewayPolicyEnabled(policy); enabled != nil {
 		record.Enabled = fmt.Sprintf("%t", *enabled)

--- a/internal/cmd/root/products/konnect/aigateway/providers.go
+++ b/internal/cmd/root/products/konnect/aigateway/providers.go
@@ -403,7 +403,7 @@ func aiGatewayProviderToDisplayRecord(provider kkComps.AIGatewayModelProvider) a
 
 	id := aiGatewayProviderStringFieldFromRaw(raw, aiGatewayFieldID)
 	if id != "" {
-		id = util.AbbreviateUUID(id)
+		id = strings.TrimSpace(id)
 	} else {
 		id = aiGatewayMissingValue
 	}

--- a/internal/cmd/root/products/konnect/aigateway/vaults.go
+++ b/internal/cmd/root/products/konnect/aigateway/vaults.go
@@ -382,7 +382,7 @@ func aiGatewayVaultToRecord(vault kkComps.AIGatewayVault) aiGatewayVaultRecord {
 		LocalUpdatedTime: aiGatewayMissingValue,
 	}
 	if id := declresources.AIGatewayVaultID(vault); id != "" {
-		record.ID = util.AbbreviateUUID(id)
+		record.ID = id
 	}
 	if updatedAt := declresources.AIGatewayVaultUpdatedAt(vault); !updatedAt.IsZero() {
 		record.LocalUpdatedTime = updatedAt.In(time.Local).Format("2006-01-02 15:04:05")

--- a/internal/cmd/root/products/konnect/analytics/dashboards.go
+++ b/internal/cmd/root/products/konnect/analytics/dashboards.go
@@ -18,7 +18,6 @@ import (
 	"github.com/kong/kongctl/internal/config"
 	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/meta"
-	"github.com/kong/kongctl/internal/util"
 	"github.com/kong/kongctl/internal/util/i18n"
 	"github.com/kong/kongctl/internal/util/normalizers"
 	"github.com/segmentio/cli"
@@ -71,7 +70,7 @@ func dashboardToDisplayRecord(dashboard kkComps.DashboardResponse) dashboardDisp
 	}
 
 	if dashboard.ID != nil && strings.TrimSpace(*dashboard.ID) != "" {
-		record.ID = util.AbbreviateUUID(*dashboard.ID)
+		record.ID = *dashboard.ID
 	}
 	if strings.TrimSpace(dashboard.Name) != "" {
 		record.Name = dashboard.Name

--- a/internal/cmd/root/products/konnect/api/documents.go
+++ b/internal/cmd/root/products/konnect/api/documents.go
@@ -315,7 +315,7 @@ func (h apiDocumentsHandler) getSingleDocument(
 	}
 
 	record := apiDocumentSummaryRecord{
-		ID:    util.AbbreviateUUID(doc.GetID()),
+		ID:    doc.GetID(),
 		Title: doc.GetTitle(),
 		Slug:  doc.GetSlug(),
 		Status: func() string {
@@ -326,7 +326,7 @@ func (h apiDocumentsHandler) getSingleDocument(
 		}(),
 		ParentDocumentID: func() string {
 			if doc.GetParentDocumentID() != nil && *doc.GetParentDocumentID() != "" {
-				return util.AbbreviateUUID(*doc.GetParentDocumentID())
+				return *doc.GetParentDocumentID()
 			}
 			return valueNA
 		}(),
@@ -419,7 +419,7 @@ func documentSummaryToRecord(doc kkComps.APIDocumentSummaryWithChildren) apiDocu
 	}
 
 	return apiDocumentSummaryRecord{
-		ID:               util.AbbreviateUUID(doc.ID),
+		ID:               doc.ID,
 		Title:            doc.Title,
 		Slug:             doc.Slug,
 		Status:           status,
@@ -537,13 +537,13 @@ func apiDocumentDetailToRecord(doc *kkComps.APIDocumentResponse) apiDocumentDeta
 
 	parentID := valueNA
 	if doc.GetParentDocumentID() != nil && *doc.GetParentDocumentID() != "" {
-		parentID = util.AbbreviateUUID(*doc.GetParentDocumentID())
+		parentID = *doc.GetParentDocumentID()
 	}
 
 	content := normalizeAPIDocumentContent(doc.GetContent())
 
 	return apiDocumentDetailRecord{
-		ID:    util.AbbreviateUUID(doc.GetID()),
+		ID:    doc.GetID(),
 		RawID: strings.TrimSpace(doc.GetID()),
 		Title: doc.GetTitle(),
 		Slug:  doc.GetSlug(),

--- a/internal/cmd/root/products/konnect/api/getAPI.go
+++ b/internal/cmd/root/products/konnect/api/getAPI.go
@@ -62,7 +62,7 @@ func apiToDisplayRecord(a *kkComps.APIResponseSchema) textDisplayRecord {
 
 	var id, name string
 	if a.ID != "" {
-		id = util.AbbreviateUUID(a.ID)
+		id = a.ID
 	} else {
 		id = missing
 	}

--- a/internal/cmd/root/products/konnect/api/implementations.go
+++ b/internal/cmd/root/products/konnect/api/implementations.go
@@ -16,7 +16,6 @@ import (
 	"github.com/kong/kongctl/internal/config"
 	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/meta"
-	"github.com/kong/kongctl/internal/util"
 	"github.com/kong/kongctl/internal/util/i18n"
 	"github.com/kong/kongctl/internal/util/normalizers"
 	"github.com/segmentio/cli"
@@ -292,15 +291,15 @@ func implementationToRecord(implementation kkComps.APIImplementationListItem) ap
 	controlPlaneID := "n/a"
 	if svc := entity.GetService(); svc != nil {
 		if id := svc.GetID(); id != "" {
-			serviceID = util.AbbreviateUUID(id)
+			serviceID = id
 		}
 		if cp := svc.GetControlPlaneID(); cp != "" {
-			controlPlaneID = util.AbbreviateUUID(cp)
+			controlPlaneID = cp
 		}
 	}
 
 	return apiImplementationRecord{
-		ImplementationID: util.AbbreviateUUID(entity.GetID()),
+		ImplementationID: entity.GetID(),
 		ServiceID:        serviceID,
 		ControlPlaneID:   controlPlaneID,
 		LocalCreatedTime: entity.GetCreatedAt().In(time.Local).Format("2006-01-02 15:04:05"),

--- a/internal/cmd/root/products/konnect/api/versions.go
+++ b/internal/cmd/root/products/konnect/api/versions.go
@@ -244,7 +244,7 @@ func (h apiVersionsHandler) listVersions(
 	for _, summary := range summaries {
 		record := versionSummaryToRecord(summary)
 		displayRecords = append(displayRecords, record)
-		rows = append(rows, table.Row{summary.GetVersion(), util.AbbreviateUUID(record.ID)})
+		rows = append(rows, table.Row{summary.GetVersion(), record.ID})
 	}
 
 	detailFn := func(index int) string {
@@ -332,7 +332,7 @@ func (h apiVersionsHandler) getSingleVersion(
 	cache.Set(record.RawID, record)
 
 	rows := []table.Row{
-		{record.Version, util.AbbreviateUUID(record.ID)},
+		{record.Version, record.ID},
 	}
 
 	display := any(record)
@@ -442,7 +442,7 @@ func versionDetailToRecord(version *kkComps.APIVersionResponse) apiVersionDetail
 	}
 
 	return apiVersionDetailRecord{
-		ID:       util.AbbreviateUUID(version.GetID()),
+		ID:       version.GetID(),
 		RawID:    strings.TrimSpace(version.GetID()),
 		Version:  version.GetVersion(),
 		SpecType: specType,

--- a/internal/cmd/root/products/konnect/authstrategy/getAuthStrategy.go
+++ b/internal/cmd/root/products/konnect/authstrategy/getAuthStrategy.go
@@ -151,7 +151,7 @@ func authStrategyToDisplayRecord(strategy kkComps.AppAuthStrategy) textDisplayRe
 
 	if info.rawParent != nil {
 		if info.id != "" {
-			record.ID = util.AbbreviateUUID(info.id)
+			record.ID = info.id
 		}
 		if strings.TrimSpace(info.name) != "" {
 			record.Name = info.name

--- a/internal/cmd/root/products/konnect/dcrprovider/getDCRProvider.go
+++ b/internal/cmd/root/products/konnect/dcrprovider/getDCRProvider.go
@@ -18,7 +18,6 @@ import (
 	"github.com/kong/kongctl/internal/config"
 	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/meta"
-	"github.com/kong/kongctl/internal/util"
 	"github.com/kong/kongctl/internal/util/i18n"
 	"github.com/kong/kongctl/internal/util/normalizers"
 	"github.com/segmentio/cli"
@@ -128,7 +127,7 @@ func dcrProviderToDisplayRecord(provider dcrProvider) textDisplayRecord {
 	}
 
 	if strings.TrimSpace(provider.ID) != "" {
-		record.ID = util.AbbreviateUUID(provider.ID)
+		record.ID = provider.ID
 	}
 	if strings.TrimSpace(provider.Name) != "" {
 		record.Name = provider.Name

--- a/internal/cmd/root/products/konnect/eventgateway/backend_clusters.go
+++ b/internal/cmd/root/products/konnect/eventgateway/backend_clusters.go
@@ -405,9 +405,7 @@ func findClusterByName(clusters []kkComps.BackendCluster, identifier string) *kk
 
 func backendClusterToRecord(cluster kkComps.BackendCluster) backendClusterSummaryRecord {
 	id := cluster.ID
-	if id != "" {
-		id = util.AbbreviateUUID(id)
-	} else {
+	if id == "" {
 		id = valueNA
 	}
 

--- a/internal/cmd/root/products/konnect/eventgateway/cluster-policies.go
+++ b/internal/cmd/root/products/konnect/eventgateway/cluster-policies.go
@@ -482,9 +482,7 @@ func makeClusterPolicySummaryRecord(
 	createdAt, updatedAt time.Time,
 ) clusterPolicySummaryRecord {
 	recordID := id
-	if recordID != "" {
-		recordID = util.AbbreviateUUID(recordID)
-	} else {
+	if recordID == "" {
 		recordID = valueNA
 	}
 

--- a/internal/cmd/root/products/konnect/eventgateway/consume-policies.go
+++ b/internal/cmd/root/products/konnect/eventgateway/consume-policies.go
@@ -487,9 +487,7 @@ func findConsumePolicyByName(
 
 func consumePolicyToRecord(policy kkComps.EventGatewayPolicy) consumePolicySummaryRecord {
 	recordID := policy.ID
-	if recordID != "" {
-		recordID = util.AbbreviateUUID(recordID)
-	} else {
+	if recordID == "" {
 		recordID = valueNA
 	}
 
@@ -521,9 +519,7 @@ func consumePolicyToRecord(policy kkComps.EventGatewayPolicy) consumePolicySumma
 
 func consumePolicyWithConfigToRecord(policy consumePolicyWithConfig) consumePolicySummaryRecord {
 	id := policy.ID
-	if id != "" {
-		id = util.AbbreviateUUID(id)
-	} else {
+	if id == "" {
 		id = valueNA
 	}
 

--- a/internal/cmd/root/products/konnect/eventgateway/data_plane_certificates.go
+++ b/internal/cmd/root/products/konnect/eventgateway/data_plane_certificates.go
@@ -395,9 +395,7 @@ func findDataPlaneCertByName(
 
 func dataPlaneCertToRecord(cert kkComps.EventGatewayDataPlaneCertificate) dataPlaneCertSummaryRecord {
 	id := cert.ID
-	if id != "" {
-		id = util.AbbreviateUUID(id)
-	} else {
+	if id == "" {
 		id = valueNA
 	}
 

--- a/internal/cmd/root/products/konnect/eventgateway/getEventGateway.go
+++ b/internal/cmd/root/products/konnect/eventgateway/getEventGateway.go
@@ -68,7 +68,7 @@ func eventGatewayControlPlaneToDisplayRecord(e *kkComps.EventGatewayInfo) textDi
 
 	var id, name string
 	if e.ID != "" {
-		id = util.AbbreviateUUID(e.ID)
+		id = e.ID
 	} else {
 		id = missing
 	}

--- a/internal/cmd/root/products/konnect/eventgateway/listener-policies.go
+++ b/internal/cmd/root/products/konnect/eventgateway/listener-policies.go
@@ -531,9 +531,7 @@ func makeListenerPolicySummaryRecord(
 	createdAt, updatedAt time.Time,
 ) listenerPolicySummaryRecord {
 	recordID := id
-	if recordID != "" {
-		recordID = util.AbbreviateUUID(recordID)
-	} else {
+	if recordID == "" {
 		recordID = valueNA
 	}
 

--- a/internal/cmd/root/products/konnect/eventgateway/listeners.go
+++ b/internal/cmd/root/products/konnect/eventgateway/listeners.go
@@ -375,9 +375,7 @@ func findListenerByName(listeners []kkComps.EventGatewayListener, name string) *
 
 func listenerToRecord(listener kkComps.EventGatewayListener) listenerSummaryRecord {
 	id := listener.ID
-	if id != "" {
-		id = util.AbbreviateUUID(id)
-	} else {
+	if id == "" {
 		id = valueNA
 	}
 

--- a/internal/cmd/root/products/konnect/eventgateway/produce-policies.go
+++ b/internal/cmd/root/products/konnect/eventgateway/produce-policies.go
@@ -495,9 +495,7 @@ func findProducePolicyByName(
 
 func producePolicyToRecord(policy kkComps.EventGatewayPolicy) producePolicySummaryRecord {
 	id := policy.ID
-	if id != "" {
-		id = util.AbbreviateUUID(id)
-	} else {
+	if id == "" {
 		id = valueNA
 	}
 
@@ -609,9 +607,7 @@ func producePolicyWithConfigDetailView(policy *producePolicyWithConfig) string {
 
 func producePolicyWithConfigToRecord(policy producePolicyWithConfig) producePolicySummaryRecord {
 	id := policy.ID
-	if id != "" {
-		id = util.AbbreviateUUID(id)
-	} else {
+	if id == "" {
 		id = valueNA
 	}
 

--- a/internal/cmd/root/products/konnect/eventgateway/schema_registries.go
+++ b/internal/cmd/root/products/konnect/eventgateway/schema_registries.go
@@ -440,9 +440,7 @@ func findSchemaRegistryByName(
 
 func schemaRegistryToRecord(sr schemaRegistryEntry) schemaRegistrySummaryRecord {
 	id := sr.ID
-	if id != "" {
-		id = util.AbbreviateUUID(id)
-	} else {
+	if id == "" {
 		id = valueNA
 	}
 

--- a/internal/cmd/root/products/konnect/eventgateway/static_keys.go
+++ b/internal/cmd/root/products/konnect/eventgateway/static_keys.go
@@ -384,9 +384,7 @@ func findStaticKeyByName(
 
 func staticKeyToRecord(sk kkComps.EventGatewayStaticKey) staticKeySummaryRecord {
 	id := sk.ID
-	if id != "" {
-		id = util.AbbreviateUUID(id)
-	} else {
+	if id == "" {
 		id = valueNA
 	}
 

--- a/internal/cmd/root/products/konnect/eventgateway/tls_trust_bundles.go
+++ b/internal/cmd/root/products/konnect/eventgateway/tls_trust_bundles.go
@@ -388,9 +388,7 @@ func findTLSTrustBundleByName(
 
 func tlsTrustBundleToRecord(tb kkComps.TLSTrustBundle) tlsTrustBundleSummaryRecord {
 	id := tb.ID
-	if id != "" {
-		id = util.AbbreviateUUID(id)
-	} else {
+	if id == "" {
 		id = valueNA
 	}
 

--- a/internal/cmd/root/products/konnect/eventgateway/virtual_clusters.go
+++ b/internal/cmd/root/products/konnect/eventgateway/virtual_clusters.go
@@ -449,9 +449,7 @@ func findVirtualClusterByName(clusters []kkComps.VirtualCluster, identifier stri
 
 func virtualClusterToRecord(cluster kkComps.VirtualCluster) virtualClusterSummaryRecord {
 	id := cluster.ID
-	if id != "" {
-		id = util.AbbreviateUUID(id)
-	} else {
+	if id == "" {
 		id = valueNA
 	}
 

--- a/internal/cmd/root/products/konnect/gateway/consumer/getConsumer.go
+++ b/internal/cmd/root/products/konnect/gateway/consumer/getConsumer.go
@@ -239,7 +239,7 @@ func renderConsumers(
 	for i := range consumers {
 		record := consumerToDisplayRecord(&consumers[i])
 		records = append(records, record)
-		rows = append(rows, table.Row{util.AbbreviateUUID(record.ID), record.Username})
+		rows = append(rows, table.Row{record.ID, record.Username})
 	}
 
 	detailFn := func(index int) string {
@@ -302,7 +302,7 @@ func consumerToDisplayRecord(consumer *kkComps.Consumer) consumerDisplayRecord {
 	tags := consumer.GetTags()
 
 	return consumerDisplayRecord{
-		ID:               util.AbbreviateUUID(id),
+		ID:               id,
 		Username:         username,
 		CustomID:         customID,
 		TagCount:         len(tags),

--- a/internal/cmd/root/products/konnect/gateway/controlplane/getControlPlane.go
+++ b/internal/cmd/root/products/konnect/gateway/controlplane/getControlPlane.go
@@ -72,7 +72,7 @@ func controlPlaneToDisplayRecord(c *kkComps.ControlPlane) textDisplayRecord {
 
 	var id, name string
 	if c.ID != "" {
-		id = util.AbbreviateUUID(c.ID)
+		id = c.ID
 	} else {
 		id = missing
 	}

--- a/internal/cmd/root/products/konnect/gateway/controlplane/getControlPlane_test.go
+++ b/internal/cmd/root/products/konnect/gateway/controlplane/getControlPlane_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/kong/kongctl/internal/iostreams"
 	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/log"
-	"github.com/kong/kongctl/internal/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -95,14 +94,14 @@ func TestTextDisplayConversion(t *testing.T) {
 			},
 		},
 		{
-			name: "uuid truncated",
+			name: "uuid retained for formatter",
 			input: kkComps.ControlPlane{
 				ID:        uuidValue,
 				CreatedAt: timeValue,
 				UpdatedAt: timeValue,
 			},
 			expected: textDisplayRecord{
-				ID:                   util.AbbreviateUUID(uuidValue),
+				ID:                   uuidValue,
 				Name:                 "n/a",
 				ClusterType:          "n/a",
 				Description:          "n/a",

--- a/internal/cmd/root/products/konnect/gateway/route/getRoute.go
+++ b/internal/cmd/root/products/konnect/gateway/route/getRoute.go
@@ -93,7 +93,7 @@ func jsonRouteToDisplayRecord(r *kkComps.RouteJSON) textDisplayRecord {
 
 	id := missing
 	if r.ID != nil {
-		id = util.AbbreviateUUID(*r.ID)
+		id = *r.ID
 	}
 
 	return textDisplayRecord{

--- a/internal/cmd/root/products/konnect/gateway/service/getService.go
+++ b/internal/cmd/root/products/konnect/gateway/service/getService.go
@@ -57,7 +57,7 @@ func serviceToDisplayRecord(s *kkComps.ServiceOutput) textDisplayRecord {
 
 	id := missing
 	if s.ID != nil {
-		id = util.AbbreviateUUID(*s.ID)
+		id = *s.ID
 	}
 
 	enabled := missing

--- a/internal/cmd/root/products/konnect/me/getMe.go
+++ b/internal/cmd/root/products/konnect/me/getMe.go
@@ -10,7 +10,6 @@ import (
 	"github.com/kong/kongctl/internal/cmd/root/verbs"
 	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/meta"
-	"github.com/kong/kongctl/internal/util"
 	"github.com/kong/kongctl/internal/util/i18n"
 	"github.com/kong/kongctl/internal/util/normalizers"
 	"github.com/segmentio/cli"
@@ -49,7 +48,7 @@ func userToDisplayRecord(u *kkComps.User) textDisplayRecord {
 	var id, email, fullName, preferredName, active, inferredRegion string
 
 	if u.ID != nil && *u.ID != "" {
-		id = util.AbbreviateUUID(*u.ID)
+		id = *u.ID
 	} else {
 		id = missing
 	}

--- a/internal/cmd/root/products/konnect/organization/getOrganization.go
+++ b/internal/cmd/root/products/konnect/organization/getOrganization.go
@@ -69,7 +69,7 @@ func organizationToDisplayRecord(org *kkComps.MeOrganization) textDisplayRecord 
 	}
 
 	if id := org.GetID(); id != nil && *id != "" {
-		record.ID = util.AbbreviateUUID(*id)
+		record.ID = *id
 	}
 
 	if name := org.GetName(); name != nil && *name != "" {
@@ -81,7 +81,7 @@ func organizationToDisplayRecord(org *kkComps.MeOrganization) textDisplayRecord 
 	}
 
 	if ownerID := org.GetOwnerID(); ownerID != nil && *ownerID != "" {
-		record.OwnerID = util.AbbreviateUUID(*ownerID)
+		record.OwnerID = *ownerID
 	}
 
 	if loginPath := org.GetLoginPath(); loginPath != nil && *loginPath != "" {

--- a/internal/cmd/root/products/konnect/organization/getOrganization_test.go
+++ b/internal/cmd/root/products/konnect/organization/getOrganization_test.go
@@ -55,10 +55,10 @@ func TestOrganizationToDisplayRecord(t *testing.T) {
 				UpdatedAt:           &now,
 			},
 			expected: textDisplayRecord{
-				ID:                  "1234…",
+				ID:                  id,
 				Name:                name,
 				State:               string(state),
-				OwnerID:             "abcd…",
+				OwnerID:             ownerID,
 				LoginPath:           loginPath,
 				RetentionPeriodDays: "30",
 				LocalCreatedTime:    now.In(time.Local).Format("2006-01-02 15:04:05"),

--- a/internal/cmd/root/products/konnect/organization/systemaccount/getSystemAccount.go
+++ b/internal/cmd/root/products/konnect/organization/systemaccount/getSystemAccount.go
@@ -75,7 +75,7 @@ func systemAccountToDisplayRecord(s *kkComps.SystemAccount) textDisplayRecord {
 	}
 
 	if id := s.GetID(); id != nil && *id != "" {
-		record.ID = util.AbbreviateUUID(*id)
+		record.ID = *id
 	}
 
 	if name := s.GetName(); name != nil && *name != "" {

--- a/internal/cmd/root/products/konnect/organization/team/getTeam.go
+++ b/internal/cmd/root/products/konnect/organization/team/getTeam.go
@@ -78,7 +78,7 @@ func teamToDisplayRecord(s *kkComps.Team) textDisplayRecord {
 	}
 
 	if id := s.GetID(); id != nil && *id != "" {
-		record.ID = util.AbbreviateUUID(*id)
+		record.ID = *id
 	}
 
 	if name := s.GetName(); name != nil && *name != "" {

--- a/internal/cmd/root/products/konnect/organization/user/getUser.go
+++ b/internal/cmd/root/products/konnect/organization/user/getUser.go
@@ -293,7 +293,7 @@ func buildUserChildView(users []kkComps.User) tableview.ChildView {
 	rows := make([]table.Row, 0, len(users))
 	for i := range users {
 		record := userToDisplayRecord(&users[i])
-		rows = append(rows, table.Row{util.AbbreviateUUID(record.ID), record.Email, record.FullName})
+		rows = append(rows, table.Row{record.ID, record.Email, record.FullName})
 	}
 
 	return tableview.ChildView{

--- a/internal/cmd/root/products/konnect/portal/application_registrations.go
+++ b/internal/cmd/root/products/konnect/portal/application_registrations.go
@@ -518,7 +518,7 @@ func portalApplicationRegistrationSummaryToRecord(
 	}
 
 	return portalApplicationRegistrationSummaryRecord{
-		ID:               util.AbbreviateUUID(reg.GetID()),
+		ID:               reg.GetID(),
 		Status:           string(reg.GetStatus()),
 		Application:      application,
 		API:              apiLabel,
@@ -543,7 +543,7 @@ func portalApplicationRegistrationDetailRecordFromResponse(
 	}
 
 	return portalApplicationRegistrationDetailRecord{
-		ID:               util.AbbreviateUUID(res.GetID()),
+		ID:               res.GetID(),
 		Status:           string(res.GetStatus()),
 		Application:      app.GetName(),
 		ApplicationID:    app.GetID(),

--- a/internal/cmd/root/products/konnect/portal/applications.go
+++ b/internal/cmd/root/products/konnect/portal/applications.go
@@ -362,7 +362,7 @@ func portalApplicationSummaryToRecord(app kkComps.Application) portalApplication
 		}
 		strategy := key.GetAuthStrategy()
 		return portalApplicationSummaryRecord{
-			ID:                util.AbbreviateUUID(key.GetID()),
+			ID:                key.GetID(),
 			Name:              key.GetName(),
 			Type:              "key-auth",
 			AuthStrategy:      stringPtrOrNA(strategy.GetName()),
@@ -386,7 +386,7 @@ func portalApplicationSummaryToRecord(app kkComps.Application) portalApplication
 		}
 		strategy := client.GetAuthStrategy()
 		return portalApplicationSummaryRecord{
-			ID:                util.AbbreviateUUID(client.GetID()),
+			ID:                client.GetID(),
 			Name:              client.GetName(),
 			Type:              "client-credentials",
 			AuthStrategy:      stringPtrOrNA(strategy.GetName()),
@@ -413,7 +413,7 @@ func portalApplicationDetailToRecord(app *kkComps.GetApplicationResponse) portal
 		key := app.KeyAuthApplication
 		strategy := key.GetAuthStrategy()
 		return portalApplicationDetailRecord{
-			ID:                util.AbbreviateUUID(key.GetID()),
+			ID:                key.GetID(),
 			Name:              key.GetName(),
 			Type:              "key-auth",
 			AuthStrategy:      stringPtrOrNA(strategy.GetName()),
@@ -430,7 +430,7 @@ func portalApplicationDetailToRecord(app *kkComps.GetApplicationResponse) portal
 		client := app.ClientCredentialsApplication
 		strategy := client.GetAuthStrategy()
 		return portalApplicationDetailRecord{
-			ID:                util.AbbreviateUUID(client.GetID()),
+			ID:                client.GetID(),
 			Name:              client.GetName(),
 			Type:              "client-credentials",
 			AuthStrategy:      stringPtrOrNA(strategy.GetName()),

--- a/internal/cmd/root/products/konnect/portal/developer_teams.go
+++ b/internal/cmd/root/products/konnect/portal/developer_teams.go
@@ -308,7 +308,7 @@ func fetchPortalTeamDevelopers(
 func portalTeamDeveloperSummaryToRecord(dev kkComps.BasicDeveloper) portalTeamDeveloperRecord {
 	id := valueNA
 	if dev.GetID() != nil && *dev.GetID() != "" {
-		id = util.AbbreviateUUID(*dev.GetID())
+		id = *dev.GetID()
 	}
 
 	return portalTeamDeveloperRecord{

--- a/internal/cmd/root/products/konnect/portal/developers.go
+++ b/internal/cmd/root/products/konnect/portal/developers.go
@@ -332,7 +332,7 @@ func findDeveloperByEmailOrID(developers []kkComps.PortalDeveloper, identifier s
 
 func portalDeveloperSummaryToRecord(developer kkComps.PortalDeveloper) portalDeveloperSummaryRecord {
 	return portalDeveloperSummaryRecord{
-		ID:               util.AbbreviateUUID(developer.GetID()),
+		ID:               developer.GetID(),
 		Email:            developer.GetEmail(),
 		FullName:         developer.GetFullName(),
 		Status:           string(developer.GetStatus()),

--- a/internal/cmd/root/products/konnect/portal/getPortal.go
+++ b/internal/cmd/root/products/konnect/portal/getPortal.go
@@ -61,7 +61,7 @@ func portalToDisplayRecord(p *kkComps.ListPortalsResponsePortal) textDisplayReco
 
 	var id, name string
 	if p.GetID() != "" {
-		id = util.AbbreviateUUID(p.GetID())
+		id = p.GetID()
 	} else {
 		id = missing
 	}
@@ -98,7 +98,7 @@ func portalResponseToDisplayRecord(p *kkComps.PortalResponse) textDisplayRecord 
 
 	var id, name string
 	if p.ID != "" {
-		id = util.AbbreviateUUID(p.ID)
+		id = p.ID
 	} else {
 		id = missing
 	}

--- a/internal/cmd/root/products/konnect/portal/pages.go
+++ b/internal/cmd/root/products/konnect/portal/pages.go
@@ -570,11 +570,11 @@ func portalPageDetailView(record portalPageDetailRecord) string {
 func portalPageSummaryToRecord(page kkComps.PortalPageInfo) portalPageSummaryRecord {
 	parentID := valueNA
 	if parent := page.GetParentPageID(); parent != nil && *parent != "" {
-		parentID = util.AbbreviateUUID(*parent)
+		parentID = *parent
 	}
 
 	return portalPageSummaryRecord{
-		ID:               util.AbbreviateUUID(page.GetID()),
+		ID:               page.GetID(),
 		Title:            page.GetTitle(),
 		Slug:             normalizePortalPageSlugValue(page.GetSlug()),
 		Visibility:       string(page.GetVisibility()),
@@ -589,11 +589,11 @@ func portalPageSummaryToRecord(page kkComps.PortalPageInfo) portalPageSummaryRec
 func portalPageDetailToRecord(page *kkComps.PortalPageResponse) portalPageDetailRecord {
 	parentID := valueNA
 	if parent := page.GetParentPageID(); parent != nil && *parent != "" {
-		parentID = util.AbbreviateUUID(*parent)
+		parentID = *parent
 	}
 
 	record := portalPageDetailRecord{
-		ID:               util.AbbreviateUUID(page.GetID()),
+		ID:               page.GetID(),
 		Title:            page.GetTitle(),
 		Slug:             normalizePortalPageSlugValue(page.GetSlug()),
 		Visibility:       string(page.GetVisibility()),

--- a/internal/cmd/root/products/konnect/portal/snippets.go
+++ b/internal/cmd/root/products/konnect/portal/snippets.go
@@ -416,7 +416,7 @@ func findSnippetByNameOrTitle(snippets []kkComps.PortalSnippetInfo, identifier s
 
 func portalSnippetSummaryToRecord(snippet kkComps.PortalSnippetInfo) portalSnippetSummaryRecord {
 	return portalSnippetSummaryRecord{
-		ID:               util.AbbreviateUUID(snippet.GetID()),
+		ID:               snippet.GetID(),
 		Name:             snippet.GetName(),
 		Title:            snippet.GetTitle(),
 		Visibility:       string(snippet.GetVisibility()),
@@ -430,7 +430,7 @@ func portalSnippetSummaryToRecord(snippet kkComps.PortalSnippetInfo) portalSnipp
 func portalSnippetDetailToRecord(snippet *kkComps.PortalSnippetResponse) portalSnippetDetailRecord {
 	content := normalizePortalPageContent(snippet.GetContent())
 	record := portalSnippetDetailRecord{
-		ID:               util.AbbreviateUUID(snippet.GetID()),
+		ID:               snippet.GetID(),
 		Name:             snippet.GetName(),
 		Title:            optionalString(snippet.GetTitle()),
 		Visibility:       string(snippet.GetVisibility()),

--- a/internal/cmd/root/products/konnect/portal/team_roles.go
+++ b/internal/cmd/root/products/konnect/portal/team_roles.go
@@ -15,7 +15,6 @@ import (
 	"github.com/kong/kongctl/internal/config"
 	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/kong/kongctl/internal/meta"
-	"github.com/kong/kongctl/internal/util"
 	"github.com/kong/kongctl/internal/util/i18n"
 	"github.com/kong/kongctl/internal/util/normalizers"
 	"github.com/segmentio/cli"
@@ -284,9 +283,6 @@ func roleResponsesToRecords(
 	records := make([]portalTeamRoleRecord, 0, len(roles))
 	for _, role := range roles {
 		entityID := optionalStringValue(role.GetEntityID())
-		if util.IsValidUUID(entityID) {
-			entityID = util.AbbreviateUUID(entityID)
-		}
 		records = append(records, portalTeamRoleRecord{
 			Team:           teamName,
 			TeamID:         teamID,

--- a/internal/cmd/root/products/konnect/portal/teams.go
+++ b/internal/cmd/root/products/konnect/portal/teams.go
@@ -339,9 +339,6 @@ func findTeamByName(teams []kkComps.PortalTeamResponse, identifier string) *kkCo
 
 func portalTeamSummaryToRecord(team kkComps.PortalTeamResponse) portalTeamSummaryRecord {
 	id := stringOrNA(team.GetID())
-	if id != valueNA {
-		id = util.AbbreviateUUID(id)
-	}
 	return portalTeamSummaryRecord{
 		ID:               id,
 		Name:             stringOrNA(team.GetName()),

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kong/kongctl/internal/build"
 	cmdpkg "github.com/kong/kongctl/internal/cmd"
 	"github.com/kong/kongctl/internal/cmd/common"
+	textoutput "github.com/kong/kongctl/internal/cmd/output/text"
 	konnectcommon "github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
 	"github.com/kong/kongctl/internal/cmd/root/verbs/adopt"
 	"github.com/kong/kongctl/internal/cmd/root/verbs/api"
@@ -226,6 +227,15 @@ func newRootCmd() *cobra.Command {
 			if err := validateOutputFormat(cmd); err != nil {
 				return &cmdpkg.ConfigurationError{Err: err}
 			}
+			configuredOutput := common.DefaultOutputFormat
+			if currConfig != nil {
+				if value := strings.TrimSpace(currConfig.GetString(common.OutputConfigPath)); value != "" {
+					configuredOutput = value
+				}
+			}
+			if _, err := textoutput.Resolve(cmd, currConfig, configuredOutput); err != nil {
+				return &cmdpkg.ConfigurationError{Err: err}
+			}
 			ctx := context.WithValue(cmd.Context(), config.ConfigKey, currConfig)
 			ctx = context.WithValue(ctx, iostreams.StreamsKey, streams)
 			ctx = context.WithValue(ctx, profile.ProfileManagerKey, pMgr)
@@ -276,6 +286,7 @@ func newRootCmd() *cobra.Command {
 	// in the pFlag library
 	rootCmd.PersistentFlags().VarP(outputFormat, common.OutputFlagName, common.OutputFlagShort,
 		outputFlagUsage(outputFormat.Allowed))
+	textoutput.AddFlags(rootCmd.PersistentFlags())
 
 	rootCmd.PersistentFlags().Var(logLevel, common.LogLevelFlagName,
 		fmt.Sprintf(`Configures the logging level. Execution logs are written to STDERR.
@@ -605,6 +616,7 @@ func init() {
 func bindFlags(config config.Hook) {
 	f := rootCmd.Flags().Lookup(common.OutputFlagName)
 	util.CheckError(config.BindFlag(common.OutputConfigPath, f))
+	util.CheckError(textoutput.BindFlags(config, rootCmd.PersistentFlags()))
 
 	f = rootCmd.Flags().Lookup(common.LogLevelFlagName)
 	util.CheckError(config.BindFlag(common.LogLevelConfigPath, f))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -85,3 +85,18 @@ func TestBuildProfiledConfig_ProfileHTTPTransportEnv(t *testing.T) {
 		t.Fatalf("expected http-recycle-connections-on-error to be %q, got %q", "1", got)
 	}
 }
+
+func TestBuildProfiledConfig_ProfileTextOutputEnv(t *testing.T) {
+	t.Setenv("KONGCTL_DEFAULT_TEXT_LAYOUT", "auto")
+	t.Setenv("KONGCTL_DEFAULT_TEXT_ID_FORMAT", "full")
+
+	mainv := utilviper.NewViper("nonexistent.yaml")
+	cfg := BuildProfiledConfig("default", "nonexistent.yaml", mainv)
+
+	if got := cfg.GetString("text.layout"); got != "auto" {
+		t.Fatalf("expected text.layout to be %q, got %q", "auto", got)
+	}
+	if got := cfg.GetString("text.id-format"); got != "full" {
+		t.Fatalf("expected text.id-format to be %q, got %q", "full", got)
+	}
+}


### PR DESCRIPTION
## Summary

- add profile-backed compact, auto, and wide static text-table layouts
- add compact and full UUID formatting with full-ID width protection
- preserve raw resource IDs until centralized text rendering
- keep explicit custom columns authoritative and structured output unchanged
- document text layout, ID formatting, precedence, and environment variables

## Testing

- `go fix ./...`
- `make format`
- `CGO_ENABLED=0 GOFLAGS=-buildvcs=false make build`
- `make test`
- `make test-integration`
- focused output, root command, and configuration tests

`make lint` is clean for changed code. The repository-wide command continues
to report 56 existing findings in generated mocks and the generated portal
client.

Closes #1749
