### PR TITLE
test(e2e): verify org assignment dump round trips

### DIFF
--- a/test/e2e/scenarios/org/system-accounts/assignments/scenario.yaml
+++ b/test/e2e/scenarios/org/system-accounts/assignments/scenario.yaml
@@ -198,7 +198,9 @@ steps:
                 name: "{{ .vars.teamName }}"
 
       - name: 007-dump-team-with-system-accounts
+        outputFormat: none
         parseAs: yaml
+        stdoutFile: "{{ .workdir }}/dump.yaml"
         run:
           - dump
           - declarative
@@ -231,6 +233,20 @@ steps:
             expect:
               fields:
                 "organization.\"system-accounts\"[?ref=='{{ .vars.systemAccountName }}'][0].teams[0].team == organization.teams[?name=='{{ .vars.teamName }}'][0].ref": true
+
+      - name: 008-plan-from-dump
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/dump.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
 
   - name: 003-cleanup
     inputOverlayDirs:

--- a/test/e2e/scenarios/org/users/assignments/scenario.yaml
+++ b/test/e2e/scenarios/org/users/assignments/scenario.yaml
@@ -219,7 +219,9 @@ steps:
                 entity_region: us
 
       - name: 006-dump-team-with-users
+        outputFormat: none
         parseAs: yaml
+        stdoutFile: "{{ .workdir }}/dump.yaml"
         run:
           - dump
           - declarative
@@ -309,6 +311,20 @@ steps:
                 role_name: Viewer
                 entity_type_name: APIs
                 entity_region: "*"
+
+      - name: 007-plan-from-dump
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/dump.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
 
   - name: 002-cleanup
     inputOverlayDirs:


### PR DESCRIPTION
## Summary

- save system-account assignment dumps and plan them back as no-ops
- save user assignment dumps and plan them back as no-ops
- preserve the existing structural dump assertions

## Rationale

This validates that organization assignment dumps are accepted by the planner without changes, covering schema and reference compatibility beyond the existing YAML assertions.

## Validation

- `go fix ./...`
- `make format`
- `make build`
- `make lint`
- `make test`
- `make test-e2e-scenarios SCENARIO=org/system-accounts/assignments`
- `make test-e2e-scenarios SCENARIO=org/users/assignments`

Closes #1894