### PR TITLE
test(e2e): cover adopt namespace rejection

### DIFF
--- a/test/e2e/scenarios/adopt/full/scenario.yaml
+++ b/test/e2e/scenarios/adopt/full/scenario.yaml
@@ -89,7 +89,28 @@ steps:
                 id: "{{ .vars.api_id }}"
                 resource_type: api
 
-  - name: 003-overwrite-namespace
+  - name: 003-reject-overwrite-without-flag
+    skipInputs: true
+    commands:
+      - name: reject-portal-namespace-overwrite
+        run:
+          - adopt
+          - portal
+          - "{{ .vars.portal_id }}"
+          - --namespace
+          - "{{ .vars.overwrite_namespace }}"
+        expectFailure:
+          exitCode: 1
+          contains: "already has namespace label"
+      - name: verify-portal-namespace-unchanged
+        run: ["get", "portals", "-o", "json"]
+        assertions:
+          - select: "[?id=='{{ .vars.portal_id }}'] | [0]"
+            expect:
+              fields:
+                labels."KONGCTL-namespace": "{{ .vars.namespace }}"
+
+  - name: 004-overwrite-namespace
     skipInputs: true
     commands:
       - name: overwrite-cp-namespace
@@ -135,7 +156,7 @@ steps:
                 id: "{{ .vars.api_id }}"
                 resource_type: api
 
-  - name: 004-dump-and-plan
+  - name: 005-dump-and-plan
     skipInputs: true
     commands:
       - name: dump
@@ -179,7 +200,7 @@ steps:
               fields:
                 total_changes: 0
 
-  - name: 005-delete-cleanup
+  - name: 006-delete-cleanup
     skipInputs: true
     commands:
       - name: 000-delete


### PR DESCRIPTION
## Summary

- add an adopt E2E step that rejects a portal namespace change without `--overwrite-namespace`
- assert the command exits with the namespace-label guard error
- verify the portal retains its original namespace after the rejected operation

Closes #1960.

## Tests

- `go fix ./...`
- `make format`
- `make build`
- `make test-installer`
- `make test`
- `make test-integration`
- `make test-e2e-scenarios SCENARIO=adopt/full`
  - artifacts: `/home/rspurgeon/go/e2e-artifacts/20260824-101627`

`make lint` is currently blocked by pre-existing generated client and mock findings already present on `main`; this PR changes only the E2E scenario YAML.