### PR TITLE
fix(declarative): allow consecutive hyphens in namespaces

### DIFF
--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -359,6 +359,10 @@ apis:
       protected: false
 ```
 
+A namespace must contain 1–63 lowercase alphanumeric characters or hyphens
+and must start and end with an alphanumeric character. Consecutive hyphens are
+permitted and are preserved exactly.
+
 ### File-Level Defaults
 
 Use `_defaults` to set default values for all resources in a file:

--- a/internal/cmd/root/products/konnect/adopt/common/common_test.go
+++ b/internal/cmd/root/products/konnect/adopt/common/common_test.go
@@ -1,0 +1,18 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadAdoptFlagsAcceptsConsecutiveHyphens(t *testing.T) {
+	cmd := &cobra.Command{Use: "adopt"}
+	require.NoError(t, AddAdoptFlags(cmd))
+	require.NoError(t, cmd.ParseFlags([]string{"--namespace", "team--service--prod"}))
+
+	flags, err := ReadAdoptFlags(cmd)
+	require.NoError(t, err)
+	require.Equal(t, "team--service--prod", flags.Namespace)
+}

--- a/internal/declarative/validator/namespace_validator.go
+++ b/internal/declarative/validator/namespace_validator.go
@@ -159,11 +159,6 @@ func (v *NamespaceValidator) ValidateNamespace(namespace string) error {
 		return fmt.Errorf("namespace '%s' is reserved and cannot be used", namespace)
 	}
 
-	// Additional validation: no double hyphens
-	if strings.Contains(namespace, "--") {
-		return fmt.Errorf("namespace '%s' is invalid: cannot contain consecutive hyphens", namespace)
-	}
-
 	return nil
 }
 

--- a/internal/declarative/validator/namespace_validator_test.go
+++ b/internal/declarative/validator/namespace_validator_test.go
@@ -97,10 +97,9 @@ func TestValidateNamespace(t *testing.T) {
 			errMsg:    "must consist of lowercase alphanumeric",
 		},
 		{
-			name:      "double hyphen",
-			namespace: "my--namespace",
-			wantErr:   true,
-			errMsg:    "cannot contain consecutive hyphens",
+			name:      "consecutive hyphens",
+			namespace: "team--service---prod",
+			wantErr:   false,
 		},
 		{
 			name:      "exceeds max length",
@@ -254,6 +253,14 @@ func TestParseNamespaceRequirementSlice(t *testing.T) {
 			expect: NamespaceRequirement{Mode: NamespaceRequirementSpecific, AllowedNamespaces: []string{"foo"}},
 		},
 		{
+			name:  "namespace with consecutive hyphens",
+			input: []string{"team--service--prod"},
+			expect: NamespaceRequirement{
+				Mode:              NamespaceRequirementSpecific,
+				AllowedNamespaces: []string{"team--service--prod"},
+			},
+		},
+		{
 			name:  "multiple namespaces",
 			input: []string{"foo", "bar", "baz"},
 			expect: NamespaceRequirement{
@@ -367,6 +374,14 @@ func TestParseNamespaceRequirement(t *testing.T) {
 			name:   "specific namespace",
 			input:  "team-alpha",
 			expect: NamespaceRequirement{Mode: NamespaceRequirementSpecific, AllowedNamespaces: []string{"team-alpha"}},
+		},
+		{
+			name:  "specific namespace with consecutive hyphens",
+			input: "team--service--prod",
+			expect: NamespaceRequirement{
+				Mode:              NamespaceRequirementSpecific,
+				AllowedNamespaces: []string{"team--service--prod"},
+			},
 		},
 		{
 			name:    "invalid namespace",

--- a/test/integration/declarative/namespace_test.go
+++ b/test/integration/declarative/namespace_test.go
@@ -40,13 +40,13 @@ apis:
     name: "Team API"
     description: "API for team operations"
     kongctl:
-      namespace: team-alpha
+      namespace: team--service--prod
 portals:
   - ref: team-portal
     name: "Team Portal"
     description: "Portal for team"
     kongctl:
-      namespace: team-alpha
+      namespace: team--service--prod
 `
 
 	err := os.WriteFile(configFile, []byte(configContent), 0o600)
