### PR TITLE
fix(declarative): centralize managed protection label updates

### DIFF
--- a/docs/contributor/declarative-resource-implementation-guide.md
+++ b/docs/contributor/declarative-resource-implementation-guide.md
@@ -918,13 +918,10 @@ func (a *FooAdapter) MapCreateFields(
 }
 
 func (a *FooAdapter) MapUpdateFields(
-    _ context.Context, execCtx *ExecutionContext,
+    _ context.Context, _ *ExecutionContext,
     fields map[string]any, update *components.UpdateFooRequest,
-    currentLabels map[string]string,
+    _ map[string]string,
 ) error {
-    namespace := execCtx.Namespace
-    protection := execCtx.Protection
-
     // Only include changed fields
     for field, value := range fields {
         switch field {
@@ -939,26 +936,18 @@ func (a *FooAdapter) MapUpdateFields(
         }
     }
 
-    // Handle labels
-    desiredLabels := labels.ExtractLabelsFromField(fields[planner.FieldLabels])
-    if desiredLabels != nil {
-        plannerCurrentLabels := labels.ExtractLabelsFromField(fields[planner.FieldCurrentLabels])
-        if plannerCurrentLabels != nil {
-            currentLabels = plannerCurrentLabels
-        }
-
-        labelsMap := labels.BuildUpdateLabels(desiredLabels, currentLabels, namespace, protection)
-
-        // Convert to SDK format
-        update.Labels = labels.ConvertStringMapToPointerMap(labelsMap)
-        // OR: update.Labels = labelsMap
-    } else if currentLabels != nil {
-        // No label changes, preserve with updated protection
-        labelsMap := labels.BuildUpdateLabels(currentLabels, currentLabels, namespace, protection)
-        update.Labels = labels.ConvertStringMapToPointerMap(labelsMap)
-    }
-
     return nil
+}
+
+func (a *FooAdapter) MapUpdateLabels(
+    execCtx *ExecutionContext,
+    update *components.UpdateFooRequest,
+    desiredLabels map[string]string,
+    currentLabels map[string]string,
+) {
+    mapPointerUpdateLabels(
+        &update.Labels, execCtx, desiredLabels, currentLabels,
+    )
 }
 
 func (a *FooAdapter) Create(
@@ -1003,14 +992,20 @@ func (a *FooAdapter) SupportsUpdate() bool {
 **ADD TO**: `internal/declarative/executor/executor.go`
 ```go
 type Executor struct {
-    fooAdapter *FooAdapter
-    // ... existing adapters
+    fooExecutor *BaseExecutor[
+        components.CreateFooRequest,
+        components.UpdateFooRequest,
+    ]
+    // ... existing executors
 }
 
 func New(client *state.Client, reporter ProgressReporter, dryRun bool) *Executor {
     return &Executor{
-        fooAdapter: NewFooAdapter(client),
-        // ... other adapters
+        fooExecutor: NewManagedLabelBaseExecutor[
+            components.CreateFooRequest,
+            components.UpdateFooRequest,
+        ](NewFooAdapter(client), client, dryRun),
+        // ... other executors
     }
 }
 
@@ -1023,35 +1018,17 @@ func (e *Executor) executeChange(ctx context.Context, change planner.PlannedChan
 }
 
 func (e *Executor) executeFooChange(ctx context.Context, change planner.PlannedChange) error {
-    execCtx := &ExecutionContext{
-        PlannedChange: &change,
-        Namespace:     change.Namespace,
-        Protection:    change.Protection,
-    }
-
     switch change.Action {
     case planner.ActionCreate:
-        var req components.CreateFooRequest
-        if err := e.fooAdapter.MapCreateFields(ctx, execCtx, change.Fields, &req); err != nil {
-            return err
-        }
-        id, err := e.fooAdapter.Create(ctx, req, change.Namespace, execCtx)
-        if err != nil {
-            return err
-        }
-        e.trackCreatedResource(change.ResourceRef, id)
-        return nil
+        _, err := e.fooExecutor.Create(ctx, change)
+        return err
 
     case planner.ActionUpdate:
-        var req components.UpdateFooRequest
-        if err := e.fooAdapter.MapUpdateFields(ctx, execCtx, change.Fields, &req, nil); err != nil {
-            return err
-        }
-        _, err := e.fooAdapter.Update(ctx, change.ResourceID, req, change.Namespace, execCtx)
+        _, err := e.fooExecutor.Update(ctx, change)
         return err
 
     case planner.ActionDelete:
-        return e.fooAdapter.Delete(ctx, change.ResourceID, execCtx)
+        return e.fooExecutor.Delete(ctx, change)
     }
 
     return fmt.Errorf("unknown action: %s", change.Action)

--- a/internal/declarative/executor/ai_gateway_adapter.go
+++ b/internal/declarative/executor/ai_gateway_adapter.go
@@ -43,10 +43,10 @@ func (a *AIGatewayAdapter) MapCreateFields(
 // MapUpdateFields maps planner fields to UpdateAIGatewayRequest.
 func (a *AIGatewayAdapter) MapUpdateFields(
 	_ context.Context,
-	execCtx *ExecutionContext,
+	_ *ExecutionContext,
 	fields map[string]any,
 	update *kkComps.UpdateAIGatewayRequest,
-	currentLabels map[string]string,
+	_ map[string]string,
 ) error {
 	if err := mapAIGatewaySDKRequest("AI Gateway update", fields, update); err != nil {
 		return err
@@ -55,18 +55,21 @@ func (a *AIGatewayAdapter) MapUpdateFields(
 		return fmt.Errorf("AI Gateway name is required")
 	}
 
-	desiredLabels := labels.ExtractLabelsFromField(fields[planner.FieldLabels])
-	if desiredLabels != nil {
-		plannerCurrentLabels := labels.ExtractLabelsFromField(fields[planner.FieldCurrentLabels])
-		if plannerCurrentLabels != nil {
-			currentLabels = plannerCurrentLabels
-		}
-		update.Labels = labels.BuildUpdateStringLabels(desiredLabels, currentLabels, execCtx.Namespace, execCtx.Protection)
-	} else if currentLabels != nil {
-		update.Labels = labels.BuildUpdateStringLabels(currentLabels, currentLabels, execCtx.Namespace, execCtx.Protection)
-	}
-
 	return nil
+}
+
+func (a *AIGatewayAdapter) MapUpdateLabels(
+	execCtx *ExecutionContext,
+	update *kkComps.UpdateAIGatewayRequest,
+	desiredLabels map[string]string,
+	currentLabels map[string]string,
+) {
+	update.Labels = labels.BuildUpdateStringLabels(
+		desiredLabels,
+		currentLabels,
+		execCtx.Namespace,
+		execCtx.Protection,
+	)
 }
 
 // Create creates an AI Gateway.

--- a/internal/declarative/executor/ai_gateway_adapter_test.go
+++ b/internal/declarative/executor/ai_gateway_adapter_test.go
@@ -61,6 +61,7 @@ func TestAIGatewayAdapterMapUpdateFieldsPreservesCurrentName(t *testing.T) {
 	require.NoError(t, adapter.MapUpdateFields(context.Background(), execCtx, fields, &req, map[string]string{
 		labels.NamespaceKey: "ai-gateway-example",
 	}))
+	adapter.MapUpdateLabels(execCtx, &req, nil, nil)
 
 	assert.Equal(t, "support-gateway", req.Name)
 	assert.Equal(t, "Customer Support AI Gateway Renamed", req.DisplayName)

--- a/internal/declarative/executor/api_adapter.go
+++ b/internal/declarative/executor/api_adapter.go
@@ -97,7 +97,7 @@ func (p *APIAdapter) MapUpdateLabels(
 	desiredLabels map[string]string,
 	currentLabels map[string]string,
 ) {
-	update.Labels = labels.BuildUpdateLabels(desiredLabels, currentLabels, execCtx.Namespace, execCtx.Protection)
+	mapPointerUpdateLabels(&update.Labels, execCtx, desiredLabels, currentLabels)
 }
 
 // Create creates a new API

--- a/internal/declarative/executor/api_adapter.go
+++ b/internal/declarative/executor/api_adapter.go
@@ -53,13 +53,9 @@ func (p *APIAdapter) MapCreateFields(_ context.Context, execCtx *ExecutionContex
 }
 
 // MapUpdateFields maps fields to UpdateAPIRequest
-func (p *APIAdapter) MapUpdateFields(_ context.Context, execCtx *ExecutionContext, fields map[string]any,
-	update *kkComps.UpdateAPIRequest, currentLabels map[string]string,
+func (p *APIAdapter) MapUpdateFields(_ context.Context, _ *ExecutionContext, fields map[string]any,
+	update *kkComps.UpdateAPIRequest, _ map[string]string,
 ) error {
-	// Extract namespace and protection from execution context
-	namespace := execCtx.Namespace
-	protection := execCtx.Protection
-
 	// Only include fields that are in the fields map
 	// These represent actual changes detected by the planner
 	for field, value := range fields {
@@ -84,22 +80,6 @@ func (p *APIAdapter) MapUpdateFields(_ context.Context, execCtx *ExecutionContex
 		}
 	}
 
-	// Handle labels using centralized helper
-	desiredLabels := labels.ExtractLabelsFromField(fields[planner.FieldLabels])
-	if desiredLabels != nil {
-		// Get current labels if passed from planner
-		plannerCurrentLabels := labels.ExtractLabelsFromField(fields[planner.FieldCurrentLabels])
-		if plannerCurrentLabels != nil {
-			currentLabels = plannerCurrentLabels
-		}
-
-		// Build update labels with removal support
-		update.Labels = labels.BuildUpdateLabels(desiredLabels, currentLabels, namespace, protection)
-	} else if currentLabels != nil {
-		// If no labels in change, preserve existing labels with updated protection
-		update.Labels = labels.BuildUpdateLabels(currentLabels, currentLabels, namespace, protection)
-	}
-
 	if attrs, ok := fields[planner.FieldAttributes]; ok {
 		if normalized, ok := attributes.NormalizeAPIAttributes(attrs); ok {
 			update.Attributes = normalized
@@ -109,6 +89,15 @@ func (p *APIAdapter) MapUpdateFields(_ context.Context, execCtx *ExecutionContex
 	}
 
 	return nil
+}
+
+func (p *APIAdapter) MapUpdateLabels(
+	execCtx *ExecutionContext,
+	update *kkComps.UpdateAPIRequest,
+	desiredLabels map[string]string,
+	currentLabels map[string]string,
+) {
+	update.Labels = labels.BuildUpdateLabels(desiredLabels, currentLabels, execCtx.Namespace, execCtx.Protection)
 }
 
 // Create creates a new API

--- a/internal/declarative/executor/auth_strategy_adapter.go
+++ b/internal/declarative/executor/auth_strategy_adapter.go
@@ -105,7 +105,7 @@ func (a *AuthStrategyAdapter) MapUpdateLabels(
 	desiredLabels map[string]string,
 	currentLabels map[string]string,
 ) {
-	update.Labels = labels.BuildUpdateLabels(desiredLabels, currentLabels, execCtx.Namespace, execCtx.Protection)
+	mapPointerUpdateLabels(&update.Labels, execCtx, desiredLabels, currentLabels)
 }
 
 // Create creates a new auth strategy

--- a/internal/declarative/executor/auth_strategy_adapter.go
+++ b/internal/declarative/executor/auth_strategy_adapter.go
@@ -68,25 +68,12 @@ func (a *AuthStrategyAdapter) MapCreateFields(
 
 // MapUpdateFields maps fields to UpdateAppAuthStrategyRequest
 func (a *AuthStrategyAdapter) MapUpdateFields(
-	_ context.Context, execCtx *ExecutionContext, fields map[string]any,
-	update *kkComps.UpdateAppAuthStrategyRequest, currentLabels map[string]string,
+	_ context.Context, _ *ExecutionContext, fields map[string]any,
+	update *kkComps.UpdateAppAuthStrategyRequest, _ map[string]string,
 ) error {
 	// Update display name if present
 	if displayName, ok := fields[planner.FieldDisplayName].(string); ok {
 		update.DisplayName = &displayName
-	}
-
-	// Handle labels using centralized helper
-	desiredLabels := labels.ExtractLabelsFromField(fields[planner.FieldLabels])
-	if desiredLabels != nil {
-		// Get current labels if passed from planner
-		plannerCurrentLabels := labels.ExtractLabelsFromField(fields[planner.FieldCurrentLabels])
-		if plannerCurrentLabels != nil {
-			currentLabels = plannerCurrentLabels
-		}
-
-		// Build update labels with removal support
-		update.Labels = labels.BuildUpdateLabels(desiredLabels, currentLabels, execCtx.Namespace, execCtx.Protection)
 	}
 
 	// Handle config updates if present
@@ -110,6 +97,15 @@ func (a *AuthStrategyAdapter) MapUpdateFields(
 	}
 
 	return nil
+}
+
+func (a *AuthStrategyAdapter) MapUpdateLabels(
+	execCtx *ExecutionContext,
+	update *kkComps.UpdateAppAuthStrategyRequest,
+	desiredLabels map[string]string,
+	currentLabels map[string]string,
+) {
+	update.Labels = labels.BuildUpdateLabels(desiredLabels, currentLabels, execCtx.Namespace, execCtx.Protection)
 }
 
 // Create creates a new auth strategy

--- a/internal/declarative/executor/auth_strategy_adapter_test.go
+++ b/internal/declarative/executor/auth_strategy_adapter_test.go
@@ -137,6 +137,64 @@ func TestAuthStrategyAdapterUpdateFallsBackToIDLookup(t *testing.T) {
 	}
 }
 
+func TestAuthStrategyAdapterAppliesProtectionOnlyUpdate(t *testing.T) {
+	const strategyID = "1da45676-c973-4693-ab9f-c2986757ed07"
+	managedLabels := map[string]string{
+		labels.NamespaceKey: "default",
+		labels.ProtectedKey: labels.TrueValue,
+		"team":              "identity",
+	}
+
+	api := &stubAppAuthStrategiesAPI{
+		t: t,
+		listData: []kkComps.AppAuthStrategy{
+			oidcAuthStrategy(strategyID, "oidc-e2e", managedLabels),
+		},
+		getByID: map[string]*kkComps.CreateAppAuthStrategyResponse{},
+	}
+
+	client := state.NewClient(state.ClientConfig{AppAuthAPI: api})
+	adapter := NewAuthStrategyAdapter(client)
+	base := NewBaseExecutor[kkComps.CreateAppAuthStrategyRequest, kkComps.UpdateAppAuthStrategyRequest](
+		adapter,
+		client,
+		false,
+	)
+
+	change := planner.PlannedChange{
+		ID:           "1:u:application_auth_strategy:oidc-e2e",
+		ResourceType: planner.ResourceTypeApplicationAuthStrategy,
+		ResourceRef:  "oidc-e2e",
+		ResourceID:   strategyID,
+		Action:       planner.ActionUpdate,
+		Fields: map[string]any{
+			planner.FieldName: "oidc-e2e",
+		},
+		Namespace: "default",
+		Protection: planner.ProtectionChange{
+			Old: true,
+			New: false,
+		},
+	}
+
+	if _, err := base.Update(testContextWithLogger(), change); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+
+	if api.lastUpdate.Labels == nil {
+		t.Fatal("expected protection-only update request labels to be populated")
+	}
+	if protected, ok := api.lastUpdate.Labels[labels.ProtectedKey]; !ok || protected != nil {
+		t.Fatalf("expected protected label removal, got %v", protected)
+	}
+	if namespace := api.lastUpdate.Labels[labels.NamespaceKey]; namespace == nil || *namespace != "default" {
+		t.Fatalf("expected namespace label to be preserved, got %v", namespace)
+	}
+	if team := api.lastUpdate.Labels["team"]; team == nil || *team != "identity" {
+		t.Fatalf("expected user label to be preserved, got %v", team)
+	}
+}
+
 func oidcAuthStrategy(id, name string, lbls map[string]string) kkComps.AppAuthStrategy {
 	return kkComps.CreateAppAuthStrategyOpenidConnect(
 		kkComps.AppAuthStrategyOpenIDConnectResponseAppAuthStrategyOpenIDConnectResponse{

--- a/internal/declarative/executor/auth_strategy_adapter_test.go
+++ b/internal/declarative/executor/auth_strategy_adapter_test.go
@@ -195,6 +195,64 @@ func TestAuthStrategyAdapterAppliesProtectionOnlyUpdate(t *testing.T) {
 	}
 }
 
+func TestAuthStrategyAdapterUsesPlanTimeLabelsForUpdate(t *testing.T) {
+	const strategyID = "1da45676-c973-4693-ab9f-c2986757ed07"
+	liveLabels := map[string]string{
+		labels.NamespaceKey: "default",
+		"live-only":         "preserve",
+		"remove":            "live-value",
+		"team":              "live-value",
+	}
+
+	api := &stubAppAuthStrategiesAPI{
+		t: t,
+		listData: []kkComps.AppAuthStrategy{
+			oidcAuthStrategy(strategyID, "oidc-e2e", liveLabels),
+		},
+		getByID: map[string]*kkComps.CreateAppAuthStrategyResponse{},
+	}
+
+	client := state.NewClient(state.ClientConfig{AppAuthAPI: api})
+	base := NewBaseExecutor[kkComps.CreateAppAuthStrategyRequest, kkComps.UpdateAppAuthStrategyRequest](
+		NewAuthStrategyAdapter(client),
+		client,
+		false,
+	)
+	change := planner.PlannedChange{
+		ID:           "1:u:application_auth_strategy:oidc-e2e",
+		ResourceType: planner.ResourceTypeApplicationAuthStrategy,
+		ResourceRef:  "oidc-e2e",
+		ResourceID:   strategyID,
+		Action:       planner.ActionUpdate,
+		Fields: map[string]any{
+			planner.FieldName: "oidc-e2e",
+			planner.FieldLabels: map[string]any{
+				"team": "desired-value",
+			},
+			planner.FieldCurrentLabels: map[string]any{
+				labels.NamespaceKey: "default",
+				"remove":            "planned-value",
+				"team":              "planned-value",
+			},
+		},
+		Namespace: "default",
+	}
+
+	if _, err := base.Update(testContextWithLogger(), change); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+
+	if team := api.lastUpdate.Labels["team"]; team == nil || *team != "desired-value" {
+		t.Fatalf("expected desired team label, got %v", team)
+	}
+	if removed, ok := api.lastUpdate.Labels["remove"]; !ok || removed != nil {
+		t.Fatalf("expected planned label removal, got %v", removed)
+	}
+	if _, ok := api.lastUpdate.Labels["live-only"]; ok {
+		t.Fatalf("expected out-of-band label to be omitted from the approved update, got %v", api.lastUpdate.Labels)
+	}
+}
+
 func oidcAuthStrategy(id, name string, lbls map[string]string) kkComps.AppAuthStrategy {
 	return kkComps.CreateAppAuthStrategyOpenidConnect(
 		kkComps.AppAuthStrategyOpenIDConnectResponseAppAuthStrategyOpenIDConnectResponse{

--- a/internal/declarative/executor/base_executor.go
+++ b/internal/declarative/executor/base_executor.go
@@ -36,6 +36,23 @@ type ResourceOperations[TCreate any, TUpdate any] interface {
 	SupportsUpdate() bool
 }
 
+// ManagedLabelOperations maps declarative user and kongctl-managed labels onto an update request.
+// BaseExecutor invokes it for every update so protection-only changes cannot be dropped when no
+// ordinary label fields changed.
+type ManagedLabelOperations[TUpdate any] interface {
+	MapUpdateLabels(
+		execCtx *ExecutionContext,
+		update *TUpdate,
+		desiredLabels map[string]string,
+		currentLabels map[string]string,
+	)
+}
+
+type ManagedLabelResourceOperations[TCreate any, TUpdate any] interface {
+	ResourceOperations[TCreate, TUpdate]
+	ManagedLabelOperations[TUpdate]
+}
+
 // ResourceInfo provides common resource information
 type ResourceInfo interface {
 	GetID() string
@@ -62,6 +79,14 @@ func NewBaseExecutor[TCreate any, TUpdate any](
 		client: client,
 		dryRun: dryRun,
 	}
+}
+
+func NewManagedLabelBaseExecutor[TCreate any, TUpdate any](
+	ops ManagedLabelResourceOperations[TCreate, TUpdate],
+	client *state.Client,
+	dryRun bool,
+) *BaseExecutor[TCreate, TUpdate] {
+	return NewBaseExecutor[TCreate, TUpdate](ops, client, dryRun)
 }
 
 // Create handles CREATE operations for any resource type
@@ -147,6 +172,16 @@ func (b *BaseExecutor[TCreate, TUpdate]) Update(ctx context.Context, change plan
 	var update TUpdate
 	if err := b.ops.MapUpdateFields(ctx, execCtx, change.Fields, &update, currentLabels); err != nil {
 		return "", common.FormatAPIError(b.ops.ResourceType(), resourceName, "update", err)
+	}
+	if labelOps, ok := b.ops.(ManagedLabelOperations[TUpdate]); ok {
+		desiredLabels := currentLabels
+		if rawDesiredLabels, labelsChanged := change.Fields[planner.FieldLabels]; labelsChanged {
+			desiredLabels = labels.ExtractLabelsFromField(rawDesiredLabels)
+			if desiredLabels == nil {
+				desiredLabels = make(map[string]string)
+			}
+		}
+		labelOps.MapUpdateLabels(execCtx, &update, desiredLabels, currentLabels)
 	}
 
 	// Handle dry-run

--- a/internal/declarative/executor/base_executor.go
+++ b/internal/declarative/executor/base_executor.go
@@ -53,6 +53,15 @@ type ManagedLabelResourceOperations[TCreate any, TUpdate any] interface {
 	ManagedLabelOperations[TUpdate]
 }
 
+func mapPointerUpdateLabels(
+	destination *map[string]*string,
+	execCtx *ExecutionContext,
+	desiredLabels map[string]string,
+	currentLabels map[string]string,
+) {
+	*destination = labels.BuildUpdateLabels(desiredLabels, currentLabels, execCtx.Namespace, execCtx.Protection)
+}
+
 // ResourceInfo provides common resource information
 type ResourceInfo interface {
 	GetID() string

--- a/internal/declarative/executor/base_executor.go
+++ b/internal/declarative/executor/base_executor.go
@@ -183,6 +183,12 @@ func (b *BaseExecutor[TCreate, TUpdate]) Update(ctx context.Context, change plan
 		return "", common.FormatAPIError(b.ops.ResourceType(), resourceName, "update", err)
 	}
 	if labelOps, ok := b.ops.(ManagedLabelOperations[TUpdate]); ok {
+		if rawCurrentLabels, present := change.Fields[planner.FieldCurrentLabels]; present {
+			currentLabels = labels.ExtractLabelsFromField(rawCurrentLabels)
+			if currentLabels == nil {
+				currentLabels = make(map[string]string)
+			}
+		}
 		desiredLabels := currentLabels
 		if rawDesiredLabels, labelsChanged := change.Fields[planner.FieldLabels]; labelsChanged {
 			desiredLabels = labels.ExtractLabelsFromField(rawDesiredLabels)

--- a/internal/declarative/executor/catalog_service_adapter.go
+++ b/internal/declarative/executor/catalog_service_adapter.go
@@ -51,14 +51,11 @@ func (a *CatalogServiceAdapter) MapCreateFields(
 // MapUpdateFields maps planner fields to UpdateCatalogService.
 func (a *CatalogServiceAdapter) MapUpdateFields(
 	_ context.Context,
-	execCtx *ExecutionContext,
+	_ *ExecutionContext,
 	fields map[string]any,
 	update *kkComps.UpdateCatalogService,
-	currentLabels map[string]string,
+	_ map[string]string,
 ) error {
-	namespace := execCtx.Namespace
-	protection := execCtx.Protection
-
 	for field, value := range fields {
 		switch field {
 		case planner.FieldName:
@@ -78,18 +75,16 @@ func (a *CatalogServiceAdapter) MapUpdateFields(
 		}
 	}
 
-	desiredLabels := labels.ExtractLabelsFromField(fields[planner.FieldLabels])
-	if desiredLabels != nil {
-		plannerCurrentLabels := labels.ExtractLabelsFromField(fields[planner.FieldCurrentLabels])
-		if plannerCurrentLabels != nil {
-			currentLabels = plannerCurrentLabels
-		}
-		update.Labels = labels.BuildUpdateLabels(desiredLabels, currentLabels, namespace, protection)
-	} else if currentLabels != nil {
-		update.Labels = labels.BuildUpdateLabels(currentLabels, currentLabels, namespace, protection)
-	}
-
 	return nil
+}
+
+func (a *CatalogServiceAdapter) MapUpdateLabels(
+	execCtx *ExecutionContext,
+	update *kkComps.UpdateCatalogService,
+	desiredLabels map[string]string,
+	currentLabels map[string]string,
+) {
+	update.Labels = labels.BuildUpdateLabels(desiredLabels, currentLabels, execCtx.Namespace, execCtx.Protection)
 }
 
 // Create creates a catalog service.

--- a/internal/declarative/executor/catalog_service_adapter.go
+++ b/internal/declarative/executor/catalog_service_adapter.go
@@ -84,7 +84,7 @@ func (a *CatalogServiceAdapter) MapUpdateLabels(
 	desiredLabels map[string]string,
 	currentLabels map[string]string,
 ) {
-	update.Labels = labels.BuildUpdateLabels(desiredLabels, currentLabels, execCtx.Namespace, execCtx.Protection)
+	mapPointerUpdateLabels(&update.Labels, execCtx, desiredLabels, currentLabels)
 }
 
 // Create creates a catalog service.

--- a/internal/declarative/executor/control_plane_adapter.go
+++ b/internal/declarative/executor/control_plane_adapter.go
@@ -57,8 +57,8 @@ func (a *ControlPlaneAdapter) MapCreateFields(_ context.Context, execCtx *Execut
 }
 
 // MapUpdateFields maps planner fields to UpdateControlPlaneRequest
-func (a *ControlPlaneAdapter) MapUpdateFields(_ context.Context, execCtx *ExecutionContext,
-	fields map[string]any, update *kkComps.UpdateControlPlaneRequest, currentLabels map[string]string,
+func (a *ControlPlaneAdapter) MapUpdateFields(_ context.Context, _ *ExecutionContext,
+	fields map[string]any, update *kkComps.UpdateControlPlaneRequest, _ map[string]string,
 ) error {
 	for field, value := range fields {
 		switch field {
@@ -84,23 +84,21 @@ func (a *ControlPlaneAdapter) MapUpdateFields(_ context.Context, execCtx *Execut
 		}
 	}
 
-	desiredLabels := labels.ExtractLabelsFromField(fields[planner.FieldLabels])
-	if plannerLabels := labels.ExtractLabelsFromField(fields[planner.FieldCurrentLabels]); plannerLabels != nil {
-		currentLabels = plannerLabels
-	}
-
-	if desiredLabels != nil {
-		update.Labels = labels.BuildUpdateStringLabels(
-			desiredLabels,
-			currentLabels,
-			execCtx.Namespace,
-			execCtx.Protection,
-		)
-	} else if currentLabels != nil {
-		update.Labels = labels.BuildUpdateStringLabels(currentLabels, currentLabels, execCtx.Namespace, execCtx.Protection)
-	}
-
 	return nil
+}
+
+func (a *ControlPlaneAdapter) MapUpdateLabels(
+	execCtx *ExecutionContext,
+	update *kkComps.UpdateControlPlaneRequest,
+	desiredLabels map[string]string,
+	currentLabels map[string]string,
+) {
+	update.Labels = labels.BuildUpdateStringLabels(
+		desiredLabels,
+		currentLabels,
+		execCtx.Namespace,
+		execCtx.Protection,
+	)
 }
 
 // Create issues a create call via the state client

--- a/internal/declarative/executor/control_plane_operations_test.go
+++ b/internal/declarative/executor/control_plane_operations_test.go
@@ -73,6 +73,7 @@ func TestControlPlaneAdapter_MapUpdateFields(t *testing.T) {
 	currentLabels := map[string]string{"env": "prod"}
 	var update kkComps.UpdateControlPlaneRequest
 	require.NoError(t, adapter.MapUpdateFields(context.Background(), execCtx, fields, &update, currentLabels))
+	adapter.MapUpdateLabels(execCtx, &update, map[string]string{"env": "staging"}, currentLabels)
 	require.NotNil(t, update.Description)
 	assert.Equal(t, "updated", *update.Description)
 	require.NotNil(t, update.AuthType)

--- a/internal/declarative/executor/dashboard_adapter.go
+++ b/internal/declarative/executor/dashboard_adapter.go
@@ -69,9 +69,6 @@ func (a *DashboardAdapter) MapUpdateLabels(
 		execCtx.Namespace,
 		execCtx.Protection,
 	)
-	if update.Labels == nil {
-		update.Labels = make(map[string]string)
-	}
 }
 
 func (a *DashboardAdapter) Create(

--- a/internal/declarative/executor/dashboard_adapter.go
+++ b/internal/declarative/executor/dashboard_adapter.go
@@ -42,10 +42,10 @@ func (a *DashboardAdapter) MapCreateFields(
 
 func (a *DashboardAdapter) MapUpdateFields(
 	_ context.Context,
-	execCtx *ExecutionContext,
+	_ *ExecutionContext,
 	fields map[string]any,
 	update *kkComps.DashboardUpdateRequest,
-	currentLabels map[string]string,
+	_ map[string]string,
 ) error {
 	update.Name, _ = fields[planner.FieldName].(string)
 	definition, err := dashboardDefinitionFromField(fields[planner.FieldDefinition])
@@ -54,26 +54,24 @@ func (a *DashboardAdapter) MapUpdateFields(
 	}
 	update.Definition = definition
 
-	desiredLabels := labels.ExtractLabelsFromField(fields[planner.FieldLabels])
-	if desiredLabels != nil {
-		plannerCurrentLabels := labels.ExtractLabelsFromField(fields[planner.FieldCurrentLabels])
-		if plannerCurrentLabels != nil {
-			currentLabels = plannerCurrentLabels
-		}
-		update.Labels = labels.BuildUpdateStringLabels(
-			desiredLabels,
-			currentLabels,
-			execCtx.Namespace,
-			execCtx.Protection,
-		)
-	} else if currentLabels != nil {
-		update.Labels = labels.BuildUpdateStringLabels(currentLabels, currentLabels, execCtx.Namespace, execCtx.Protection)
-	}
+	return nil
+}
+
+func (a *DashboardAdapter) MapUpdateLabels(
+	execCtx *ExecutionContext,
+	update *kkComps.DashboardUpdateRequest,
+	desiredLabels map[string]string,
+	currentLabels map[string]string,
+) {
+	update.Labels = labels.BuildUpdateStringLabels(
+		desiredLabels,
+		currentLabels,
+		execCtx.Namespace,
+		execCtx.Protection,
+	)
 	if update.Labels == nil {
 		update.Labels = make(map[string]string)
 	}
-
-	return nil
 }
 
 func (a *DashboardAdapter) Create(

--- a/internal/declarative/executor/dcr_provider_adapter.go
+++ b/internal/declarative/executor/dcr_provider_adapter.go
@@ -51,8 +51,8 @@ func (a *DCRProviderAdapter) MapCreateFields(
 }
 
 func (a *DCRProviderAdapter) MapUpdateFields(
-	_ context.Context, execCtx *ExecutionContext, fields map[string]any,
-	update *kkComps.UpdateDcrProviderRequest, currentLabels map[string]string,
+	_ context.Context, _ *ExecutionContext, fields map[string]any,
+	update *kkComps.UpdateDcrProviderRequest, _ map[string]string,
 ) error {
 	payload := map[string]any{}
 	if displayName, ok := fields[planner.FieldDisplayName].(string); ok {
@@ -62,37 +62,12 @@ func (a *DCRProviderAdapter) MapUpdateFields(
 		payload[planner.FieldDCRProviderIssuer] = issuer
 	}
 
-	desiredLabels := labels.ExtractLabelsFromField(fields[planner.FieldLabels])
-	if desiredLabels != nil {
-		plannerCurrentLabels := labels.ExtractLabelsFromField(fields[planner.FieldCurrentLabels])
-		if plannerCurrentLabels != nil {
-			currentLabels = plannerCurrentLabels
-		}
-		payload[planner.FieldLabels] = labels.BuildUpdateLabels(
-			desiredLabels,
-			currentLabels,
-			execCtx.Namespace,
-			execCtx.Protection,
-		)
-	} else if currentLabels != nil {
-		payload[planner.FieldLabels] = labels.BuildUpdateLabels(
-			currentLabels,
-			currentLabels,
-			execCtx.Namespace,
-			execCtx.Protection,
-		)
-	}
-
 	if displayName, ok := payload[planner.FieldDisplayName].(string); ok {
 		update.DisplayName = &displayName
 	}
 	if issuer, ok := payload[planner.FieldDCRProviderIssuer].(string); ok {
 		update.Issuer = &issuer
 	}
-	if updateLabels, ok := payload[planner.FieldLabels].(map[string]*string); ok {
-		update.Labels = updateLabels
-	}
-
 	if dcrConfig, ok := fields[planner.FieldDCRProviderConfig]; ok {
 		providerType, _ := fields[planner.FieldDCRProviderUpdateType].(string)
 		if providerType == "" {
@@ -107,6 +82,15 @@ func (a *DCRProviderAdapter) MapUpdateFields(
 	}
 
 	return nil
+}
+
+func (a *DCRProviderAdapter) MapUpdateLabels(
+	execCtx *ExecutionContext,
+	update *kkComps.UpdateDcrProviderRequest,
+	desiredLabels map[string]string,
+	currentLabels map[string]string,
+) {
+	update.Labels = labels.BuildUpdateLabels(desiredLabels, currentLabels, execCtx.Namespace, execCtx.Protection)
 }
 
 func (a *DCRProviderAdapter) Create(ctx context.Context, req kkComps.CreateDcrProviderRequest,

--- a/internal/declarative/executor/dcr_provider_adapter.go
+++ b/internal/declarative/executor/dcr_provider_adapter.go
@@ -90,7 +90,7 @@ func (a *DCRProviderAdapter) MapUpdateLabels(
 	desiredLabels map[string]string,
 	currentLabels map[string]string,
 ) {
-	update.Labels = labels.BuildUpdateLabels(desiredLabels, currentLabels, execCtx.Namespace, execCtx.Protection)
+	mapPointerUpdateLabels(&update.Labels, execCtx, desiredLabels, currentLabels)
 }
 
 func (a *DCRProviderAdapter) Create(ctx context.Context, req kkComps.CreateDcrProviderRequest,

--- a/internal/declarative/executor/dcr_provider_adapter_test.go
+++ b/internal/declarative/executor/dcr_provider_adapter_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
-	"github.com/kong/kongctl/internal/declarative/labels"
 	"github.com/kong/kongctl/internal/declarative/planner"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -57,28 +56,4 @@ func TestDCRProviderAdapterMapUpdateFieldsKeepsHTTPPatchPayloadSparse(t *testing
 	var payload map[string]any
 	require.NoError(t, json.Unmarshal(body, &payload))
 	assert.NotContains(t, payload, "allow_multiple_credentials")
-}
-
-func TestDCRProviderAdapterMapUpdateFieldsAppliesProtectionOnlyChange(t *testing.T) {
-	adapter := NewDCRProviderAdapter(nil)
-	execCtx := &ExecutionContext{
-		Namespace:  "test",
-		Protection: planner.ProtectionChange{Old: true, New: false},
-	}
-	currentLabels := map[string]string{
-		labels.NamespaceKey: "test",
-		labels.ProtectedKey: "true",
-		"team":              "platform",
-	}
-
-	var update kkComps.UpdateDcrProviderRequest
-	err := adapter.MapUpdateFields(t.Context(), execCtx, map[string]any{planner.FieldName: "http-dcr"}, &update,
-		currentLabels)
-	require.NoError(t, err)
-	require.NotNil(t, update.Labels)
-	assert.Nil(t, update.Labels[labels.ProtectedKey])
-	require.NotNil(t, update.Labels[labels.NamespaceKey])
-	assert.Equal(t, "test", *update.Labels[labels.NamespaceKey])
-	require.NotNil(t, update.Labels["team"])
-	assert.Equal(t, "platform", *update.Labels["team"])
 }

--- a/internal/declarative/executor/event_gateway_control_plane_adapter.go
+++ b/internal/declarative/executor/event_gateway_control_plane_adapter.go
@@ -48,13 +48,10 @@ func (a *EventGatewayControlPlaneControlPlaneAdapter) MapCreateFields(_ context.
 }
 
 func (a *EventGatewayControlPlaneControlPlaneAdapter) MapUpdateFields(
-	_ context.Context, execCtx *ExecutionContext,
+	_ context.Context, _ *ExecutionContext,
 	fields map[string]any, update *components.UpdateGatewayRequest,
-	currentLabels map[string]string,
+	_ map[string]string,
 ) error {
-	namespace := execCtx.Namespace
-	protection := execCtx.Protection
-
 	// Only include changed fields
 	for field, value := range fields {
 		switch field {
@@ -73,26 +70,21 @@ func (a *EventGatewayControlPlaneControlPlaneAdapter) MapUpdateFields(
 		}
 	}
 
-	// Handle labels
-	desiredLabels := labels.ExtractLabelsFromField(fields[planner.FieldLabels])
-	if desiredLabels != nil {
-		plannerCurrentLabels := labels.ExtractLabelsFromField(fields[planner.FieldCurrentLabels])
-		if plannerCurrentLabels != nil {
-			currentLabels = plannerCurrentLabels
-		}
-
-		labelsMap := labels.BuildUpdateLabels(desiredLabels, currentLabels, namespace, protection)
-
-		// Convert to SDK format
-		update.Labels = labels.ConvertPointerMapsToStringMap(labelsMap)
-		// OR: update.Labels = labelsMap
-	} else if currentLabels != nil {
-		// No label changes, preserve with updated protection
-		labelsMap := labels.BuildUpdateLabels(currentLabels, currentLabels, namespace, protection)
-		update.Labels = labels.ConvertPointerMapsToStringMap(labelsMap)
-	}
-
 	return nil
+}
+
+func (a *EventGatewayControlPlaneControlPlaneAdapter) MapUpdateLabels(
+	execCtx *ExecutionContext,
+	update *components.UpdateGatewayRequest,
+	desiredLabels map[string]string,
+	currentLabels map[string]string,
+) {
+	update.Labels = labels.BuildUpdateStringLabels(
+		desiredLabels,
+		currentLabels,
+		execCtx.Namespace,
+		execCtx.Protection,
+	)
 }
 
 func (a *EventGatewayControlPlaneControlPlaneAdapter) Create(

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -228,37 +228,43 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 	}
 
 	// Initialize resource executors
-	e.portalExecutor = NewBaseExecutor[kkComps.CreatePortal, kkComps.UpdatePortal](
+	e.portalExecutor = NewManagedLabelBaseExecutor[kkComps.CreatePortal, kkComps.UpdatePortal](
 		NewPortalAdapter(client),
 		client,
 		dryRun,
 	)
-	e.controlPlaneExecutor = NewBaseExecutor[kkComps.CreateControlPlaneRequest, kkComps.UpdateControlPlaneRequest](
+	e.controlPlaneExecutor = NewManagedLabelBaseExecutor[
+		kkComps.CreateControlPlaneRequest, kkComps.UpdateControlPlaneRequest,
+	](
 		NewControlPlaneAdapter(client),
 		client,
 		dryRun,
 	)
-	e.apiExecutor = NewBaseExecutor[kkComps.CreateAPIRequest, kkComps.UpdateAPIRequest](
+	e.apiExecutor = NewManagedLabelBaseExecutor[kkComps.CreateAPIRequest, kkComps.UpdateAPIRequest](
 		NewAPIAdapter(client),
 		client,
 		dryRun,
 	)
-	e.authStrategyExecutor = NewBaseExecutor[kkComps.CreateAppAuthStrategyRequest, kkComps.UpdateAppAuthStrategyRequest](
+	e.authStrategyExecutor = NewManagedLabelBaseExecutor[
+		kkComps.CreateAppAuthStrategyRequest, kkComps.UpdateAppAuthStrategyRequest,
+	](
 		NewAuthStrategyAdapter(client),
 		client,
 		dryRun,
 	)
-	e.dcrProviderExecutor = NewBaseExecutor[kkComps.CreateDcrProviderRequest, kkComps.UpdateDcrProviderRequest](
+	e.dcrProviderExecutor = NewManagedLabelBaseExecutor[
+		kkComps.CreateDcrProviderRequest, kkComps.UpdateDcrProviderRequest,
+	](
 		NewDCRProviderAdapter(client),
 		client,
 		dryRun,
 	)
-	e.catalogServiceExecutor = NewBaseExecutor[kkComps.CreateCatalogService, kkComps.UpdateCatalogService](
+	e.catalogServiceExecutor = NewManagedLabelBaseExecutor[kkComps.CreateCatalogService, kkComps.UpdateCatalogService](
 		NewCatalogServiceAdapter(client),
 		client,
 		dryRun,
 	)
-	e.aiGatewayExecutor = NewBaseExecutor[kkComps.CreateAIGatewayRequest, kkComps.UpdateAIGatewayRequest](
+	e.aiGatewayExecutor = NewManagedLabelBaseExecutor[kkComps.CreateAIGatewayRequest, kkComps.UpdateAIGatewayRequest](
 		NewAIGatewayAdapter(client),
 		client,
 		dryRun,
@@ -337,17 +343,19 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 		NewAIGatewayDataPlaneCertificateAdapter(client),
 		dryRun,
 	)
-	e.dashboardExecutor = NewBaseExecutor[kkComps.DashboardUpdateRequest, kkComps.DashboardUpdateRequest](
+	e.dashboardExecutor = NewManagedLabelBaseExecutor[kkComps.DashboardUpdateRequest, kkComps.DashboardUpdateRequest](
 		NewDashboardAdapter(client),
 		client,
 		dryRun,
 	)
-	e.eventGatewayControlPlaneExecutor = NewBaseExecutor[kkComps.CreateGatewayRequest, kkComps.UpdateGatewayRequest](
+	e.eventGatewayControlPlaneExecutor = NewManagedLabelBaseExecutor[
+		kkComps.CreateGatewayRequest, kkComps.UpdateGatewayRequest,
+	](
 		NewEventGatewayControlPlaneControlPlaneAdapter(client),
 		client,
 		dryRun,
 	)
-	e.organizationTeamExecutor = NewBaseExecutor[kkComps.CreateTeam, kkComps.UpdateTeam](
+	e.organizationTeamExecutor = NewManagedLabelBaseExecutor[kkComps.CreateTeam, kkComps.UpdateTeam](
 		NewOrganizationTeamAdapter(client),
 		client,
 		dryRun,

--- a/internal/declarative/executor/managed_labels_test.go
+++ b/internal/declarative/executor/managed_labels_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"reflect"
 	"testing"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
@@ -166,18 +167,12 @@ func verifyStringManagedLabels[T any](
 func assertAllProtectableResourcesCovered(t *testing.T, covered map[resources.ResourceType]bool) {
 	t.Helper()
 
-	resourceSet := resources.ResourceSet{
-		Portals:                   []resources.PortalResource{{}},
-		APIs:                      []resources.APIResource{{}},
-		CatalogServices:           []resources.CatalogServiceResource{{}},
-		AIGateways:                []resources.AIGatewayResource{{}},
-		Dashboards:                []resources.DashboardResource{{}},
-		EventGatewayControlPlanes: []resources.EventGatewayControlPlaneResource{{}},
-		ApplicationAuthStrategies: []resources.ApplicationAuthStrategyResource{{}},
-		DCRProviders:              []resources.DCRProviderResource{{}},
-		ControlPlanes:             []resources.ControlPlaneResource{{}},
-		OrganizationTeams:         []resources.OrganizationTeamResource{{}},
-	}
+	resourceSet := resources.ResourceSet{}
+	populateStructSlices(&resourceSet)
+	resourceSet.Analytics = &resources.AnalyticsResource{}
+	populateStructSlices(resourceSet.Analytics)
+	resourceSet.Organization = &resources.OrganizationResource{}
+	populateStructSlices(resourceSet.Organization)
 
 	protectable := make(map[resources.ResourceType]bool)
 	err := resourceSet.ForEachNamespaceParticipant(func(participant resources.NamespaceParticipant) error {
@@ -188,4 +183,14 @@ func assertAllProtectableResourcesCovered(t *testing.T, covered map[resources.Re
 	})
 	require.NoError(t, err)
 	assert.Equal(t, protectable, covered)
+}
+
+func populateStructSlices(target any) {
+	value := reflect.ValueOf(target).Elem()
+	for i := range value.NumField() {
+		field := value.Field(i)
+		if field.CanSet() && field.Kind() == reflect.Slice && field.Type().Elem().Kind() == reflect.Struct {
+			field.Set(reflect.MakeSlice(field.Type(), 1, 1))
+		}
+	}
 }

--- a/internal/declarative/executor/managed_labels_test.go
+++ b/internal/declarative/executor/managed_labels_test.go
@@ -1,0 +1,191 @@
+package executor
+
+import (
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/labels"
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProtectableAdaptersMapProtectionOnlyLabelUpdates(t *testing.T) {
+	covered := make(map[resources.ResourceType]bool)
+
+	t.Run("portal", func(t *testing.T) {
+		covered[resources.ResourceTypePortal] = true
+		verifyPointerManagedLabels(t, NewPortalAdapter(nil), func(update *kkComps.UpdatePortal) map[string]*string {
+			return update.Labels
+		})
+	})
+	t.Run("api", func(t *testing.T) {
+		covered[resources.ResourceTypeAPI] = true
+		verifyPointerManagedLabels(t, NewAPIAdapter(nil), func(update *kkComps.UpdateAPIRequest) map[string]*string {
+			return update.Labels
+		})
+	})
+	t.Run("catalog_service", func(t *testing.T) {
+		covered[resources.ResourceTypeCatalogService] = true
+		verifyPointerManagedLabels(t, NewCatalogServiceAdapter(nil),
+			func(update *kkComps.UpdateCatalogService) map[string]*string {
+				return update.Labels
+			})
+	})
+	t.Run("ai_gateway", func(t *testing.T) {
+		covered[resources.ResourceTypeAIGateway] = true
+		verifyStringManagedLabels(t, NewAIGatewayAdapter(nil),
+			func(update *kkComps.UpdateAIGatewayRequest) map[string]string {
+				return update.Labels
+			})
+	})
+	t.Run("dashboard", func(t *testing.T) {
+		covered[resources.ResourceTypeDashboard] = true
+		verifyStringManagedLabels(t, NewDashboardAdapter(nil),
+			func(update *kkComps.DashboardUpdateRequest) map[string]string {
+				return update.Labels
+			})
+	})
+	t.Run("event_gateway", func(t *testing.T) {
+		covered[resources.ResourceTypeEventGatewayControlPlane] = true
+		verifyStringManagedLabels(t, NewEventGatewayControlPlaneControlPlaneAdapter(nil),
+			func(update *kkComps.UpdateGatewayRequest) map[string]string {
+				return update.Labels
+			})
+	})
+	t.Run("application_auth_strategy", func(t *testing.T) {
+		covered[resources.ResourceTypeApplicationAuthStrategy] = true
+		verifyPointerManagedLabels(t, NewAuthStrategyAdapter(nil),
+			func(update *kkComps.UpdateAppAuthStrategyRequest) map[string]*string {
+				return update.Labels
+			})
+	})
+	t.Run("dcr_provider", func(t *testing.T) {
+		covered[resources.ResourceTypeDCRProvider] = true
+		verifyPointerManagedLabels(t, NewDCRProviderAdapter(nil),
+			func(update *kkComps.UpdateDcrProviderRequest) map[string]*string {
+				return update.Labels
+			})
+	})
+	t.Run("control_plane", func(t *testing.T) {
+		covered[resources.ResourceTypeControlPlane] = true
+		verifyStringManagedLabels(t, NewControlPlaneAdapter(nil),
+			func(update *kkComps.UpdateControlPlaneRequest) map[string]string {
+				return update.Labels
+			})
+	})
+	t.Run("organization_team", func(t *testing.T) {
+		covered[resources.ResourceTypeOrganizationTeam] = true
+		verifyPointerManagedLabels(t, NewOrganizationTeamAdapter(nil), func(update *kkComps.UpdateTeam) map[string]*string {
+			return update.Labels
+		})
+	})
+
+	assertAllProtectableResourcesCovered(t, covered)
+}
+
+func verifyPointerManagedLabels[T any](
+	t *testing.T,
+	mapper ManagedLabelOperations[T],
+	getLabels func(*T) map[string]*string,
+) {
+	t.Helper()
+
+	currentLabels := map[string]string{"team": "platform"}
+	var unprotectUpdate T
+	mapper.MapUpdateLabels(
+		&ExecutionContext{
+			Namespace:  "test",
+			Protection: planner.ProtectionChange{Old: true, New: false},
+		},
+		&unprotectUpdate,
+		currentLabels,
+		currentLabels,
+	)
+	unprotectedLabels := getLabels(&unprotectUpdate)
+	require.Contains(t, unprotectedLabels, labels.ProtectedKey)
+	assert.Nil(t, unprotectedLabels[labels.ProtectedKey])
+	require.NotNil(t, unprotectedLabels[labels.NamespaceKey])
+	assert.Equal(t, "test", *unprotectedLabels[labels.NamespaceKey])
+	require.NotNil(t, unprotectedLabels["team"])
+	assert.Equal(t, "platform", *unprotectedLabels["team"])
+
+	var protectUpdate T
+	mapper.MapUpdateLabels(
+		&ExecutionContext{
+			Namespace:  "test",
+			Protection: planner.ProtectionChange{Old: false, New: true},
+		},
+		&protectUpdate,
+		currentLabels,
+		currentLabels,
+	)
+	protectedLabels := getLabels(&protectUpdate)
+	require.NotNil(t, protectedLabels[labels.ProtectedKey])
+	assert.Equal(t, labels.TrueValue, *protectedLabels[labels.ProtectedKey])
+}
+
+func verifyStringManagedLabels[T any](
+	t *testing.T,
+	mapper ManagedLabelOperations[T],
+	getLabels func(*T) map[string]string,
+) {
+	t.Helper()
+
+	currentLabels := map[string]string{"team": "platform"}
+	var unprotectUpdate T
+	mapper.MapUpdateLabels(
+		&ExecutionContext{
+			Namespace:  "test",
+			Protection: planner.ProtectionChange{Old: true, New: false},
+		},
+		&unprotectUpdate,
+		currentLabels,
+		currentLabels,
+	)
+	unprotectedLabels := getLabels(&unprotectUpdate)
+	assert.NotContains(t, unprotectedLabels, labels.ProtectedKey)
+	assert.Equal(t, "test", unprotectedLabels[labels.NamespaceKey])
+	assert.Equal(t, "platform", unprotectedLabels["team"])
+
+	var protectUpdate T
+	mapper.MapUpdateLabels(
+		&ExecutionContext{
+			Namespace:  "test",
+			Protection: planner.ProtectionChange{Old: false, New: true},
+		},
+		&protectUpdate,
+		currentLabels,
+		currentLabels,
+	)
+	protectedLabels := getLabels(&protectUpdate)
+	assert.Equal(t, labels.TrueValue, protectedLabels[labels.ProtectedKey])
+}
+
+func assertAllProtectableResourcesCovered(t *testing.T, covered map[resources.ResourceType]bool) {
+	t.Helper()
+
+	resourceSet := resources.ResourceSet{
+		Portals:                   []resources.PortalResource{{}},
+		APIs:                      []resources.APIResource{{}},
+		CatalogServices:           []resources.CatalogServiceResource{{}},
+		AIGateways:                []resources.AIGatewayResource{{}},
+		Dashboards:                []resources.DashboardResource{{}},
+		EventGatewayControlPlanes: []resources.EventGatewayControlPlaneResource{{}},
+		ApplicationAuthStrategies: []resources.ApplicationAuthStrategyResource{{}},
+		DCRProviders:              []resources.DCRProviderResource{{}},
+		ControlPlanes:             []resources.ControlPlaneResource{{}},
+		OrganizationTeams:         []resources.OrganizationTeamResource{{}},
+	}
+
+	protectable := make(map[resources.ResourceType]bool)
+	err := resourceSet.ForEachNamespaceParticipant(func(participant resources.NamespaceParticipant) error {
+		if participant.SupportsProtected {
+			protectable[participant.Type] = true
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, protectable, covered)
+}

--- a/internal/declarative/executor/organization_team_adapter.go
+++ b/internal/declarative/executor/organization_team_adapter.go
@@ -34,8 +34,8 @@ func (a *OrganizationTeamAdapter) MapCreateFields(_ context.Context, execCtx *Ex
 }
 
 // MapUpdateFields maps planner fields to UpdateTeam request
-func (a *OrganizationTeamAdapter) MapUpdateFields(_ context.Context, execCtx *ExecutionContext,
-	fields map[string]any, update *kkComps.UpdateTeam, currentLabels map[string]string,
+func (a *OrganizationTeamAdapter) MapUpdateFields(_ context.Context, _ *ExecutionContext,
+	fields map[string]any, update *kkComps.UpdateTeam, _ map[string]string,
 ) error {
 	for field, value := range fields {
 		switch field {
@@ -50,28 +50,16 @@ func (a *OrganizationTeamAdapter) MapUpdateFields(_ context.Context, execCtx *Ex
 		}
 	}
 
-	desiredLabels := labels.ExtractLabelsFromField(fields[planner.FieldLabels])
-	if plannerLabels := labels.ExtractLabelsFromField(fields[planner.FieldCurrentLabels]); plannerLabels != nil {
-		currentLabels = plannerLabels
-	}
-
-	if desiredLabels != nil {
-		update.Labels = labels.BuildUpdateLabels(
-			desiredLabels,
-			currentLabels,
-			execCtx.Namespace,
-			execCtx.Protection,
-		)
-	} else if currentLabels != nil {
-		update.Labels = labels.BuildUpdateLabels(
-			currentLabels,
-			currentLabels,
-			execCtx.Namespace,
-			execCtx.Protection,
-		)
-	}
-
 	return nil
+}
+
+func (a *OrganizationTeamAdapter) MapUpdateLabels(
+	execCtx *ExecutionContext,
+	update *kkComps.UpdateTeam,
+	desiredLabels map[string]string,
+	currentLabels map[string]string,
+) {
+	update.Labels = labels.BuildUpdateLabels(desiredLabels, currentLabels, execCtx.Namespace, execCtx.Protection)
 }
 
 // Create issues a create call via the state client

--- a/internal/declarative/executor/organization_team_adapter.go
+++ b/internal/declarative/executor/organization_team_adapter.go
@@ -59,7 +59,7 @@ func (a *OrganizationTeamAdapter) MapUpdateLabels(
 	desiredLabels map[string]string,
 	currentLabels map[string]string,
 ) {
-	update.Labels = labels.BuildUpdateLabels(desiredLabels, currentLabels, execCtx.Namespace, execCtx.Protection)
+	mapPointerUpdateLabels(&update.Labels, execCtx, desiredLabels, currentLabels)
 }
 
 // Create issues a create call via the state client

--- a/internal/declarative/executor/portal_adapter.go
+++ b/internal/declarative/executor/portal_adapter.go
@@ -73,13 +73,9 @@ func (p *PortalAdapter) MapCreateFields(_ context.Context, execCtx *ExecutionCon
 }
 
 // MapUpdateFields maps fields to UpdatePortal request
-func (p *PortalAdapter) MapUpdateFields(_ context.Context, execCtx *ExecutionContext, fields map[string]any,
-	update *kkComps.UpdatePortal, currentLabels map[string]string,
+func (p *PortalAdapter) MapUpdateFields(_ context.Context, _ *ExecutionContext, fields map[string]any,
+	update *kkComps.UpdatePortal, _ map[string]string,
 ) error {
-	// Extract namespace and protection from execution context
-	namespace := execCtx.Namespace
-	protection := execCtx.Protection
-
 	// Only include fields that are in the fields map
 	// These represent actual changes detected by the planner
 	for field, value := range fields {
@@ -133,23 +129,16 @@ func (p *PortalAdapter) MapUpdateFields(_ context.Context, execCtx *ExecutionCon
 		}
 	}
 
-	// Handle labels using centralized helper
-	desiredLabels := labels.ExtractLabelsFromField(fields[planner.FieldLabels])
-	if desiredLabels != nil {
-		// Get current labels if passed from planner
-		plannerCurrentLabels := labels.ExtractLabelsFromField(fields[planner.FieldCurrentLabels])
-		if plannerCurrentLabels != nil {
-			currentLabels = plannerCurrentLabels
-		}
-
-		// Build update labels with removal support
-		update.Labels = labels.BuildUpdateLabels(desiredLabels, currentLabels, namespace, protection)
-	} else if currentLabels != nil {
-		// If no labels in change, preserve existing labels with updated protection
-		update.Labels = labels.BuildUpdateLabels(currentLabels, currentLabels, namespace, protection)
-	}
-
 	return nil
+}
+
+func (p *PortalAdapter) MapUpdateLabels(
+	execCtx *ExecutionContext,
+	update *kkComps.UpdatePortal,
+	desiredLabels map[string]string,
+	currentLabels map[string]string,
+) {
+	update.Labels = labels.BuildUpdateLabels(desiredLabels, currentLabels, execCtx.Namespace, execCtx.Protection)
 }
 
 // Create creates a new portal

--- a/internal/declarative/executor/portal_adapter.go
+++ b/internal/declarative/executor/portal_adapter.go
@@ -138,7 +138,7 @@ func (p *PortalAdapter) MapUpdateLabels(
 	desiredLabels map[string]string,
 	currentLabels map[string]string,
 ) {
-	update.Labels = labels.BuildUpdateLabels(desiredLabels, currentLabels, execCtx.Namespace, execCtx.Protection)
+	mapPointerUpdateLabels(&update.Labels, execCtx, desiredLabels, currentLabels)
 }
 
 // Create creates a new portal

--- a/internal/declarative/labels/labels.go
+++ b/internal/declarative/labels/labels.go
@@ -376,20 +376,3 @@ func ConvertStringMapToPointerMap(labels map[string]string) map[string]*string {
 	}
 	return result
 }
-
-// ConvertPointerMapsToStringMap converts map[string]*string to map[string]string
-func ConvertPointerMapsToStringMap(labels map[string]*string) map[string]string {
-	if len(labels) == 0 {
-		return nil
-	}
-
-	result := make(map[string]string)
-	for k, v := range labels {
-		val := v
-
-		if val != nil {
-			result[k] = *val
-		}
-	}
-	return result
-}

--- a/test/e2e/scenarios/ai-gateway/root/overlays/001a-protected-update-fail/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/root/overlays/001a-protected-update-fail/config.yaml
@@ -2,7 +2,7 @@ ai_gateways:
   - ref: ai-gateway-root-ref
     name: ai-gateway-root-api-name
     display_name: "AI Gateway Root E2E"
-    description: "Initial AI Gateway root e2e description"
+    description: "Protected AI Gateway update should fail"
     proxy_urls:
       - host: "ai-gateway-root.example.com"
         port: 443

--- a/test/e2e/scenarios/ai-gateway/root/overlays/001b-unprotect/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/root/overlays/001b-unprotect/config.yaml
@@ -12,4 +12,4 @@ ai_gateways:
       lifecycle: "dev"
     kongctl:
       namespace: "ai-gateway-root-e2e"
-      protected: true
+      protected: false

--- a/test/e2e/scenarios/ai-gateway/root/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/root/scenario.yaml
@@ -99,6 +99,7 @@ steps:
               fields:
                 total_changes: 1
                 by_action.CREATE: 1
+                protection_changes.protecting: 1
           - select: "changes[?resource_type=='ai_gateway' && resource_ref=='{{ .vars.gateway_ref }}'] | [0]"
             expect:
               fields:
@@ -158,6 +159,7 @@ steps:
                 labels.owner: "platform"
                 labels.lifecycle: "dev"
                 labels."KONGCTL-namespace": "{{ .vars.namespace }}"
+                labels."KONGCTL-protected": "true"
       - name: 004-list-ai-gateways
         run:
           - list
@@ -209,6 +211,90 @@ steps:
             expect:
               fields:
                 "@": "{{ .vars.gateway_name }}"
+
+  - name: 002a-protected-update-fails
+    inputOverlayDirs:
+      - overlays/001a-protected-update-fail
+    commands:
+      - name: 000-sync-protected-should-fail
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        expectFailure:
+          exitCode: 1
+          contains: "protected"
+
+      - name: 001-verify-protected-unchanged
+        run:
+          - get
+          - ai-gateway
+          - "{{ .vars.gateway_api_name }}"
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                description: "{{ .vars.gateway_initial_description }}"
+                labels."KONGCTL-protected": "true"
+
+  - name: 002b-unprotect
+    inputOverlayDirs:
+      - overlays/001b-unprotect
+    commands:
+      - name: 000-plan-unprotect
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-unprotect.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+          - select: "changes[?resource_type=='ai_gateway' && resource_ref=='{{ .vars.gateway_ref }}'] | [0]"
+            expect:
+              fields:
+                action: UPDATE
+          - select: summary.protection_changes
+            expect:
+              fields:
+                unprotecting: 1
+
+      - name: 001-apply-unprotect
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-unprotect.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+
+      - name: 002-verify-unprotected
+        run:
+          - get
+          - ai-gateway
+          - "{{ .vars.gateway_api_name }}"
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                description: "{{ .vars.gateway_initial_description }}"
+                labels."KONGCTL-protected": null
 
   - name: 003-plan-apply-update
     inputOverlayDirs:

--- a/test/e2e/scenarios/analytics/dashboard/scenario.yaml
+++ b/test/e2e/scenarios/analytics/dashboard/scenario.yaml
@@ -110,6 +110,20 @@ steps:
                 failed: 0
                 status: success
 
+      - name: 001-verify-unprotected
+        run:
+          - get
+          - analytics
+          - dashboard
+          - "{{ .vars.dashboardName }}"
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                labels."KONGCTL-protected": null
+
   - name: 004-update-dashboard
     inputOverlayDirs:
       - overlays/004-update-dashboard

--- a/test/e2e/scenarios/portal/app-auth-strategy/overlays/001a-protected-update-fail/app-auth-strategy.yaml
+++ b/test/e2e/scenarios/portal/app-auth-strategy/overlays/001a-protected-update-fail/app-auth-strategy.yaml
@@ -5,7 +5,7 @@ _defaults:
 application_auth_strategies:
   - ref: key-auth-strategy-e2e
     name: key-auth-strategy-e2e
-    display_name: E2E Key Auth Strategy
+    display_name: Protected Update Should Fail
     strategy_type: key_auth
     configs:
       key_auth:

--- a/test/e2e/scenarios/portal/app-auth-strategy/overlays/001b-unprotect/app-auth-strategy.yaml
+++ b/test/e2e/scenarios/portal/app-auth-strategy/overlays/001b-unprotect/app-auth-strategy.yaml
@@ -13,4 +13,4 @@ application_auth_strategies:
           - X-API-Key
           - Api-Key
     kongctl:
-      protected: true
+      protected: false

--- a/test/e2e/scenarios/portal/app-auth-strategy/scenario.yaml
+++ b/test/e2e/scenarios/portal/app-auth-strategy/scenario.yaml
@@ -34,6 +34,7 @@ steps:
               fields:
                 total_changes: 1
                 by_action.CREATE: 1
+                protection_changes.protecting: 1
 
           - select: >-
               changes[?resource_type=='application_auth_strategy' &&
@@ -84,6 +85,93 @@ steps:
             expect:
               fields:
                 total_changes: 0
+
+  - name: 002a-protected-update-fail
+    inputOverlayDirs:
+      - overlays/001a-protected-update-fail
+    commands:
+      - name: 000-sync-protected-should-fail
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/app-auth-strategy.yaml"
+          - --auto-approve
+        expectFailure:
+          exitCode: 1
+          contains: "protected"
+
+      - name: 001-verify-protected-unchanged
+        run:
+          - get
+          - auth-strategies
+          - -o
+          - json
+        assertions:
+          - select: "[?name=='key-auth-strategy-e2e'] | [0]"
+            expect:
+              fields:
+                display_name: "E2E Key Auth Strategy"
+                labels."KONGCTL-protected": "true"
+
+  - name: 002b-unprotect
+    inputOverlayDirs:
+      - overlays/001b-unprotect
+    commands:
+      - name: 000-plan-unprotect
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-unprotect.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/app-auth-strategy.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+
+          - select: >-
+              changes[?resource_type=='application_auth_strategy' &&
+                resource_ref=='key-auth-strategy-e2e'] | [0]
+            expect:
+              fields:
+                action: UPDATE
+
+          - select: summary.protection_changes
+            expect:
+              fields:
+                unprotecting: 1
+
+      - name: 001-apply-unprotect
+        outputFormat: json
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-unprotect.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+
+      - name: 002-verify-unprotected
+        run:
+          - get
+          - auth-strategy
+          - key-auth-strategy-e2e
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                display_name: "E2E Key Auth Strategy"
+                labels."KONGCTL-protected": null
 
   - name: 003-update-key-names
     inputOverlayDirs:

--- a/test/e2e/scenarios/protected-resources/apis/scenario.yaml
+++ b/test/e2e/scenarios/protected-resources/apis/scenario.yaml
@@ -244,6 +244,7 @@ steps:
             expect:
               fields:
                 labels."KONGCTL-namespace": "default"
+                labels."KONGCTL-protected": null
 
   # Step 4: Update child after parent is unprotected (should succeed)
   - name: 004-update-child-unprotected

--- a/test/e2e/scenarios/protected-resources/event-gateways/scenario.yaml
+++ b/test/e2e/scenarios/protected-resources/event-gateways/scenario.yaml
@@ -192,6 +192,7 @@ steps:
             expect:
               fields:
                 labels."KONGCTL-namespace": "egw-protection"
+                labels."KONGCTL-protected": null
 
   # Step 5: Update child after parent is unprotected (should succeed)
   - name: 005-update-child-unprotected

--- a/test/e2e/scenarios/protected-resources/org/teams/scenario.yaml
+++ b/test/e2e/scenarios/protected-resources/org/teams/scenario.yaml
@@ -153,6 +153,7 @@ steps:
             expect:
               fields:
                 labels."KONGCTL-namespace": "default"
+                labels."KONGCTL-protected": null
 
   # Step 4: Delete now-unprotected teams (should succeed)
   - name: 004-delete-unprotected


### PR DESCRIPTION
## Summary

- centralize managed-label mapping in the base executor so protection-only updates cannot be dropped by resource adapters
- add conformance coverage for every resource that supports `kongctl.protected`
- expand auth strategy and AI Gateway E2E scenarios through protect, rejected update, unprotect, update, and delete lifecycle behavior
- verify unprotection against remote state in the affected protection scenarios

## Why

Protection changes are stored separately from ordinary changed fields. Adapters previously applied managed labels inside their ordinary field-mapping paths, so a protection-only update could become an empty API request when `labels` was absent from the plan fields. PR #1913 fixed that symptom for DCR providers. This change moves the invariant into the shared executor path and makes protectable adapters opt into a compile-time-checked managed-label contract.

Fixes #1883

## Validation

- `go fix ./...`
- `make format`
- `make build`
- `make test`
- `make test-integration`
- `golangci-lint run --new-from-rev=origin/main ./...`
- `make test-e2e-scenarios SCENARIO=portal/app-auth-strategy`
- `make test-e2e-scenarios SCENARIO=ai-gateway/root`
- `make test-e2e-scenarios SCENARIO=protected-resources`
- `make test-e2e-scenarios SCENARIO=analytics/dashboard`
- `make test-e2e-scenarios SCENARIO=dcr-providers/workflow`
- `make test-e2e-scenarios SCENARIO=catalog/service`

`make lint` also ran, but the full-tree invocation reports 56 existing findings in generated mocks and generated portal API code. Change-scoped lint reports zero issues.