### PR TITLE
fix(declarative): preserve empty portal menu arrays

### DIFF
--- a/internal/declarative/executor/portal_customization_adapter.go
+++ b/internal/declarative/executor/portal_customization_adapter.go
@@ -61,11 +61,14 @@ func (p *PortalCustomizationAdapter) MapUpdateFields(_ context.Context, fields m
 	if menuData, ok := fields[planner.FieldMenu].(map[string]any); ok {
 		menu := &kkComps.Menu{}
 
-		if mainItems := toAnySlice(menuData["main"]); mainItems != nil {
+		if mainItems := toAnySlice(menuData[planner.FieldMenuMain]); mainItems != nil {
 			menu.Main = mapPortalMenuItems(mainItems)
 		}
-		if footerItems := toAnySlice(menuData["footer_sections"]); footerItems != nil {
+		if footerItems := toAnySlice(menuData[planner.FieldMenuFooterSections]); footerItems != nil {
 			menu.FooterSections = mapFooterSections(footerItems)
+		}
+		if footerBottomItems := toAnySlice(menuData[planner.FieldMenuFooterBottom]); footerBottomItems != nil {
+			menu.FooterBottom = mapPortalMenuItems(footerBottomItems)
 		}
 
 		update.Menu = menu
@@ -134,7 +137,7 @@ func toAnySlice(v any) []any {
 }
 
 func mapPortalMenuItems(raw []any) []kkComps.PortalMenuItem {
-	var items []kkComps.PortalMenuItem
+	items := make([]kkComps.PortalMenuItem, 0, len(raw))
 	for _, entry := range raw {
 		itemMap, ok := entry.(map[string]any)
 		if !ok {
@@ -156,7 +159,7 @@ func mapPortalMenuItems(raw []any) []kkComps.PortalMenuItem {
 }
 
 func mapFooterSections(raw []any) []kkComps.PortalFooterMenuSection {
-	var sections []kkComps.PortalFooterMenuSection
+	sections := make([]kkComps.PortalFooterMenuSection, 0, len(raw))
 	for _, entry := range raw {
 		sectionMap, ok := entry.(map[string]any)
 		if !ok {

--- a/internal/declarative/executor/portal_customization_adapter_test.go
+++ b/internal/declarative/executor/portal_customization_adapter_test.go
@@ -128,6 +128,54 @@ func TestPortalCustomizationAdapterMapUpdateFieldsMenuFooterSections_AnySlice(t 
 	assert.Equal(t, "Privacy", update.Menu.FooterSections[0].Items[0].Title)
 }
 
+func TestPortalCustomizationAdapterMapUpdateFieldsPreservesEmptyMenuListsFromPlanJSON(t *testing.T) {
+	adapter := NewPortalCustomizationAdapter(nil)
+	fields := map[string]any{
+		planner.FieldMenu: map[string]any{
+			planner.FieldMenuMain:           []any{},
+			planner.FieldMenuFooterSections: []any{},
+			planner.FieldMenuFooterBottom:   []any{},
+		},
+	}
+	var update kkComps.PortalCustomization
+
+	err := adapter.MapUpdateFields(context.Background(), fields, &update)
+
+	require.NoError(t, err)
+	require.NotNil(t, update.Menu)
+	assert.NotNil(t, update.Menu.Main)
+	assert.Empty(t, update.Menu.Main)
+	assert.NotNil(t, update.Menu.FooterSections)
+	assert.Empty(t, update.Menu.FooterSections)
+	assert.NotNil(t, update.Menu.FooterBottom)
+	assert.Empty(t, update.Menu.FooterBottom)
+}
+
+func TestPortalCustomizationAdapterMapUpdateFieldsMenuFooterBottom(t *testing.T) {
+	adapter := NewPortalCustomizationAdapter(nil)
+	fields := map[string]any{
+		planner.FieldMenu: map[string]any{
+			planner.FieldMenuFooterBottom: []any{
+				map[string]any{
+					"path":                  "/terms",
+					planner.FieldTitle:      "Terms",
+					planner.FieldVisibility: "public",
+					"external":              false,
+				},
+			},
+		},
+	}
+	var update kkComps.PortalCustomization
+
+	err := adapter.MapUpdateFields(context.Background(), fields, &update)
+
+	require.NoError(t, err)
+	require.NotNil(t, update.Menu)
+	require.Len(t, update.Menu.FooterBottom, 1)
+	assert.Equal(t, "/terms", update.Menu.FooterBottom[0].Path)
+	assert.Equal(t, "Terms", update.Menu.FooterBottom[0].Title)
+}
+
 func TestPortalCustomizationAdapterMapUpdateFieldsSpecRendererAndRobots(t *testing.T) {
 	adapter := NewPortalCustomizationAdapter(nil)
 	fields := map[string]any{

--- a/internal/declarative/planner/constants.go
+++ b/internal/declarative/planner/constants.go
@@ -172,6 +172,13 @@ const (
 	FieldTryItUI               = "try_it_ui"
 )
 
+// Common portal customization menu plan field identifiers.
+const (
+	FieldMenuMain           = "main"
+	FieldMenuFooterSections = "footer_sections"
+	FieldMenuFooterBottom   = "footer_bottom"
+)
+
 // Common gateway and event-gateway plan field identifiers.
 const (
 	FieldACLMode                                    = "acl_mode"

--- a/internal/declarative/planner/portal_child_planner.go
+++ b/internal/declarative/planner/portal_child_planner.go
@@ -1311,32 +1311,20 @@ func (p *Planner) buildMenuFields(menu *kkComps.Menu) map[string]any {
 
 	// Add main menu items
 	if menu.Main != nil {
-		var mainMenuItems []map[string]any
+		mainMenuItems := make([]map[string]any, 0, len(menu.Main))
 		for _, item := range menu.Main {
-			menuItem := map[string]any{
-				"path":          item.Path,
-				FieldTitle:      item.Title,
-				"external":      item.External,
-				FieldVisibility: string(item.Visibility),
-			}
-			mainMenuItems = append(mainMenuItems, menuItem)
+			mainMenuItems = append(mainMenuItems, buildPortalMenuItemFields(item))
 		}
-		menuFields["main"] = mainMenuItems
+		menuFields[FieldMenuMain] = mainMenuItems
 	}
 
 	// Add footer sections
 	if menu.FooterSections != nil {
-		var footerSections []map[string]any
+		footerSections := make([]map[string]any, 0, len(menu.FooterSections))
 		for _, section := range menu.FooterSections {
-			var items []map[string]any
+			items := make([]map[string]any, 0, len(section.Items))
 			for _, item := range section.Items {
-				menuItem := map[string]any{
-					"path":          item.Path,
-					FieldTitle:      item.Title,
-					"external":      item.External,
-					FieldVisibility: string(item.Visibility),
-				}
-				items = append(items, menuItem)
+				items = append(items, buildPortalMenuItemFields(item))
 			}
 			sectionMap := map[string]any{
 				FieldTitle: section.Title,
@@ -1344,10 +1332,28 @@ func (p *Planner) buildMenuFields(menu *kkComps.Menu) map[string]any {
 			}
 			footerSections = append(footerSections, sectionMap)
 		}
-		menuFields["footer_sections"] = footerSections
+		menuFields[FieldMenuFooterSections] = footerSections
+	}
+
+	// Add bottom footer menu items
+	if menu.FooterBottom != nil {
+		footerBottomItems := make([]map[string]any, 0, len(menu.FooterBottom))
+		for _, item := range menu.FooterBottom {
+			footerBottomItems = append(footerBottomItems, buildPortalMenuItemFields(item))
+		}
+		menuFields[FieldMenuFooterBottom] = footerBottomItems
 	}
 
 	return menuFields
+}
+
+func buildPortalMenuItemFields(item kkComps.PortalMenuItem) map[string]any {
+	return map[string]any{
+		"path":          item.Path,
+		FieldTitle:      item.Title,
+		"external":      item.External,
+		FieldVisibility: string(item.Visibility),
+	}
 }
 
 func (p *Planner) buildSpecRendererFields(specRenderer *kkComps.SpecRenderer) map[string]any {
@@ -1417,18 +1423,8 @@ func (p *Planner) compareMenu(current, desired *kkComps.Menu) bool {
 		return false
 	}
 
-	// Compare main menu items
-	if len(current.Main) != len(desired.Main) {
+	if !comparePortalMenuItems(current.Main, desired.Main) {
 		return false
-	}
-	for i, currentItem := range current.Main {
-		desiredItem := desired.Main[i]
-		if currentItem.Path != desiredItem.Path ||
-			currentItem.Title != desiredItem.Title ||
-			currentItem.External != desiredItem.External ||
-			currentItem.Visibility != desiredItem.Visibility {
-			return false
-		}
 	}
 
 	// Compare footer sections
@@ -1443,14 +1439,26 @@ func (p *Planner) compareMenu(current, desired *kkComps.Menu) bool {
 		}
 
 		// Compare items in section
-		for j, currentItem := range currentSection.Items {
-			desiredItem := desiredSection.Items[j]
-			if currentItem.Path != desiredItem.Path ||
-				currentItem.Title != desiredItem.Title ||
-				currentItem.External != desiredItem.External ||
-				currentItem.Visibility != desiredItem.Visibility {
-				return false
-			}
+		if !comparePortalMenuItems(currentSection.Items, desiredSection.Items) {
+			return false
+		}
+	}
+
+	return comparePortalMenuItems(current.FooterBottom, desired.FooterBottom)
+}
+
+func comparePortalMenuItems(current, desired []kkComps.PortalMenuItem) bool {
+	if len(current) != len(desired) {
+		return false
+	}
+
+	for i, currentItem := range current {
+		desiredItem := desired[i]
+		if currentItem.Path != desiredItem.Path ||
+			currentItem.Title != desiredItem.Title ||
+			currentItem.External != desiredItem.External ||
+			currentItem.Visibility != desiredItem.Visibility {
+			return false
 		}
 	}
 

--- a/internal/declarative/planner/portal_child_test.go
+++ b/internal/declarative/planner/portal_child_test.go
@@ -2,6 +2,7 @@ package planner
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"testing"
 	"time"
@@ -537,6 +538,30 @@ func TestBuildAllCustomizationFieldsIncludesSpecRendererAndRobots(t *testing.T) 
 	assert.Equal(t, true, specRenderer[FieldHideDeprecated])
 	assert.Equal(t, false, specRenderer[FieldAllowCustomServerURLs])
 	assert.Equal(t, "User-agent: *", fields[FieldRobots])
+}
+
+func TestBuildAllCustomizationFieldsPreservesEmptyMenuArrays(t *testing.T) {
+	planner := NewPlanner(nil, slog.Default())
+
+	fields := planner.buildAllCustomizationFields(resources.PortalCustomizationResource{
+		PortalCustomization: kkComps.PortalCustomization{
+			Menu: &kkComps.Menu{
+				Main:           []kkComps.PortalMenuItem{},
+				FooterSections: []kkComps.PortalFooterMenuSection{},
+				FooterBottom:   []kkComps.PortalMenuItem{},
+			},
+		},
+	})
+
+	serialized, err := json.Marshal(fields)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"menu": {
+			"main": [],
+			"footer_sections": [],
+			"footer_bottom": []
+		}
+	}`, string(serialized))
 }
 
 func TestPlanPortalTeamGroupMappingsSkipsUnconfiguredPortalAuthSettingsAPI(t *testing.T) {

--- a/internal/declarative/planner/portal_child_test.go
+++ b/internal/declarative/planner/portal_child_test.go
@@ -564,6 +564,32 @@ func TestBuildAllCustomizationFieldsPreservesEmptyMenuArrays(t *testing.T) {
 	}`, string(serialized))
 }
 
+func TestShouldUpdatePortalCustomizationDetectsFooterBottomDrift(t *testing.T) {
+	planner := NewPlanner(nil, slog.Default())
+	current := &kkComps.PortalCustomization{
+		Menu: &kkComps.Menu{
+			FooterBottom: []kkComps.PortalMenuItem{{
+				Path:       "/terms",
+				Title:      "Terms",
+				Visibility: kkComps.PortalMenuItemVisibilityPublic,
+			}},
+		},
+	}
+	desired := resources.PortalCustomizationResource{
+		PortalCustomization: kkComps.PortalCustomization{
+			Menu: &kkComps.Menu{FooterBottom: []kkComps.PortalMenuItem{}},
+		},
+	}
+
+	needsUpdate, updates, changedFields := planner.shouldUpdatePortalCustomization(current, desired)
+
+	require.True(t, needsUpdate)
+	menuFields, ok := updates[FieldMenu].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, []map[string]any{}, menuFields[FieldMenuFooterBottom])
+	assert.Contains(t, changedFields, FieldMenu)
+}
+
 func TestPlanPortalTeamGroupMappingsSkipsUnconfiguredPortalAuthSettingsAPI(t *testing.T) {
 	client := state.NewClient(state.ClientConfig{})
 	planner := NewPlanner(client, slog.Default())

--- a/internal/konnect/helpers/api_publications.go
+++ b/internal/konnect/helpers/api_publications.go
@@ -207,7 +207,7 @@ func (a *APIPublicationAPIImpl) publishAPIToPortalWithMergedPayload(
 		ctx,
 		http.MethodPut,
 		path,
-		map[string]string{"Content-Type": "application/json"},
+		map[string]string{contentTypeHeader: applicationJSONContent},
 		bytes.NewReader(payload),
 	)
 	if err != nil {
@@ -215,7 +215,7 @@ func (a *APIPublicationAPIImpl) publishAPIToPortalWithMergedPayload(
 	}
 
 	response := &kkOps.PublishAPIToPortalResponse{
-		ContentType: result.Header.Get("Content-Type"),
+		ContentType: result.Header.Get(contentTypeHeader),
 		StatusCode:  result.StatusCode,
 		RawResponse: &http.Response{
 			StatusCode: result.StatusCode,

--- a/internal/konnect/helpers/constants.go
+++ b/internal/konnect/helpers/constants.go
@@ -1,0 +1,6 @@
+package helpers
+
+const (
+	contentTypeHeader      = "Content-Type"
+	applicationJSONContent = "application/json"
+)

--- a/internal/konnect/helpers/dcr_providers.go
+++ b/internal/konnect/helpers/dcr_providers.go
@@ -173,13 +173,13 @@ func (a *DCRProvidersAPIImpl) CreateDcrProvider(ctx context.Context,
 		}
 
 		result, err := a.request(ctx, http.MethodPost, "/v2/dcr-providers",
-			map[string]string{"Content-Type": "application/json"}, bytes.NewReader(payload))
+			map[string]string{contentTypeHeader: applicationJSONContent}, bytes.NewReader(payload))
 		if err != nil {
 			return nil, err
 		}
 
 		response := &kkOPS.CreateDcrProviderResponse{
-			ContentType: result.Header.Get("Content-Type"),
+			ContentType: result.Header.Get(contentTypeHeader),
 			StatusCode:  result.StatusCode,
 			RawResponse: newDCRProviderRawResponse(result),
 		}
@@ -203,13 +203,13 @@ func (a *DCRProvidersAPIImpl) UpdateDcrProvider(ctx context.Context, id string,
 
 		path := fmt.Sprintf("/v2/dcr-providers/%s", url.PathEscape(id))
 		result, err := a.request(ctx, http.MethodPatch, path,
-			map[string]string{"Content-Type": "application/json"}, bytes.NewReader(payload))
+			map[string]string{contentTypeHeader: applicationJSONContent}, bytes.NewReader(payload))
 		if err != nil {
 			return nil, err
 		}
 
 		response := &kkOPS.UpdateDcrProviderResponse{
-			ContentType: result.Header.Get("Content-Type"),
+			ContentType: result.Header.Get(contentTypeHeader),
 			StatusCode:  result.StatusCode,
 			RawResponse: newDCRProviderRawResponse(result),
 		}
@@ -233,7 +233,7 @@ func (a *DCRProvidersAPIImpl) DeleteDcrProvider(ctx context.Context,
 		}
 
 		response := &kkOPS.DeleteDcrProviderResponse{
-			ContentType: result.Header.Get("Content-Type"),
+			ContentType: result.Header.Get(contentTypeHeader),
 			StatusCode:  result.StatusCode,
 			RawResponse: newDCRProviderRawResponse(result),
 		}

--- a/internal/konnect/helpers/portal_customizations.go
+++ b/internal/konnect/helpers/portal_customizations.go
@@ -1,12 +1,20 @@
 package helpers
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
 
 	kkSDK "github.com/Kong/sdk-konnect-go"
 	kkComponents "github.com/Kong/sdk-konnect-go/models/components"
 	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+
+	"github.com/kong/kongctl/internal/konnect/apiutil"
 )
 
 // PortalCustomizationAPI defines the interface for operations on Portal Customizations
@@ -20,7 +28,11 @@ type PortalCustomizationAPI interface {
 
 // PortalCustomizationAPIImpl provides an implementation of the PortalCustomizationAPI interface
 type PortalCustomizationAPIImpl struct {
-	SDK *kkSDK.SDK
+	SDK         *kkSDK.SDK
+	BaseURL     string
+	Token       string
+	TokenSource apiutil.TokenSource
+	HTTPClient  kkSDK.HTTPClient
 }
 
 // UpdatePortalCustomization implements the PortalCustomizationAPI interface
@@ -30,6 +42,9 @@ func (p *PortalCustomizationAPIImpl) UpdatePortalCustomization(
 ) (*kkOps.UpdatePortalCustomizationResponse, error) {
 	if p.SDK == nil {
 		return nil, fmt.Errorf("SDK is nil")
+	}
+	if requiresExplicitEmptyPortalMenu(request) {
+		return p.updatePortalCustomizationWithExplicitEmptyMenu(ctx, portalID, request)
 	}
 	return p.SDK.PortalCustomization.UpdatePortalCustomization(ctx, portalID, request, opts...)
 }
@@ -43,4 +58,125 @@ func (p *PortalCustomizationAPIImpl) GetPortalCustomization(
 		return nil, fmt.Errorf("SDK is nil")
 	}
 	return p.SDK.PortalCustomization.GetPortalCustomization(ctx, portalID, opts...)
+}
+
+type portalCustomizationPayload struct {
+	Theme        *kkComponents.Theme        `json:"theme,omitempty"`
+	Layout       *string                    `json:"layout,omitempty"`
+	CSS          *string                    `json:"css,omitempty"`
+	Menu         *portalCustomizationMenu   `json:"menu,omitempty"`
+	SpecRenderer *kkComponents.SpecRenderer `json:"spec_renderer,omitempty"`
+	Robots       *string                    `json:"robots,omitempty"`
+}
+
+type portalCustomizationMenu struct {
+	Main           *[]kkComponents.PortalMenuItem          `json:"main,omitempty"`
+	FooterSections *[]kkComponents.PortalFooterMenuSection `json:"footer_sections,omitempty"`
+	FooterBottom   *[]kkComponents.PortalMenuItem          `json:"footer_bottom,omitempty"`
+}
+
+func requiresExplicitEmptyPortalMenu(customization *kkComponents.PortalCustomization) bool {
+	if customization == nil || customization.Menu == nil {
+		return false
+	}
+
+	menu := customization.Menu
+	return menu.Main != nil && len(menu.Main) == 0 ||
+		menu.FooterSections != nil && len(menu.FooterSections) == 0 ||
+		menu.FooterBottom != nil && len(menu.FooterBottom) == 0
+}
+
+func marshalPortalCustomizationPayload(customization *kkComponents.PortalCustomization) ([]byte, error) {
+	payload := portalCustomizationPayload{
+		Theme:        customization.Theme,
+		Layout:       customization.Layout,
+		CSS:          customization.CSS,
+		SpecRenderer: customization.SpecRenderer,
+		Robots:       customization.Robots,
+	}
+
+	if customization.Menu != nil {
+		payload.Menu = &portalCustomizationMenu{}
+		if customization.Menu.Main != nil {
+			payload.Menu.Main = &customization.Menu.Main
+		}
+		if customization.Menu.FooterSections != nil {
+			payload.Menu.FooterSections = &customization.Menu.FooterSections
+		}
+		if customization.Menu.FooterBottom != nil {
+			payload.Menu.FooterBottom = &customization.Menu.FooterBottom
+		}
+	}
+
+	return json.Marshal(payload)
+}
+
+func (p *PortalCustomizationAPIImpl) updatePortalCustomizationWithExplicitEmptyMenu(
+	ctx context.Context,
+	portalID string,
+	customization *kkComponents.PortalCustomization,
+) (*kkOps.UpdatePortalCustomizationResponse, error) {
+	if strings.TrimSpace(p.BaseURL) == "" {
+		return nil, fmt.Errorf("base URL is required for portal customization requests")
+	}
+
+	payload, err := marshalPortalCustomizationPayload(customization)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal portal customization request: %w", err)
+	}
+
+	path := fmt.Sprintf("/v3/portals/%s/customization", url.PathEscape(portalID))
+	result, err := p.request(
+		ctx,
+		http.MethodPatch,
+		path,
+		map[string]string{contentTypeHeader: applicationJSONContent},
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	response := &kkOps.UpdatePortalCustomizationResponse{
+		ContentType: result.Header.Get(contentTypeHeader),
+		StatusCode:  result.StatusCode,
+		RawResponse: &http.Response{
+			StatusCode: result.StatusCode,
+			Header:     result.Header.Clone(),
+			Body:       io.NopCloser(bytes.NewReader(result.Body)),
+		},
+	}
+
+	if result.StatusCode < http.StatusOK || result.StatusCode >= http.StatusMultipleChoices {
+		body := strings.TrimSpace(string(result.Body))
+		if body == "" {
+			return nil, fmt.Errorf("update portal customization failed with status %d", result.StatusCode)
+		}
+		return nil, fmt.Errorf("update portal customization failed with status %d: %s", result.StatusCode, body)
+	}
+
+	if len(bytes.TrimSpace(result.Body)) == 0 {
+		return response, nil
+	}
+
+	var customizationResponse kkComponents.PortalCustomization
+	if err := json.Unmarshal(result.Body, &customizationResponse); err != nil {
+		return nil, fmt.Errorf("failed to decode portal customization response: %w", err)
+	}
+	response.PortalCustomization = &customizationResponse
+
+	return response, nil
+}
+
+func (p *PortalCustomizationAPIImpl) request(
+	ctx context.Context,
+	method string,
+	path string,
+	headers map[string]string,
+	body io.Reader,
+) (*apiutil.Result, error) {
+	if p.TokenSource != nil {
+		return apiutil.RequestWithTokenSource(ctx, p.HTTPClient, method, p.BaseURL, path, p.TokenSource, headers, body)
+	}
+	return apiutil.Request(ctx, p.HTTPClient, method, p.BaseURL, path, p.Token, headers, body)
 }

--- a/internal/konnect/helpers/portal_customizations_test.go
+++ b/internal/konnect/helpers/portal_customizations_test.go
@@ -1,0 +1,104 @@
+package helpers
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	kkSDK "github.com/Kong/sdk-konnect-go"
+	kkComponents "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type portalCustomizationCapturingClient struct {
+	request *http.Request
+	body    []byte
+}
+
+func (c *portalCustomizationCapturingClient) Do(req *http.Request) (*http.Response, error) {
+	c.request = req
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	c.body = body
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{}`)),
+		Request:    req,
+	}, nil
+}
+
+func TestPortalCustomizationAPIImplUpdatePreservesExplicitEmptyMenuLists(t *testing.T) {
+	client := &portalCustomizationCapturingClient{}
+	sdk := kkSDK.New(
+		kkSDK.WithServerURL("https://example.test"),
+		kkSDK.WithClient(client),
+	)
+	layout := "sidebar"
+	api := &PortalCustomizationAPIImpl{
+		SDK:        sdk,
+		BaseURL:    "https://example.test",
+		Token:      "test-token",
+		HTTPClient: client,
+	}
+
+	_, err := api.UpdatePortalCustomization(t.Context(), "portal-123", &kkComponents.PortalCustomization{
+		Layout: &layout,
+		Menu: &kkComponents.Menu{
+			Main:           []kkComponents.PortalMenuItem{},
+			FooterSections: []kkComponents.PortalFooterMenuSection{},
+			FooterBottom:   []kkComponents.PortalMenuItem{},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, client.request)
+	assert.Equal(t, http.MethodPatch, client.request.Method)
+	assert.Equal(t, "https://example.test/v3/portals/portal-123/customization", client.request.URL.String())
+	assert.Equal(t, "Bearer test-token", client.request.Header.Get("Authorization"))
+	assert.JSONEq(t, `{
+		"layout": "sidebar",
+		"menu": {
+			"main": [],
+			"footer_sections": [],
+			"footer_bottom": []
+		}
+	}`, string(client.body))
+}
+
+func TestPortalCustomizationAPIImplUpdateUsesSDKForNonEmptyMenuLists(t *testing.T) {
+	client := &portalCustomizationCapturingClient{}
+	sdk := kkSDK.New(
+		kkSDK.WithServerURL("https://example.test"),
+		kkSDK.WithClient(client),
+	)
+	api := &PortalCustomizationAPIImpl{SDK: sdk}
+
+	_, err := api.UpdatePortalCustomization(t.Context(), "portal-123", &kkComponents.PortalCustomization{
+		Menu: &kkComponents.Menu{
+			Main: []kkComponents.PortalMenuItem{{
+				Path:       "/docs",
+				Title:      "Docs",
+				Visibility: kkComponents.PortalMenuItemVisibilityPublic,
+			}},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, client.request)
+	assert.JSONEq(t, `{
+		"menu": {
+			"main": [{
+				"path": "/docs",
+				"title": "Docs",
+				"visibility": "public",
+				"external": false
+			}]
+		}
+	}`, string(client.body))
+}

--- a/internal/konnect/helpers/portal_customizations_test.go
+++ b/internal/konnect/helpers/portal_customizations_test.go
@@ -19,9 +19,13 @@ type portalCustomizationCapturingClient struct {
 
 func (c *portalCustomizationCapturingClient) Do(req *http.Request) (*http.Response, error) {
 	c.request = req
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
+	body, readErr := io.ReadAll(req.Body)
+	closeErr := req.Body.Close()
+	if readErr != nil {
+		return nil, readErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
 	}
 	c.body = body
 

--- a/internal/konnect/helpers/sdk.go
+++ b/internal/konnect/helpers/sdk.go
@@ -407,7 +407,13 @@ func (k *KonnectSDK) GetPortalCustomizationAPI() PortalCustomizationAPI {
 		return nil
 	}
 
-	return &PortalCustomizationAPIImpl{SDK: k.SDK}
+	return &PortalCustomizationAPIImpl{
+		SDK:         k.SDK,
+		BaseURL:     k.BaseURL,
+		Token:       k.Token,
+		TokenSource: k.TokenSource,
+		HTTPClient:  k.HTTPClient,
+	}
 }
 
 // Returns the implementation of the PortalCustomDomainAPI interface

--- a/test/e2e/scenarios/portal/customization/overlays/006-clear-menu/config.yaml
+++ b/test/e2e/scenarios/portal/customization/overlays/006-clear-menu/config.yaml
@@ -1,0 +1,31 @@
+_defaults:
+  kongctl:
+    namespace: portal-customization
+
+portals:
+  - ref: portal-customization
+    name: portal-customization
+    display_name: Portal Customization
+    description: Portal with customization managed declaratively
+    kongctl:
+      namespace: portal-customization
+    customization:
+      ref: portal-customization-settings
+      theme:
+        mode: "dark"
+        colors:
+          primary: "#FF5733"
+      layout: "sidebar"
+      spec_renderer:
+        try_it_ui: false
+        try_it_insomnia: false
+        infinite_scroll: false
+        show_schemas: false
+        hide_internal: true
+        hide_deprecated: true
+        allow_custom_server_urls: false
+      robots: "User-agent: *\nDisallow: /internal"
+      menu:
+        main: []
+        footer_sections: []
+        footer_bottom: []

--- a/test/e2e/scenarios/portal/customization/scenario.yaml
+++ b/test/e2e/scenarios/portal/customization/scenario.yaml
@@ -165,9 +165,103 @@ steps:
               fields:
                 total_changes: 0
 
-  - name: 005-delete-cleanup
+  - name: 005-seed-all-menu-lists
     inputOverlayDirs:
       - overlays/003-update
+    commands:
+      - name: 000-record-portal-id
+        outputFormat: json
+        run:
+          - get
+          - portal
+          - "{{ .vars.portalRef }}"
+        recordVar:
+          name: portalID
+          responsePath: id
+      - name: 001-seed-menu-lists
+        outputFormat: json
+        run:
+          - api
+          - patch
+          - "/v3/portals/{{ .vars.portalID }}/customization"
+          - --body-file
+          - "{{ .workdir }}/seed-menu.json"
+      - name: 002-verify-seeded-menu-lists
+        outputFormat: json
+        run:
+          - api
+          - get
+          - "/v3/portals/{{ .vars.portalID }}/customization"
+        assertions:
+          - select: menu
+            expect:
+              fields:
+                "length(main)": 1
+                "length(footer_sections)": 1
+                "length(footer_bottom)": 1
+
+  - name: 006-clear-menu-lists
+    inputOverlayDirs:
+      - overlays/006-clear-menu
+    commands:
+      - name: 000-plan-clear-menu-lists
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-clear-menu-lists.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+      - name: 001-apply-clear-menu-lists
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-clear-menu-lists.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 002-verify-menu-lists-cleared-in-konnect
+        outputFormat: json
+        run:
+          - api
+          - get
+          - "/v3/portals/{{ .vars.portalID }}/customization"
+        assertions:
+          - select: menu
+            expect:
+              fields:
+                "length(main)": 0
+                "length(footer_sections)": 0
+                "length(footer_bottom)": 0
+      - name: 003-plan-after-clear-no-op
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+
+  - name: 007-delete-cleanup
+    inputOverlayDirs:
+      - overlays/006-clear-menu
     commands:
       - name: 000-delete
         outputFormat: json

--- a/test/e2e/scenarios/portal/customization/testdata/seed-menu.json
+++ b/test/e2e/scenarios/portal/customization/testdata/seed-menu.json
@@ -1,0 +1,33 @@
+{
+  "menu": {
+    "main": [
+      {
+        "path": "/seed-main",
+        "title": "Seed Main",
+        "external": false,
+        "visibility": "public"
+      }
+    ],
+    "footer_sections": [
+      {
+        "title": "Seed Section",
+        "items": [
+          {
+            "path": "/seed-section",
+            "title": "Seed Section Item",
+            "external": false,
+            "visibility": "public"
+          }
+        ]
+      }
+    ],
+    "footer_bottom": [
+      {
+        "path": "/seed-bottom",
+        "title": "Seed Bottom",
+        "external": false,
+        "visibility": "public"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- preserve explicit empty portal customization menu arrays in saved plans
- map and compare main, footer_sections, and footer_bottom consistently
- send explicit empty arrays through an authenticated PATCH path when the SDK model would omit them
- retain the SDK update path for ordinary non-empty customization updates

## Validation

- go fix ./...
- make format
- GOFLAGS=-buildvcs=false make build
- make lint
- make test
- make test-integration
- GOFLAGS=-buildvcs=false make test-e2e-scenarios SCENARIO=portal/customization

Closes #1803