### PR TITLE
task(declarative): remove Portal IdP enabled workaround

### DIFF
--- a/internal/declarative/executor/portal_identity_provider_adapter.go
+++ b/internal/declarative/executor/portal_identity_provider_adapter.go
@@ -77,24 +77,9 @@ func (p *PortalIdentityProviderAdapter) Create(
 		return "", err
 	}
 
-	enabled := req.Enabled
-
 	id, err := p.client.CreatePortalIdentityProvider(ctx, portalID, req, namespace)
 	if err != nil {
 		return "", err
-	}
-
-	if enabled != nil {
-		update := kkComps.UpdateIdentityProvider{Enabled: enabled}
-		if err := p.client.UpdatePortalIdentityProvider(
-			ctx,
-			portalID,
-			id,
-			update,
-			namespace,
-		); err != nil {
-			return "", err
-		}
 	}
 
 	return id, nil

--- a/internal/declarative/executor/portal_identity_provider_adapter_test.go
+++ b/internal/declarative/executor/portal_identity_provider_adapter_test.go
@@ -15,10 +15,11 @@ import (
 )
 
 type stubPortalIdentityProviderAPI struct {
-	createReq kkComps.CreateIdentityProvider
-	updateReq kkOps.UpdatePortalIdentityProviderRequest
-	getResp   *kkOps.GetPortalIdentityProviderResponse
-	deleteReq struct {
+	createReq   kkComps.CreateIdentityProvider
+	updateReq   kkOps.UpdatePortalIdentityProviderRequest
+	updateCalls int
+	getResp     *kkOps.GetPortalIdentityProviderResponse
+	deleteReq   struct {
 		portalID string
 		id       string
 	}
@@ -62,6 +63,7 @@ func (s *stubPortalIdentityProviderAPI) UpdatePortalIdentityProvider(
 	request kkOps.UpdatePortalIdentityProviderRequest,
 	_ ...kkOps.Option,
 ) (*kkOps.UpdatePortalIdentityProviderResponse, error) {
+	s.updateCalls++
 	s.updateReq = request
 	return &kkOps.UpdatePortalIdentityProviderResponse{}, nil
 }
@@ -79,7 +81,7 @@ func (s *stubPortalIdentityProviderAPI) DeletePortalIdentityProvider(
 
 var _ helpers.PortalIdentityProviderAPI = (*stubPortalIdentityProviderAPI)(nil)
 
-func TestPortalIdentityProviderAdapterCreateUpdatesExplicitFalseEnabled(t *testing.T) {
+func TestPortalIdentityProviderAdapterCreatePreservesExplicitFalseWithoutUpdate(t *testing.T) {
 	t.Parallel()
 
 	api := &stubPortalIdentityProviderAPI{}
@@ -99,10 +101,9 @@ func TestPortalIdentityProviderAdapterCreateUpdatesExplicitFalseEnabled(t *testi
 	require.NoError(t, err)
 	assert.Equal(t, "provider-1", id)
 
-	require.NotNil(t, api.updateReq.PortalUpdateIdentityProvider.Enabled)
-	assert.False(t, *api.updateReq.PortalUpdateIdentityProvider.Enabled)
-	assert.Equal(t, "portal-1", api.updateReq.PortalID)
-	assert.Equal(t, "provider-1", api.updateReq.ID)
+	require.NotNil(t, api.createReq.Enabled)
+	assert.False(t, *api.createReq.Enabled)
+	assert.Zero(t, api.updateCalls)
 }
 
 func TestPortalIdentityProviderAdapterUpdateKeepsPatchPayloadSparse(t *testing.T) {

--- a/internal/konnect/helpers/portal_identity_providers.go
+++ b/internal/konnect/helpers/portal_identity_providers.go
@@ -1,20 +1,12 @@
 package helpers
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"strconv"
-	"strings"
 
 	kkSDK "github.com/Kong/sdk-konnect-go"
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
-
-	"github.com/kong/kongctl/internal/konnect/apiutil"
 )
 
 // PortalIdentityProviderAPI defines the interface for portal identity provider operations.
@@ -51,11 +43,7 @@ type PortalIdentityProviderAPI interface {
 
 // PortalIdentityProviderAPIImpl provides an implementation backed by the SDK.
 type PortalIdentityProviderAPIImpl struct {
-	SDK         *kkSDK.SDK
-	BaseURL     string
-	Token       string
-	TokenSource apiutil.TokenSource
-	HTTPClient  kkSDK.HTTPClient
+	SDK *kkSDK.SDK
 }
 
 // ListPortalIdentityProviders lists identity providers for a portal.
@@ -97,33 +85,7 @@ func (p *PortalIdentityProviderAPIImpl) CreatePortalIdentityProvider(
 	if err != nil {
 		return nil, err
 	}
-	if p.BaseURL == "" || p.HTTPClient == nil {
-		return p.SDK.PortalAuthSettings.CreatePortalIdentityProvider(ctx, portalID, portalRequest, opts...)
-	}
-
-	sdkOpts := []kkSDK.SDKOption{
-		kkSDK.WithServerURL(p.BaseURL),
-		kkSDK.WithClient(&portalIdentityProviderCreateHTTPClient{base: p.HTTPClient}),
-	}
-	if p.TokenSource != nil {
-		sdkOpts = append(sdkOpts, kkSDK.WithSecuritySource(func(ctx context.Context) (kkComps.Security, error) {
-			token, err := p.TokenSource.Token(ctx)
-			if err != nil {
-				return kkComps.Security{}, err
-			}
-			return kkComps.Security{PersonalAccessToken: &token}, nil
-		}))
-	} else {
-		sdkOpts = append(sdkOpts, kkSDK.WithSecurity(kkComps.Security{
-			PersonalAccessToken: &p.Token,
-		}))
-	}
-
-	sdk := kkSDK.New(sdkOpts...)
-	if sdk == nil || sdk.PortalAuthSettings == nil {
-		return nil, fmt.Errorf("failed to initialize SDK for portal identity provider create")
-	}
-	return sdk.PortalAuthSettings.CreatePortalIdentityProvider(ctx, portalID, portalRequest, opts...)
+	return p.SDK.PortalAuthSettings.CreatePortalIdentityProvider(ctx, portalID, portalRequest, opts...)
 }
 
 // UpdatePortalIdentityProvider updates an identity provider for a portal.
@@ -197,101 +159,6 @@ func createPortalIdentityProviderConfig(
 	default:
 		return nil, fmt.Errorf("identity provider config type is required")
 	}
-}
-
-type portalIdentityProviderCreateHTTPClient struct {
-	base kkSDK.HTTPClient
-}
-
-func (c *portalIdentityProviderCreateHTTPClient) Do(req *http.Request) (*http.Response, error) {
-	if c == nil || c.base == nil {
-		return nil, fmt.Errorf("http client is not configured")
-	}
-
-	if err := stripEnabledFromPortalIdentityProviderCreateRequest(req); err != nil {
-		return nil, err
-	}
-
-	return c.base.Do(req)
-}
-
-func stripEnabledFromPortalIdentityProviderCreateRequest(req *http.Request) error {
-	if !isPortalIdentityProviderCreateRequest(req) {
-		return nil
-	}
-
-	body, err := readAndRestoreRequestBody(req)
-	if err != nil {
-		return err
-	}
-	if len(bytes.TrimSpace(body)) == 0 {
-		return nil
-	}
-
-	var payload map[string]json.RawMessage
-	if err := json.Unmarshal(body, &payload); err != nil {
-		return fmt.Errorf("failed to decode portal identity provider create request: %w", err)
-	}
-	if _, ok := payload["enabled"]; !ok {
-		return nil
-	}
-
-	delete(payload, "enabled")
-
-	encoded, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("failed to encode portal identity provider create request: %w", err)
-	}
-	restoreRequestBody(req, encoded)
-	return nil
-}
-
-func isPortalIdentityProviderCreateRequest(req *http.Request) bool {
-	if req == nil || req.URL == nil {
-		return false
-	}
-	if req.Method != http.MethodPost {
-		return false
-	}
-
-	path := strings.Trim(req.URL.Path, "/")
-	segments := strings.Split(path, "/")
-	if len(segments) != 4 {
-		return false
-	}
-
-	return segments[0] == "v3" &&
-		segments[1] == "portals" &&
-		segments[2] != "" &&
-		segments[3] == "identity-providers"
-}
-
-func readAndRestoreRequestBody(req *http.Request) ([]byte, error) {
-	if req == nil || req.Body == nil {
-		return nil, nil
-	}
-
-	originalBody := req.Body
-	defer originalBody.Close()
-
-	body, err := io.ReadAll(originalBody)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read request body: %w", err)
-	}
-	restoreRequestBody(req, body)
-	return body, nil
-}
-
-func restoreRequestBody(req *http.Request, body []byte) {
-	if req == nil {
-		return
-	}
-	req.Body = io.NopCloser(bytes.NewReader(body))
-	req.ContentLength = int64(len(body))
-	req.GetBody = func() (io.ReadCloser, error) {
-		return io.NopCloser(bytes.NewReader(body)), nil
-	}
-	req.Header.Set("Content-Length", strconv.Itoa(len(body)))
 }
 
 var _ PortalIdentityProviderAPI = (*PortalIdentityProviderAPIImpl)(nil)

--- a/internal/konnect/helpers/portal_identity_providers.go
+++ b/internal/konnect/helpers/portal_identity_providers.go
@@ -78,8 +78,8 @@ func (p *PortalIdentityProviderAPIImpl) CreatePortalIdentityProvider(
 	request kkComps.CreateIdentityProvider,
 	opts ...kkOps.Option,
 ) (*kkOps.CreatePortalIdentityProviderResponse, error) {
-	if p.SDK == nil {
-		return nil, fmt.Errorf("SDK is nil")
+	if p.SDK == nil || p.SDK.PortalAuthSettings == nil {
+		return nil, fmt.Errorf("SDK portal auth settings API is nil")
 	}
 	portalRequest, err := createPortalIdentityProviderRequest(request)
 	if err != nil {

--- a/internal/konnect/helpers/portal_identity_providers_test.go
+++ b/internal/konnect/helpers/portal_identity_providers_test.go
@@ -152,3 +152,22 @@ func TestPortalIdentityProviderAPIImplCreatePortalIdentityProviderOmitsLoginPath
 		t.Fatalf("expected enabled to be omitted from portal create body, got %v", requestBody["enabled"])
 	}
 }
+
+func TestPortalIdentityProviderAPIImplCreatePortalIdentityProviderRejectsMissingPortalAuthSettings(t *testing.T) {
+	t.Parallel()
+
+	api := &PortalIdentityProviderAPIImpl{SDK: &kkSDK.SDK{}}
+	_, err := api.CreatePortalIdentityProvider(t.Context(), "portal-123", kkComps.CreateIdentityProvider{})
+	if err == nil {
+		t.Fatal("expected missing portal auth settings API to return an error")
+	}
+}
+
+func TestKonnectSDKGetPortalIdentityProviderAPIRejectsMissingPortalAuthSettings(t *testing.T) {
+	t.Parallel()
+
+	sdk := &KonnectSDK{SDK: &kkSDK.SDK{}}
+	if api := sdk.GetPortalIdentityProviderAPI(); api != nil {
+		t.Fatalf("expected nil portal identity provider API, got %#v", api)
+	}
+}

--- a/internal/konnect/helpers/portal_identity_providers_test.go
+++ b/internal/konnect/helpers/portal_identity_providers_test.go
@@ -2,7 +2,6 @@ package helpers
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -48,65 +47,82 @@ func (c *portalIdentityProviderCapturingClient) Do(req *http.Request) (*http.Res
 	}, nil
 }
 
-func TestPortalIdentityProviderAPIImplCreatePortalIdentityProviderStripsEnabledFromCreateBody(t *testing.T) {
+func newPortalIdentityProviderTestAPI(client kkSDK.HTTPClient) *PortalIdentityProviderAPIImpl {
+	token := "test-token"
+	return &PortalIdentityProviderAPIImpl{SDK: kkSDK.New(
+		kkSDK.WithServerURL("https://example.test"),
+		kkSDK.WithSecurity(kkComps.Security{PersonalAccessToken: &token}),
+		kkSDK.WithClient(client),
+	)}
+}
+
+func TestPortalIdentityProviderAPIImplCreatePortalIdentityProviderIncludesExplicitEnabled(t *testing.T) {
 	t.Parallel()
 
-	client := &portalIdentityProviderCapturingClient{t: t}
-	api := &PortalIdentityProviderAPIImpl{
-		SDK:        kkSDK.New(),
-		BaseURL:    "https://example.test",
-		Token:      "test-token",
-		HTTPClient: client,
+	tests := []struct {
+		name    string
+		enabled bool
+	}{
+		{name: "true", enabled: true},
+		{name: "false", enabled: false},
 	}
 
-	config := kkComps.CreateCreateIdentityProviderConfigOIDCIdentityProviderConfig(kkComps.OIDCIdentityProviderConfig{
-		IssuerURL: "https://accounts.google.com",
-		ClientID:  "client-id-1",
-		Scopes:    []string{"openid"},
-	})
-	enabled := true
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	resp, err := api.CreatePortalIdentityProvider(context.Background(), "portal-123", kkComps.CreateIdentityProvider{
-		Type:    kkComps.IdentityProviderTypeOidc.ToPointer(),
-		Enabled: &enabled,
-		Config:  &config,
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+			client := &portalIdentityProviderCapturingClient{t: t}
+			api := newPortalIdentityProviderTestAPI(client)
+			config := kkComps.CreateCreateIdentityProviderConfigOIDCIdentityProviderConfig(
+				kkComps.OIDCIdentityProviderConfig{
+					IssuerURL: "https://accounts.google.com",
+					ClientID:  "client-id-1",
+					Scopes:    []string{"openid"},
+				},
+			)
 
-	if client.request == nil {
-		t.Fatal("expected request to be captured")
-	}
-	if client.request.Method != http.MethodPost {
-		t.Fatalf("unexpected method: %s", client.request.Method)
-	}
-	if got := client.request.URL.String(); got != "https://example.test/v3/portals/portal-123/identity-providers" {
-		t.Fatalf("unexpected URL: %s", got)
-	}
+			resp, err := api.CreatePortalIdentityProvider(t.Context(), "portal-123", kkComps.CreateIdentityProvider{
+				Type:    kkComps.IdentityProviderTypeOidc.ToPointer(),
+				Enabled: &tt.enabled,
+				Config:  &config,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
-	var requestBody map[string]any
-	if err := json.Unmarshal(client.requestBody, &requestBody); err != nil {
-		t.Fatalf("failed to decode request body: %v", err)
-	}
+			if client.request == nil {
+				t.Fatal("expected request to be captured")
+			}
+			if client.request.Method != http.MethodPost {
+				t.Fatalf("unexpected method: %s", client.request.Method)
+			}
+			if got := client.request.URL.String(); got != "https://example.test/v3/portals/portal-123/identity-providers" {
+				t.Fatalf("unexpected URL: %s", got)
+			}
 
-	if _, ok := requestBody["enabled"]; ok {
-		t.Fatalf("expected enabled to be removed from create body, got %v", requestBody["enabled"])
-	}
-	if got := requestBody["type"]; got != "oidc" {
-		t.Fatalf("unexpected type: %v", got)
-	}
+			var requestBody map[string]any
+			if err := json.Unmarshal(client.requestBody, &requestBody); err != nil {
+				t.Fatalf("failed to decode request body: %v", err)
+			}
+			if got := requestBody["enabled"]; got != tt.enabled {
+				t.Fatalf("unexpected enabled: %v", got)
+			}
+			if got := requestBody["type"]; got != "oidc" {
+				t.Fatalf("unexpected type: %v", got)
+			}
 
-	configBody, ok := requestBody["config"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected config object, got %#v", requestBody["config"])
-	}
-	if got := configBody["client_id"]; got != "client-id-1" {
-		t.Fatalf("unexpected client_id: %v", got)
-	}
+			configBody, ok := requestBody["config"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected config object, got %#v", requestBody["config"])
+			}
+			if got := configBody["client_id"]; got != "client-id-1" {
+				t.Fatalf("unexpected client_id: %v", got)
+			}
 
-	if resp == nil || resp.PortalIdentityProvider == nil || resp.PortalIdentityProvider.ID == nil {
-		t.Fatalf("expected identity provider response, got %#v", resp)
+			if resp == nil || resp.PortalIdentityProvider == nil || resp.PortalIdentityProvider.ID == nil {
+				t.Fatalf("expected identity provider response, got %#v", resp)
+			}
+		})
 	}
 }
 
@@ -114,15 +130,10 @@ func TestPortalIdentityProviderAPIImplCreatePortalIdentityProviderOmitsLoginPath
 	t.Parallel()
 
 	client := &portalIdentityProviderCapturingClient{t: t}
-	api := &PortalIdentityProviderAPIImpl{
-		SDK:        kkSDK.New(),
-		BaseURL:    "https://example.test",
-		Token:      "test-token",
-		HTTPClient: client,
-	}
+	api := newPortalIdentityProviderTestAPI(client)
 	loginPath := "oidc-login"
 
-	_, err := api.CreatePortalIdentityProvider(context.Background(), "portal-123", kkComps.CreateIdentityProvider{
+	_, err := api.CreatePortalIdentityProvider(t.Context(), "portal-123", kkComps.CreateIdentityProvider{
 		Type:      kkComps.IdentityProviderTypeOidc.ToPointer(),
 		LoginPath: &loginPath,
 	})
@@ -137,49 +148,7 @@ func TestPortalIdentityProviderAPIImplCreatePortalIdentityProviderOmitsLoginPath
 	if _, ok := requestBody["login_path"]; ok {
 		t.Fatalf("expected login_path to be omitted from portal create body, got %v", requestBody["login_path"])
 	}
-}
-
-type trackingReadCloser struct {
-	reader io.Reader
-	closed bool
-}
-
-func (t *trackingReadCloser) Read(p []byte) (int, error) {
-	return t.reader.Read(p)
-}
-
-func (t *trackingReadCloser) Close() error {
-	t.closed = true
-	return nil
-}
-
-func TestReadAndRestoreRequestBodyClosesOriginalBody(t *testing.T) {
-	t.Parallel()
-
-	originalBody := &trackingReadCloser{reader: bytes.NewBufferString(`{"type":"oidc"}`)}
-	req, err := http.NewRequest(http.MethodPost, "https://example.test/v3/portals/p/identity-providers", originalBody)
-	if err != nil {
-		t.Fatalf("unexpected error creating request: %v", err)
-	}
-	req.Body = originalBody
-
-	body, err := readAndRestoreRequestBody(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if string(body) != `{"type":"oidc"}` {
-		t.Fatalf("unexpected body: %s", body)
-	}
-	if !originalBody.closed {
-		t.Fatal("expected original request body to be closed")
-	}
-
-	restoredBody, err := io.ReadAll(req.Body)
-	if err != nil {
-		t.Fatalf("unexpected error reading restored body: %v", err)
-	}
-	if string(restoredBody) != `{"type":"oidc"}` {
-		t.Fatalf("unexpected restored body: %s", restoredBody)
+	if _, ok := requestBody["enabled"]; ok {
+		t.Fatalf("expected enabled to be omitted from portal create body, got %v", requestBody["enabled"])
 	}
 }

--- a/internal/konnect/helpers/sdk.go
+++ b/internal/konnect/helpers/sdk.go
@@ -398,13 +398,7 @@ func (k *KonnectSDK) GetPortalIdentityProviderAPI() PortalIdentityProviderAPI {
 		return nil
 	}
 
-	return &PortalIdentityProviderAPIImpl{
-		SDK:         k.SDK,
-		BaseURL:     k.BaseURL,
-		Token:       k.Token,
-		TokenSource: k.TokenSource,
-		HTTPClient:  k.HTTPClient,
-	}
+	return &PortalIdentityProviderAPIImpl{SDK: k.SDK}
 }
 
 // Returns the implementation of the PortalCustomizationAPI interface

--- a/internal/konnect/helpers/sdk.go
+++ b/internal/konnect/helpers/sdk.go
@@ -394,7 +394,7 @@ func (k *KonnectSDK) GetPortalIntegrationsAPI() PortalIntegrationsAPI {
 
 // Returns the implementation of the PortalIdentityProviderAPI interface
 func (k *KonnectSDK) GetPortalIdentityProviderAPI() PortalIdentityProviderAPI {
-	if k.SDK == nil {
+	if k.SDK == nil || k.SDK.PortalAuthSettings == nil {
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

- send explicit Portal IdP `enabled` values in the create POST
- remove the custom body-stripping transport and follow-up PATCH
- preserve OIDC/SAML conversion and sparse update behavior

## Rationale

Konnect now accepts `enabled` when creating Portal Identity Providers. Removing the workaround makes creation a single atomic mutating request and avoids reporting a failed apply after a successful POST.

## Testing

- `go fix ./...`
- `make format`
- `GOFLAGS=-buildvcs=false make build`
- `make lint`
- `make test`

Closes #1780