### PR TITLE
fix(declarative): apply DCR provider unprotection updates

### DIFF
--- a/internal/declarative/executor/dcr_provider_adapter.go
+++ b/internal/declarative/executor/dcr_provider_adapter.go
@@ -74,6 +74,13 @@ func (a *DCRProviderAdapter) MapUpdateFields(
 			execCtx.Namespace,
 			execCtx.Protection,
 		)
+	} else if currentLabels != nil {
+		payload[planner.FieldLabels] = labels.BuildUpdateLabels(
+			currentLabels,
+			currentLabels,
+			execCtx.Namespace,
+			execCtx.Protection,
+		)
 	}
 
 	if displayName, ok := payload[planner.FieldDisplayName].(string); ok {

--- a/internal/declarative/executor/dcr_provider_adapter_test.go
+++ b/internal/declarative/executor/dcr_provider_adapter_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/labels"
 	"github.com/kong/kongctl/internal/declarative/planner"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -56,4 +57,28 @@ func TestDCRProviderAdapterMapUpdateFieldsKeepsHTTPPatchPayloadSparse(t *testing
 	var payload map[string]any
 	require.NoError(t, json.Unmarshal(body, &payload))
 	assert.NotContains(t, payload, "allow_multiple_credentials")
+}
+
+func TestDCRProviderAdapterMapUpdateFieldsAppliesProtectionOnlyChange(t *testing.T) {
+	adapter := NewDCRProviderAdapter(nil)
+	execCtx := &ExecutionContext{
+		Namespace:  "test",
+		Protection: planner.ProtectionChange{Old: true, New: false},
+	}
+	currentLabels := map[string]string{
+		labels.NamespaceKey: "test",
+		labels.ProtectedKey: "true",
+		"team":              "platform",
+	}
+
+	var update kkComps.UpdateDcrProviderRequest
+	err := adapter.MapUpdateFields(t.Context(), execCtx, map[string]any{planner.FieldName: "http-dcr"}, &update,
+		currentLabels)
+	require.NoError(t, err)
+	require.NotNil(t, update.Labels)
+	assert.Nil(t, update.Labels[labels.ProtectedKey])
+	require.NotNil(t, update.Labels[labels.NamespaceKey])
+	assert.Equal(t, "test", *update.Labels[labels.NamespaceKey])
+	require.NotNil(t, update.Labels["team"])
+	assert.Equal(t, "platform", *update.Labels["team"])
 }

--- a/test/e2e/scenarios/dcr-providers/workflow/overlays/001a-protected-update-fail/initial.yaml
+++ b/test/e2e/scenarios/dcr-providers/workflow/overlays/001a-protected-update-fail/initial.yaml
@@ -16,9 +16,9 @@ dcr_providers:
   - ref: e2e-dcr-http
     name: e2e-dcr-http
     provider_type: http
-    issuer: https://e2e-http-issuer.example.com
+    issuer: https://e2e-protected-update.example.com
     dcr_config:
-      dcr_base_url: https://e2e-http.example.com/v1/dcr
+      dcr_base_url: https://e2e-protected-update.example.com/v1/dcr
       api_key: e2e_http_api_key
       allow_multiple_credentials: true
     labels:

--- a/test/e2e/scenarios/dcr-providers/workflow/overlays/001b-unprotect/initial.yaml
+++ b/test/e2e/scenarios/dcr-providers/workflow/overlays/001b-unprotect/initial.yaml
@@ -25,7 +25,7 @@ dcr_providers:
       team: platform
       provider: http
     kongctl:
-      protected: true
+      protected: false
 
 application_auth_strategies:
   - ref: e2e-oidc-dcr-auth

--- a/test/e2e/scenarios/dcr-providers/workflow/scenario.yaml
+++ b/test/e2e/scenarios/dcr-providers/workflow/scenario.yaml
@@ -75,6 +75,89 @@ steps:
                 applied: 3
                 failed: 0
 
+  - name: 001a-protected-update-fail
+    inputOverlayDirs:
+      - overlays/001a-protected-update-fail
+    commands:
+      - name: 000-sync-protected-should-fail
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/initial.yaml"
+          - --auto-approve
+        expectFailure:
+          exitCode: 1
+          contains: "protected"
+      - name: 001-verify-protected-provider-unchanged
+        run:
+          - get
+          - dcr-provider
+          - "{{ .vars.httpName }}"
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                issuer: https://e2e-http-issuer.example.com
+                dcr_config.dcr_base_url: https://e2e-http.example.com/v1/dcr
+                labels."KONGCTL-protected": "true"
+
+  - name: 001b-unprotect
+    inputOverlayDirs:
+      - overlays/001b-unprotect
+    commands:
+      - name: 000-plan-unprotect
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-unprotect.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/initial.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+          - select: >-
+              changes[?resource_type=='dcr_provider' && resource_ref=='{{ .vars.httpName }}'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+                fields.labels."KONGCTL-protected": null
+          - select: summary.protection_changes
+            expect:
+              fields:
+                unprotecting: 1
+      - name: 001-apply-unprotect
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-unprotect.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+      - name: 002-verify-unprotected
+        run:
+          - get
+          - dcr-provider
+          - "{{ .vars.httpName }}"
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                labels."KONGCTL-protected": null
+
   - name: 002-get-and-list
     skipInputs: true
     commands:


### PR DESCRIPTION
## Summary

- expand the DCR provider workflow scenario to cover protected update rejection and unprotection
- preserve current labels when executing protection-only DCR provider updates
- add a unit regression test for protection-only label updates

## Rationale

The new lifecycle coverage exposed that a protection-only DCR provider plan reported success without sending a label update. This left the resource protected even though the plan recorded an unprotect transition. The adapter now builds the update labels from the current labels when no user label changes are present.

Fixes #1882

## Testing

- go fix ./...
- make format
- make build
- make lint
- make test
- make test-integration
- make scenario SCENARIO=dcr-providers/workflow