### PR TITLE
test(e2e): expand event gateway dump backend assertions

### DIFF
--- a/test/e2e/scenarios/event-gateway/dump/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/dump/scenario.yaml
@@ -87,6 +87,11 @@ steps:
             expect:
               fields:
                 name: "{{ .vars.bcRef }}"
+                description: "Backend Cluster for Dump Test"
+                "bootstrap_servers[0]": "egw-backend-1.example.com:9092"
+                "length(bootstrap_servers)": 2
+                authentication.type: anonymous
+                tls.enabled: true
           - name: dataplane-certificate-present
             select: >-
               event_gateways[?name=='{{ .vars.egwName }}'] | [0].data_plane_certificates[?name=='{{ .vars.dataplaneCertName }}'] | [0]


### PR DESCRIPTION
## Summary

- verify dumped backend cluster descriptions and bootstrap server serialization
- assert authentication and TLS fields match the applied fixture
- cover the required backend cluster fields without adding scenario steps or overlays

## Rationale

The event gateway dump scenario previously asserted only the backend cluster name, allowing serialization regressions in required declarative fields to go unnoticed.

Closes #1860

## Testing

- `go fix ./...`
- `make format`
- `make build`
- `make lint`
- `make test`
- `CGO_ENABLED=0 go test -tags=e2e ./test/e2e/harness/scenario`

Live Konnect E2E validation was not run locally and is reserved for manual testing.