### PR TITLE
feat(extensions): control host flag visibility in command help

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -143,6 +143,33 @@ kongctl get foo -- --output raw
 Inside the extension, read `remaining_args` from the runtime context, or parse
 the process arguments passed to the executable.
 
+## Host Flags
+
+Extension command help lists the host `kongctl` flags a command inherits, such
+as `--output` and `--profile`. When a command ignores some of them, a
+contribution can trim the section with `host_flags`:
+
+```yaml
+command_paths:
+  - path:
+      - name: convert
+      - name: ai-gateway
+    host_flags:
+      hidden: true            # drop the Host Flags section entirely
+  - path:
+      - name: get
+      - name: report
+    host_flags:
+      only: [output, profile] # list only these host flags
+```
+
+Omit `host_flags` to list every host flag, which is the default. `hidden` and
+`only` cannot be set together. Valid host flag names are `output`, `jq`,
+`jq-raw-output`, `jq-color`, `jq-color-theme`, `profile`, and `color-theme`.
+
+This controls help output only. Hidden host flags are still recognized and
+applied when the command runs.
+
 ## Runtime Context
 
 When `kongctl` runs an extension, it writes a `context.json` file and sets:

--- a/internal/extensions/cobra.go
+++ b/internal/extensions/cobra.go
@@ -513,7 +513,7 @@ func PrintExtensionHelp(w io.Writer, extensionID string, contribution CommandPat
 			}
 		}
 	}
