### PR TITLE
fix(declarative): support portal-owned dump round trips

### DIFF
--- a/internal/declarative/planner/resolver.go
+++ b/internal/declarative/planner/resolver.go
@@ -67,6 +67,21 @@ func (r *ReferenceResolver) ResolveReferences(ctx context.Context, changes []Pla
 	for _, change := range changes {
 		changeRefs := make(map[string]ResolvedReference)
 
+		// Planner-specific resource code may pre-populate reference metadata for
+		// fields that are not part of the request payload. A UUID-shaped ref can
+		// still be a declarative ref when dump output uses the resource's Konnect
+		// ID as its ref. If that resource is being recreated in this plan, discard
+		// the stale ID so execution hydrates it from the CREATE result.
+		for field, reference := range change.References {
+			resourceType := r.getResourceTypeForChangeField(change, field)
+			if referenceCreatedInPlan(createdResources, resourceType, referenceTargetRef(reference.Ref)) {
+				changeRefs[field] = ResolvedReference{
+					Ref: reference.Ref,
+					ID:  resources.UnknownReferenceID,
+				}
+			}
+		}
+
 		// Check fields that might contain references
 		for _, fieldRef := range r.extractReferencesFromFields(change.Fields) {
 			// Determine resource type from field name and role entity metadata.

--- a/internal/declarative/planner/resolver_test.go
+++ b/internal/declarative/planner/resolver_test.go
@@ -1070,6 +1070,48 @@ func TestResolveReferences_UUIDSkipped(t *testing.T) {
 	mockAPI.AssertNotCalled(t, "ListPortals")
 }
 
+func TestResolveReferences_UUIDRefCreatedInPlanOverridesStaleID(t *testing.T) {
+	ctx := context.Background()
+	resolver := NewReferenceResolver(state.NewClient(state.ClientConfig{}), nil)
+	portalRef := "12345678-1234-5678-1234-567812345678"
+
+	changes := []PlannedChange{
+		{
+			ID:           "1-c-portal",
+			ResourceType: ResourceTypePortal,
+			ResourceRef:  portalRef,
+			Action:       ActionCreate,
+			Fields: map[string]any{
+				FieldName: "Recreated Portal",
+			},
+		},
+		{
+			ID:           "2-c-publication",
+			ResourceType: ResourceTypeAPIPublication,
+			ResourceRef:  "publication",
+			Action:       ActionCreate,
+			Fields:       map[string]any{},
+			References: map[string]ReferenceInfo{
+				FieldPortalID: {
+					Ref: portalRef,
+					ID:  portalRef,
+				},
+			},
+		},
+	}
+
+	result, err := resolver.ResolveReferences(ctx, changes)
+	require.NoError(t, err)
+	require.Empty(t, result.Errors)
+
+	publicationRefs, ok := result.ChangeReferences["2-c-publication"]
+	require.True(t, ok, "expected publication references")
+	portalReference, ok := publicationRefs[FieldPortalID]
+	require.True(t, ok, "expected portal_id reference")
+	assert.Equal(t, portalRef, portalReference.Ref)
+	assert.Equal(t, declresources.UnknownReferenceID, portalReference.ID)
+}
+
 func TestResolveReferences_FieldChange(t *testing.T) {
 	ctx := context.Background()
 	mockAPI := new(MockPortalAPI)

--- a/test/e2e/scenarios/dump/portal-owned/scenario.yaml
+++ b/test/e2e/scenarios/dump/portal-owned/scenario.yaml
@@ -151,6 +151,75 @@ steps:
               fields:
                 total_changes: 0
 
+      - name: 004-reset-before-round-trip
+        resetOrg: true
+
+      - name: 005-sync-dumped-config
+        outputFormat: json
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/dump.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: sync
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success
+
+      - name: 006-dump-after-round-trip
+        run:
+          - dump
+          - declarative
+          - "--resources=portals,apis,application_auth_strategies"
+          - --include-child-resources
+        outputFormat: none
+        parseAs: yaml
+        stdoutFile: "{{ .workdir }}/round-trip-dump.yaml"
+        assertions:
+          - select: "portals[?name=='My First Portal'] | [0]"
+            expect:
+              fields:
+                display_name: "A Getting Started Portal"
+          - select: "portals[?name=='My First Portal'] | [0].pages[?title=='Kong API'] | [0]"
+            expect:
+              fields:
+                slug: "/"
+          - select: >-
+              portals[?name=='My First Portal'] | [0].pages[?title=='Guides'] |
+              [0].children[?title=='Document APIs'] | [0]
+            expect:
+              fields:
+                slug: document-apis
+          - select: "apis[?name=='SMS API'] | [0]"
+            expect:
+              fields:
+                "versions[?version=='1.0.11'] | length(@)": 1
+                "length(documents)": 4
+          - select: "application_auth_strategies[?name=='key-auth'] | [0]"
+            expect:
+              fields:
+                strategy_type: key_auth
+
+      - name: 007-plan-after-round-trip
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/round-trip-dump.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+
   - name: 003-delete-cleanup
     commands:
       - name: 000-delete


### PR DESCRIPTION
## Summary

- reset and recreate the portal-owned resource graph from dump output
- verify the recreated portal, nested pages, API children, and auth strategy
- invalidate stale UUID-shaped reference IDs when their resources are recreated in the same plan
- confirm the round-tripped dump is idempotent

## Testing

- `go fix ./...`
- `make format`
- `make build`
- `golangci-lint run --new-from-rev=HEAD`
- `make test`
- `make test-integration`
- `make test-e2e-scenarios SCENARIO=dump/portal-owned`

Closes #1941