### PR TITLE
refactor(declarative): standardize planner payload contracts

### DIFF
--- a/docs/contributor/declarative-resource-implementation-guide.md
+++ b/docs/contributor/declarative-resource-implementation-guide.md
@@ -91,6 +91,33 @@ resource, plan, or view contracts.
 
 ## IMPLEMENTATION CHECKLIST
 
+### PLANNER-TO-EXECUTOR PAYLOAD CONTRACT
+
+Declarative resources and API request bodies are different representations.
+Resource serialization may contain `ref`, `kongctl`, nested resources, and
+root-level parent selectors. Do not use that serialization as an API payload.
+
+- `PlannedChange.Fields` contains fields intended for the action-specific API
+  request body plus explicitly registered executor-only fields.
+- `PlannedChange.Parent`, `References`, and resource identity contain API path
+  and relationship routing data.
+- Relationships marked `kongctl_parent_selector` never belong in `Fields`.
+  Relationships marked `api_foreign_key` remain eligible when the
+  action-specific request schema contains that field.
+- Create and update mappings are separate contracts, even when they currently
+  use similar SDK structures. The executor validates every planned payload
+  against the selected SDK request before executing any change.
+- Managed-label updates use the same `ManagedLabelOperations` hook during
+  preflight and execution. `current_labels` is internal plan context rather
+  than an API body field.
+- Mappers must report unsupported fields. Silently dropping a planner field is
+  a contract violation. Intentional executor-only transformations must be
+  recorded in the central payload contract rather than hidden in an adapter.
+
+Saved plans are not migrated between payload contracts. Kongctl accepts only
+the current plan version and rejects structurally incompatible plans before
+execution with guidance to regenerate the plan.
+
 ### LOGGING & DIAGNOSTICS
 - Always add verbose `slog` debug statements when introducing a new planner or executor path. Helpful patterns:
   - Planner: log when you fetch existing resources, how many desired items you saw, and each change you enqueue.

