### PR TITLE
test(e2e): cover backend cluster sasl scram authentication

### DIFF
--- a/test/e2e/scenarios/event-gateway/backend-cluster/overlays/002-update-to-sasl-scram/egw-bc.yaml
+++ b/test/e2e/scenarios/event-gateway/backend-cluster/overlays/002-update-to-sasl-scram/egw-bc.yaml
@@ -1,0 +1,24 @@
+_defaults:
+  kongctl:
+    namespace: event-gateways-bc-comprehensive-test
+
+event_gateways:
+  - ref: egw-cp-for-bc-test
+    name: egw-cp-for-bc-test
+    description: "EGW CP for Backend Cluster Test"
+    backend_clusters:
+      - ref: default-backend-cluster
+        name: default-backend-cluster
+        description: "Backend Cluster with SCRAM auth"
+        bootstrap_servers:
+          - "egw-backend-1.example.com:9094"
+          - "egw-backend-2.example.com:9095"
+        authentication:
+          type: sasl_scram
+          algorithm: sha512
+          username: ${env["scram-username"]}
+          password: ${env["scram-password"]}
+        tls:
+          enabled: true
+          tls_versions:
+            - tls13

--- a/test/e2e/scenarios/event-gateway/backend-cluster/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/backend-cluster/scenario.yaml
@@ -249,6 +249,73 @@ steps:
                 tls.tls_versions:
                   - "tls12"
                   - "tls13"
+  - name: 003-plan-update-to-sasl-scram
+    inputOverlayDirs:
+      - overlays/002-update-to-sasl-scram
+    commands:
+      - name: 001-plan-scram-update
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-scram-update.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/egw-bc.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_backend_cluster' && resource_ref=='{{ .vars.bcRef }}'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                resource_ref: "{{ .vars.bcRef }}"
+      - name: 002-apply-scram-update
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-scram-update.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 003-verify-scram-update
+        run:
+          - get
+          - event-gateway
+          - backend-clusters
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "[0]"
+            expect:
+              fields:
+                name: "{{ .vars.bcRef }}"
+                authentication.type: sasl_scram
+                authentication.algorithm: sha512
+      - name: 004-idempotency-check
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/egw-bc.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
   - name: 004-update-tls-fields
     inputOverlayDirs:
       - overlays/003-update-tls-fields


### PR DESCRIPTION
## Summary

- add a backend-cluster overlay that transitions authentication from SASL/PLAIN to SASL/SCRAM
- verify the update plan, apply result, SCRAM type and algorithm, and idempotency
- retain the existing anonymous and SASL/PLAIN scenario coverage

## Rationale

The backend-cluster E2E scenario did not exercise the SASL/SCRAM create-to-update conversion path, including its required algorithm and sensitive credentials.

## Testing

- `go fix ./...`
- `make format`
- `make build`
- `make lint`
- `make test`
- `make test-e2e-scenarios SCENARIO=event-gateway/backend-cluster`

Closes #1859