### PR TITLE
feat(declarative): support nested YAML tag composition

### DIFF
--- a/docs/contributor/declarative-resource-implementation-guide.md
+++ b/docs/contributor/declarative-resource-implementation-guide.md
@@ -1769,6 +1769,20 @@ or mapping syntax and serializes an opaque placeholder; it never performs
 network access. The planner resolves the placeholder before managed identity
 matching and writes only the resulting ID into the resource and plan.
 
+Nested tag composition is controlled by an explicit allowlist in the tag
+resolver. Currently, only `!env` as a direct mapping selector value inside
+`!external` or `!lookup` is supported. The external resolver must resolve that
+child concretely in both loader passes, mark its selector field as sensitive,
+and carry the sensitivity marker in its opaque placeholder. Planner cache keys
+use the real selector while user-facing diagnostics use a redacted form.
+
+Do not add a nested combination based only on compatible YAML node shapes.
+Define its resolution phase, allowed locations and result type, behavior in
+both loader representations, diagnostic disclosure policy, and saved-plan
+semantics first. Tags in control fields such as `var`, `extract`, and `path`
+remain unsupported unless the allowlist and documentation explicitly say
+otherwise.
+
 Resource types that support `_external` or inline lookup targets must:
 
 1. Implement `ExternallyResolvableResource`.

--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -60,6 +60,31 @@ Use YAML tags in field values to load files or reference other resources.
 - `!file` paths are resolved relative to the config file and must remain
   within the configured base directory boundary.
 
