### PR TITLE
test(e2e): cover namespace flag mutual exclusion

### DIFF
--- a/test/e2e/scenarios/errors/declarative/scenario.yaml
+++ b/test/e2e/scenarios/errors/declarative/scenario.yaml
@@ -174,6 +174,24 @@ steps:
           exitCode: 1
           contains: "--require-namespace cannot be used together with --plan"
 
+  - name: 011a-require-namespace-mutual-exclusion
+    skipInputs: true
+    commands:
+      - name: 000-plan-both-namespace-flags
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .scenario_dir }}/testdata/config.yaml"
+          - --mode
+          - apply
+          - --require-namespace
+          - my-ns
+          - --require-any-namespace
+        expectFailure:
+          exitCode: 1
+          contains: "mutually exclusive"
+
   - name: 012-dump-output-flag-rejected
     skipInputs: true
     commands:


### PR DESCRIPTION
## Summary

- extend the declarative errors scenario with both namespace requirement flags
- assert the command fails with the mutual-exclusion error
- keep the new coverage beside the existing declarative flag-conflict cases

Closes #1927

## Testing

- make test-e2e-scenarios SCENARIO=errors/declarative
- make build
- make test
- make test-integration

Full make lint was attempted from the shared base and currently reports pre-existing findings in generated portal client and mock files, plus a neighboring worktree permission warning.