### PR TITLE
fix(executor): treat api document title as optional on create

### DIFF
--- a/internal/declarative/executor/api_document_adapter.go
+++ b/internal/declarative/executor/api_document_adapter.go
@@ -26,12 +26,6 @@ func (a *APIDocumentAdapter) MapCreateFields(
 	create *kkComps.CreateAPIDocumentRequest,
 ) error {
 	// Required fields
-	title, ok := fields[planner.FieldTitle].(string)
-	if !ok {
-		return fmt.Errorf("title is required")
-	}
-	create.Title = &title
-
 	content, ok := fields[planner.FieldContent].(string)
 	if !ok {
 		return fmt.Errorf("content is required")
@@ -39,6 +33,13 @@ func (a *APIDocumentAdapter) MapCreateFields(
 	create.Content = content
 
 	// Optional fields
+	// The API (and the explain schema and scaffold) treat title as
+	// optional: CreateAPIDocumentRequest.Title is a pointer. Requiring it
+	// here rejected plans built straight from the scaffold output (#1947).
+	if title, ok := fields[planner.FieldTitle].(string); ok {
+		create.Title = &title
+	}
+
 	if slug, ok := fields[planner.FieldSlug].(string); ok {
 		create.Slug = &slug
 	}
@@ -183,7 +184,7 @@ func (a *APIDocumentAdapter) ResourceType() string {
 
 // RequiredFields returns the required fields for creation
 func (a *APIDocumentAdapter) RequiredFields() []string {
-	return []string{planner.FieldTitle, planner.FieldContent}
+	return []string{planner.FieldContent}
 }
 
 // SupportsUpdate returns true as documents support updates

--- a/internal/declarative/executor/api_document_adapter_test.go
+++ b/internal/declarative/executor/api_document_adapter_test.go
@@ -1,0 +1,63 @@
+package executor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression (#1947): title is optional for API documents everywhere
+// upstream — the SDK's CreateAPIDocumentRequest.Title is a pointer, and
+// explain/scaffold/resource validation treat it as optional — so a plan
+// created without title must map cleanly instead of failing apply with
+// "title is required".
+func TestAPIDocumentAdapter_CreateWithoutTitle(t *testing.T) {
+	adapter := NewAPIDocumentAdapter(nil)
+
+	fields := map[string]any{
+		"content": "document body",
+		"slug":    "my-resource",
+		"ref":     "my-resource",
+	}
+
+	var create components.CreateAPIDocumentRequest
+	require.NoError(t, adapter.MapCreateFields(context.Background(), nil, fields, &create))
+
+	assert.Equal(t, "document body", create.Content)
+	require.NotNil(t, create.Slug)
+	assert.Equal(t, "my-resource", *create.Slug)
+	// title stays unset: the API treats it as optional.
+	assert.Nil(t, create.Title)
+}
+
+func TestAPIDocumentAdapter_CreateWithTitle(t *testing.T) {
+	adapter := NewAPIDocumentAdapter(nil)
+
+	fields := map[string]any{
+		"title":   "My document",
+		"content": "document body",
+	}
+
+	var create components.CreateAPIDocumentRequest
+	require.NoError(t, adapter.MapCreateFields(context.Background(), nil, fields, &create))
+
+	require.NotNil(t, create.Title)
+	assert.Equal(t, "My document", *create.Title)
+	assert.Equal(t, "document body", create.Content)
+}
+
+func TestAPIDocumentAdapter_CreateStillRequiresContent(t *testing.T) {
+	adapter := NewAPIDocumentAdapter(nil)
+
+	var create components.CreateAPIDocumentRequest
+	err := adapter.MapCreateFields(context.Background(), nil, map[string]any{
+		"title": "My document",
+	}, &create)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "content is required")
+
+	assert.Equal(t, []string{"content"}, adapter.RequiredFields())
+}


### PR DESCRIPTION
Fixes #1947.

## Root cause

Every layer of the declarative pipeline treats an API document's `title` as **optional** — the SDK's `CreateAPIDocumentRequest.Title` is a `*string`, the generated explain schema does not list it as required, `scaffold api.documents` emits it commented out, and `APIDocumentResource.Validate()` only requires `content`. Only the executor disagreed: `MapCreateFields` returned `title is required` and `RequiredFields()` listed both — so a plan built verbatim from the scaffold passed loading, validation and planning, then failed `apply` with `incompatible plan change ... title is required; regenerate the plan`.

## Fix

`APIDocumentAdapter`:

- `MapCreateFields` maps `title` only when present (the same optional pattern the update path already uses); `content` remains required;
- `RequiredFields()` returns only `content`, matching the explain schema and resource validation.

## Testing

New `api_document_adapter_test.go`:

- **CreateWithoutTitle** — the scaffold-shaped field set (content/slug/ref, no title) maps cleanly, title stays nil;
- **CreateWithTitle** — title flows through when present;
- **CreateStillRequiresContent** — content-only requirement pinned (`RequiredFields() == ["content"]`).

`go test ./internal/declarative/executor/ -run TestAPIDocumentAdapter` passes; differential with the adapter reverted fails on the title-required error. The full `./internal/...` suite: 76 packages ok; `internal/cmd/output/columns` and `internal/cmd/root/verbs/dump` fail identically on `main` in this Windows environment (pre-existing, unrelated).
