### PR TITLE
refactor(simplify): simplify flag binding and routing validation

### DIFF
--- a/internal/cmd/root/verbs/del/del.go
+++ b/internal/cmd/root/verbs/del/del.go
@@ -179,23 +179,13 @@ func bindKonnectFlags(c *cobra.Command, args []string) error {
 		{common.BaseURLFlagName, common.BaseURLConfigPath},
 		{common.RegionFlagName, common.RegionConfigPath},
 		{common.PATFlagName, common.PATConfigPath},
-	}
-	for _, b := range bindings {
-		if f := c.Flags().Lookup(b.flag); f != nil {
-			if err := cfg.BindFlag(b.config, f); err != nil {
-				return err
-			}
-		}
-	}
-
-	retryBindings := []struct{ flag, config string }{
 		{cmdcommon.HTTPRetryMaxAttemptsFlagName, common.HTTPRetryMaxAttemptsConfigPath},
 		{cmdcommon.HTTPRetryInitialIntervalFlagName, common.HTTPRetryInitialIntervalConfigPath},
 		{cmdcommon.HTTPRetryMaxIntervalFlagName, common.HTTPRetryMaxIntervalConfigPath},
 		{cmdcommon.HTTPRetryBackoffFactorFlagName, common.HTTPRetryBackoffFactorConfigPath},
 		{cmdcommon.HTTPRetryOnConnectionErrorsFlagName, common.HTTPRetryOnConnectionErrorsConfigPath},
 	}
-	for _, b := range retryBindings {
+	for _, b := range bindings {
 		if f := c.Flags().Lookup(b.flag); f != nil {
 			if err := cfg.BindFlag(b.config, f); err != nil {
 				return err

--- a/internal/declarative/planner/plan_compatibility.go
+++ b/internal/declarative/planner/plan_compatibility.go
@@ -102,12 +102,11 @@ func validateRoutingBoundary(change *PlannedChange) error {
 
 	descriptors := resources.RelationshipDescriptorsForType(resources.ResourceType(change.ResourceType))
 	for _, descriptor := range descriptors {
-		if descriptor.Kind == resources.RelationshipKindKongctlParentSelector &&
-			hasPayloadPath(change.Fields, descriptor.FieldPath) {
-			return fmt.Errorf("routing-only field %q must not appear in fields", descriptor.FieldPath)
-		}
 		if descriptor.Kind != resources.RelationshipKindKongctlParentSelector {
 			continue
+		}
+		if hasPayloadPath(change.Fields, descriptor.FieldPath) {
+			return fmt.Errorf("routing-only field %q must not appear in fields", descriptor.FieldPath)
 		}
 		for _, routingField := range routingIDFields(descriptor) {
 			if hasPayloadPath(change.Fields, routingField) {


### PR DESCRIPTION
## Summary

- consolidate Konnect delete flag bindings into one loop
- simplify routing boundary validation with an early continue
- preserve existing behavior without changing tests

## Rationale

This removes duplicated control flow and aligns the delete command flag binding with established verb command patterns.

## Testing

- `go fix ./...`
- `make format`
- `make build`
- `make lint`
- `make test-all`

Closes #1939