### PR TITLE
test(e2e): cover apply dry-run safety behavior

### DIFF
--- a/test/e2e/scenarios/plan/apply-workflow/scenario.yaml
+++ b/test/e2e/scenarios/plan/apply-workflow/scenario.yaml
@@ -98,7 +98,57 @@ steps:
                 description: "Orders API for plan apply workflow"
                 labels.domain: commerce
 
-  - name: 002-plan-apply-update
+  - name: 002-apply-dry-run
+    inputOverlayDirs:
+      - overlays/002-plan-update
+    commands:
+      - name: 000-apply-dry-run
+        outputFormat: json
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --dry-run
+          - --auto-approve
+        assertions:
+          - select: plan.metadata
+            expect:
+              fields:
+                mode: apply
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 3
+                by_action.CREATE: 1
+                by_action.UPDATE: 2
+          - select: summary
+            expect:
+              fields:
+                skipped: 3
+                applied: 0
+                failed: 0
+                status: success
+      - name: 001-get-portals
+        run: ["get", "portals", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.portalRef }}'] | [0]"
+            expect:
+              fields:
+                display_name: "{{ .vars.portalName }}"
+      - name: 002-get-apis
+        run: ["get", "apis", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.ordersAPIRef }}'] | [0]"
+            expect:
+              fields:
+                description: "Orders API for plan apply workflow"
+                labels.domain: commerce
+          - select: "@"
+            expect:
+              fields:
+                "[?name=='{{ .vars.analyticsAPIRef }}'] | length(@)": 0
+
+  - name: 003-plan-apply-update
     inputOverlayDirs:
       - overlays/002-plan-update
     commands:
@@ -204,7 +254,7 @@ steps:
               fields:
                 total_changes: 0
 
-  - name: 003-delete-cleanup
+  - name: 004-delete-cleanup
     inputOverlayDirs:
       - overlays/002-plan-update
     commands:


### PR DESCRIPTION
## Summary

- add an apply dry-run step to the plan/apply workflow scenario
- assert the update overlay produces one create and two updates that are all skipped
- verify the portal and existing API remain unchanged and the new API is not created

## Rationale

Users rely on apply dry runs to preview declarative changes without mutating Konnect resources. This adds E2E coverage for both the preview output and the unchanged-resource safety invariant.

## Testing

- go fix ./...
- make format
- make build
- make test
- make test-integration
- make test-installer
- go test -tags=e2e ./test/e2e/... -run '^$'
- targeted scenario load with the PAT unset; scenario parsed successfully and skipped before organization reset
- make lint attempted with local golangci-lint 2.12.2; blocked by inherited findings in generated portal API code and existing mocks, with no findings in the changed scenario

Closes #1959