### PR TITLE
test(e2e): expand portal email dump and idempotency coverage

### DIFF
--- a/test/e2e/scenarios/portal/email/overlays/002-update/config.yaml
+++ b/test/e2e/scenarios/portal/email/overlays/002-update/config.yaml
@@ -1,4 +1,3 @@
-{{- $uid := uuidv4 | trunc 8 -}}
 _defaults:
   kongctl:
     namespace: portal-email-config
@@ -11,7 +10,7 @@ portals:
       namespace: portal-email-config
     email_config:
       ref: portal-email-config
-      domain_name: null
+      domain_name: "{{ .vars.emailDomain }}"
       from_name: "Kong Portal Team"
-      from_email: "team@{{ $uid }}.mail.kongctl-e2e.io"
-      reply_to_email: "help@{{ $uid }}.mail.kongctl-e2e.io"
+      from_email: "team@{{ .vars.emailDomain }}"
+      reply_to_email: "help@{{ .vars.emailDomain }}"

--- a/test/e2e/scenarios/portal/email/scenario.yaml
+++ b/test/e2e/scenarios/portal/email/scenario.yaml
@@ -31,6 +31,11 @@ steps:
       - name: 000-plan-email-config
         outputFormat: disable
         stdoutFile: "{{ .workdir }}/plan-email-config.json"
+        recordVar:
+          name: emailDomain
+          responsePath: >-
+            changes[?resource_type=='portal_email_config' && resource_ref=='{{ .vars.emailConfigRef }}'] |
+            [0].fields.domain_name
         run:
           - plan
           - -f
@@ -113,6 +118,65 @@ steps:
               fields:
                 applied: 1
                 failed: 0
+
+  - name: 002b-idempotency-after-update
+    inputOverlayDirs:
+      - overlays/002-update
+    commands:
+      - name: 000-plan-idempotent
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+
+  - name: 002c-dump-and-round-trip
+    skipInputs: true
+    commands:
+      - name: 000-dump-portal-email-config
+        outputFormat: none
+        parseAs: yaml
+        stdoutFile: "{{ .workdir }}/dump.yaml"
+        run:
+          - dump
+          - declarative
+          - "--resources=portals"
+          - --include-child-resources
+          - --default-namespace
+          - "{{ .vars.namespace }}"
+        assertions:
+          - select: "_defaults.kongctl"
+            expect:
+              fields:
+                namespace: "{{ .vars.namespace }}"
+          - select: "portals[?name=='{{ .vars.portalRef }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.portalRef }}"
+          - select: "portals[?name=='{{ .vars.portalRef }}'] | [0].email_config"
+            expect:
+              fields:
+                from_name: "Kong Portal Team"
+      - name: 001-plan-from-dump
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/dump.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
 
   - name: 003-sync-remove-email-config
     inputOverlayDirs:


### PR DESCRIPTION
## Summary

- add a post-update idempotency check for portal email configuration
- verify portal email configuration dump output and zero-change round-trip planning
- retain the generated email domain across update overlays so repeated plans are stable

## Rationale

Portal email configuration had no dump coverage and did not verify idempotency after updates. The scenario now exercises both behaviors while preserving its UUID-based domain values.

Closes #1876

## Testing

- `make test-e2e-scenarios SCENARIO=portal/email`
- `go fix ./...`
- `make format`
- `make build`
- `make lint`
- `make test`
- `make test-integration`
- `git diff --check`