### PR TITLE
feat(cmd): add api-gateway alias

### DIFF
--- a/internal/cmd/root/products/konnect/gateway/gateway.go
+++ b/internal/cmd/root/products/konnect/gateway/gateway.go
@@ -27,7 +27,7 @@ func NewGatewayCmd(verb verbs.VerbValue,
 		Use:     gatewayUse,
 		Short:   gatewayShort,
 		Long:    gatewayLong,
-		Aliases: []string{"gw", "GW"},
+		Aliases: []string{"gw", "GW", "api-gateway"},
 	}
 	cmdpkg.ConfigureRequiresSubcommand(cmd)
 

--- a/internal/cmd/root/products/konnect/gateway/gateway.go
+++ b/internal/cmd/root/products/konnect/gateway/gateway.go
@@ -27,7 +27,7 @@ func NewGatewayCmd(verb verbs.VerbValue,
 		Use:     gatewayUse,
 		Short:   gatewayShort,
 		Long:    gatewayLong,
-		Aliases: []string{"gw", "GW", "api-gateway"},
+		Aliases: []string{"gw", "GW", "api-gateway", "apigw"},
 	}
 	cmdpkg.ConfigureRequiresSubcommand(cmd)
 

--- a/internal/cmd/root/products/konnect/gateway/gateway_test.go
+++ b/internal/cmd/root/products/konnect/gateway/gateway_test.go
@@ -30,6 +30,13 @@ func TestGatewayCoreEntityCommandsAreNestedUnderControlPlane(t *testing.T) {
 	}
 }
 
+func TestGatewayCommandAliases(t *testing.T) {
+	cmd, err := NewGatewayCmd(verbs.Get, nil, nil)
+	require.NoError(t, err)
+
+	assert.Contains(t, cmd.Aliases, "api-gateway")
+}
+
 func TestGatewayCoreEntitySiblingPathsFail(t *testing.T) {
 	for _, name := range []string{"services", "routes", "consumers"} {
 		t.Run(name, func(t *testing.T) {

--- a/internal/cmd/root/verbs/get/gateway_test.go
+++ b/internal/cmd/root/verbs/get/gateway_test.go
@@ -1,0 +1,23 @@
+package get
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIGatewayAliasCommandPaths(t *testing.T) {
+	cmd, err := NewGetCmd()
+	require.NoError(t, err)
+
+	for _, path := range [][]string{
+		{"api-gateway", "control-planes"},
+		{"konnect", "api-gateway", "control-planes"},
+	} {
+		resolved, remaining, err := cmd.Find(path)
+		require.NoError(t, err)
+		assert.Equal(t, "control-plane", resolved.Name())
+		assert.Empty(t, remaining)
+	}
+}

--- a/internal/cmd/root/verbs/get/gateway_test.go
+++ b/internal/cmd/root/verbs/get/gateway_test.go
@@ -15,8 +15,10 @@ func TestAPIGatewayAliasCommandPaths(t *testing.T) {
 		name string
 		path []string
 	}{
-		{name: "Konnect-first", path: []string{"api-gateway", "control-planes"}},
-		{name: "explicit Konnect", path: []string{"konnect", "api-gateway", "control-planes"}},
+		{name: "Konnect-first api-gateway", path: []string{"api-gateway", "control-planes"}},
+		{name: "explicit Konnect api-gateway", path: []string{"konnect", "api-gateway", "control-planes"}},
+		{name: "Konnect-first apigw", path: []string{"apigw", "control-planes"}},
+		{name: "explicit Konnect apigw", path: []string{"konnect", "apigw", "control-planes"}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			resolved, remaining, err := cmd.Find(test.path)

--- a/internal/cmd/root/verbs/get/gateway_test.go
+++ b/internal/cmd/root/verbs/get/gateway_test.go
@@ -11,13 +11,18 @@ func TestAPIGatewayAliasCommandPaths(t *testing.T) {
 	cmd, err := NewGetCmd()
 	require.NoError(t, err)
 
-	for _, path := range [][]string{
-		{"api-gateway", "control-planes"},
-		{"konnect", "api-gateway", "control-planes"},
+	for _, test := range []struct {
+		name string
+		path []string
+	}{
+		{name: "Konnect-first", path: []string{"api-gateway", "control-planes"}},
+		{name: "explicit Konnect", path: []string{"konnect", "api-gateway", "control-planes"}},
 	} {
-		resolved, remaining, err := cmd.Find(path)
-		require.NoError(t, err)
-		assert.Equal(t, "control-plane", resolved.Name())
-		assert.Empty(t, remaining)
+		t.Run(test.name, func(t *testing.T) {
+			resolved, remaining, err := cmd.Find(test.path)
+			require.NoError(t, err)
+			assert.Equal(t, "control-plane", resolved.Name())
+			assert.Empty(t, remaining)
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- add `api-gateway` as an alias for the existing Konnect `gateway` command
- support both explicit and Konnect-first command paths
- add focused alias and command-resolution tests

## Testing

- `go fix ./...`
- `make format`
- `make lint`
- `make test`
- `make test-integration`
- `GOFLAGS=-buildvcs=false make build`
- manual `--help` verification for both command paths

Closes #1750