### PR TITLE
feat(declarative): add skip-defaults to declarative dumps

### DIFF
--- a/docs/contributor/declarative-resource-implementation-guide.md
+++ b/docs/contributor/declarative-resource-implementation-guide.md
@@ -166,6 +166,46 @@ before environment values are resolved. Error formatting must identify the
 declarative path without including input values, because an invalid field may
 contain a secret.
 
+### DUMP DEFAULT OMISSION
+
+`kongctl dump declarative --skip-defaults` derives its runtime default index
+lazily from `default` tags on SDK fields reachable from `ResourceSet`. Adding a
+registered resource to `ResourceSet` and embedding its generated SDK request
+types therefore opts the resource and its nested children into default
+omission automatically. No separate production catalog is maintained or
+loaded. The entire reflection and YAML-walk path is bypassed when the flag is
+absent.
+
+Only literal API defaults are eligible. Do not add tags for kongctl-derived
+conveniences such as `SetDefaults` behavior or deriving `name` from `ref`.
+Those values are client behavior, not an API contract. Explicit YAML `null`
+values and fields without SDK default metadata are preserved.
+
+The reviewed catalog at
+`internal/declarative/resources/testdata/dump_defaults_inventory.yaml` is a
+golden test artifact, not a runtime data source. It makes SDK dependency
+changes reviewable by listing each registered resource, field path, type,
+value, and source. `TestDumpDefaultInventory` runs with the normal unit suite
+and fails when the SDK version, reachable resources, or default tags change.
+After reviewing such a diff, regenerate it with:
+
+```shell
+UPDATE_GOLDEN=1 go test ./internal/declarative/resources \
+  -run TestDumpDefaultInventory
+```
+
+If SDK metadata is missing or unsafe, add exactly one documented registration
+rule beside the resource's `registerResourceType` call:
+
+- `WithDumpDefaultOverride(path, value, reason)` supplies a reviewed literal
+  API default.
+- `WithDumpDefaultExclusion(path, reason)` keeps an SDK-tagged field in dumps.
+
+Rules for the same resource path are mutually exclusive; duplicate rules fail
+resource registration. Every rule requires a reason and appears in the golden
+inventory. Remove a rule when the SDK metadata becomes authoritative, then
+regenerate and review the inventory.
+
 ### SYNC SCOPE (REQUIRED)
 
 `sync` uses explicit manifest scope. Do not treat omitted configuration as a

