### PR TITLE
feat(declarative): validate input before SDK unmarshalling

### DIFF
--- a/docs/contributor/declarative-resource-implementation-guide.md
+++ b/docs/contributor/declarative-resource-implementation-guide.md
@@ -153,6 +153,14 @@ opaque value that is normalized by a custom unmarshaller, set `LoadOpaque` on
 its `ExplainFieldHint`. Use this narrowly: it disables shape traversal only for
 that field while retaining its explain and scaffold representation.
 
+When kongctl recognizes a field but intentionally rejects it, register the
+field with `ExplainNode.rejectLoadField` on the relevant object or union branch.
+This keeps the field out of explain and scaffold output while allowing the
+load-schema error formatter to return migration or branch-specific guidance.
+Do not use rejected-field metadata for typos, stale fields, or supported fields
+missing from explain; those must remain unknown-field errors or be added to the
+accepted schema.
+
 Load validation runs against the placeholder-preserving `!env` representation
 before environment values are resolved. Error formatting must identify the
 declarative path without including input values, because an invalid field may

--- a/docs/contributor/declarative-resource-implementation-guide.md
+++ b/docs/contributor/declarative-resource-implementation-guide.md
@@ -140,6 +140,24 @@ resource, plan, or view contracts.
   declarative engine supports both, for example `api_version` and
   `api.versions`.
 
+The explain registry also provides the runtime load schema. The loader renders
+a full-document, shape-oriented schema from every registered resource and
+validates processed YAML before decoding embedded SDK request structs. Objects
+are closed by default, map fields remain open, and union discriminators select
+the accepted branch fields. This prevents generated SDK unmarshallers from
+silently discarding unknown declarative keys.
+
+Custom explain builders must therefore describe the raw accepted declarative
+shape, not only the eventual SDK payload. When a field intentionally accepts an
+opaque value that is normalized by a custom unmarshaller, set `LoadOpaque` on
+its `ExplainFieldHint`. Use this narrowly: it disables shape traversal only for
+that field while retaining its explain and scaffold representation.
+
+Load validation runs against the placeholder-preserving `!env` representation
+before environment values are resolved. Error formatting must identify the
+declarative path without including input values, because an invalid field may
+contain a secret.
+
 ### SYNC SCOPE (REQUIRED)
 
 `sync` uses explicit manifest scope. Do not treat omitted configuration as a

--- a/internal/declarative/loader/load_schema.go
+++ b/internal/declarative/loader/load_schema.go
@@ -118,6 +118,15 @@ func formatDeclarativeSchemaError(
 		})
 		unknown := unknownFields[0]
 		path := declarativePath(unknown.location)
