### PR TITLE
refactor(simplify): dedupe team pagination and field-path traversal

### DIFF
--- a/internal/cmd/root/products/konnect/organization/team/getTeam.go
+++ b/internal/cmd/root/products/konnect/organization/team/getTeam.go
@@ -227,8 +227,8 @@ func runGet(id string, kkClient helpers.OrganizationTeamAPI, helper cmd.Helper) 
 	return res.GetTeamResponse(), nil
 }
 
-func runList(kkClient helpers.OrganizationTeamAPI, helper cmd.Helper,
-	cfg config.Hook, skipSystemTeams bool,
+func fetchTeams(kkClient helpers.OrganizationTeamAPI, helper cmd.Helper,
+	cfg config.Hook, skipSystemTeams bool, filter *kkOps.ListTeamsQueryParamFilter,
 ) ([]kkComps.TeamResponse, error) {
 	var pageNumber int64 = 1
 	requestPageSize := int64(cfg.GetInt(common.RequestPageSizeConfigPath))
@@ -243,12 +243,12 @@ func runList(kkClient helpers.OrganizationTeamAPI, helper cmd.Helper,
 		req := kkOps.ListTeamsRequest{
 			PageSize:   new(requestPageSize),
 			PageNumber: new(pageNumber),
+			Filter:     filter,
 		}
 
 		res, err := kkClient.ListOrganizationTeams(helper.GetContext(), req)
 		if err != nil {
-			attrs := cmd.TryConvertErrorToAttrs(err)
-			return nil, cmd.PrepareExecutionError("Failed to list Teams", err, helper.GetCmd(), attrs...)
+			return nil, err
 		}
 
 		data := res.GetTeamCollectionResponse().Data
@@ -273,53 +273,30 @@ func runList(kkClient helpers.OrganizationTeamAPI, helper cmd.Helper,
 	return allData, nil
 }
 
+func runList(kkClient helpers.OrganizationTeamAPI, helper cmd.Helper,
+	cfg config.Hook, skipSystemTeams bool,
+) ([]kkComps.TeamResponse, error) {
+	allData, err := fetchTeams(kkClient, helper, cfg, skipSystemTeams, nil)
+	if err != nil {
+		attrs := cmd.TryConvertErrorToAttrs(err)
+		return nil, cmd.PrepareExecutionError("Failed to list Teams", err, helper.GetCmd(), attrs...)
+	}
+	return allData, nil
+}
+
 func runListByName(name string, kkClient helpers.OrganizationTeamAPI, helper cmd.Helper,
 	cfg config.Hook, skipSystemTeams bool,
 ) ([]kkComps.TeamResponse, error) {
-	var pageNumber int64 = 1
-	requestPageSize := int64(cfg.GetInt(common.RequestPageSizeConfigPath))
-	if requestPageSize < 1 {
-		requestPageSize = int64(common.DefaultRequestPageSize)
+	filter := &kkOps.ListTeamsQueryParamFilter{
+		Name: &kkComps.LegacyStringFieldFilter{
+			Eq: new(name),
+		},
 	}
 
-	var allData []kkComps.TeamResponse
-	var totalFetched int
-
-	for {
-		req := kkOps.ListTeamsRequest{
-			PageSize:   new(requestPageSize),
-			PageNumber: new(pageNumber),
-			Filter: &kkOps.ListTeamsQueryParamFilter{
-				Name: &kkComps.LegacyStringFieldFilter{
-					Eq: new(name),
-				},
-			},
-		}
-
-		res, err := kkClient.ListOrganizationTeams(helper.GetContext(), req)
-		if err != nil {
-			attrs := cmd.TryConvertErrorToAttrs(err)
-			return nil, cmd.PrepareExecutionError("Failed to list OrganizationTeams", err, helper.GetCmd(), attrs...)
-		}
-
-		data := res.GetTeamCollectionResponse().Data
-		totalFetched += len(data)
-
-		// Filter out system teams if flag is set
-		for _, team := range data {
-			if skipSystemTeams && team.SystemTeam != nil && *team.SystemTeam {
-				continue
-			}
-			allData = append(allData, team)
-		}
-
-		totalItems := res.GetTeamCollectionResponse().Meta.Page.Total
-
-		if totalFetched >= int(totalItems) {
-			break
-		}
-
-		pageNumber++
+	allData, err := fetchTeams(kkClient, helper, cfg, skipSystemTeams, filter)
+	if err != nil {
+		attrs := cmd.TryConvertErrorToAttrs(err)
+		return nil, cmd.PrepareExecutionError("Failed to list OrganizationTeams", err, helper.GetCmd(), attrs...)
 	}
 
 	if len(allData) > 0 {

--- a/internal/declarative/planner/external_lookup.go
+++ b/internal/declarative/planner/external_lookup.go
@@ -758,30 +758,41 @@ func setStringFieldByPath(resource resources.Resource, path, value string) error
 		}
 	}
 
-	current := reflect.ValueOf(resource)
-	for part := range strings.SplitSeq(path, ".") {
-		for current.Kind() == reflect.Pointer {
-			if current.IsNil() {
-				return fmt.Errorf("field %s is nil", path)
-			}
-			current = current.Elem()
-		}
-		current = findSettableTaggedField(current, part)
-		if !current.IsValid() {
-			return fmt.Errorf("field %s not found", path)
-		}
-	}
-	for current.Kind() == reflect.Pointer {
-		if current.IsNil() {
-			return fmt.Errorf("field %s is nil", path)
-		}
-		current = current.Elem()
+	current, err := resolveFieldPath(resource, path)
+	if err != nil {
+		return err
 	}
 	if current.Kind() != reflect.String || !current.CanSet() {
 		return fmt.Errorf("field %s is not a settable string", path)
 	}
 	current.SetString(value)
 	return nil
+}
+
+// resolveFieldPath walks a dotted field path through a resource using the
+// yaml/json struct tags, unwrapping pointers along the way, and returns the
+// addressable value at the end of the path.
+func resolveFieldPath(resource resources.Resource, path string) (reflect.Value, error) {
+	current := reflect.ValueOf(resource)
+	for part := range strings.SplitSeq(path, ".") {
+		for current.Kind() == reflect.Pointer {
+			if current.IsNil() {
+				return reflect.Value{}, fmt.Errorf("field %s is nil", path)
+			}
+			current = current.Elem()
+		}
+		current = findSettableTaggedField(current, part)
+		if !current.IsValid() {
+			return reflect.Value{}, fmt.Errorf("field %s not found", path)
+		}
+	}
+	for current.Kind() == reflect.Pointer {
+		if current.IsNil() {
+			return reflect.Value{}, fmt.Errorf("field %s is nil", path)
+		}
+		current = current.Elem()
+	}
+	return current, nil
 }
 
 func stringFieldByPath(resource resources.Resource, path string) (string, error) {
@@ -802,24 +813,9 @@ func stringFieldByPath(resource resources.Resource, path string) (string, error)
 		}
 	}
 
-	current := reflect.ValueOf(resource)
-	for part := range strings.SplitSeq(path, ".") {
-		for current.Kind() == reflect.Pointer {
-			if current.IsNil() {
-				return "", fmt.Errorf("field %s is nil", path)
-			}
-			current = current.Elem()
-		}
-		current = findSettableTaggedField(current, part)
-		if !current.IsValid() {
-			return "", fmt.Errorf("field %s not found", path)
-		}
-	}
-	for current.Kind() == reflect.Pointer {
-		if current.IsNil() {
-			return "", fmt.Errorf("field %s is nil", path)
-		}
-		current = current.Elem()
+	current, err := resolveFieldPath(resource, path)
+	if err != nil {
+		return "", err
 	}
 	if current.Kind() != reflect.String {
 		return "", fmt.Errorf("field %s is not a string", path)
@@ -832,7 +828,7 @@ func findSettableTaggedField(value reflect.Value, name string) reflect.Value {
 		return reflect.Value{}
 	}
 	typeOfValue := value.Type()
-	for i := 0; i < value.NumField(); i++ {
+	for i := range value.NumField() {
 		fieldInfo := typeOfValue.Field(i)
 		for _, tagName := range []string{"yaml", "json"} {
 			tag := strings.Split(fieldInfo.Tag.Get(tagName), ",")[0]
@@ -841,7 +837,7 @@ func findSettableTaggedField(value reflect.Value, name string) reflect.Value {
 			}
 		}
 	}
-	for i := 0; i < value.NumField(); i++ {
+	for i := range value.NumField() {
 		fieldInfo := typeOfValue.Field(i)
 		if !fieldInfo.Anonymous {
 			continue


### PR DESCRIPTION
Follows the simplifier's suggestions in #1887, split across two files.

In `getTeam.go`, `runList` and `runListByName` shared the whole page-size setup, pagination loop, and system-team filtering. Pulled that into a `fetchTeams` helper that takes an optional filter. I kept the two callers distinct on purpose: they use different error wording ("Failed to list Teams" vs "Failed to list OrganizationTeams") and the by-name path still errors when nothing matches, so `fetchTeams` returns the raw error and each caller wraps it as before. No wording changes.

In `external_lookup.go`, `stringFieldByPath` and `setStringFieldByPath` shared the same dotted-path reflection walk. Extracted it into `resolveFieldPath`; each caller keeps its own final type check. Also switched the two `findSettableTaggedField` loops to range-over-integer per the Go 1.26 standards in AGENTS.md.

Behavior is unchanged. The planner reflection paths are covered by the existing `external_lookup_test.go`, which still passes; tests are untouched.

closes #1887