### PR TITLE
refactor(simplify): tidy service fast-paths and team error labels

### DIFF
--- a/internal/cmd/root/products/konnect/organization/team/getTeam.go
+++ b/internal/cmd/root/products/konnect/organization/team/getTeam.go
@@ -296,7 +296,7 @@ func runListByName(name string, kkClient helpers.OrganizationTeamAPI, helper cmd
 	allData, err := fetchTeams(kkClient, helper, cfg, skipSystemTeams, filter)
 	if err != nil {
 		attrs := cmd.TryConvertErrorToAttrs(err)
-		return nil, cmd.PrepareExecutionError("Failed to list OrganizationTeams", err, helper.GetCmd(), attrs...)
+		return nil, cmd.PrepareExecutionError("Failed to list Teams", err, helper.GetCmd(), attrs...)
 	}
 
 	if len(allData) > 0 {

--- a/internal/declarative/planner/external_lookup.go
+++ b/internal/declarative/planner/external_lookup.go
@@ -741,19 +741,20 @@ func (r *externalLookupResolver) lookupEventGatewayVirtualCluster(
 
 func setStringFieldByPath(resource resources.Resource, path, value string) error {
 	if implementation, ok := resource.(*resources.APIImplementationResource); ok {
-		if implementation.ServiceReference == nil {
-			return fmt.Errorf("service is not configured")
-		}
-		service := implementation.ServiceReference.GetService()
-		if service == nil {
-			return fmt.Errorf("service is not configured")
-		}
 		switch path {
-		case "service.id":
-			service.ID = value
-			return nil
-		case "service.control_plane_id":
-			service.ControlPlaneID = value
+		case "service.id", "service.control_plane_id":
+			if implementation.ServiceReference == nil {
+				return fmt.Errorf("service is not configured")
+			}
+			service := implementation.ServiceReference.GetService()
+			if service == nil {
+				return fmt.Errorf("service is not configured")
+			}
+			if path == "service.id" {
+				service.ID = value
+			} else {
+				service.ControlPlaneID = value
+			}
 			return nil
 		}
 	}
@@ -798,17 +799,14 @@ func resolveFieldPath(resource resources.Resource, path string) (reflect.Value, 
 func stringFieldByPath(resource resources.Resource, path string) (string, error) {
 	if implementation, ok := resource.(*resources.APIImplementationResource); ok {
 		switch path {
-		case "service.id":
+		case "service.id", "service.control_plane_id":
 			if implementation.ServiceReference == nil || implementation.ServiceReference.GetService() == nil {
 				return "", nil
 			}
 			service := implementation.ServiceReference.GetService()
-			return service.ID, nil
-		case "service.control_plane_id":
-			if implementation.ServiceReference == nil || implementation.ServiceReference.GetService() == nil {
-				return "", nil
+			if path == "service.id" {
+				return service.ID, nil
 			}
-			service := implementation.ServiceReference.GetService()
 			return service.ControlPlaneID, nil
 		}
 	}
@@ -831,7 +829,7 @@ func findSettableTaggedField(value reflect.Value, name string) reflect.Value {
 	for i := range value.NumField() {
 		fieldInfo := typeOfValue.Field(i)
 		for _, tagName := range []string{"yaml", "json"} {
-			tag := strings.Split(fieldInfo.Tag.Get(tagName), ",")[0]
+			tag, _, _ := strings.Cut(fieldInfo.Tag.Get(tagName), ",")
 			if tag == name {
 				return value.Field(i)
 			}

--- a/internal/declarative/planner/external_lookup_test.go
+++ b/internal/declarative/planner/external_lookup_test.go
@@ -329,3 +329,17 @@ func nestedEnvExternalPlaceholder(t *testing.T, tag string, variable string) str
 	require.True(t, strings.HasPrefix(placeholder, tags.ExternalPlaceholderPrefix))
 	return placeholder
 }
+
+func TestSetStringFieldByPathScopesServiceCheckToServicePaths(t *testing.T) {
+	t.Parallel()
+
+	// A service path on an implementation without a configured service still errors.
+	svcErr := setStringFieldByPath(&resources.APIImplementationResource{}, "service.id", "svc")
+	require.ErrorContains(t, svcErr, "service is not configured")
+
+	// A non-service path falls through to field resolution instead of reporting
+	// the service as unconfigured.
+	otherErr := setStringFieldByPath(&resources.APIImplementationResource{}, "missing", "v")
+	require.Error(t, otherErr)
+	require.NotContains(t, otherErr.Error(), "service is not configured")
+}


### PR DESCRIPTION
Simplifier follow-up on #1892. Four small changes in `external_lookup.go` and `getTeam.go`. Two are just tidy-ups: `strings.Cut` over `strings.Split(...)[0]`, and the two `service.*` cases into one

Two actually small change behavior-
- `setStringFieldByPath` checked for a service before looking at the path, so a non-service path on an implementation with no service returned "service is not configured" instead of falling through. The getter already did the right thing; now the setter matches. Test added.
- `runListByName` said "Failed to list OrganizationTeams", `runList` said "Failed to list Teams", same call. Both say "Teams" now.

closes #1901