### PR TITLE
refactor(simplify): simplify declarative executor and planner code

### DIFF
--- a/internal/declarative/executor/dcr_provider_adapter.go
+++ b/internal/declarative/executor/dcr_provider_adapter.go
@@ -54,18 +54,10 @@ func (a *DCRProviderAdapter) MapUpdateFields(
 	_ context.Context, _ *ExecutionContext, fields map[string]any,
 	update *kkComps.UpdateDcrProviderRequest, _ map[string]string,
 ) error {
-	payload := map[string]any{}
 	if displayName, ok := fields[planner.FieldDisplayName].(string); ok {
-		payload[planner.FieldDisplayName] = displayName
-	}
-	if issuer, ok := fields[planner.FieldDCRProviderIssuer].(string); ok {
-		payload[planner.FieldDCRProviderIssuer] = issuer
-	}
-
-	if displayName, ok := payload[planner.FieldDisplayName].(string); ok {
 		update.DisplayName = &displayName
 	}
-	if issuer, ok := payload[planner.FieldDCRProviderIssuer].(string); ok {
+	if issuer, ok := fields[planner.FieldDCRProviderIssuer].(string); ok {
 		update.Issuer = &issuer
 	}
 	if dcrConfig, ok := fields[planner.FieldDCRProviderConfig]; ok {

--- a/internal/declarative/labels/labels.go
+++ b/internal/declarative/labels/labels.go
@@ -127,28 +127,7 @@ func IsKongctlLabel(key string) bool {
 // CompareUserLabels compares only user-defined labels between current and desired states
 // Returns true if user labels differ, ignoring KONGCTL system labels
 func CompareUserLabels(current, desired map[string]string) bool {
-	// Get user labels from both maps
-	currentUser := GetUserLabels(current)
-	desiredUser := GetUserLabels(desired)
-
-	// If both are empty or nil, they're equal
-	if len(currentUser) == 0 && len(desiredUser) == 0 {
-		return false
-	}
-
-	// If lengths differ, they're not equal
-	if len(currentUser) != len(desiredUser) {
-		return true
-	}
-
-	// Compare each user label
-	for k, v := range desiredUser {
-		if currentVal, exists := currentUser[k]; !exists || currentVal != v {
-			return true
-		}
-	}
-
-	return false
+	return !maps.Equal(GetUserLabels(current), GetUserLabels(desired))
 }
 
 // ValidateLabel ensures label key follows Konnect rules

--- a/internal/declarative/planner/portal_child_planner.go
+++ b/internal/declarative/planner/portal_child_planner.go
@@ -3422,10 +3422,7 @@ func indexPortalPagesByPath(pages []state.PortalPage) map[string]state.PortalPag
 			return ""
 		}
 
-		slug := page.Slug
-		if slug != "/" {
-			slug = strings.TrimPrefix(slug, "/")
-		}
+		slug := normalizePageSlug(page.Slug)
 		if page.ParentPageID == "" {
 			pathsByID[pageID] = slug
 			return slug
@@ -3455,15 +3452,19 @@ func (p *Planner) desiredPortalPagePath(
 	page resources.PortalPageResource,
 	allPages []resources.PortalPageResource,
 ) string {
-	slug := page.Slug
-	if slug != "/" {
-		slug = strings.TrimPrefix(slug, "/")
-	}
+	slug := normalizePageSlug(page.Slug)
 	if page.ParentPageRef == "" {
 		return slug
 	}
 	if parentPath := p.buildParentPath(page.ParentPageRef, allPages); parentPath != "" {
 		return parentPath + "/" + slug
+	}
+	return slug
+}
+
+func normalizePageSlug(slug string) string {
+	if slug != "/" {
+		return strings.TrimPrefix(slug, "/")
 	}
 	return slug
 }


### PR DESCRIPTION
## Summary

- map DCR provider updates directly from planner fields
- compare user labels with `maps.Equal`
- share portal page slug normalization between path builders

## Rationale

Remove redundant and duplicated declarative code while preserving existing behavior.

Closes #1925

## Validation

- `go fix ./...`
- `make format`
- `make build`
- `make lint`
- `make test-all`

No tests were changed.