### PR TITLE
task(deps): update TypeScript to v6

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,16 @@
       ]
     },
     {
+      "description": "Hold TypeScript 7 until Astro supports its programmatic API",
+      "allowedVersions": "<7.0.0",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "typescript"
+      ]
+    },
+    {
       "description": "Hold lipgloss upgrades until manually approved",
       "matchPackageNames": [
         "github.com/charmbracelet/lipgloss"

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -20,7 +20,7 @@
         "jsdom": "30.0.1",
         "prettier": "3.9.6",
         "prettier-plugin-astro": "0.14.1",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "vitest": "4.1.10"
       },
       "engines": {
@@ -5278,9 +5278,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/site/package.json
+++ b/site/package.json
@@ -28,7 +28,7 @@
     "jsdom": "30.0.1",
     "prettier": "3.9.6",
     "prettier-plugin-astro": "0.14.1",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.10"
   }
 }


### PR DESCRIPTION
## Summary

- update the Learn site from TypeScript 5.9.3 to the Astro-supported 6.0.3 release
- constrain Renovate to TypeScript versions below 7 until Astro supports the native compiler programmatic API

## Rationale

Renovate PR #1861 attempted TypeScript 7.0.2, but Renovate could not regenerate the lockfile because @astrojs/check supports TypeScript 5 and 6. Forcing the dependency installation also makes astro check fail because TypeScript 7 does not yet expose the programmatic API Astro requires.

This PR provides the latest compatible TypeScript upgrade and prevents Renovate from repeatedly proposing the incompatible major version.

## Testing

- npm ci
- npm run check
- npm test
- npm run build
- npm run test:e2e

All 11 unit tests and 25 browser tests pass.