### PR TITLE
fix(cmd): validate sources for bare declarative delete

### DIFF
--- a/internal/cmd/root/verbs/del/del.go
+++ b/internal/cmd/root/verbs/del/del.go
@@ -51,17 +51,7 @@ func NewDeleteCmd() (*cobra.Command, error) {
 		Long:    deleteLong,
 		Example: declDeleteCmd.Example,
 		Aliases: []string{"d", "D", "del", "rm", "DEL", "RM"},
-		// When -f is provided, run declarative delete; otherwise show help
-		RunE: func(c *cobra.Command, args []string) error {
-			filenames, _ := c.Flags().GetStringSlice("filename")
-			planFile, _ := c.Flags().GetString("plan")
-			if len(filenames) > 0 || planFile != "" {
-				return declDeleteCmd.RunE(c, args)
-			}
-			return &cmdpkg.UsageError{
-				Err: fmt.Errorf("command %q requires -f/--filename or --plan", c.CommandPath()),
-			}
-		},
+		RunE:    declDeleteCmd.RunE,
 		PersistentPreRunE: func(c *cobra.Command, args []string) error {
 			ctx := c.Context()
 			if ctx == nil {

--- a/test/e2e/scenarios/errors/declarative/scenario.yaml
+++ b/test/e2e/scenarios/errors/declarative/scenario.yaml
@@ -135,6 +135,17 @@ steps:
           exitCode: 1
           contains: "no configuration sources specified"
 
+  - name: 009a-bare-delete-no-file
+    skipInputs: true
+    commands:
+      - name: 000-bare-delete
+        outputFormat: disable
+        run:
+          - delete
+        expectFailure:
+          exitCode: 1
+          contains: "no configuration sources specified"
+
   - name: 010-mode-plan-conflict
     skipInputs: true
     commands:


### PR DESCRIPTION
## Summary

- route bare declarative delete through the shared source validator
- add E2E coverage for the no-source error
- align delete with apply, sync, plan, and diff error handling

Closes #1926

## Testing

- make test-e2e-scenarios SCENARIO=errors/declarative
- make build
- make test
- make test-integration
- golangci-lint run ./internal/cmd/root/verbs/del/...

Full make lint currently reports pre-existing findings in generated portal client and mock files, plus a neighboring worktree permission warning.