+Nested tag composition is opt-in. The only supported combination is `!env`
+as a direct mapping selector value inside `!lookup` or `!external`:
+
+```yaml
+portal_id: !lookup
+  name: !env PORTAL_NAME
+
+control_plane: !external {name: !env CONTROL_PLANE_NAME}
+```
+
+| Outer tag | Supported inner tags |
+|---|---|
+| `!lookup` / `!external` | `!env` in direct mapping values |
+| `!env`, `!file`, `!ref` | None |
+
+`!file`, `!ref`, and nested lookup tags are not supported inside lookup tags.
+Tags are not supported in mapping keys or control fields such as `var`,
+`extract`, and `path`. Use mapping lookup syntax for composition; tags cannot
+be interpolated into the scalar `field:value` form.
+
+Nested environment values are used only for planner-time lookup and are
+redacted from diagnostics. A saved plan contains the resolved ID, so execution
+does not reread the variable or repeat the lookup. This differs from ordinary
+`!env` fields, which remain deferred until execution.
+
 ```yaml
 portals:
   - ref: docs-portal

--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -617,6 +617,50 @@ The supported relationship tags are:
 the field is an API foreign key or a kongctl parent selector, supported tags,
 selectors, and any required scope field.
 
+### Nested YAML Tags
+
+Nested tags are supported only for combinations whose resolution order and
+security behavior are defined explicitly. `!env` may be used as a direct
+mapping selector value inside `!lookup` or `!external`:
+
+```yaml
+# Block mapping syntax
+portal_id: !lookup
+  name: !env PORTAL_NAME
+
+# Compact flow syntax
+control_plane: !external {name: !env CONTROL_PLANE_NAME}
+```
+
+Both scalar and map forms of the nested `!env` tag are supported. Multiple
+lookup selectors may use `!env`, subject to the selectors supported by the
+target resource. The existing rule that `id` cannot be combined with other
+selectors still applies.
+
+The current nested-tag support matrix is:
+
+| Outer tag | Inner tag | Status |
+|---|---|---|
+| `!lookup` / `!external` | `!env` | Direct mapping values only |
+| `!lookup` / `!external` | `!file`, `!ref`, lookup tags | Unsupported |
+| `!env`, `!file`, `!ref` | Any custom tag | Unsupported |
+
+The scalar `field:value` lookup form cannot contain a nested YAML tag; use a
+mapping form instead. Tags are also rejected in mapping keys, nested lookup
+objects, and control fields such as `var`, `extract`, or `path`.
+
+Nested `!file` values are not enabled because the permitted value types and
+disclosure behavior have not been defined. Nested `!ref` values are not
+enabled because references resolve after resources load, while remote lookups
+must resolve during planning. A tag contained in data loaded by `!file`
+continues to be treated as file content and is not processed recursively.
+
+For a supported nested `!env`, the environment value is read before the
+planner performs the remote lookup. Diagnostics redact that selector value.
+After a match is found, only the resolved resource ID is written to the plan.
+Saved-plan execution does not read the environment variable again or repeat
+the lookup, even if the environment later changes.
+
 ### Loading File Content to YAML Fields
 
 Load the entire content of a file as a string:
@@ -776,6 +820,9 @@ A runnable example is available in
   calculate changes.
 - Saved plan files preserve the deferred `!env` reference instead of the
   resolved plaintext value.
+- The exception is `!env` nested inside `!lookup` or `!external`: it is a
+  planner-only selector input, so the saved plan retains the resolved resource
+  ID and does not defer that environment value to execution.
 - During execution, `kongctl` performs a fresh environment lookup for each
   deferred `!env` value instead of reusing the value observed during
   planning.

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -276,8 +276,8 @@ func (l *Loader) parseYAML(r io.Reader, sourcePath string, rootDir string) (*res
 	placeholderRegistry := tags.NewResolverRegistry()
 	placeholderRegistry.Register(fileResolver)
 	placeholderRegistry.Register(refResolver)
-	placeholderRegistry.Register(tags.NewExternalTagResolver("!external"))
-	placeholderRegistry.Register(tags.NewExternalTagResolver("!lookup"))
+	placeholderRegistry.Register(tags.NewExternalTagResolver(tags.TagExternal))
+	placeholderRegistry.Register(tags.NewExternalTagResolver(tags.TagLookup))
 	placeholderRegistry.Register(tags.NewEnvTagResolver(tags.EnvTagModePlaceholder))
 
 	placeholderContent, err := placeholderRegistry.Process(rawContent)
@@ -293,8 +293,8 @@ func (l *Loader) parseYAML(r io.Reader, sourcePath string, rootDir string) (*res
 	registry := l.getTagRegistry()
 	registry.Register(fileResolver)
 	registry.Register(refResolver)
-	registry.Register(tags.NewExternalTagResolver("!external"))
-	registry.Register(tags.NewExternalTagResolver("!lookup"))
+	registry.Register(tags.NewExternalTagResolver(tags.TagExternal))
+	registry.Register(tags.NewExternalTagResolver(tags.TagLookup))
 	registry.Register(tags.NewEnvTagResolver(tags.EnvTagModeResolve))
 	if registry.HasResolvers() {
 		processedContent, err := registry.Process(rawContent)

--- a/internal/declarative/loader/tag_integration_test.go
+++ b/internal/declarative/loader/tag_integration_test.go
@@ -38,6 +38,58 @@ apis:
 	require.Equal(t, external.MatchFields, lookup.MatchFields)
 }
 
+func TestLoader_NestedEnvExternalLookupTags(t *testing.T) {
+	t.Setenv("BLOCK_PORTAL_NAME", "Block Portal")
+	t.Setenv("FLOW_PORTAL_NAME", "Flow Portal")
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+apis:
+  - ref: products
+    name: Products
+    publications:
+      - ref: block-publication
+        portal_id: !lookup
+          name: !env BLOCK_PORTAL_NAME
+      - ref: flow-publication
+        portal_id: !external {name: !env FLOW_PORTAL_NAME}
+`), 0o600))
+
+	rs, err := NewWithBaseDir(tmpDir).LoadFile(configFile)
+	require.NoError(t, err)
+	require.Len(t, rs.APIPublications, 2)
+	require.False(t, rs.HasEnvSources())
+
+	blockLookup, ok := tags.ParseExternalPlaceholder(rs.APIPublications[0].PortalID)
+	require.True(t, ok)
+	require.Equal(t, map[string]string{"name": "Block Portal"}, blockLookup.MatchFields)
+	require.Equal(t, []string{"name"}, blockLookup.SensitiveFields)
+
+	flowLookup, ok := tags.ParseExternalPlaceholder(rs.APIPublications[1].PortalID)
+	require.True(t, ok)
+	require.Equal(t, map[string]string{"name": "Flow Portal"}, flowLookup.MatchFields)
+	require.Equal(t, []string{"name"}, flowLookup.SensitiveFields)
+}
+
+func TestLoader_RejectsUnsupportedNestedTagWithSource(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+apis:
+  - ref: products
+    name: Products
+    publications:
+      - ref: products-publication
+        portal_id: !lookup {name: !ref portal-name}
+`), 0o600))
+
+	_, err := NewWithBaseDir(tmpDir).LoadFile(configFile)
+	require.ErrorContains(t, err, configFile)
+	require.ErrorContains(t, err, "nested YAML tag !ref is not supported inside !lookup")
+	require.ErrorContains(t, err, "line 7, column")
+}
+
 func TestLoader_RejectsMalformedExternalLookupPlaceholder(t *testing.T) {
 	t.Parallel()
 

--- a/internal/declarative/planner/external_lookup.go
+++ b/internal/declarative/planner/external_lookup.go
@@ -15,10 +15,11 @@ import (
 )
 
 type externalLookupRequest struct {
-	ResourceType resources.ResourceType
-	MatchFields  map[string]string
-	ParentID     string
-	Source       string
+	ResourceType    resources.ResourceType
+	MatchFields     map[string]string
+	SensitiveFields []string
+	ParentID        string
+	Source          string
 }
 
 type externalLookupCacheEntry struct {
@@ -296,10 +297,11 @@ func (r *externalLookupResolver) resolveInlineLookups(
 				source += fmt.Sprintf(" (line %d, column %d)", lookup.Line, lookup.Column)
 			}
 			id, err := r.resolve(ctx, externalLookupRequest{
-				ResourceType: targetType,
-				MatchFields:  lookup.MatchFields,
-				ParentID:     parentID,
-				Source:       source,
+				ResourceType:    targetType,
+				MatchFields:     lookup.MatchFields,
+				SensitiveFields: lookup.SensitiveFields,
+				ParentID:        parentID,
+				Source:          source,
 			})
 			if err != nil {
 				resolutionErr = err
@@ -492,13 +494,19 @@ func matchExternalCandidates[T any](
 	}
 	if len(matches) == 0 {
 		return "", fmt.Errorf(
-			"%s: no %s matched selector {%s}", req.Source, req.ResourceType, tags.ExternalLookupKey(req.MatchFields),
+			"%s: no %s matched selector {%s}",
+			req.Source,
+			req.ResourceType,
+			tags.ExternalLookupDisplayKey(req.MatchFields, req.SensitiveFields),
 		)
 	}
 	if len(matches) > 1 {
 		return "", fmt.Errorf(
 			"%s: selector {%s} matched %d %s resources",
-			req.Source, tags.ExternalLookupKey(req.MatchFields), len(matches), req.ResourceType,
+			req.Source,
+			tags.ExternalLookupDisplayKey(req.MatchFields, req.SensitiveFields),
+			len(matches),
+			req.ResourceType,
 		)
 	}
 	return matches[0], nil
@@ -604,13 +612,19 @@ func (r *externalLookupResolver) lookupEventGatewayVirtualCluster(
 func singleExternalID(req externalLookupRequest, matches []string) (string, error) {
 	if len(matches) == 0 {
 		return "", fmt.Errorf(
-			"%s: no %s matched selector {%s}", req.Source, req.ResourceType, tags.ExternalLookupKey(req.MatchFields),
+			"%s: no %s matched selector {%s}",
+			req.Source,
+			req.ResourceType,
+			tags.ExternalLookupDisplayKey(req.MatchFields, req.SensitiveFields),
 		)
 	}
 	if len(matches) > 1 {
 		return "", fmt.Errorf(
 			"%s: selector {%s} matched %d %s resources",
-			req.Source, tags.ExternalLookupKey(req.MatchFields), len(matches), req.ResourceType,
+			req.Source,
+			tags.ExternalLookupDisplayKey(req.MatchFields, req.SensitiveFields),
+			len(matches),
+			req.ResourceType,
 		)
 	}
 	return matches[0], nil

--- a/internal/declarative/planner/external_lookup_test.go
+++ b/internal/declarative/planner/external_lookup_test.go
@@ -2,7 +2,9 @@ package planner
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
+	"strings"
 	"testing"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
@@ -52,6 +54,75 @@ func TestExternalLookupResolverRejectsUnsupportedPlacement(t *testing.T) {
 		Source:       "api_publication products field portal_id",
 	})
 	require.ErrorContains(t, err, "does not support external lookup")
+}
+
+func TestExternalLookupResolverRedactsNestedEnvSelectorErrors(t *testing.T) {
+	t.Setenv("PORTAL_LOOKUP_NAME", "secret-portal-name")
+
+	portalAPI := &MockPortalAPI{}
+	portalAPI.On("ListPortals", mock.Anything, mock.Anything).Return(&kkOps.ListPortalsResponse{
+		ListPortalsResponse: &kkComps.ListPortalsResponse{
+			Data: []kkComps.ListPortalsResponsePortal{},
+			Meta: kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: 0}},
+		},
+	}, nil).Once()
+
+	rs := &resources.ResourceSet{APIPublications: []resources.APIPublicationResource{{
+		Ref:      "publication",
+		PortalID: nestedEnvExternalPlaceholder(t, tags.TagLookup, "PORTAL_LOOKUP_NAME"),
+	}}}
+	resolver := newExternalLookupResolver(NewPlanner(
+		state.NewClient(state.ClientConfig{PortalAPI: portalAPI}),
+		slog.Default(),
+	))
+
+	err := resolver.resolveInlineLookups(t.Context(), rs, resources.ResourceTypePortal)
+	require.ErrorContains(t, err, `"name"="[redacted from !env]"`)
+	require.NotContains(t, err.Error(), "secret-portal-name")
+	portalAPI.AssertExpectations(t)
+}
+
+func TestExternalLookupResolverSavedPlanRetainsResolvedID(t *testing.T) {
+	t.Setenv("PORTAL_LOOKUP_NAME", "Shared Portal")
+
+	portalAPI := &MockPortalAPI{}
+	portalAPI.On("ListPortals", mock.Anything, mock.Anything).Return(&kkOps.ListPortalsResponse{
+		ListPortalsResponse: &kkComps.ListPortalsResponse{
+			Data: []kkComps.ListPortalsResponsePortal{newListPortal("portal-id", "Shared Portal", nil)},
+			Meta: kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: 1}},
+		},
+	}, nil).Once()
+
+	rs := &resources.ResourceSet{APIPublications: []resources.APIPublicationResource{{
+		Ref:      "publication",
+		PortalID: nestedEnvExternalPlaceholder(t, tags.TagExternal, "PORTAL_LOOKUP_NAME"),
+	}}}
+	resolver := newExternalLookupResolver(NewPlanner(
+		state.NewClient(state.ClientConfig{PortalAPI: portalAPI}),
+		slog.Default(),
+	))
+	require.NoError(t, resolver.resolveInlineLookups(t.Context(), rs, resources.ResourceTypePortal))
+	require.Equal(t, "portal-id", rs.APIPublications[0].PortalID)
+
+	plan := NewPlan("1.0", "test", PlanModeApply)
+	plan.AddChange(PlannedChange{
+		ID:           "1:c:api_publication:publication",
+		ResourceType: ResourceTypeAPIPublication,
+		ResourceRef:  "publication",
+		Action:       ActionCreate,
+		Fields:       map[string]any{FieldPortalID: rs.APIPublications[0].PortalID},
+	})
+	payload, err := json.Marshal(plan)
+	require.NoError(t, err)
+	require.NotContains(t, string(payload), "Shared Portal")
+	require.NotContains(t, string(payload), tags.EnvPlaceholderPrefix)
+	require.NotContains(t, string(payload), tags.ExternalPlaceholderPrefix)
+
+	t.Setenv("PORTAL_LOOKUP_NAME", "Different Portal")
+	var savedPlan Plan
+	require.NoError(t, json.Unmarshal(payload, &savedPlan))
+	require.Equal(t, "portal-id", savedPlan.Changes[0].Fields[FieldPortalID])
+	portalAPI.AssertExpectations(t)
 }
 
 func TestExternalLookupResolverSkipsAPIImplementationWithoutService(t *testing.T) {
@@ -135,4 +206,18 @@ func externalPlaceholder(t *testing.T, tag string) string {
 	})
 	require.NoError(t, err)
 	return value.(string)
+}
+
+func nestedEnvExternalPlaceholder(t *testing.T, tag string, variable string) string {
+	t.Helper()
+	var doc yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(
+		"value: "+tag+" {name: !env "+variable+"}\n",
+	), &doc))
+	value, err := tags.NewExternalTagResolver(tag).Resolve(doc.Content[0].Content[1])
+	require.NoError(t, err)
+	placeholder, ok := value.(string)
+	require.True(t, ok)
+	require.True(t, strings.HasPrefix(placeholder, tags.ExternalPlaceholderPrefix))
+	return placeholder
 }

--- a/internal/declarative/tags/env.go
+++ b/internal/declarative/tags/env.go
@@ -34,7 +34,7 @@ func NewEnvTagResolver(mode EnvTagMode) *EnvTagResolver {
 
 // Tag returns the YAML tag this resolver handles.
 func (r *EnvTagResolver) Tag() string {
-	return "!env"
+	return TagEnv
 }
 
 // Resolve processes a YAML node with the !env tag.

--- a/internal/declarative/tags/external.go
+++ b/internal/declarative/tags/external.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"gopkg.in/yaml.v3" //nolint:gomodguard_v2 // yaml.v3 required for custom tag processing
@@ -15,9 +15,10 @@ const ExternalPlaceholderPrefix = "__EXTERNAL__:"
 
 // ExternalLookup describes a lookup parsed from !external or !lookup.
 type ExternalLookup struct {
-	MatchFields map[string]string `json:"match_fields"`
-	Line        int               `json:"line,omitempty"`
-	Column      int               `json:"column,omitempty"`
+	MatchFields     map[string]string `json:"match_fields"`
+	SensitiveFields []string          `json:"sensitive_fields,omitempty"`
+	Line            int               `json:"line,omitempty"`
+	Column          int               `json:"column,omitempty"`
 }
 
 // ExternalTagResolver converts external lookup tags into planner-time placeholders.
@@ -56,18 +57,24 @@ func (r *ExternalTagResolver) Resolve(node *yaml.Node) (any, error) {
 			}
 			key := node.Content[i]
 			value := node.Content[i+1]
-			if key.Kind != yaml.ScalarNode || value.Kind != yaml.ScalarNode {
+			if key.Kind != yaml.ScalarNode {
 				return nil, fmt.Errorf("%s mapping keys and values must be strings", r.tag)
 			}
-			if (key.Tag != "" && key.Tag != "!!str") || (value.Tag != "" && value.Tag != "!!str") {
+			if key.Tag != "" && key.Tag != "!!str" {
 				return nil, fmt.Errorf("%s mapping keys and values must be strings", r.tag)
 			}
 			field := strings.TrimSpace(key.Value)
-			match := strings.TrimSpace(value.Value)
+			match, sensitive, err := resolveExternalSelectorValue(value)
+			if err != nil {
+				return nil, fmt.Errorf("%s selector %q: %w", r.tag, field, err)
+			}
 			if field == "" || match == "" {
 				return nil, fmt.Errorf("%s mapping keys and values cannot be empty", r.tag)
 			}
 			lookup.MatchFields[field] = match
+			if sensitive {
+				lookup.SensitiveFields = append(lookup.SensitiveFields, field)
+			}
 		}
 		if len(lookup.MatchFields) == 0 {
 			return nil, fmt.Errorf("%s mapping must contain at least one selector", r.tag)
@@ -81,12 +88,32 @@ func (r *ExternalTagResolver) Resolve(node *yaml.Node) (any, error) {
 	if _, hasID := lookup.MatchFields["id"]; hasID && len(lookup.MatchFields) != 1 {
 		return nil, fmt.Errorf("%s id cannot be combined with other selectors", r.tag)
 	}
+	slices.Sort(lookup.SensitiveFields)
 
 	payload, err := json.Marshal(lookup)
 	if err != nil {
 		return nil, fmt.Errorf("encode external lookup: %w", err)
 	}
 	return ExternalPlaceholderPrefix + base64.RawURLEncoding.EncodeToString(payload), nil
+}
+
+func resolveExternalSelectorValue(node *yaml.Node) (string, bool, error) {
+	if node.Tag == TagEnv {
+		resolved, err := NewEnvTagResolver(EnvTagModeResolve).Resolve(node)
+		if err != nil {
+			return "", true, fmt.Errorf("failed to resolve nested %s: %w", TagEnv, err)
+		}
+		value, ok := resolved.(string)
+		if !ok {
+			return "", true, fmt.Errorf("nested %s value must resolve to a string", TagEnv)
+		}
+		return strings.TrimSpace(value), true, nil
+	}
+
+	if node.Kind != yaml.ScalarNode || (node.Tag != "" && node.Tag != "!!str") {
+		return "", false, fmt.Errorf("mapping value must be a string")
+	}
+	return strings.TrimSpace(node.Value), false, nil
 }
 
 // IsExternalPlaceholder reports whether a string contains a planner-time lookup.
@@ -116,7 +143,7 @@ func ExternalLookupKey(matchFields map[string]string) string {
 	for field := range matchFields {
 		fields = append(fields, field)
 	}
-	sort.Strings(fields)
+	slices.Sort(fields)
 	var b strings.Builder
 	for i, field := range fields {
 		if i > 0 {
@@ -125,4 +152,17 @@ func ExternalLookupKey(matchFields map[string]string) string {
 		fmt.Fprintf(&b, "%q=%q", field, matchFields[field])
 	}
 	return b.String()
+}
+
+// ExternalLookupDisplayKey returns a selector representation suitable for diagnostics.
+func ExternalLookupDisplayKey(matchFields map[string]string, sensitiveFields []string) string {
+	displayFields := make(map[string]string, len(matchFields))
+	for field, value := range matchFields {
+		if slices.Contains(sensitiveFields, field) {
+			displayFields[field] = "[redacted from !env]"
+			continue
+		}
+		displayFields[field] = value
+	}
+	return ExternalLookupKey(displayFields)
 }

--- a/internal/declarative/tags/external.go
+++ b/internal/declarative/tags/external.go
@@ -58,10 +58,10 @@ func (r *ExternalTagResolver) Resolve(node *yaml.Node) (any, error) {
 			key := node.Content[i]
 			value := node.Content[i+1]
 			if key.Kind != yaml.ScalarNode {
-				return nil, fmt.Errorf("%s mapping keys and values must be strings", r.tag)
+				return nil, fmt.Errorf("%s mapping keys must be strings", r.tag)
 			}
 			if key.Tag != "" && key.Tag != "!!str" {
-				return nil, fmt.Errorf("%s mapping keys and values must be strings", r.tag)
+				return nil, fmt.Errorf("%s mapping keys must be strings", r.tag)
 			}
 			field := strings.TrimSpace(key.Value)
 			match, sensitive, err := resolveExternalSelectorValue(value)

--- a/internal/declarative/tags/external_test.go
+++ b/internal/declarative/tags/external_test.go
@@ -124,12 +124,29 @@ func TestExternalTagResolverRejectsInvalidValues(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
-		node *yaml.Node
+		name    string
+		node    *yaml.Node
+		wantErr string
 	}{
 		{name: "missing delimiter", node: &yaml.Node{Kind: yaml.ScalarNode, Value: "shared"}},
 		{name: "invalid node kind", node: &yaml.Node{}},
 		{name: "empty selector", node: &yaml.Node{Kind: yaml.MappingNode}},
+		{
+			name: "non-scalar key",
+			node: &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
+				{Kind: yaml.MappingNode},
+				{Kind: yaml.ScalarNode, Tag: "!!str", Value: "shared"},
+			}},
+			wantErr: "mapping keys must be strings",
+		},
+		{
+			name: "non-string key",
+			node: &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
+				{Kind: yaml.ScalarNode, Tag: "!!int", Value: "123"},
+				{Kind: yaml.ScalarNode, Tag: "!!str", Value: "shared"},
+			}},
+			wantErr: "mapping keys must be strings",
+		},
 		{name: "id combined", node: &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
 			{Kind: yaml.ScalarNode, Value: "id"},
 			{Kind: yaml.ScalarNode, Value: "123"},
@@ -147,6 +164,9 @@ func TestExternalTagResolverRejectsInvalidValues(t *testing.T) {
 			t.Parallel()
 			_, err := NewExternalTagResolver("!external").Resolve(tt.node)
 			require.Error(t, err)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
 		})
 	}
 }

--- a/internal/declarative/tags/external_test.go
+++ b/internal/declarative/tags/external_test.go
@@ -42,6 +42,75 @@ func TestExternalTagResolverMapping(t *testing.T) {
 	require.Equal(t, map[string]string{"name": "shared", "display_name": "Shared Gateway"}, lookup.MatchFields)
 }
 
+func TestExternalTagResolverNestedEnvSelector(t *testing.T) {
+	t.Setenv("EXTERNAL_SELECTOR", "Shared Portal")
+
+	var doc yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte("value: !lookup {name: !env EXTERNAL_SELECTOR}\n"), &doc))
+	node := doc.Content[0].Content[1]
+
+	value, err := NewExternalTagResolver(TagLookup).Resolve(node)
+	require.NoError(t, err)
+	lookup, ok := ParseExternalPlaceholder(value.(string))
+	require.True(t, ok)
+	require.Equal(t, map[string]string{"name": "Shared Portal"}, lookup.MatchFields)
+	require.Equal(t, []string{"name"}, lookup.SensitiveFields)
+	require.Equal(
+		t,
+		`"name"="[redacted from !env]"`,
+		ExternalLookupDisplayKey(lookup.MatchFields, lookup.SensitiveFields),
+	)
+}
+
+func TestExternalTagResolverNestedEnvMapExtraction(t *testing.T) {
+	t.Setenv("EXTERNAL_SELECTOR_DOCUMENT", "portal:\n  name: Shared Portal\n")
+
+	var doc yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(`value: !external
+  name: !env
+    var: EXTERNAL_SELECTOR_DOCUMENT
+    extract: portal.name
+`), &doc))
+	node := doc.Content[0].Content[1]
+
+	value, err := NewExternalTagResolver(TagExternal).Resolve(node)
+	require.NoError(t, err)
+	lookup, ok := ParseExternalPlaceholder(value.(string))
+	require.True(t, ok)
+	require.Equal(t, map[string]string{"name": "Shared Portal"}, lookup.MatchFields)
+	require.Equal(t, []string{"name"}, lookup.SensitiveFields)
+}
+
+func TestExternalTagResolverRejectsInvalidNestedEnvSelector(t *testing.T) {
+	t.Run("unset", func(t *testing.T) {
+		var doc yaml.Node
+		require.NoError(t, yaml.Unmarshal([]byte("value: !lookup {name: !env UNSET_EXTERNAL_SELECTOR}\n"), &doc))
+
+		_, err := NewExternalTagResolver(TagLookup).Resolve(doc.Content[0].Content[1])
+		require.ErrorContains(t, err, "environment variable not set: UNSET_EXTERNAL_SELECTOR")
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		t.Setenv("EMPTY_EXTERNAL_SELECTOR", "")
+		var doc yaml.Node
+		require.NoError(t, yaml.Unmarshal([]byte("value: !lookup {name: !env EMPTY_EXTERNAL_SELECTOR}\n"), &doc))
+
+		_, err := NewExternalTagResolver(TagLookup).Resolve(doc.Content[0].Content[1])
+		require.ErrorContains(t, err, "mapping keys and values cannot be empty")
+	})
+
+	t.Run("non-string extraction", func(t *testing.T) {
+		t.Setenv("NON_STRING_EXTERNAL_SELECTOR", "portal:\n  enabled: true\n")
+		var doc yaml.Node
+		require.NoError(t, yaml.Unmarshal([]byte(
+			"value: !lookup {name: !env NON_STRING_EXTERNAL_SELECTOR#portal.enabled}\n",
+		), &doc))
+
+		_, err := NewExternalTagResolver(TagLookup).Resolve(doc.Content[0].Content[1])
+		require.ErrorContains(t, err, "!env value must resolve to a string")
+	})
+}
+
 func TestExternalLookupKeyIsUnambiguous(t *testing.T) {
 	t.Parallel()
 

--- a/internal/declarative/tags/file.go
+++ b/internal/declarative/tags/file.go
@@ -55,7 +55,7 @@ func NewFileTagResolver(baseDir string, rootDir string) *FileTagResolver {
 
 // Tag returns the YAML tag this resolver handles
 func (f *FileTagResolver) Tag() string {
-	return "!file"
+	return TagFile
 }
 
 // Resolve processes a YAML node with the !file tag

--- a/internal/declarative/tags/ref.go
+++ b/internal/declarative/tags/ref.go
@@ -24,7 +24,7 @@ func NewRefTagResolver(baseDir string) *RefTagResolver {
 
 // Tag returns the YAML tag this resolver handles
 func (r *RefTagResolver) Tag() string {
-	return "!ref"
+	return TagRef
 }
 
 // Resolve processes a YAML node with the !ref tag

--- a/internal/declarative/tags/resolver.go
+++ b/internal/declarative/tags/resolver.go
@@ -2,6 +2,7 @@ package tags
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -73,6 +74,10 @@ func (r *ResolverRegistry) processNode(node *yaml.Node) error {
 		r.mu.RUnlock()
 
 		if exists {
+			if err := validateNestedTags(node); err != nil {
+				return err
+			}
+
 			// Resolve the tag
 			resolved, err := resolver.Resolve(node)
 			if err != nil {
@@ -123,6 +128,100 @@ func (r *ResolverRegistry) processNode(node *yaml.Node) error {
 	}
 
 	return nil
+}
+
+type nestedTagLocation int
+
+const (
+	nestedTagLocationDirectMappingValue nestedTagLocation = iota
+	nestedTagLocationOther
+)
+
+var supportedNestedTags = map[string]map[string]nestedTagLocation{
+	TagExternal: {TagEnv: nestedTagLocationDirectMappingValue},
+	TagLookup:   {TagEnv: nestedTagLocationDirectMappingValue},
+}
+
+func validateNestedTags(outer *yaml.Node) error {
+	return validateNestedContent(outer, outer.Tag, true)
+}
+
+func validateNestedContent(node *yaml.Node, outerTag string, direct bool) error {
+	if node == nil {
+		return nil
+	}
+
+	switch node.Kind {
+	case yaml.DocumentNode, yaml.SequenceNode:
+		for _, child := range node.Content {
+			if err := validateNestedChild(child, outerTag, nestedTagLocationOther); err != nil {
+				return err
+			}
+		}
+	case yaml.MappingNode:
+		for i := 0; i < len(node.Content); i += 2 {
+			key := node.Content[i]
+			if err := validateNestedChild(key, outerTag, nestedTagLocationOther); err != nil {
+				return err
+			}
+			if i+1 >= len(node.Content) {
+				continue
+			}
+
+			location := nestedTagLocationOther
+			if direct {
+				location = nestedTagLocationDirectMappingValue
+			}
+			if err := validateNestedChild(node.Content[i+1], outerTag, location); err != nil {
+				return err
+			}
+		}
+	case yaml.ScalarNode, yaml.AliasNode:
+		return nil
+	}
+
+	return nil
+}
+
+func validateNestedChild(child *yaml.Node, outerTag string, location nestedTagLocation) error {
+	if child == nil {
+		return nil
+	}
+
+	if isCustomTag(child.Tag) {
+		allowedLocation, ok := supportedNestedTags[outerTag][child.Tag]
+		if !ok {
+			return nestedTagError(
+				child,
+				"nested YAML tag %s is not supported inside %s",
+				child.Tag,
+				outerTag,
+			)
+		}
+		if location != allowedLocation {
+			return nestedTagError(
+				child,
+				"nested YAML tag %s is only supported in direct mapping selector values inside %s",
+				child.Tag,
+				outerTag,
+			)
+		}
+		return validateNestedTags(child)
+	}
+
+	return validateNestedContent(child, outerTag, false)
+}
+
+func isCustomTag(tag string) bool {
+	return len(tag) > 1 && tag[0] == '!' && tag[1] != '!'
+}
+
+func nestedTagError(node *yaml.Node, format string, args ...any) error {
+	message := fmt.Sprintf(format, args...)
+	if node.Line > 0 {
+		return fmt.Errorf("%s at line %d, column %d", message, node.Line, node.Column)
+	}
+	return errors.New(message)
 }
 
 // replaceNodeWithValue replaces a node's content with the resolved value

--- a/internal/declarative/tags/resolver_test.go
+++ b/internal/declarative/tags/resolver_test.go
@@ -1,9 +1,11 @@
 package tags
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3" //nolint:gomodguard_v2 // yaml.v3 required for custom tag processing
 )
 
@@ -160,4 +162,59 @@ func TestResolverRegistry_InvalidYAML(t *testing.T) {
 	_, err := registry.Process([]byte(invalidYAML))
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse YAML")
+}
+
+func TestResolverRegistry_NestedTagSupportMatrix(t *testing.T) {
+	t.Setenv("NESTED_SELECTOR", "Shared Portal")
+
+	tags := []string{TagLookup, TagExternal, TagEnv, TagFile, TagRef}
+	for _, outerTag := range tags {
+		for _, innerTag := range tags {
+			name := fmt.Sprintf("%s contains %s", outerTag, innerTag)
+			t.Run(name, func(t *testing.T) {
+				registry := NewResolverRegistry()
+				registry.Register(NewExternalTagResolver(TagLookup))
+				registry.Register(NewExternalTagResolver(TagExternal))
+				registry.Register(NewEnvTagResolver(EnvTagModeResolve))
+				registry.Register(NewFileTagResolver(t.TempDir(), t.TempDir()))
+				registry.Register(NewRefTagResolver("."))
+
+				input := fmt.Sprintf("value: %s {name: %s NESTED_SELECTOR}\n", outerTag, innerTag)
+				_, err := registry.Process([]byte(input))
+				if (outerTag == TagLookup || outerTag == TagExternal) && innerTag == TagEnv {
+					require.NoError(t, err)
+					return
+				}
+
+				require.ErrorContains(t, err, "nested YAML tag "+innerTag+" is not supported inside "+outerTag)
+				require.ErrorContains(t, err, "line 1, column")
+			})
+		}
+	}
+}
+
+func TestResolverRegistry_RejectsNestedEnvOutsideDirectLookupSelector(t *testing.T) {
+	t.Setenv("NESTED_SELECTOR", "Shared Portal")
+
+	registry := NewResolverRegistry()
+	registry.Register(NewExternalTagResolver(TagLookup))
+	registry.Register(NewEnvTagResolver(EnvTagModeResolve))
+
+	_, err := registry.Process([]byte("value: !lookup {name: {nested: !env NESTED_SELECTOR}}\n"))
+	require.ErrorContains(
+		t,
+		err,
+		"nested YAML tag !env is only supported in direct mapping selector values inside !lookup",
+	)
+	require.ErrorContains(t, err, "line 1, column")
+}
+
+func TestResolverRegistry_RejectsNestedTagInEnvControlField(t *testing.T) {
+	registry := NewResolverRegistry()
+	registry.Register(NewExternalTagResolver(TagLookup))
+	registry.Register(NewEnvTagResolver(EnvTagModeResolve))
+
+	_, err := registry.Process([]byte("value: !lookup {name: !env {var: !env VARIABLE_NAME}}\n"))
+	require.ErrorContains(t, err, "nested YAML tag !env is not supported inside !env")
+	require.ErrorContains(t, err, "line 1, column")
 }

--- a/internal/declarative/tags/types.go
+++ b/internal/declarative/tags/types.go
@@ -4,6 +4,19 @@ package tags
 //nolint:gomodguard_v2 // yaml.v3 required for custom tag processing
 import "gopkg.in/yaml.v3"
 
+const (
+	// TagEnv identifies environment-backed values.
+	TagEnv = "!env"
+	// TagExternal identifies planner-time external lookups.
+	TagExternal = "!external"
+	// TagFile identifies file-backed values.
+	TagFile = "!file"
+	// TagLookup identifies the alias for planner-time external lookups.
+	TagLookup = "!lookup"
+	// TagRef identifies declarative resource references.
+	TagRef = "!ref"
+)
+
 // TagResolver processes custom YAML tags
 type TagResolver interface {
 	// Tag returns the YAML tag this resolver handles (e.g., "!file")

--- a/test/e2e/scenarios/event-gateway/virtual-cluster/overlays/003b-root-level-update/config.yaml
+++ b/test/e2e/scenarios/event-gateway/virtual-cluster/overlays/003b-root-level-update/config.yaml
@@ -17,7 +17,7 @@ event_gateways:
           type: anonymous
         tls:
           enabled: true
-          skip_verify: false
+          insecure_skip_verify: false
           tls_versions:
             - tls12
             - tls13

--- a/test/integration/declarative/external_lookup_test.go
+++ b/test/integration/declarative/external_lookup_test.go
@@ -43,3 +43,39 @@ gateway_services:
 	require.Equal(t, map[string]string{"name": "Shared Portal"}, publicationLookup.MatchFields)
 	require.Equal(t, map[string]string{"name": "Shared Control Plane"}, parentLookup.MatchFields)
 }
+
+func TestNestedEnvExternalLookupTags(t *testing.T) {
+	t.Setenv("BLOCK_PORTAL_NAME", "Block Portal")
+	t.Setenv("FLOW_CONTROL_PLANE_NAME", "Flow Control Plane")
+
+	configFile := filepath.Join(t.TempDir(), "nested-external-lookups.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+apis:
+  - ref: products
+    name: Products
+    publications:
+      - ref: products-publication
+        portal_id: !lookup
+          name: !env BLOCK_PORTAL_NAME
+
+gateway_services:
+  - ref: billing-service
+    control_plane: !external {name: !env FLOW_CONTROL_PLANE_NAME}
+    _external:
+      id: service-id
+`), 0o600))
+
+	rs, err := loader.New().LoadFile(configFile)
+	require.NoError(t, err)
+	require.False(t, rs.HasEnvSources())
+
+	publicationLookup, ok := tags.ParseExternalPlaceholder(rs.APIPublications[0].PortalID)
+	require.True(t, ok)
+	require.Equal(t, map[string]string{"name": "Block Portal"}, publicationLookup.MatchFields)
+	require.Equal(t, []string{"name"}, publicationLookup.SensitiveFields)
+
+	parentLookup, ok := tags.ParseExternalPlaceholder(rs.GatewayServices[0].ControlPlane)
+	require.True(t, ok)
+	require.Equal(t, map[string]string{"name": "Flow Control Plane"}, parentLookup.MatchFields)
+	require.Equal(t, []string{"name"}, parentLookup.SensitiveFields)
+}


### PR DESCRIPTION
## Summary

- support `!env` selector values nested directly inside `!lookup` and `!external` mappings
- enforce an explicit composition allowlist with source-oriented errors for unsupported combinations
- preserve planner-time lookup and saved-plan ID semantics while redacting environment-backed selector values
- document the support matrix, resolution phases, and currently unsupported combinations

## Testing

- `go fix ./...`
- `make format`
- `GOFLAGS=-buildvcs=false make build`
- `GOLANGCI_LINT_CACHE=/home/rspurgeon/.cache/golangci-lint-gh1716 make test-all`

Closes #1716