### PR TITLE
refactor(simplify): use cmp.Compare in dump sort comparators

### DIFF
--- a/internal/cmd/root/verbs/dump/declarative_children.go
+++ b/internal/cmd/root/verbs/dump/declarative_children.go
@@ -1373,13 +1373,13 @@ func collectOrganizationUsersFromTeamMemberships(
 				})
 			}
 			slices.SortFunc(user.Roles, func(a, b declresources.OrganizationUserRoleResource) int {
-				return strings.Compare(a.Ref, b.Ref)
+				return cmp.Compare(a.Ref, b.Ref)
 			})
 		}
 		users = append(users, *user)
 	}
 	slices.SortFunc(users, func(a, b declresources.OrganizationUserResource) int {
-		return strings.Compare(a.Ref, b.Ref)
+		return cmp.Compare(a.Ref, b.Ref)
 	})
 
 	return users
@@ -1470,13 +1470,13 @@ func collectOrganizationSystemAccountsFromTeamMemberships(
 			return cmp.Compare(a.Ref, b.Ref)
 		})
 		slices.SortFunc(accountRes.Roles, func(a, b declresources.OrganizationSystemAccountRoleResource) int {
-			return strings.Compare(a.Ref, b.Ref)
+			return cmp.Compare(a.Ref, b.Ref)
 		})
 		results = append(results, accountRes)
 	}
 
 	slices.SortFunc(results, func(a, b declresources.OrganizationSystemAccountResource) int {
-		return strings.Compare(a.Ref, b.Ref)
+		return cmp.Compare(a.Ref, b.Ref)
 	})
 
 	return results


### PR DESCRIPTION
`declarative_children.go` sorts with `cmp.Compare` in 26 places, but four comparators added in #1815 use `strings.Compare`. Identical result for strings, so this just makes the file consistent.

closes #1820