### PR TITLE
fix(declarative): support listener policies on external gateways

### DIFF
--- a/internal/declarative/planner/event_gateway_dependencies_test.go
+++ b/internal/declarative/planner/event_gateway_dependencies_test.go
@@ -180,6 +180,37 @@ func TestEventGatewayByNameDependenciesAreScopedToGateway(t *testing.T) {
 	require.NotContains(t, planChange(t, plan, policyID).References, FieldEventGatewayVirtualClusterID)
 }
 
+func TestNewListenerPolicyRetainsExistingGatewayID(t *testing.T) {
+	var policy resources.EventGatewayListenerPolicyResource
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"ref":"policy",
+		"name":"policy-name",
+		"type":"forward_to_virtual_cluster",
+		"config":{"type":"sni","sni_suffix":".example.com"}
+	}`), &policy))
+
+	planner := &Planner{logger: slog.Default()}
+	plan := NewPlan("1.0", "test", PlanModeSync)
+	require.NoError(t, planner.planEventGatewayListenerPolicyChanges(
+		t.Context(),
+		nil,
+		"default",
+		"gateway-id",
+		"gateway-ref",
+		"listener-name",
+		"",
+		"listener-ref",
+		"listener-create",
+		[]resources.EventGatewayListenerPolicyResource{policy},
+		plan,
+	))
+
+	policyID := plannedChangeID(t, plan, ResourceTypeEventGatewayListenerPolicy, "policy")
+	gatewayRef := planChange(t, plan, policyID).References[FieldEventGatewayID]
+	require.Equal(t, "gateway-ref", gatewayRef.Ref)
+	require.Equal(t, "gateway-id", gatewayRef.ID)
+}
+
 func TestEventGatewayExplicitRefsRemainDependencies(t *testing.T) {
 	backendCluster := resources.EventGatewayBackendClusterResource{
 		Ref: "backend",

--- a/internal/declarative/planner/event_gateway_listener_planner.go
+++ b/internal/declarative/planner/event_gateway_listener_planner.go
@@ -212,7 +212,7 @@ func (p *Planner) planListenerCreatesForNewGateway(
 			resources.ResourceTypeEventGatewayListenerPolicy,
 		) && len(listenerPolicies) > 0 {
 			p.planListenerPolicyCreatesForNewListener(
-				namespace, gatewayRef, listener.Ref, listener.Name,
+				namespace, "", gatewayRef, listener.Ref, listener.Name,
 				listenerChangeID, listenerPolicies, plan,
 			)
 		}

--- a/internal/declarative/planner/event_gateway_listener_policy_planner.go
+++ b/internal/declarative/planner/event_gateway_listener_policy_planner.go
@@ -47,7 +47,7 @@ func (p *Planner) planEventGatewayListenerPolicyChanges(
 
 	// Listener doesn't exist yet: plan creates only with dependency on listener creation
 	p.planListenerPolicyCreatesForNewListener(
-		namespace, gatewayRef, listenerRef, listenerName, listenerChangeID, desired, plan,
+		namespace, gatewayID, gatewayRef, listenerRef, listenerName, listenerChangeID, desired, plan,
 	)
 	return nil
 }
@@ -159,6 +159,7 @@ func (p *Planner) planListenerPolicyChangesForExistingListener(
 // when the parent listener doesn't exist yet.
 func (p *Planner) planListenerPolicyCreatesForNewListener(
 	namespace string,
+	gatewayID string,
 	gatewayRef string,
 	listenerRef string,
 	listenerName string,
@@ -180,9 +181,8 @@ func (p *Planner) planListenerPolicyCreatesForNewListener(
 	}
 
 	for _, policy := range policies {
-		// Gateway ID is empty because gateway may also be new
 		p.planListenerPolicyCreate(
-			namespace, "", gatewayRef, "", listenerRef, listenerName,
+			namespace, gatewayID, gatewayRef, "", listenerRef, listenerName,
 			policy, dependsOn, plan,
 		)
 	}

--- a/test/e2e/scenarios/event-gateway/external-sync/overlays/007-add-listener/external-event-gateway.yaml
+++ b/test/e2e/scenarios/event-gateway/external-sync/overlays/007-add-listener/external-event-gateway.yaml
@@ -1,0 +1,23 @@
+event_gateways:
+  - ref: "{{ .vars.egw_name }}"
+    _external:
+      selector:
+        matchFields:
+          name: "{{ .vars.egw_name }}"
+    listeners:
+      - ref: "{{ .vars.listener_ref }}"
+        name: "{{ .vars.listener_name }}"
+        description: "{{ .vars.listener_description }}"
+        ports:
+          - 19092
+        addresses:
+          - localhost
+        policies:
+          - ref: "{{ .vars.listener_policy_ref }}"
+            name: "{{ .vars.listener_policy_name }}"
+            description: "{{ .vars.listener_policy_description }}"
+            type: forward_to_virtual_cluster
+            enabled: true
+            config:
+              type: sni
+              sni_suffix: ".external-sync.example.com"

--- a/test/e2e/scenarios/event-gateway/external-sync/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/external-sync/scenario.yaml
@@ -18,6 +18,12 @@ vars:
   consume_policy_ref: external-sync-consume-policy
   consume_policy_name: external-sync-consume-policy
   consume_policy_description: External sync consume policy
+  listener_ref: external-sync-listener
+  listener_name: external-sync-listener
+  listener_description: External sync listener
+  listener_policy_ref: external-sync-listener-forward-policy
+  listener_policy_name: external-sync-listener-forward-policy
+  listener_policy_description: External sync listener forward policy
 
 defaults:
   mask:
@@ -420,7 +426,182 @@ steps:
                 name: "{{ .vars.consume_policy_name }}"
                 description: "{{ .vars.consume_policy_description }}"
 
-  - name: 011-idempotency-all-declarative-policies
+  - name: 011-sync-with-declarative-listener
+    inputOverlayDirs:
+      - overlays/007-add-listener
+    commands:
+      - name: 000-sync-add-listener
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/external-event-gateway.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 2
+                by_action.CREATE: 2
+          - select: >-
+              plan.changes[?resource_type=='event_gateway_listener' &&
+              resource_ref=='{{ .vars.listener_ref }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.listener_ref }}"
+          - select: >-
+              plan.changes[?resource_type=='event_gateway_listener_policy' &&
+              resource_ref=='{{ .vars.listener_policy_ref }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.listener_policy_ref }}"
+          - select: plan.changes[?action=='DELETE']
+            expect:
+              fields:
+                "length(@)": 0
+          - select: plan.changes[?resource_type=='event_gateway' && action=='DELETE']
+            expect:
+              fields:
+                "length(@)": 0
+          - select: plan.changes[?resource_type=='event_gateway_virtual_cluster' && action=='DELETE']
+            expect:
+              fields:
+                "length(@)": 0
+          - select: summary
+            expect:
+              fields:
+                applied: 2
+                failed: 0
+
+      - name: 001-get-listeners
+        run:
+          - get
+          - event-gateway
+          - listeners
+          - --gateway-name
+          - "{{ .vars.egw_name }}"
+          - -o
+          - json
+        assertions:
+          - select: "[?name=='{{ .vars.listener_name }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.listener_name }}"
+                description: "{{ .vars.listener_description }}"
+                ports:
+                  - "19092"
+                addresses:
+                  - localhost
+
+      - name: 002-get-listener-policies
+        run:
+          - get
+          - event-gateway
+          - listener-policies
+          - --gateway-name
+          - "{{ .vars.egw_name }}"
+          - --listener-name
+          - "{{ .vars.listener_name }}"
+          - -o
+          - json
+        assertions:
+          - select: "[?name=='{{ .vars.listener_policy_name }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.listener_policy_name }}"
+                description: "{{ .vars.listener_policy_description }}"
+                type: forward_to_virtual_cluster
+                enabled: true
+                config.type: sni
+                config.sni_suffix: ".external-sync.example.com"
+
+  - name: 012-sync-idempotency-declarative-listener
+    inputOverlayDirs:
+      - overlays/007-add-listener
+    commands:
+      - name: 000-sync-no-changes
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/external-event-gateway.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 0
+          - select: plan.changes[?action=='DELETE']
+            expect:
+              fields:
+                "length(@)": 0
+
+  - name: 013-sync-omit-declarative-listener
+    commands:
+      - name: 000-sync-no-deletions
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/external-event-gateway.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 0
+          - select: plan.changes[?resource_type=='event_gateway_listener' && action=='DELETE']
+            expect:
+              fields:
+                "length(@)": 0
+          - select: plan.changes[?resource_type=='event_gateway_listener_policy' && action=='DELETE']
+            expect:
+              fields:
+                "length(@)": 0
+          - select: plan.changes[?resource_type=='event_gateway' && action=='DELETE']
+            expect:
+              fields:
+                "length(@)": 0
+          - select: plan.changes[?resource_type=='event_gateway_virtual_cluster' && action=='DELETE']
+            expect:
+              fields:
+                "length(@)": 0
+
+      - name: 001-get-listeners-after-omission
+        run:
+          - get
+          - event-gateway
+          - listeners
+          - --gateway-name
+          - "{{ .vars.egw_name }}"
+          - -o
+          - json
+        assertions:
+          - select: "[?name=='{{ .vars.listener_name }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.listener_name }}"
+                description: "{{ .vars.listener_description }}"
+
+      - name: 002-get-listener-policies-after-omission
+        run:
+          - get
+          - event-gateway
+          - listener-policies
+          - --gateway-name
+          - "{{ .vars.egw_name }}"
+          - --listener-name
+          - "{{ .vars.listener_name }}"
+          - -o
+          - json
+        assertions:
+          - select: "[?name=='{{ .vars.listener_policy_name }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.listener_policy_name }}"
+                type: forward_to_virtual_cluster
+                enabled: true
+
+  - name: 014-idempotency-all-declarative-policies
     inputOverlayDirs:
       - overlays/002-add-cluster-policy
       - overlays/003-add-produce-policy
@@ -442,7 +623,7 @@ steps:
               fields:
                 "length(@)": 0
 
-  - name: 012-cleanup-declarative-policies
+  - name: 015-cleanup-declarative-policies
     commands:
       - name: 000-sync-no-deletions
         run:


### PR DESCRIPTION
## Summary

- extend the event gateway external-sync scenario with listener and listener-policy ownership coverage
- verify creation, idempotency, and preservation after omission from sync config
- retain a known external gateway ID when planning policies for a newly created listener
- add a planner regression test for the gateway reference

## Rationale

The new scenario exposed that listener creation under an external gateway succeeded, but its nested policy lost the already-resolved gateway ID and failed an unnecessary runtime name lookup. Preserving the ID allows the listener and policy to execute together and validates their no-delete ownership behavior.

## Validation

- `go fix ./...`
- `make format`
- `make build`
- `make lint`
- `make test`
- `make test-integration`
- `make test-e2e-scenarios SCENARIO=event-gateway/external-sync`

Closes #1919