### PR TITLE
refactor(simplify): simplify external lookup and team detail

### DIFF
--- a/internal/cmd/root/products/konnect/organization/team/getTeam.go
+++ b/internal/cmd/root/products/konnect/organization/team/getTeam.go
@@ -363,12 +363,8 @@ func teamDetailView(team *kkComps.TeamResponse) string {
 		return ""
 	}
 
-	const missing = "n/a"
 	record := teamToDisplayRecord(team)
-	id := record.ID
-	if id != missing {
-		id = util.AbbreviateUUID(id)
-	}
+	id := util.AbbreviateUUID(record.ID)
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "id: %s\n", id)

--- a/internal/cmd/root/products/konnect/organization/team/getTeam.go
+++ b/internal/cmd/root/products/konnect/organization/team/getTeam.go
@@ -364,44 +364,19 @@ func teamDetailView(team *kkComps.TeamResponse) string {
 	}
 
 	const missing = "n/a"
-
-	id := missing
-	if value := team.GetID(); value != "" {
-		id = util.AbbreviateUUID(value)
-	}
-
-	name := missing
-	if value := team.GetName(); value != "" {
-		name = value
-	}
-
-	description := missing
-	if value := team.GetDescription(); value != nil && *value != "" {
-		description = *value
-	}
-
-	isSystem := missing
-	if value := team.GetSystemTeam(); value != nil {
-		isSystem = fmt.Sprintf("%t", *value)
-	}
-
-	createdAt := missing
-	if value := team.GetCreatedAt(); !value.IsZero() {
-		createdAt = value.In(time.Local).Format("2006-01-02 15:04:05")
-	}
-
-	updatedAt := missing
-	if value := team.GetUpdatedAt(); !value.IsZero() {
-		updatedAt = value.In(time.Local).Format("2006-01-02 15:04:05")
+	record := teamToDisplayRecord(team)
+	id := record.ID
+	if id != missing {
+		id = util.AbbreviateUUID(id)
 	}
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "id: %s\n", id)
-	fmt.Fprintf(&b, "name: %s\n", name)
-	fmt.Fprintf(&b, "description: %s\n", description)
-	fmt.Fprintf(&b, "system_team: %s\n", isSystem)
-	fmt.Fprintf(&b, "created_at: %s\n", createdAt)
-	fmt.Fprintf(&b, "updated_at: %s\n", updatedAt)
+	fmt.Fprintf(&b, "name: %s\n", record.Name)
+	fmt.Fprintf(&b, "description: %s\n", record.Description)
+	fmt.Fprintf(&b, "system_team: %s\n", record.IsSystemTeam)
+	fmt.Fprintf(&b, "created_at: %s\n", record.LocalCreatedTime)
+	fmt.Fprintf(&b, "updated_at: %s\n", record.LocalUpdatedTime)
 
 	return strings.TrimRight(b.String(), "\n")
 }

--- a/internal/declarative/planner/external_lookup.go
+++ b/internal/declarative/planner/external_lookup.go
@@ -691,22 +691,7 @@ func (r *externalLookupResolver) lookupAIGateway(ctx context.Context, req extern
 	if err != nil {
 		return "", fmt.Errorf("%s: list AI Gateways: %w", req.Source, err)
 	}
-	matches := make([]string, 0, 1)
-	for _, item := range items {
-		matched := true
-		for field, value := range req.MatchFields {
-			switch field {
-			case FieldName:
-				matched = matched && item.Name == value
-			case FieldDisplayName:
-				matched = matched && item.DisplayName == value
-			}
-		}
-		if matched {
-			matches = append(matches, item.ID)
-		}
-	}
-	return singleExternalID(req, matches)
+	return matchExternalCandidates(req, items, func(item state.AIGateway) string { return item.ID })
 }
 
 func (r *externalLookupResolver) lookupAuditLogWebhookDestination(
@@ -728,13 +713,7 @@ func (r *externalLookupResolver) lookupOrganizationTeam(
 	if err != nil {
 		return "", fmt.Errorf("%s: list organization teams: %w", req.Source, err)
 	}
-	matches := make([]string, 0, 1)
-	for _, team := range teams {
-		if team.Name == req.MatchFields[FieldName] && team.ID != "" {
-			matches = append(matches, team.ID)
-		}
-	}
-	return singleExternalID(req, matches)
+	return matchExternalCandidates(req, teams, func(item state.OrganizationTeam) string { return item.ID })
 }
 
 func (r *externalLookupResolver) lookupEventGatewayControlPlane(
@@ -757,27 +736,6 @@ func (r *externalLookupResolver) lookupEventGatewayVirtualCluster(
 		return "", fmt.Errorf("%s: list Event Gateway virtual clusters: %w", req.Source, err)
 	}
 	return matchExternalCandidates(req, items, func(item state.EventGatewayVirtualCluster) string { return item.ID })
-}
-
-func singleExternalID(req externalLookupRequest, matches []string) (string, error) {
-	if len(matches) == 0 {
-		return "", fmt.Errorf(
-			"%s: no %s matched selector {%s}",
-			req.Source,
-			req.ResourceType,
-			tags.ExternalLookupDisplayKey(req.MatchFields, req.SensitiveFields),
-		)
-	}
-	if len(matches) > 1 {
-		return "", fmt.Errorf(
-			"%s: selector {%s} matched %d %s resources",
-			req.Source,
-			tags.ExternalLookupDisplayKey(req.MatchFields, req.SensitiveFields),
-			len(matches),
-			req.ResourceType,
-		)
-	}
-	return matches[0], nil
 }
 
 func setStringFieldByPath(resource resources.Resource, path, value string) error {

--- a/internal/declarative/planner/external_lookup.go
+++ b/internal/declarative/planner/external_lookup.go
@@ -713,6 +713,7 @@ func (r *externalLookupResolver) lookupOrganizationTeam(
 	if err != nil {
 		return "", fmt.Errorf("%s: list organization teams: %w", req.Source, err)
 	}
+	teams = slices.DeleteFunc(teams, func(team state.OrganizationTeam) bool { return team.ID == "" })
 	return matchExternalCandidates(req, teams, func(item state.OrganizationTeam) string { return item.ID })
 }
 


### PR DESCRIPTION
## Summary

- route AI Gateway and organization team lookups through the shared candidate matcher
- remove the duplicate single-result validation helper
- reuse the team display record when rendering team details

## Rationale

This reduces duplicate matching and formatting logic while preserving existing lookup errors and detail output.

Closes #1875

## Testing

- go fix ./...
- make format
- make build
- make lint
- make test-all