--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -1113,6 +1113,25 @@ kongctl dump tf-import --resources=api --include-child-resources
 kongctl dump declarative --resources=portal,api --default-namespace=team-alpha
 ```
 
+Add `--skip-defaults` to omit values that equal defaults declared by the
+Konnect API SDK:
+
+```shell
+kongctl dump declarative --resources=portal,api \
+  --include-child-resources --skip-defaults > konnect.yaml
+```
+
+This option makes dumps smaller while preserving non-default values. It
+applies to parent and nested child resources. Only literal API defaults from
+the generated SDK are omitted; kongctl conveniences such as deriving `name`
+from `ref` are not considered API defaults and remain in the output when
+present. Explicit `null` values are also preserved.
+
+Without `--skip-defaults`, dump behavior and output are unchanged. Default
+discovery and YAML filtering are not run. The option affects only
+`dump declarative`; it does not change `plan`, `apply`, `diff`, or
+`dump tf-import` behavior.
+
 For custom dashboards created in the Konnect UI, adopt the dashboard first,
 then dump it with the same namespace:
 

--- a/internal/cmd/root/verbs/dump/declarative.go
+++ b/internal/cmd/root/verbs/dump/declarative.go
@@ -31,6 +31,7 @@ type declarativeOptions struct {
 	outputFile            string
 	defaultNamespace      string
 	includeChildResources bool
+	skipDefaults          bool
 	filter                filterOptions
 }
 
@@ -40,6 +41,7 @@ type DeclarativeDumpOptions struct {
 	OutputFile            string
 	DefaultNamespace      string
 	IncludeChildResources bool
+	SkipDefaults          bool
 	FilterName            string
 	FilterID              string
 }
@@ -106,6 +108,8 @@ func newDeclarativeCmd() *cobra.Command {
 
 	cmd.Flags().BoolVar(&opts.includeChildResources, "include-child-resources", false,
 		"Include child resources in the dump.")
+	cmd.Flags().BoolVar(&opts.skipDefaults, "skip-defaults", false,
+		"Omit fields whose values match defaults declared by the Konnect API.")
 
 	cmd.Flags().StringVar(&opts.outputFile, "output-file", "",
 		"File to write the output to. If not specified, output is written to stdout.")
@@ -183,6 +187,7 @@ func RunDeclarativeDump(helper cmdpkg.Helper, opts DeclarativeDumpOptions) error
 		outputFile:            strings.TrimSpace(opts.OutputFile),
 		defaultNamespace:      strings.TrimSpace(opts.DefaultNamespace),
 		includeChildResources: opts.IncludeChildResources,
+		skipDefaults:          opts.SkipDefaults,
 		filter: filterOptions{
 			name: strings.TrimSpace(opts.FilterName),
 			id:   strings.TrimSpace(opts.FilterID),
@@ -585,6 +590,12 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 	yamlBytes, err := yaml.Marshal(output)
 	if err != nil {
 		return fmt.Errorf("failed to marshal declarative configuration: %w", err)
+	}
+	if opts.skipDefaults {
+		yamlBytes, err = declresources.OmitAPIDefaults(yamlBytes)
+		if err != nil {
+			return fmt.Errorf("failed to omit API defaults: %w", err)
+		}
 	}
 
 	if len(yamlBytes) == 0 {

--- a/internal/cmd/root/verbs/dump/dump_declarative_test.go
+++ b/internal/cmd/root/verbs/dump/dump_declarative_test.go
@@ -61,6 +61,16 @@ func (runDumpOrganizationTeamAPIStub) DeleteOrganizationTeam(
 	return nil, nil
 }
 
+func TestDeclarativeDumpHasSkipDefaultsFlag(t *testing.T) {
+	flag := newDeclarativeCmd().Flags().Lookup("skip-defaults")
+	if flag == nil {
+		t.Fatal("expected --skip-defaults flag")
+	}
+	if flag.DefValue != "false" {
+		t.Fatalf("--skip-defaults default = %q, want false", flag.DefValue)
+	}
+}
+
 func TestRunDeclarativeDumpIncludesSystemAccountAssignments(t *testing.T) {
 	teamID := "team-123"
 	teamName := "team-one"
@@ -179,6 +189,66 @@ func TestRunDeclarativeDumpIncludesSystemAccountAssignments(t *testing.T) {
 	}
 	if account.Roles[0].RoleName != roleName {
 		t.Fatalf("expected role %q, got %q", roleName, account.Roles[0].RoleName)
+	}
+}
+
+func TestRunDeclarativeDumpSkipDefaults(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		skipDefaults bool
+		wantAuth     bool
+	}{
+		{name: "default output unchanged", wantAuth: true},
+		{name: "API default omitted", skipDefaults: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			authenticationEnabled := true
+			api := &portalPaginationStub{
+				t: t,
+				listPortalsFunc: func(
+					_ context.Context,
+					request kkOps.ListPortalsRequest,
+				) (*kkOps.ListPortalsResponse, error) {
+					if request.PageNumber != nil && *request.PageNumber > 1 {
+						return &kkOps.ListPortalsResponse{
+							ListPortalsResponse: &kkComps.ListPortalsResponse{},
+						}, nil
+					}
+					return &kkOps.ListPortalsResponse{ListPortalsResponse: &kkComps.ListPortalsResponse{
+						Data: []kkComps.ListPortalsResponsePortal{{ID: "portal-id", Name: "developer-portal"}},
+					}}, nil
+				},
+				getPortalFunc: func(context.Context, string) (*kkOps.GetPortalResponse, error) {
+					return &kkOps.GetPortalResponse{PortalResponse: &kkComps.PortalResponse{
+						ID:                    "portal-id",
+						Name:                  "developer-portal",
+						AuthenticationEnabled: &authenticationEnabled,
+					}}, nil
+				},
+			}
+			sdk := &helpers.MockKonnectSDK{PortalFactory: func() helpers.PortalAPI { return api }}
+			var output bytes.Buffer
+			helper := &cmdtest.MockHelper{
+				GetStreamsMock: func() *iostreams.IOStreams { return &iostreams.IOStreams{Out: &output} },
+				GetConfigMock:  func() (config.Hook, error) { return &configtest.MockConfigHook{}, nil },
+				GetLoggerMock: func() (*slog.Logger, error) {
+					return slog.New(slog.NewTextHandler(io.Discard, nil)), nil
+				},
+				GetContextMock:    func() context.Context { return t.Context() },
+				GetKonnectSDKMock: func(config.Hook, *slog.Logger) (helpers.SDKAPI, error) { return sdk, nil },
+			}
+
+			err := runDeclarativeDump(helper, declarativeOptions{
+				resources:    []string{"portals"},
+				skipDefaults: test.skipDefaults,
+			})
+			if err != nil {
+				t.Fatalf("runDeclarativeDump() error = %v", err)
+			}
+			if got := strings.Contains(output.String(), "authentication_enabled: true"); got != test.wantAuth {
+				t.Fatalf("authentication_enabled presence = %v, want %v\n%s", got, test.wantAuth, output.String())
+			}
+		})
 	}
 }
 

--- a/internal/declarative/loader/dump_defaults_test.go
+++ b/internal/declarative/loader/dump_defaults_test.go
@@ -1,0 +1,33 @@
+package loader
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkipDefaultsOutputLoadsWithAPIDefaultsRestored(t *testing.T) {
+	input := []byte(`
+portals:
+  - ref: developer-portal
+    name: Developer Portal
+    authentication_enabled: true
+    rbac_enabled: true
+`)
+
+	filtered, err := resources.OmitAPIDefaults(input)
+	require.NoError(t, err)
+	require.NotContains(t, string(filtered), "authentication_enabled")
+
+	loader := New()
+	resourceSet, err := loader.parseYAML(strings.NewReader(string(filtered)), "inline", "")
+	require.NoError(t, err)
+	require.NoError(t, loader.validateResourceSet(resourceSet))
+	require.Len(t, resourceSet.Portals, 1)
+	require.NotNil(t, resourceSet.Portals[0].AuthenticationEnabled)
+	require.True(t, *resourceSet.Portals[0].AuthenticationEnabled)
+	require.NotNil(t, resourceSet.Portals[0].RbacEnabled)
+	require.True(t, *resourceSet.Portals[0].RbacEnabled)
+}

--- a/internal/declarative/resources/dump_defaults.go
+++ b/internal/declarative/resources/dump_defaults.go
@@ -1,0 +1,704 @@
+package resources
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+
+	"go.yaml.in/yaml/v4"
+)
+
+type dumpDefaultSource string
+
+const (
+	dumpDefaultSourceSDK      dumpDefaultSource = "sdk"
+	dumpDefaultSourceOverride dumpDefaultSource = "override"
+)
+
+type dumpDefault struct {
+	value  any
+	kind   reflect.Kind
+	typ    string
+	source dumpDefaultSource
+}
+
+type dumpDefaultRuleKind int
+
+const (
+	dumpDefaultRuleOverride dumpDefaultRuleKind = iota
+	dumpDefaultRuleExclusion
+)
+
+type dumpDefaultRule struct {
+	kind   dumpDefaultRuleKind
+	value  any
+	reason string
+}
+
+// WithDumpDefaultOverride supplies a reviewed API default when generated SDK
+// metadata is missing or incorrect. The path is relative to the resource.
+func WithDumpDefaultOverride(path string, value any, reason string) ResourceRegistrationOption {
+	return withDumpDefaultRule(path, dumpDefaultRule{
+		kind:   dumpDefaultRuleOverride,
+		value:  value,
+		reason: reason,
+	})
+}
+
+// WithDumpDefaultExclusion prevents an SDK default from being omitted when
+// omission is not semantically safe. The path is relative to the resource.
+func WithDumpDefaultExclusion(path, reason string) ResourceRegistrationOption {
+	return withDumpDefaultRule(path, dumpDefaultRule{
+		kind:   dumpDefaultRuleExclusion,
+		reason: reason,
+	})
+}
+
+func withDumpDefaultRule(path string, rule dumpDefaultRule) ResourceRegistrationOption {
+	return func(ops *resourceOps) error {
+		path = strings.TrimSpace(path)
+		rule.reason = strings.TrimSpace(rule.reason)
+		if path == "" {
+			return fmt.Errorf("dump default rule path is required")
+		}
+		if rule.reason == "" {
+			return fmt.Errorf("dump default rule %q requires a reason", path)
+		}
+		if ops.dumpDefaultRules == nil {
+			ops.dumpDefaultRules = make(map[string]dumpDefaultRule)
+		}
+		if _, exists := ops.dumpDefaultRules[path]; exists {
+			return fmt.Errorf("dump default rule %q is declared more than once", path)
+		}
+		ops.dumpDefaultRules[path] = rule
+		return nil
+	}
+}
+
+type dumpSchema struct {
+	typ          reflect.Type
+	kind         reflect.Kind
+	resourceType ResourceType
+	fields       map[string]*dumpField
+	inline       []*dumpSchema
+	union        []dumpUnionBranch
+	elem         *dumpSchema
+	additional   *dumpSchema
+}
+
+type dumpField struct {
+	schema            *dumpSchema
+	defaultValue      *dumpDefault
+	defaultOverrides  map[ResourceType]*dumpDefault
+	defaultExclusions map[ResourceType]bool
+}
+
+type dumpUnionBranch struct {
+	schema        *dumpSchema
+	discriminator string
+	value         string
+}
+
+type dumpSchemaBuilder struct {
+	cache map[reflect.Type]*dumpSchema
+}
+
+var (
+	dumpSchemaOnce sync.Once
+	dumpSchemaRoot *dumpSchema
+	dumpSchemaErr  error
+)
+
+// OmitAPIDefaults removes fields equal to SDK-declared API defaults. All
+// reflection and schema construction is intentionally lazy behind this call.
+func OmitAPIDefaults(data []byte) ([]byte, error) {
+	dumpSchemaOnce.Do(func() {
+		dumpSchemaRoot, dumpSchemaErr = buildDumpDefaultSchema()
+	})
+	if dumpSchemaErr != nil {
+		return nil, dumpSchemaErr
+	}
+
+	var document yaml.Node
+	if err := yaml.Unmarshal(data, &document); err != nil {
+		return nil, fmt.Errorf("parse declarative YAML: %w", err)
+	}
+	if len(document.Content) == 0 {
+		return data, nil
+	}
+
+	if err := pruneDumpDefaults(document.Content[0], dumpSchemaRoot, "", nil); err != nil {
+		return nil, err
+	}
+
+	var result bytes.Buffer
+	encoder := yaml.NewEncoder(&result)
+	encoder.SetIndent(2)
+	encoder.CompactSeqIndent()
+	if err := encoder.Encode(&document); err != nil {
+		return nil, fmt.Errorf("marshal declarative YAML: %w", err)
+	}
+	return result.Bytes(), nil
+}
+
+func buildDumpDefaultSchema() (*dumpSchema, error) {
+	builder := dumpSchemaBuilder{cache: make(map[reflect.Type]*dumpSchema)}
+	root, err := builder.build(reflect.TypeFor[ResourceSet]())
+	if err != nil {
+		return nil, err
+	}
+
+	types := RegisteredTypes()
+	slices.Sort(types)
+	for _, resourceType := range types {
+		ops := registry[resourceType]
+		schema, err := builder.build(ops.explain.typ)
+		if err != nil {
+			return nil, fmt.Errorf("build dump defaults for %s: %w", resourceType, err)
+		}
+		schema.resourceType = resourceType
+		if err := applyDumpDefaultRules(resourceType, schema, ops.dumpDefaultRules); err != nil {
+			return nil, err
+		}
+	}
+
+	return root, nil
+}
+
+func (b *dumpSchemaBuilder) build(typ reflect.Type) (*dumpSchema, error) {
+	for typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+	if schema, ok := b.cache[typ]; ok {
+		return schema, nil
+	}
+
+	schema := &dumpSchema{typ: typ, kind: typ.Kind()}
+	b.cache[typ] = schema
+
+	//exhaustive:ignore // Unsupported reflection kinds return an error below.
+	switch typ.Kind() {
+	case reflect.Struct:
+		schema.fields = make(map[string]*dumpField)
+		for field := range typ.Fields() {
+			if !field.IsExported() {
+				continue
+			}
+			if field.Tag.Get("additionalProperties") == "true" {
+				fieldType := derefDumpType(field.Type)
+				if fieldType.Kind() == reflect.Map {
+					additional, err := b.build(fieldType.Elem())
+					if err != nil {
+						return nil, err
+					}
+					schema.additional = additional
+				}
+				continue
+			}
+
+			if field.Tag.Get("union") == "member" {
+				branch, err := b.build(field.Type)
+				if err != nil {
+					return nil, err
+				}
+				discriminator, value, _ := dumpConstDiscriminator(field.Type)
+				schema.union = append(schema.union, dumpUnionBranch{
+					schema:        branch,
+					discriminator: discriminator,
+					value:         value,
+				})
+				continue
+			}
+
+			name, inline, skip := dumpFieldName(field)
+			if skip {
+				continue
+			}
+			child, err := b.build(field.Type)
+			if err != nil {
+				return nil, err
+			}
+			if inline {
+				schema.inline = append(schema.inline, child)
+				continue
+			}
+			defaultValue, err := parseDumpDefault(field)
+			if err != nil {
+				return nil, err
+			}
+			schema.fields[name] = &dumpField{schema: child, defaultValue: defaultValue}
+		}
+	case reflect.Slice, reflect.Array:
+		elem, err := b.build(typ.Elem())
+		if err != nil {
+			return nil, err
+		}
+		schema.elem = elem
+	case reflect.Map:
+		additional, err := b.build(typ.Elem())
+		if err != nil {
+			return nil, err
+		}
+		schema.additional = additional
+	case reflect.Bool, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64, reflect.String, reflect.Interface:
+	case reflect.Invalid, reflect.Uintptr, reflect.Complex64, reflect.Complex128, reflect.Chan, reflect.Func,
+		reflect.UnsafePointer:
+		return nil, fmt.Errorf("unsupported declarative field type %s", typ)
+	}
+
+	return schema, nil
+}
+
+func derefDumpType(typ reflect.Type) reflect.Type {
+	for typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+	return typ
+}
+
+func dumpFieldName(field reflect.StructField) (name string, inline, skip bool) {
+	jsonName, jsonInline, _, jsonSkip := explainFieldName(field, "json")
+	yamlName, yamlInline, _, yamlSkip := explainFieldName(field, "yaml")
+	if jsonSkip || yamlSkip {
+		return "", false, true
+	}
+	if field.Anonymous && (jsonInline || yamlInline || (jsonName == "" && yamlName == "")) {
+		return "", true, false
+	}
+	name = jsonName
+	if name == "" {
+		name = yamlName
+	}
+	if name == "" {
+		name = snakeCase(field.Name)
+	}
+	return name, false, false
+}
+
+func parseDumpDefault(field reflect.StructField) (*dumpDefault, error) {
+	raw, ok := field.Tag.Lookup("default")
+	if !ok {
+		return nil, nil
+	}
+	typ := derefDumpType(field.Type)
+	result := &dumpDefault{kind: typ.Kind(), source: dumpDefaultSourceSDK}
+
+	//exhaustive:ignore // Only scalar SDK defaults are supported.
+	switch typ.Kind() {
+	case reflect.String:
+		result.value = raw
+		result.typ = "string"
+	case reflect.Bool:
+		value, err := strconv.ParseBool(raw)
+		if err != nil {
+			return nil, fmt.Errorf("parse default for %s: %w", field.Name, err)
+		}
+		result.value = value
+		result.typ = "boolean"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		value, err := strconv.ParseInt(raw, 10, typ.Bits())
+		if err != nil {
+			return nil, fmt.Errorf("parse default for %s: %w", field.Name, err)
+		}
+		result.value = value
+		result.typ = "integer"
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		value, err := strconv.ParseUint(raw, 10, typ.Bits())
+		if err != nil {
+			return nil, fmt.Errorf("parse default for %s: %w", field.Name, err)
+		}
+		result.value = value
+		result.typ = "integer"
+	case reflect.Float32, reflect.Float64:
+		value, err := strconv.ParseFloat(raw, typ.Bits())
+		if err != nil {
+			return nil, fmt.Errorf("parse default for %s: %w", field.Name, err)
+		}
+		result.value = value
+		result.typ = "number"
+	default:
+		return nil, fmt.Errorf("field %s has unsupported %s default %q", field.Name, typ, raw)
+	}
+	return result, nil
+}
+
+func dumpConstDiscriminator(typ reflect.Type) (string, string, bool) {
+	typ = derefDumpType(typ)
+	if typ.Kind() != reflect.Struct {
+		return "", "", false
+	}
+	for field := range typ.Fields() {
+		value, ok := field.Tag.Lookup("const")
+		if !ok {
+			continue
+		}
+		name, _, skip := dumpFieldName(field)
+		if skip || name == "" {
+			continue
+		}
+		return name, value, true
+	}
+	return "", "", false
+}
+
+func applyDumpDefaultRules(resourceType ResourceType, schema *dumpSchema, rules map[string]dumpDefaultRule) error {
+	paths := make([]string, 0, len(rules))
+	for path := range rules {
+		paths = append(paths, path)
+	}
+	slices.Sort(paths)
+	for _, path := range paths {
+		fields := lookupDumpFields(schema, strings.Split(path, "."), make(map[*dumpSchema]bool))
+		if len(fields) == 0 {
+			return fmt.Errorf("dump default rule for %s.%s does not match a declarative field", resourceType, path)
+		}
+		rule := rules[path]
+		for _, field := range fields {
+			switch rule.kind {
+			case dumpDefaultRuleExclusion:
+				if field.defaultValue == nil {
+					return fmt.Errorf("dump default exclusion for %s.%s does not match an SDK default", resourceType, path)
+				}
+				if field.defaultExclusions == nil {
+					field.defaultExclusions = make(map[ResourceType]bool)
+				}
+				field.defaultExclusions[resourceType] = true
+			case dumpDefaultRuleOverride:
+				value, err := dumpDefaultFromOverride(field.schema.typ, rule.value)
+				if err != nil {
+					return fmt.Errorf("dump default override for %s.%s: %w", resourceType, path, err)
+				}
+				if field.defaultOverrides == nil {
+					field.defaultOverrides = make(map[ResourceType]*dumpDefault)
+				}
+				field.defaultOverrides[resourceType] = value
+			}
+		}
+	}
+	return nil
+}
+
+func dumpDefaultFromOverride(typ reflect.Type, value any) (*dumpDefault, error) {
+	typ = derefDumpType(typ)
+	valueType := reflect.TypeOf(value)
+	if valueType == nil || !valueType.ConvertibleTo(typ) {
+		return nil, fmt.Errorf("value of type %T is not compatible with %s", value, typ)
+	}
+	converted := reflect.ValueOf(value).Convert(typ)
+	result := &dumpDefault{kind: typ.Kind(), source: dumpDefaultSourceOverride}
+	//exhaustive:ignore // Only scalar registration overrides are supported.
+	switch typ.Kind() {
+	case reflect.String:
+		result.value = converted.String()
+		result.typ = "string"
+	case reflect.Bool:
+		result.value = converted.Bool()
+		result.typ = "boolean"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		result.value = converted.Int()
+		result.typ = "integer"
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		result.value = converted.Uint()
+		result.typ = "integer"
+	case reflect.Float32, reflect.Float64:
+		result.value = converted.Float()
+		result.typ = "number"
+	default:
+		return nil, fmt.Errorf("unsupported override type %s", typ)
+	}
+	return result, nil
+}
+
+func lookupDumpFields(schema *dumpSchema, path []string, visiting map[*dumpSchema]bool) []*dumpField {
+	if schema == nil || len(path) == 0 || visiting[schema] {
+		return nil
+	}
+	visiting[schema] = true
+	defer delete(visiting, schema)
+
+	if schema.kind == reflect.Slice || schema.kind == reflect.Array {
+		return lookupDumpFields(schema.elem, path, visiting)
+	}
+	if field, ok := schema.fields[path[0]]; ok {
+		if len(path) == 1 {
+			return []*dumpField{field}
+		}
+		return lookupDumpFields(field.schema, path[1:], visiting)
+	}
+
+	var result []*dumpField
+	for _, inline := range schema.inline {
+		result = append(result, lookupDumpFields(inline, path, visiting)...)
+	}
+	for _, branch := range schema.union {
+		result = append(result, lookupDumpFields(branch.schema, path, visiting)...)
+	}
+	return result
+}
+
+func pruneDumpDefaults(node *yaml.Node, schema *dumpSchema, resourceType ResourceType, path []string) error {
+	if node == nil || schema == nil {
+		return nil
+	}
+	if schema.resourceType != "" {
+		resourceType = schema.resourceType
+		path = nil
+	}
+
+	//exhaustive:ignore // Only collection nodes can contain fields to prune.
+	switch node.Kind {
+	case yaml.SequenceNode:
+		for index, child := range node.Content {
+			if err := pruneDumpDefaults(child, schema.elem, resourceType, append(path, strconv.Itoa(index))); err != nil {
+				return err
+			}
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(node.Content); {
+			keyNode := node.Content[i]
+			valueNode := node.Content[i+1]
+			field, err := findDumpField(schema, node, keyNode.Value, path, make(map[*dumpSchema]bool))
+			if err != nil {
+				return fmt.Errorf("inspect defaults for %s: %w", resourceType, err)
+			}
+			if field == nil {
+				if schema.additional != nil {
+					if err := pruneDumpDefaults(
+						valueNode,
+						schema.additional,
+						resourceType,
+						append(path, keyNode.Value),
+					); err != nil {
+						return err
+					}
+				}
+				i += 2
+				continue
+			}
+			if err := pruneDumpDefaults(
+				valueNode,
+				field.schema,
+				resourceType,
+				append(path, keyNode.Value),
+			); err != nil {
+				return err
+			}
+			if defaultValue := field.effectiveDefault(resourceType); defaultValue != nil &&
+				dumpNodeEqualsDefault(valueNode, defaultValue) {
+				node.Content = append(node.Content[:i], node.Content[i+2:]...)
+				continue
+			}
+			i += 2
+		}
+	}
+	return nil
+}
+
+func (f *dumpField) effectiveDefault(resourceType ResourceType) *dumpDefault {
+	if f == nil || f.defaultExclusions[resourceType] {
+		return nil
+	}
+	if override := f.defaultOverrides[resourceType]; override != nil {
+		return override
+	}
+	return f.defaultValue
+}
+
+func selectDumpUnionBranch(node *yaml.Node, schema *dumpSchema, path []string) (*dumpSchema, error) {
+	if len(schema.union) == 0 {
+		return nil, nil
+	}
+	var matches []*dumpSchema
+	for _, branch := range schema.union {
+		if branch.discriminator == "" {
+			continue
+		}
+		value, ok := dumpMappingValue(node, branch.discriminator)
+		if ok && value.Value == branch.value {
+			matches = append(matches, branch.schema)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	if selected := selectDumpUnionWithUnmarshaller(node, schema); selected != nil {
+		return selected, nil
+	}
+	if !dumpSchemaHasDefaults(schema, make(map[*dumpSchema]bool)) {
+		return nil, nil
+	}
+	location := strings.Join(path, ".")
+	if location == "" {
+		location = "<root>"
+	}
+	return nil, fmt.Errorf("cannot determine default-bearing union branch at %s", location)
+}
+
+func selectDumpUnionWithUnmarshaller(node *yaml.Node, schema *dumpSchema) *dumpSchema {
+	instance := reflect.New(schema.typ)
+	unmarshaler, ok := instance.Interface().(json.Unmarshaler)
+	if !ok {
+		return nil
+	}
+
+	var value any
+	if err := node.Decode(&value); err != nil {
+		return nil
+	}
+	data, err := json.Marshal(value)
+	if err != nil || unmarshaler.UnmarshalJSON(data) != nil {
+		return nil
+	}
+
+	unionValue := instance.Elem()
+	for index := range unionValue.NumField() {
+		fieldType := schema.typ.Field(index)
+		fieldValue := unionValue.Field(index)
+		if fieldType.Tag.Get("union") != "member" || fieldValue.Kind() != reflect.Pointer || fieldValue.IsNil() {
+			continue
+		}
+		selectedType := derefDumpType(fieldType.Type)
+		for _, branch := range schema.union {
+			if branch.schema.typ == selectedType {
+				return branch.schema
+			}
+		}
+	}
+	return nil
+}
+
+func dumpMappingValue(node *yaml.Node, name string) (*yaml.Node, bool) {
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == name {
+			return node.Content[i+1], true
+		}
+	}
+	return nil, false
+}
+
+func findDumpField(
+	schema *dumpSchema,
+	node *yaml.Node,
+	name string,
+	path []string,
+	visiting map[*dumpSchema]bool,
+) (*dumpField, error) {
+	if schema == nil || visiting[schema] {
+		return nil, nil
+	}
+	visiting[schema] = true
+	defer delete(visiting, schema)
+
+	if field := schema.fields[name]; field != nil {
+		return field, nil
+	}
+	for _, inline := range schema.inline {
+		field, err := findDumpField(inline, node, name, path, visiting)
+		if err != nil || field != nil {
+			return field, err
+		}
+	}
+
+	selected, err := selectDumpUnionBranch(node, schema, path)
+	if err != nil {
+		return nil, err
+	}
+	if selected != nil {
+		return findDumpField(selected, node, name, path, visiting)
+	}
+
+	var candidates []*dumpField
+	for _, branch := range schema.union {
+		field, err := findDumpField(branch.schema, node, name, path, visiting)
+		if err != nil {
+			return nil, err
+		}
+		if field != nil {
+			candidates = append(candidates, field)
+		}
+	}
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+	first := candidates[0]
+	for _, candidate := range candidates[1:] {
+		if !sameDumpDefault(first.defaultValue, candidate.defaultValue) {
+			return nil, fmt.Errorf("ambiguous defaults for %s.%s", strings.Join(path, "."), name)
+		}
+	}
+	return first, nil
+}
+
+func sameDumpDefault(a, b *dumpDefault) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.kind == b.kind && reflect.DeepEqual(a.value, b.value)
+}
+
+func dumpNodeEqualsDefault(node *yaml.Node, defaultValue *dumpDefault) bool {
+	if node == nil || node.Kind != yaml.ScalarNode || node.Tag == "!!null" {
+		return false
+	}
+	//exhaustive:ignore // Default construction limits this to scalar kinds.
+	switch defaultValue.kind {
+	case reflect.String:
+		return node.Tag == "!!str" && node.Value == defaultValue.value.(string)
+	case reflect.Bool:
+		if node.Tag != "!!bool" {
+			return false
+		}
+		value, err := strconv.ParseBool(node.Value)
+		return err == nil && value == defaultValue.value.(bool)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		if node.Tag != "!!int" {
+			return false
+		}
+		value, err := strconv.ParseInt(node.Value, 10, 64)
+		return err == nil && value == defaultValue.value.(int64)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		if node.Tag != "!!int" {
+			return false
+		}
+		value, err := strconv.ParseUint(node.Value, 10, 64)
+		return err == nil && value == defaultValue.value.(uint64)
+	case reflect.Float32, reflect.Float64:
+		if node.Tag != "!!float" && node.Tag != "!!int" {
+			return false
+		}
+		value, err := strconv.ParseFloat(node.Value, 64)
+		return err == nil && value == defaultValue.value.(float64)
+	}
+	return false
+}
+
+func dumpSchemaHasDefaults(schema *dumpSchema, visiting map[*dumpSchema]bool) bool {
+	if schema == nil || visiting[schema] {
+		return false
+	}
+	visiting[schema] = true
+	defer delete(visiting, schema)
+	for _, field := range schema.fields {
+		if field.defaultValue != nil || dumpSchemaHasDefaults(field.schema, visiting) {
+			return true
+		}
+	}
+	for _, inline := range schema.inline {
+		if dumpSchemaHasDefaults(inline, visiting) {
+			return true
+		}
+	}
+	for _, branch := range schema.union {
+		if dumpSchemaHasDefaults(branch.schema, visiting) {
+			return true
+		}
+	}
+	return dumpSchemaHasDefaults(schema.elem, visiting) || dumpSchemaHasDefaults(schema.additional, visiting)
+}

--- a/internal/declarative/resources/dump_defaults_test.go
+++ b/internal/declarative/resources/dump_defaults_test.go
@@ -1,0 +1,457 @@
+package resources
+
+import (
+	"bytes"
+	"cmp"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v4"
+)
+
+const dumpDefaultInventorySchemaVersion = 1
+
+func TestOmitAPIDefaults(t *testing.T) {
+	input := []byte(`
+portals:
+  - ref: developer-portal
+    name: Developer Portal
+    authentication_enabled: true
+    rbac_enabled: true
+    sipr_enabled: false
+    teams:
+      - ref: developers
+        name: Developers
+        can_own_applications: false
+apis:
+  - ref: orders
+    name: Orders
+    publications:
+      - ref: orders-publication
+        portal_id: developer-portal
+        visibility: private
+application_auth_strategies:
+  - ref: key-auth
+    name: key-auth
+    display_name: API Key Authentication
+    strategy_type: key_auth
+    configs:
+      key-auth:
+        key_names:
+          - X-API-Key
+`)
+
+	actual, err := OmitAPIDefaults(input)
+	require.NoError(t, err)
+	require.Contains(t, string(actual), "portals:\n- ref: developer-portal")
+	require.NotContains(t, string(actual), "portals:\n    -")
+
+	var document map[string]any
+	require.NoError(t, yaml.Unmarshal(actual, &document))
+	portals := document["portals"].([]any)
+	portal := portals[0].(map[string]any)
+	require.NotContains(t, portal, "authentication_enabled")
+	require.Equal(t, true, portal["rbac_enabled"])
+	require.NotContains(t, portal, "sipr_enabled")
+	teams := portal["teams"].([]any)
+	require.NotContains(t, teams[0].(map[string]any), "can_own_applications")
+
+	apis := document["apis"].([]any)
+	publications := apis[0].(map[string]any)["publications"].([]any)
+	require.NotContains(t, publications[0].(map[string]any), "visibility")
+}
+
+func TestOmitAPIDefaultsPreservesNullAndUnknownFields(t *testing.T) {
+	input := []byte(`
+portals:
+  - ref: developer-portal
+    name: Developer Portal
+    authentication_enabled: null
+    future_api_field: false
+`)
+
+	actual, err := OmitAPIDefaults(input)
+	require.NoError(t, err)
+	require.Contains(t, string(actual), "authentication_enabled: null")
+	require.Contains(t, string(actual), "future_api_field: false")
+}
+
+func TestDumpNodeEqualsDefaultScalarTypes(t *testing.T) {
+	tests := []struct {
+		name         string
+		node         yaml.Node
+		defaultValue dumpDefault
+		want         bool
+	}{
+		{
+			name:         "bool scalar",
+			node:         yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "false"},
+			defaultValue: dumpDefault{kind: reflect.Bool, value: false},
+			want:         true,
+		},
+		{
+			name:         "boolean-looking string is not boolean",
+			node:         yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "false"},
+			defaultValue: dumpDefault{kind: reflect.Bool, value: false},
+		},
+		{
+			name:         "string enum",
+			node:         yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "private"},
+			defaultValue: dumpDefault{kind: reflect.String, value: "private"},
+			want:         true,
+		},
+		{
+			name:         "integer",
+			node:         yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: "-2"},
+			defaultValue: dumpDefault{kind: reflect.Int64, value: int64(-2)},
+			want:         true,
+		},
+		{
+			name:         "integer-looking float is not integer",
+			node:         yaml.Node{Kind: yaml.ScalarNode, Tag: "!!float", Value: "2.0"},
+			defaultValue: dumpDefault{kind: reflect.Int64, value: int64(2)},
+		},
+		{
+			name:         "unsigned integer",
+			node:         yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: "42"},
+			defaultValue: dumpDefault{kind: reflect.Uint32, value: uint64(42)},
+			want:         true,
+		},
+		{
+			name:         "floating point",
+			node:         yaml.Node{Kind: yaml.ScalarNode, Tag: "!!float", Value: "1.5"},
+			defaultValue: dumpDefault{kind: reflect.Float64, value: 1.5},
+			want:         true,
+		},
+		{
+			name:         "integer representation of floating point",
+			node:         yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: "2"},
+			defaultValue: dumpDefault{kind: reflect.Float64, value: 2.0},
+			want:         true,
+		},
+		{
+			name:         "explicit null",
+			node:         yaml.Node{Kind: yaml.ScalarNode, Tag: "!!null", Value: "null"},
+			defaultValue: dumpDefault{kind: reflect.Bool, value: false},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, dumpNodeEqualsDefault(&test.node, &test.defaultValue))
+		})
+	}
+}
+
+func TestOmitAPIDefaultsUnionHeavyFixtures(t *testing.T) {
+	tests := []struct {
+		name     string
+		fixture  string
+		validate func(*testing.T, map[string]any)
+	}{
+		{
+			name:    "AI Gateway model",
+			fixture: filepath.Join("ai-gateway", "model", "testdata", "config.yaml"),
+			validate: func(t *testing.T, document map[string]any) {
+				gateway := firstDumpFixtureResource(t, document, "ai_gateways")
+				model := firstDumpFixtureResource(t, gateway, "models")
+				require.NotContains(t, model, "enabled")
+				require.Equal(t, "model", model["type"])
+			},
+		},
+		{
+			name:    "AI Gateway policy branches",
+			fixture: filepath.Join("ai-gateway", "policy", "testdata", "config.yaml"),
+			validate: func(t *testing.T, document map[string]any) {
+				gateway := firstDumpFixtureResource(t, document, "ai_gateways")
+				policies, ok := gateway["policies"].([]any)
+				require.True(t, ok)
+				require.Len(t, policies, 2)
+				for _, value := range policies {
+					policy, ok := value.(map[string]any)
+					require.True(t, ok)
+					require.NotContains(t, policy, "enabled")
+					require.NotContains(t, policy, "global")
+				}
+			},
+		},
+		{
+			name:    "Event Gateway nested policies",
+			fixture: filepath.Join("event-gateway", "dump", "testdata", "config.yaml"),
+			validate: func(t *testing.T, document map[string]any) {
+				gateway := firstDumpFixtureResource(t, document, "event_gateways")
+				listener := firstDumpFixtureResource(t, gateway, "listeners")
+				listenerPolicy := firstDumpFixtureResource(t, listener, "policies")
+				require.NotContains(t, listenerPolicy, "enabled")
+
+				virtualCluster := firstDumpFixtureResource(t, gateway, "virtual_clusters")
+				consumePolicy := firstDumpFixtureResource(t, virtualCluster, "consume_policies")
+				require.NotContains(t, consumePolicy, "condition")
+				require.NotContains(t, consumePolicy, "description")
+				require.NotContains(t, consumePolicy, "enabled")
+
+				schemaRegistry := firstDumpFixtureResource(t, gateway, "schema_registries")
+				config, ok := schemaRegistry["config"].(map[string]any)
+				require.True(t, ok)
+				require.Equal(t, 30, config["timeout_seconds"])
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixturePath := filepath.Join("..", "..", "..", "test", "e2e", "scenarios", test.fixture)
+			input, err := os.ReadFile(fixturePath)
+			require.NoError(t, err)
+
+			actual, err := OmitAPIDefaults(input)
+			require.NoError(t, err)
+			var document map[string]any
+			require.NoError(t, yaml.Unmarshal(actual, &document))
+			test.validate(t, document)
+		})
+	}
+}
+
+func firstDumpFixtureResource(t *testing.T, parent map[string]any, field string) map[string]any {
+	t.Helper()
+	values, ok := parent[field].([]any)
+	require.True(t, ok, "%s is not a resource sequence", field)
+	require.NotEmpty(t, values, "%s is empty", field)
+	resource, ok := values[0].(map[string]any)
+	require.True(t, ok, "%s does not contain a resource object", field)
+	return resource
+}
+
+func TestDumpDefaultRulesAreResourceScoped(t *testing.T) {
+	builder := dumpSchemaBuilder{cache: make(map[reflect.Type]*dumpSchema)}
+	schema, err := builder.build(reflect.TypeFor[PortalResource]())
+	require.NoError(t, err)
+
+	err = applyDumpDefaultRules(ResourceTypePortal, schema, map[string]dumpDefaultRule{
+		"authentication_enabled": {
+			kind: dumpDefaultRuleExclusion,
+		},
+		"rbac_enabled": {
+			kind:  dumpDefaultRuleOverride,
+			value: true,
+		},
+	})
+	require.NoError(t, err)
+
+	authentication := lookupDumpFields(schema, []string{"authentication_enabled"}, make(map[*dumpSchema]bool))[0]
+	rbac := lookupDumpFields(schema, []string{"rbac_enabled"}, make(map[*dumpSchema]bool))[0]
+	require.Nil(t, authentication.effectiveDefault(ResourceTypePortal))
+	require.NotNil(t, authentication.effectiveDefault(ResourceTypeAPI))
+	require.Equal(t, true, rbac.effectiveDefault(ResourceTypePortal).value)
+	require.Equal(t, false, rbac.effectiveDefault(ResourceTypeAPI).value)
+}
+
+func TestDumpDefaultRulesAffectEmittedYAML(t *testing.T) {
+	builder := dumpSchemaBuilder{cache: make(map[reflect.Type]*dumpSchema)}
+	schema, err := builder.build(reflect.TypeFor[PortalResource]())
+	require.NoError(t, err)
+	schema.resourceType = ResourceTypePortal
+	require.NoError(t, applyDumpDefaultRules(ResourceTypePortal, schema, map[string]dumpDefaultRule{
+		"authentication_enabled": {kind: dumpDefaultRuleExclusion},
+		"rbac_enabled":           {kind: dumpDefaultRuleOverride, value: true},
+	}))
+
+	var document yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(`
+ref: portal
+name: Portal
+authentication_enabled: true
+rbac_enabled: true
+auto_approve_developers: false
+`), &document))
+	require.NoError(t, pruneDumpDefaults(document.Content[0], schema, "", nil))
+
+	var output map[string]any
+	require.NoError(t, document.Content[0].Decode(&output))
+	require.Equal(t, true, output["authentication_enabled"], "exclusion must preserve the SDK default")
+	require.NotContains(t, output, "rbac_enabled", "override must replace the SDK default used for omission")
+	require.NotContains(t, output, "auto_approve_developers", "unmodified SDK defaults must still be omitted")
+}
+
+func TestDumpDefaultRulesRejectDuplicatePaths(t *testing.T) {
+	ops := &resourceOps{}
+	require.NoError(t, WithDumpDefaultOverride("enabled", true, "API documentation")(ops))
+	require.Error(t, WithDumpDefaultExclusion("enabled", "unsafe to omit")(ops))
+}
+
+func TestDumpDefaultInventory(t *testing.T) {
+	actual, err := renderDumpDefaultInventory(t)
+	require.NoError(t, err)
+
+	goldenPath := filepath.Join("testdata", "dump_defaults_inventory.yaml")
+	if os.Getenv("UPDATE_GOLDEN") == "1" {
+		require.NoError(t, os.WriteFile(goldenPath, actual, 0o600))
+	}
+	expected, err := os.ReadFile(goldenPath)
+	require.NoError(t, err, "run UPDATE_GOLDEN=1 go test ./internal/declarative/resources -run TestDumpDefaultInventory")
+	require.Equal(t, string(expected), string(actual),
+		"SDK defaults changed; review the diff, update rules if needed, then regenerate the golden inventory")
+}
+
+type dumpDefaultInventory struct {
+	SDKVersion    string                         `yaml:"sdk_version"`
+	SchemaVersion int                            `yaml:"schema_version"`
+	Resources     []dumpDefaultInventoryResource `yaml:"resources"`
+}
+
+type dumpDefaultInventoryResource struct {
+	ResourceType ResourceType                `yaml:"resource_type"`
+	Defaults     []dumpDefaultInventoryEntry `yaml:"defaults"`
+	Overrides    []dumpDefaultInventoryRule  `yaml:"overrides"`
+	Exclusions   []dumpDefaultInventoryRule  `yaml:"exclusions"`
+}
+
+type dumpDefaultInventoryEntry struct {
+	Path   string            `yaml:"path"`
+	Type   string            `yaml:"type"`
+	Value  any               `yaml:"value"`
+	Source dumpDefaultSource `yaml:"source"`
+}
+
+type dumpDefaultInventoryRule struct {
+	Path   string `yaml:"path"`
+	Reason string `yaml:"reason"`
+}
+
+func renderDumpDefaultInventory(t *testing.T) ([]byte, error) {
+	t.Helper()
+	root, err := buildDumpDefaultSchema()
+	if err != nil {
+		return nil, err
+	}
+
+	inventory := dumpDefaultInventory{
+		SDKVersion:    sdkVersionFromGoMod(t),
+		SchemaVersion: dumpDefaultInventorySchemaVersion,
+	}
+	types := RegisteredTypes()
+	slices.Sort(types)
+	for _, resourceType := range types {
+		schema := dumpSchemaForResource(root, resourceType, make(map[*dumpSchema]bool))
+		resource := dumpDefaultInventoryResource{ResourceType: resourceType}
+		if schema != nil {
+			collectDumpDefaultInventory(schema, resourceType, nil, &resource.Defaults, make(map[*dumpSchema]bool))
+		}
+		slices.SortFunc(resource.Defaults, func(a, b dumpDefaultInventoryEntry) int {
+			if pathCmp := cmp.Compare(a.Path, b.Path); pathCmp != 0 {
+				return pathCmp
+			}
+			return cmp.Compare(fmt.Sprint(a.Value), fmt.Sprint(b.Value))
+		})
+		resource.Defaults = slices.CompactFunc(resource.Defaults, func(a, b dumpDefaultInventoryEntry) bool {
+			return a.Path == b.Path && a.Type == b.Type && reflect.DeepEqual(a.Value, b.Value) && a.Source == b.Source
+		})
+		for path, rule := range registry[resourceType].dumpDefaultRules {
+			entry := dumpDefaultInventoryRule{Path: path, Reason: rule.reason}
+			if rule.kind == dumpDefaultRuleExclusion {
+				resource.Exclusions = append(resource.Exclusions, entry)
+			} else {
+				resource.Overrides = append(resource.Overrides, entry)
+			}
+		}
+		slices.SortFunc(resource.Overrides, func(a, b dumpDefaultInventoryRule) int { return cmp.Compare(a.Path, b.Path) })
+		slices.SortFunc(resource.Exclusions, func(a, b dumpDefaultInventoryRule) int { return cmp.Compare(a.Path, b.Path) })
+		inventory.Resources = append(inventory.Resources, resource)
+	}
+
+	var output bytes.Buffer
+	encoder := yaml.NewEncoder(&output)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(inventory); err != nil {
+		return nil, err
+	}
+	return output.Bytes(), nil
+}
+
+func sdkVersionFromGoMod(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "..", "..", "go.mod"))
+	require.NoError(t, err)
+	for line := range strings.Lines(string(data)) {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[0] == "github.com/Kong/sdk-konnect-go" {
+			return fields[1]
+		}
+	}
+	t.Fatal("github.com/Kong/sdk-konnect-go is not declared in go.mod")
+	return ""
+}
+
+func dumpSchemaForResource(schema *dumpSchema, resourceType ResourceType, visiting map[*dumpSchema]bool) *dumpSchema {
+	if schema == nil || visiting[schema] {
+		return nil
+	}
+	if schema.resourceType == resourceType {
+		return schema
+	}
+	visiting[schema] = true
+	defer delete(visiting, schema)
+	for _, field := range schema.fields {
+		if found := dumpSchemaForResource(field.schema, resourceType, visiting); found != nil {
+			return found
+		}
+	}
+	for _, inline := range schema.inline {
+		if found := dumpSchemaForResource(inline, resourceType, visiting); found != nil {
+			return found
+		}
+	}
+	for _, branch := range schema.union {
+		if found := dumpSchemaForResource(branch.schema, resourceType, visiting); found != nil {
+			return found
+		}
+	}
+	if found := dumpSchemaForResource(schema.elem, resourceType, visiting); found != nil {
+		return found
+	}
+	return dumpSchemaForResource(schema.additional, resourceType, visiting)
+}
+
+func collectDumpDefaultInventory(
+	schema *dumpSchema,
+	resourceType ResourceType,
+	path []string,
+	entries *[]dumpDefaultInventoryEntry,
+	visiting map[*dumpSchema]bool,
+) {
+	if schema == nil || visiting[schema] {
+		return
+	}
+	if schema.resourceType != "" {
+		resourceType = schema.resourceType
+	}
+	visiting[schema] = true
+	defer delete(visiting, schema)
+	for name, field := range schema.fields {
+		fieldPath := append(path, name)
+		if defaultValue := field.effectiveDefault(resourceType); defaultValue != nil {
+			*entries = append(*entries, dumpDefaultInventoryEntry{
+				Path:   strings.Join(fieldPath, "."),
+				Type:   defaultValue.typ,
+				Value:  defaultValue.value,
+				Source: defaultValue.source,
+			})
+		}
+		collectDumpDefaultInventory(field.schema, resourceType, fieldPath, entries, visiting)
+	}
+	for _, inline := range schema.inline {
+		collectDumpDefaultInventory(inline, resourceType, path, entries, visiting)
+	}
+	for _, branch := range schema.union {
+		collectDumpDefaultInventory(branch.schema, resourceType, path, entries, visiting)
+	}
+	collectDumpDefaultInventory(schema.elem, resourceType, path, entries, visiting)
+	collectDumpDefaultInventory(schema.additional, resourceType, path, entries, visiting)
+}

--- a/internal/declarative/resources/registry.go
+++ b/internal/declarative/resources/registry.go
@@ -18,6 +18,7 @@ type resourceOps struct {
 	forEach           func(rs *ResourceSet, fn func(Resource) bool) bool
 	count             func(rs *ResourceSet) int
 	explain           ExplainRegistration
+	dumpDefaultRules  map[string]dumpDefaultRule
 	maturity          *maturity.Metadata
 	operationMaturity map[Operation]maturity.Metadata
 	external          *ExternalResolutionRegistration

--- a/internal/declarative/resources/testdata/dump_defaults_inventory.yaml
+++ b/internal/declarative/resources/testdata/dump_defaults_inventory.yaml
@@ -1,0 +1,1739 @@
+sdk_version: v0.51.2-0.20260803181245-b21f2210627b
+schema_version: 1
+resources:
+  - resource_type: ai_gateway
+    defaults:
+      - path: agents.config.logging.max_payload_size
+        type: integer
+        value: 1048576
+        source: sdk
+      - path: agents.config.logging.payloads
+        type: boolean
+        value: false
+        source: sdk
+      - path: agents.config.max_request_body_size
+        type: integer
+        value: 8388608
+        source: sdk
+      - path: agents.config.route.https_redirect_status_code
+        type: integer
+        value: 426
+        source: sdk
+      - path: agents.config.route.preserve_host
+        type: boolean
+        value: false
+        source: sdk
+      - path: agents.config.route.regex_priority
+        type: integer
+        value: 0
+        source: sdk
+      - path: agents.config.route.request_buffering
+        type: boolean
+        value: true
+        source: sdk
+      - path: agents.config.route.response_buffering
+        type: boolean
+        value: true
+        source: sdk
+      - path: agents.config.route.strip_path
+        type: boolean
+        value: true
+        source: sdk
+      - path: agents.enabled
+        type: boolean
+        value: true
+        source: sdk
+      - path: consumers.credentials.ttl
+        type: integer
+        value: 0
+        source: sdk
+      - path: mcp_servers.access.acl_attribute_type
+        type: string
+        value: consumer
+        source: sdk
+      - path: mcp_servers.config.logging.audits
+        type: boolean
+        value: false
+        source: sdk
+      - path: mcp_servers.config.logging.payloads
+        type: boolean
+        value: false
+        source: sdk
+      - path: mcp_servers.config.max_request_body_size
+        type: integer
+        value: 8388608
+        source: sdk
+      - path: mcp_servers.config.proxy.proxy_scheme
+        type: string
+        value: http
+        source: sdk
+      - path: mcp_servers.config.route.https_redirect_status_code
+        type: integer
+        value: 426
+        source: sdk
+      - path: mcp_servers.config.route.preserve_host
+        type: boolean
+        value: false
+        source: sdk
+      - path: mcp_servers.config.route.regex_priority
+        type: integer
+        value: 0
+        source: sdk
+      - path: mcp_servers.config.route.request_buffering
+        type: boolean
+        value: true
+        source: sdk
+      - path: mcp_servers.config.route.response_buffering
+        type: boolean
+        value: true
+        source: sdk
+      - path: mcp_servers.config.route.strip_path
+        type: boolean
+        value: true
+        source: sdk
+      - path: mcp_servers.config.server.forward_client_headers
+        type: boolean
+        value: true
+        source: sdk
+      - path: mcp_servers.config.server.preserve_upstream_tool_names
+        type: boolean
+        value: false
+        source: sdk
+      - path: mcp_servers.config.server.session.managed
+        type: boolean
+        value: true
+        source: sdk
+      - path: mcp_servers.config.server.session.redis.cloud_authentication.is_serverless
+        type: boolean
+        value: true
+        source: sdk
+      - path: mcp_servers.config.server.session.redis.cluster.max_redirections
+        type: integer
+        value: 5
+        source: sdk
+      - path: mcp_servers.config.server.session.redis.cluster.nodes.ip
+        type: string
+        value: 127.0.0.1
+        source: sdk
+      - path: mcp_servers.config.server.session.redis.cluster.nodes.port
+        type: integer
+        value: 6379
+        source: sdk
+      - path: mcp_servers.config.server.session.redis.connect_timeout
+        type: integer
+        value: 2000
+        source: sdk
+      - path: mcp_servers.config.server.session.redis.connection_is_proxied
+        type: boolean
+        value: false
+        source: sdk
+      - path: mcp_servers.config.server.session.redis.database
+        type: integer
+        value: 0
+        source: sdk
+      - path: mcp_servers.config.server.session.redis.host
+        type: string
+        value: 127.0.0.1
+        source: sdk
+      - path: mcp_servers.config.server.session.redis.keepalive.pool_size
+        type: integer
+        value: 256
+        source: sdk
+      - path: mcp_servers.config.server.session.redis.read_timeout
+        type: integer
+        value: 2000
+        source: sdk
+      - path: mcp_servers.config.server.session.redis.send_timeout
+        type: integer
+        value: 2000
+        source: sdk
+      - path: mcp_servers.config.server.session.redis.sentinel.nodes.host
+        type: string
+        value: 127.0.0.1
+        source: sdk
+      - path: mcp_servers.config.server.session.redis.sentinel.nodes.port
+        type: integer
+        value: 6379
+        source: sdk
+      - path: mcp_servers.config.server.session.redis.ssl
+        type: boolean
+        value: true
+        source: sdk
+      - path: mcp_servers.config.server.session.redis.ssl_verify
+        type: boolean
+        value: true
+        source: sdk
+      - path: mcp_servers.config.server.session.session_ttl
+        type: integer
+        value: 86400
+        source: sdk
+      - path: mcp_servers.config.server.timeout
+        type: integer
+        value: 10000
+        source: sdk
+      - path: mcp_servers.config.server.tools_list_auth.access_token_header
+        type: string
+        value: Authorization
+        source: sdk
+      - path: mcp_servers.enabled
+        type: boolean
+        value: true
+        source: sdk
+      - path: models.config.balancer.connect_timeout
+        type: integer
+        value: 60000
+        source: sdk
+      - path: models.config.balancer.embeddings.allow_auth_override
+        type: boolean
+        value: false
+        source: sdk
+      - path: models.config.balancer.embeddings.config.api_version
+        type: string
+        value: "2023-05-15"
+        source: sdk
+      - path: models.config.balancer.embeddings.config.embeddings_normalize
+        type: boolean
+        value: false
+        source: sdk
+      - path: models.config.balancer.embeddings.config.use_cache
+        type: boolean
+        value: false
+        source: sdk
+      - path: models.config.balancer.embeddings.config.wait_for_model
+        type: boolean
+        value: false
+        source: sdk
+      - path: models.config.balancer.fail_timeout
+        type: integer
+        value: 10000
+        source: sdk
+      - path: models.config.balancer.hash_on_header
+        type: string
+        value: X-Kong-LLM-Request-ID
+        source: sdk
+      - path: models.config.balancer.latency_strategy
+        type: string
+        value: tpot
+        source: sdk
+      - path: models.config.balancer.max_fails
+        type: integer
+        value: 0
+        source: sdk
+      - path: models.config.balancer.read_timeout
+        type: integer
+        value: 60000
+        source: sdk
+      - path: models.config.balancer.retries
+        type: integer
+        value: 5
+        source: sdk
+      - path: models.config.balancer.slots
+        type: integer
+        value: 10000
+        source: sdk
+      - path: models.config.balancer.tokens_count_strategy
+        type: string
+        value: total-tokens
+        source: sdk
+      - path: models.config.balancer.vectordb.cloud_authentication.is_serverless
+        type: boolean
+        value: true
+        source: sdk
+      - path: models.config.balancer.vectordb.cluster.max_redirections
+        type: integer
+        value: 5
+        source: sdk
+      - path: models.config.balancer.vectordb.cluster.nodes.ip
+        type: string
+        value: 127.0.0.1
+        source: sdk
+      - path: models.config.balancer.vectordb.cluster.nodes.port
+        type: integer
+        value: 6379
+        source: sdk
+      - path: models.config.balancer.vectordb.connect_timeout
+        type: integer
+        value: 2000
+        source: sdk
+      - path: models.config.balancer.vectordb.connection_is_proxied
+        type: boolean
+        value: false
+        source: sdk
+      - path: models.config.balancer.vectordb.database
+        type: integer
+        value: 0
+        source: sdk
+      - path: models.config.balancer.vectordb.database
+        type: string
+        value: kong-pgvector
+        source: sdk
+      - path: models.config.balancer.vectordb.host
+        type: string
+        value: 127.0.0.1
+        source: sdk
+      - path: models.config.balancer.vectordb.keepalive.pool_size
+        type: integer
+        value: 256
+        source: sdk
+      - path: models.config.balancer.vectordb.port
+        type: integer
+        value: 5432
+        source: sdk
+      - path: models.config.balancer.vectordb.read_timeout
+        type: integer
+        value: 2000
+        source: sdk
+      - path: models.config.balancer.vectordb.send_timeout
+        type: integer
+        value: 2000
+        source: sdk
+      - path: models.config.balancer.vectordb.sentinel.nodes.host
+        type: string
+        value: 127.0.0.1
+        source: sdk
+      - path: models.config.balancer.vectordb.sentinel.nodes.port
+        type: integer
+        value: 6379
+        source: sdk
+      - path: models.config.balancer.vectordb.ssl
+        type: boolean
+        value: true
+        source: sdk
+      - path: models.config.balancer.vectordb.ssl.enabled
+        type: boolean
+        value: true
+        source: sdk
+      - path: models.config.balancer.vectordb.ssl.required
+        type: boolean
+        value: true
+        source: sdk
+      - path: models.config.balancer.vectordb.ssl.verify
+        type: boolean
+        value: true
+        source: sdk
+      - path: models.config.balancer.vectordb.ssl.version
+        type: string
+        value: tlsv1_2
+        source: sdk
+      - path: models.config.balancer.vectordb.ssl_verify
+        type: boolean
+        value: true
+        source: sdk
+      - path: models.config.balancer.vectordb.timeout
+        type: number
+        value: 5000
+        source: sdk
+      - path: models.config.balancer.vectordb.user
+        type: string
+        value: postgres
+        source: sdk
+      - path: models.config.balancer.write_timeout
+        type: integer
+        value: 60000
+        source: sdk
+      - path: models.config.logging.payloads
+        type: boolean
+        value: false
+        source: sdk
+      - path: models.config.max_request_body_size
+        type: integer
+        value: 8388608
+        source: sdk
+      - path: models.config.model.name_header
+        type: boolean
+        value: true
+        source: sdk
+      - path: models.config.proxy.proxy_scheme
+        type: string
+        value: http
+        source: sdk
+      - path: models.config.response_streaming
+        type: string
+        value: allow
+        source: sdk
+      - path: models.config.route.https_redirect_status_code
+        type: integer
+        value: 426
+        source: sdk
+      - path: models.config.route.preserve_host
+        type: boolean
+        value: false
+        source: sdk
+      - path: models.config.route.regex_priority
+        type: integer
+        value: 0
+        source: sdk
+      - path: models.config.route.request_buffering
+        type: boolean
+        value: true
+        source: sdk
+      - path: models.config.route.response_buffering
+        type: boolean
+        value: true
+        source: sdk
+      - path: models.config.route.strip_path
+        type: boolean
+        value: true
+        source: sdk
+      - path: models.enabled
+        type: boolean
+        value: true
+        source: sdk
+      - path: models.targets.allow_auth_override
+        type: boolean
+        value: false
+        source: sdk
+      - path: models.targets.config.api_version
+        type: string
+        value: "2023-05-15"
+        source: sdk
+      - path: models.targets.config.api_version
+        type: string
+        value: v2
+        source: sdk
+      - path: models.targets.config.embedding_input_type
+        type: string
+        value: classification
+        source: sdk
+      - path: models.targets.config.embeddings_normalize
+        type: boolean
+        value: false
+        source: sdk
+      - path: models.targets.config.international
+        type: boolean
+        value: true
+        source: sdk
+      - path: models.targets.config.use_cache
+        type: boolean
+        value: false
+        source: sdk
+      - path: models.targets.config.version
+        type: string
+        value: "2023-06-01"
+        source: sdk
+      - path: models.targets.config.wait_for_model
+        type: boolean
+        value: false
+        source: sdk
+      - path: models.targets.weight
+        type: integer
+        value: 100
+        source: sdk
+      - path: policies.enabled
+        type: boolean
+        value: true
+        source: sdk
+      - path: policies.global
+        type: boolean
+        value: false
+        source: sdk
+      - path: vaults.config.api_token_file
+        type: string
+        value: /run/secrets/kubernetes.io/serviceaccount/token
+        source: sdk
+      - path: vaults.config.credentials_prefix
+        type: string
+        value: AZURE
+        source: sdk
+      - path: vaults.config.kv
+        type: string
+        value: v1
+        source: sdk
+      - path: vaults.config.login_path
+        type: string
+        value: /v1/auth/aws/login
+        source: sdk
+      - path: vaults.config.login_path
+        type: string
+        value: /v1/auth/azure/login
+        source: sdk
+      - path: vaults.config.login_path
+        type: string
+        value: /v1/auth/gcp/login
+        source: sdk
+      - path: vaults.config.mount
+        type: string
+        value: secret
+        source: sdk
+      - path: vaults.config.neg_ttl
+        type: integer
+        value: 0
+        source: sdk
+      - path: vaults.config.path
+        type: string
+        value: approle
+        source: sdk
+      - path: vaults.config.path
+        type: string
+        value: kubernetes
+        source: sdk
+      - path: vaults.config.protocol
+        type: string
+        value: https
+        source: sdk
+      - path: vaults.config.response_wrapping
+        type: boolean
+        value: false
+        source: sdk
+      - path: vaults.config.resurrect_ttl
+        type: integer
+        value: 100000000
+        source: sdk
+      - path: vaults.config.role_session_name
+        type: string
+        value: KongVault
+        source: sdk
+      - path: vaults.config.ssl_verify
+        type: boolean
+        value: true
+        source: sdk
+      - path: vaults.config.ttl
+        type: integer
+        value: 0
+        source: sdk
+      - path: vaults.config.type
+        type: string
+        value: secrets
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: ai_gateway_agent
+    defaults:
+      - path: config.logging.max_payload_size
+        type: integer
+        value: 1048576
+        source: sdk
+      - path: config.logging.payloads
+        type: boolean
+        value: false
+        source: sdk
+      - path: config.max_request_body_size
+        type: integer
+        value: 8388608
+        source: sdk
+      - path: config.route.https_redirect_status_code
+        type: integer
+        value: 426
+        source: sdk
+      - path: config.route.preserve_host
+        type: boolean
+        value: false
+        source: sdk
+      - path: config.route.regex_priority
+        type: integer
+        value: 0
+        source: sdk
+      - path: config.route.request_buffering
+        type: boolean
+        value: true
+        source: sdk
+      - path: config.route.response_buffering
+        type: boolean
+        value: true
+        source: sdk
+      - path: config.route.strip_path
+        type: boolean
+        value: true
+        source: sdk
+      - path: enabled
+        type: boolean
+        value: true
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: ai_gateway_config_store
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: ai_gateway_consumer
+    defaults:
+      - path: credentials.ttl
+        type: integer
+        value: 0
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: ai_gateway_consumer_credential
+    defaults:
+      - path: ttl
+        type: integer
+        value: 0
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: ai_gateway_consumer_group
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: ai_gateway_data_plane_certificate
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: ai_gateway_identity_provider
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: ai_gateway_mcp_server
+    defaults:
+      - path: access.acl_attribute_type
+        type: string
+        value: consumer
+        source: sdk
+      - path: config.logging.audits
+        type: boolean
+        value: false
+        source: sdk
+      - path: config.logging.payloads
+        type: boolean
+        value: false
+        source: sdk
+      - path: config.max_request_body_size
+        type: integer
+        value: 8388608
+        source: sdk
+      - path: config.proxy.proxy_scheme
+        type: string
+        value: http
+        source: sdk
+      - path: config.route.https_redirect_status_code
+        type: integer
+        value: 426
+        source: sdk
+      - path: config.route.preserve_host
+        type: boolean
+        value: false
+        source: sdk
+      - path: config.route.regex_priority
+        type: integer
+        value: 0
+        source: sdk
+      - path: config.route.request_buffering
+        type: boolean
+        value: true
+        source: sdk
+      - path: config.route.response_buffering
+        type: boolean
+        value: true
+        source: sdk
+      - path: config.route.strip_path
+        type: boolean
+        value: true
+        source: sdk
+      - path: config.server.forward_client_headers
+        type: boolean
+        value: true
+        source: sdk
+      - path: config.server.preserve_upstream_tool_names
+        type: boolean
+        value: false
+        source: sdk
+      - path: config.server.session.managed
+        type: boolean
+        value: true
+        source: sdk
+      - path: config.server.session.redis.cloud_authentication.is_serverless
+        type: boolean
+        value: true
+        source: sdk
+      - path: config.server.session.redis.cluster.max_redirections
+        type: integer
+        value: 5
+        source: sdk
+      - path: config.server.session.redis.cluster.nodes.ip
+        type: string
+        value: 127.0.0.1
+        source: sdk
+      - path: config.server.session.redis.cluster.nodes.port
+        type: integer
+        value: 6379
+        source: sdk
+      - path: config.server.session.redis.connect_timeout
+        type: integer
+        value: 2000
+        source: sdk
+      - path: config.server.session.redis.connection_is_proxied
+        type: boolean
+        value: false
+        source: sdk
+      - path: config.server.session.redis.database
+        type: integer
+        value: 0
+        source: sdk
+      - path: config.server.session.redis.host
+        type: string
+        value: 127.0.0.1
+        source: sdk
+      - path: config.server.session.redis.keepalive.pool_size
+        type: integer
+        value: 256
+        source: sdk
+      - path: config.server.session.redis.read_timeout
+        type: integer
+        value: 2000
+        source: sdk
+      - path: config.server.session.redis.send_timeout
+        type: integer
+        value: 2000
+        source: sdk
+      - path: config.server.session.redis.sentinel.nodes.host
+        type: string
+        value: 127.0.0.1
+        source: sdk
+      - path: config.server.session.redis.sentinel.nodes.port
+        type: integer
+        value: 6379
+        source: sdk
+      - path: config.server.session.redis.ssl
+        type: boolean
+        value: true
+        source: sdk
+      - path: config.server.session.redis.ssl_verify
+        type: boolean
+        value: true
+        source: sdk
+      - path: config.server.session.session_ttl
+        type: integer
+        value: 86400
+        source: sdk
+      - path: config.server.timeout
+        type: integer
+        value: 10000
+        source: sdk
+      - path: config.server.tools_list_auth.access_token_header
+        type: string
+        value: Authorization
+        source: sdk
+      - path: enabled
+        type: boolean
+        value: true
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: ai_gateway_model
+    defaults:
+      - path: config.balancer.connect_timeout
+        type: integer
+        value: 60000
+        source: sdk
+      - path: config.balancer.embeddings.allow_auth_override
+        type: boolean
+        value: false
+        source: sdk
+      - path: config.balancer.embeddings.config.api_version
+        type: string
+        value: "2023-05-15"
+        source: sdk
+      - path: config.balancer.embeddings.config.embeddings_normalize
+        type: boolean
+        value: false
+        source: sdk
+      - path: config.balancer.embeddings.config.use_cache
+        type: boolean
+        value: false
+        source: sdk
+      - path: config.balancer.embeddings.config.wait_for_model
+        type: boolean
+        value: false
+        source: sdk
+      - path: config.balancer.fail_timeout
+        type: integer
+        value: 10000
+        source: sdk
+      - path: config.balancer.hash_on_header
+        type: string
+        value: X-Kong-LLM-Request-ID
+        source: sdk
+      - path: config.balancer.latency_strategy
+        type: string
+        value: tpot
+        source: sdk
+      - path: config.balancer.max_fails
+        type: integer
+        value: 0
+        source: sdk
+      - path: config.balancer.read_timeout
+        type: integer
+        value: 60000
+        source: sdk
+      - path: config.balancer.retries
+        type: integer
+        value: 5
+        source: sdk
+      - path: config.balancer.slots
+        type: integer
+        value: 10000
+        source: sdk
+      - path: config.balancer.tokens_count_strategy
+        type: string
+        value: total-tokens
+        source: sdk
+      - path: config.balancer.vectordb.cloud_authentication.is_serverless
+        type: boolean
+        value: true
+        source: sdk
+      - path: config.balancer.vectordb.cluster.max_redirections
+        type: integer
+        value: 5
+        source: sdk
+      - path: config.balancer.vectordb.cluster.nodes.ip
+        type: string
+        value: 127.0.0.1
+        source: sdk
+      - path: config.balancer.vectordb.cluster.nodes.port
+        type: integer
+        value: 6379
+        source: sdk
+      - path: config.balancer.vectordb.connect_timeout
+        type: integer
+        value: 2000
+        source: sdk
+      - path: config.balancer.vectordb.connection_is_proxied
+        type: boolean
+        value: false
+        source: sdk
+      - path: config.balancer.vectordb.database
+        type: integer
+        value: 0
+        source: sdk
+      - path: config.balancer.vectordb.database
+        type: string
+        value: kong-pgvector
+        source: sdk
+      - path: config.balancer.vectordb.host
+        type: string
+        value: 127.0.0.1
+        source: sdk
+      - path: config.balancer.vectordb.keepalive.pool_size
+        type: integer
+        value: 256
+        source: sdk
+      - path: config.balancer.vectordb.port
+        type: integer
+        value: 5432
+        source: sdk
+      - path: config.balancer.vectordb.read_timeout
+        type: integer
+        value: 2000
+        source: sdk
+      - path: config.balancer.vectordb.send_timeout
+        type: integer
+        value: 2000
+        source: sdk
+      - path: config.balancer.vectordb.sentinel.nodes.host
+        type: string
+        value: 127.0.0.1
+        source: sdk
+      - path: config.balancer.vectordb.sentinel.nodes.port
+        type: integer
+        value: 6379
+        source: sdk
+      - path: config.balancer.vectordb.ssl
+        type: boolean
+        value: true
+        source: sdk
+      - path: config.balancer.vectordb.ssl.enabled
+        type: boolean
+        value: true
+        source: sdk
+      - path: config.balancer.vectordb.ssl.required
+        type: boolean
+        value: true
+        source: sdk
+      - path: config.balancer.vectordb.ssl.verify
+        type: boolean
+        value: true
+        source: sdk
+      - path: config.balancer.vectordb.ssl.version
+        type: string
+        value: tlsv1_2
+        source: sdk
+      - path: config.balancer.vectordb.ssl_verify
+        type: boolean
+        value: true
+        source: sdk
+      - path: config.balancer.vectordb.timeout
+        type: number
+        value: 5000
+        source: sdk
+      - path: config.balancer.vectordb.user
+        type: string
+        value: postgres
+        source: sdk
+      - path: config.balancer.write_timeout
+        type: integer
+        value: 60000
+        source: sdk
+      - path: config.logging.payloads
+        type: boolean
+        value: false
+        source: sdk
+      - path: config.max_request_body_size
+        type: integer
+        value: 8388608
+        source: sdk
+      - path: config.model.name_header
+        type: boolean
+        value: true
+        source: sdk
+      - path: config.proxy.proxy_scheme
+        type: string
+        value: http
+        source: sdk
+      - path: config.response_streaming
+        type: string
+        value: allow
+        source: sdk
+      - path: config.route.https_redirect_status_code
+        type: integer
+        value: 426
+        source: sdk
+      - path: config.route.preserve_host
+        type: boolean
+        value: false
+        source: sdk
+      - path: config.route.regex_priority
+        type: integer
+        value: 0
+        source: sdk
+      - path: config.route.request_buffering
+        type: boolean
+        value: true
+        source: sdk
+      - path: config.route.response_buffering
+        type: boolean
+        value: true
+        source: sdk
+      - path: config.route.strip_path
+        type: boolean
+        value: true
+        source: sdk
+      - path: enabled
+        type: boolean
+        value: true
+        source: sdk
+      - path: targets.allow_auth_override
+        type: boolean
+        value: false
+        source: sdk
+      - path: targets.config.api_version
+        type: string
+        value: "2023-05-15"
+        source: sdk
+      - path: targets.config.api_version
+        type: string
+        value: v2
+        source: sdk
+      - path: targets.config.embedding_input_type
+        type: string
+        value: classification
+        source: sdk
+      - path: targets.config.embeddings_normalize
+        type: boolean
+        value: false
+        source: sdk
+      - path: targets.config.international
+        type: boolean
+        value: true
+        source: sdk
+      - path: targets.config.use_cache
+        type: boolean
+        value: false
+        source: sdk
+      - path: targets.config.version
+        type: string
+        value: "2023-06-01"
+        source: sdk
+      - path: targets.config.wait_for_model
+        type: boolean
+        value: false
+        source: sdk
+      - path: targets.weight
+        type: integer
+        value: 100
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: ai_gateway_model_provider
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: ai_gateway_policy
+    defaults:
+      - path: enabled
+        type: boolean
+        value: true
+        source: sdk
+      - path: global
+        type: boolean
+        value: false
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: ai_gateway_vault
+    defaults:
+      - path: config.api_token_file
+        type: string
+        value: /run/secrets/kubernetes.io/serviceaccount/token
+        source: sdk
+      - path: config.credentials_prefix
+        type: string
+        value: AZURE
+        source: sdk
+      - path: config.kv
+        type: string
+        value: v1
+        source: sdk
+      - path: config.login_path
+        type: string
+        value: /v1/auth/aws/login
+        source: sdk
+      - path: config.login_path
+        type: string
+        value: /v1/auth/azure/login
+        source: sdk
+      - path: config.login_path
+        type: string
+        value: /v1/auth/gcp/login
+        source: sdk
+      - path: config.mount
+        type: string
+        value: secret
+        source: sdk
+      - path: config.neg_ttl
+        type: integer
+        value: 0
+        source: sdk
+      - path: config.path
+        type: string
+        value: approle
+        source: sdk
+      - path: config.path
+        type: string
+        value: kubernetes
+        source: sdk
+      - path: config.protocol
+        type: string
+        value: https
+        source: sdk
+      - path: config.response_wrapping
+        type: boolean
+        value: false
+        source: sdk
+      - path: config.resurrect_ttl
+        type: integer
+        value: 100000000
+        source: sdk
+      - path: config.role_session_name
+        type: string
+        value: KongVault
+        source: sdk
+      - path: config.ssl_verify
+        type: boolean
+        value: true
+        source: sdk
+      - path: config.ttl
+        type: integer
+        value: 0
+        source: sdk
+      - path: config.type
+        type: string
+        value: secrets
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: api
+    defaults:
+      - path: documents.status
+        type: string
+        value: unpublished
+        source: sdk
+      - path: publications.visibility
+        type: string
+        value: private
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: api_document
+    defaults:
+      - path: status
+        type: string
+        value: unpublished
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: api_implementation
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: api_publication
+    defaults:
+      - path: visibility
+        type: string
+        value: private
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: api_version
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: application_auth_strategy
+    defaults:
+      - path: principals.enabled
+        type: boolean
+        value: false
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: audit_log_webhook_destination
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: catalog_service
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: control_plane
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: control_plane_data_plane_certificate
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: dashboard
+    defaults:
+      - path: definition.tiles.definition.query.limit
+        type: number
+        value: 50
+        source: sdk
+      - path: definition.tiles.definition.query.time_range.time_range
+        type: string
+        value: 1h
+        source: sdk
+      - path: definition.tiles.definition.query.time_range.time_range
+        type: string
+        value: 30d
+        source: sdk
+      - path: definition.tiles.definition.query.time_range.tz
+        type: string
+        value: Etc/UTC
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: dcr_provider
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: event_gateway
+    defaults:
+      - path: backend_clusters.description
+        type: string
+        value: ""
+        source: sdk
+      - path: backend_clusters.insecure_allow_anonymous_virtual_cluster_auth
+        type: boolean
+        value: false
+        source: sdk
+      - path: backend_clusters.metadata_update_interval_seconds
+        type: integer
+        value: 60
+        source: sdk
+      - path: listeners.description
+        type: string
+        value: ""
+        source: sdk
+      - path: listeners.policies.config.allow_plaintext
+        type: boolean
+        value: false
+        source: sdk
+      - path: listeners.policies.config.bootstrap_port
+        type: string
+        value: at_start
+        source: sdk
+      - path: listeners.policies.config.broker_host_format.type
+        type: string
+        value: per_cluster_suffix
+        source: sdk
+      - path: listeners.policies.config.min_broker_id
+        type: integer
+        value: 0
+        source: sdk
+      - path: listeners.policies.config.versions.max
+        type: string
+        value: TLSv1.3
+        source: sdk
+      - path: listeners.policies.config.versions.min
+        type: string
+        value: TLSv1.2
+        source: sdk
+      - path: listeners.policies.description
+        type: string
+        value: ""
+        source: sdk
+      - path: listeners.policies.enabled
+        type: boolean
+        value: true
+        source: sdk
+      - path: schema_registries.config.timeout_seconds
+        type: integer
+        value: 10
+        source: sdk
+      - path: schema_registries.description
+        type: string
+        value: ""
+        source: sdk
+      - path: static_keys.description
+        type: string
+        value: ""
+        source: sdk
+      - path: tls_trust_bundles.description
+        type: string
+        value: ""
+        source: sdk
+      - path: virtual_clusters.authentication.jwks.cache_expiration
+        type: string
+        value: 1h
+        source: sdk
+      - path: virtual_clusters.authentication.jwks.timeout
+        type: string
+        value: 10s
+        source: sdk
+      - path: virtual_clusters.cluster_policies.condition
+        type: string
+        value: ""
+        source: sdk
+      - path: virtual_clusters.cluster_policies.description
+        type: string
+        value: ""
+        source: sdk
+      - path: virtual_clusters.cluster_policies.enabled
+        type: boolean
+        value: true
+        source: sdk
+      - path: virtual_clusters.consume_policies.condition
+        type: string
+        value: ""
+        source: sdk
+      - path: virtual_clusters.consume_policies.description
+        type: string
+        value: ""
+        source: sdk
+      - path: virtual_clusters.consume_policies.enabled
+        type: boolean
+        value: true
+        source: sdk
+      - path: virtual_clusters.description
+        type: string
+        value: ""
+        source: sdk
+      - path: virtual_clusters.namespace.additional.topics.conflict
+        type: string
+        value: warn
+        source: sdk
+      - path: virtual_clusters.produce_policies.condition
+        type: string
+        value: ""
+        source: sdk
+      - path: virtual_clusters.produce_policies.description
+        type: string
+        value: ""
+        source: sdk
+      - path: virtual_clusters.produce_policies.enabled
+        type: boolean
+        value: true
+        source: sdk
+      - path: virtual_clusters.topic_aliases.condition
+        type: string
+        value: ""
+        source: sdk
+      - path: virtual_clusters.topic_aliases.conflict
+        type: string
+        value: warn
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: event_gateway_backend_cluster
+    defaults:
+      - path: description
+        type: string
+        value: ""
+        source: sdk
+      - path: insecure_allow_anonymous_virtual_cluster_auth
+        type: boolean
+        value: false
+        source: sdk
+      - path: metadata_update_interval_seconds
+        type: integer
+        value: 60
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: event_gateway_data_plane_certificate
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: event_gateway_listener
+    defaults:
+      - path: description
+        type: string
+        value: ""
+        source: sdk
+      - path: policies.config.allow_plaintext
+        type: boolean
+        value: false
+        source: sdk
+      - path: policies.config.bootstrap_port
+        type: string
+        value: at_start
+        source: sdk
+      - path: policies.config.broker_host_format.type
+        type: string
+        value: per_cluster_suffix
+        source: sdk
+      - path: policies.config.min_broker_id
+        type: integer
+        value: 0
+        source: sdk
+      - path: policies.config.versions.max
+        type: string
+        value: TLSv1.3
+        source: sdk
+      - path: policies.config.versions.min
+        type: string
+        value: TLSv1.2
+        source: sdk
+      - path: policies.description
+        type: string
+        value: ""
+        source: sdk
+      - path: policies.enabled
+        type: boolean
+        value: true
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: event_gateway_listener_policy
+    defaults:
+      - path: config.allow_plaintext
+        type: boolean
+        value: false
+        source: sdk
+      - path: config.bootstrap_port
+        type: string
+        value: at_start
+        source: sdk
+      - path: config.broker_host_format.type
+        type: string
+        value: per_cluster_suffix
+        source: sdk
+      - path: config.min_broker_id
+        type: integer
+        value: 0
+        source: sdk
+      - path: config.versions.max
+        type: string
+        value: TLSv1.3
+        source: sdk
+      - path: config.versions.min
+        type: string
+        value: TLSv1.2
+        source: sdk
+      - path: description
+        type: string
+        value: ""
+        source: sdk
+      - path: enabled
+        type: boolean
+        value: true
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: event_gateway_schema_registry
+    defaults:
+      - path: config.timeout_seconds
+        type: integer
+        value: 10
+        source: sdk
+      - path: description
+        type: string
+        value: ""
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: event_gateway_static_key
+    defaults:
+      - path: description
+        type: string
+        value: ""
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: event_gateway_tls_trust_bundle
+    defaults:
+      - path: description
+        type: string
+        value: ""
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: event_gateway_virtual_cluster
+    defaults:
+      - path: authentication.jwks.cache_expiration
+        type: string
+        value: 1h
+        source: sdk
+      - path: authentication.jwks.timeout
+        type: string
+        value: 10s
+        source: sdk
+      - path: cluster_policies.condition
+        type: string
+        value: ""
+        source: sdk
+      - path: cluster_policies.description
+        type: string
+        value: ""
+        source: sdk
+      - path: cluster_policies.enabled
+        type: boolean
+        value: true
+        source: sdk
+      - path: consume_policies.condition
+        type: string
+        value: ""
+        source: sdk
+      - path: consume_policies.description
+        type: string
+        value: ""
+        source: sdk
+      - path: consume_policies.enabled
+        type: boolean
+        value: true
+        source: sdk
+      - path: description
+        type: string
+        value: ""
+        source: sdk
+      - path: namespace.additional.topics.conflict
+        type: string
+        value: warn
+        source: sdk
+      - path: produce_policies.condition
+        type: string
+        value: ""
+        source: sdk
+      - path: produce_policies.description
+        type: string
+        value: ""
+        source: sdk
+      - path: produce_policies.enabled
+        type: boolean
+        value: true
+        source: sdk
+      - path: topic_aliases.condition
+        type: string
+        value: ""
+        source: sdk
+      - path: topic_aliases.conflict
+        type: string
+        value: warn
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: event_gateway_virtual_cluster_cluster_policy
+    defaults:
+      - path: condition
+        type: string
+        value: ""
+        source: sdk
+      - path: description
+        type: string
+        value: ""
+        source: sdk
+      - path: enabled
+        type: boolean
+        value: true
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: event_gateway_virtual_cluster_consume_policy
+    defaults:
+      - path: condition
+        type: string
+        value: ""
+        source: sdk
+      - path: description
+        type: string
+        value: ""
+        source: sdk
+      - path: enabled
+        type: boolean
+        value: true
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: event_gateway_virtual_cluster_produce_policy
+    defaults:
+      - path: condition
+        type: string
+        value: ""
+        source: sdk
+      - path: description
+        type: string
+        value: ""
+        source: sdk
+      - path: enabled
+        type: boolean
+        value: true
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: gateway_service
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: organization_system_account_role
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: organization_system_account_team_membership
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: organization_team
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: organization_team_role
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: organization_user_role
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: organization_user_team_membership
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: portal
+    defaults:
+      - path: auth_settings.oidc_claim_mappings.email
+        type: string
+        value: email
+        source: sdk
+      - path: auth_settings.oidc_claim_mappings.groups
+        type: string
+        value: groups
+        source: sdk
+      - path: auth_settings.oidc_claim_mappings.name
+        type: string
+        value: name
+        source: sdk
+      - path: authentication_enabled
+        type: boolean
+        value: true
+        source: sdk
+      - path: auto_approve_applications
+        type: boolean
+        value: false
+        source: sdk
+      - path: auto_approve_developers
+        type: boolean
+        value: false
+        source: sdk
+      - path: custom_domain.ssl.skip_ca_check
+        type: boolean
+        value: false
+        source: sdk
+      - path: customization.spec_renderer.allow_custom_server_urls
+        type: boolean
+        value: true
+        source: sdk
+      - path: customization.spec_renderer.hide_deprecated
+        type: boolean
+        value: false
+        source: sdk
+      - path: customization.spec_renderer.hide_internal
+        type: boolean
+        value: false
+        source: sdk
+      - path: customization.spec_renderer.infinite_scroll
+        type: boolean
+        value: true
+        source: sdk
+      - path: customization.spec_renderer.show_schemas
+        type: boolean
+        value: true
+        source: sdk
+      - path: customization.spec_renderer.try_it_insomnia
+        type: boolean
+        value: true
+        source: sdk
+      - path: customization.spec_renderer.try_it_ui
+        type: boolean
+        value: true
+        source: sdk
+      - path: identity_providers.config.claim_mappings.email
+        type: string
+        value: email
+        source: sdk
+      - path: identity_providers.config.claim_mappings.groups
+        type: string
+        value: groups
+        source: sdk
+      - path: identity_providers.config.claim_mappings.name
+        type: string
+        value: name
+        source: sdk
+      - path: identity_providers.enabled
+        type: boolean
+        value: false
+        source: sdk
+      - path: notifications_developer_pii_visibility_enabled
+        type: boolean
+        value: false
+        source: sdk
+      - path: rbac_enabled
+        type: boolean
+        value: false
+        source: sdk
+      - path: sipr_enabled
+        type: boolean
+        value: false
+        source: sdk
+      - path: teams.can_own_applications
+        type: boolean
+        value: false
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: portal_asset_favicon
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: portal_asset_logo
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: portal_audit_log_webhook
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: portal_auth_settings
+    defaults:
+      - path: oidc_claim_mappings.email
+        type: string
+        value: email
+        source: sdk
+      - path: oidc_claim_mappings.groups
+        type: string
+        value: groups
+        source: sdk
+      - path: oidc_claim_mappings.name
+        type: string
+        value: name
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: portal_custom_domain
+    defaults:
+      - path: ssl.skip_ca_check
+        type: boolean
+        value: false
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: portal_customization
+    defaults:
+      - path: spec_renderer.allow_custom_server_urls
+        type: boolean
+        value: true
+        source: sdk
+      - path: spec_renderer.hide_deprecated
+        type: boolean
+        value: false
+        source: sdk
+      - path: spec_renderer.hide_internal
+        type: boolean
+        value: false
+        source: sdk
+      - path: spec_renderer.infinite_scroll
+        type: boolean
+        value: true
+        source: sdk
+      - path: spec_renderer.show_schemas
+        type: boolean
+        value: true
+        source: sdk
+      - path: spec_renderer.try_it_insomnia
+        type: boolean
+        value: true
+        source: sdk
+      - path: spec_renderer.try_it_ui
+        type: boolean
+        value: true
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: portal_email_config
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: portal_email_template
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: portal_identity_provider
+    defaults:
+      - path: config.claim_mappings.email
+        type: string
+        value: email
+        source: sdk
+      - path: config.claim_mappings.groups
+        type: string
+        value: groups
+        source: sdk
+      - path: config.claim_mappings.name
+        type: string
+        value: name
+        source: sdk
+      - path: enabled
+        type: boolean
+        value: false
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: portal_integration
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: portal_ip_allow_list
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: portal_page
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: portal_snippet
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: portal_team
+    defaults:
+      - path: can_own_applications
+        type: boolean
+        value: false
+        source: sdk
+    overrides: []
+    exclusions: []
+  - resource_type: portal_team_group_mapping
+    defaults: []
+    overrides: []
+    exclusions: []
+  - resource_type: portal_team_role
+    defaults: []
+    overrides: []
+    exclusions: []

--- a/test/e2e/scenarios/dump/portal-owned/scenario.yaml
+++ b/test/e2e/scenarios/dump/portal-owned/scenario.yaml
@@ -110,6 +110,47 @@ steps:
               fields:
                 total_changes: 0
 
+      - name: 002-dump-skip-defaults
+        run:
+          - dump
+          - declarative
+          - "--resources=portals,apis,application_auth_strategies"
+          - --include-child-resources
+          - --skip-defaults
+        outputFormat: none
+        parseAs: yaml
+        stdoutFile: "{{ .workdir }}/dump-skip-defaults.yaml"
+        assertions:
+          - select: "portals[?name=='My First Portal'] | [0]"
+            expect:
+              fields:
+                authentication_enabled: false
+                rbac_enabled: null
+                auto_approve_developers: null
+                auto_approve_applications: null
+          - select: "portals[?name=='My First Portal'] | [0].teams[?name=='Platform Team'] | [0]"
+            expect:
+              fields:
+                can_own_applications: null
+          - select: "apis[?name=='SMS API'] | [0].publications[0]"
+            expect:
+              fields:
+                visibility: public
+
+      - name: 003-plan-from-skip-defaults-dump
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/dump-skip-defaults.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+
   - name: 003-delete-cleanup
     commands:
       - name: 000-delete


### PR DESCRIPTION
## Summary

- add `kongctl dump declarative --skip-defaults` as an opt-in way to omit
  fields equal to literal Konnect API defaults
- derive defaults lazily from SDK metadata, with documented resource-scoped
  overrides and exclusions for exceptional API contracts
- add a reviewed, SDK-versioned inventory snapshot so resource and default
  changes are visible during ordinary unit testing
- preserve non-default values, explicit `null` values, unknown fields, nested
  child resources, SDK union behavior, and existing YAML sequence formatting

## Rationale

Declarative dumps currently include values that simply restate API defaults,
which makes generated configuration larger and harder to review. The new flag
keeps existing dump behavior unchanged unless explicitly requested.

There is no separate production default catalog. When the flag is present,
the runtime index is built lazily from generated SDK `default` tags reachable
from registered declarative resources. The checked-in inventory is test-only:
it makes SDK upgrades and newly registered resources produce a reviewable diff
without loading snapshot data at runtime.

## Testing

- `go fix ./...`
- `make format`
- `make build`
- `golangci-lint run ./internal/declarative/resources ./internal/declarative/loader ./internal/cmd/root/verbs/dump`
- `make test`
- `make test-integration`
- `make test-e2e-scenarios SCENARIO=dump/portal-owned`

The E2E scenario verifies parent and child default omission, non-default
preservation, valid reload behavior, and a zero-change plan from the compact
dump.

Closes #1836