@@ -62,11 +62,11 @@ portals:
 	// Verify namespace was parsed correctly
 	require.NotNil(t, resourceSet.APIs[0].Kongctl)
 	require.NotNil(t, resourceSet.APIs[0].Kongctl.Namespace)
-	assert.Equal(t, "team-alpha", *resourceSet.APIs[0].Kongctl.Namespace)
+	assert.Equal(t, "team--service--prod", *resourceSet.APIs[0].Kongctl.Namespace)
 
 	require.NotNil(t, resourceSet.Portals[0].Kongctl)
 	require.NotNil(t, resourceSet.Portals[0].Kongctl.Namespace)
-	assert.Equal(t, "team-alpha", *resourceSet.Portals[0].Kongctl.Namespace)
+	assert.Equal(t, "team--service--prod", *resourceSet.Portals[0].Kongctl.Namespace)
 
 	// Debug: print loaded resources
 	t.Logf("Loaded %d APIs, %d Portals", len(resourceSet.APIs), len(resourceSet.Portals))
@@ -81,7 +81,7 @@ portals:
 			APIResponseSchema: &kkComps.APIResponseSchema{
 				ID:     "mock-api",
 				Name:   "mock-api",
-				Labels: map[string]string{labels.NamespaceKey: "team-alpha"},
+				Labels: map[string]string{labels.NamespaceKey: "team--service--prod"},
 			},
 		}, nil).Maybe()
 	mockPortalAPI := GetMockPortalAPI(ctx, t)
@@ -107,7 +107,7 @@ portals:
 			APIResponseSchema: &kkComps.APIResponseSchema{
 				ID:          "alpha-1",
 				Name:        "alpha-1",
-				Labels:      map[string]string{labels.NamespaceKey: "team-alpha"},
+				Labels:      map[string]string{labels.NamespaceKey: "team--service--prod"},
 				Description: stringPtr("alpha api"),
 			},
 		}, nil).Maybe()
@@ -132,7 +132,7 @@ portals:
 			APIResponseSchema: &kkComps.APIResponseSchema{
 				ID:     "api-protected",
 				Name:   "Protected Alpha API",
-				Labels: map[string]string{labels.NamespaceKey: "team-alpha", labels.ProtectedKey: "true"},
+				Labels: map[string]string{labels.NamespaceKey: "team--service--prod", labels.ProtectedKey: "true"},
 			},
 		}, nil).Maybe()
 
@@ -142,7 +142,7 @@ portals:
 		if api.Labels == nil {
 			return false
 		}
