### PR TITLE
fix(konnect): gate static login banner on terminal height

### DIFF
--- a/internal/cmd/root/products/konnect/loginKonnect.go
+++ b/internal/cmd/root/products/konnect/loginKonnect.go
@@ -329,7 +329,7 @@ func displayStaticLoginBanner(streams *iostreams.IOStreams) error {
 	}
 
 	terminal := loginTerminalData(streams.Out)
-	if roarcmd.CanRenderFrameWidth(terminal) {
+	if roarcmd.CanRenderFrame(terminal) {
 		useNativeColor := roarcmd.ShouldUseNativeAnimationColor(roarcmd.NativeColorValue, terminal)
 		return roarcmd.RenderStaticFrame(streams.Out, nil, useNativeColor)
 	}

--- a/internal/cmd/root/products/konnect/loginKonnect_test.go
+++ b/internal/cmd/root/products/konnect/loginKonnect_test.go
@@ -165,7 +165,7 @@ func TestDisplayStaticLoginBannerFallsBackToClimberInNarrowTerminal(t *testing.T
 	t.Setenv("LC_ALL", "en_US.UTF-8")
 	streams, _, out, _ := iostreams.NewTestIOStreams()
 	stubLoginTerminals(t, true, true)
-	stubLoginTerminalData(t, roarcmd.NewTerminalCapabilities(79, art.KongRoarAnimationHeight, true))
+	stubLoginTerminalData(t, roarcmd.NewTerminalCapabilities(79, 40, true))
 
 	if err := displayStaticLoginBanner(streams); err != nil {
 		t.Fatalf("displayStaticLoginBanner: %v", err)
@@ -176,6 +176,43 @@ func TestDisplayStaticLoginBannerFallsBackToClimberInNarrowTerminal(t *testing.T
 	}
 	if got := maxLineWidth(output); got != 48 {
 		t.Fatalf("login banner width = %d, want 48\noutput:\n%s", got, output)
+	}
+}
+
+func TestDisplayStaticLoginBannerSkipsImageWhenTerminalCannotFitFallback(t *testing.T) {
+	t.Setenv("TERM", "xterm-256color")
+	t.Setenv("LC_ALL", "en_US.UTF-8")
+	tests := []struct {
+		name     string
+		terminal roarcmd.TerminalCapabilities
+	}{
+		{
+			name:     "short terminal",
+			terminal: roarcmd.NewTerminalCapabilities(art.KongRoarAnimationWidth, 21, true),
+		},
+		{
+			name:     "fallback is taller than terminal",
+			terminal: roarcmd.NewTerminalCapabilities(79, art.KongRoarAnimationHeight, true),
+		},
+		{
+			name:     "unknown size",
+			terminal: roarcmd.NewTerminalCapabilities(0, 0, true),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			streams, _, out, _ := iostreams.NewTestIOStreams()
+			stubLoginTerminals(t, true, true)
+			stubLoginTerminalData(t, tt.terminal)
+
+			if err := displayStaticLoginBanner(streams); err != nil {
+				t.Fatalf("displayStaticLoginBanner: %v", err)
+			}
+			if out.Len() != 0 {
+				t.Fatalf("expected no image output, got:\n%s", out.String())
+			}
+		})
 	}
 }
 

--- a/internal/cmd/root/verbs/roar/roar.go
+++ b/internal/cmd/root/verbs/roar/roar.go
@@ -271,7 +271,7 @@ func (c *roarCmd) run(command *cobra.Command, _ []string) error {
 	if err != nil {
 		return &cmdpkg.ConfigurationError{Err: err}
 	}
-	if !rendered {
+	if !rendered && !canRenderOutputWidth(terminal, fallbackWidth) {
 		writeNarrowTerminalMessage(streams.ErrOut)
 	}
 	return nil
@@ -372,10 +372,23 @@ func renderRoarBanner(out io.Writer, width int, bannerType art.KongBannerType, b
 }
 
 func RenderFallbackClimber(out io.Writer, terminal TerminalCapabilities, bannerColor color.Color) (bool, error) {
-	if !canRenderOutputWidth(terminal, fallbackWidth) {
+	if terminal.width <= 0 || terminal.height <= 0 || !canRenderOutputWidth(terminal, fallbackWidth) {
 		return false, nil
 	}
-	return true, renderRoarBanner(out, fallbackWidth, autoBannerType(), bannerColor)
+
+	var banner bytes.Buffer
+	if err := renderRoarBanner(&banner, fallbackWidth, autoBannerType(), bannerColor); err != nil {
+		return false, err
+	}
+	if terminal.height < strings.Count(banner.String(), "\n") {
+		return false, nil
+	}
+	if out == nil {
+		return true, nil
+	}
+
+	_, err := io.Copy(out, &banner)
+	return true, err
 }
 
 func renderRoarStaticFrame(out io.Writer, bannerColor color.Color, useNativeColor bool) error {

--- a/internal/cmd/root/verbs/roar/roar.go
+++ b/internal/cmd/root/verbs/roar/roar.go
@@ -870,8 +870,13 @@ func ShouldRenderAnimation(noAnimate bool, terminal TerminalCapabilities) bool {
 	return shouldRenderAnimation(noAnimate, terminal)
 }
 
-func CanRenderFrameWidth(terminal TerminalCapabilities) bool {
-	return canRenderOutputWidth(terminal, art.KongRoarAnimationWidth)
+// CanRenderFrame reports whether the terminal can display the full static Kong
+// frame. It requires a measured size large enough in both dimensions, matching
+// the animation gate, so short or unmeasurable terminals fall back to a smaller
+// banner instead of rendering a frame that overflows the screen.
+func CanRenderFrame(terminal TerminalCapabilities) bool {
+	return terminal.width >= art.KongRoarAnimationWidth &&
+		terminal.height >= art.KongRoarAnimationHeight
 }
 
 func canRenderOutputWidth(terminal terminalCapabilities, width int) bool {

--- a/internal/cmd/root/verbs/roar/roar_test.go
+++ b/internal/cmd/root/verbs/roar/roar_test.go
@@ -1030,3 +1030,37 @@ func containsBraillePattern(s string) bool {
 	}
 	return false
 }
+
+func TestCanRenderFrameRequiresMeasuredSpace(t *testing.T) {
+	tests := []struct {
+		name     string
+		terminal terminalCapabilities
+		want     bool
+	}{
+		{
+			name:     "fits",
+			terminal: terminalCapabilities{width: art.KongRoarAnimationWidth, height: art.KongRoarAnimationHeight},
+			want:     true,
+		},
+		{
+			name:     "too short",
+			terminal: terminalCapabilities{width: 120, height: art.KongRoarAnimationHeight - 1},
+		},
+		{
+			name:     "too narrow",
+			terminal: terminalCapabilities{width: art.KongRoarAnimationWidth - 1, height: 40},
+		},
+		{
+			name:     "unknown size",
+			terminal: terminalCapabilities{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CanRenderFrame(tt.terminal); got != tt.want {
+				t.Fatalf("CanRenderFrame = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/root/verbs/roar/roar_test.go
+++ b/internal/cmd/root/verbs/roar/roar_test.go
@@ -620,6 +620,23 @@ func TestRoarRunFallsBackToClimberInNarrowTerminal(t *testing.T) {
 	}
 }
 
+func TestRoarRunSkipsClimberWhenTerminalIsTooShort(t *testing.T) {
+	t.Setenv("TERM", "xterm-256color")
+	t.Setenv("LC_ALL", "en_US.UTF-8")
+	streams, _, out, errOut := iostreams.NewTestIOStreams()
+	stubTerminalData(t, terminalCapabilities{width: 60, height: 30, isTTY: true})
+
+	if err := runRoarForTest(t, streams); err != nil {
+		t.Fatalf("roar run: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("expected no banner output for short terminal, got:\n%s", out.String())
+	}
+	if errOut.Len() != 0 {
+		t.Fatalf("expected no stderr output, got:\n%s", errOut.String())
+	}
+}
+
 func TestRoarRunReportsTooNarrowTerminal(t *testing.T) {
 	t.Setenv("TERM", "xterm-256color")
 	t.Setenv("LC_ALL", "en_US.UTF-8")


### PR DESCRIPTION
`kongctl login` shows a static Kong banner when it skips the animation. The animation already bails on terminals under 80x22, but the static frame only checked width and treated an unknown size as renderable. So a short terminal (or one where the size can't be measured) still got a 22-row frame that overflows the screen, which is the "hard to read in small terminals" complaint.

`CanRenderFrame` now requires a measured width and height that fit the frame, matching the animation gate. Anything too small or unmeasurable falls back to the smaller climber banner.

I read #1838 as "make the static path fall back the same way the animation already does." If you had different behavior in mind for small terminals, let me know and I'll adjust.

closes #1838