### PR TITLE
fix(declarative): stop advertising unsupported MCP logging statistics

### DIFF
--- a/internal/declarative/resources/ai_gateway_mcp_server.go
+++ b/internal/declarative/resources/ai_gateway_mcp_server.go
@@ -550,7 +550,6 @@ func aiGatewayMCPServerConfigExplainNode() *ExplainNode {
 		explainField("route", aiGatewayRouteExplainNode(), false, false),
 		explainField("logging", explainObject(
 			explainField("payloads", explainBoolNode("false"), false, false),
-			explainField("statistics", explainBoolNode("true"), false, false),
 			explainField("audits", explainBoolNode("false"), false, false),
 		), false, false),
 		explainField("max_request_body_size", &ExplainNode{Kind: explainKindInteger, Literal: "8388608"}, false, false),

--- a/test/e2e/scenarios/ai-gateway/mcp-server/overlays/001-update/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/mcp-server/overlays/001-update/config.yaml
@@ -96,6 +96,9 @@ ai_gateways:
           acl_attribute_type: consumer
         config:
           url: https://support-conversion-listener.example.com
+          logging:
+            audits: false
+            payloads: false
           route:
             paths:
               - /support-conversion-listener

--- a/test/e2e/scenarios/ai-gateway/mcp-server/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/mcp-server/scenario.yaml
@@ -116,6 +116,17 @@ steps:
                 query.type: object
                 request_body.type: object
                 responses.type: object
+          - select: >-
+              oneOf[?properties.type.const=='conversion-listener'] | [0].properties.config.properties.logging.properties
+            expect:
+              fields:
+                audits.type: boolean
+                payloads.type: boolean
+          - select: >-
+              contains(keys(oneOf[?properties.type.const=='conversion-listener'] | [0].properties.config.properties.logging.properties), 'statistics')
+            expect:
+              fields:
+                "@": false
       - name: 003-scaffold-ai-gateway-mcp-server
         run:
           - scaffold
@@ -224,6 +235,8 @@ steps:
                 fields.labels.team: support
                 fields.labels.phase: create
                 fields.config.url: https://support-conversion-listener.example.com
+                fields.config.logging.audits: false
+                fields.config.logging.payloads: false
                 fields.config.route.paths[0]: /support-conversion-listener
                 fields.access.acl_attribute_type: consumer
           - select: >-
@@ -388,6 +401,8 @@ steps:
                 labels.team: support
                 labels.phase: create
                 config.url: https://support-conversion-listener.example.com
+                config.logging.audits: false
+                config.logging.payloads: false
                 config.route.paths[0]: /support-conversion-listener
                 access:
                   acl_attribute_type: consumer
@@ -474,6 +489,8 @@ steps:
               fields:
                 name: "{{ .vars.conversion_listener_server_name }}"
                 type: conversion-listener
+                config.logging.audits: false
+                config.logging.payloads: false
                 config.route.paths[0]: /support-conversion-listener
                 access:
                   acl_attribute_type: consumer
@@ -680,6 +697,8 @@ steps:
                 name: "{{ .vars.conversion_listener_server_name }}"
                 display_name: "{{ .vars.conversion_listener_server_display_name }}"
                 type: conversion-listener
+                config.logging.audits: false
+                config.logging.payloads: false
                 access:
                   acl_attribute_type: consumer
           - select: >-

--- a/test/e2e/scenarios/ai-gateway/mcp-server/testdata/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/mcp-server/testdata/config.yaml
@@ -96,6 +96,9 @@ ai_gateways:
           acl_attribute_type: consumer
         config:
           url: https://support-conversion-listener.example.com
+          logging:
+            audits: false
+            payloads: false
           route:
             paths:
               - /support-conversion-listener


### PR DESCRIPTION
## Summary

- remove unsupported MCP server `config.logging.statistics` from explain and scaffold output
- exercise supported `logging.audits` and `logging.payloads` through the MCP server lifecycle scenario
- preserve both logging fields through update, no-diff, and dump round-trip coverage

Unknown-field rejection remains part of the schema-driven load validation work in #1739.

## Validation

- `go fix ./...`
- `make format`
- `GOFLAGS=-buildvcs=false make build`
- `make test`
- `make test-integration`
- `golangci-lint run -v ./internal/declarative/resources/...`
- `make test-e2e-scenarios SCENARIO=ai-gateway/mcp-server`

Closes #1755