--- a/internal/declarative/common/plan.go
+++ b/internal/declarative/common/plan.go
@@ -38,12 +38,8 @@ func LoadPlan(source string, stdin io.Reader) (*planner.Plan, error) {
 
 	normalizePlanProtection(plan)
 
-	// Basic validation
-	if plan.Metadata.Version == "" {
-		return nil, fmt.Errorf("invalid plan: missing version")
-	}
-	if plan.Metadata.Mode == "" {
-		return nil, fmt.Errorf("invalid plan: missing mode")
+	if err := planner.ValidatePlanCompatibility(plan); err != nil {
+		return nil, err
 	}
 
 	return plan, nil

--- a/internal/declarative/executor/ai_gateway_sdk_mapping.go
+++ b/internal/declarative/executor/ai_gateway_sdk_mapping.go
@@ -35,7 +35,7 @@ func mapAIGatewaySDKRequest(resource string, payload any, destination any) error
 		return fmt.Errorf("failed to inspect %s SDK payload: %w", resource, err)
 	}
 
-	dropped := droppedAIGatewayPayloadPaths(sourceValue, mappedValue, "")
+	dropped := droppedPayloadPaths(sourceValue, mappedValue, "")
 	if len(dropped) > 0 {
 		slices.Sort(dropped)
 		return fmt.Errorf(
@@ -73,39 +73,39 @@ func (e *aiGatewaySDKDecodeError) Unwrap() error {
 	return e.cause
 }
 
-func droppedAIGatewayPayloadPaths(source, mapped any, path string) []string {
+func droppedPayloadPaths(source, mapped any, path string) []string {
 	switch sourceValue := source.(type) {
 	case map[string]any:
 		mappedValue, ok := mapped.(map[string]any)
 		if !ok {
-			return declaredAIGatewayPayloadPaths(sourceValue, path)
+			return declaredPayloadPaths(sourceValue, path)
 		}
 
 		var dropped []string
 		for key, value := range sourceValue {
-			childPath := joinAIGatewayPayloadPath(path, key)
+			childPath := joinPayloadPath(path, key)
 			mappedChild, found := mappedValue[key]
 			if !found {
-				dropped = append(dropped, declaredAIGatewayPayloadPaths(value, childPath)...)
+				dropped = append(dropped, declaredPayloadPaths(value, childPath)...)
 				continue
 			}
-			dropped = append(dropped, droppedAIGatewayPayloadPaths(value, mappedChild, childPath)...)
+			dropped = append(dropped, droppedPayloadPaths(value, mappedChild, childPath)...)
 		}
 		return dropped
 	case []any:
 		mappedValue, ok := mapped.([]any)
 		if !ok {
-			return declaredAIGatewayPayloadPaths(sourceValue, path)
+			return declaredPayloadPaths(sourceValue, path)
 		}
 
 		var dropped []string
 		for i, value := range sourceValue {
 			childPath := fmt.Sprintf("%s[%d]", path, i)
 			if i >= len(mappedValue) {
-				dropped = append(dropped, declaredAIGatewayPayloadPaths(value, childPath)...)
+				dropped = append(dropped, declaredPayloadPaths(value, childPath)...)
 				continue
 			}
-			dropped = append(dropped, droppedAIGatewayPayloadPaths(value, mappedValue[i], childPath)...)
+			dropped = append(dropped, droppedPayloadPaths(value, mappedValue[i], childPath)...)
 		}
 		return dropped
 	default:
@@ -113,20 +113,20 @@ func droppedAIGatewayPayloadPaths(source, mapped any, path string) []string {
 	}
 }
 
-func declaredAIGatewayPayloadPaths(value any, path string) []string {
+func declaredPayloadPaths(value any, path string) []string {
 	switch typed := value.(type) {
 	case nil:
 		return nil
 	case map[string]any:
 		var paths []string
 		for key, child := range typed {
-			paths = append(paths, declaredAIGatewayPayloadPaths(child, joinAIGatewayPayloadPath(path, key))...)
+			paths = append(paths, declaredPayloadPaths(child, joinPayloadPath(path, key))...)
 		}
 		return paths
 	case []any:
 		var paths []string
 		for i, child := range typed {
-			paths = append(paths, declaredAIGatewayPayloadPaths(child, fmt.Sprintf("%s[%d]", path, i))...)
+			paths = append(paths, declaredPayloadPaths(child, fmt.Sprintf("%s[%d]", path, i))...)
 		}
 		return paths
 	default:
@@ -137,7 +137,7 @@ func declaredAIGatewayPayloadPaths(value any, path string) []string {
 	}
 }
 
-func joinAIGatewayPayloadPath(parent, child string) string {
+func joinPayloadPath(parent, child string) string {
 	if parent == "" {
 		return child
 	}

--- a/internal/declarative/executor/api_publication_adapter.go
+++ b/internal/declarative/executor/api_publication_adapter.go
@@ -94,7 +94,6 @@ func (a *APIPublicationAdapter) Delete(ctx context.Context, id string, execCtx *
 
 	portalID, err := a.getPortalIDFromExecutionContext(execCtx)
 	if err != nil {
-		// Older plans may only provide the composite api_id:portal_id resource ID.
 		if _, parsedPortalID, ok := strings.Cut(id, ":"); ok && parsedPortalID != "" {
 			portalID = parsedPortalID
 		} else if id != "" {
@@ -128,7 +127,7 @@ func (a *APIPublicationAdapter) ResourceType() string {
 
 // RequiredFields returns the required fields for creation
 func (a *APIPublicationAdapter) RequiredFields() []string {
-	return []string{planner.FieldPortalID}
+	return nil
 }
 
 // MapUpdateFields maps fields for update operations (not supported for API publications)
@@ -161,7 +160,6 @@ func (a *APIPublicationAdapter) getPortalIDFromExecutionContext(execCtx *Executi
 	if portalRef, ok := change.References[planner.FieldPortalID]; ok && portalRef.ID != "" {
 		return portalRef.ID, nil
 	}
-	// Check fields as fallback
 	if portalID, ok := change.Fields[planner.FieldPortalID].(string); ok {
 		return portalID, nil
 	}
@@ -186,8 +184,6 @@ func (a *APIPublicationAdapter) getAPIIDFromExecutionContext(execCtx *ExecutionC
 	if change.Parent != nil && change.Parent.ID != "" {
 		return change.Parent.ID, nil
 	}
-
-	// Priority 3: Check Fields (special case for api_publication delete)
 	if apiID, ok := change.Fields[planner.FieldAPIID].(string); ok && apiID != "" {
 		return apiID, nil
 	}

--- a/internal/declarative/executor/base_executor.go
+++ b/internal/declarative/executor/base_executor.go
@@ -77,6 +77,70 @@ type BaseExecutor[TCreate any, TUpdate any] struct {
 	dryRun bool
 }
 
+// ResourceType identifies the resource covered by this action-aware payload contract.
+func (b *BaseExecutor[TCreate, TUpdate]) ResourceType() string {
+	return b.ops.ResourceType()
+}
+
+// ValidatePayload maps planner fields into the action-specific SDK request and
+// verifies that the mapper did not silently discard planner payload fields.
+func (b *BaseExecutor[TCreate, TUpdate]) ValidatePayload(
+	ctx context.Context,
+	change planner.PlannedChange,
+) error {
+	execCtx := NewExecutionContext(&change)
+	switch change.Action {
+	case planner.ActionCreate:
+		var create TCreate
+		if err := b.ops.MapCreateFields(ctx, execCtx, change.Fields, &create); err != nil {
+			return err
+		}
+		return validateMappedPayload(b.ops.ResourceType(), change.Action, change.Fields, create)
+	case planner.ActionUpdate:
+		if !b.ops.SupportsUpdate() {
+			return fmt.Errorf("action %q is not supported", change.Action)
+		}
+		var update TUpdate
+		if err := b.ops.MapUpdateFields(ctx, execCtx, change.Fields, &update, nil); err != nil {
+			return err
+		}
+		b.mapUpdateLabels(execCtx, change.Fields, &update, nil)
+		return validateMappedPayload(b.ops.ResourceType(), change.Action, change.Fields, update)
+	case planner.ActionDelete:
+		return nil
+	case planner.ActionExternalTool:
+		return fmt.Errorf("action %q is not supported", change.Action)
+	default:
+		return fmt.Errorf("action %q is not supported", change.Action)
+	}
+}
+
+func (b *BaseExecutor[TCreate, TUpdate]) mapUpdateLabels(
+	execCtx *ExecutionContext,
+	fields map[string]any,
+	update *TUpdate,
+	currentLabels map[string]string,
+) {
+	labelOps, ok := b.ops.(ManagedLabelOperations[TUpdate])
+	if !ok {
+		return
+	}
+	if rawCurrentLabels, present := fields[planner.FieldCurrentLabels]; present {
+		currentLabels = labels.ExtractLabelsFromField(rawCurrentLabels)
+		if currentLabels == nil {
+			currentLabels = make(map[string]string)
+		}
+	}
+	desiredLabels := currentLabels
+	if rawDesiredLabels, labelsChanged := fields[planner.FieldLabels]; labelsChanged {
+		desiredLabels = labels.ExtractLabelsFromField(rawDesiredLabels)
+		if desiredLabels == nil {
+			desiredLabels = make(map[string]string)
+		}
+	}
+	labelOps.MapUpdateLabels(execCtx, update, desiredLabels, currentLabels)
+}
+
 // NewBaseExecutor creates a new base executor instance
 func NewBaseExecutor[TCreate any, TUpdate any](
 	ops ResourceOperations[TCreate, TUpdate],
@@ -182,22 +246,7 @@ func (b *BaseExecutor[TCreate, TUpdate]) Update(ctx context.Context, change plan
 	if err := b.ops.MapUpdateFields(ctx, execCtx, change.Fields, &update, currentLabels); err != nil {
 		return "", common.FormatAPIError(b.ops.ResourceType(), resourceName, "update", err)
 	}
-	if labelOps, ok := b.ops.(ManagedLabelOperations[TUpdate]); ok {
-		if rawCurrentLabels, present := change.Fields[planner.FieldCurrentLabels]; present {
-			currentLabels = labels.ExtractLabelsFromField(rawCurrentLabels)
-			if currentLabels == nil {
-				currentLabels = make(map[string]string)
-			}
-		}
-		desiredLabels := currentLabels
-		if rawDesiredLabels, labelsChanged := change.Fields[planner.FieldLabels]; labelsChanged {
-			desiredLabels = labels.ExtractLabelsFromField(rawDesiredLabels)
-			if desiredLabels == nil {
-				desiredLabels = make(map[string]string)
-			}
-		}
-		labelOps.MapUpdateLabels(execCtx, &update, desiredLabels, currentLabels)
-	}
+	b.mapUpdateLabels(execCtx, change.Fields, &update, currentLabels)
 
 	// Handle dry-run
 	if b.dryRun {
@@ -310,21 +359,18 @@ func (b *BaseExecutor[TCreate, TUpdate]) validateResourceForUpdate(
 		}
 	}
 
-	// Strategy 3: For protection changes, try lookup with preserved labels context
-	if isProtectionChange(change) && change.Fields != nil {
-		if namespace, ok := change.Fields[planner.FieldNamespace].(string); ok {
-			// Try namespace-specific lookup
-			if nsLookup, ok := b.ops.(interface {
-				GetByNameInNamespace(context.Context, string, string) (ResourceInfo, error)
-			}); ok {
-				resource, err := nsLookup.GetByNameInNamespace(ctx, resourceName, namespace)
-				if err == nil && resource != nil {
-					logger.Debug("Resource found via namespace lookup during protection change",
-						"resource_type", b.ops.ResourceType(),
-						"name", resourceName,
-						"namespace", namespace)
-					return resource, nil
-				}
+	// Strategy 3: For protection changes, try a namespace-specific lookup.
+	if isProtectionChange(change) && change.Namespace != "" {
+		if nsLookup, ok := b.ops.(interface {
+			GetByNameInNamespace(context.Context, string, string) (ResourceInfo, error)
+		}); ok {
+			resource, err := nsLookup.GetByNameInNamespace(ctx, resourceName, change.Namespace)
+			if err == nil && resource != nil {
+				logger.Debug("Resource found via namespace lookup during protection change",
+					"resource_type", b.ops.ResourceType(),
+					"name", resourceName,
+					"namespace", change.Namespace)
+				return resource, nil
 			}
 		}
 	}

--- a/internal/declarative/executor/base_operations.go
+++ b/internal/declarative/executor/base_operations.go
@@ -50,6 +50,34 @@ type BaseCreateDeleteExecutor[TCreate any] struct {
 	dryRun bool
 }
 
+// ResourceType identifies the resource covered by this action-aware payload contract.
+func (b *BaseCreateDeleteExecutor[TCreate]) ResourceType() string {
+	return b.ops.ResourceType()
+}
+
+// ValidatePayload validates create bodies while allowing delete operations,
+// which have no API request body.
+func (b *BaseCreateDeleteExecutor[TCreate]) ValidatePayload(
+	ctx context.Context,
+	change planner.PlannedChange,
+) error {
+	switch change.Action {
+	case planner.ActionCreate:
+		execCtx := NewExecutionContext(&change)
+		var create TCreate
+		if err := b.ops.MapCreateFields(ctx, execCtx, change.Fields, &create); err != nil {
+			return err
+		}
+		return validateMappedPayload(b.ops.ResourceType(), change.Action, change.Fields, create)
+	case planner.ActionDelete:
+		return nil
+	case planner.ActionUpdate, planner.ActionExternalTool:
+		return fmt.Errorf("action %q is not supported", change.Action)
+	default:
+		return fmt.Errorf("action %q is not supported", change.Action)
+	}
+}
+
 // NewBaseCreateDeleteExecutor creates a new executor for create/delete only resources
 func NewBaseCreateDeleteExecutor[TCreate any](
 	ops CreateDeleteOperations[TCreate],
@@ -109,6 +137,26 @@ func (b *BaseCreateDeleteExecutor[TCreate]) Delete(ctx context.Context, change p
 type BaseSingletonExecutor[TUpdate any] struct {
 	ops    SingletonOperations[TUpdate]
 	dryRun bool
+}
+
+// ResourceType identifies the resource covered by this action-aware payload contract.
+func (b *BaseSingletonExecutor[TUpdate]) ResourceType() string {
+	return b.ops.ResourceType()
+}
+
+// ValidatePayload validates the singleton's full update request shape.
+func (b *BaseSingletonExecutor[TUpdate]) ValidatePayload(
+	ctx context.Context,
+	change planner.PlannedChange,
+) error {
+	if change.Action != planner.ActionUpdate {
+		return fmt.Errorf("action %q is not supported", change.Action)
+	}
+	var update TUpdate
+	if err := b.ops.MapUpdateFields(ctx, change.Fields, &update); err != nil {
+		return err
+	}
+	return validateMappedPayload(b.ops.ResourceType(), change.Action, change.Fields, update)
 }
 
 // NewBaseSingletonExecutor creates a new executor for singleton resources

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -685,15 +685,16 @@ func (e *Executor) Execute(ctx context.Context, plan *planner.Plan) *ExecutionRe
 	result := &ExecutionResult{
 		DryRun: e.dryRun,
 	}
+	if e.reporter != nil && plan != nil {
+		e.reporter.StartExecution(plan)
+	}
 	if err := e.validatePlanPayloads(ctx, plan); err != nil {
 		result.Errors = append(result.Errors, ExecutionError{Error: err.Error()})
 		result.FailureCount = 1
+		if e.reporter != nil {
+			e.reporter.FinishExecution(result)
+		}
 		return result
-	}
-
-	// Notify reporter of execution start
-	if e.reporter != nil {
-		e.reporter.StartExecution(plan)
 	}
 
 	// Choose execution strategy.

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -32,6 +32,9 @@ type Executor struct {
 	client   *state.Client
 	reporter ProgressReporter
 	dryRun   bool
+	// payloadContracts is the exhaustive executor inventory of action-specific
+	// planner-to-SDK request mappings.
+	payloadContracts map[string]payloadContract
 	// Track created resources during execution
 	createdResources map[string]string // changeID -> resourceID
 	cacheMu          sync.RWMutex
@@ -204,6 +207,7 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 		client:             client,
 		reporter:           reporter,
 		dryRun:             dryRun,
+		payloadContracts:   make(map[string]payloadContract),
 		createdResources:   make(map[string]string),
 		refToID:            make(map[string]map[string]string),
 		stateCache:         state.NewCache(),
@@ -572,6 +576,68 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 		dryRun,
 	)
 
+	e.registerPayloadContracts(
+		e.portalExecutor,
+		e.controlPlaneExecutor,
+		e.apiExecutor,
+		e.authStrategyExecutor,
+		e.dcrProviderExecutor,
+		e.catalogServiceExecutor,
+		e.aiGatewayExecutor,
+		e.aiGatewayProviderExecutor,
+		e.aiGatewayIdentityProviderExecutor,
+		e.aiGatewayPolicyExecutor,
+		e.aiGatewayAgentExecutor,
+		e.aiGatewayConsumerExecutor,
+		e.aiGatewayConsumerCredentialExecutor,
+		e.aiGatewayConsumerGroupExecutor,
+		e.aiGatewayModelExecutor,
+		e.aiGatewayMCPServerExecutor,
+		e.aiGatewayConfigStoreExecutor,
+		e.aiGatewayVaultExecutor,
+		e.aiGatewayDataPlaneCertificateExecutor,
+		e.dashboardExecutor,
+		e.eventGatewayControlPlaneExecutor,
+		e.organizationTeamExecutor,
+		e.organizationTeamRoleExecutor,
+		e.organizationUserTeamMembershipExecutor,
+		e.organizationUserRoleExecutor,
+		e.organizationSystemAccountTeamMembershipExecutor,
+		e.organizationSystemAccountRoleExecutor,
+		e.controlPlaneDataPlaneCertificateExecutor,
+		e.eventGatewayBackendClusterExecutor,
+		e.eventGatewayVirtualClusterExecutor,
+		e.eventGatewayListenerExecutor,
+		e.eventGatewayListenerPolicyExecutor,
+		e.eventGatewayClusterPolicyExecutor,
+		e.eventGatewayProducePolicyExecutor,
+		e.eventGatewayConsumePolicyExecutor,
+		e.eventGatewayDataPlaneCertificateExecutor,
+		e.eventGatewaySchemaRegistryExecutor,
+		e.eventGatewayStaticKeyExecutor,
+		e.eventGatewayTLSTrustBundleExecutor,
+		e.portalCustomizationExecutor,
+		e.portalAuthSettingsExecutor,
+		e.portalIntegrationExecutor,
+		e.portalIdentityProviderExecutor,
+		e.portalAssetLogoExecutor,
+		e.portalAssetFaviconExecutor,
+		e.portalDomainExecutor,
+		e.portalIPAllowListExecutor,
+		e.portalPageExecutor,
+		e.portalSnippetExecutor,
+		e.portalTeamExecutor,
+		e.portalTeamGroupMappingExecutor,
+		e.portalTeamRoleExecutor,
+		e.portalEmailConfigExecutor,
+		e.portalAuditLogWebhookExecutor,
+		e.portalEmailTemplateExecutor,
+		e.apiVersionExecutor,
+		upsertPayloadContract[kkComps.APIPublication]{base: e.apiPublicationExecutor},
+		e.apiDocumentExecutor,
+		e.apiImplementationExecutor,
+	)
+
 	return e
 }
 
@@ -618,6 +684,11 @@ func (e *Executor) Execute(ctx context.Context, plan *planner.Plan) *ExecutionRe
 
 	result := &ExecutionResult{
 		DryRun: e.dryRun,
+	}
+	if err := e.validatePlanPayloads(ctx, plan); err != nil {
+		result.Errors = append(result.Errors, ExecutionError{Error: err.Error()})
+		result.FailureCount = 1
+		return result
 	}
 
 	// Notify reporter of execution start
@@ -1328,6 +1399,7 @@ func (e *Executor) syncResolvedRef(
 	fieldName string,
 	resolver func(context.Context, planner.ReferenceInfo) (string, error),
 	errMsg string,
+	writePayload bool,
 ) error {
 	if change == nil {
 		return nil
@@ -1347,7 +1419,7 @@ func (e *Executor) syncResolvedRef(
 		change.References[fieldName] = ref
 	}
 
-	if change.Fields != nil && !setResolvedFieldValue(change.Fields, fieldName, ref.ID) {
+	if writePayload && change.Fields != nil && !setResolvedFieldValue(change.Fields, fieldName, ref.ID) {
 		change.Fields[fieldName] = ref.ID
 	}
 
@@ -1487,6 +1559,7 @@ func (e *Executor) syncResolvedDCRProviderID(
 		planner.FieldDCRProviderID,
 		e.resolveDCRProviderRef,
 		"failed to resolve DCR provider reference",
+		true,
 	)
 }
 
@@ -1500,6 +1573,7 @@ func (e *Executor) syncResolvedPortalDefaultAuthStrategyID(
 		planner.FieldDefaultApplicationStrategyID,
 		e.resolveAuthStrategyRef,
 		"failed to resolve auth strategy reference",
+		true,
 	)
 }
 
@@ -1513,6 +1587,7 @@ func (e *Executor) syncResolvedAIGatewayID(
 		planner.FieldAIGatewayID,
 		e.resolveAIGatewayRef,
 		"failed to resolve AI Gateway reference",
+		false,
 	)
 }
 

--- a/internal/declarative/executor/organization_system_account_team_membership_adapter.go
+++ b/internal/declarative/executor/organization_system_account_team_membership_adapter.go
@@ -21,12 +21,20 @@ func NewOrganizationSystemAccountTeamMembershipAdapter(
 
 func (o *OrganizationSystemAccountTeamMembershipAdapter) MapCreateFields(
 	_ context.Context,
-	_ *ExecutionContext,
+	execCtx *ExecutionContext,
 	fields map[string]any,
 	create *state.OrganizationSystemAccountTeamMembership,
 ) error {
 	accountID, _ := fields[planner.FieldSystemAccountID].(string)
 	teamID, _ := fields[planner.FieldTeamID].(string)
+	if execCtx != nil && execCtx.PlannedChange != nil {
+		if ref, ok := execCtx.PlannedChange.References[planner.FieldSystemAccountID]; ok && ref.ID != "" {
+			accountID = ref.ID
+		}
+		if ref, ok := execCtx.PlannedChange.References[planner.FieldTeamID]; ok && ref.ID != "" {
+			teamID = ref.ID
+		}
+	}
 	create.SystemAccountID = accountID
 	create.TeamID = teamID
 	return nil
@@ -109,7 +117,7 @@ func (o *OrganizationSystemAccountTeamMembershipAdapter) ResourceType() string {
 }
 
 func (o *OrganizationSystemAccountTeamMembershipAdapter) RequiredFields() []string {
-	return []string{planner.FieldSystemAccountID}
+	return nil
 }
 
 func (o *OrganizationSystemAccountTeamMembershipAdapter) SupportsUpdate() bool {

--- a/internal/declarative/executor/organization_user_team_membership_adapter.go
+++ b/internal/declarative/executor/organization_user_team_membership_adapter.go
@@ -19,12 +19,20 @@ func NewOrganizationUserTeamMembershipAdapter(client *state.Client) *Organizatio
 
 func (o *OrganizationUserTeamMembershipAdapter) MapCreateFields(
 	_ context.Context,
-	_ *ExecutionContext,
+	execCtx *ExecutionContext,
 	fields map[string]any,
 	create *state.OrganizationUserTeamMembership,
 ) error {
 	userID, _ := fields[planner.FieldUserID].(string)
 	teamID, _ := fields[planner.FieldTeamID].(string)
+	if execCtx != nil && execCtx.PlannedChange != nil {
+		if ref, ok := execCtx.PlannedChange.References[planner.FieldUserID]; ok && ref.ID != "" {
+			userID = ref.ID
+		}
+		if ref, ok := execCtx.PlannedChange.References[planner.FieldTeamID]; ok && ref.ID != "" {
+			teamID = ref.ID
+		}
+	}
 	create.UserID = userID
 	create.TeamID = teamID
 	return nil
@@ -98,7 +106,7 @@ func (o *OrganizationUserTeamMembershipAdapter) ResourceType() string {
 }
 
 func (o *OrganizationUserTeamMembershipAdapter) RequiredFields() []string {
-	return []string{planner.FieldUserID}
+	return nil
 }
 
 func (o *OrganizationUserTeamMembershipAdapter) SupportsUpdate() bool {

--- a/internal/declarative/executor/payload_contract.go
+++ b/internal/declarative/executor/payload_contract.go
@@ -158,8 +158,23 @@ func removePayloadPath(value any, path []string) {
 func validationChange(change planner.PlannedChange) planner.PlannedChange {
 	result := change
 	result.Fields = cloneValidationFields(change.Fields)
-	result.References = maps.Clone(change.References)
+	result.References = cloneValidationReferences(change.References)
 	for field, reference := range result.References {
+		if reference.IsArray {
+			if len(reference.ResolvedIDs) < len(reference.Refs) {
+				reference.ResolvedIDs = append(
+					reference.ResolvedIDs,
+					make([]string, len(reference.Refs)-len(reference.ResolvedIDs))...,
+				)
+			}
+			for i := range reference.Refs {
+				if reference.ResolvedIDs[i] == "" {
+					reference.ResolvedIDs[i] = "payload-validation-id"
+				}
+			}
+			result.References[field] = reference
+			continue
+		}
 		if !reference.HasResolvedID() {
 			reference.ID = "payload-validation-id"
 		}
@@ -170,6 +185,27 @@ func validationChange(change planner.PlannedChange) planner.PlannedChange {
 		parent := *result.Parent
 		parent.ID = "payload-validation-id"
 		result.Parent = &parent
+	}
+	return result
+}
+
+func cloneValidationReferences(references map[string]planner.ReferenceInfo) map[string]planner.ReferenceInfo {
+	if references == nil {
+		return nil
+	}
+	result := make(map[string]planner.ReferenceInfo, len(references))
+	for field, reference := range references {
+		reference.Refs = slices.Clone(reference.Refs)
+		reference.ResolvedIDs = slices.Clone(reference.ResolvedIDs)
+		reference.LookupFields = maps.Clone(reference.LookupFields)
+		if reference.LookupArrays != nil {
+			lookupArrays := make(map[string][]string, len(reference.LookupArrays))
+			for name, values := range reference.LookupArrays {
+				lookupArrays[name] = slices.Clone(values)
+			}
+			reference.LookupArrays = lookupArrays
+		}
+		result[field] = reference
 	}
 	return result
 }
@@ -216,12 +252,12 @@ func (e *Executor) registerPayloadContracts(contracts ...payloadContract) {
 
 func (e *Executor) validatePlanPayloads(ctx context.Context, plan *planner.Plan) error {
 	if err := planner.ValidatePlanCompatibility(plan); err != nil {
-		return err
+		return e.withPlanCompatibilityGuidance(err)
 	}
 	for i := range plan.Changes {
 		change := plan.Changes[i]
-		change.Fields = maps.Clone(change.Fields)
-		change.References = maps.Clone(change.References)
+		change.Fields = cloneValidationFields(change.Fields)
+		change.References = cloneValidationReferences(change.References)
 		if err := e.resolveDeferredEnvPlaceholders(&change); err != nil {
 			return fmt.Errorf(
 				"incompatible plan change %d (%q): failed to resolve deferred environment values: %w",
@@ -241,15 +277,24 @@ func (e *Executor) validatePlanPayloads(ctx context.Context, plan *planner.Plan)
 			continue
 		}
 		if err := contract.ValidatePayload(ctx, change); err != nil {
-			return fmt.Errorf(
-				"incompatible plan change %d (%q) for %s %s: %w; regenerate the plan",
+			err = fmt.Errorf(
+				"incompatible plan change %d (%q) for %s %s: %w",
 				i,
 				change.ID,
 				change.Action,
 				change.ResourceType,
 				err,
 			)
+			return e.withPlanCompatibilityGuidance(err)
 		}
 	}
 	return nil
+}
+
+func (e *Executor) withPlanCompatibilityGuidance(err error) error {
+	message := strings.TrimSuffix(err.Error(), "; regenerate the plan")
+	if e.planBaseDir != "" {
+		return fmt.Errorf("%s; regenerate the plan", message)
+	}
+	return fmt.Errorf("%s; this is an internal planner-to-executor contract violation", message)
 }

--- a/internal/declarative/executor/payload_contract.go
+++ b/internal/declarative/executor/payload_contract.go
@@ -1,0 +1,255 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/kong/kongctl/internal/declarative/planner"
+)
+
+type payloadContract interface {
+	ResourceType() string
+	ValidatePayload(context.Context, planner.PlannedChange) error
+}
+
+type upsertPayloadContract[TRequest any] struct {
+	base *BaseCreateDeleteExecutor[TRequest]
+}
+
+func (c upsertPayloadContract[TRequest]) ResourceType() string {
+	return c.base.ResourceType()
+}
+
+func (c upsertPayloadContract[TRequest]) ValidatePayload(
+	ctx context.Context,
+	change planner.PlannedChange,
+) error {
+	switch change.Action {
+	case planner.ActionCreate, planner.ActionUpdate:
+		execCtx := NewExecutionContext(&change)
+		var request TRequest
+		if err := c.base.ops.MapCreateFields(ctx, execCtx, change.Fields, &request); err != nil {
+			return err
+		}
+		return validateMappedPayload(c.base.ops.ResourceType(), change.Action, change.Fields, request)
+	case planner.ActionDelete:
+		return nil
+	case planner.ActionExternalTool:
+		return fmt.Errorf("action %q is not supported", change.Action)
+	default:
+		return fmt.Errorf("action %q is not supported", change.Action)
+	}
+}
+
+type payloadContractKey struct {
+	resourceType string
+	action       planner.ActionType
+}
+
+// translatedPayloadFields records planner fields that are intentionally consumed
+// outside the same JSON path in the SDK request. Entries are action-specific so
+// adding a planner field still requires an explicit decision about its execution.
+var translatedPayloadFields = map[payloadContractKey][]string{
+	{planner.ResourceTypeAPI, planner.ActionUpdate}:                    {planner.FieldCurrentLabels},
+	{planner.ResourceTypeAIGateway, planner.ActionUpdate}:              {planner.FieldCurrentLabels},
+	{planner.ResourceTypeAIGatewayConsumerGroup, planner.ActionCreate}: {planner.FieldConsumers},
+	{planner.ResourceTypeAIGatewayConsumerGroup, planner.ActionUpdate}: {planner.FieldConsumers},
+	{planner.ResourceTypeApplicationAuthStrategy, planner.ActionUpdate}: {
+		planner.FieldCurrentLabels,
+		planner.FieldError,
+		planner.FieldName,
+		planner.FieldStrategyType,
+	},
+	{planner.ResourceTypeCatalogService, planner.ActionUpdate}: {planner.FieldCurrentLabels},
+	{planner.ResourceTypeControlPlane, planner.ActionCreate}:   {planner.FieldMembers},
+	{planner.ResourceTypeControlPlane, planner.ActionUpdate}: {
+		planner.FieldCurrentLabels,
+		planner.FieldMembers,
+	},
+	{planner.ResourceTypeDashboard, planner.ActionUpdate}: {planner.FieldCurrentLabels},
+	{planner.ResourceTypeDCRProvider, planner.ActionUpdate}: {
+		planner.FieldCurrentLabels,
+		planner.FieldDCRProviderUpdateType,
+		planner.FieldError,
+		planner.FieldName,
+	},
+	{planner.ResourceTypeEventGatewayVirtualCluster, planner.ActionCreate}: {planner.FieldDestination + ".name"},
+	{planner.ResourceTypeEventGatewayVirtualCluster, planner.ActionUpdate}: {planner.FieldDestination + ".name"},
+	{planner.ResourceTypeEventGatewayClusterPolicy, planner.ActionUpdate}:  {planner.FieldCurrentLabels},
+	{planner.ResourceTypeEventGatewayConsumePolicy, planner.ActionUpdate}:  {planner.FieldCurrentLabels},
+	{planner.ResourceTypeEventGatewayControlPlane, planner.ActionUpdate}:   {planner.FieldCurrentLabels},
+	{planner.ResourceTypeEventGatewayProducePolicy, planner.ActionUpdate}:  {planner.FieldCurrentLabels},
+	{planner.ResourceTypeOrganizationTeam, planner.ActionUpdate}:           {planner.FieldCurrentLabels},
+	{planner.ResourceTypePortal, planner.ActionUpdate}:                     {planner.FieldCurrentLabels},
+	{planner.ResourceTypePortalAssetFavicon, planner.ActionUpdate}:         {planner.FieldDataURL},
+	{planner.ResourceTypePortalAssetLogo, planner.ActionUpdate}:            {planner.FieldDataURL},
+	{planner.ResourceTypePortalEmailTemplate, planner.ActionCreate}: {
+		planner.FieldContent,
+		planner.FieldEnabled,
+		planner.FieldName,
+	},
+	{planner.ResourceTypePortalEmailTemplate, planner.ActionUpdate}: {
+		planner.FieldContent,
+		planner.FieldEnabled,
+		planner.FieldName,
+	},
+	{planner.ResourceTypePortalIdentityProvider, planner.ActionCreate}: {planner.FieldConfig + ".type"},
+	{planner.ResourceTypePortalIdentityProvider, planner.ActionUpdate}: {planner.FieldConfig + ".type"},
+}
+
+func validateMappedPayload(
+	resourceType string,
+	action planner.ActionType,
+	fields map[string]any,
+	request any,
+) error {
+	sourceData, err := json.Marshal(fields)
+	if err != nil {
+		return fmt.Errorf("failed to encode planner payload: %w", err)
+	}
+	mappedData, err := json.Marshal(request)
+	if err != nil {
+		return fmt.Errorf("failed to encode SDK request: %w", err)
+	}
+
+	var sourceValue map[string]any
+	if err := json.Unmarshal(sourceData, &sourceValue); err != nil {
+		return fmt.Errorf("failed to inspect planner payload: %w", err)
+	}
+	for _, field := range translatedPayloadFields[payloadContractKey{resourceType, action}] {
+		removePayloadPath(sourceValue, strings.Split(field, "."))
+	}
+	var mappedValue any
+	if err := json.Unmarshal(mappedData, &mappedValue); err != nil {
+		return fmt.Errorf("failed to inspect SDK request: %w", err)
+	}
+
+	dropped := droppedPayloadPaths(sourceValue, mappedValue, "")
+	if len(dropped) == 0 {
+		return nil
+	}
+	slices.Sort(dropped)
+	return fmt.Errorf(
+		"%s contains fields not represented by the action-specific SDK request: %s",
+		resourceType,
+		strings.Join(dropped, ", "),
+	)
+}
+
+func removePayloadPath(value any, path []string) {
+	if len(path) == 0 {
+		return
+	}
+	object, ok := value.(map[string]any)
+	if !ok {
+		return
+	}
+	if len(path) == 1 {
+		delete(object, path[0])
+		return
+	}
+	removePayloadPath(object[path[0]], path[1:])
+}
+
+func validationChange(change planner.PlannedChange) planner.PlannedChange {
+	result := change
+	result.Fields = cloneValidationFields(change.Fields)
+	result.References = maps.Clone(change.References)
+	for field, reference := range result.References {
+		if !reference.HasResolvedID() {
+			reference.ID = "payload-validation-id"
+		}
+		result.References[field] = reference
+		setResolvedFieldValue(result.Fields, field, reference.ID)
+	}
+	if result.Parent != nil && unresolvedReferenceID(result.Parent.ID) {
+		parent := *result.Parent
+		parent.ID = "payload-validation-id"
+		result.Parent = &parent
+	}
+	return result
+}
+
+func cloneValidationFields(fields map[string]any) map[string]any {
+	if fields == nil {
+		return nil
+	}
+	result := make(map[string]any, len(fields))
+	for field, value := range fields {
+		result[field] = cloneValidationValue(value)
+	}
+	return result
+}
+
+func cloneValidationValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneValidationFields(typed)
+	case []any:
+		result := make([]any, len(typed))
+		for i := range typed {
+			result[i] = cloneValidationValue(typed[i])
+		}
+		return result
+	case planner.FieldChange:
+		typed.Old = cloneValidationValue(typed.Old)
+		typed.New = cloneValidationValue(typed.New)
+		return typed
+	default:
+		return typed
+	}
+}
+
+func (e *Executor) registerPayloadContracts(contracts ...payloadContract) {
+	for _, contract := range contracts {
+		resourceType := contract.ResourceType()
+		if _, exists := e.payloadContracts[resourceType]; exists {
+			panic("duplicate payload contract for resource type " + resourceType)
+		}
+		e.payloadContracts[resourceType] = contract
+	}
+}
+
+func (e *Executor) validatePlanPayloads(ctx context.Context, plan *planner.Plan) error {
+	if err := planner.ValidatePlanCompatibility(plan); err != nil {
+		return err
+	}
+	for i := range plan.Changes {
+		change := plan.Changes[i]
+		change.Fields = maps.Clone(change.Fields)
+		change.References = maps.Clone(change.References)
+		if err := e.resolveDeferredEnvPlaceholders(&change); err != nil {
+			return fmt.Errorf(
+				"incompatible plan change %d (%q): failed to resolve deferred environment values: %w",
+				i,
+				change.ID,
+				err,
+			)
+		}
+		change = validationChange(change)
+		if change.ResourceType == planner.ResourceTypeDeck {
+			continue
+		}
+		contract, ok := e.payloadContracts[change.ResourceType]
+		if !ok {
+			// Unsupported resource types retain the existing execution error path.
+			// Every resource dispatched by this executor is registered above.
+			continue
+		}
+		if err := contract.ValidatePayload(ctx, change); err != nil {
+			return fmt.Errorf(
+				"incompatible plan change %d (%q) for %s %s: %w; regenerate the plan",
+				i,
+				change.ID,
+				change.Action,
+				change.ResourceType,
+				err,
+			)
+		}
+	}
+	return nil
+}

--- a/internal/declarative/executor/portal_team_group_mapping_adapter.go
+++ b/internal/declarative/executor/portal_team_group_mapping_adapter.go
@@ -14,6 +14,27 @@ type PortalTeamGroupMappingExecutor struct {
 	dryRun bool
 }
 
+// ResourceType identifies the singleton mapping contract.
+func (p *PortalTeamGroupMappingExecutor) ResourceType() string {
+	return planner.ResourceTypePortalTeamGroupMapping
+}
+
+// ValidatePayload enforces the action-specific body for group mapping updates.
+func (p *PortalTeamGroupMappingExecutor) ValidatePayload(
+	_ context.Context,
+	change planner.PlannedChange,
+) error {
+	if change.Action != planner.ActionUpdate {
+		return fmt.Errorf("action %q is not supported", change.Action)
+	}
+	for field := range change.Fields {
+		if field != planner.FieldGroups {
+			return fmt.Errorf("field %q is not supported by the update request", field)
+		}
+	}
+	return nil
+}
+
 // NewPortalTeamGroupMappingExecutor creates a portal team group mapping executor.
 func NewPortalTeamGroupMappingExecutor(client *state.Client, dryRun bool) *PortalTeamGroupMappingExecutor {
 	return &PortalTeamGroupMappingExecutor{client: client, dryRun: dryRun}

--- a/internal/declarative/planner/api_planner.go
+++ b/internal/declarative/planner/api_planner.go
@@ -543,30 +543,8 @@ func (p *Planner) planAPIProtectionChangeWithFields(
 	// Include any field updates if present
 	maps.Copy(fields, updateFields)
 
-	// ALWAYS include essential identification fields for protection changes
+	// Include the API name used by executor lookup and request mapping.
 	fields[FieldName] = current.Name
-	fields[FieldID] = current.ID
-
-	// Preserve namespace context for execution phase
-	if current.Labels != nil {
-		if namespace, exists := current.Labels[labels.NamespaceKey]; exists {
-			fields[FieldNamespace] = namespace
-		}
-	}
-
-	// Preserve other critical labels that identify managed resources
-	if current.Labels != nil {
-		preservedLabels := make(map[string]string)
-		for key, value := range current.Labels {
-			// Preserve all KONGCTL- prefixed labels except protected (which will be updated)
-			if strings.HasPrefix(key, "KONGCTL-") && key != labels.ProtectedKey {
-				preservedLabels[key] = value
-			}
-		}
-		if len(preservedLabels) > 0 {
-			fields[FieldPreservedLabels] = preservedLabels
-		}
-	}
 
 	change.Fields = fields
 	if len(changedFields) > 0 {
@@ -1169,7 +1147,6 @@ func (p *Planner) planAPIPublicationCreate(
 	dependsOn []string, plan *Plan,
 ) {
 	fields := make(map[string]any)
-	fields[FieldPortalID] = publication.PortalID
 	if publication.AuthStrategyIds != nil {
 		fields[FieldAuthStrategyIDs] = publication.AuthStrategyIds
 	}
@@ -1301,12 +1278,13 @@ func (p *Planner) planAPIPublicationDelete(
 		ResourceID:   fmt.Sprintf("%s:%s", apiID, portalID), // Composite ID for API publication
 		Parent:       &ParentInfo{Ref: apiRef, ID: apiID},
 		Action:       ActionDelete,
-		Fields: map[string]any{
-			FieldAPIID:    apiID,
-			FieldPortalID: portalID,
+		Fields:       map[string]any{},
+		DependsOn:    []string{},
+		Namespace:    parentNamespace,
+		References: map[string]ReferenceInfo{
+			FieldAPIID:    {Ref: apiRef, ID: apiID},
+			FieldPortalID: {Ref: portalRef, ID: portalID},
 		},
-		DependsOn: []string{},
-		Namespace: parentNamespace,
 	}
 
 	if len(current.AuthStrategyIDs) > 0 {
@@ -1323,9 +1301,6 @@ func (p *Planner) planAPIPublicationUpdate(
 	current state.APIPublication, desired resources.APIPublicationResource,
 	updateFields map[string]any, changedFields map[string]FieldChange, plan *Plan,
 ) {
-	// Update fields with resolved portal ID
-	updateFields[FieldPortalID] = current.PortalID
-
 	change := PlannedChange{
 		ID:            p.nextChangeID(ActionUpdate, ResourceTypeAPIPublication, desired.GetRef()),
 		ResourceType:  ResourceTypeAPIPublication,

--- a/internal/declarative/planner/catalog_service_planner.go
+++ b/internal/declarative/planner/catalog_service_planner.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"maps"
 	"reflect"
-	"strings"
 
 	"github.com/kong/kongctl/internal/declarative/labels"
 	"github.com/kong/kongctl/internal/declarative/resources"
@@ -378,23 +377,6 @@ func (p *Planner) planCatalogServiceProtectionChangeWithFields(
 	maps.Copy(fields, updateFields)
 	fields[FieldName] = current.Name
 	fields[FieldDisplayName] = current.DisplayName
-	fields[FieldID] = current.ID
-
-	if ns, ok := current.NormalizedLabels[labels.NamespaceKey]; ok {
-		fields[FieldNamespace] = ns
-	}
-
-	if current.NormalizedLabels != nil {
-		preserved := make(map[string]string)
-		for key, val := range current.NormalizedLabels {
-			if strings.HasPrefix(key, "KONGCTL-") && key != labels.ProtectedKey {
-				preserved[key] = val
-			}
-		}
-		if len(preserved) > 0 {
-			fields[FieldPreservedLabels] = preserved
-		}
-	}
 
 	change.Fields = fields
 	if len(changedFields) > 0 {

--- a/internal/declarative/planner/constants.go
+++ b/internal/declarative/planner/constants.go
@@ -47,9 +47,6 @@ const (
 	// FieldManagedBy contains tool ownership metadata for resources that expose managed_by
 	FieldManagedBy = "managed_by"
 
-	// FieldPreservedLabels contains labels preserved during resource recreation
-	FieldPreservedLabels = "preserved_labels"
-
 	// FieldError contains validation errors that should be reported
 	// Used when the planner detects an invalid operation
 	FieldError = "_error"

--- a/internal/declarative/planner/egw_control_plane_planner.go
+++ b/internal/declarative/planner/egw_control_plane_planner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"strings"
 
 	"github.com/kong/kongctl/internal/declarative/labels"
 	"github.com/kong/kongctl/internal/declarative/resources"
@@ -384,28 +383,8 @@ func (p *Planner) planEGWControlPlaneProtectionChangeWithFields(
 	// Include any field updates if present
 	maps.Copy(fields, updateFields)
 
-	// ALWAYS include essential identification fields for protection changes
+	// Include the gateway name used by executor lookup and request mapping.
 	fields[FieldName] = current.Name
-	fields[FieldID] = current.ID
-
-	// Preserve namespace context for execution phase
-	if current.Labels != nil {
-		if namespace, exists := current.Labels[labels.NamespaceKey]; exists {
-			fields[FieldNamespace] = namespace
-		}
-
-		// Preserve other critical labels that identify managed resources
-		preservedLabels := make(map[string]string)
-		for key, value := range current.Labels {
-			// Preserve all KONGCTL- prefixed labels except protected (which will be updated)
-			if strings.HasPrefix(key, "KONGCTL-") && key != labels.ProtectedKey {
-				preservedLabels[key] = value
-			}
-		}
-		if len(preservedLabels) > 0 {
-			fields[FieldPreservedLabels] = preservedLabels
-		}
-	}
 
 	change.Fields = fields
 	if len(changedFields) > 0 {

--- a/internal/declarative/planner/organization_system_account_assignments.go
+++ b/internal/declarative/planner/organization_system_account_assignments.go
@@ -245,10 +245,7 @@ func (t *OrganizationTeamPlannerImpl) planOrganizationSystemAccountTeamMembershi
 		ResourceType: ResourceTypeOrganizationSystemAccountTeamMembership,
 		ResourceRef:  membershipRef,
 		Action:       ActionCreate,
-		Fields: map[string]any{
-			FieldSystemAccountID: accountID,
-			FieldTeamID:          teamID,
-		},
+		Fields:       map[string]any{},
 		References: map[string]ReferenceInfo{
 			FieldSystemAccountID: {Ref: accountRef, ID: accountID},
 			FieldTeamID: {
@@ -282,10 +279,7 @@ func (t *OrganizationTeamPlannerImpl) planOrganizationSystemAccountTeamMembershi
 		ResourceRef:  accountRef + "|" + membership.TeamID,
 		ResourceID:   membership.TeamID,
 		Action:       ActionDelete,
-		Fields: map[string]any{
-			FieldSystemAccountID: accountID,
-			FieldTeamID:          membership.TeamID,
-		},
+		Fields:       map[string]any{},
 		References: map[string]ReferenceInfo{
 			FieldSystemAccountID: {Ref: accountRef, ID: accountID},
 			FieldTeamID:          {ID: membership.TeamID},

--- a/internal/declarative/planner/organization_user_assignments.go
+++ b/internal/declarative/planner/organization_user_assignments.go
@@ -219,10 +219,7 @@ func (t *OrganizationTeamPlannerImpl) planOrganizationUserTeamMembershipCreate(
 		ResourceType: ResourceTypeOrganizationUserTeamMembership,
 		ResourceRef:  membershipRef,
 		Action:       ActionCreate,
-		Fields: map[string]any{
-			FieldUserID: userID,
-			FieldTeamID: teamID,
-		},
+		Fields:       map[string]any{},
 		References: map[string]ReferenceInfo{
 			FieldUserID: {Ref: userRef, ID: userID},
 			FieldTeamID: {
@@ -256,10 +253,7 @@ func (t *OrganizationTeamPlannerImpl) planOrganizationUserTeamMembershipDelete(
 		ResourceRef:  userRef + "|" + membership.TeamID,
 		ResourceID:   membership.TeamID,
 		Action:       ActionDelete,
-		Fields: map[string]any{
-			FieldUserID: userID,
-			FieldTeamID: membership.TeamID,
-		},
+		Fields:       map[string]any{},
 		References: map[string]ReferenceInfo{
 			FieldUserID: {Ref: userRef, ID: userID},
 			FieldTeamID: {ID: membership.TeamID},

--- a/internal/declarative/planner/plan_compatibility.go
+++ b/internal/declarative/planner/plan_compatibility.go
@@ -1,0 +1,163 @@
+package planner
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+)
+
+// CurrentPlanVersion is the only plan format version accepted by this build.
+// Plans are intentionally rejected rather than migrated when their serialized
+// contract is not compatible with the current planner-to-executor boundary.
+const CurrentPlanVersion = "1.0"
+
+// ValidatePlanCompatibility validates the portion of the serialized plan
+// contract that is independent of executor SDK request types.
+func ValidatePlanCompatibility(plan *Plan) error {
+	if plan == nil {
+		return fmt.Errorf("invalid plan: plan is required")
+	}
+	if plan.Metadata.Version == "" {
+		return fmt.Errorf("invalid plan: missing version")
+	}
+	if plan.Metadata.Version != CurrentPlanVersion {
+		return fmt.Errorf(
+			"plan version %q is not supported by this kongctl version; regenerate the plan",
+			plan.Metadata.Version,
+		)
+	}
+	if err := validatePlanMode(plan.Metadata.Mode); err != nil {
+		return err
+	}
+
+	for i := range plan.Changes {
+		if err := validateChangeCompatibility(&plan.Changes[i]); err != nil {
+			return fmt.Errorf("incompatible plan change %d (%q): %w; regenerate the plan", i, plan.Changes[i].ID, err)
+		}
+	}
+	return nil
+}
+
+func validatePlanMode(mode PlanMode) error {
+	switch mode {
+	case PlanModeSync, PlanModeApply, PlanModeDelete:
+		return nil
+	case "":
+		return fmt.Errorf("invalid plan: missing mode")
+	default:
+		return fmt.Errorf("invalid plan: unsupported mode %q", mode)
+	}
+}
+
+func validateChangeCompatibility(change *PlannedChange) error {
+	if change == nil {
+		return fmt.Errorf("change is required")
+	}
+	if strings.TrimSpace(change.ID) == "" {
+		return fmt.Errorf("missing change ID")
+	}
+	if strings.TrimSpace(change.ResourceType) == "" {
+		return fmt.Errorf("missing resource type")
+	}
+	switch change.Action {
+	case ActionCreate, ActionUpdate, ActionDelete:
+		if change.ResourceType == ResourceTypeDeck && change.Action != ActionCreate {
+			return fmt.Errorf("action %q is not supported for resource type %q", change.Action, change.ResourceType)
+		}
+	case ActionExternalTool:
+		if change.ResourceType != ResourceTypeDeck {
+			return fmt.Errorf("action %q is only supported for resource type %q", change.Action, ResourceTypeDeck)
+		}
+	default:
+		return fmt.Errorf("unsupported action %q", change.Action)
+	}
+
+	return validateRoutingBoundary(change)
+}
+
+func validateRoutingBoundary(change *PlannedChange) error {
+	switch change.ResourceType {
+	case ResourceTypeOrganizationUserTeamMembership:
+		if hasPayloadPath(change.Fields, FieldUserID) {
+			return fmt.Errorf("routing-only field %q must not appear in fields", FieldUserID)
+		}
+	case ResourceTypeOrganizationSystemAccountTeamMembership:
+		if hasPayloadPath(change.Fields, FieldSystemAccountID) {
+			return fmt.Errorf("routing-only field %q must not appear in fields", FieldSystemAccountID)
+		}
+	}
+
+	if change.ResourceType == ResourceTypeAPIPublication {
+		if hasPayloadPath(change.Fields, FieldAPIID) || hasPayloadPath(change.Fields, FieldPortalID) {
+			return fmt.Errorf("API and portal routing IDs must not appear in fields")
+		}
+		if _, ok := change.References[FieldPortalID]; !ok {
+			return fmt.Errorf("missing portal routing reference")
+		}
+		if _, ok := change.References[FieldAPIID]; !ok && change.Parent == nil {
+			return fmt.Errorf("missing API routing reference or parent")
+		}
+	}
+
+	descriptors := resources.RelationshipDescriptorsForType(resources.ResourceType(change.ResourceType))
+	for _, descriptor := range descriptors {
+		if descriptor.Kind == resources.RelationshipKindKongctlParentSelector &&
+			hasPayloadPath(change.Fields, descriptor.FieldPath) {
+			return fmt.Errorf("routing-only field %q must not appear in fields", descriptor.FieldPath)
+		}
+		if descriptor.Kind != resources.RelationshipKindKongctlParentSelector {
+			continue
+		}
+		for _, routingField := range routingIDFields(descriptor) {
+			if hasPayloadPath(change.Fields, routingField) {
+				return fmt.Errorf("routing-only field %q must not appear in fields", routingField)
+			}
+		}
+	}
+	return nil
+}
+
+func routingIDFields(descriptor resources.RelationshipDescriptor) []string {
+	// Only resource types that can be API-routing parents have a corresponding
+	// planner routing ID field.
+	//exhaustive:ignore
+	switch descriptor.TargetType {
+	case resources.ResourceTypeAIGateway:
+		return []string{FieldAIGatewayID}
+	case resources.ResourceTypeAIGatewayConsumer:
+		return []string{FieldAIGatewayConsumerID}
+	case resources.ResourceTypeControlPlane:
+		return []string{FieldControlPlaneID}
+	case resources.ResourceTypeEventGatewayControlPlane:
+		return []string{FieldEventGatewayID}
+	case resources.ResourceTypeEventGatewayListener:
+		return []string{FieldEventGatewayListenerID}
+	case resources.ResourceTypeEventGatewayVirtualCluster:
+		return []string{FieldEventGatewayVirtualClusterID}
+	case resources.ResourceTypeOrganizationTeam, resources.ResourceTypePortalTeam:
+		return []string{FieldTeamID}
+	case resources.ResourceTypePortal:
+		return []string{FieldPortalID}
+	default:
+		return nil
+	}
+}
+
+func hasPayloadPath(fields map[string]any, path string) bool {
+	if len(fields) == 0 || path == "" {
+		return false
+	}
+	current := any(fields)
+	for part := range strings.SplitSeq(path, ".") {
+		object, ok := current.(map[string]any)
+		if !ok {
+			return false
+		}
+		current, ok = object[part]
+		if !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/declarative/planner/planner.go
+++ b/internal/declarative/planner/planner.go
@@ -147,7 +147,7 @@ func (p *Planner) GeneratePlan(ctx context.Context, rs *resources.ResourceSet, o
 	}
 
 	// Create base plan
-	basePlan := NewPlan("1.0", generator, opts.Mode)
+	basePlan := NewPlan(CurrentPlanVersion, generator, opts.Mode)
 	p.resources = rs
 
 	if opts.Mode == PlanModeSync {
@@ -266,7 +266,7 @@ func (p *Planner) GeneratePlan(ctx context.Context, rs *resources.ResourceSet, o
 		namespacePlanner.desiredPortalAuditLogWebhooks = rs.PortalAuditLogWebhooks
 
 		// Create a plan for this namespace
-		namespacePlan := NewPlan("1.0", generator, opts.Mode)
+		namespacePlan := NewPlan(CurrentPlanVersion, generator, opts.Mode)
 
 		// Generate changes using interface-based planners
 		// Pass the specific namespace to planners instead of wildcard

--- a/internal/declarative/planner/portal_child_planner.go
+++ b/internal/declarative/planner/portal_child_planner.go
@@ -4468,9 +4468,6 @@ func (p *Planner) planPortalTeamGroupMappingUpdate(
 	fields := map[string]any{
 		FieldGroups: cloneStringSlicePreserveEmpty(mapping.Groups),
 	}
-	if teamID != "" {
-		fields[FieldTeamID] = teamID
-	}
 
 	dependencies := findPortalTeamGroupMappingDependencies(plan, portalRef, mapping.Team)
 	references := make(map[string]ReferenceInfo)


### PR DESCRIPTION
## Summary

- enforce an action-aware planner-to-executor payload contract before execution
- keep parent selectors and routing identifiers in plan relationships instead of API bodies
- reject incompatible saved plans with actionable regeneration guidance
- inventory intentional internal and transformed fields centrally
- integrate payload validation with centralized managed-label mapping
- document the declarative resource, plan, and SDK request boundary

## Rationale

Executor adapters previously differed in how unexpected planner fields were handled. Some mappings rejected unsupported fields while others silently discarded them. This change validates every supported resource mapping through its action-specific SDK request shape before any API mutation.

No saved-plan migration is introduced. Plans with incompatible structure are rejected and must be regenerated.

## Validation

- make build
- make test
- make test-integration
- production declarative golangci-lint: zero issues
- protected-resources E2E suite
- AI Gateway root and consumer-group E2E scenarios
- portal app-auth-strategy and asset E2E scenarios
- analytics dashboard, catalog service, control-plane membership, and Event Gateway dependency E2E scenarios
- git diff --check

No test files or test packages were changed. Full make lint remains blocked by 56 pre-existing findings in generated mock and portal-client files.

Closes #1905