+		containerPath := unknown.location[:len(unknown.location)-1]
+		if message := declarativeRejectedFieldMessageAt(
+			schema,
+			document,
+			containerPath,
+			unknown.field,
+		); message != "" {
+			return errors.New(message)
+		}
 		if strings.HasSuffix(path, ".config.auth.header_name") ||
 			strings.HasSuffix(path, ".config.auth.header_value") {
 			return errors.New(
@@ -133,7 +142,6 @@ func formatDeclarativeSchemaError(
 				"apis[].spec_content is not supported in declarative configuration; use versions[].spec instead",
 			)
 		}
-		containerPath := unknown.location[:len(unknown.location)-1]
 		candidates := declarativeSchemaPropertiesAt(schema, document, containerPath)
 		if suggestion := suggestDeclarativeField(unknown.field, candidates); suggestion != "" {
 			return fmt.Errorf(
@@ -298,6 +306,46 @@ func declarativeSchemaPropertiesAt(
 	document any,
 	path []string,
 ) []string {
+	currentSchema := declarativeSchemaAt(root, document, path)
+	if currentSchema == nil {
+		return nil
+	}
+	properties := make(map[string]struct{})
+	for name := range currentSchema.Properties {
+		properties[name] = struct{}{}
+	}
+	for _, branch := range currentSchema.OneOf {
+		branch = resolveDeclarativeSchemaRef(root, branch)
+		for name := range branch.Properties {
+			properties[name] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(properties))
+	for name := range properties {
+		result = append(result, name)
+	}
+	slices.Sort(result)
+	return result
+}
+
+func declarativeRejectedFieldMessageAt(
+	root *resources.JSONSchema,
+	document any,
+	path []string,
+	field string,
+) string {
+	schema := declarativeSchemaAt(root, document, path)
+	if schema == nil {
+		return ""
+	}
+	return schema.LoadRejectedFieldMessage(field)
+}
+
+func declarativeSchemaAt(
+	root *resources.JSONSchema,
+	document any,
+	path []string,
+) *resources.JSONSchema {
 	currentSchema := root
 	currentValue := document
 	for _, token := range path {
@@ -323,25 +371,7 @@ func declarativeSchemaPropertiesAt(
 	}
 
 	currentSchema = selectDeclarativeSchema(root, currentSchema, currentValue, "")
-	if currentSchema == nil {
-		return nil
-	}
-	properties := make(map[string]struct{})
-	for name := range currentSchema.Properties {
-		properties[name] = struct{}{}
-	}
-	for _, branch := range currentSchema.OneOf {
-		branch = resolveDeclarativeSchemaRef(root, branch)
-		for name := range branch.Properties {
-			properties[name] = struct{}{}
-		}
-	}
-	result := make([]string, 0, len(properties))
-	for name := range properties {
-		result = append(result, name)
-	}
-	slices.Sort(result)
-	return result
+	return currentSchema
 }
 
 func selectDeclarativeSchema(

--- a/internal/declarative/loader/load_schema.go
+++ b/internal/declarative/loader/load_schema.go
@@ -1,0 +1,431 @@
+package loader
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/santhosh-tekuri/jsonschema/v6/kind"
+	"sigs.k8s.io/yaml"
+)
+
+const declarativeLoadSchemaURL = "kongctl://declarative/load"
+
+type declarativeLoadSchemaBundle struct {
+	rendered *resources.JSONSchema
+	compiled *jsonschema.Schema
+}
+
+type offlineSchemaLoader struct{}
+
+func (offlineSchemaLoader) Load(url string) (any, error) {
+	return nil, fmt.Errorf("external schema loading is disabled: %s", url)
+}
+
+var (
+	declarativeSchemaOnce   sync.Once
+	declarativeSchemaBundle *declarativeLoadSchemaBundle
+	declarativeSchemaErr    error
+)
+
+func compiledDeclarativeLoadSchema() (*declarativeLoadSchemaBundle, error) {
+	declarativeSchemaOnce.Do(func() {
+		rendered, err := resources.RenderLoadSchema(resources.LoadSchemaProfileShape)
+		if err != nil {
+			declarativeSchemaErr = err
+			return
+		}
+
+		data, err := json.Marshal(rendered)
+		if err != nil {
+			declarativeSchemaErr = fmt.Errorf("marshal declarative load schema: %w", err)
+			return
+		}
+		var document any
+		if err := json.Unmarshal(data, &document); err != nil {
+			declarativeSchemaErr = fmt.Errorf("decode declarative load schema: %w", err)
+			return
+		}
+
+		compiler := jsonschema.NewCompiler()
+		compiler.UseLoader(offlineSchemaLoader{})
+		if err := compiler.AddResource(declarativeLoadSchemaURL, document); err != nil {
+			declarativeSchemaErr = fmt.Errorf("register declarative load schema: %w", err)
+			return
+		}
+		compiled, err := compiler.Compile(declarativeLoadSchemaURL)
+		if err != nil {
+			declarativeSchemaErr = fmt.Errorf("compile declarative load schema: %w", err)
+			return
+		}
+		declarativeSchemaBundle = &declarativeLoadSchemaBundle{rendered: rendered, compiled: compiled}
+	})
+	return declarativeSchemaBundle, declarativeSchemaErr
+}
+
+func validateDeclarativeDocumentShape(content []byte, sourcePath string) error {
+	var document any
+	if err := yaml.Unmarshal(content, &document); err != nil {
+		return fmt.Errorf("failed to parse YAML in %s: %w", sourcePath, err)
+	}
+
+	bundle, err := compiledDeclarativeLoadSchema()
+	if err != nil {
+		return fmt.Errorf("prepare declarative validation schema: %w", err)
+	}
+	if err := bundle.compiled.Validate(document); err != nil {
+		return formatDeclarativeSchemaError(bundle.rendered, document, sourcePath, err)
+	}
+	return nil
+}
+
+type unknownDeclarativeField struct {
+	field    string
+	location []string
+}
+
+func formatDeclarativeSchemaError(
+	schema *resources.JSONSchema,
+	document any,
+	sourcePath string,
+	err error,
+) error {
+	var validationErr *jsonschema.ValidationError
+	if !errors.As(err, &validationErr) {
+		return fmt.Errorf("declarative schema validation failed for %s: %w", sourcePath, err)
+	}
+
+	unknownFields := collectUnknownDeclarativeFields(validationErr)
+	unknownFields = slices.DeleteFunc(unknownFields, func(unknown unknownDeclarativeField) bool {
+		containerPath := unknown.location[:len(unknown.location)-1]
+		candidates := declarativeSchemaPropertiesAt(schema, document, containerPath)
+		return slices.Contains(candidates, unknown.field)
+	})
+	if len(unknownFields) > 0 {
+		sort.Slice(unknownFields, func(i, j int) bool {
+			if len(unknownFields[i].location) != len(unknownFields[j].location) {
+				return len(unknownFields[i].location) < len(unknownFields[j].location)
+			}
+			return declarativePath(unknownFields[i].location) < declarativePath(unknownFields[j].location)
+		})
+		unknown := unknownFields[0]
+		path := declarativePath(unknown.location)
+		if strings.HasSuffix(path, ".config.auth.header_name") ||
+			strings.HasSuffix(path, ".config.auth.header_value") {
+			return errors.New(
+				"config.auth.header_name and config.auth.header_value are not supported; " +
+					"use config.auth.headers[].name and config.auth.headers[].value",
+			)
+		}
+		if strings.HasPrefix(path, "ai_gateways[") && strings.HasSuffix(path, ".providers") {
+			return errors.New("ai_gateways.providers is not supported; use ai_gateways.model_providers")
+		}
+		if strings.HasPrefix(path, "apis[") && strings.HasSuffix(path, ".spec_content") {
+			return errors.New(
+				"apis[].spec_content is not supported in declarative configuration; use versions[].spec instead",
+			)
+		}
+		containerPath := unknown.location[:len(unknown.location)-1]
+		candidates := declarativeSchemaPropertiesAt(schema, document, containerPath)
+		if suggestion := suggestDeclarativeField(unknown.field, candidates); suggestion != "" {
+			return fmt.Errorf(
+				"unknown field '%s' at %s in %s. Did you mean '%s'?",
+				unknown.field,
+				path,
+				sourcePath,
+				suggestion,
+			)
+		}
+		return fmt.Errorf(
+			"unknown field '%s' at %s in %s. Please check the field name against the schema",
+			unknown.field,
+			path,
+			sourcePath,
+		)
+	}
+
+	leaf := firstDeclarativeValidationLeaf(validationErr)
+	path := declarativePath(leaf.InstanceLocation)
+	if message := portalSingletonNullSchemaError(path); message != "" {
+		return errors.New(message)
+	}
+	if message := dashboardDeclarativeSchemaError(sourcePath, path); message != "" {
+		return errors.New(message)
+	}
+	if path == "" {
+		path = "<document>"
+	}
+	return fmt.Errorf("invalid declarative value at %s in %s: %s", path, sourcePath, declarativeErrorMessage(leaf))
+}
+
+func portalSingletonNullSchemaError(path string) string {
+	const portalPrefix = "portals["
+	if !strings.HasPrefix(path, portalPrefix) {
+		return ""
+	}
+	for key := range portalSingletonChildKeys {
+		if strings.HasSuffix(path, "."+key) {
+			return fmt.Sprintf(
+				"portal child singleton %q cannot be null; omit the key to ignore it or provide an object to manage it",
+				key,
+			)
+		}
+	}
+	if strings.HasSuffix(path, ".assets") {
+		return "portal child singleton \"assets\" cannot be null; " +
+			"omit the key to ignore assets or provide an object to manage them"
+	}
+	for _, key := range []string{"assets.logo", "assets.favicon"} {
+		if strings.HasSuffix(path, "."+key) {
+			return fmt.Sprintf(
+				"portal child singleton %q cannot be null; omit the key to ignore it or provide a value",
+				key,
+			)
+		}
+	}
+	return ""
+}
+
+func dashboardDeclarativeSchemaError(sourcePath, path string) string {
+	switch {
+	case strings.HasSuffix(path, ".definition.query.datasource"):
+		return fmt.Sprintf(
+			"failed to parse YAML in %s: invalid analytics dashboard tile query.datasource; "+
+				"expected one of api_usage, llm_usage, agentic_usage, platform_usage",
+			sourcePath,
+		)
+	case strings.HasSuffix(path, ".definition.chart.type"):
+		return fmt.Sprintf(
+			"failed to parse YAML in %s: invalid analytics dashboard tile chart.type; "+
+				"expected one of donut, timeseries_line, timeseries_bar, horizontal_bar, vertical_bar, "+
+				"single_value, choropleth_map, top_n",
+			sourcePath,
+		)
+	case strings.HasSuffix(path, ".query.time_range.type"):
+		return fmt.Sprintf(
+			"failed to parse YAML in %s: invalid analytics dashboard tile query.time_range.type; "+
+				"expected one of relative, absolute",
+			sourcePath,
+		)
+	default:
+		return ""
+	}
+}
+
+func collectUnknownDeclarativeFields(validationErr *jsonschema.ValidationError) []unknownDeclarativeField {
+	if validationErr == nil {
+		return nil
+	}
+	var result []unknownDeclarativeField
+	if additional, ok := validationErr.ErrorKind.(*kind.AdditionalProperties); ok {
+		for _, property := range additional.Properties {
+			location := append([]string(nil), validationErr.InstanceLocation...)
+			location = append(location, property)
+			result = append(result, unknownDeclarativeField{field: property, location: location})
+		}
+	}
+	for _, cause := range validationErr.Causes {
+		result = append(result, collectUnknownDeclarativeFields(cause)...)
+	}
+	return result
+}
+
+func firstDeclarativeValidationLeaf(validationErr *jsonschema.ValidationError) *jsonschema.ValidationError {
+	if validationErr == nil || len(validationErr.Causes) == 0 {
+		return validationErr
+	}
+	leaves := make([]*jsonschema.ValidationError, 0)
+	var collect func(*jsonschema.ValidationError)
+	collect = func(current *jsonschema.ValidationError) {
+		if len(current.Causes) == 0 {
+			leaves = append(leaves, current)
+			return
+		}
+		for _, cause := range current.Causes {
+			collect(cause)
+		}
+	}
+	collect(validationErr)
+	sort.Slice(leaves, func(i, j int) bool {
+		return declarativePath(leaves[i].InstanceLocation) < declarativePath(leaves[j].InstanceLocation)
+	})
+	return leaves[0]
+}
+
+func declarativeErrorMessage(validationErr *jsonschema.ValidationError) string {
+	if validationErr == nil {
+		return "schema validation failed"
+	}
+	switch failure := validationErr.ErrorKind.(type) {
+	case *kind.Type:
+		return "expected " + strings.Join(failure.Want, " or ")
+	case *kind.Required:
+		return "missing required union selector " + strings.Join(failure.Missing, ", ")
+	case *kind.Const:
+		return fmt.Sprintf("expected union discriminator %v", failure.Want)
+	case *kind.OneOf:
+		return "does not match exactly one supported union shape"
+	default:
+		return validationErr.Error()
+	}
+}
+
+func declarativePath(tokens []string) string {
+	var result strings.Builder
+	for _, token := range tokens {
+		if _, err := strconv.Atoi(token); err == nil {
+			fmt.Fprintf(&result, "[%s]", token)
+			continue
+		}
+		if result.Len() > 0 {
+			result.WriteByte('.')
+		}
+		result.WriteString(token)
+	}
+	return result.String()
+}
+
+func declarativeSchemaPropertiesAt(
+	root *resources.JSONSchema,
+	document any,
+	path []string,
+) []string {
+	currentSchema := root
+	currentValue := document
+	for _, token := range path {
+		currentSchema = selectDeclarativeSchema(root, currentSchema, currentValue, token)
+		if currentSchema == nil {
+			return nil
+		}
+		if index, err := strconv.Atoi(token); err == nil {
+			currentSchema = currentSchema.Items
+			if values, ok := currentValue.([]any); ok && index >= 0 && index < len(values) {
+				currentValue = values[index]
+			} else {
+				currentValue = nil
+			}
+			continue
+		}
+		currentSchema = currentSchema.Properties[token]
+		if values, ok := currentValue.(map[string]any); ok {
+			currentValue = values[token]
+		} else {
+			currentValue = nil
+		}
+	}
+
+	currentSchema = selectDeclarativeSchema(root, currentSchema, currentValue, "")
+	if currentSchema == nil {
+		return nil
+	}
+	properties := make(map[string]struct{})
+	for name := range currentSchema.Properties {
+		properties[name] = struct{}{}
+	}
+	for _, branch := range currentSchema.OneOf {
+		branch = resolveDeclarativeSchemaRef(root, branch)
+		for name := range branch.Properties {
+			properties[name] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(properties))
+	for name := range properties {
+		result = append(result, name)
+	}
+	slices.Sort(result)
+	return result
+}
+
+func selectDeclarativeSchema(
+	root *resources.JSONSchema,
+	schema *resources.JSONSchema,
+	value any,
+	nextToken string,
+) *resources.JSONSchema {
+	schema = resolveDeclarativeSchemaRef(root, schema)
+	if schema == nil || len(schema.OneOf) == 0 {
+		return schema
+	}
+	var matches []*resources.JSONSchema
+	for _, branch := range schema.OneOf {
+		branch = resolveDeclarativeSchemaRef(root, branch)
+		if declarativeSchemaBranchMatches(root, branch, value) {
+			matches = append(matches, branch)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0]
+	}
+	for _, branch := range matches {
+		if _, ok := branch.Properties[nextToken]; ok {
+			return branch
+		}
+	}
+	for _, branch := range schema.OneOf {
+		branch = resolveDeclarativeSchemaRef(root, branch)
+		if _, ok := branch.Properties[nextToken]; ok {
+			return branch
+		}
+	}
+	return schema
+}
+
+func declarativeSchemaBranchMatches(root *resources.JSONSchema, schema *resources.JSONSchema, value any) bool {
+	values, ok := value.(map[string]any)
+	if !ok {
+		return false
+	}
+	for _, required := range schema.Required {
+		if _, ok := values[required]; !ok {
+			return false
+		}
+	}
+	for name, property := range schema.Properties {
+		property = resolveDeclarativeSchemaRef(root, property)
+		if property == nil || property.Const == nil {
+			continue
+		}
+		if !reflect.DeepEqual(values[name], property.Const) {
+			return false
+		}
+	}
+	return true
+}
+
+func resolveDeclarativeSchemaRef(root *resources.JSONSchema, schema *resources.JSONSchema) *resources.JSONSchema {
+	for schema != nil && strings.HasPrefix(schema.Ref, "#/$defs/") {
+		name := strings.TrimPrefix(schema.Ref, "#/$defs/")
+		name = strings.ReplaceAll(name, "~1", "/")
+		name = strings.ReplaceAll(name, "~0", "~")
+		schema = root.Defs[name]
+	}
+	return schema
+}
+
+func suggestDeclarativeField(field string, candidates []string) string {
+	field = strings.ToLower(field)
+	legacy := map[string]string{
+		"lables":            "labels",
+		"label":             "labels",
+		"strategytype":      "strategy_type",
+		"integration":       "integrations",
+		"service_reference": "service",
+	}
+	if candidate := legacy[field]; candidate != "" && slices.Contains(candidates, candidate) {
+		return candidate
+	}
+	for _, candidate := range candidates {
+		if levenshteinClose(field, strings.ToLower(candidate)) {
+			return candidate
+		}
+	}
+	return ""
+}

--- a/internal/declarative/loader/load_schema_test.go
+++ b/internal/declarative/loader/load_schema_test.go
@@ -1,6 +1,7 @@
 package loader
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -109,6 +110,69 @@ application_auth_strategies:
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "unknown field 'openid_connect'")
 	assert.ErrorContains(t, err, "application_auth_strategies[0].configs.openid_connect")
+}
+
+func TestDeclarativeLoadSchemaReportsKnownRejectedUnionField(t *testing.T) {
+	input := `
+ai_gateways:
+  - ref: example-gateway
+    name: Example Gateway
+    display_name: Example Gateway
+    mcp_servers:
+      - ref: example-server
+        type: conversion-only
+        name: Example Server
+        display_name: Example Server
+        access:
+          acl_attribute_type: consumer
+        config:
+          url: https://example.com
+`
+
+	_, err := New().parseYAML(strings.NewReader(input), "manifest.yaml", ".")
+	require.Error(t, err)
+	assert.EqualError(
+		t,
+		err,
+		`AI Gateway MCP Server field "access" is not supported when type is "conversion-only"`,
+	)
+}
+
+func TestDeclarativeLoadSchemaReportsDeprecatedPortalAuthSettingsFields(t *testing.T) {
+	tests := []struct {
+		field string
+		value string
+	}{
+		{field: "oidc_auth_enabled", value: "true"},
+		{field: "saml_auth_enabled", value: "true"},
+		{field: "oidc_team_mapping_enabled", value: "true"},
+		{field: "oidc_issuer", value: "https://issuer.example.com"},
+		{field: "oidc_client_id", value: "client-id"},
+		{field: "oidc_client_secret", value: "must-not-appear-in-errors"},
+		{field: "oidc_scopes", value: "[openid, profile]"},
+		{field: "oidc_claim_mappings", value: "{name: name, email: email}"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.field, func(t *testing.T) {
+			input := fmt.Sprintf(`
+portals:
+  - ref: example-portal
+    name: Example Portal
+    display_name: Example Portal
+    auth_settings:
+      ref: example-auth-settings
+      basic_auth_enabled: true
+      %s: %s
+`, tt.field, tt.value)
+
+			_, err := New().parseYAML(strings.NewReader(input), "manifest.yaml", ".")
+			require.Error(t, err)
+			assert.ErrorContains(t, err, fmt.Sprintf("uses deprecated field %q", tt.field))
+			assert.ErrorContains(t, err, "move identity provider configuration to identity_providers")
+			assert.NotContains(t, err.Error(), tt.value)
+		})
+	}
 }
 
 func TestDeclarativeLoadSchemaValidatesScalarSelectedUnionBranches(t *testing.T) {

--- a/internal/declarative/loader/load_schema_test.go
+++ b/internal/declarative/loader/load_schema_test.go
@@ -1,0 +1,291 @@
+package loader
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeclarativeLoadSchemaRejectsUnknownFieldsAtFullPaths(t *testing.T) {
+	tests := []struct {
+		name  string
+		yaml  string
+		field string
+		path  string
+	}{
+		{
+			name: "custom unmarshaller nested resource",
+			yaml: `
+ai_gateways:
+  - ref: example-gateway
+    display_name: Example Gateway
+    consumers:
+      - ref: eason
+        name: eason
+        display_name: Eason
+        type: api-key
+        policies: []
+        credentials:
+          - ref: eason-key
+            name: eason-key
+            display_name: Eason API Key
+            type: api-key
+            key: discarded-secret
+`,
+			field: "key",
+			path:  "ai_gateways[0].consumers[0].credentials[0].key",
+		},
+		{
+			name: "custom unmarshaller root resource",
+			yaml: `
+ai_gateway_consumer_credentials:
+  - ref: eason-key
+    ai_gateway_consumer: eason
+    name: eason-key
+    display_name: Eason API Key
+    type: api-key
+    unexpected: value
+`,
+			field: "unexpected",
+			path:  "ai_gateway_consumer_credentials[0].unexpected",
+		},
+		{
+			name: "ordinary unmarshaller root resource",
+			yaml: `
+control_plane_data_plane_certificates:
+  - ref: example-cert
+    control_plane: example-control-plane
+    cert: certificate
+    unexpected: value
+`,
+			field: "unexpected",
+			path:  "control_plane_data_plane_certificates[0].unexpected",
+		},
+		{
+			name: "nested SDK model",
+			yaml: `
+control_planes:
+  - ref: example-control-plane
+    name: Example Control Plane
+    proxy_urls:
+      - host: proxy.example.com
+        port: 443
+        protocol: https
+        hostname: proxy.example.com
+`,
+			field: "hostname",
+			path:  "control_planes[0].proxy_urls[0].hostname",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := New().parseYAML(strings.NewReader(tt.yaml), "manifest.yaml", ".")
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "unknown field '"+tt.field+"'")
+			assert.ErrorContains(t, err, tt.path)
+		})
+	}
+}
+
+func TestDeclarativeLoadSchemaSelectsUnionBranch(t *testing.T) {
+	input := `
+application_auth_strategies:
+  - ref: key-auth
+    name: Key Auth
+    display_name: Key Auth
+    strategy_type: key_auth
+    configs:
+      key_auth:
+        key_names: [apikey]
+      openid_connect:
+        issuer: https://issuer.example.com
+`
+
+	_, err := New().parseYAML(strings.NewReader(input), "manifest.yaml", ".")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "unknown field 'openid_connect'")
+	assert.ErrorContains(t, err, "application_auth_strategies[0].configs.openid_connect")
+}
+
+func TestDeclarativeLoadSchemaValidatesScalarSelectedUnionBranches(t *testing.T) {
+	tests := []struct {
+		name      string
+		yaml      string
+		errPath   string
+		errDetail string
+	}{
+		{
+			name: "listener accepts integer and string ports",
+			yaml: `
+event_gateways:
+  - ref: example-event-gateway
+    name: Example Event Gateway
+    listeners:
+      - ref: example-listener
+        name: Example Listener
+        ports:
+          - 9092
+          - "9093-9095"
+`,
+		},
+		{
+			name: "ACL resource names accept array and string forms",
+			yaml: `
+event_gateways:
+  - ref: example-event-gateway
+    name: Example Event Gateway
+    virtual_clusters:
+      - ref: example-virtual-cluster
+        name: Example Virtual Cluster
+        cluster_policies:
+          - ref: example-cluster-policy
+            name: Example Cluster Policy
+            type: acls
+            config:
+              rules:
+                - action: allow
+                  operations:
+                    - name: describe_configs
+                  resource_names:
+                    - match: "*"
+                  resource_type: transactional_id
+                - action: deny
+                  operations:
+                    - name: read
+                  resource_names: 'name == "orders"'
+                  resource_type: topic
+`,
+		},
+		{
+			name: "listener rejects a boolean port",
+			yaml: `
+event_gateways:
+  - ref: example-event-gateway
+    name: Example Event Gateway
+    listeners:
+      - ref: example-listener
+        name: Example Listener
+        ports:
+          - true
+`,
+			errPath:   "event_gateways[0].listeners[0].ports[0]",
+			errDetail: "expected string",
+		},
+		{
+			name: "ACL resource names reject an object",
+			yaml: `
+event_gateways:
+  - ref: example-event-gateway
+    name: Example Event Gateway
+    virtual_clusters:
+      - ref: example-virtual-cluster
+        name: Example Virtual Cluster
+        cluster_policies:
+          - ref: example-cluster-policy
+            name: Example Cluster Policy
+            type: acls
+            config:
+              rules:
+                - action: allow
+                  operations:
+                    - name: describe_configs
+                  resource_names:
+                    match: "*"
+                  resource_type: transactional_id
+`,
+			errPath:   "event_gateways[0].virtual_clusters[0].cluster_policies[0].config.rules[0].resource_names",
+			errDetail: "expected array",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := New().parseYAML(strings.NewReader(tt.yaml), "manifest.yaml", ".")
+			if tt.errPath == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.errPath)
+			assert.ErrorContains(t, err, tt.errDetail)
+		})
+	}
+}
+
+func TestDeclarativeLoadSchemaKeepsMapFieldsOpen(t *testing.T) {
+	input := `
+control_planes:
+  - ref: example-control-plane
+    name: Example Control Plane
+    labels:
+      owner.example.com/team: platform
+      arbitrary-key: arbitrary-value
+`
+
+	_, err := New().parseYAML(strings.NewReader(input), "manifest.yaml", ".")
+	require.NoError(t, err)
+}
+
+func TestDeclarativeLoadSchemaRejectsMalformedKnownShape(t *testing.T) {
+	input := `
+control_planes:
+  - ref: example-control-plane
+    name: Example Control Plane
+    proxy_urls: not-an-array
+`
+
+	_, err := New().parseYAML(strings.NewReader(input), "manifest.yaml", ".")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "control_planes[0].proxy_urls")
+	assert.ErrorContains(t, err, "expected array")
+}
+
+func TestDeclarativeLoadSchemaDoesNotExposeResolvedEnvValues(t *testing.T) {
+	t.Setenv("LOAD_SCHEMA_SECRET", "must-not-appear-in-errors")
+	input := `
+ai_gateway_consumer_credentials:
+  - ref: eason-key
+    ai_gateway_consumer: eason
+    name: eason-key
+    display_name: Eason API Key
+    type: api-key
+    key: !env LOAD_SCHEMA_SECRET
+`
+
+	_, err := New().parseYAML(strings.NewReader(input), "manifest.yaml", ".")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "ai_gateway_consumer_credentials[0].key")
+	assert.NotContains(t, err.Error(), "must-not-appear-in-errors")
+}
+
+func TestCompiledDeclarativeLoadSchemaIsCached(t *testing.T) {
+	first, err := compiledDeclarativeLoadSchema()
+	require.NoError(t, err)
+	second, err := compiledDeclarativeLoadSchema()
+	require.NoError(t, err)
+	assert.Same(t, first, second)
+	assert.Same(t, first.compiled, second.compiled)
+}
+
+func TestDeclarativeLoadSchemaValidatesCuratedE2EFixtures(t *testing.T) {
+	fixtures := []string{
+		"test/e2e/scenarios/ai-gateway/consumer/testdata/config.yaml",
+		"test/e2e/scenarios/ai-gateway/model-provider/testdata/config.yaml",
+		"test/e2e/scenarios/apis/comprehensive-fields/testdata/apis.yaml",
+		"test/e2e/scenarios/portal/api_docs_with_children/testdata/apis.yaml",
+		"test/e2e/scenarios/portal/api_docs_with_children/testdata/portal.yaml",
+		"test/e2e/testdata/declarative/event-gateways/comprehensive-fields/event-gateways.yaml",
+	}
+
+	for _, fixture := range fixtures {
+		t.Run(fixture, func(t *testing.T) {
+			path := filepath.Join("..", "..", "..", fixture)
+			_, err := New().LoadFile(path)
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -251,9 +251,6 @@ func (l *Loader) parseYAML(r io.Reader, sourcePath string, rootDir string) (*res
 		}
 	}
 
-	// Process custom tags if needed
-	registry := l.getTagRegistry()
-
 	// Update base directory based on source file location
 	baseDir := l.baseDir
 	if sourcePath != "stdin" && sourcePath != "" {
@@ -271,24 +268,11 @@ func (l *Loader) parseYAML(r io.Reader, sourcePath string, rootDir string) (*res
 		tagRootDir = strings.TrimSpace(rootDir)
 	}
 
-	// Always register/update resolvers with correct base directory
-	// This ensures each file gets the correct base directory for relative paths.
+	// Build the placeholder-preserving representation first. Schema validation
+	// runs against this representation so resolved environment values cannot be
+	// included in validation errors.
 	fileResolver := tags.NewFileTagResolver(baseDir, tagRootDir)
 	refResolver := tags.NewRefTagResolver(baseDir)
-	registry.Register(fileResolver)
-	registry.Register(refResolver)
-	registry.Register(tags.NewExternalTagResolver("!external"))
-	registry.Register(tags.NewExternalTagResolver("!lookup"))
-	registry.Register(tags.NewEnvTagResolver(tags.EnvTagModeResolve))
-
-	if registry.HasResolvers() {
-		processedContent, err := registry.Process(rawContent)
-		if err != nil {
-			return nil, fmt.Errorf("failed to process tags in %s: %w", sourcePath, err)
-		}
-		content = processedContent
-	}
-
 	placeholderRegistry := tags.NewResolverRegistry()
 	placeholderRegistry.Register(fileResolver)
 	placeholderRegistry.Register(refResolver)
@@ -299,6 +283,25 @@ func (l *Loader) parseYAML(r io.Reader, sourcePath string, rootDir string) (*res
 	placeholderContent, err := placeholderRegistry.Process(rawContent)
 	if err != nil {
 		return nil, fmt.Errorf("failed to preserve !env tags in %s: %w", sourcePath, err)
+	}
+	if err := validateDeclarativeDocumentShape(placeholderContent, sourcePath); err != nil {
+		return nil, err
+	}
+
+	// Resolve environment-backed values only after the placeholder document has
+	// passed schema validation.
+	registry := l.getTagRegistry()
+	registry.Register(fileResolver)
+	registry.Register(refResolver)
+	registry.Register(tags.NewExternalTagResolver("!external"))
+	registry.Register(tags.NewExternalTagResolver("!lookup"))
+	registry.Register(tags.NewEnvTagResolver(tags.EnvTagModeResolve))
+	if registry.HasResolvers() {
+		processedContent, err := registry.Process(rawContent)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process tags in %s: %w", sourcePath, err)
+		}
+		content = processedContent
 	}
 
 	parseErr := yaml.UnmarshalStrict(content, &temp)

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -282,7 +282,7 @@ func (l *Loader) parseYAML(r io.Reader, sourcePath string, rootDir string) (*res
 
 	placeholderContent, err := placeholderRegistry.Process(rawContent)
 	if err != nil {
-		return nil, fmt.Errorf("failed to preserve !env tags in %s: %w", sourcePath, err)
+		return nil, fmt.Errorf("failed to process placeholder tags in %s: %w", sourcePath, err)
 	}
 	if err := validateDeclarativeDocumentShape(placeholderContent, sourcePath); err != nil {
 		return nil, err

--- a/internal/declarative/loader/loader_test.go
+++ b/internal/declarative/loader/loader_test.go
@@ -1547,21 +1547,22 @@ func TestLoader_LoadFile_UnknownFields(t *testing.T) {
 		expectedError string
 	}{
 		{
-			name:          "misspelled labels field with suggestion",
-			file:          "invalid/unknown-field-portal.yaml",
-			expectedError: "unknown field 'lables' in testdata/invalid/unknown-field-portal.yaml. Did you mean 'labels'?",
+			name: "misspelled labels field with suggestion",
+			file: "invalid/unknown-field-portal.yaml",
+			expectedError: "unknown field 'lables' at portals[0].lables in " +
+				"testdata/invalid/unknown-field-portal.yaml. Did you mean 'labels'?",
 		},
 		{
 			name: "unknown field with no suggestion",
 			file: "invalid/unknown-field-no-suggestion.yaml",
-			expectedError: "unknown field 'completely_unknown_field' in " +
+			expectedError: "unknown field 'completely_unknown_field' at portals[0].completely_unknown_field in " +
 				"testdata/invalid/unknown-field-no-suggestion.yaml. " +
 				"Please check the field name against the schema",
 		},
 		{
 			name: "misspelled strategy_type field",
 			file: "invalid/unknown-field-auth.yaml",
-			expectedError: "unknown field 'strategytype' in " +
+			expectedError: "unknown field 'strategytype' at application_auth_strategies[0].strategytype in " +
 				"testdata/invalid/unknown-field-auth.yaml. Did you mean 'strategy_type'?",
 		},
 	}

--- a/internal/declarative/loader/testdata/complex/multi-resource.yaml
+++ b/internal/declarative/loader/testdata/complex/multi-resource.yaml
@@ -95,7 +95,6 @@ apis:
     publications:
       - ref: test-api-pub
         portal_id: test-portal
-        publish_status: "published"
         auth_strategy_ids: ["oauth-strategy"]
         
     implementations:
@@ -116,7 +115,6 @@ apis:
     publications:
       - ref: prod-api-pub
         portal_id: prod-portal
-        publish_status: "published"
         auth_strategy_ids: ["key-auth-strategy"]
         
     implementations:

--- a/internal/declarative/loader/testdata/multifile/apis.yaml
+++ b/internal/declarative/loader/testdata/multifile/apis.yaml
@@ -11,7 +11,6 @@ apis:
     publications:
       - ref: multifile-api-pub
         portal_id: multifile-portal1
-        publish_status: "published"
         auth_strategy_ids:
           - multifile-oauth
           

--- a/internal/declarative/loader/testdata/valid/api-with-children.yaml
+++ b/internal/declarative/loader/testdata/valid/api-with-children.yaml
@@ -32,7 +32,6 @@ apis:
     publications:
       - ref: my-api-pub
         portal_id: test-portal
-        publish_status: "published"
         auth_strategy_ids: ["oauth-strategy"]
         
     implementations:

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -1422,9 +1422,9 @@ func (l *Loader) validateSeparateAPIChildResources(rs *resources.ResourceSet) er
 		}
 		if deprecatedField := deprecatedPortalAuthSettingsField(settings); deprecatedField != "" {
 			return fmt.Errorf(
-				"portal_auth_settings %q uses deprecated field %q; move identity provider configuration to identity_providers",
+				"portal_auth_settings %q %s",
 				settings.GetRef(),
-				deprecatedField,
+				resources.PortalAuthSettingsDeprecatedFieldMessage(deprecatedField),
 			)
 		}
 		for j := i + 1; j < len(rs.PortalAuthSettings); j++ {

--- a/internal/declarative/resources/ai_gateway.go
+++ b/internal/declarative/resources/ai_gateway.go
@@ -355,6 +355,7 @@ func aiGatewayExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
 	return explainObject(
 		explainResourceRefField(),
 		explainKongctlField(),
+		explainExternalField(),
 		explainField("name", explainStringNode("my-ai-gateway"), false, true),
 		explainField("display_name", explainStringNode("My AI Gateway"), true, true),
 		explainField("description", &ExplainNode{Kind: explainKindString, Nullable: true}, false, false),
@@ -384,6 +385,18 @@ func aiGatewayExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
 			false,
 		),
 	), nil
+}
+
+func explainExternalField() *ExplainField {
+	return explainField("_external", explainObject(
+		explainField("id", explainStringNode("00000000-0000-0000-0000-000000000000"), false, false),
+		explainField("selector", explainObject(
+			explainField("matchFields", &ExplainNode{
+				Kind:       explainKindObject,
+				Additional: explainStringNode("value"),
+			}, true, true),
+		), false, false),
+	), false, false)
 }
 
 func aiGatewayProviderInlineExplainNode() *ExplainNode {

--- a/internal/declarative/resources/ai_gateway_mcp_server.go
+++ b/internal/declarative/resources/ai_gateway_mcp_server.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"time"
@@ -9,6 +10,9 @@ import (
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/kong/kongctl/internal/util"
 )
+
+const aiGatewayMCPServerConversionOnlyAccessMessage = `AI Gateway MCP Server field "access" is not supported ` +
+	`when type is "conversion-only"`
 
 const (
 	aiGatewayMCPServerFieldID          = "id"
@@ -322,7 +326,7 @@ func rejectUnsupportedAIGatewayMCPServerAccess(raw map[string]json.RawMessage) e
 		return fmt.Errorf("invalid AI Gateway MCP Server type: %w", err)
 	}
 	if serverType == "conversion-only" {
-		return fmt.Errorf(`AI Gateway MCP Server field "access" is not supported when type is "conversion-only"`)
+		return errors.New(aiGatewayMCPServerConversionOnlyAccessMessage)
 	}
 	return nil
 }
@@ -512,11 +516,13 @@ func aiGatewayMCPServerExplainNode(_ ExplainBuildContext) (*ExplainNode, error) 
 		slices.Clone(commonFields),
 		explainField("access", aiGatewayMCPServerAccessExplainNode(), false, false),
 	)
+	conversionOnly := explainObject(append(
+		slices.Clone(commonFields),
+		explainField("type", explainConstStringNode("conversion-only"), true, true),
+	)...)
+	conversionOnly.rejectLoadField("access", aiGatewayMCPServerConversionOnlyAccessMessage)
 	return explainUnionNode(
-		explainObject(append(
-			slices.Clone(commonFields),
-			explainField("type", explainConstStringNode("conversion-only"), true, true),
-		)...),
+		conversionOnly,
 		explainObject(append(
 			slices.Clone(accessFields),
 			explainField("type", explainConstStringNode("conversion-listener"), true, true),

--- a/internal/declarative/resources/api_version.go
+++ b/internal/declarative/resources/api_version.go
@@ -20,6 +20,7 @@ func init() {
 			WithExplainFieldHint("spec", ExplainFieldHint{
 				Literal:      "!file ./specs/api.yaml",
 				PreferredTag: "!file",
+				LoadOpaque:   true,
 			}),
 			// Override the generic "content" !file guidance for this nested field so
 			// it does not steer users toward the double-wrapping spec.content form.

--- a/internal/declarative/resources/explain.go
+++ b/internal/declarative/resources/explain.go
@@ -124,6 +124,7 @@ type ExplainNode struct {
 	OneOf        []*ExplainNode
 	truncated    bool
 	loadOpaque   bool
+	loadRejected map[string]string
 }
 
 type ExplainField struct {
@@ -163,6 +164,16 @@ type JSONSchema struct {
 	XRoot         *bool                   `json:"x-kongctl-supports-root,omitempty" yaml:"x-kongctl-supports-root,omitempty"`                             //nolint:lll
 	XNestedDecl   *bool                   `json:"x-kongctl-supports-nested-declaration,omitempty" yaml:"x-kongctl-supports-nested-declaration,omitempty"` //nolint:lll
 	XMaturity     *ExplainMaturity        `json:"x-kongctl-maturity,omitempty" yaml:"x-kongctl-maturity,omitempty"`
+	loadRejected  map[string]string
+}
+
+// LoadRejectedFieldMessage returns load-only guidance for a recognized field
+// that is intentionally excluded from the accepted schema.
+func (s *JSONSchema) LoadRejectedFieldMessage(name string) string {
+	if s == nil {
+		return ""
+	}
+	return s.loadRejected[name]
 }
 
 // ExplainRelationship describes the user-visible contract of a resource relationship field.
@@ -2118,6 +2129,16 @@ func (n *ExplainNode) addField(field *ExplainField) {
 	n.propIndex[field.Name] = field
 }
 
+func (n *ExplainNode) rejectLoadField(name, message string) {
+	if n == nil || name == "" || message == "" {
+		return
+	}
+	if n.loadRejected == nil {
+		n.loadRejected = make(map[string]string)
+	}
+	n.loadRejected[name] = message
+}
+
 func (n *ExplainNode) lookup(path []string) (*ExplainNode, bool) {
 	current := n
 	for _, segment := range path {
@@ -2175,6 +2196,7 @@ func (n *ExplainNode) clone() *ExplainNode {
 		Additional:   n.Additional.clone(),
 		truncated:    n.truncated,
 		loadOpaque:   n.loadOpaque,
+		loadRejected: maps.Clone(n.loadRejected),
 		propIndex:    make(map[string]*ExplainField),
 	}
 	if n.Relationship != nil {

--- a/internal/declarative/resources/explain.go
+++ b/internal/declarative/resources/explain.go
@@ -44,6 +44,7 @@ type ExplainFieldHint struct {
 	PreferredTag string
 	RefKind      string
 	Notes        []string
+	LoadOpaque   bool
 }
 
 type ExplainBuildContext struct {
@@ -121,6 +122,8 @@ type ExplainNode struct {
 	Items        *ExplainNode
 	Additional   *ExplainNode
 	OneOf        []*ExplainNode
+	truncated    bool
+	loadOpaque   bool
 }
 
 type ExplainField struct {
@@ -133,6 +136,8 @@ type ExplainField struct {
 type JSONSchema struct {
 	Schema        string                  `json:"$schema,omitempty" yaml:"$schema,omitempty"`
 	ID            string                  `json:"$id,omitempty" yaml:"$id,omitempty"`
+	Ref           string                  `json:"$ref,omitempty" yaml:"$ref,omitempty"`
+	Defs          map[string]*JSONSchema  `json:"$defs,omitempty" yaml:"$defs,omitempty"`
 	Title         string                  `json:"title,omitempty" yaml:"title,omitempty"`
 	Description   string                  `json:"description,omitempty" yaml:"description,omitempty"`
 	Type          any                     `json:"type,omitempty" yaml:"type,omitempty"`
@@ -287,6 +292,7 @@ func mergeExplainFieldHint(base ExplainFieldHint, override ExplainFieldHint) Exp
 	if len(override.Notes) > 0 {
 		result.Notes = append([]string(nil), override.Notes...)
 	}
+	result.LoadOpaque = result.LoadOpaque || override.LoadOpaque
 	return result
 }
 
@@ -1098,6 +1104,17 @@ func autoExplainNode(
 			if !field.IsExported() {
 				continue
 			}
+			if field.Tag.Get("additionalProperties") == "true" {
+				additionalType := derefExplainType(field.Type)
+				if additionalType.Kind() == reflect.Map {
+					additional, err := autoExplainValueNode(additionalType.Elem(), path, hints, stack)
+					if err != nil {
+						return nil, err
+					}
+					node.Additional = additional
+				}
+				continue
+			}
 
 			yamlName, yamlInline, yamlOmit, skip := explainFieldName(field, "yaml")
 			if skip {
@@ -1300,6 +1317,7 @@ func recursiveExplainNode(typ reflect.Type) *ExplainNode {
 	return &ExplainNode{
 		Kind:        explainKindObject,
 		Description: fmt.Sprintf("Recursive %s object", snakeCase(typ.Name())),
+		truncated:   true,
 		Notes: []string{
 			"schema recursion truncated after the first expansion",
 		},
@@ -1337,6 +1355,7 @@ func applyExplainFieldHint(node *ExplainNode, hint ExplainFieldHint) {
 	if len(hint.Notes) > 0 {
 		node.Notes = append([]string(nil), hint.Notes...)
 	}
+	node.loadOpaque = node.loadOpaque || hint.LoadOpaque
 }
 
 func explainLiteralFor(node *ExplainNode, name string) string {
@@ -2154,6 +2173,8 @@ func (n *ExplainNode) clone() *ExplainNode {
 		Literal:      n.Literal,
 		Items:        n.Items.clone(),
 		Additional:   n.Additional.clone(),
+		truncated:    n.truncated,
+		loadOpaque:   n.loadOpaque,
 		propIndex:    make(map[string]*ExplainField),
 	}
 	if n.Relationship != nil {

--- a/internal/declarative/resources/explain_conformance_test.go
+++ b/internal/declarative/resources/explain_conformance_test.go
@@ -1,0 +1,72 @@
+package resources
+
+import (
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDashboardQueryExplainBranchesConformToSDKShapes(t *testing.T) {
+	query := dashboardQueryExplainNode()
+	require.Len(t, query.OneOf, 4)
+
+	t.Run("api_usage", func(t *testing.T) {
+		assertCustomExplainSupportsSDKShape[kkComps.AdvancedQuery](t, query.OneOf[0])
+	})
+	t.Run("llm_usage", func(t *testing.T) {
+		assertCustomExplainSupportsSDKShape[kkComps.LLMQuery](t, query.OneOf[1])
+	})
+	t.Run("agentic_usage", func(t *testing.T) {
+		assertCustomExplainSupportsSDKShape[kkComps.AgenticQuery](t, query.OneOf[2])
+	})
+	t.Run("platform_usage", func(t *testing.T) {
+		assertCustomExplainSupportsSDKShape[kkComps.PlatformQuery](t, query.OneOf[3])
+	})
+}
+
+func assertCustomExplainSupportsSDKShape[T any](t *testing.T, actual *ExplainNode) {
+	t.Helper()
+
+	expected, err := autoExplainConcreteNode[T](nil)
+	require.NoError(t, err)
+	require.NotNil(t, actual)
+	require.Equal(t, expected.Kind, actual.Kind)
+
+	for _, expectedField := range expected.Properties {
+		actualField, ok := actual.property(expectedField.Name)
+		require.Truef(t, ok, "custom explain schema is missing SDK field %q", expectedField.Name)
+		assertExplainFieldShapeCompatible(t, expectedField.Name, expectedField.Node, actualField.Node)
+	}
+}
+
+func assertExplainFieldShapeCompatible(t *testing.T, path string, expected, actual *ExplainNode) {
+	t.Helper()
+
+	require.NotNilf(t, actual, "custom explain field %q has no schema", path)
+	assert.Equalf(t, expected.Kind, actual.Kind, "custom explain field %q has an incompatible kind", path)
+	if expected.Kind == explainKindArray {
+		require.NotNilf(t, actual.Items, "custom explain array field %q has no item schema", path)
+		assert.Equalf(
+			t,
+			expected.Items.Kind,
+			actual.Items.Kind,
+			"custom explain array field %q has an incompatible item kind",
+			path,
+		)
+	}
+	if len(expected.OneOf) > 0 {
+		require.Lenf(t, actual.OneOf, len(expected.OneOf), "custom explain union field %q has incompatible branches", path)
+		for i := range expected.OneOf {
+			assert.Equalf(
+				t,
+				expected.OneOf[i].Kind,
+				actual.OneOf[i].Kind,
+				"custom explain union field %q branch %d has an incompatible kind",
+				path,
+				i,
+			)
+		}
+	}
+}

--- a/internal/declarative/resources/explain_union_schemas.go
+++ b/internal/declarative/resources/explain_union_schemas.go
@@ -434,8 +434,8 @@ func dashboardQueryExplainNode() *ExplainNode {
 	)
 }
 
-// dashboardPlatformQueryBranch describes the platform_usage query. Its metrics,
-// granularity, and limit differ from the other datasources, so it does not reuse
+// dashboardPlatformQueryBranch describes the platform_usage query. Its metrics
+// and granularity differ from the other datasources, so it does not reuse
 // dashboardQueryBranch.
 func dashboardPlatformQueryBranch() *ExplainNode {
 	return explainObject(
@@ -450,12 +450,7 @@ func dashboardPlatformQueryBranch() *ExplainNode {
 			false,
 		),
 		explainField("time_range", dashboardTimeRangeExplainNode(), false, false),
-		explainField(
-			"limit",
-			&ExplainNode{Kind: "integer", Nullable: true, Literal: "10"},
-			false,
-			false,
-		),
+		explainField("limit", dashboardQueryLimitExplainNode(), false, false),
 	)
 }
 
@@ -472,7 +467,12 @@ func dashboardQueryBranch(datasource string, metric string) *ExplainNode {
 			false,
 		),
 		explainField("time_range", dashboardTimeRangeExplainNode(), false, false),
+		explainField("limit", dashboardQueryLimitExplainNode(), false, false),
 	)
+}
+
+func dashboardQueryLimitExplainNode() *ExplainNode {
+	return &ExplainNode{Kind: "number", Nullable: true, Literal: "50"}
 }
 
 func dashboardChartExplainNode() *ExplainNode {

--- a/internal/declarative/resources/explain_union_schemas.go
+++ b/internal/declarative/resources/explain_union_schemas.go
@@ -370,6 +370,7 @@ func apiImplementationExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
 		explainField(SchemaFieldRef, explainStringNode("my-resource"), true, true),
 		explainField("api", explainStringNode("my-api"), false, false),
 		explainField("type", explainConstStringNode("service"), false, true),
+		explainField("implementation_url", explainStringNode("https://api.example.com"), false, false),
 		explainField("service", explainObject(
 			explainRefField("id", ResourceTypeGatewayService, true),
 			explainRefField("control_plane_id", ResourceTypeControlPlane, true),
@@ -570,6 +571,7 @@ func applicationAuthStrategyExplainNode(_ ExplainBuildContext) (*ExplainNode, er
 	}
 	explainSetConstStringField(keyAuth, "strategy_type", "key_auth")
 	explainSetPathRequired(keyAuth, []string{"configs", "key-auth", "key_names"})
+	explainAddPropertyAlias(keyAuth, []string{"configs"}, "key-auth", "key_auth")
 
 	oidc, err := autoExplainConcreteNode[kkComps.AppAuthStrategyOpenIDConnectRequest](hints)
 	if err != nil {
@@ -579,12 +581,40 @@ func applicationAuthStrategyExplainNode(_ ExplainBuildContext) (*ExplainNode, er
 	explainSetPathRequired(oidc, []string{"configs", "openid-connect", "credential_claim"})
 	explainSetPathRequired(oidc, []string{"configs", "openid-connect", "scopes"})
 	explainSetPathRequired(oidc, []string{"configs", "openid-connect", "auth_methods"})
+	explainAddPropertyAlias(oidc, []string{"configs"}, "openid-connect", "openid_connect")
 
 	common := []*ExplainField{explainResourceRefField(), explainKongctlField()}
 	return explainUnionNode(
 		explainWithCommonFields(keyAuth, common...),
 		explainWithCommonFields(oidc, common...),
 	), nil
+}
+
+func explainAddPropertyAlias(node *ExplainNode, path []string, source, alias string) {
+	target := node
+	for _, segment := range path {
+		field, ok := target.property(segment)
+		if !ok {
+			return
+		}
+		target = field.Node
+	}
+	explainAddDirectPropertyAlias(target, source, alias)
+}
+
+func explainAddDirectPropertyAlias(node *ExplainNode, source, alias string) {
+	if node == nil {
+		return
+	}
+	if field, ok := node.property(source); ok && !node.propertyExists(alias) {
+		cloned := field.clone()
+		cloned.Name = alias
+		cloned.Required = false
+		node.addField(cloned)
+	}
+	for _, branch := range node.OneOf {
+		explainAddDirectPropertyAlias(branch, source, alias)
+	}
 }
 
 func eventGatewayVirtualClusterExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {

--- a/internal/declarative/resources/load_schema.go
+++ b/internal/declarative/resources/load_schema.go
@@ -200,7 +200,7 @@ func reflectLoadSchema(typ reflect.Type, stack []reflect.Type) *JSONSchema {
 	}
 
 	if slices.Contains(stack, typ) {
-		return &JSONSchema{Type: explainKindObject, Additional: true}
+		return &JSONSchema{Type: schemaTypeValue(explainKindObject, nullable), Additional: true}
 	}
 
 	switch typ.Kind() {
@@ -238,7 +238,7 @@ func reflectLoadSchema(typ reflect.Type, stack []reflect.Type) *JSONSchema {
 		return schema
 	case reflect.Slice, reflect.Array:
 		return &JSONSchema{
-			Type:  schemaTypeValue(explainKindArray, false),
+			Type:  schemaTypeValue(explainKindArray, nullable),
 			Items: reflectLoadSchema(typ.Elem(), stack),
 		}
 	case reflect.Map:

--- a/internal/declarative/resources/load_schema.go
+++ b/internal/declarative/resources/load_schema.go
@@ -1,0 +1,261 @@
+package resources
+
+import (
+	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+)
+
+const loadSchemaID = "kongctl://declarative/load"
+
+// LoadSchemaProfile selects which parts of the declarative schema are enforced
+// before typed unmarshalling.
+type LoadSchemaProfile int
+
+const (
+	// LoadSchemaProfileShape validates collection and object shapes, rejects
+	// unknown fields, and retains only the constraints needed to select unions.
+	LoadSchemaProfileShape LoadSchemaProfile = iota
+)
+
+type declarativeLoadDocument struct {
+	Defaults    *FileDefaults `yaml:"_defaults,omitempty" json:"_defaults,omitempty"`
+	ResourceSet `yaml:",inline" json:",inline"`
+}
+
+// RenderLoadSchema renders the schema used to validate a complete declarative
+// document before decoding it into ResourceSet and embedded SDK request types.
+func RenderLoadSchema(profile LoadSchemaProfile) (*JSONSchema, error) {
+	if profile != LoadSchemaProfileShape {
+		return nil, fmt.Errorf("unsupported declarative load schema profile %d", profile)
+	}
+
+	definitions := make(map[string]*JSONSchema)
+	resourceTypes := RegisteredTypes()
+	slices.Sort(resourceTypes)
+	for _, resourceType := range resourceTypes {
+		doc, err := buildExplainDoc(resourceType)
+		if err != nil {
+			return nil, fmt.Errorf("build explain schema for %s: %w", resourceType, err)
+		}
+
+		definition := renderShapeSchema(doc.Schema)
+		for _, relation := range doc.NestedRelations {
+			childType := ResourceType(relation.ChildAlias)
+			replaceLoadSchemaProperty(
+				definition,
+				relation.FieldName,
+				loadSchemaResourceRef(childType, relation.FieldArray),
+			)
+		}
+		definitions[string(resourceType)] = definition
+	}
+
+	root := reflectLoadSchema(reflect.TypeFor[declarativeLoadDocument](), nil)
+	root.Schema = jsonSchemaDraft202012
+	root.ID = loadSchemaID
+	root.Title = "kongctl declarative load schema"
+	root.Defs = definitions
+	return root, nil
+}
+
+func loadSchemaResourceRef(resourceType ResourceType, array bool) *JSONSchema {
+	ref := &JSONSchema{Ref: "#/$defs/" + escapeJSONPointerToken(string(resourceType))}
+	if !array {
+		return ref
+	}
+	return &JSONSchema{Type: explainKindArray, Items: ref}
+}
+
+func replaceLoadSchemaProperty(schema *JSONSchema, name string, replacement *JSONSchema) {
+	if schema == nil {
+		return
+	}
+	if _, ok := schema.Properties[name]; ok {
+		schema.Properties[name] = replacement
+	}
+	for _, branch := range schema.OneOf {
+		replaceLoadSchemaProperty(branch, name, replacement)
+	}
+}
+
+func renderShapeSchema(node *ExplainNode) *JSONSchema {
+	if node == nil || node.loadOpaque {
+		return &JSONSchema{}
+	}
+
+	schema := &JSONSchema{}
+
+	if len(node.OneOf) > 0 {
+		if node.Kind == explainKindObject || node.Kind == explainKindArray {
+			schema.Type = schemaTypeValue(node.Kind, node.Nullable)
+		}
+		for _, branch := range node.OneOf {
+			branchSchema := renderShapeSchema(branch)
+			retainLoadSchemaBranchType(branchSchema, branch)
+			retainLoadSchemaBranchDiscriminators(branchSchema, branch)
+			branchSchema.Required = loadSchemaBranchSelectors(branch, node.OneOf)
+			schema.OneOf = append(schema.OneOf, branchSchema)
+		}
+		return schema
+	}
+
+	switch node.Kind {
+	case explainKindObject:
+		schema.Type = schemaTypeValue(explainKindObject, node.Nullable)
+		if node.truncated {
+			schema.Additional = true
+			return schema
+		}
+		schema.Additional = false
+		if node.Additional != nil {
+			schema.Additional = renderShapeSchema(node.Additional)
+		}
+		if len(node.Properties) > 0 {
+			schema.Properties = make(map[string]*JSONSchema, len(node.Properties))
+		}
+		for _, field := range node.Properties {
+			schema.Properties[field.Name] = renderShapeSchema(field.Node)
+		}
+	case explainKindArray:
+		schema.Type = schemaTypeValue(explainKindArray, node.Nullable)
+		schema.Items = renderShapeSchema(node.Items)
+	}
+
+	return schema
+}
+
+func retainLoadSchemaBranchType(schema *JSONSchema, node *ExplainNode) {
+	if schema == nil || node == nil {
+		return
+	}
+	switch node.Kind {
+	case explainKindString, explainKindInteger, "number", "boolean", jsonNullLiteral:
+		schema.Type = schemaTypeValue(node.Kind, node.Nullable)
+	}
+}
+
+func retainLoadSchemaBranchDiscriminators(schema *JSONSchema, node *ExplainNode) {
+	if schema == nil || node == nil {
+		return
+	}
+	for _, field := range node.Properties {
+		if field.Node == nil || field.Node.Const == nil {
+			continue
+		}
+		if property := schema.Properties[field.Name]; property != nil {
+			property.Const = field.Node.Const
+		}
+	}
+}
+
+func loadSchemaBranchSelectors(branch *ExplainNode, branches []*ExplainNode) []string {
+	if branch == nil || branch.Kind != explainKindObject {
+		return nil
+	}
+
+	selectors := make([]string, 0)
+	for _, field := range branch.Properties {
+		if field.Node != nil && field.Node.Const != nil {
+			selectors = append(selectors, field.Name)
+		}
+	}
+	if len(selectors) == 0 {
+		for _, field := range branch.Properties {
+			if field.Required && !loadSchemaFieldExistsInEveryBranch(field.Name, branches) {
+				selectors = append(selectors, field.Name)
+			}
+		}
+	}
+	if len(selectors) == 0 {
+		for _, field := range branch.Properties {
+			if field.Required {
+				selectors = append(selectors, field.Name)
+			}
+		}
+	}
+	slices.Sort(selectors)
+	return slices.Compact(selectors)
+}
+
+func loadSchemaFieldExistsInEveryBranch(name string, branches []*ExplainNode) bool {
+	for _, branch := range branches {
+		if branch == nil || !branch.propertyExists(name) {
+			return false
+		}
+	}
+	return true
+}
+
+func reflectLoadSchema(typ reflect.Type, stack []reflect.Type) *JSONSchema {
+	nullable := typ.Kind() == reflect.Pointer
+	typ = derefExplainType(typ)
+
+	if typ.Kind() == reflect.Struct {
+		if resourceType, ok := explainRegisteredResourceType(typ); ok {
+			return loadSchemaResourceRef(resourceType, false)
+		}
+	}
+
+	if slices.Contains(stack, typ) {
+		return &JSONSchema{Type: explainKindObject, Additional: true}
+	}
+
+	switch typ.Kind() {
+	case reflect.Struct:
+		schema := &JSONSchema{
+			Type:       schemaTypeValue(explainKindObject, nullable),
+			Properties: make(map[string]*JSONSchema),
+			Additional: false,
+		}
+		stack = append(stack, typ)
+		for field := range typ.Fields() {
+			if !field.IsExported() {
+				continue
+			}
+			name, inline, _, skip := explainFieldName(field, "yaml")
+			if skip {
+				continue
+			}
+			if inline {
+				embedded := reflectLoadSchema(field.Type, stack)
+				maps.Copy(schema.Properties, embedded.Properties)
+				continue
+			}
+			if name == "" {
+				name, _, _, skip = explainFieldName(field, "json")
+				if skip {
+					continue
+				}
+			}
+			if name == "" {
+				name = snakeCase(field.Name)
+			}
+			schema.Properties[name] = reflectLoadSchema(field.Type, stack)
+		}
+		return schema
+	case reflect.Slice, reflect.Array:
+		return &JSONSchema{
+			Type:  schemaTypeValue(explainKindArray, false),
+			Items: reflectLoadSchema(typ.Elem(), stack),
+		}
+	case reflect.Map:
+		return &JSONSchema{
+			Type:       schemaTypeValue(explainKindObject, nullable),
+			Additional: reflectLoadSchema(typ.Elem(), stack),
+		}
+	case reflect.Invalid, reflect.Bool, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64, reflect.Complex64, reflect.Complex128, reflect.Chan, reflect.Func,
+		reflect.Interface, reflect.Pointer, reflect.String, reflect.UnsafePointer:
+		return &JSONSchema{}
+	}
+	return &JSONSchema{}
+}
+
+func escapeJSONPointerToken(value string) string {
+	value = strings.ReplaceAll(value, "~", "~0")
+	return strings.ReplaceAll(value, "/", "~1")
+}

--- a/internal/declarative/resources/load_schema.go
+++ b/internal/declarative/resources/load_schema.go
@@ -86,7 +86,7 @@ func renderShapeSchema(node *ExplainNode) *JSONSchema {
 		return &JSONSchema{}
 	}
 
-	schema := &JSONSchema{}
+	schema := &JSONSchema{loadRejected: maps.Clone(node.loadRejected)}
 
 	if len(node.OneOf) > 0 {
 		if node.Kind == explainKindObject || node.Kind == explainKindArray {

--- a/internal/declarative/resources/load_schema_test.go
+++ b/internal/declarative/resources/load_schema_test.go
@@ -95,3 +95,34 @@ func TestRenderShapeSchemaRetainsScalarTypesOnlyForUnionBranches(t *testing.T) {
 	ordinaryScalar := renderShapeSchema(&ExplainNode{Kind: explainKindString})
 	assert.Nil(t, ordinaryScalar.Type)
 }
+
+func TestRenderLoadSchemaRetainsKnownRejectedFieldDiagnostics(t *testing.T) {
+	schema, err := RenderLoadSchema(LoadSchemaProfileShape)
+	require.NoError(t, err)
+
+	mcpServer := schema.Defs[string(ResourceTypeAIGatewayMCPServer)]
+	require.NotNil(t, mcpServer)
+	var conversionOnly *JSONSchema
+	for _, branch := range mcpServer.OneOf {
+		if branch.Properties["type"].Const == "conversion-only" {
+			conversionOnly = branch
+			break
+		}
+	}
+	require.NotNil(t, conversionOnly)
+	assert.NotContains(t, conversionOnly.Properties, "access")
+	assert.Equal(
+		t,
+		aiGatewayMCPServerConversionOnlyAccessMessage,
+		conversionOnly.LoadRejectedFieldMessage("access"),
+	)
+
+	portalAuthSettings := schema.Defs[string(ResourceTypePortalAuthSettings)]
+	require.NotNil(t, portalAuthSettings)
+	assert.NotContains(t, portalAuthSettings.Properties, "oidc_auth_enabled")
+	assert.Equal(
+		t,
+		"portal_auth_settings "+PortalAuthSettingsDeprecatedFieldMessage("oidc_auth_enabled"),
+		portalAuthSettings.LoadRejectedFieldMessage("oidc_auth_enabled"),
+	)
+}

--- a/internal/declarative/resources/load_schema_test.go
+++ b/internal/declarative/resources/load_schema_test.go
@@ -1,11 +1,18 @@
 package resources
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type nullableLoadSchemaFixture struct {
+	Slice  *[]string                  `yaml:"slice,omitempty"`
+	Array  *[1]string                 `yaml:"array,omitempty"`
+	Nested *nullableLoadSchemaFixture `yaml:"nested,omitempty"`
+}
 
 func TestRenderLoadSchemaComposesRegisteredResources(t *testing.T) {
 	schema, err := RenderLoadSchema(LoadSchemaProfileShape)
@@ -41,6 +48,15 @@ func TestRenderLoadSchemaClosesObjectsAndKeepsMapsOpen(t *testing.T) {
 	require.NotNil(t, proxyURLs)
 	require.NotNil(t, proxyURLs.Items)
 	assert.False(t, proxyURLs.Items.Additional.(bool))
+}
+
+func TestReflectLoadSchemaPreservesPointerNullability(t *testing.T) {
+	schema := reflectLoadSchema(reflect.TypeFor[nullableLoadSchemaFixture](), nil)
+
+	assert.Equal(t, []string{explainKindArray, jsonNullLiteral}, schema.Properties["slice"].Type)
+	assert.Equal(t, []string{explainKindArray, jsonNullLiteral}, schema.Properties["array"].Type)
+	assert.Equal(t, []string{explainKindObject, jsonNullLiteral}, schema.Properties["nested"].Type)
+	assert.True(t, schema.Properties["nested"].Additional.(bool))
 }
 
 func TestRenderLoadSchemaRetainsOnlyUnionDiscriminatorScalars(t *testing.T) {

--- a/internal/declarative/resources/load_schema_test.go
+++ b/internal/declarative/resources/load_schema_test.go
@@ -1,0 +1,97 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderLoadSchemaComposesRegisteredResources(t *testing.T) {
+	schema, err := RenderLoadSchema(LoadSchemaProfileShape)
+	require.NoError(t, err)
+
+	assert.Equal(t, jsonSchemaDraft202012, schema.Schema)
+	assert.Equal(t, loadSchemaID, schema.ID)
+	assert.False(t, schema.Additional.(bool))
+	for _, resourceType := range RegisteredTypes() {
+		assert.Contains(t, schema.Defs, string(resourceType))
+	}
+
+	aiGateways := schema.Properties["ai_gateways"]
+	require.NotNil(t, aiGateways)
+	require.NotNil(t, aiGateways.Items)
+	assert.Equal(t, "#/$defs/ai_gateway", aiGateways.Items.Ref)
+}
+
+func TestRenderLoadSchemaClosesObjectsAndKeepsMapsOpen(t *testing.T) {
+	schema, err := RenderLoadSchema(LoadSchemaProfileShape)
+	require.NoError(t, err)
+
+	controlPlane := schema.Defs[string(ResourceTypeControlPlane)]
+	require.NotNil(t, controlPlane)
+	assert.False(t, controlPlane.Additional.(bool))
+
+	labels := controlPlane.Properties["labels"]
+	require.NotNil(t, labels)
+	require.NotNil(t, labels.Additional)
+	assert.NotEqual(t, false, labels.Additional)
+
+	proxyURLs := controlPlane.Properties["proxy_urls"]
+	require.NotNil(t, proxyURLs)
+	require.NotNil(t, proxyURLs.Items)
+	assert.False(t, proxyURLs.Items.Additional.(bool))
+}
+
+func TestRenderLoadSchemaRetainsOnlyUnionDiscriminatorScalars(t *testing.T) {
+	schema, err := RenderLoadSchema(LoadSchemaProfileShape)
+	require.NoError(t, err)
+
+	authStrategy := schema.Defs[string(ResourceTypeApplicationAuthStrategy)]
+	require.Len(t, authStrategy.OneOf, 2)
+	for _, branch := range authStrategy.OneOf {
+		strategyType := branch.Properties["strategy_type"]
+		require.NotNil(t, strategyType)
+		assert.NotNil(t, strategyType.Const)
+		assert.Contains(t, branch.Required, "strategy_type")
+	}
+
+	implementation := schema.Defs[string(ResourceTypeAPIImplementation)]
+	require.NotNil(t, implementation)
+	assert.Nil(t, implementation.Properties["type"].Const)
+	assert.Nil(t, implementation.Properties["type"].Type)
+}
+
+func TestRenderShapeSchemaRetainsScalarTypesOnlyForUnionBranches(t *testing.T) {
+	ports := renderShapeSchema(&ExplainNode{
+		OneOf: []*ExplainNode{
+			{Kind: explainKindString},
+			{Kind: explainKindInteger},
+		},
+	})
+	require.Len(t, ports.OneOf, 2)
+	assert.Equal(t, explainKindString, ports.OneOf[0].Type)
+	assert.Equal(t, explainKindInteger, ports.OneOf[1].Type)
+
+	resourceNames := renderShapeSchema(&ExplainNode{
+		OneOf: []*ExplainNode{
+			{
+				Kind: explainKindArray,
+				Items: &ExplainNode{
+					Kind: explainKindObject,
+					Properties: []*ExplainField{
+						{Name: "match", Node: &ExplainNode{Kind: explainKindString}},
+					},
+				},
+			},
+			{Kind: explainKindString},
+		},
+	})
+	require.Len(t, resourceNames.OneOf, 2)
+	assert.Equal(t, explainKindArray, resourceNames.OneOf[0].Type)
+	assert.Equal(t, explainKindString, resourceNames.OneOf[1].Type)
+	assert.Nil(t, resourceNames.OneOf[0].Items.Properties["match"].Type)
+
+	ordinaryScalar := renderShapeSchema(&ExplainNode{Kind: explainKindString})
+	assert.Nil(t, ordinaryScalar.Type)
+}

--- a/internal/declarative/resources/portal_auth_settings.go
+++ b/internal/declarative/resources/portal_auth_settings.go
@@ -35,10 +35,20 @@ func portalAuthSettingsExplainNode(_ ExplainBuildContext) (*ExplainNode, error) 
 		"oidc_scopes",
 		"oidc_claim_mappings",
 	} {
+		node.rejectLoadField(field, "portal_auth_settings "+PortalAuthSettingsDeprecatedFieldMessage(field))
 		explainRemoveField(node, field)
 	}
 
 	return node, nil
+}
+
+// PortalAuthSettingsDeprecatedFieldMessage returns the shared migration
+// guidance for an unsupported legacy portal authentication field.
+func PortalAuthSettingsDeprecatedFieldMessage(field string) string {
+	return fmt.Sprintf(
+		"uses deprecated field %q; move identity provider configuration to identity_providers",
+		field,
+	)
 }
 
 // PortalAuthSettingsResource represents portal authentication settings (singleton child).

--- a/test/e2e/scenarios/ai-gateway/model-provider/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/model-provider/scenario.yaml
@@ -55,7 +55,7 @@ steps:
           - select: "length(oneOf)"
             expect:
               fields:
-                "@": 19
+                "@": 20
           - select: >-
               oneOf[?properties.type.const=='openai'] | [0].properties.config.properties.auth.properties
             expect:

--- a/test/e2e/scenarios/all/testdata/config.yaml
+++ b/test/e2e/scenarios/all/testdata/config.yaml
@@ -349,7 +349,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/all/testdata/config.yaml
+++ b/test/e2e/scenarios/all/testdata/config.yaml
@@ -433,7 +433,6 @@ event_gateways:
             type: forward_to_virtual_cluster
             description: Listener policy for all resources
             enabled: true
-            condition: "${ssl_sni} == \"all.example.com\""
             labels:
               suite: all
             config:

--- a/test/e2e/scenarios/event-gateway/backend-cluster/overlays/001-update-fields/egw-bc.yaml
+++ b/test/e2e/scenarios/event-gateway/backend-cluster/overlays/001-update-fields/egw-bc.yaml
@@ -23,7 +23,7 @@ event_gateways:
           password: ${env["updated-password"]}
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/cluster-policy/overlays/001-update-fields/config.yaml
+++ b/test/e2e/scenarios/event-gateway/cluster-policy/overlays/001-update-fields/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/cluster-policy/overlays/002-sync-delete/config.yaml
+++ b/test/e2e/scenarios/event-gateway/cluster-policy/overlays/002-sync-delete/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/cluster-policy/overlays/003-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/cluster-policy/overlays/003-root-level-declaration/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/cluster-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/cluster-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -18,7 +18,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/cluster-policy/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/cluster-policy/testdata/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/consume-policy/overlays/001-update-fields/config.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/overlays/001-update-fields/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/consume-policy/overlays/002-sync-delete/config.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/overlays/002-sync-delete/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/consume-policy/overlays/003-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/overlays/003-root-level-declaration/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/consume-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -18,7 +18,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/consume-policy/overlays/005-skip-record-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/overlays/005-skip-record-policy/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/consume-policy/overlays/006-schema-validation-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/overlays/006-schema-validation-policy/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/consume-policy/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/consume-policy/testdata/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/diff/overlays/003-diff/config.yaml
+++ b/test/e2e/scenarios/event-gateway/diff/overlays/003-diff/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13
@@ -29,7 +29,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/diff/overlays/004-diff-sync/config.yaml
+++ b/test/e2e/scenarios/event-gateway/diff/overlays/004-diff-sync/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/diff/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/diff/testdata/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/dump/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/dump/testdata/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/external-sync/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/external-sync/scenario.yaml
@@ -54,7 +54,7 @@ steps:
                 - "external-sync-backend-2.example.com:9092"
               tls:
                 enabled: true
-                skip_verify: false
+                insecure_skip_verify: false
                 tls_versions:
                   - tls12
                   - tls13

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/002-backend-cluster/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/002-backend-cluster/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/003-virtual-cluster/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/003-virtual-cluster/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/004-listener/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/004-listener/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/005-listener-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/005-listener-policy/config.yaml
@@ -45,7 +45,6 @@ event_gateways:
           type: forward_to_virtual_cluster
           description: "Plan Apply Listener 1 Policy 1"
           enabled: true
-          condition: "${ssl_sni} == \"example.com\""
           labels:
             env: staging
             team: payments
@@ -54,4 +53,3 @@ event_gateways:
             advertised_port: 9092
             sni_suffix: ".example.com"
 
-    

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/005-listener-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/005-listener-policy/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/006-data-plane-certificate/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/006-data-plane-certificate/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/006-data-plane-certificate/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/006-data-plane-certificate/config.yaml
@@ -45,7 +45,6 @@ event_gateways:
             type: forward_to_virtual_cluster
             description: "Plan Apply Listener 1 Policy 1"
             enabled: true
-            condition: "${ssl_sni} == \"example.com\""
             labels:
               env: staging
               team: payments

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/007-cluster-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/007-cluster-policy/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/007-cluster-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/007-cluster-policy/config.yaml
@@ -59,7 +59,6 @@ event_gateways:
             type: forward_to_virtual_cluster
             description: "Plan Apply Listener 1 Policy 1"
             enabled: true
-            condition: "${ssl_sni} == \"example.com\""
             labels:
               env: staging
               team: payments

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/008-produce-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/008-produce-policy/config.yaml
@@ -75,7 +75,6 @@ event_gateways:
             type: forward_to_virtual_cluster
             description: "Plan Apply Listener 1 Policy 1"
             enabled: true
-            condition: "${ssl_sni} == \"example.com\""
             labels:
               env: staging
               team: payments

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/008-produce-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/008-produce-policy/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/009-consume-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/009-consume-policy/config.yaml
@@ -82,7 +82,6 @@ event_gateways:
             type: forward_to_virtual_cluster
             description: "Plan Apply Listener 1 Policy 1"
             enabled: true
-            condition: "${ssl_sni} == \"example.com\""
             labels:
               env: staging
               team: payments

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/009-consume-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/009-consume-policy/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/010-schema-registry/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/010-schema-registry/config.yaml
@@ -95,7 +95,6 @@ event_gateways:
             type: forward_to_virtual_cluster
             description: "Plan Apply Listener 1 Policy 1"
             enabled: true
-            condition: "${ssl_sni} == \"example.com\""
             labels:
               env: staging
               team: payments

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/010-schema-registry/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/010-schema-registry/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/011-static-key/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/011-static-key/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/011-static-key/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/011-static-key/config.yaml
@@ -100,7 +100,6 @@ event_gateways:
             type: forward_to_virtual_cluster
             description: "Plan Apply Listener 1 Policy 1"
             enabled: true
-            condition: "${ssl_sni} == \"example.com\""
             labels:
               env: staging
               team: payments

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/012-trust-bundles/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/012-trust-bundles/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/012-trust-bundles/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/apply-workflow/overlays/012-trust-bundles/config.yaml
@@ -100,7 +100,6 @@ event_gateways:
             type: forward_to_virtual_cluster
             description: "Plan Apply Listener 1 Policy 1"
             enabled: true
-            condition: "${ssl_sni} == \"example.com\""
             labels:
               env: staging
               team: payments

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/002-backend-cluster/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/002-backend-cluster/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/003-virtual-cluster/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/003-virtual-cluster/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/004-listener/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/004-listener/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/005-listener-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/005-listener-policy/config.yaml
@@ -44,7 +44,6 @@ event_gateways:
           type: forward_to_virtual_cluster
           description: "Plan Sync Listener 1 Policy 1"
           enabled: true
-          condition: "${ssl_sni} == \"example.com\""
           labels:
             env: staging
             team: payments
@@ -53,4 +52,3 @@ event_gateways:
             destination:
               id: !ref plan-sync-virtual-cluster#id
             advertised_host: "example.com"
-    

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/005-listener-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/005-listener-policy/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/006-data-plane-certificate/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/006-data-plane-certificate/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/006-data-plane-certificate/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/006-data-plane-certificate/config.yaml
@@ -44,7 +44,6 @@ event_gateways:
             type: forward_to_virtual_cluster
             description: "Plan Sync Listener 1 Policy 1"
             enabled: true
-            condition: "${ssl_sni} == \"example.com\""
             labels:
               env: staging
               team: payments

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/007-cluster-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/007-cluster-policy/config.yaml
@@ -58,7 +58,6 @@ event_gateways:
             type: forward_to_virtual_cluster
             description: "Plan Sync Listener 1 Policy 1"
             enabled: true
-            condition: "${ssl_sni} == \"example.com\""
             labels:
               env: staging
               team: payments

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/007-cluster-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/007-cluster-policy/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/008-produce-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/008-produce-policy/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/008-produce-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/008-produce-policy/config.yaml
@@ -74,7 +74,6 @@ event_gateways:
             type: forward_to_virtual_cluster
             description: "Plan Sync Listener 1 Policy 1"
             enabled: true
-            condition: "${ssl_sni} == \"example.com\""
             labels:
               env: staging
               team: payments

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/009-consume-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/009-consume-policy/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/009-consume-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/009-consume-policy/config.yaml
@@ -85,7 +85,6 @@ event_gateways:
             type: forward_to_virtual_cluster
             description: "Plan Sync Listener 1 Policy 1"
             enabled: true
-            condition: "${ssl_sni} == \"example.com\""
             labels:
               env: staging
               team: payments

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/010-schema-registry/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/010-schema-registry/config.yaml
@@ -98,7 +98,6 @@ event_gateways:
             type: forward_to_virtual_cluster
             description: "Plan Sync Listener 1 Policy 1"
             enabled: true
-            condition: "${ssl_sni} == \"example.com\""
             labels:
               env: staging
               team: payments

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/010-schema-registry/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/010-schema-registry/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/011-static-key/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/011-static-key/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/011-static-key/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/011-static-key/config.yaml
@@ -103,7 +103,6 @@ event_gateways:
             type: forward_to_virtual_cluster
             description: "Plan Sync Listener 1 Policy 1"
             enabled: true
-            condition: "${ssl_sni} == \"example.com\""
             labels:
               env: staging
               team: payments

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/012-trust-bundles/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/012-trust-bundles/config.yaml
@@ -16,7 +16,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/012-trust-bundles/config.yaml
+++ b/test/e2e/scenarios/event-gateway/plan/sync-workflow/overlays/012-trust-bundles/config.yaml
@@ -103,7 +103,6 @@ event_gateways:
             type: forward_to_virtual_cluster
             description: "Plan Sync Listener 1 Policy 1"
             enabled: true
-            condition: "${ssl_sni} == \"example.com\""
             labels:
               env: staging
               team: payments

--- a/test/e2e/scenarios/event-gateway/principal-metadata/overlays/001-update-principal-metadata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/principal-metadata/overlays/001-update-principal-metadata/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/principal-metadata/overlays/002-sync-delete/config.yaml
+++ b/test/e2e/scenarios/event-gateway/principal-metadata/overlays/002-sync-delete/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/principal-metadata/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/principal-metadata/testdata/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/001-update-fields/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/001-update-fields/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/002-sync-delete/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/002-sync-delete/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/003-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/003-root-level-declaration/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -18,7 +18,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/005-schema-validation-policy/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/005-schema-validation-policy/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/006-update-schema-validation/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/006-update-schema-validation/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/produce-policy/overlays/007-sync-delete-schema-validation/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/overlays/007-sync-delete-schema-validation/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/produce-policy/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/produce-policy/testdata/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/topic-aliases/overlays/001-update-aliases/config.yaml
+++ b/test/e2e/scenarios/event-gateway/topic-aliases/overlays/001-update-aliases/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/topic-aliases/overlays/003-sync-delete/config.yaml
+++ b/test/e2e/scenarios/event-gateway/topic-aliases/overlays/003-sync-delete/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/topic-aliases/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/topic-aliases/testdata/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/virtual-cluster/overlays/001-update-fields/config.yaml
+++ b/test/e2e/scenarios/event-gateway/virtual-cluster/overlays/001-update-fields/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/virtual-cluster/overlays/002-sync-delete/config.yaml
+++ b/test/e2e/scenarios/event-gateway/virtual-cluster/overlays/002-sync-delete/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/virtual-cluster/overlays/003-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/virtual-cluster/overlays/003-root-level-declaration/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/virtual-cluster/overlays/004-sync-delete-root-level-declaration/config.yaml
+++ b/test/e2e/scenarios/event-gateway/virtual-cluster/overlays/004-sync-delete-root-level-declaration/config.yaml
@@ -18,7 +18,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/e2e/scenarios/event-gateway/virtual-cluster/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/virtual-cluster/testdata/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/integration/declarative/cross_reference_validation_test.go
+++ b/test/integration/declarative/cross_reference_validation_test.go
@@ -36,7 +36,6 @@ apis:
     publications:
       - ref: main-pub
         portal_id: main-portal
-        publish_status: published
 `,
 			wantErr: false,
 		},
@@ -55,7 +54,6 @@ apis:
     publications:
       - ref: main-pub
         portal_id: nonexistent-portal
-        publish_status: published
 `,
 			wantErr:     true,
 			expectedErr: `references unknown portal: nonexistent-portal`,
@@ -112,10 +110,8 @@ apis:
     publications:
       - ref: main-pub
         portal_id: main-portal
-        publish_status: published
       - ref: invalid-pub
         portal_id: nonexistent-portal
-        publish_status: published
 `,
 			wantErr:     true,
 			expectedErr: `references unknown portal: nonexistent-portal`,
@@ -146,10 +142,8 @@ apis:
     publications:
       - ref: main-pub
         portal_id: main-portal
-        publish_status: published
       - ref: dev-pub
         portal_id: dev-portal
-        publish_status: unpublished
     implementations:
       - ref: users-impl-external
         implementation_url: "https://api.example.com"
@@ -191,7 +185,6 @@ api_publications:
   - ref: main-pub
     api: users-api
     portal_id: main-portal
-    publish_status: published
 
 api_implementations:
   - ref: users-impl


### PR DESCRIPTION
## Summary

- derive a cached load-time schema from the declarative resource and explain registries
- reject unknown object fields before custom SDK unmarshallers can silently discard them
- preserve open map fields, union branch shapes, declarative tags, and semantic diagnostics for known rejected fields
- add schema conformance and loader coverage, and align E2E fixtures with the current SDK/API contracts

Closes #1739

## Testing

- `go fix ./...`
- `make format`
- `GOFLAGS=-buildvcs=false make build`
- `make lint`
- `make test`
- `make test-integration`
- `make test-e2e-scenarios`

Full E2E artifacts: `/home/rspurgeon/go/e2e-artifacts/20260801-185113`

The full scenario suite passed. Scenarios requiring optional user-profile, Kong Identity, Gmail, or GitHub workflow credentials remained skipped by their existing environment guards.