### PR TITLE
refactor(simplify): tidy alias helpers in extensions cobra

### DIFF
--- a/internal/extensions/cobra.go
+++ b/internal/extensions/cobra.go
@@ -662,10 +662,7 @@ func findChildByName(parent *cobra.Command, name string) *cobra.Command {
 
 func findChildByNameOrAlias(parent *cobra.Command, name string) *cobra.Command {
 	for _, child := range parent.Commands() {
-		if child.Name() == name {
-			return child
-		}
-		if slices.Contains(child.Aliases, name) {
+		if child.Name() == name || slices.Contains(child.Aliases, name) {
 			return child
 		}
 	}
@@ -681,16 +678,10 @@ func syntheticOwnedBy(command *cobra.Command, extensionID string) bool {
 }
 
 func mergeAliases(command *cobra.Command, aliases []string) {
-	seen := map[string]struct{}{}
-	for _, alias := range command.Aliases {
-		seen[alias] = struct{}{}
-	}
 	for _, alias := range aliases {
-		if _, ok := seen[alias]; ok {
-			continue
+		if !slices.Contains(command.Aliases, alias) {
+			command.Aliases = append(command.Aliases, alias)
 		}
-		command.Aliases = append(command.Aliases, alias)
-		seen[alias] = struct{}{}
 	}
 }
 


### PR DESCRIPTION
Two small no-op cleanups the simplifier flagged in the extensions `cobra.go`: `mergeAliases` drops the `map[string]struct{}` bookkeeping for a `slices.Contains` check (alias lists are tiny, and appending as we go keeps the intra-list dedup), and `findChildByNameOrAlias` folds its two `if` returns into one `||`.

Behavior is unchanged, so the existing registration tests cover it and aren't touched.

closes #1881