### PR TITLE
test(e2e): cover AI Gateway identity provider field preservation

### DIFF
--- a/test/e2e/scenarios/ai-gateway/identity-provider/overlays/001-update/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/identity-provider/overlays/001-update/config.yaml
@@ -38,13 +38,8 @@ ai_gateways:
             - bearer
           cache_tokens_salt: support-oidc-cache-salt-000001
           issuer: https://issuer.example.com
-          consumer_groups_claim:
-            - groups
-          consumer_groups_optional: false
-          upstream_headers_claims:
-            - sub
-          upstream_headers_names:
-            - x-consumer-subject
+          # Access-control and upstream-header fields are intentionally omitted.
+          # The update must preserve their live values from the initial fixture.
           principals:
             enabled: true
             directory: default

--- a/test/e2e/scenarios/ai-gateway/identity-provider/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/identity-provider/scenario.yaml
@@ -220,7 +220,7 @@ steps:
               fields:
                 "contains(@, 'No changes detected. Konnect is up to date.')": true
 
-  - name: 003-plan-apply-update
+  - name: 003-plan-apply-update-preserves-undeclared-security-config
     inputOverlayDirs:
       - overlays/001-update
     commands:


### PR DESCRIPTION
## Summary

- omit access-control and upstream-header fields from the AI Gateway identity-provider update fixture
- force an unrelated identity-provider update and verify live security configuration is merged into the PUT payload
- retain post-update and no-diff assertions to guard against destructive field removal and perpetual drift

## Rationale

The production behavior reported in #1828 is already fixed, but the E2E update fixture continued to declare the affected fields. This change exercises the reported regression shape directly: Konnect has the fields while the update manifest omits them.

Closes #1828

## Validation

- `go fix ./...`
- `make format`
- `make build`
- `make lint`
- `make test`
- `make test-integration`
- `make test-e2e-scenarios SCENARIO=ai-gateway/identity-provider`

E2E artifacts: `/home/rspurgeon/go/e2e-artifacts/20260824-132402`