### PR TITLE
test(e2e): verify user roles after sync

### DIFF
--- a/test/e2e/scenarios/org/users/sync/scenario.yaml
+++ b/test/e2e/scenarios/org/users/sync/scenario.yaml
@@ -188,7 +188,48 @@ steps:
                 entity_type_name: APIs
                 entity_region: "*"
 
-      - name: 002-diff-noop
+      - name: 002-get-user-1-roles-after-sync
+        exec:
+          - sh
+          - -c
+          - >-
+            {{ .bin }} get org user roles --profile e2e
+            --user-email "$KONGCTL_E2E_ORG_USER_EMAIL_1"
+            -o json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 2
+          - select: "[?role_name=='Viewer'] | [0]"
+            expect:
+              fields:
+                role_name: Viewer
+                entity_type_name: APIs
+                entity_region: us
+          - select: "[?role_name=='Admin'] | [0]"
+            expect:
+              fields:
+                role_name: Admin
+                entity_id: "*"
+                entity_type_name: APIs
+                entity_region: "*"
+
+      - name: 003-get-user-2-roles-after-sync
+        exec:
+          - sh
+          - -c
+          - >-
+            {{ .bin }} get org user roles --profile e2e
+            --user-email "$KONGCTL_E2E_ORG_USER_EMAIL_2"
+            -o json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 0
+
+      - name: 004-diff-noop
         run:
           - diff
           - -f


### PR DESCRIPTION
## Summary

- query both users' direct roles after the organization user sync update
- verify user 1 retains Viewer and gains wildcard Admin
- verify user 2 has no roles after its wildcard Viewer role is removed

## Rationale

This covers the direct user-role API after sync for retained, created, and deleted roles while preserving the scenario's existing fixture semantics.

## Validation

- `go fix ./...`
- `make format`
- `make build`
- `make lint`
- `make test`
- `make test-e2e-scenarios SCENARIO=org/users/sync`

Closes #1895