### PR TITLE
test(e2e): cover portal visibility dump round trip

### DIFF
--- a/test/e2e/scenarios/portal/visibility/scenario.yaml
+++ b/test/e2e/scenarios/portal/visibility/scenario.yaml
@@ -310,6 +310,37 @@ steps:
             expect:
               fields:
                 total_changes: 0
+      - name: 002-dump-portal-with-children
+        run:
+          - dump
+          - declarative
+          - "--resources=portals"
+          - --include-child-resources
+          - "--filter-name={{ .vars.portalName }}"
+        outputFormat: none
+        parseAs: yaml
+        stdoutFile: "{{ .workdir }}/dump-portal.yaml"
+        assertions:
+          - select: "portals[?name=='{{ .vars.portalName }}'] | [0]"
+            expect:
+              fields:
+                auto_approve_applications: true
+                default_api_visibility: "private"
+                authentication_enabled: false
+                rbac_enabled: false
+      - name: 003-plan-from-portal-dump
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/dump-portal.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
 
   - name: 006-delete-cleanup
     commands:


### PR DESCRIPTION
## Summary

- dump the mutated portal and its child resources in the portal visibility scenario
- assert non-default portal visibility and application approval settings are preserved
- verify planning from the portal dump produces zero changes

## Testing

- `go fix ./...`
- `make format`
- `make build`
- `make test`
- `make test-e2e-scenarios SCENARIO=portal/visibility`

`make lint` was also run with local golangci-lint 2.12.2 and reported pre-existing findings in generated portal client code and mocks; repository guidance specifies 2.10.1.

Closes #1870