-		return api.Labels[labels.NamespaceKey] == "team-alpha"
+		return api.Labels[labels.NamespaceKey] == "team--service--prod"
 	})).Return(&kkOps.CreateAPIResponse{
 		StatusCode: 201,
 		APIResponseSchema: &kkComps.APIResponseSchema{
@@ -150,7 +150,7 @@ portals:
 			Name:        "Team API",
 			Description: stringPtr("API for team operations"),
 			Labels: map[string]string{
-				labels.NamespaceKey: "team-alpha",
+				labels.NamespaceKey: "team--service--prod",
 			},
 			CreatedAt: time.Now(),
 			UpdatedAt: time.Now(),
@@ -165,7 +165,7 @@ portals:
 		}
 		// Portal.Labels is a map[string]*string, need to dereference
 		if nsLabel, ok := portal.Labels[labels.NamespaceKey]; ok && nsLabel != nil {
-			return *nsLabel == "team-alpha"
+			return *nsLabel == "team--service--prod"
 		}
 		return false
 	})).Return(&kkOps.CreatePortalResponse{
@@ -239,7 +239,7 @@ portals:
 
 	// Verify both changes have namespace set
 	for _, change := range plan.Changes {
-		assert.Equal(t, "team-alpha", change.Namespace)
+		assert.Equal(t, "team--service--prod", change.Namespace)
 		assert.Equal(t, planner.ActionCreate, change.Action)
 	}
 
@@ -759,17 +759,6 @@ apis:
 			expectError: "exceeds maximum length of 63 characters",
 		},
 		{
-			name: "invalid namespace with double hyphen",
-			yaml: `
-apis:
-  - ref: api1
-    name: "API 1"
-    kongctl:
-      namespace: team--alpha
-`,
-			expectError: "cannot contain consecutive hyphens",
-		},
-		{
 			name: "empty namespace explicitly set",
 			yaml: `
 apis:
@@ -899,6 +888,22 @@ organization:
 }
 
 func TestNamespace_CommandRequirementCoversOrganizationTeams(t *testing.T) {
+	t.Run("specific namespace accepts consecutive hyphens", func(t *testing.T) {
+		configFile := writeNamespaceRegressionConfig(t, `
+_defaults:
+  kongctl:
+    namespace: ns--a
+organization:
+  teams:
+    - ref: repro-team
+      name: repro-team
+`)
+
+		err := executeDeclarativeNamespaceCommand(t, "plan", "-f", configFile, "--require-namespace", "ns--a")
+
+		require.NoError(t, err)
+	})
+
 	t.Run("specific namespace reports team mismatch", func(t *testing.T) {
 		configFile := writeNamespaceRegressionConfig(t, `
 _defaults:

--- a/test/integration/declarative/namespace_test.go
+++ b/test/integration/declarative/namespace_test.go
@@ -877,7 +877,7 @@ organization:
 		t.Run(tc.name, func(t *testing.T) {
 			configFile := writeNamespaceRegressionConfig(t, tc.yaml)
 
-			err := executeDeclarativeNamespaceCommand(t, "plan", "-f", configFile)
+			err := executeDeclarativeNamespaceCommand(t, "-f", configFile)
 
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "failed to load configuration")
@@ -899,7 +899,7 @@ organization:
       name: repro-team
 `)
 
-		err := executeDeclarativeNamespaceCommand(t, "plan", "-f", configFile, "--require-namespace", "ns--a")
+		err := executeDeclarativeNamespaceCommand(t, "-f", configFile, "--require-namespace", "ns--a")
 
 		require.NoError(t, err)
 	})
@@ -915,7 +915,7 @@ organization:
       name: repro-team
 `)
 
-		err := executeDeclarativeNamespaceCommand(t, "plan", "-f", configFile, "--require-namespace", "ns-b")
+		err := executeDeclarativeNamespaceCommand(t, "-f", configFile, "--require-namespace", "ns-b")
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "organization_team 'repro-team': uses namespace 'ns-a'")
@@ -932,7 +932,7 @@ organization:
         namespace: ns-a
 `)
 
-		err := executeDeclarativeNamespaceCommand(t, "plan", "-f", configFile, "--require-any-namespace")
+		err := executeDeclarativeNamespaceCommand(t, "-f", configFile, "--require-any-namespace")
 
 		require.NoError(t, err)
 	})
@@ -1118,10 +1118,10 @@ func writeNamespaceRegressionConfig(t *testing.T, content string) string {
 	return configFile
 }
 
-func executeDeclarativeNamespaceCommand(t *testing.T, verb string, args ...string) error {
+func executeDeclarativeNamespaceCommand(t *testing.T, args ...string) error {
 	t.Helper()
 
-	cmd, err := declarative.NewDeclarativeCmd(verbs.VerbValue(verb))
+	cmd, err := declarative.NewDeclarativeCmd(verbs.Plan)
 	require.NoError(t, err)
 	cmd.SetContext(SetupTestContext(t))
 


### PR DESCRIPTION
## Summary

- allow consecutive internal hyphens in declarative namespaces
- preserve namespace values exactly through planning and Konnect labels
- cover loader, namespace requirement, and adopt validation paths
- document the supported namespace syntax

## Rationale

The existing namespace pattern and external platform constraints permit consecutive hyphens, but an additional validator check rejected them without a documented compatibility or safety requirement. Removing that check broadens accepted input without changing existing namespace ownership or isolation semantics.

## Testing

- go fix ./...
- make format
- make lint
- make test
- make test-integration
- GOFLAGS=-buildvcs=false make build

Fixes #1773