### PR TITLE
fix(extensions): keep broken links recoverable

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -254,6 +254,49 @@ kongctl uninstall extension kong/foo
 Linked extensions and local path installs are not upgraded. Re-link or reinstall
 them from the local source path.
 
+### Recovering Broken Extensions
+
+An extension problem does not prevent built-in commands or `kongctl --help`
+from running. Use the lifecycle commands to inspect and recover extension
+state:
+
+```sh
+kongctl list extensions
+kongctl get extension kong/foo
+kongctl uninstall extension kong/foo
+```
+
+If a linked working tree is moved, re-link the same extension from its new
+location. This replaces the old link after the new source has been validated:
+
+```sh
+kongctl link extension ../new/path/to/foo
+```
+
+If the working tree was deleted or is temporarily unavailable, `kongctl`
+reports the link as `unavailable`. Restore it at the recorded path, re-link it,
+or uninstall the link. A missing or invalid manifest and a missing or
+non-executable runtime are reported against that extension instead of aborting
+CLI startup.
+
+`kongctl` keeps a validated command metadata cache for help and recovery. The
+cache never authorizes execution when the live linked source is unavailable or
+invalid. Broken cached commands are omitted from normal help and completion,
+but invoking an exact previously linked command produces an actionable
+extension-specific diagnostic.
+
+Installed extension packages are host-managed. If their manifest, runtime, or
+install record is missing or modified, reinstall or upgrade the extension.
+Runtime integrity mismatches are never accepted automatically.
+
+Uninstall removes only the managed install or link record by default. It never
+deletes a linked working tree, and it preserves the extension-owned data
+directory. Delete that data explicitly when it is no longer needed:
+
+```sh
+kongctl uninstall extension kong/foo --remove-data
+```
+
 ## GitHub Installs
 
 GitHub repositories do not need a `kongctl-*` prefix. Use a clear repository

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -821,7 +821,12 @@ func registerExtensions() error {
 	if err != nil {
 		return err
 	}
-	return extensioncore.RegisterInstalledCommands(rootCmd, store)
+	if err := extensioncore.RegisterInstalledCommands(rootCmd, store); err != nil {
+		if streams != nil && streams.ErrOut != nil {
+			fmt.Fprintf(streams.ErrOut, "warning: extension commands are unavailable: %v\n", err)
+		}
+	}
+	return nil
 }
 
 func closeLogFile() {

--- a/internal/cmd/root/verbs/extensions/extensions.go
+++ b/internal/cmd/root/verbs/extensions/extensions.go
@@ -339,6 +339,7 @@ func runListExtensions(command *cobra.Command, args []string) error {
 	if err != nil {
 		return cmdpkg.PrepareExecutionErrorWithHelper(helper, "failed to list extensions", err)
 	}
+	extensions = extensioncore.MarkCommandConflicts(command.Root(), extensions)
 	version, err := cliVersion(helper)
 	if err != nil {
 		return err
@@ -357,6 +358,14 @@ func runGetExtension(command *cobra.Command, args []string, id string) error {
 	ext, err := store.Get(id)
 	if err != nil {
 		return &cmdpkg.ConfigurationError{Err: err}
+	}
+	if extensions, listErr := store.List(); listErr == nil {
+		for _, candidate := range extensioncore.MarkCommandConflicts(command.Root(), extensions) {
+			if candidate.ID == id && candidate.Health.Status == extensioncore.ExtensionHealthConflict {
+				ext.Health = candidate.Health
+				break
+			}
+		}
 	}
 	version, err := cliVersion(helper)
 	if err != nil {
@@ -447,6 +456,12 @@ func runUpgradeAllExtensions(command *cobra.Command, args []string, opts upgrade
 }
 
 func upgradeAllSkipReason(ext extensioncore.Extension) string {
+	if !ext.IsReady() {
+		if err := ext.HealthError(); err != nil {
+			return err.Error()
+		}
+		return "extension is not ready"
+	}
 	if ext.InstallType == extensioncore.InstallTypeLinked {
 		return "linked extension; linked extensions read directly from the linked working tree"
 	}
@@ -1140,7 +1155,11 @@ func writeListSummary(w io.Writer, extensions []extensioncore.Extension, cliVers
 		}
 		icon := ui.success.Render("✓")
 		compatibilityStatus := extensionListCompatibilityStatus(ext, cliVersion)
-		if compatibilityStatus != "" {
+		healthStatus := ""
+		if !ext.IsReady() {
+			healthStatus = string(ext.Health.Status)
+		}
+		if compatibilityStatus != "" || healthStatus != "" {
 			icon = ui.warning.Render("!")
 		}
 		fields := []string{
@@ -1152,8 +1171,15 @@ func writeListSummary(w io.Writer, extensions []extensioncore.Extension, cliVers
 		if compatibilityStatus != "" {
 			fields = append(fields, ui.warning.Render(compatibilityStatus))
 		}
+		if healthStatus != "" {
+			fields = append(fields, ui.warning.Render(healthStatus))
+		}
 		if _, err := fmt.Fprintln(w, strings.Join(fields, "  ")); err != nil {
 			return err
+		}
+		for _, diagnostic := range ext.Health.Diagnostics {
+			writeOptionalField(w, ui, "Issue", diagnostic.Message)
+			writeOptionalField(w, ui, "Next", diagnostic.Remediation)
 		}
 		writeCommands(w, ui, ext.CommandPaths)
 	}
@@ -1168,6 +1194,15 @@ func writeExtensionSummary(w io.Writer, ext extensioncore.Extension, cliVersion 
 	writeField(w, ui, "Name", ext.Manifest.Name)
 	writeField(w, ui, "Publisher", ext.Manifest.Publisher)
 	writeField(w, ui, "Type", string(ext.InstallType))
+	status := ext.Health.Status
+	if status == "" {
+		status = extensioncore.ExtensionHealthReady
+	}
+	writeField(w, ui, "Status", string(status))
+	for _, diagnostic := range ext.Health.Diagnostics {
+		writeOptionalField(w, ui, "Issue", diagnostic.Message)
+		writeOptionalField(w, ui, "Next", diagnostic.Remediation)
+	}
 	writeOptionalField(w, ui, "Version", extensionDisplayVersion(ext))
 	writeOptionalField(w, ui, "Summary", ext.Manifest.Summary)
 	writeCompatibilityFields(w, ui, ext, cliVersion)
@@ -1195,6 +1230,12 @@ func writeUninstallSummary(w io.Writer, result extensioncore.UninstallResult) er
 		result.ID,
 	); err != nil {
 		return err
+	}
+	if result.RemovedInstall {
+		writeField(w, ui, "Install", "removed")
+	}
+	if result.RemovedLink {
+		writeField(w, ui, "Link", "removed")
 	}
 	if result.RemovedData {
 		writeField(w, ui, "Data", "removed")

--- a/internal/cmd/root/verbs/extensions/extensions_test.go
+++ b/internal/cmd/root/verbs/extensions/extensions_test.go
@@ -254,6 +254,39 @@ func TestWriteExtensionSummaryShowsUnknownCompatibilityForDevelopmentVersion(t *
 	require.Contains(t, plain, "  Current kongctl: dev\n")
 }
 
+func TestWriteListSummaryShowsUnavailableExtensionRecovery(t *testing.T) {
+	ext := testRemoteCandidate()
+	ext.InstallType = extensions.InstallTypeLinked
+	ext.LinkedDir = "/missing/extension"
+	ext.Health = extensions.ExtensionHealth{
+		Status: extensions.ExtensionHealthUnavailable,
+		Diagnostics: []extensions.ExtensionDiagnostic{{
+			Code:        "linked_source_unavailable",
+			Message:     "linked source is unavailable",
+			Remediation: "restore the source or uninstall the extension",
+		}},
+	}
+	var out bytes.Buffer
+
+	require.NoError(t, writeListSummary(&out, []extensions.Extension{ext}, "0.20.0"))
+	require.Contains(t, out.String(), "unavailable")
+	require.Contains(t, out.String(), "linked source is unavailable")
+	require.Contains(t, out.String(), "restore the source or uninstall the extension")
+}
+
+func TestWriteUninstallSummaryReportsRemovedStateAndPreservedData(t *testing.T) {
+	var out bytes.Buffer
+
+	require.NoError(t, writeUninstallSummary(&out, extensions.UninstallResult{
+		ID:          "kong/foo",
+		RemovedLink: true,
+	}))
+	require.Contains(t, out.String(), "Link:")
+	require.Contains(t, out.String(), "removed")
+	require.Contains(t, out.String(), "Data:")
+	require.Contains(t, out.String(), "preserved")
+}
+
 func TestUpgradeExtensionCommandSupportsUpgradeAll(t *testing.T) {
 	cmd := newUpgradeExtensionCmd()
 

--- a/internal/extensions/cobra.go
+++ b/internal/extensions/cobra.go
@@ -3,6 +3,7 @@ package extensions
 import (
 	"fmt"
 	"io"
+	"maps"
 	"slices"
 	"strconv"
 	"strings"
@@ -34,7 +35,82 @@ func RegisterInstalledCommands(root *cobra.Command, store Store) error {
 	if err != nil {
 		return err
 	}
-	return RegisterCommands(root, store, extensions)
+	extensions = MarkCommandConflicts(root, extensions)
+	for _, ready := range []bool{true, false} {
+		for _, ext := range extensions {
+			if ext.Health.Status == ExtensionHealthConflict || ext.IsReady() != ready {
+				continue
+			}
+			// Extension state may become stale independently of the host binary.
+			// Keep registration failures scoped so built-ins and recovery remain available.
+			if ValidateExtensionCommands(root, ext) != nil {
+				continue
+			}
+			_ = RegisterCommands(root, store, []Extension{ext})
+		}
+	}
+	return nil
+}
+
+func MarkCommandConflicts(root *cobra.Command, extensions []Extension) []Extension {
+	result := append([]Extension(nil), extensions...)
+	conflicts := map[string]string{}
+	claims := map[string]map[string]struct{}{}
+	for _, ext := range result {
+		if !ext.IsReady() {
+			continue
+		}
+		if err := ValidateExtensionCommands(root, ext); err != nil {
+			conflicts[ext.ID] = err.Error()
+			continue
+		}
+		for _, contribution := range ext.CommandPaths {
+			start := 0
+			parent := ""
+			if IsOpenBuiltInRoot(contribution.Path[0].Name) {
+				start = 1
+				parent = contribution.Path[0].Name
+			}
+			for index := start; index < len(contribution.Path); index++ {
+				segment := contribution.Path[index]
+				for _, token := range append([]string{segment.Name}, segment.Aliases...) {
+					key := parent + "\x00" + token
+					if claims[key] == nil {
+						claims[key] = map[string]struct{}{}
+					}
+					claims[key][ext.ID] = struct{}{}
+				}
+				if parent == "" {
+					parent = segment.Name
+				} else {
+					parent += " " + segment.Name
+				}
+			}
+		}
+	}
+	for _, owners := range claims {
+		if len(owners) < 2 {
+			continue
+		}
+		ids := slices.Sorted(maps.Keys(owners))
+		message := "command path collides between extensions " + strings.Join(ids, ", ")
+		for _, id := range ids {
+			conflicts[id] = message
+		}
+	}
+	for index := range result {
+		message, ok := conflicts[result[index].ID]
+		if !ok {
+			continue
+		}
+		result[index].Health = unhealthy(
+			ExtensionHealthConflict,
+			"command_conflict",
+			message,
+			"upgrade, reinstall, re-link, or uninstall one of the conflicting extensions",
+		)
+	}
+	return result
 }
 
 func RegisterCommands(root *cobra.Command, store Store, extensions []Extension) error {
@@ -179,6 +255,7 @@ func newSyntheticCommand(
 	command := &cobra.Command{
 		Use:     segment.Name,
 		Aliases: append([]string(nil), segment.Aliases...),
+		Hidden:  !ext.IsReady(),
 		Short:   extensionShort(ext.ID, contribution),
 		Long:    extensionLong(ext.ID, contribution),
 		Example: strings.Join(contribution.Examples, "\n"),
@@ -203,6 +280,7 @@ func configureTerminalCommand(command *cobra.Command, ext Extension, contributio
 	command.Example = strings.Join(contribution.Examples, "\n")
 	command.DisableFlagParsing = true
 	command.SilenceUsage = true
+	command.Hidden = !ext.IsReady()
 	ensureExtensionHostFlags(command)
 	if command.Annotations == nil {
 		command.Annotations = map[string]string{}
@@ -222,6 +300,15 @@ func runExtensionCommand(
 	ext Extension,
 	contribution CommandPath,
 ) error {
+	if !ext.IsReady() {
+		if slices.Contains(args, "--help") || slices.Contains(args, "-h") {
+			if err := PrintExtensionHelp(command.OutOrStdout(), ext.ID, contribution); err != nil {
+				return err
+			}
+			return printExtensionHealth(command.OutOrStdout(), ext)
+		}
+		return ext.HealthError()
+	}
 	helper := cmdpkg.BuildHelper(command, args)
 	cfg, err := helper.GetConfig()
 	if err != nil {
@@ -252,6 +339,26 @@ func runExtensionCommand(
 		split.Remaining,
 		split.ProfileOverride,
 	)
+}
+
+func printExtensionHealth(w io.Writer, ext Extension) error {
+	if ext.IsReady() {
+		return nil
+	}
+	if _, err := fmt.Fprintf(w, "\nStatus: %s\n", ext.Health.Status); err != nil {
+		return err
+	}
+	for _, diagnostic := range ext.Health.Diagnostics {
+		if _, err := fmt.Fprintf(w, "Reason: %s\n", diagnostic.Message); err != nil {
+			return err
+		}
+		if diagnostic.Remediation != "" {
+			if _, err := fmt.Fprintf(w, "Next: %s\n", diagnostic.Remediation); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func SplitExtensionArgs(command *cobra.Command, args []string, cfg config.Hook) (SplitArgsResult, error) {

--- a/internal/extensions/cobra_test.go
+++ b/internal/extensions/cobra_test.go
@@ -1,7 +1,11 @@
 package extensions
 
 import (
+	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	cmdcommon "github.com/kong/kongctl/internal/cmd/common"
 	jqoutput "github.com/kong/kongctl/internal/cmd/output/jq"
@@ -53,6 +57,135 @@ command_paths:
 	err := RegisterCommands(root, NewStore(t.TempDir()), []Extension{ext})
 
 	require.ErrorContains(t, err, "collides with existing command")
+}
+
+func TestRegisterCommandsAddsHiddenRecoveryStubForUnavailableExtension(t *testing.T) {
+	root := testRootCommand()
+	ext := mustExtension(t, `
+schema_version: 1
+publisher: kong
+name: foo
+runtime:
+  command: kongctl-ext-foo
+command_paths:
+  - path:
+      - name: get
+      - name: foo
+    summary: Get Foo resources
+`)
+	ext.Health = unhealthy(
+		ExtensionHealthUnavailable,
+		"linked_source_unavailable",
+		"linked source is unavailable",
+		"restore the source or uninstall the extension",
+	)
+	require.NoError(t, RegisterCommands(root, NewStore(t.TempDir()), []Extension{ext}))
+
+	command, _, err := root.Find([]string{"get", "foo"})
+	require.NoError(t, err)
+	require.True(t, command.Hidden)
+
+	root.SetArgs([]string{"get", "foo"})
+	err = root.Execute()
+	require.ErrorContains(t, err, `extension "kong/foo": linked source is unavailable`)
+}
+
+func TestUnavailableExtensionCachedHelpExplainsRecovery(t *testing.T) {
+	root := testRootCommand()
+	ext := mustExtension(t, `
+schema_version: 1
+publisher: kong
+name: foo
+runtime:
+  command: kongctl-ext-foo
+command_paths:
+  - path:
+      - name: get
+      - name: foo
+    summary: Get Foo resources
+`)
+	ext.Health = unhealthy(
+		ExtensionHealthUnavailable,
+		"linked_source_unavailable",
+		"linked source is unavailable",
+		"restore the source or uninstall the extension",
+	)
+	require.NoError(t, RegisterCommands(root, NewStore(t.TempDir()), []Extension{ext}))
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetArgs([]string{"get", "foo", "--help"})
+
+	require.NoError(t, root.Execute())
+	require.Contains(t, out.String(), "Status: unavailable")
+	require.Contains(t, out.String(), "restore the source or uninstall the extension")
+}
+
+func TestRegisterInstalledCommandsIsolatesACommandCollision(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "extensions"))
+	badSource := t.TempDir()
+	badManifest := []byte(`schema_version: 1
+publisher: kong
+name: bad
+runtime:
+  command: kongctl-ext-bad
+command_paths:
+  - path:
+      - name: get
+      - name: bad
+  - path:
+      - name: get
+      - name: apis
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(badSource, ManifestFileName), badManifest, 0o600))
+	badRuntime := filepath.Join(badSource, "kongctl-ext-bad")
+	require.NoError(t, os.WriteFile(badRuntime, []byte("#!/bin/sh\n"), 0o600))
+	require.NoError(t, os.Chmod(badRuntime, 0o700))
+	_, err := store.LinkLocal(badSource, "dev", time.Unix(100, 0))
+	require.NoError(t, err)
+
+	goodSource := t.TempDir()
+	writeManifest(t, goodSource, "good", openBuiltInRootGet, "good")
+	goodRuntime := filepath.Join(goodSource, "kongctl-ext-good")
+	require.NoError(t, os.WriteFile(goodRuntime, []byte("#!/bin/sh\n"), 0o600))
+	require.NoError(t, os.Chmod(goodRuntime, 0o700))
+	_, err = store.LinkLocal(goodSource, "dev", time.Unix(100, 0))
+	require.NoError(t, err)
+
+	root := testRootCommand()
+	require.NoError(t, RegisterInstalledCommands(root, store))
+	getCommand, _, err := root.Find([]string{"get"})
+	require.NoError(t, err)
+	require.Nil(t, findChildByName(getCommand, "bad"), "colliding extension must not be partially registered")
+	require.NotNil(t, findChildByName(getCommand, "good"), "healthy extensions must still be registered")
+	require.NotNil(t, findChildByName(getCommand, "apis"), "built-in command must remain authoritative")
+}
+
+func TestRegisterInstalledCommandsDisablesBothCrossExtensionCollisions(t *testing.T) {
+	store := NewStore(filepath.Join(t.TempDir(), "extensions"))
+	for _, name := range []string{"one", "two"} {
+		source := t.TempDir()
+		writeManifest(t, source, name, openBuiltInRootGet, "shared")
+		runtimePath := filepath.Join(source, "kongctl-ext-"+name)
+		require.NoError(t, os.WriteFile(runtimePath, []byte("#!/bin/sh\n"), 0o600))
+		require.NoError(t, os.Chmod(runtimePath, 0o700))
+		_, err := store.LinkLocal(source, "dev", time.Unix(100, 0))
+		require.NoError(t, err)
+	}
+
+	root := testRootCommand()
+	require.NoError(t, RegisterInstalledCommands(root, store))
+	getCommand, _, err := root.Find([]string{"get"})
+	require.NoError(t, err)
+	require.Nil(t, findChildByName(getCommand, "shared"))
+
+	extensions, err := store.List()
+	require.NoError(t, err)
+	extensions = MarkCommandConflicts(root, extensions)
+	require.Len(t, extensions, 2)
+	for _, ext := range extensions {
+		require.Equal(t, ExtensionHealthConflict, ext.Health.Status)
+		require.Equal(t, "command_conflict", ext.Health.Diagnostics[0].Code)
+	}
 }
 
 func TestSplitExtensionArgsConsumesHostFlagsBeforeTerminator(t *testing.T) {

--- a/internal/extensions/manifest.go
+++ b/internal/extensions/manifest.go
@@ -17,6 +17,7 @@ import (
 const (
 	ManifestFileName   = "kongctl-extension.yaml"
 	ManifestSchemaV1   = 1
+	openBuiltInRootGet = "get"
 	MaxManifestBytes   = 256 * 1024
 	maxCommandPaths    = 64
 	maxPathSegments    = 8
@@ -43,7 +44,7 @@ var (
 		"command_paths",
 	}
 
-	openBuiltInRoots = []string{"get", "list"}
+	openBuiltInRoots = []string{openBuiltInRootGet, "list"}
 
 	closedBuiltInRoots = []string{
 		"add",
@@ -125,14 +126,59 @@ type Flag struct {
 }
 
 type Extension struct {
-	ID           string        `json:"id"`
-	InstallType  InstallType   `json:"install_type"`
-	Manifest     Manifest      `json:"manifest"`
-	CommandPaths []CommandPath `json:"command_paths"`
-	PackageDir   string        `json:"package_dir,omitempty"`
-	LinkedDir    string        `json:"linked_dir,omitempty"`
-	Install      *InstallState `json:"install,omitempty"`
-	Link         *LinkState    `json:"link,omitempty"`
+	ID           string          `json:"id"`
+	InstallType  InstallType     `json:"install_type"`
+	Health       ExtensionHealth `json:"health"`
+	Manifest     Manifest        `json:"manifest"`
+	CommandPaths []CommandPath   `json:"command_paths"`
+	PackageDir   string          `json:"package_dir,omitempty"`
+	LinkedDir    string          `json:"linked_dir,omitempty"`
+	Install      *InstallState   `json:"install,omitempty"`
+	Link         *LinkState      `json:"link,omitempty"`
+}
+
+type ExtensionHealth struct {
+	Status      ExtensionHealthStatus `json:"status"`
+	Diagnostics []ExtensionDiagnostic `json:"diagnostics,omitempty"`
+}
+
+type ExtensionDiagnostic struct {
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+type ExtensionHealthStatus string
+
+const (
+	ExtensionHealthReady        ExtensionHealthStatus = "ready"
+	ExtensionHealthUnavailable  ExtensionHealthStatus = "unavailable"
+	ExtensionHealthInvalid      ExtensionHealthStatus = "invalid"
+	ExtensionHealthDamaged      ExtensionHealthStatus = "damaged"
+	ExtensionHealthIncompatible ExtensionHealthStatus = "incompatible"
+	ExtensionHealthConflict     ExtensionHealthStatus = "conflict"
+)
+
+func (e Extension) IsReady() bool {
+	return e.Health.Status == "" || e.Health.Status == ExtensionHealthReady
+}
+
+func (e Extension) HealthError() error {
+	if e.IsReady() {
+		return nil
+	}
+	if len(e.Health.Diagnostics) == 0 {
+		return fmt.Errorf("extension %q is %s", e.ID, e.Health.Status)
+	}
+	diagnostic := e.Health.Diagnostics[0]
+	message := strings.TrimSpace(diagnostic.Message)
+	if message == "" {
+		message = fmt.Sprintf("extension is %s", e.Health.Status)
+	}
+	if remediation := strings.TrimSpace(diagnostic.Remediation); remediation != "" {
+		return fmt.Errorf("extension %q: %s; %s", e.ID, message, remediation)
+	}
+	return fmt.Errorf("extension %q: %s", e.ID, message)
 }
 
 type InstallType string

--- a/internal/extensions/runtime.go
+++ b/internal/extensions/runtime.go
@@ -121,10 +121,41 @@ func (s Store) Dispatch(
 	if err := EnsureCompatible(ext.Manifest, runtimeCLIVersion(buildInfo)); err != nil {
 		return err
 	}
+	if ext.InstallType == InstallTypeLinked {
+		latest, err := s.loadLinked(ext.ID)
+		if err != nil {
+			return fmt.Errorf("reload linked extension %q: %w", ext.ID, err)
+		}
+		if err := latest.HealthError(); err != nil {
+			return err
+		}
+		matched := false
+		for _, candidate := range latest.CommandPaths {
+			if candidate.ID == contribution.ID && slices.Equal(CommandPathNames(candidate), CommandPathNames(contribution)) {
+				contribution = candidate
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return fmt.Errorf(
+				"extension %q command metadata changed during invocation; rerun the command",
+				ext.ID,
+			)
+		}
+		ext = latest
+	}
+	if err := EnsureCompatible(ext.Manifest, runtimeCLIVersion(buildInfo)); err != nil {
+		return err
+	}
 
 	runtimePath, err := s.ResolveRuntime(ext)
 	if err != nil {
-		return err
+		remediation := "reinstall, upgrade, or uninstall the extension"
+		if ext.InstallType == InstallTypeLinked {
+			remediation = "restore or rebuild the linked runtime, re-link it, or uninstall the extension"
+		}
+		return fmt.Errorf("extension %q runtime is unavailable: %w; %s", ext.ID, err, remediation)
 	}
 
 	contributionID := contribution.ID

--- a/internal/extensions/storage.go
+++ b/internal/extensions/storage.go
@@ -275,6 +275,7 @@ func (s Store) installDirectory(
 	ext := Extension{
 		ID:           id,
 		InstallType:  InstallTypeInstalled,
+		Health:       ExtensionHealth{Status: ExtensionHealthReady},
 		Manifest:     manifest,
 		CommandPaths: manifest.CommandPaths,
 		PackageDir:   packageDir,
@@ -364,6 +365,7 @@ func (s Store) LinkLocal(source, cliVersion string, now time.Time) (Extension, e
 	ext := Extension{
 		ID:           id,
 		InstallType:  InstallTypeLinked,
+		Health:       ExtensionHealth{Status: ExtensionHealthReady},
 		Manifest:     manifest,
 		CommandPaths: manifest.CommandPaths,
 		LinkedDir:    sourceRoot,
@@ -392,6 +394,7 @@ func LoadLocalExtension(source string, installType InstallType) (Extension, erro
 	ext := Extension{
 		ID:           id,
 		InstallType:  installType,
+		Health:       ExtensionHealth{Status: ExtensionHealthReady},
 		Manifest:     manifest,
 		CommandPaths: manifest.CommandPaths,
 	}
@@ -482,6 +485,27 @@ func (s Store) List() ([]Extension, error) {
 		}
 		return 0
 	})
+	for i := 0; i < len(extensions); {
+		j := i + 1
+		for j < len(extensions) && extensions[j].ID == extensions[i].ID {
+			j++
+		}
+		if j-i > 1 {
+			for index := i; index < j; index++ {
+				remediation := fmt.Sprintf(
+					"run `kongctl uninstall extension %s` to remove both records, then install or link it again",
+					extensions[index].ID,
+				)
+				extensions[index].Health = unhealthy(
+					ExtensionHealthConflict,
+					"duplicate_install_state",
+					"both installed and linked state exist for this extension id",
+					remediation,
+				)
+			}
+		}
+		i = j
+	}
 	return extensions, nil
 }
 
@@ -489,21 +513,30 @@ func (s Store) Get(id string) (Extension, error) {
 	if err := ValidateExtensionID(id); err != nil {
 		return Extension{}, err
 	}
-	linked, err := s.loadLinked(id)
-	if err == nil {
+	linked, linkedErr := s.loadLinked(id)
+	installed, installedErr := s.loadInstalled(id)
+	if linkedErr == nil && installedErr == nil {
+		linked.Health = unhealthy(
+			ExtensionHealthConflict,
+			"duplicate_install_state",
+			"both installed and linked state exist for this extension id",
+			fmt.Sprintf("run `kongctl uninstall extension %s` to remove both records, then install or link it again", id),
+		)
 		return linked, nil
 	}
-	if !os.IsNotExist(err) {
-		return Extension{}, err
+	if linkedErr == nil {
+		return linked, nil
 	}
-	installed, err := s.loadInstalled(id)
-	if err == nil {
+	if !os.IsNotExist(linkedErr) {
+		return Extension{}, linkedErr
+	}
+	if installedErr == nil {
 		return installed, nil
 	}
-	if os.IsNotExist(err) {
+	if os.IsNotExist(installedErr) {
 		return Extension{}, fmt.Errorf("extension %q is not installed or linked", id)
 	}
-	return Extension{}, err
+	return Extension{}, installedErr
 }
 
 func (s Store) VerifyInstalledRuntime(ext Extension) (string, error) {
@@ -600,6 +633,9 @@ func (s Store) walkExtensionState(root string, load func(string) (Extension, err
 				continue
 			}
 			id := ExtensionID(publisher.Name(), name.Name())
+			if ValidateExtensionID(id) != nil {
+				continue
+			}
 			ext, err := load(id)
 			if err != nil {
 				return nil, err
@@ -615,20 +651,60 @@ func (s Store) loadInstalled(id string) (Extension, error) {
 	if err != nil {
 		return Extension{}, err
 	}
+	if _, err := os.Stat(installDir); err != nil {
+		return Extension{}, err
+	}
+	cache, cacheErr := s.loadCommandCache(id, InstallTypeInstalled)
 	var state InstallState
 	if err := readJSON(filepath.Join(installDir, installStateName), &state); err != nil {
-		return Extension{}, err
+		return degradedExtension(id, InstallTypeInstalled, cache, ExtensionHealthDamaged,
+			"install_state_invalid", fmt.Sprintf("cannot read install state: %v", err),
+			"reinstall or uninstall this extension"), nil
 	}
-	manifest, _, err := LoadManifestFile(filepath.Join(packageDir, ManifestFileName))
-	if err != nil {
-		return Extension{}, err
+	if state.SchemaVersion != stateSchemaVersion {
+		return degradedExtension(id, InstallTypeInstalled, cache, ExtensionHealthDamaged,
+			"install_state_invalid", fmt.Sprintf("unsupported install state schema_version %d", state.SchemaVersion),
+			"reinstall or uninstall this extension"), nil
 	}
 	if state.ID != id {
-		return Extension{}, fmt.Errorf("install state id %q does not match path id %q", state.ID, id)
+		return degradedExtension(id, InstallTypeInstalled, cache, ExtensionHealthDamaged,
+			"install_identity_mismatch", fmt.Sprintf("install state id %q does not match path id %q", state.ID, id),
+			"reinstall or uninstall this extension"), nil
+	}
+	manifest, manifestBytes, err := LoadManifestFile(filepath.Join(packageDir, ManifestFileName))
+	if err != nil {
+		ext := degradedExtension(id, InstallTypeInstalled, cache, ExtensionHealthDamaged,
+			"installed_manifest_invalid", fmt.Sprintf("cannot load installed manifest: %v", err),
+			"reinstall, upgrade, or uninstall this extension")
+		ext.PackageDir = packageDir
+		ext.Install = &state
+		return ext, nil
+	}
+	if ExtensionID(manifest.Publisher, manifest.Name) != id || hashBytes(manifestBytes) != state.ManifestHash {
+		ext := degradedExtension(id, InstallTypeInstalled, cache, ExtensionHealthDamaged,
+			"installed_manifest_modified", "the installed manifest no longer matches the install record",
+			"reinstall, upgrade, or uninstall this extension")
+		ext.PackageDir = packageDir
+		ext.Install = &state
+		return ext, nil
+	}
+	if _, err := ResolveRuntime(packageDir, manifest.Runtime.Command); err != nil {
+		ext := degradedExtension(id, InstallTypeInstalled, cache, ExtensionHealthDamaged,
+			"installed_runtime_invalid", fmt.Sprintf("cannot use installed runtime: %v", err),
+			"reinstall, upgrade, or uninstall this extension")
+		ext.PackageDir = packageDir
+		ext.Install = &state
+		return ext, nil
+	}
+	if cacheErr != nil {
+		_ = s.writeCommandCache(id, Extension{
+			ID: id, InstallType: InstallTypeInstalled, Manifest: manifest, CommandPaths: manifest.CommandPaths,
+		}, time.Now())
 	}
 	return Extension{
 		ID:           id,
 		InstallType:  InstallTypeInstalled,
+		Health:       manifestHealth(manifest),
 		Manifest:     manifest,
 		CommandPaths: manifest.CommandPaths,
 		PackageDir:   packageDir,
@@ -641,25 +717,157 @@ func (s Store) loadLinked(id string) (Extension, error) {
 	if err != nil {
 		return Extension{}, err
 	}
+	if _, err := os.Stat(linkDir); err != nil {
+		return Extension{}, err
+	}
+	cache, cacheErr := s.loadCommandCache(id, InstallTypeLinked)
 	var state LinkState
 	if err := readJSON(filepath.Join(linkDir, linkStateName), &state); err != nil {
-		return Extension{}, err
+		return degradedExtension(id, InstallTypeLinked, cache, ExtensionHealthInvalid,
+			"link_state_invalid", fmt.Sprintf("cannot read link state: %v", err),
+			fmt.Sprintf("re-link the extension or run `kongctl uninstall extension %s`", id)), nil
+	}
+	if state.SchemaVersion != stateSchemaVersion {
+		ext := degradedExtension(id, InstallTypeLinked, cache, ExtensionHealthInvalid,
+			"link_state_invalid", fmt.Sprintf("unsupported link state schema_version %d", state.SchemaVersion),
+			fmt.Sprintf("re-link the extension or run `kongctl uninstall extension %s`", id))
+		ext.LinkedDir = state.Path
+		ext.Link = &state
+		return ext, nil
+	}
+	if state.ID != id {
+		ext := degradedExtension(id, InstallTypeLinked, cache, ExtensionHealthInvalid,
+			"link_identity_mismatch", fmt.Sprintf("link state id %q does not match path id %q", state.ID, id),
+			fmt.Sprintf("re-link the extension or run `kongctl uninstall extension %s`", id))
+		ext.LinkedDir = state.Path
+		ext.Link = &state
+		return ext, nil
 	}
 	manifest, _, err := LoadManifestFile(filepath.Join(state.Path, ManifestFileName))
 	if err != nil {
-		return Extension{}, err
+		status := ExtensionHealthInvalid
+		code := "linked_manifest_invalid"
+		if os.IsNotExist(err) || os.IsPermission(err) {
+			status = ExtensionHealthUnavailable
+			code = "linked_source_unavailable"
+		}
+		ext := degradedExtension(id, InstallTypeLinked, cache, status, code,
+			fmt.Sprintf("cannot load linked manifest from %q: %v", state.Path, err),
+			fmt.Sprintf("restore the source, re-link it, or run `kongctl uninstall extension %s`", id))
+		ext.LinkedDir = state.Path
+		ext.Link = &state
+		return ext, nil
 	}
-	if state.ID != id {
-		return Extension{}, fmt.Errorf("link state id %q does not match path id %q", state.ID, id)
+	if ExtensionID(manifest.Publisher, manifest.Name) != id {
+		ext := degradedExtension(id, InstallTypeLinked, cache, ExtensionHealthInvalid,
+			"linked_identity_mismatch",
+			fmt.Sprintf("linked manifest declares %q instead of %q", ExtensionID(manifest.Publisher, manifest.Name), id),
+			fmt.Sprintf("restore the original identity, re-link it, or run `kongctl uninstall extension %s`", id))
+		ext.LinkedDir = state.Path
+		ext.Link = &state
+		return ext, nil
+	}
+	if _, err := ResolveRuntime(state.Path, manifest.Runtime.Command); err != nil {
+		status := ExtensionHealthInvalid
+		code := "linked_runtime_invalid"
+		if os.IsNotExist(err) || os.IsPermission(err) {
+			status = ExtensionHealthUnavailable
+			code = "linked_runtime_unavailable"
+		}
+		ext := Extension{
+			ID: id, InstallType: InstallTypeLinked, Manifest: manifest, CommandPaths: manifest.CommandPaths,
+			LinkedDir: state.Path, Link: &state,
+			Health: unhealthy(status, code, fmt.Sprintf("cannot use linked runtime: %v", err),
+				fmt.Sprintf("restore or rebuild the runtime, re-link it, or run `kongctl uninstall extension %s`", id)),
+		}
+		return ext, nil
+	}
+	if cacheErr != nil {
+		_ = s.writeCommandCache(id, Extension{
+			ID: id, InstallType: InstallTypeLinked, Manifest: manifest, CommandPaths: manifest.CommandPaths,
+		}, time.Now())
 	}
 	return Extension{
 		ID:           id,
 		InstallType:  InstallTypeLinked,
+		Health:       manifestHealth(manifest),
 		Manifest:     manifest,
 		CommandPaths: manifest.CommandPaths,
 		LinkedDir:    state.Path,
 		Link:         &state,
 	}, nil
+}
+
+func (s Store) loadCommandCache(id string, installType InstallType) (*CommandCache, error) {
+	var cacheDir string
+	var err error
+	switch installType {
+	case InstallTypeInstalled:
+		cacheDir, _, err = s.installPaths(id)
+	case InstallTypeLinked:
+		cacheDir, err = s.linkDir(id)
+	default:
+		err = fmt.Errorf("unsupported extension install type %q", installType)
+	}
+	if err != nil {
+		return nil, err
+	}
+	var cache CommandCache
+	if err := readJSON(filepath.Join(cacheDir, commandsCacheName), &cache); err != nil {
+		return nil, err
+	}
+	if cache.SchemaVersion != stateSchemaVersion || cache.ID != id || cache.InstallType != installType {
+		return nil, fmt.Errorf("command cache metadata does not match extension %q", id)
+	}
+	if err := NormalizeAndValidateManifest(&cache.Manifest); err != nil {
+		return nil, fmt.Errorf("invalid command cache manifest: %w", err)
+	}
+	if ExtensionID(cache.Manifest.Publisher, cache.Manifest.Name) != id {
+		return nil, fmt.Errorf("command cache manifest identity does not match extension %q", id)
+	}
+	cache.CommandPaths = cache.Manifest.CommandPaths
+	return &cache, nil
+}
+
+func degradedExtension(
+	id string,
+	installType InstallType,
+	cache *CommandCache,
+	status ExtensionHealthStatus,
+	code, message, remediation string,
+) Extension {
+	ext := Extension{
+		ID:          id,
+		InstallType: installType,
+		Health:      unhealthy(status, code, message, remediation),
+	}
+	if cache != nil {
+		ext.Manifest = cache.Manifest
+		ext.CommandPaths = cache.CommandPaths
+	}
+	return ext
+}
+
+func unhealthy(status ExtensionHealthStatus, code, message, remediation string) ExtensionHealth {
+	return ExtensionHealth{
+		Status: status,
+		Diagnostics: []ExtensionDiagnostic{{
+			Code: code, Message: message, Remediation: remediation,
+		}},
+	}
+}
+
+func manifestHealth(manifest Manifest) ExtensionHealth {
+	result, err := CheckCompatibility(manifest, meta.CLIVersion())
+	if err == nil && !result.Compatible {
+		return unhealthy(
+			ExtensionHealthIncompatible,
+			"extension_incompatible",
+			fmt.Sprintf("requires kongctl %s; current version is %s", result.Constraint, result.CurrentVersion),
+			"upgrade the extension or use a compatible kongctl version",
+		)
+	}
+	return ExtensionHealth{Status: ExtensionHealthReady}
 }
 
 func (s Store) installPaths(id string) (string, string, error) {

--- a/internal/extensions/storage.go
+++ b/internal/extensions/storage.go
@@ -692,8 +692,13 @@ func (s Store) loadInstalled(id string) (Extension, error) {
 		ext := degradedExtension(id, InstallTypeInstalled, cache, ExtensionHealthDamaged,
 			"installed_runtime_invalid", fmt.Sprintf("cannot use installed runtime: %v", err),
 			"reinstall, upgrade, or uninstall this extension")
+		ext.Manifest = manifest
+		ext.CommandPaths = manifest.CommandPaths
 		ext.PackageDir = packageDir
 		ext.Install = &state
+		if cacheErr != nil {
+			_ = s.writeCommandCache(id, ext, time.Now())
+		}
 		return ext, nil
 	}
 	if cacheErr != nil {

--- a/internal/extensions/storage_test.go
+++ b/internal/extensions/storage_test.go
@@ -41,7 +41,7 @@ func TestStoreLinkLocalRefreshesManifestFromSource(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, InstallTypeLinked, linked.InstallType)
 
-	writeManifest(t, source, "kong", "foo", "list", "foo")
+	writeManifest(t, source, "foo", "list", "foo")
 	reloaded, err := store.Get("kong/foo")
 	require.NoError(t, err)
 	require.Equal(t, "list foo", CommandPathString(reloaded.CommandPaths[0]))
@@ -161,20 +161,164 @@ func TestStoreUninstallPreservesDataByDefault(t *testing.T) {
 	require.FileExists(t, filepath.Join(dataDir, "state.json"))
 }
 
+func TestStoreListKeepsMissingLinkedSourceRecoverable(t *testing.T) {
+	source := writeTestExtension(t)
+	store := NewStore(filepath.Join(t.TempDir(), "extensions"))
+	_, err := store.LinkLocal(source, "test-version", time.Unix(100, 0))
+	require.NoError(t, err)
+
+	require.NoError(t, os.RemoveAll(source))
+
+	extensions, err := store.List()
+	require.NoError(t, err)
+	require.Len(t, extensions, 1)
+	ext := extensions[0]
+	require.Equal(t, "kong/foo", ext.ID)
+	require.Equal(t, ExtensionHealthUnavailable, ext.Health.Status)
+	require.Equal(t, "linked_source_unavailable", ext.Health.Diagnostics[0].Code)
+	require.NotEmpty(t, ext.CommandPaths, "last-known-good commands should remain available for recovery")
+
+	result, err := store.Uninstall("kong/foo", false)
+	require.NoError(t, err)
+	require.True(t, result.RemovedLink)
+	require.False(t, result.RemovedData)
+}
+
+func TestStoreListKeepsInvalidLinkedManifestRecoverable(t *testing.T) {
+	source := writeTestExtension(t)
+	store := NewStore(filepath.Join(t.TempDir(), "extensions"))
+	_, err := store.LinkLocal(source, "test-version", time.Unix(100, 0))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(source, ManifestFileName), []byte("not: [valid"), 0o600))
+
+	extensions, err := store.List()
+	require.NoError(t, err)
+	require.Len(t, extensions, 1)
+	require.Equal(t, ExtensionHealthInvalid, extensions[0].Health.Status)
+	require.Equal(t, "linked_manifest_invalid", extensions[0].Health.Diagnostics[0].Code)
+	require.NotEmpty(t, extensions[0].CommandPaths)
+}
+
+func TestStoreListRepairsCorruptLinkedCommandCache(t *testing.T) {
+	source := writeTestExtension(t)
+	store := NewStore(filepath.Join(t.TempDir(), "extensions"))
+	_, err := store.LinkLocal(source, "test-version", time.Unix(100, 0))
+	require.NoError(t, err)
+	linkDir, err := store.linkDir("kong/foo")
+	require.NoError(t, err)
+	cachePath := filepath.Join(linkDir, commandsCacheName)
+	require.NoError(t, os.WriteFile(cachePath, []byte("{"), 0o600))
+
+	extensions, err := store.List()
+	require.NoError(t, err)
+	require.Len(t, extensions, 1)
+	require.True(t, extensions[0].IsReady())
+
+	cache, err := store.loadCommandCache("kong/foo", InstallTypeLinked)
+	require.NoError(t, err)
+	require.Equal(t, "kong/foo", cache.ID)
+}
+
+func TestStoreUninstallBrokenLinkPreservesExistingData(t *testing.T) {
+	source := writeTestExtension(t)
+	store := NewStore(filepath.Join(t.TempDir(), "extensions"))
+	_, err := store.LinkLocal(source, "test-version", time.Unix(100, 0))
+	require.NoError(t, err)
+	dataDir, err := store.DataDir("kong/foo")
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(dataDir, 0o700))
+	dataPath := filepath.Join(dataDir, "state.json")
+	require.NoError(t, os.WriteFile(dataPath, []byte("{}"), 0o600))
+	require.NoError(t, os.RemoveAll(source))
+
+	result, err := store.Uninstall("kong/foo", false)
+	require.NoError(t, err)
+	require.True(t, result.RemovedLink)
+	require.False(t, result.RemovedData)
+	require.FileExists(t, dataPath)
+}
+
+func TestStoreListReportsCorruptLinkStateWithoutFailing(t *testing.T) {
+	source := writeTestExtension(t)
+	store := NewStore(filepath.Join(t.TempDir(), "extensions"))
+	_, err := store.LinkLocal(source, "test-version", time.Unix(100, 0))
+	require.NoError(t, err)
+	linkDir, err := store.linkDir("kong/foo")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(linkDir, linkStateName), []byte("{"), 0o600))
+
+	extensions, err := store.List()
+	require.NoError(t, err)
+	require.Len(t, extensions, 1)
+	require.Equal(t, ExtensionHealthInvalid, extensions[0].Health.Status)
+	require.Equal(t, "link_state_invalid", extensions[0].Health.Diagnostics[0].Code)
+
+	result, err := store.Uninstall("kong/foo", false)
+	require.NoError(t, err)
+	require.True(t, result.RemovedLink)
+}
+
+func TestStoreListReportsDuplicateInstalledAndLinkedState(t *testing.T) {
+	source := writeTestExtension(t)
+	store := NewStore(filepath.Join(t.TempDir(), "extensions"))
+	_, err := store.InstallLocal(source, "test-version", time.Unix(100, 0))
+	require.NoError(t, err)
+	linkDir, err := store.linkDir("kong/foo")
+	require.NoError(t, err)
+	state := LinkState{
+		SchemaVersion: stateSchemaVersion,
+		ID:            "kong/foo",
+		Path:          source,
+	}
+	require.NoError(t, writeJSON(filepath.Join(linkDir, linkStateName), state))
+
+	extensions, err := store.List()
+	require.NoError(t, err)
+	require.Len(t, extensions, 2)
+	for _, ext := range extensions {
+		require.Equal(t, ExtensionHealthConflict, ext.Health.Status)
+		require.Equal(t, "duplicate_install_state", ext.Health.Diagnostics[0].Code)
+	}
+
+	result, err := store.Uninstall("kong/foo", false)
+	require.NoError(t, err)
+	require.True(t, result.RemovedInstall)
+	require.True(t, result.RemovedLink)
+}
+
+func TestStoreListKeepsDamagedInstalledRuntimeRecoverable(t *testing.T) {
+	source := writeTestExtension(t)
+	store := NewStore(filepath.Join(t.TempDir(), "extensions"))
+	result, err := store.InstallLocal(source, "test-version", time.Unix(100, 0))
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(filepath.Join(result.Extension.PackageDir, "kongctl-ext-foo")))
+
+	extensions, err := store.List()
+	require.NoError(t, err)
+	require.Len(t, extensions, 1)
+	require.Equal(t, ExtensionHealthDamaged, extensions[0].Health.Status)
+	require.Equal(t, "installed_runtime_invalid", extensions[0].Health.Diagnostics[0].Code)
+	require.NotEmpty(t, extensions[0].CommandPaths)
+
+	uninstalled, err := store.Uninstall("kong/foo", false)
+	require.NoError(t, err)
+	require.True(t, uninstalled.RemovedInstall)
+}
+
 func writeTestExtension(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()
-	writeManifest(t, root, "kong", "foo", "get", "foo")
+	writeManifest(t, root, "foo", openBuiltInRootGet, "foo")
 	runtime := filepath.Join(root, "kongctl-ext-foo")
 	require.NoError(t, os.WriteFile(runtime, []byte("#!/bin/sh\necho ok\n"), 0o600))
 	require.NoError(t, os.Chmod(runtime, 0o755))
 	return root
 }
 
-func writeManifest(t *testing.T, root, publisher, name, verb, resource string) {
+func writeManifest(t *testing.T, root, name, verb, resource string) {
 	t.Helper()
 	manifest := []byte(`schema_version: 1
-publisher: ` + publisher + `
+publisher: kong
 name: ` + name + `
 version: 0.1.0
 runtime:

--- a/internal/extensions/storage_test.go
+++ b/internal/extensions/storage_test.go
@@ -292,6 +292,7 @@ func TestStoreListKeepsDamagedInstalledRuntimeRecoverable(t *testing.T) {
 	result, err := store.InstallLocal(source, "test-version", time.Unix(100, 0))
 	require.NoError(t, err)
 	require.NoError(t, os.Remove(filepath.Join(result.Extension.PackageDir, "kongctl-ext-foo")))
+	require.NoError(t, os.Remove(filepath.Join(filepath.Dir(result.Extension.PackageDir), commandsCacheName)))
 
 	extensions, err := store.List()
 	require.NoError(t, err)
@@ -299,6 +300,9 @@ func TestStoreListKeepsDamagedInstalledRuntimeRecoverable(t *testing.T) {
 	require.Equal(t, ExtensionHealthDamaged, extensions[0].Health.Status)
 	require.Equal(t, "installed_runtime_invalid", extensions[0].Health.Diagnostics[0].Code)
 	require.NotEmpty(t, extensions[0].CommandPaths)
+	cache, err := store.loadCommandCache("kong/foo", InstallTypeInstalled)
+	require.NoError(t, err)
+	require.NotEmpty(t, cache.CommandPaths)
 
 	uninstalled, err := store.Uninstall("kong/foo", false)
 	require.NoError(t, err)

--- a/test/e2e/extensions_test.go
+++ b/test/e2e/extensions_test.go
@@ -25,8 +25,20 @@ const (
 type extensionRecord struct {
 	ID           string                 `json:"id"`
 	InstallType  string                 `json:"install_type"`
+	Health       extensionHealth        `json:"health"`
 	CommandPaths []extensionCommandPath `json:"command_paths"`
 	Install      *extensionInstallState `json:"install,omitempty"`
+}
+
+type extensionHealth struct {
+	Status      string                `json:"status"`
+	Diagnostics []extensionDiagnostic `json:"diagnostics"`
+}
+
+type extensionDiagnostic struct {
+	Code        string `json:"code"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation"`
 }
 
 type extensionCommandPath struct {
@@ -227,6 +239,55 @@ func TestE2E_ExtensionsGoSDKOutput(t *testing.T) {
 	runKongctlJSON(t, cli, &uninstall, "uninstall", "extension", goExtensionID, "--remove-data")
 }
 
+func TestE2E_ExtensionsMissingLinkedSourceRemainsRecoverable(t *testing.T) {
+	cli := newExtensionCLI(t)
+	fixtureDir := prepareScriptExtensionFixture(t, cli)
+
+	var linked extensionRecord
+	runKongctlJSON(t, cli, &linked, "link", "extension", fixtureDir)
+	var runtimeCtx extensionRuntimeContext
+	runKongctlJSON(t, cli, &runtimeCtx, "get", "e2e-script")
+	dataDir := runtimeCtx.Resolved.ExtensionDataDir
+	if dataDir == "" {
+		t.Fatal("linked extension did not receive a data directory")
+	}
+
+	movedDir := fixtureDir + "-moved"
+	requireNoError(t, os.Rename(fixtureDir, movedDir), "move linked extension source")
+
+	res, err := cli.Run(context.Background(), "--help")
+	requireNoCommandError(t, res, err, "run help with unavailable linked extension")
+	res, err = cli.Run(context.Background(), "version")
+	requireNoCommandError(t, res, err, "run built-in command with unavailable linked extension")
+
+	var listed []extensionRecord
+	runKongctlJSON(t, cli, &listed, "list", "extensions")
+	broken := requireExtensionRecord(t, listed, scriptExtensionID)
+	requireEqual(t, "unavailable", broken.Health.Status, "missing source health")
+	requireEqual(t, "linked_source_unavailable", broken.Health.Diagnostics[0].Code, "missing source diagnostic")
+
+	res, err = cli.Run(context.Background(), "get", "e2e-script")
+	if err == nil {
+		t.Fatal("unavailable linked extension command unexpectedly succeeded")
+	}
+	if !strings.Contains(res.Stderr, scriptExtensionID) || !strings.Contains(res.Stderr, "restore") {
+		t.Fatalf("missing actionable extension diagnostic:\n%s", res.Stderr)
+	}
+
+	runKongctlJSON(t, cli, &linked, "link", "extension", movedDir)
+	runKongctlJSON(t, cli, &runtimeCtx, "get", "e2e-script")
+	requireNoError(t, os.RemoveAll(movedDir), "delete re-linked extension source")
+
+	var uninstall map[string]any
+	runKongctlJSON(t, cli, &uninstall, "uninstall", "extension", scriptExtensionID)
+	if removed, _ := uninstall["removed_link"].(bool); !removed {
+		t.Fatalf("uninstall did not report removed link state: %+v", uninstall)
+	}
+	if _, err := os.Stat(dataDir); err != nil {
+		t.Fatalf("extension data was not preserved: %v", err)
+	}
+}
+
 func TestE2E_ExtensionsRemoteReleaseLifecycle(t *testing.T) {
 	repo := strings.TrimSpace(os.Getenv("KONGCTL_E2E_EXTENSION_REMOTE_REPO"))
 	oldTag := strings.TrimSpace(os.Getenv("KONGCTL_E2E_EXTENSION_REMOTE_OLD_TAG"))
@@ -382,6 +443,17 @@ func requireExtensionListed(t *testing.T, extensions []extensionRecord, id strin
 		}
 	}
 	t.Fatalf("extension %s not listed in %+v", id, extensions)
+}
+
+func requireExtensionRecord(t *testing.T, extensions []extensionRecord, id string) extensionRecord {
+	t.Helper()
+	for _, ext := range extensions {
+		if ext.ID == id {
+			return ext
+		}
+	}
+	t.Fatalf("extension %s not found in %+v", id, extensions)
+	return extensionRecord{}
 }
 
 func requireInstallSource(t *testing.T, ext extensionRecord) extensionSourceState {


### PR DESCRIPTION
## Summary

- keep built-in commands, help, and extension lifecycle commands available when an extension record is broken
- expose structured extension health and actionable recovery diagnostics
- use validated cached command metadata for hidden recovery stubs without executing unavailable linked sources
- isolate command conflicts and damaged installed or linked state
- preserve extension data during recovery unless `--remove-data` is specified

## Root cause

Extension registration loaded every linked manifest before Cobra dispatched a command. If a linked source directory or manifest disappeared, `Store.List` returned the filesystem error and aborted root command startup, including the uninstall command needed for recovery.

## User impact

Users can restore or re-link a moved source, inspect degraded state with `list extensions` or `get extension`, or uninstall a stale record without editing the extension store manually. Exact cached command invocations return extension-scoped recovery guidance, while normal help and completion omit broken commands.

## Testing

- `go fix ./...`
- `make format`
- `GOFLAGS=-buildvcs=false make build`
- `golangci-lint run ./internal/extensions ./internal/cmd/root/verbs/extensions ./internal/cmd/root`
- `make test`
- `go test -tags=e2e ./test/e2e -run 'TestE2E_Extensions' -count=1`
- `git diff --check`

Closes #1795