-	if err := printExtensionHostFlags(w); err != nil {
+	if err := printExtensionHostFlags(w, contribution.HostFlags); err != nil {
 		return err
 	}
 	if len(contribution.Examples) > 0 {
@@ -529,24 +529,54 @@ func PrintExtensionHelp(w io.Writer, extensionID string, contribution CommandPat
 	return nil
 }
 
-func printExtensionHostFlags(w io.Writer) error {
-	hostFlags := []struct {
-		flag        string
-		description string
-	}{
-		{"-o, --output string", "Output format: text, json, or yaml"},
-		{"--jq string", "Filter JSON or YAML output using a jq expression"},
-		{"-r, --jq-raw-output", "Output string jq results without JSON quotes"},
-		{"--jq-color string", "Color mode for jq output: auto, always, or never"},
-		{"--jq-color-theme string", "Color theme for jq output"},
-		{"-p, --profile string", "Configuration profile to use"},
-		{"--color-theme string", "kongctl color theme"},
+// extensionHostFlags is the ordered set of host flags kongctl exposes to
+// extension commands. Names key the manifest host_flags.only allow-list, so
+// they reference the shared flag-name constants rather than raw literals.
+var extensionHostFlags = []struct {
+	name        string
+	display     string
+	description string
+}{
+	{cmdcommon.OutputFlagName, "-o, --output string", "Output format: text, json, or yaml"},
+	{jqoutput.FlagName, "--jq string", "Filter JSON or YAML output using a jq expression"},
+	{jqoutput.RawOutputFlagName, "-r, --jq-raw-output", "Output string jq results without JSON quotes"},
+	{jqoutput.ColorFlagName, "--jq-color string", "Color mode for jq output: auto, always, or never"},
+	{jqoutput.ColorThemeFlagName, "--jq-color-theme string", "Color theme for jq output"},
+	{cmdcommon.ProfileFlagName, "-p, --profile string", "Configuration profile to use"},
+	{cmdcommon.ColorThemeFlagName, "--color-theme string", "kongctl color theme"},
+}
+
+// HostFlagNames returns the canonical host flag names in display order.
+func HostFlagNames() []string {
+	names := make([]string, len(extensionHostFlags))
+	for i, hostFlag := range extensionHostFlags {
+		names[i] = hostFlag.name
+	}
+	return names
+}
+
+// IsHostFlagName reports whether name is a recognized host flag.
+func IsHostFlagName(name string) bool {
+	for _, hostFlag := range extensionHostFlags {
+		if hostFlag.name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func printExtensionHostFlags(w io.Writer, visibility *HostFlags) error {
+	if visibility != nil && visibility.Hidden {
+		return nil
 	}
 	if _, err := fmt.Fprintln(w, "\nHost Flags:"); err != nil {
 		return err
 	}
-	for _, hostFlag := range hostFlags {
-		if _, err := fmt.Fprintf(w, "  %s\t%s\n", hostFlag.flag, hostFlag.description); err != nil {
+	for _, hostFlag := range extensionHostFlags {
+		if visibility != nil && len(visibility.Only) > 0 && !slices.Contains(visibility.Only, hostFlag.name) {
+			continue
+		}
+		if _, err := fmt.Fprintf(w, "  %s\t%s\n", hostFlag.display, hostFlag.description); err != nil {
 			return err
 		}
 	}

--- a/internal/extensions/cobra_test.go
+++ b/internal/extensions/cobra_test.go
@@ -344,3 +344,39 @@ func (h *testHook) GetPath() string {
 func (h *testHook) InConfig(string) bool {
 	return false
 }
+
+func TestPrintExtensionHelpShowsAllHostFlagsByDefault(t *testing.T) {
+	var buf bytes.Buffer
+	contribution := CommandPath{Usage: "kongctl get foo", Summary: "Get foo"}
+	require.NoError(t, PrintExtensionHelp(&buf, "kong/foo", contribution))
+	out := buf.String()
+	require.Contains(t, out, "\nHost Flags:")
+	for _, name := range HostFlagNames() {
+		require.Contains(t, out, "--"+name)
+	}
+}
+
+func TestPrintExtensionHelpHidesHostFlagsSection(t *testing.T) {
+	var buf bytes.Buffer
+	contribution := CommandPath{
+		Usage: "kongctl get foo", Summary: "Get foo",
+		HostFlags: &HostFlags{Hidden: true},
+	}
+	require.NoError(t, PrintExtensionHelp(&buf, "kong/foo", contribution))
+	require.NotContains(t, buf.String(), "Host Flags:")
+}
+
+func TestPrintExtensionHelpShowsOnlySelectedHostFlags(t *testing.T) {
+	var buf bytes.Buffer
+	contribution := CommandPath{
+		Usage: "kongctl get foo", Summary: "Get foo",
+		HostFlags: &HostFlags{Only: []string{cmdcommon.OutputFlagName, cmdcommon.ProfileFlagName}},
+	}
+	require.NoError(t, PrintExtensionHelp(&buf, "kong/foo", contribution))
+	out := buf.String()
+	require.Contains(t, out, "Host Flags:")
+	require.Contains(t, out, "--output")
+	require.Contains(t, out, "--profile")
+	require.NotContains(t, out, "--jq")
+	require.NotContains(t, out, "--color-theme")
+}

--- a/internal/extensions/cobra_test.go
+++ b/internal/extensions/cobra_test.go
@@ -350,10 +350,15 @@ func TestPrintExtensionHelpShowsAllHostFlagsByDefault(t *testing.T) {
 	contribution := CommandPath{Usage: "kongctl get foo", Summary: "Get foo"}
 	require.NoError(t, PrintExtensionHelp(&buf, "kong/foo", contribution))
 	out := buf.String()
-	require.Contains(t, out, "\nHost Flags:")
-	for _, name := range HostFlagNames() {
-		require.Contains(t, out, "--"+name)
-	}
+	expected := "\nHost Flags:\n" +
+		"  -o, --output string\tOutput format: text, json, or yaml\n" +
+		"  --jq string\tFilter JSON or YAML output using a jq expression\n" +
+		"  -r, --jq-raw-output\tOutput string jq results without JSON quotes\n" +
+		"  --jq-color string\tColor mode for jq output: auto, always, or never\n" +
+		"  --jq-color-theme string\tColor theme for jq output\n" +
+		"  -p, --profile string\tConfiguration profile to use\n" +
+		"  --color-theme string\tkongctl color theme\n"
+	require.Contains(t, out, expected)
 }
 
 func TestPrintExtensionHelpHidesHostFlagsSection(t *testing.T) {

--- a/internal/extensions/manifest.go
+++ b/internal/extensions/manifest.go
@@ -105,6 +105,15 @@ type CommandPath struct {
 	Examples    []string      `json:"examples,omitempty"    yaml:"examples,omitempty"`
 	Args        []Argument    `json:"args,omitempty"        yaml:"args,omitempty"`
 	Flags       []Flag        `json:"flags,omitempty"       yaml:"flags,omitempty"`
+	HostFlags   *HostFlags    `json:"host_flags,omitempty"  yaml:"host_flags,omitempty"`
+}
+
+// HostFlags controls which host flags a command contribution lists in its
+// generated help. When nil, help lists every host flag. Hidden drops the
+// section entirely; Only restricts it to the named host flags.
+type HostFlags struct {
+	Hidden bool     `json:"hidden,omitempty" yaml:"hidden,omitempty"`
+	Only   []string `json:"only,omitempty"   yaml:"only,omitempty"`
 }
 
 type PathSegment struct {
@@ -523,7 +532,34 @@ func normalizeAndValidateCommandPath(extensionID string, path *CommandPath) erro
 			return fmt.Errorf("flags[%d]: %w", i, err)
 		}
 	}
+	if err := normalizeHostFlags(path.HostFlags); err != nil {
+		return fmt.Errorf("host_flags: %w", err)
+	}
 
+	return nil
+}
+
+func normalizeHostFlags(hostFlags *HostFlags) error {
+	if hostFlags == nil {
+		return nil
+	}
+	if hostFlags.Hidden && len(hostFlags.Only) > 0 {
+		return errors.New("hidden and only cannot be set together")
+	}
+	if hostFlags.Only != nil && len(hostFlags.Only) == 0 {
+		return errors.New("only must list at least one host flag; use hidden: true to hide all host flags")
+	}
+	if len(hostFlags.Only) > maxMetadataEntries {
+		return fmt.Errorf("only must contain %d entries or fewer", maxMetadataEntries)
+	}
+	for i := range hostFlags.Only {
+		name := strings.TrimSpace(strings.ToLower(hostFlags.Only[i]))
+		if !IsHostFlagName(name) {
+			return fmt.Errorf("only[%d]: unknown host flag %q; valid host flags are %s",
+				i, hostFlags.Only[i], strings.Join(HostFlagNames(), ", "))
+		}
+		hostFlags.Only[i] = name
+	}
 	return nil
 }
 

--- a/internal/extensions/manifest_test.go
+++ b/internal/extensions/manifest_test.go
@@ -166,3 +166,96 @@ func TestParseManifestRejectsOversizedManifest(t *testing.T) {
 
 	require.Error(t, err)
 }
+
+func TestParseManifestNormalizesHostFlagsOnly(t *testing.T) {
+	manifest, err := ParseManifest([]byte(`
+schema_version: 1
+publisher: kong
+name: foo
+runtime:
+  command: bin/kongctl-ext-foo
+command_paths:
+  - path:
+      - name: get
+      - name: foo
+    host_flags:
+      only: [OUTPUT, " profile "]
+`))
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"output", "profile"}, manifest.CommandPaths[0].HostFlags.Only)
+}
+
+func TestParseManifestHidesHostFlags(t *testing.T) {
+	manifest, err := ParseManifest([]byte(`
+schema_version: 1
+publisher: kong
+name: foo
+runtime:
+  command: bin/kongctl-ext-foo
+command_paths:
+  - path:
+      - name: get
+      - name: foo
+    host_flags:
+      hidden: true
+`))
+
+	require.NoError(t, err)
+	require.True(t, manifest.CommandPaths[0].HostFlags.Hidden)
+}
+
+func TestParseManifestRejectsUnknownHostFlag(t *testing.T) {
+	_, err := ParseManifest([]byte(`
+schema_version: 1
+publisher: kong
+name: foo
+runtime:
+  command: bin/kongctl-ext-foo
+command_paths:
+  - path:
+      - name: get
+      - name: foo
+    host_flags:
+      only: [not-a-flag]
+`))
+
+	require.ErrorContains(t, err, "unknown host flag")
+}
+
+func TestParseManifestRejectsHiddenAndOnlyHostFlags(t *testing.T) {
+	_, err := ParseManifest([]byte(`
+schema_version: 1
+publisher: kong
+name: foo
+runtime:
+  command: bin/kongctl-ext-foo
+command_paths:
+  - path:
+      - name: get
+      - name: foo
+    host_flags:
+      hidden: true
+      only: [output]
+`))
+
+	require.ErrorContains(t, err, "hidden and only cannot be set together")
+}
+
+func TestParseManifestRejectsEmptyHostFlagsOnly(t *testing.T) {
+	_, err := ParseManifest([]byte(`
+schema_version: 1
+publisher: kong
+name: foo
+runtime:
+  command: bin/kongctl-ext-foo
+command_paths:
+  - path:
+      - name: get
+      - name: foo
+    host_flags:
+      only: []
+`))
+
+	require.ErrorContains(t, err, "at least one host flag")
+}


### PR DESCRIPTION
extension help always prints the full Host Flags section -even when a command uses none of them (e.g. `kong/ai-gateway-converter` just converts a file locally). So it lists seven flags that do nothing :')

Adds an optional `host_flags` per command path: `hidden: true` to drop the section  or `only: [output, profile]` for a subset. Leave it off and you get the full list like today. Help-only, the flags still work at runtime. 
Validator rejects unknown names and `hidden`+`only` together.

closes #1723