### PR TITLE
fix(ci): preserve local Muthur action for post steps

### DIFF
--- a/.github/workflows/muthur.yaml
+++ b/.github/workflows/muthur.yaml
@@ -35,6 +35,14 @@ jobs:
           permission-contents: read
           permission-members: read
 
+      # The composite checks the PR head out at the workspace root. Initialize that root as a Git
+      # repository first so checkout updates it in place instead of deleting the nested KSAI action.
+      - name: Checkout trusted default branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
       - name: Checkout ksai action
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
## Summary

- initialize the workspace root with the trusted default branch before checking out the private KSAI action
- allow the reviewer composite to replace the root with the PR head without deleting its nested local action
- preserve the local action manifest for GitHub post-job processing

## Rationale

The review on PR #1916 completed and posted five findings, but run https://github.com/Kong/kongctl/actions/runs/32282218344 ended red during `Post Run agentic reviewer`. The composite source checkout found no Git repository at the workspace root and deleted the entire workspace, including the locally checked-out KSAI action. GitHub could not reload that action for its post hook.

## Validation

- `actionlint -config-file .github/actionlint.yaml .github/workflows/muthur.yaml`
- `git diff --check`

## Test note

The issue-comment workflow is loaded from the default branch, so end-to-end confirmation requires another `/muthur` request after this fix merges.