### PR TITLE
feat(konnect): add audit-log pull and follow

### DIFF
--- a/docs/audit-logs.md
+++ b/docs/audit-logs.md
@@ -7,6 +7,9 @@ including detached process management with `kongctl ps`.
 
 `kongctl` can:
 
+- Pull Konnect organization audit logs on demand.
+- Automatically retrieve every cursor page in a result set.
+- Follow new organization audit logs by polling until interrupted.
 - Create a Konnect audit-log destination.
 - Configure the regional Konnect audit-log webhook.
 - Start a local HTTP listener to receive webhook events.
@@ -26,6 +29,9 @@ Supported forms (Konnect-first):
 - `kongctl tail`
 - `kongctl tail audit-logs`
 - `kongctl tail konnect audit-logs`
+- `kongctl tail audit-logs listener`
+- `kongctl get audit-logs`
+- `kongctl get konnect audit-logs`
 - `kongctl get audit-logs destinations`
 - `kongctl get audit-logs destination <id|name>`
 - `kongctl get audit-logs webhook`
@@ -39,8 +45,8 @@ Important:
 - `--endpoint` is the full public listener URL, including the listener path.
 - `--public-url` is a public base URL; `kongctl` appends `--path` to build
   the destination endpoint.
-- `--jq` requires `--tail`.
-- `--detach` is not compatible with `--tail`.
+- Listener `--jq` requires listener `--tail`.
+- Listener `--detach` is not compatible with listener `--tail`.
 
 ## Choosing a Command
 
@@ -49,9 +55,16 @@ audit-log destination, optionally binds the regional webhook to that
 destination, starts the local listener, stores events, and cleans up its
 destination when the listener stops.
 
-Use `tail audit-logs` when you want the same listener setup and also want
-received records streamed to STDOUT. `tail` enables the same flow as `listen`
-with `--tail` set.
+Use `get audit-logs` to retrieve Konnect organization audit logs through the
+pull API. It follows cursor pagination automatically, so `--page-size` affects
+the number of API requests but not the total number of records retrieved.
+
+Use `tail audit-logs` to retrieve a five-minute catch-up window and then poll
+for new organization audit logs until interrupted. It is equivalent to
+`get audit-logs --since 5m --follow`.
+
+Use `tail audit-logs listener` for the webhook listener setup and live STDOUT
+streaming previously provided directly by `tail audit-logs`.
 
 Use `get audit-logs destinations` to inspect existing audit-log destinations.
 Use `get audit-logs destination <id|name>` when you already know the
@@ -62,6 +75,148 @@ including whether it is enabled and which destination it currently references.
 
 Use `ps` to inspect and stop detached listener processes created with
 `listen --detach`.
+
+## Pull Organization Audit Logs
+
+Retrieve the 50 most recent events:
+
+```shell
+kongctl get audit-logs
+```
+
+Retrieve the last 24 hours and write one complete event per line:
+
+```shell
+kongctl get audit-logs --since 24h --output jsonl > audit-logs.jsonl
+```
+
+Use absolute inclusive bounds and an event type filter:
+
+```shell
+kongctl get audit-logs \
+  --start-time 2026-08-23T00:00:00Z \
+  --end-time 2026-08-24T00:00:00Z \
+  --type authorization
+```
+
+Supported event types are `authentication`, `authorization`, and
+`gateway_access`. The CLI preserves complete API records, including each
+record's ED25519 `signature`. Signature verification and JWKS retrieval are
+not performed by kongctl.
+
+### Pagination and Limits
+
+`--page-size` controls the maximum records requested in each Konnect API call
+and defaults to 100 for audit-log pulls. It must be between 1 and 1,000.
+kongctl follows the returned cursor until the final page, regardless of page
+size.
+
+`--limit` is the separate client-side total record limit. It defaults to 50
+when no time window is specified. Time-window queries are unlimited unless
+`--limit` is specified. Set `--limit 0` explicitly for unlimited retrieval.
+
+JSON and YAML output include `metadata.count` and `metadata.truncated`;
+`truncated` is true when either the implicit or explicit limit stops collection
+while additional records are known to exist.
+
+For example, 2,000 matching records with the default page size of 100 require
+about 20 API requests but still return all 2,000 records if every request
+succeeds. Increasing `--page-size` reduces requests without changing the
+result set.
+
+### Time Filters
+
+`--start-time` and `--end-time` accept RFC3339 timestamps and are inclusive.
+`--since` accepts a Go duration such as `30m` or `24h` and cannot be combined
+with either absolute bound. For finite retrieval, kongctl resolves `--since`
+once at startup into a fixed start and end time. When no time flag is supplied,
+the service chooses its default window.
+
+Absolute timestamps can use UTC (`Z`) or a numeric UTC offset. kongctl
+normalizes both forms to UTC:
+
+```shell
+kongctl get audit-logs \
+  --start-time 2026-08-23T14:00:00Z \
+  --end-time 2026-08-24T09:00:00-05:00
+```
+
+Common relative durations include `30s`, `15m`, `2h`, `24h`, `168h`, and
+combined values such as `1h30m`. Go durations do not support `d` or `w` units;
+use `24h` for one day and `168h` for one week.
+
+### Output and Collection Failures
+
+Finite pull supports `text`, `json`, `yaml`, and `jsonl` output:
+
+- JSON and YAML are buffered and written only after every required page is
+  retrieved successfully.
+- JSONL writes completed pages immediately and keeps memory bounded. If a
+  later page fails, STDOUT contains a partial collection and kongctl exits
+  nonzero.
+- Text provides a compact summary. Use repeated `--columns HEADER=.field`
+  flags to select fields from the complete records.
+- JSON and YAML apply `--jq` to the output envelope. JSONL applies `--jq` to
+  each record independently.
+
+Collection jobs must check the exit status rather than relying only on the
+presence of an output file:
+
+```shell
+if kongctl get audit-logs --since 24h --output jsonl > audit-logs.jsonl; then
+  echo "audit-log collection completed"
+else
+  echo "audit-log collection failed or is partial" >&2
+  exit 1
+fi
+```
+
+## Follow Organization Audit Logs
+
+Start with a five-minute catch-up and continue polling:
+
+```shell
+kongctl tail audit-logs
+```
+
+Equivalent explicit forms are:
+
+```shell
+kongctl get audit-logs --since 5m --follow
+kongctl get audit-logs --since 5m -F
+kongctl tail konnect audit-logs
+```
+
+Follow supports `text` and `jsonl`, because JSON and YAML require a bounded
+document. `--poll-interval` defaults to 10 seconds. Press Ctrl-C to stop
+cleanly.
+
+Each successful polling cycle uses a fixed end checkpoint. The next cycle
+overlaps the checkpoint by one minute, deduplicates records by signature (or a
+record hash when no signature is present), and emits new records in timestamp
+order. Retryable network, rate-limit, and server failures retain the checkpoint
+and retry with exponential backoff capped at one minute. Authentication,
+authorization, and other non-retryable client failures stop the command with a
+nonzero exit status.
+
+## Tail Listener Migration
+
+`tail audit-logs` now follows the organization pull API. The webhook-based
+listener remains available under the `listener` child:
+
+```shell
+# Previous form
+kongctl tail audit-logs \
+  --endpoint https://example.tld/audit-logs \
+  --authorization "Bearer <token>"
+
+# Current form
+kongctl tail audit-logs listener \
+  --endpoint https://example.tld/audit-logs \
+  --authorization "Bearer <token>"
+```
+
+`kongctl listen` and `kongctl listen audit-logs` are unchanged.
 
 ## End-to-End Flow
 
@@ -132,16 +287,18 @@ No additional `kongctl` event envelope is added.
 
 ## Tailing and JQ
 
-Use `tail` to stream records to STDOUT:
+Use the webhook listener child to stream received records to STDOUT:
 
 ```shell
-kongctl tail --endpoint https://example.tld/audit-logs
+kongctl tail audit-logs listener \
+  --endpoint https://example.tld/audit-logs \
+  --authorization "Bearer <token>"
 ```
 
 Filter JSON records with `jq` expression support:
 
 ```shell
-kongctl tail \
+kongctl tail audit-logs listener \
   --endpoint https://example.tld/audit-logs \
   --log-format json \
   --jq '{ts:.event_ts, name, request:(.request // null)}'
@@ -290,3 +447,9 @@ tail -n 200 ~/.config/kongctl/logs/kongctl-listener-${pid}.log
 - Event file retention and rotation are not implemented yet.
 - Replay jobs are not implemented yet.
 - `kongctl ps` currently manages tracked detached processes only.
+- Pull covers Konnect organization audit logs only. Dev Portal audit logs
+  remain webhook-based.
+- Audit-log retention is controlled by the service and is evolving toward the
+  planned one-year history.
+- Access to the pull API can still be controlled by the server-side
+  `TPS-4185-Audit-Logs-V2-Read` rollout flag.

--- a/internal/cmd/common/common.go
+++ b/internal/cmd/common/common.go
@@ -23,6 +23,10 @@ const (
 // the base set (json/yaml/text).
 const ExtraOutputFormatsAnnotation = "kongctl.output.extra-formats"
 
+// LocalExtraOutputFormatsAnnotation is the cobra command-annotation key listing
+// extra --output values accepted only by the annotated command, not its children.
+const LocalExtraOutputFormatsAnnotation = "kongctl.output.local-extra-formats"
+
 // SkipOutputFormatValidationAnnotation marks a command (or its subtree) as
 // performing its own --output handling. When set, the root-level output-format
 // validator skips the command so the command's own (often more actionable)

--- a/internal/cmd/common/output_format.go
+++ b/internal/cmd/common/output_format.go
@@ -16,6 +16,16 @@ var BaseOutputFormats = []string{"json", "yaml", "text"}
 // list in the command's Annotations under ExtraOutputFormatsAnnotation and
 // are merged with any previously-declared extras.
 func AllowExtraOutputFormats(cmd *cobra.Command, formats ...string) {
+	allowOutputFormats(cmd, ExtraOutputFormatsAnnotation, formats...)
+}
+
+// AllowLocalExtraOutputFormats marks cobraCmd as accepting additional --output
+// values without making them available to descendant commands.
+func AllowLocalExtraOutputFormats(cmd *cobra.Command, formats ...string) {
+	allowOutputFormats(cmd, LocalExtraOutputFormatsAnnotation, formats...)
+}
+
+func allowOutputFormats(cmd *cobra.Command, annotation string, formats ...string) {
 	if cmd == nil || len(formats) == 0 {
 		return
 	}
@@ -24,7 +34,7 @@ func AllowExtraOutputFormats(cmd *cobra.Command, formats ...string) {
 	}
 	seen := map[string]struct{}{}
 	merged := []string{}
-	if existing := cmd.Annotations[ExtraOutputFormatsAnnotation]; existing != "" {
+	if existing := cmd.Annotations[annotation]; existing != "" {
 		for v := range strings.SplitSeq(existing, ",") {
 			v = strings.TrimSpace(v)
 			if v == "" {
@@ -46,7 +56,7 @@ func AllowExtraOutputFormats(cmd *cobra.Command, formats ...string) {
 			merged = append(merged, v)
 		}
 	}
-	cmd.Annotations[ExtraOutputFormatsAnnotation] = strings.Join(merged, ",")
+	cmd.Annotations[annotation] = strings.Join(merged, ",")
 }
 
 // SkipOutputFormatValidation marks cmd (and its descendants) as opting out
@@ -140,20 +150,22 @@ func AllowedOutputFormats(cmd *cobra.Command) []string {
 		seen[v] = struct{}{}
 	}
 	for c := cmd; c != nil; c = c.Parent() {
-		extras, ok := c.Annotations[ExtraOutputFormatsAnnotation]
-		if !ok || extras == "" {
-			continue
+		extraSets := []string{c.Annotations[ExtraOutputFormatsAnnotation]}
+		if c == cmd {
+			extraSets = append(extraSets, c.Annotations[LocalExtraOutputFormatsAnnotation])
 		}
-		for v := range strings.SplitSeq(extras, ",") {
-			v = strings.TrimSpace(v)
-			if v == "" {
-				continue
+		for _, extras := range extraSets {
+			for v := range strings.SplitSeq(extras, ",") {
+				v = strings.TrimSpace(v)
+				if v == "" {
+					continue
+				}
+				if _, dup := seen[v]; dup {
+					continue
+				}
+				seen[v] = struct{}{}
+				allowed = append(allowed, v)
 			}
-			if _, dup := seen[v]; dup {
-				continue
-			}
-			seen[v] = struct{}{}
-			allowed = append(allowed, v)
 		}
 	}
 	return allowed

--- a/internal/cmd/common/output_format_test.go
+++ b/internal/cmd/common/output_format_test.go
@@ -52,6 +52,20 @@ func TestValidateOutputFormat_AllowsExtraFromAncestor(t *testing.T) {
 	}
 }
 
+func TestValidateOutputFormat_LocalExtraDoesNotApplyToChildren(t *testing.T) {
+	parent := &cobra.Command{Use: "parent"}
+	child := &cobra.Command{Use: "child"}
+	parent.AddCommand(child)
+	AllowLocalExtraOutputFormats(parent, "jsonl")
+
+	if err := ValidateOutputFormat(parent, "jsonl"); err != nil {
+		t.Fatalf("expected jsonl to be allowed on annotated command: %v", err)
+	}
+	if err := ValidateOutputFormat(child, "jsonl"); err == nil {
+		t.Fatal("expected jsonl to be rejected on child command")
+	}
+}
+
 func TestValidateOutputFormat_RejectsBogusEvenWithExtras(t *testing.T) {
 	cmd := &cobra.Command{Use: "leaf"}
 	AllowExtraOutputFormats(cmd, "helm")

--- a/internal/cmd/output/columns/columns.go
+++ b/internal/cmd/output/columns/columns.go
@@ -58,8 +58,8 @@ func AddFlags(flags *pflag.FlagSet) {
 	flags.StringArray(
 		FlagName,
 		nil,
-		"Select text columns as HEADER=.field (repeatable or comma-separated). "+
-			"Supports nested fields, quoted keys, array indexes, and string slices.",
+		`Select text columns as HEADER=.field (repeatable or comma-separated).
+Supports nested fields, quoted keys, array indexes, and string slices.`,
 	)
 }
 

--- a/internal/cmd/root/products/konnect/auditlogs/auditlogs.go
+++ b/internal/cmd/root/products/konnect/auditlogs/auditlogs.go
@@ -42,7 +42,7 @@ func NewAuditLogsCmd(
 		Short:   auditLogsShort,
 		Long:    auditLogsLong,
 		Example: auditLogsExample,
-		Aliases: []string{"audit-log", "al", "AL"},
+		Aliases: []string{"audit-log"},
 	}
 
 	if verb == verbs.Listen {

--- a/internal/cmd/root/products/konnect/auditlogs/create_destination.go
+++ b/internal/cmd/root/products/konnect/auditlogs/create_destination.go
@@ -39,14 +39,14 @@ const (
 
 var allowedLogFormats = []string{
 	"cef",
-	"json",
+	defaultLogFormatValue,
 	"cps",
 }
 
 var allowedLogFormatsSet = map[string]struct{}{
-	"cef":  {},
-	"json": {},
-	"cps":  {},
+	"cef":                 {},
+	defaultLogFormatValue: {},
+	"cps":                 {},
 }
 
 type createDestinationRequest struct {

--- a/internal/cmd/root/products/konnect/auditlogs/get.go
+++ b/internal/cmd/root/products/konnect/auditlogs/get.go
@@ -57,10 +57,19 @@ func newGetAuditLogsCmd(
 	addParentFlags func(verbs.VerbValue, *cobra.Command),
 	parentPreRun func(*cobra.Command, []string) error,
 ) *cobra.Command {
-	baseCmd.Short = "Get Konnect audit-log destinations and webhook state"
-	baseCmd.Long = `Use get audit-logs to inspect Konnect audit-log destinations and
-regional webhook configuration.`
-	baseCmd.Example = `  # List all audit-log destinations
+	options := pullAuditLogsOptions{PollInterval: defaultPollInterval}
+	baseCmd.Short = "Get Konnect organization audit logs"
+	baseCmd.Long = "Retrieve Konnect organization audit logs through the pull API."
+	baseCmd.Example = `  # Retrieve the 50 most recent events
+  kongctl get audit-logs
+
+  # Export every event from the last 24 hours as JSON Lines
+  kongctl get audit-logs --since 24h --output jsonl
+
+  # Follow new authorization events until interrupted
+  kongctl get audit-logs --since 1h --type authorization --follow
+
+  # List all audit-log destinations
   kongctl get audit-logs destinations
 
   # Get a single destination by id or name
@@ -77,13 +86,9 @@ regional webhook configuration.`
 	}
 
 	baseCmd.RunE = func(cmdObj *cobra.Command, args []string) error {
-		helper := cmd.BuildHelper(cmdObj, args)
-		if _, err := helper.GetOutputFormat(); err != nil {
-			return err
-		}
-		return cmd.RequireSubcommand(cmdObj, args)
+		return executePullAuditLogs(cmdObj, args, options)
 	}
-	cmd.MarkRequiresSubcommand(baseCmd)
+	addPullAuditLogsFlags(baseCmd, &options)
 
 	baseCmd.AddCommand(newGetAuditLogsDestinationsCmd(verb, addParentFlags, parentPreRun))
 	baseCmd.AddCommand(newGetAuditLogDestinationCmd(verb, addParentFlags, parentPreRun))

--- a/internal/cmd/root/products/konnect/auditlogs/listen.go
+++ b/internal/cmd/root/products/konnect/auditlogs/listen.go
@@ -133,6 +133,22 @@ then start a local listener to accept incoming audit-log events.`
 	return c.Command
 }
 
+func newTailListenerAuditLogsCmd() *cobra.Command {
+	options := DefaultListenAuditLogsOptions()
+	options.Tail = true
+	command := &cobra.Command{
+		Use:   "listener",
+		Short: "Create a webhook destination and stream received events",
+		Long: `Run the original webhook-based tail flow: create a destination,
+configure the regional webhook, and stream records received by a local listener.`,
+		RunE: func(cmdObj *cobra.Command, args []string) error {
+			return ExecuteListenAuditLogs(cmdObj, args, options)
+		},
+	}
+	AddListenAuditLogsFlags(command, &options)
+	return command
+}
+
 func (c *listenAuditLogsCmd) runE(cmdObj *cobra.Command, args []string) error {
 	return ExecuteListenAuditLogs(cmdObj, args, c.options)
 }

--- a/internal/cmd/root/products/konnect/auditlogs/pull.go
+++ b/internal/cmd/root/products/konnect/auditlogs/pull.go
@@ -126,7 +126,7 @@ Set to 0 for unlimited.`)
 		"Interval between successful polling cycles in follow mode.")
 	jqoutput.AddFlags(command.Flags())
 	columns.AddFlags(command.Flags())
-	cmdcommon.AllowExtraOutputFormats(command, jsonLinesOutput)
+	cmdcommon.AllowLocalExtraOutputFormats(command, jsonLinesOutput)
 }
 
 // ConfigureTailPullCommand configures a command as a continuous audit-log pull.
@@ -310,15 +310,15 @@ func resolveAuditLogWindow(options pullAuditLogsOptions, now time.Time) (auditLo
 		end = end.UTC()
 		window.End = &end
 	}
-	if window.Start != nil && window.End != nil && window.Start.After(*window.End) {
-		return window, errors.New("--start-time must not be later than --end-time")
-	}
 	if options.Follow {
 		if window.Start == nil {
 			start := now.Add(-defaultFollowLookback)
 			window.Start = &start
 		}
 		window.End = &now
+	}
+	if window.Start != nil && window.End != nil && window.Start.After(*window.End) {
+		return window, errors.New("--start-time must not be later than --end-time")
 	}
 	return window, nil
 }

--- a/internal/cmd/root/products/konnect/auditlogs/pull.go
+++ b/internal/cmd/root/products/konnect/auditlogs/pull.go
@@ -1,0 +1,884 @@
+package auditlogs
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/kong/kongctl/internal/cmd"
+	cmdcommon "github.com/kong/kongctl/internal/cmd/common"
+	"github.com/kong/kongctl/internal/cmd/output/columns"
+	jqoutput "github.com/kong/kongctl/internal/cmd/output/jq"
+	konnectcommon "github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
+	"github.com/kong/kongctl/internal/config"
+	"github.com/kong/kongctl/internal/konnect/apiutil"
+	"github.com/kong/kongctl/internal/konnect/httpclient"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	auditLogsPullPath       = "/v3/audit-logs"
+	jsonLinesOutput         = "jsonl"
+	defaultPollInterval     = 10 * time.Second
+	defaultFollowLookback   = 5 * time.Minute
+	defaultAuditLogLimit    = 50
+	followOverlap           = time.Minute
+	maximumAuditLogPageSize = 1000
+)
+
+// DefaultPullPageSize is the default number of audit-log records requested per API page.
+const DefaultPullPageSize = 100
+
+var auditLogNow = time.Now
+
+type pullAuditLogsOptions struct {
+	StartTime    string
+	EndTime      string
+	Since        time.Duration
+	EventType    string
+	Limit        int
+	Follow       bool
+	PollInterval time.Duration
+}
+
+type auditLogWindow struct {
+	Start *time.Time
+	End   *time.Time
+}
+
+type auditLogEnvelope struct {
+	Metadata auditLogOutputMetadata `json:"metadata" yaml:"metadata"`
+	Data     []json.RawMessage      `json:"data"     yaml:"data"`
+}
+
+type auditLogOutputMetadata struct {
+	Count     int  `json:"count"     yaml:"count"`
+	Truncated bool `json:"truncated" yaml:"truncated"`
+}
+
+type auditLogPage struct {
+	Data       []json.RawMessage
+	NextCursor string
+}
+
+type auditLogPullClient struct {
+	baseURL     string
+	tokenSource apiutil.TokenSource
+	httpClient  apiutil.Doer
+}
+
+type auditLogRequest struct {
+	Window   auditLogWindow
+	Type     string
+	PageSize int
+	After    string
+}
+
+type auditLogResponseError struct {
+	status int
+	body   string
+}
+
+func (e *auditLogResponseError) Error() string {
+	if e.body == "" {
+		return fmt.Sprintf("audit-log request failed with status %d", e.status)
+	}
+	return fmt.Sprintf("audit-log request failed with status %d: %s", e.status, e.body)
+}
+
+func addPullAuditLogsFlags(command *cobra.Command, options *pullAuditLogsOptions) {
+	command.Flags().StringVar(&options.StartTime, "start-time", options.StartTime,
+		`Inclusive RFC3339 lower bound for event timestamps.
+Accepts UTC (Z) or a numeric UTC offset.
+- UTC example   : [ 2026-08-23T14:00:00Z ]
+- Offset example: [ 2026-08-23T09:00:00-05:00 ]`)
+	command.Flags().StringVar(&options.EndTime, "end-time", options.EndTime,
+		`Inclusive RFC3339 upper bound for event timestamps.
+Accepts UTC (Z) or a numeric UTC offset.
+- UTC example   : [ 2026-08-24T14:00:00Z ]
+- Offset example: [ 2026-08-24T09:00:00-05:00 ]`)
+	command.Flags().DurationVar(&options.Since, "since", options.Since,
+		`Retrieve events from the specified lookback period.
+- Examples: [ 30s, 15m, 2h, 24h, 168h, 1h30m ]`)
+	command.Flags().StringVar(&options.EventType, "type", options.EventType,
+		"Filter by event type: authentication, authorization, or gateway_access.")
+	command.Flags().IntVar(&options.Limit, "limit", options.Limit,
+		`Maximum total events to return.
+Defaults to 50 when no time window is specified.
+Time-window queries are unlimited unless --limit is specified.
+Set to 0 for unlimited.`)
+	command.Flags().BoolVarP(&options.Follow, "follow", "F", options.Follow,
+		"Poll continuously for new events until interrupted.")
+	command.Flags().DurationVar(&options.PollInterval, "poll-interval", options.PollInterval,
+		"Interval between successful polling cycles in follow mode.")
+	jqoutput.AddFlags(command.Flags())
+	columns.AddFlags(command.Flags())
+	cmdcommon.AllowExtraOutputFormats(command, jsonLinesOutput)
+}
+
+// ConfigureTailPullCommand configures a command as a continuous audit-log pull.
+func ConfigureTailPullCommand(command *cobra.Command, addListener bool) *cobra.Command {
+	options := pullAuditLogsOptions{
+		Follow:       true,
+		PollInterval: defaultPollInterval,
+	}
+	command.Short = "Follow Konnect organization audit logs"
+	command.Long = `Retrieve a five-minute audit-log catch-up window, then poll for new
+events until interrupted. Use the listener child for the webhook-based flow.`
+	command.Example = `  # Follow organization audit logs
+  kongctl tail audit-logs
+
+  # Follow as JSON Lines
+  kongctl tail audit-logs --output jsonl
+
+  # Use the webhook listener flow
+  kongctl tail audit-logs listener --endpoint https://example.test/audit-logs --authorization "Bearer <token>"`
+	command.RunE = func(cmdObj *cobra.Command, args []string) error {
+		return executePullAuditLogs(cmdObj, args, options)
+	}
+	addPullAuditLogsFlags(command, &options)
+	if addListener {
+		command.AddCommand(newTailListenerAuditLogsCmd())
+	}
+	return command
+}
+
+func executePullAuditLogs(cobraCmd *cobra.Command, args []string, options pullAuditLogsOptions) error {
+	helper := cmd.BuildHelper(cobraCmd, args)
+	if len(args) != 0 {
+		return &cmd.ConfigurationError{Err: errors.New("the audit-logs command does not accept positional arguments")}
+	}
+
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+	output, err := auditLogOutputFormat(cobraCmd, cfg)
+	if err != nil {
+		return &cmd.ConfigurationError{Err: err}
+	}
+	if err := validateAuditLogOutputOptions(cobraCmd, cfg, output); err != nil {
+		return &cmd.ConfigurationError{Err: err}
+	}
+	pageSize := cfg.GetInt(konnectcommon.RequestPageSizeConfigPath)
+	if pageSize == 0 {
+		pageSize = DefaultPullPageSize
+	}
+	options.Limit = resolveAuditLogLimit(cobraCmd, options)
+	if err := validatePullAuditLogsOptions(cobraCmd, options, output, pageSize); err != nil {
+		return &cmd.ConfigurationError{Err: err}
+	}
+
+	now := auditLogNow().UTC()
+	window, err := resolveAuditLogWindow(options, now)
+	if err != nil {
+		return &cmd.ConfigurationError{Err: err}
+	}
+	client, err := newAuditLogPullClient(helper, cfg)
+	if err != nil {
+		return cmd.PrepareExecutionError("failed to prepare audit-log retrieval", err, cobraCmd)
+	}
+
+	if options.Follow {
+		return runAuditLogFollow(helper, client, options, output, pageSize, window)
+	}
+	return runFiniteAuditLogPull(helper, client, options, output, pageSize, window)
+}
+
+func resolveAuditLogLimit(command *cobra.Command, options pullAuditLogsOptions) int {
+	if options.Follow || options.Since > 0 || strings.TrimSpace(options.StartTime) != "" ||
+		strings.TrimSpace(options.EndTime) != "" {
+		return options.Limit
+	}
+	if command != nil && command.Flags().Changed("limit") {
+		return options.Limit
+	}
+	return defaultAuditLogLimit
+}
+
+func validatePullAuditLogsOptions(
+	cobraCmd *cobra.Command,
+	options pullAuditLogsOptions,
+	output string,
+	pageSize int,
+) error {
+	if pageSize < 1 || pageSize > maximumAuditLogPageSize {
+		return fmt.Errorf("--%s must be between 1 and %d", konnectcommon.RequestPageSizeFlagName,
+			maximumAuditLogPageSize)
+	}
+	if options.Since < 0 {
+		return errors.New("--since must be positive")
+	}
+	if options.Since > 0 && (strings.TrimSpace(options.StartTime) != "" || strings.TrimSpace(options.EndTime) != "") {
+		return errors.New("--since cannot be combined with --start-time or --end-time")
+	}
+	if options.Limit < 0 {
+		return errors.New("--limit must be non-negative")
+	}
+	if options.PollInterval <= 0 {
+		return errors.New("--poll-interval must be positive")
+	}
+	if options.EventType != "" && !slices.Contains([]string{"authentication", "authorization", "gateway_access"},
+		options.EventType) {
+		return fmt.Errorf("invalid --type %q: must be authentication, authorization, or gateway_access", options.EventType)
+	}
+	if options.Follow {
+		if strings.TrimSpace(options.EndTime) != "" {
+			return errors.New("--end-time cannot be used with --follow")
+		}
+		if options.Limit != 0 {
+			return errors.New("--limit cannot be used with --follow")
+		}
+		if output != cmdcommon.TEXT.String() && output != jsonLinesOutput {
+			return fmt.Errorf("--follow requires row-oriented output: use --output text or --output jsonl")
+		}
+	}
+	if output == jsonLinesOutput {
+		if values, _ := cobraCmd.Flags().GetStringArray(columns.FlagName); len(values) > 0 {
+			return errors.New("--columns is only supported with --output text")
+		}
+	}
+	return nil
+}
+
+func validateAuditLogOutputOptions(command *cobra.Command, cfg config.Hook, output string) error {
+	settings, err := jqoutput.ResolveSettings(command, cfg)
+	if err != nil {
+		return err
+	}
+	if output == jsonLinesOutput {
+		if settings.RawOutput && !jqoutput.HasFilter(settings) {
+			return fmt.Errorf("--%s requires --%s", jqoutput.RawOutputFlagName, jqoutput.FlagName)
+		}
+		if values, _ := command.Flags().GetStringArray(columns.FlagName); len(values) > 0 {
+			return errors.New("--columns is only supported with --output text")
+		}
+		return nil
+	}
+
+	format, err := cmdcommon.OutputFormatStringToIota(output)
+	if err != nil {
+		return err
+	}
+	if err := jqoutput.ValidateOutputFormat(format, settings); err != nil {
+		return err
+	}
+	selected, err := columns.Resolve(command, format)
+	if err != nil {
+		return err
+	}
+	if len(selected) > 0 && jqoutput.HasFilter(settings) {
+		return fmt.Errorf("--%s cannot be combined with --%s", columns.FlagName, jqoutput.FlagName)
+	}
+	return nil
+}
+
+func resolveAuditLogWindow(options pullAuditLogsOptions, now time.Time) (auditLogWindow, error) {
+	window := auditLogWindow{}
+	if options.Since > 0 {
+		start := now.Add(-options.Since)
+		window.Start = &start
+		window.End = &now
+		return window, nil
+	}
+	if strings.TrimSpace(options.StartTime) != "" {
+		start, err := time.Parse(time.RFC3339, options.StartTime)
+		if err != nil {
+			return window, fmt.Errorf("invalid --start-time: expected RFC3339: %w", err)
+		}
+		start = start.UTC()
+		window.Start = &start
+	}
+	if strings.TrimSpace(options.EndTime) != "" {
+		end, err := time.Parse(time.RFC3339, options.EndTime)
+		if err != nil {
+			return window, fmt.Errorf("invalid --end-time: expected RFC3339: %w", err)
+		}
+		end = end.UTC()
+		window.End = &end
+	}
+	if window.Start != nil && window.End != nil && window.Start.After(*window.End) {
+		return window, errors.New("--start-time must not be later than --end-time")
+	}
+	if options.Follow {
+		if window.Start == nil {
+			start := now.Add(-defaultFollowLookback)
+			window.Start = &start
+		}
+		window.End = &now
+	}
+	return window, nil
+}
+
+func newAuditLogPullClient(helper cmd.Helper, cfg config.Hook) (*auditLogPullClient, error) {
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return nil, err
+	}
+	tokenSource, err := konnectcommon.GetAccessTokenSource(cfg, logger)
+	if err != nil {
+		return nil, fmt.Errorf("resolve Konnect access token: %w", err)
+	}
+	baseURL, err := konnectcommon.ResolveBaseURL(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("resolve Konnect base URL: %w", err)
+	}
+	return &auditLogPullClient{
+		baseURL:     baseURL,
+		tokenSource: tokenSource,
+		httpClient:  httpclient.NewLoggingHTTPClient(logger),
+	}, nil
+}
+
+func (c *auditLogPullClient) fetchPage(ctx context.Context, request auditLogRequest) (auditLogPage, error) {
+	query := url.Values{}
+	query.Set("page[size]", strconv.Itoa(request.PageSize))
+	if request.Window.Start != nil {
+		query.Set("filter[ts][gte]", request.Window.Start.UTC().Format(time.RFC3339Nano))
+	}
+	if request.Window.End != nil {
+		query.Set("filter[ts][lte]", request.Window.End.UTC().Format(time.RFC3339Nano))
+	}
+	if request.Type != "" {
+		query.Set("filter[type]", request.Type)
+	}
+	if request.After != "" {
+		query.Set("page[after]", request.After)
+	}
+
+	result, err := apiutil.RequestWithTokenSource(ctx, c.httpClient, http.MethodGet, c.baseURL,
+		auditLogsPullPath+"?"+query.Encode(), c.tokenSource, nil, nil)
+	if err != nil {
+		return auditLogPage{}, err
+	}
+	if result.StatusCode < http.StatusOK || result.StatusCode >= http.StatusMultipleChoices {
+		return auditLogPage{}, &auditLogResponseError{
+			status: result.StatusCode,
+			body:   strings.TrimSpace(string(result.Body)),
+		}
+	}
+	return decodeAuditLogPage(result.Body)
+}
+
+func decodeAuditLogPage(body []byte) (auditLogPage, error) {
+	var payload struct {
+		Data []json.RawMessage `json:"data"`
+		Meta json.RawMessage   `json:"meta"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return auditLogPage{}, fmt.Errorf("decode audit-log response: %w", err)
+	}
+	if payload.Data == nil {
+		return auditLogPage{}, errors.New("decode audit-log response: missing data array")
+	}
+	nextCursor, err := extractNextCursor(payload.Meta)
+	if err != nil {
+		return auditLogPage{}, fmt.Errorf("decode audit-log response: %w", err)
+	}
+	return auditLogPage{Data: payload.Data, NextCursor: nextCursor}, nil
+}
+
+func extractNextCursor(meta json.RawMessage) (string, error) {
+	var value map[string]any
+	if len(meta) == 0 {
+		return "", errors.New("missing pagination metadata")
+	}
+	if err := json.Unmarshal(meta, &value); err != nil {
+		return "", fmt.Errorf("invalid pagination metadata: %w", err)
+	}
+	if rawNext, exists := value["next"]; exists && rawNext != nil {
+		next, ok := rawNext.(string)
+		if !ok {
+			return "", errors.New("pagination meta.next must be a string")
+		}
+		return normalizeAuditLogCursor(next)
+	}
+	if rawPage, exists := value["page"]; exists && rawPage != nil {
+		page, ok := rawPage.(map[string]any)
+		if !ok {
+			return "", errors.New("pagination meta.page must be an object")
+		}
+		if rawNext, exists := page["next"]; exists && rawNext != nil {
+			next, ok := rawNext.(string)
+			if !ok {
+				return "", errors.New("pagination meta.page.next must be a string")
+			}
+			return normalizeAuditLogCursor(next)
+		}
+	}
+	return "", nil
+}
+
+func normalizeAuditLogCursor(next string) (string, error) {
+	next = strings.TrimSpace(next)
+	if next == "" {
+		return "", nil
+	}
+	parsed, err := url.Parse(next)
+	if err != nil {
+		return "", fmt.Errorf("invalid next-page cursor: %w", err)
+	}
+	if parsed.IsAbs() || strings.HasPrefix(next, "/") {
+		if cursor := strings.TrimSpace(parsed.Query().Get("page[after]")); cursor != "" {
+			return cursor, nil
+		}
+		return "", errors.New("next-page link does not contain page[after]")
+	}
+	return next, nil
+}
+
+func fetchAllAuditLogPages(
+	ctx context.Context,
+	client *auditLogPullClient,
+	request auditLogRequest,
+	limit int,
+	onPage func([]json.RawMessage) error,
+) (int, bool, error) {
+	count := 0
+	seenCursors := map[string]struct{}{}
+	for {
+		page, err := client.fetchPage(ctx, request)
+		if err != nil {
+			return count, false, err
+		}
+		records := page.Data
+		if limit > 0 && count+len(records) > limit {
+			records = records[:limit-count]
+		}
+		if len(records) > 0 {
+			if err := onPage(records); err != nil {
+				return count, false, err
+			}
+			count += len(records)
+		}
+		if limit > 0 && count == limit {
+			return count, page.NextCursor != "" || len(page.Data) > len(records), nil
+		}
+		if page.NextCursor == "" {
+			return count, false, nil
+		}
+		if _, exists := seenCursors[page.NextCursor]; exists {
+			return count, false, fmt.Errorf("audit-log API returned repeated cursor %q", page.NextCursor)
+		}
+		seenCursors[page.NextCursor] = struct{}{}
+		request.After = page.NextCursor
+	}
+}
+
+func runFiniteAuditLogPull(
+	helper cmd.Helper,
+	client *auditLogPullClient,
+	options pullAuditLogsOptions,
+	output string,
+	pageSize int,
+	window auditLogWindow,
+) error {
+	request := auditLogRequest{Window: window, Type: options.EventType, PageSize: pageSize}
+	if output == jsonLinesOutput {
+		_, _, err := fetchAllAuditLogPages(helper.GetContext(), client, request, options.Limit,
+			func(records []json.RawMessage) error { return renderAuditLogJSONLines(helper, records) })
+		if err != nil {
+			return cmd.PrepareExecutionError("failed to retrieve all audit logs", err, helper.GetCmd())
+		}
+		return nil
+	}
+
+	records := make([]json.RawMessage, 0)
+	count, truncated, err := fetchAllAuditLogPages(helper.GetContext(), client, request, options.Limit,
+		func(page []json.RawMessage) error {
+			records = append(records, page...)
+			return nil
+		})
+	if err != nil {
+		return cmd.PrepareExecutionError("failed to retrieve all audit logs", err, helper.GetCmd())
+	}
+	return renderFiniteAuditLogs(helper, output, auditLogEnvelope{
+		Metadata: auditLogOutputMetadata{Count: count, Truncated: truncated},
+		Data:     records,
+	})
+}
+
+func renderFiniteAuditLogs(helper cmd.Helper, output string, envelope auditLogEnvelope) error {
+	streams := helper.GetStreams()
+	switch output {
+	case cmdcommon.JSON.String():
+		payload, handled, err := resolveOutputPayload(helper, cmdcommon.JSON, envelope)
+		if err != nil || handled {
+			return err
+		}
+		encoder := json.NewEncoder(streams.Out)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(payload)
+	case cmdcommon.YAML.String():
+		payload, handled, err := resolveOutputPayload(helper, cmdcommon.YAML, envelope)
+		if err != nil || handled {
+			return err
+		}
+		data, err := yaml.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		_, err = streams.Out.Write(data)
+		return err
+	case cmdcommon.TEXT.String():
+		return renderAuditLogText(helper, envelope.Data)
+	default:
+		return fmt.Errorf("unsupported audit-log output format %q", output)
+	}
+}
+
+func renderAuditLogJSONLines(helper cmd.Helper, records []json.RawMessage) error {
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+	settings, err := jqoutput.ResolveSettings(helper.GetCmd(), cfg)
+	if err != nil {
+		return err
+	}
+	out := helper.GetStreams().Out
+	for _, raw := range records {
+		if jqoutput.HasFilter(settings) {
+			if settings.RawOutput {
+				if err := jqoutput.ApplyRawFilter(raw, settings.Filter, out); err != nil {
+					return err
+				}
+				continue
+			}
+			filtered, err := jqoutput.ApplyFilter(raw, settings.Filter)
+			if err != nil {
+				return err
+			}
+			raw = filtered
+		}
+		if _, err := fmt.Fprintln(out, strings.TrimSpace(string(raw))); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func renderAuditLogText(helper cmd.Helper, records []json.RawMessage) error {
+	selected, err := columns.Resolve(helper.GetCmd(), cmdcommon.TEXT)
+	if err != nil {
+		return &cmd.ConfigurationError{Err: err}
+	}
+	if len(selected) > 0 {
+		headers, rows, err := columns.Project(records, selected)
+		if err != nil {
+			return err
+		}
+		return columns.RenderAutoWidth(helper.GetStreams().Out, headers, rows)
+	}
+
+	headers := []string{"TIMESTAMP", "TYPE", "PRINCIPAL", "ACTION", "RESULT", "TRACE ID"}
+	rows := make([][]string, 0, len(records))
+	for _, record := range records {
+		rows = append(rows, defaultAuditLogRow(record))
+	}
+	return columns.RenderAutoWidth(helper.GetStreams().Out, headers, rows)
+}
+
+func defaultAuditLogRow(raw json.RawMessage) []string {
+	var record map[string]any
+	_ = json.Unmarshal(raw, &record)
+	typeName := firstString(record, "type", "event_type")
+	principal := firstString(record, "principal_id")
+	if principal == "" {
+		principal = nestedFirstString(record, []string{"principal", "name"}, []string{"principal", "id"},
+			[]string{"actor", "name"}, []string{"actor", "id"}, []string{"user", "id"})
+	}
+	action := firstString(record, "action", "authentication_type")
+	result := firstString(record, "outcome", "result")
+	if granted, ok := record["granted"].(bool); ok {
+		if granted {
+			result = "granted"
+		} else {
+			result = "denied"
+		}
+	}
+	if typeName == "gateway_access" {
+		method := nestedFirstString(record, []string{"request", "method"}, []string{"method"})
+		uri := nestedFirstString(record, []string{"request", "uri"}, []string{"uri"})
+		action = strings.TrimSpace(method + " " + uri)
+		result = firstScalar(record, "status_code")
+		if result == "" {
+			result = nestedFirstScalar(record, []string{"response", "status_code"})
+		}
+	}
+	return []string{
+		firstString(record, "ts", "timestamp", "event_ts"),
+		typeName,
+		principal,
+		action,
+		result,
+		firstString(record, "trace_id", "traceId"),
+	}
+}
+
+func firstString(record map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value, ok := record[key].(string); ok {
+			return value
+		}
+	}
+	return ""
+}
+
+func firstScalar(record map[string]any, keys ...string) string {
+	for _, key := range keys {
+		switch value := record[key].(type) {
+		case string:
+			return value
+		case float64:
+			return strconv.FormatFloat(value, 'f', -1, 64)
+		case bool:
+			return strconv.FormatBool(value)
+		}
+	}
+	return ""
+}
+
+func nestedFirstString(record map[string]any, paths ...[]string) string {
+	for _, path := range paths {
+		if value := nestedValue(record, path); value != nil {
+			if text, ok := value.(string); ok {
+				return text
+			}
+		}
+	}
+	return ""
+}
+
+func nestedFirstScalar(record map[string]any, paths ...[]string) string {
+	for _, path := range paths {
+		value := nestedValue(record, path)
+		switch typed := value.(type) {
+		case string:
+			return typed
+		case float64:
+			return strconv.FormatFloat(typed, 'f', -1, 64)
+		}
+	}
+	return ""
+}
+
+func nestedValue(record map[string]any, path []string) any {
+	var value any = record
+	for _, key := range path {
+		object, ok := value.(map[string]any)
+		if !ok {
+			return nil
+		}
+		value = object[key]
+	}
+	return value
+}
+
+func auditLogOutputFormat(command *cobra.Command, cfg config.Hook) (string, error) {
+	output := strings.TrimSpace(cfg.GetString(cmdcommon.OutputConfigPath))
+	if output == "" {
+		output = cmdcommon.DefaultOutputFormat
+	}
+	if err := cmdcommon.ValidateOutputFormat(command, output); err != nil {
+		return "", err
+	}
+	return output, nil
+}
+
+func runAuditLogFollow(
+	helper cmd.Helper,
+	client *auditLogPullClient,
+	options pullAuditLogsOptions,
+	output string,
+	pageSize int,
+	window auditLogWindow,
+) error {
+	seen := map[string]time.Time{}
+	checkpoint := *window.End
+	initial := true
+	backoff := time.Second
+	textHeaderWritten := false
+
+	for {
+		if !initial {
+			if !waitForAuditLogPoll(helper.GetContext(), options.PollInterval) {
+				return nil
+			}
+			end := auditLogNow().UTC()
+			start := checkpoint.Add(-followOverlap)
+			window = auditLogWindow{Start: &start, End: &end}
+		}
+
+		records := make([]json.RawMessage, 0)
+		_, _, err := fetchAllAuditLogPages(helper.GetContext(), client,
+			auditLogRequest{Window: window, Type: options.EventType, PageSize: pageSize}, 0,
+			func(page []json.RawMessage) error {
+				records = append(records, page...)
+				return nil
+			})
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(helper.GetContext().Err(), context.Canceled) {
+				return nil
+			}
+			if !isRetryableAuditLogError(err) {
+				return cmd.PrepareExecutionError("failed to follow audit logs", err, helper.GetCmd())
+			}
+			_, _ = fmt.Fprintf(helper.GetStreams().ErrOut, "audit-log polling failed; retrying in %s: %v\n", backoff, err)
+			if !waitForAuditLogPoll(helper.GetContext(), backoff) {
+				return nil
+			}
+			backoff = min(backoff*2, time.Minute)
+			continue
+		}
+
+		backoff = time.Second
+		newRecords := deduplicateAuditLogRecords(records, seen, *window.End)
+		sortAuditLogRecords(newRecords)
+		if len(newRecords) > 0 {
+			if output == jsonLinesOutput {
+				err = renderAuditLogJSONLines(helper, newRecords)
+			} else {
+				err = renderFollowText(helper, newRecords, &textHeaderWritten)
+			}
+			if err != nil {
+				return cmd.PrepareExecutionError("failed to write audit logs", err, helper.GetCmd())
+			}
+		}
+		checkpoint = *window.End
+		expireAuditLogDedup(seen, checkpoint.Add(-followOverlap))
+		initial = false
+	}
+}
+
+func waitForAuditLogPoll(ctx context.Context, duration time.Duration) bool {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func isRetryableAuditLogError(err error) bool {
+	var responseErr *auditLogResponseError
+	if !errors.As(err, &responseErr) {
+		return true
+	}
+	return responseErr.status == http.StatusTooManyRequests || responseErr.status >= http.StatusInternalServerError
+}
+
+func deduplicateAuditLogRecords(
+	records []json.RawMessage,
+	seen map[string]time.Time,
+	fallbackTime time.Time,
+) []json.RawMessage {
+	unique := make([]json.RawMessage, 0, len(records))
+	for _, record := range records {
+		key := auditLogRecordKey(record)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = auditLogRecordTime(record, fallbackTime)
+		unique = append(unique, record)
+	}
+	return unique
+}
+
+func auditLogRecordKey(record json.RawMessage) string {
+	var value map[string]any
+	if json.Unmarshal(record, &value) == nil {
+		if signature := firstString(value, "signature"); signature != "" {
+			return "signature:" + signature
+		}
+	}
+	decoder := json.NewDecoder(bytes.NewReader(record))
+	decoder.UseNumber()
+	var canonical any
+	if decoder.Decode(&canonical) == nil {
+		if encoded, err := json.Marshal(canonical); err == nil {
+			record = encoded
+		}
+	}
+	sum := sha256.Sum256(record)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func auditLogRecordTime(record json.RawMessage, fallback time.Time) time.Time {
+	var value map[string]any
+	if json.Unmarshal(record, &value) == nil {
+		if timestamp := firstString(value, "ts", "timestamp", "event_ts"); timestamp != "" {
+			if parsed, err := time.Parse(time.RFC3339, timestamp); err == nil {
+				return parsed
+			}
+		}
+	}
+	return fallback
+}
+
+func sortAuditLogRecords(records []json.RawMessage) {
+	sort.SliceStable(records, func(i, j int) bool {
+		return auditLogRecordTime(records[i], time.Time{}).Before(auditLogRecordTime(records[j], time.Time{}))
+	})
+}
+
+func expireAuditLogDedup(seen map[string]time.Time, before time.Time) {
+	for key, timestamp := range seen {
+		if timestamp.Before(before) {
+			delete(seen, key)
+		}
+	}
+}
+
+func renderFollowText(helper cmd.Helper, records []json.RawMessage, headerWritten *bool) error {
+	selected, err := columns.Resolve(helper.GetCmd(), cmdcommon.TEXT)
+	if err != nil {
+		return err
+	}
+	var headers []string
+	var rows [][]string
+	if len(selected) > 0 {
+		headers, rows, err = columns.Project(records, selected)
+		if err != nil {
+			return err
+		}
+	} else {
+		headers = []string{"TIMESTAMP", "TYPE", "PRINCIPAL", "ACTION", "RESULT", "TRACE ID"}
+		rows = make([][]string, 0, len(records))
+		for _, record := range records {
+			rows = append(rows, defaultAuditLogRow(record))
+		}
+	}
+	if *headerWritten {
+		return renderRowsWithoutHeader(helper.GetStreams().Out, rows)
+	}
+	*headerWritten = true
+	if _, err := fmt.Fprintln(helper.GetStreams().Out, strings.Join(headers, "\t")); err != nil {
+		return err
+	}
+	return renderRowsWithoutHeader(helper.GetStreams().Out, rows)
+}
+
+func renderRowsWithoutHeader(out io.Writer, rows [][]string) error {
+	for _, row := range rows {
+		if _, err := fmt.Fprintln(out, strings.Join(row, "\t")); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/cmd/root/products/konnect/auditlogs/pull_test.go
+++ b/internal/cmd/root/products/konnect/auditlogs/pull_test.go
@@ -1,0 +1,478 @@
+package auditlogs
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kong/kongctl/internal/cmd"
+	"github.com/kong/kongctl/internal/config"
+	"github.com/kong/kongctl/internal/iostreams"
+	"github.com/kong/kongctl/internal/konnect/apiutil"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditLogPullClientEncodesFiltersAndCursor(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, time.August, 23, 1, 2, 3, 0, time.UTC)
+	end := start.Add(time.Hour)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, auditLogsPullPath, r.URL.Path)
+		require.Equal(t, "Bearer secret", r.Header.Get("Authorization"))
+		require.Equal(t, "1000", r.URL.Query().Get("page[size]"))
+		require.Equal(t, "cursor-value", r.URL.Query().Get("page[after]"))
+		require.Equal(t, "authorization", r.URL.Query().Get("filter[type]"))
+		require.Equal(t, start.Format(time.RFC3339Nano), r.URL.Query().Get("filter[ts][gte]"))
+		require.Equal(t, end.Format(time.RFC3339Nano), r.URL.Query().Get("filter[ts][lte]"))
+		_, _ = w.Write([]byte(`{"data":[{"signature":"sig"}],` +
+			`"meta":{"page":{"next":"/audit-logs?page%5Bafter%5D=next-token"}}}`))
+	}))
+	defer server.Close()
+
+	client := auditLogPullClient{
+		baseURL:     server.URL,
+		tokenSource: apiutil.NewStaticTokenSource("secret"),
+		httpClient:  server.Client(),
+	}
+	page, err := client.fetchPage(t.Context(), auditLogRequest{
+		Window:   auditLogWindow{Start: &start, End: &end},
+		Type:     "authorization",
+		PageSize: 1000,
+		After:    "cursor-value",
+	})
+	require.NoError(t, err)
+	require.Len(t, page.Data, 1)
+	require.Equal(t, "next-token", page.NextCursor)
+}
+
+func TestFetchAllAuditLogPagesExhaustsCursorChain(t *testing.T) {
+	t.Parallel()
+
+	requested := make([]string, 0, 3)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cursor := r.URL.Query().Get("page[after]")
+		requested = append(requested, cursor)
+		switch cursor {
+		case "":
+			_, _ = w.Write([]byte(`{"data":[{"id":1}],"meta":{"page":{"next":"one"}}}`))
+		case "one":
+			_, _ = w.Write([]byte(`{"data":[{"id":2}],"meta":{"next":"two"}}`))
+		case "two":
+			_, _ = w.Write([]byte(`{"data":[{"id":3}],"meta":{"page":{}}}`))
+		default:
+			http.Error(w, "unexpected cursor", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	client := testAuditLogClient(server)
+	var records []json.RawMessage
+	count, truncated, err := fetchAllAuditLogPages(t.Context(), &client, auditLogRequest{PageSize: 10}, 0,
+		func(page []json.RawMessage) error {
+			records = append(records, page...)
+			return nil
+		})
+	require.NoError(t, err)
+	require.Equal(t, 3, count)
+	require.False(t, truncated)
+	require.Len(t, records, 3)
+	require.Equal(t, []string{"", "one", "two"}, requested)
+}
+
+func TestFetchAllAuditLogPagesHonorsTotalLimit(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("page[after]") == "" {
+			_, _ = w.Write([]byte(`{"data":[{"id":1},{"id":2}],"meta":{"page":{"next":"two"}}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"data":[{"id":3},{"id":4}],"meta":{"page":{"next":"three"}}}`))
+	}))
+	defer server.Close()
+
+	client := testAuditLogClient(server)
+	var records []json.RawMessage
+	count, truncated, err := fetchAllAuditLogPages(t.Context(), &client, auditLogRequest{PageSize: 2}, 3,
+		func(page []json.RawMessage) error {
+			records = append(records, page...)
+			return nil
+		})
+	require.NoError(t, err)
+	require.Equal(t, 3, count)
+	require.True(t, truncated)
+	require.Len(t, records, 3)
+}
+
+func TestFetchAllAuditLogPagesRejectsRepeatedCursor(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[],"meta":{"page":{"next":"repeat"}}}`))
+	}))
+	defer server.Close()
+
+	client := testAuditLogClient(server)
+	_, _, err := fetchAllAuditLogPages(t.Context(), &client, auditLogRequest{PageSize: 10}, 0,
+		func([]json.RawMessage) error { return nil })
+	require.ErrorContains(t, err, "repeated cursor")
+}
+
+func TestDecodeAuditLogPageRejectsMissingPaginationMetadata(t *testing.T) {
+	t.Parallel()
+
+	_, err := decodeAuditLogPage([]byte(`{"data":[]}`))
+	require.ErrorContains(t, err, "missing pagination metadata")
+}
+
+func TestResolveAuditLogWindow(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 24, 12, 0, 0, 0, time.UTC)
+	window, err := resolveAuditLogWindow(pullAuditLogsOptions{Since: 24 * time.Hour}, now)
+	require.NoError(t, err)
+	require.Equal(t, now.Add(-24*time.Hour), *window.Start)
+	require.Equal(t, now, *window.End)
+
+	window, err = resolveAuditLogWindow(pullAuditLogsOptions{Follow: true}, now)
+	require.NoError(t, err)
+	require.Equal(t, now.Add(-defaultFollowLookback), *window.Start)
+	require.Equal(t, now, *window.End)
+}
+
+func TestResolveAuditLogLimit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		options    pullAuditLogsOptions
+		limitValue string
+		want       int
+	}{
+		{name: "bare command", want: defaultAuditLogLimit},
+		{name: "type filter only", options: pullAuditLogsOptions{EventType: "authorization"}, want: defaultAuditLogLimit},
+		{name: "explicit limit", limitValue: "100", want: 100},
+		{name: "explicit unlimited", limitValue: "0", want: 0},
+		{name: "relative time window", options: pullAuditLogsOptions{Since: 24 * time.Hour}, want: 0},
+		{name: "start time", options: pullAuditLogsOptions{StartTime: "2026-08-23T00:00:00Z"}, want: 0},
+		{name: "end time", options: pullAuditLogsOptions{EndTime: "2026-08-24T00:00:00Z"}, want: 0},
+		{name: "follow", options: pullAuditLogsOptions{Follow: true}, want: 0},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			options := test.options
+			command := &cobra.Command{}
+			addPullAuditLogsFlags(command, &options)
+			if test.limitValue != "" {
+				require.NoError(t, command.Flags().Set("limit", test.limitValue))
+			}
+
+			require.Equal(t, test.want, resolveAuditLogLimit(command, options))
+		})
+	}
+}
+
+func TestValidatePullAuditLogsOptions(t *testing.T) {
+	t.Parallel()
+
+	command := &cobra.Command{}
+	tests := []struct {
+		name    string
+		options pullAuditLogsOptions
+		output  string
+		page    int
+		want    string
+	}{
+		{
+			name: "page too large", options: pullAuditLogsOptions{PollInterval: time.Second}, output: "json", page: 1001,
+			want: "between 1 and 1000",
+		},
+		{name: "relative and absolute", options: pullAuditLogsOptions{
+			Since: time.Hour, StartTime: "x",
+			PollInterval: time.Second,
+		}, output: "json", page: 10, want: "cannot be combined"},
+		{
+			name: "invalid type", options: pullAuditLogsOptions{EventType: "access", PollInterval: time.Second},
+			output: "json", page: 10, want: "invalid --type",
+		},
+		{
+			name: "bounded follow", options: pullAuditLogsOptions{Follow: true, EndTime: "x", PollInterval: time.Second},
+			output: "text", page: 10, want: "cannot be used with --follow",
+		},
+		{
+			name: "document follow", options: pullAuditLogsOptions{Follow: true, PollInterval: time.Second},
+			output: "json", page: 10, want: "row-oriented",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			err := validatePullAuditLogsOptions(command, test.options, test.output, test.page)
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+}
+
+func TestValidateAuditLogOutputOptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("jsonl permits per-record jq", func(t *testing.T) {
+		t.Parallel()
+		command := &cobra.Command{}
+		addPullAuditLogsFlags(command, &pullAuditLogsOptions{})
+		require.NoError(t, command.Flags().Set("jq", ".signature"))
+		require.NoError(t, validateAuditLogOutputOptions(command, newPullTestConfig(t), jsonLinesOutput))
+	})
+
+	t.Run("jsonl raw output requires jq", func(t *testing.T) {
+		t.Parallel()
+		command := &cobra.Command{}
+		addPullAuditLogsFlags(command, &pullAuditLogsOptions{})
+		require.NoError(t, command.Flags().Set("jq-raw-output", "true"))
+		cfg := newPullTestConfig(t)
+		cfg.Set("jq.raw-output", true)
+		err := validateAuditLogOutputOptions(command, cfg, jsonLinesOutput)
+		require.ErrorContains(t, err, "requires --jq")
+	})
+
+	t.Run("text rejects jq", func(t *testing.T) {
+		t.Parallel()
+		command := &cobra.Command{}
+		addPullAuditLogsFlags(command, &pullAuditLogsOptions{})
+		require.NoError(t, command.Flags().Set("jq", ".signature"))
+		err := validateAuditLogOutputOptions(command, newPullTestConfig(t), "text")
+		require.ErrorContains(t, err, "only supported with --output json or --output yaml")
+	})
+}
+
+func TestRenderAuditLogJSONLinesPreservesSignatureAndFiltersPerRecord(t *testing.T) {
+	t.Parallel()
+
+	command := &cobra.Command{Use: "audit-logs"}
+	addPullAuditLogsFlags(command, &pullAuditLogsOptions{})
+	require.NoError(t, command.Flags().Set("jq", ".signature"))
+	cfg := newPullTestConfig(t)
+	streams := &iostreams.IOStreams{Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}}
+	helper := cmd.NewMockHelper(t)
+	helper.EXPECT().GetConfig().Return(cfg, nil)
+	helper.EXPECT().GetCmd().Return(command)
+	helper.EXPECT().GetStreams().Return(streams)
+
+	err := renderAuditLogJSONLines(helper, []json.RawMessage{
+		json.RawMessage(`{"signature":"sig-one","type":"authorization"}`),
+		json.RawMessage(`{"signature":"sig-two","type":"authentication"}`),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "\"sig-one\"\n\"sig-two\"\n", streams.Out.(*bytes.Buffer).String())
+}
+
+func TestRunFiniteAuditLogPullJSONLinesLeavesPartialOutputOnLaterFailure(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("page[after]") == "" {
+			_, _ = w.Write([]byte(`{"data":[{"signature":"first"}],"meta":{"page":{"next":"second"}}}`))
+			return
+		}
+		http.Error(w, "temporary failure", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	command := &cobra.Command{Use: "audit-logs"}
+	addPullAuditLogsFlags(command, &pullAuditLogsOptions{})
+	cfg := newPullTestConfig(t)
+	streams := &iostreams.IOStreams{Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}}
+	helper := cmd.NewMockHelper(t)
+	helper.EXPECT().GetContext().Return(context.Background())
+	helper.EXPECT().GetConfig().Return(cfg, nil)
+	helper.EXPECT().GetCmd().Return(command).Times(2)
+	helper.EXPECT().GetStreams().Return(streams)
+	client := testAuditLogClient(server)
+
+	err := runFiniteAuditLogPull(helper, &client, pullAuditLogsOptions{}, jsonLinesOutput, 10, auditLogWindow{})
+	require.Error(t, err)
+	require.Contains(t, streams.Out.(*bytes.Buffer).String(), `"signature":"first"`)
+}
+
+func TestRenderFiniteAuditLogsStructuredOutputPreservesCompleteRecords(t *testing.T) {
+	t.Parallel()
+
+	for _, output := range []string{"json", "yaml"} {
+		t.Run(output, func(t *testing.T) {
+			t.Parallel()
+			command := &cobra.Command{Use: "audit-logs"}
+			addPullAuditLogsFlags(command, &pullAuditLogsOptions{})
+			cfg := newPullTestConfig(t)
+			cfg.Set("output", output)
+			streams := &iostreams.IOStreams{Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}}
+			helper := cmd.NewMockHelper(t)
+			helper.EXPECT().GetStreams().Return(streams)
+			helper.EXPECT().GetConfig().Return(cfg, nil)
+			helper.EXPECT().GetCmd().Return(command)
+
+			err := renderFiniteAuditLogs(helper, output, auditLogEnvelope{
+				Metadata: auditLogOutputMetadata{Count: 1, Truncated: true},
+				Data: []json.RawMessage{
+					json.RawMessage(`{"type":"authentication","signature":"unchanged","future_field":{"a":1}}`),
+				},
+			})
+			require.NoError(t, err)
+			rendered := streams.Out.(*bytes.Buffer).String()
+			require.Contains(t, rendered, "unchanged")
+			require.Contains(t, rendered, "future_field")
+			require.Contains(t, rendered, "truncated")
+		})
+	}
+}
+
+func TestDefaultAuditLogRowsCoverEveryEventType(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, []string{"2026-08-24T10:00:00Z", "authentication", "user-1", "sso", "success", "trace-1"},
+		defaultAuditLogRow(json.RawMessage(
+			`{"type":"authentication","principal_id":"user-1","authentication_type":"sso","outcome":"success",`+
+				`"ts":"2026-08-24T10:00:00Z","trace_id":"trace-1"}`,
+		)))
+	require.Equal(t, []string{"2026-08-24T10:00:01Z", "authorization", "user-2", "gateway.read", "denied", "trace-2"},
+		defaultAuditLogRow(json.RawMessage(
+			`{"type":"authorization","principal_id":"user-2","action":"gateway.read","granted":false,`+
+				`"ts":"2026-08-24T10:00:01Z","trace_id":"trace-2"}`,
+		)))
+	require.Equal(t, []string{"2026-08-24T10:00:02Z", "gateway_access", "user-3", "POST /v2/services", "201", "trace-3"},
+		defaultAuditLogRow(json.RawMessage(
+			`{"type":"gateway_access","principal_id":"user-3","method":"POST","uri":"/v2/services",`+
+				`"status_code":201,"ts":"2026-08-24T10:00:02Z","trace_id":"trace-3"}`,
+		)))
+}
+
+func TestDeduplicateAuditLogRecordsUsesSignature(t *testing.T) {
+	t.Parallel()
+
+	records := []json.RawMessage{
+		json.RawMessage(`{"signature":"same","ts":"2026-08-24T10:00:00Z","value":1}`),
+		json.RawMessage(`{"signature":"same","ts":"2026-08-24T10:00:01Z","value":2}`),
+		json.RawMessage(`{"ts":"2026-08-24T10:00:02Z","value":3,"nested":{"a":1}}`),
+		json.RawMessage(`{ "nested": { "a": 1 }, "value": 3, "ts": "2026-08-24T10:00:02Z" }`),
+	}
+	unique := deduplicateAuditLogRecords(records, map[string]time.Time{}, time.Time{})
+	require.Len(t, unique, 2)
+}
+
+func TestRunAuditLogFollowDeduplicatesOverlappingCyclesAndCancelsCleanly(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	requestCount := 0
+	firstTimestamp := time.Now().UTC().Add(-time.Second).Format(time.RFC3339Nano)
+	secondTimestamp := time.Now().UTC().Format(time.RFC3339Nano)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			_, _ = fmt.Fprintf(w, `{"data":[{"signature":"one","ts":%q}],"meta":{"page":{}}}`,
+				firstTimestamp)
+		case 2:
+			_, _ = fmt.Fprintf(w, `{"data":[{"signature":"two","ts":%q},{"signature":"one","ts":%q}],`+
+				`"meta":{"page":{}}}`, secondTimestamp, firstTimestamp)
+		default:
+			cancel()
+		}
+	}))
+	defer server.Close()
+
+	command := &cobra.Command{Use: "audit-logs"}
+	addPullAuditLogsFlags(command, &pullAuditLogsOptions{})
+	cfg := newPullTestConfig(t)
+	streams := &iostreams.IOStreams{Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}}
+	helper := cmd.NewMockHelper(t)
+	helper.EXPECT().GetContext().Return(ctx).Maybe()
+	helper.EXPECT().GetConfig().Return(cfg, nil).Maybe()
+	helper.EXPECT().GetCmd().Return(command).Maybe()
+	helper.EXPECT().GetStreams().Return(streams).Maybe()
+	client := testAuditLogClient(server)
+	start := time.Now().Add(-time.Minute)
+	end := time.Now()
+
+	err := runAuditLogFollow(helper, &client, pullAuditLogsOptions{
+		Follow: true, PollInterval: time.Millisecond,
+	}, jsonLinesOutput, 10, auditLogWindow{Start: &start, End: &end})
+	require.NoError(t, err)
+	output := streams.Out.(*bytes.Buffer).String()
+	require.Equal(t, 1, strings.Count(output, `"signature":"one"`))
+	require.Equal(t, 1, strings.Count(output, `"signature":"two"`))
+}
+
+func TestRenderFollowTextWritesHeaderOnce(t *testing.T) {
+	t.Parallel()
+
+	command := &cobra.Command{Use: "audit-logs"}
+	addPullAuditLogsFlags(command, &pullAuditLogsOptions{})
+	streams := &iostreams.IOStreams{Out: &bytes.Buffer{}, ErrOut: &bytes.Buffer{}}
+	helper := cmd.NewMockHelper(t)
+	helper.EXPECT().GetCmd().Return(command).Times(2)
+	helper.EXPECT().GetStreams().Return(streams).Times(3)
+	headerWritten := false
+	record := []json.RawMessage{json.RawMessage(
+		`{"type":"authentication","ts":"2026-08-24T10:00:00Z","signature":"one"}`,
+	)}
+	require.NoError(t, renderFollowText(helper, record, &headerWritten))
+	require.NoError(t, renderFollowText(helper, record, &headerWritten))
+	require.Equal(t, 1, strings.Count(streams.Out.(*bytes.Buffer).String(), "TIMESTAMP"))
+}
+
+func TestAuditLogRetryClassification(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, isRetryableAuditLogError(context.DeadlineExceeded))
+	require.True(t, isRetryableAuditLogError(&auditLogResponseError{status: http.StatusTooManyRequests}))
+	require.True(t, isRetryableAuditLogError(&auditLogResponseError{status: http.StatusBadGateway}))
+	require.False(t, isRetryableAuditLogError(&auditLogResponseError{status: http.StatusForbidden}))
+}
+
+func testAuditLogClient(server *httptest.Server) auditLogPullClient {
+	return auditLogPullClient{
+		baseURL:     server.URL,
+		tokenSource: apiutil.NewStaticTokenSource("token"),
+		httpClient:  server.Client(),
+	}
+}
+
+func newPullTestConfig(t *testing.T) config.Hook {
+	t.Helper()
+	cfg := newTestConfigHook(t)
+	cfg.Set("jq.default-expression", "")
+	return cfg
+}
+
+func TestNormalizeAuditLogCursor(t *testing.T) {
+	t.Parallel()
+
+	cursor, err := normalizeAuditLogCursor("/audit-logs?page%5Bafter%5D=token")
+	require.NoError(t, err)
+	require.Equal(t, "token", cursor)
+	cursor, err = normalizeAuditLogCursor("token")
+	require.NoError(t, err)
+	require.Equal(t, "token", cursor)
+	cursor, err = normalizeAuditLogCursor("")
+	require.NoError(t, err)
+	require.Empty(t, cursor)
+	_, err = normalizeAuditLogCursor("/audit-logs?page%5Bbefore%5D=token")
+	require.ErrorContains(t, err, "does not contain page[after]")
+}
+
+func Example_auditLogQueryEncoding() {
+	values := url.Values{}
+	values.Set("filter[ts][gte]", "2026-08-23T00:00:00Z")
+	fmt.Println(values.Encode())
+	// Output: filter%5Bts%5D%5Bgte%5D=2026-08-23T00%3A00%3A00Z
+}

--- a/internal/cmd/root/products/konnect/auditlogs/pull_test.go
+++ b/internal/cmd/root/products/konnect/auditlogs/pull_test.go
@@ -147,6 +147,12 @@ func TestResolveAuditLogWindow(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, now.Add(-defaultFollowLookback), *window.Start)
 	require.Equal(t, now, *window.End)
+
+	_, err = resolveAuditLogWindow(pullAuditLogsOptions{
+		Follow:    true,
+		StartTime: now.Add(time.Hour).Format(time.RFC3339),
+	}, now)
+	require.ErrorContains(t, err, "--start-time must not be later")
 }
 
 func TestResolveAuditLogLimit(t *testing.T) {

--- a/internal/cmd/root/products/konnect/konnect.go
+++ b/internal/cmd/root/products/konnect/konnect.go
@@ -69,12 +69,18 @@ Setting this value overrides tokens obtained from the login command.
 	}
 
 	if verb == verbs.Get || verb == verbs.List {
+		pageSize := common.DefaultRequestPageSize
+		pageSizeDescription := "Max number of results to include per response page for get and list operations."
+		if cmd.Name() == auditlogs.CommandName {
+			pageSize = auditlogs.DefaultPullPageSize
+			pageSizeDescription = "Maximum audit-log records requested per API page (1..1000)."
+		}
 		cmd.Flags().Int(
 			common.RequestPageSizeFlagName,
-			common.DefaultRequestPageSize,
-			fmt.Sprintf(`Max number of results to include per response page for get and list operations.
+			pageSize,
+			fmt.Sprintf(`%s
 - Config path: [ %s ]`,
-				common.RequestPageSizeConfigPath),
+				pageSizeDescription, common.RequestPageSizeConfigPath),
 		)
 	}
 

--- a/internal/cmd/root/verbs/get/auditlogs.go
+++ b/internal/cmd/root/verbs/get/auditlogs.go
@@ -38,8 +38,8 @@ Setting this value overrides tokens obtained from the login command.
 		if verb == verbs.Get || verb == verbs.List {
 			cmdObj.Flags().Int(
 				common.RequestPageSizeFlagName,
-				common.DefaultRequestPageSize,
-				fmt.Sprintf(`Max number of results to include per response page for get and list operations.
+				konnectauditlogs.DefaultPullPageSize,
+				fmt.Sprintf(`Maximum audit-log records requested per API page (1..1000).
 - Config path: [ %s ]`,
 					common.RequestPageSizeConfigPath),
 			)
@@ -62,7 +62,13 @@ Setting this value overrides tokens obtained from the login command.
 		return nil, err
 	}
 
-	auditLogsCmd.Example = `  # List audit-log destinations
+	auditLogsCmd.Example = `  # Retrieve the 50 most recent events
+  kongctl get audit-logs
+
+  # Retrieve and automatically paginate every event from the last 24 hours
+  kongctl get audit-logs --since 24h --output jsonl
+
+  # List audit-log destinations
   kongctl get audit-logs destinations
 
   # Get one destination by id or name

--- a/internal/cmd/root/verbs/get/auditlogs_test.go
+++ b/internal/cmd/root/verbs/get/auditlogs_test.go
@@ -3,6 +3,7 @@ package get
 import (
 	"testing"
 
+	cmdcommon "github.com/kong/kongctl/internal/cmd/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,5 +29,12 @@ func TestAuditLogPullCommandForms(t *testing.T) {
 			require.NotNilf(t, found.Flag(flag), "expected %v to expose --%s", path, flag)
 		}
 		require.Equal(t, "100", found.Flag("page-size").DefValue)
+		require.Contains(t, cmdcommon.AllowedOutputFormats(found), "jsonl")
+		for _, childName := range []string{"destinations", "destination", "webhook"} {
+			child, _, err := found.Find([]string{childName})
+			require.NoError(t, err)
+			require.NotContains(t, cmdcommon.AllowedOutputFormats(child), "jsonl")
+			require.Error(t, cmdcommon.ValidateOutputFormat(child, "jsonl"))
+		}
 	}
 }

--- a/internal/cmd/root/verbs/get/auditlogs_test.go
+++ b/internal/cmd/root/verbs/get/auditlogs_test.go
@@ -1,0 +1,32 @@
+package get
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditLogPullCommandForms(t *testing.T) {
+	t.Parallel()
+
+	command, err := NewGetCmd()
+	require.NoError(t, err)
+	for _, path := range [][]string{{"audit-logs"}, {"konnect", "audit-logs"}} {
+		found, _, err := command.Find(path)
+		require.NoError(t, err)
+		require.Equal(t, "audit-logs", found.Name())
+		require.Equal(t, []string{"audit-log"}, found.Aliases)
+		require.Contains(t, found.Flag("since").Usage, "30s, 15m, 2h, 24h, 168h, 1h30m")
+		require.Contains(t, found.Flag("start-time").Usage, "2026-08-23T14:00:00Z")
+		require.Contains(t, found.Flag("start-time").Usage, "2026-08-23T09:00:00-05:00")
+		require.Contains(t, found.Flag("end-time").Usage, "2026-08-24T14:00:00Z")
+		require.Contains(t, found.Flag("end-time").Usage, "2026-08-24T09:00:00-05:00")
+		require.NotNil(t, found.RunE)
+		for _, flag := range []string{
+			"start-time", "end-time", "since", "type", "limit", "page-size", "follow", "poll-interval",
+		} {
+			require.NotNilf(t, found.Flag(flag), "expected %v to expose --%s", path, flag)
+		}
+		require.Equal(t, "100", found.Flag("page-size").DefValue)
+	}
+}

--- a/internal/cmd/root/verbs/get/get.go
+++ b/internal/cmd/root/verbs/get/get.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	cmdpkg "github.com/kong/kongctl/internal/cmd"
+	cmdcommon "github.com/kong/kongctl/internal/cmd/common"
 	"github.com/kong/kongctl/internal/cmd/output/columns"
 	"github.com/kong/kongctl/internal/cmd/output/jq"
 	"github.com/kong/kongctl/internal/cmd/root/products"
@@ -251,6 +252,9 @@ func bindKonnectFlags(c *cobra.Command, args []string) error {
 
 	if err := jq.BindFlags(cfg, c.Flags()); err != nil {
 		return err
+	}
+	if outputFlag := c.Flag(cmdcommon.OutputFlagName); outputFlag != nil && outputFlag.Value.String() == "jsonl" {
+		return nil
 	}
 	return columns.ValidateColumnFlags(helper, cfg)
 }

--- a/internal/cmd/root/verbs/get/get.go
+++ b/internal/cmd/root/verbs/get/get.go
@@ -3,6 +3,7 @@ package get
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	cmdpkg "github.com/kong/kongctl/internal/cmd"
 	cmdcommon "github.com/kong/kongctl/internal/cmd/common"
@@ -253,7 +254,8 @@ func bindKonnectFlags(c *cobra.Command, args []string) error {
 	if err := jq.BindFlags(cfg, c.Flags()); err != nil {
 		return err
 	}
-	if outputFlag := c.Flag(cmdcommon.OutputFlagName); outputFlag != nil && outputFlag.Value.String() == "jsonl" {
+	if outputFlag := c.Flag(cmdcommon.OutputFlagName); outputFlag != nil && outputFlag.Value.String() == "jsonl" &&
+		slices.Contains(cmdcommon.AllowedOutputFormats(c), "jsonl") {
 		return nil
 	}
 	return columns.ValidateColumnFlags(helper, cfg)

--- a/internal/cmd/root/verbs/listen/listen.go
+++ b/internal/cmd/root/verbs/listen/listen.go
@@ -6,6 +6,9 @@ import (
 	"strings"
 
 	cmdpkg "github.com/kong/kongctl/internal/cmd"
+	cmdcommon "github.com/kong/kongctl/internal/cmd/common"
+	"github.com/kong/kongctl/internal/cmd/output/jq"
+	"github.com/kong/kongctl/internal/cmd/root/products"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect"
 	konnectAuditLogs "github.com/kong/kongctl/internal/cmd/root/products/konnect/auditlogs"
 	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
@@ -38,19 +41,6 @@ var (
 	`, meta.CLIName)))
 
 	tailUse = "tail"
-
-	tailShort = i18n.T("root.verbs.tail.short", "Listen and stream events")
-	tailLong  = normalizers.LongDesc(i18n.T("root.verbs.tail.long",
-		`Use tail to create and run local receivers and stream incoming events to stdout.`))
-	tailExamples = normalizers.Examples(i18n.T("root.verbs.tail.examples",
-		fmt.Sprintf(`
-	# Konnect-first shorthand
-	%[1]s tail --public-url https://example.ngrok.app --authorization "Bearer <token>"
-	# Resource form
-	%[1]s tail audit-logs --public-url https://example.ngrok.app --authorization "Bearer <token>"
-	# Explicit product form
-	%[1]s tail konnect audit-logs --public-url https://example.ngrok.app --authorization "Bearer <token>"
-	`, meta.CLIName)))
 )
 
 type listenCommandSpec struct {
@@ -74,16 +64,70 @@ func NewListenCmd() (*cobra.Command, error) {
 	})
 }
 
-// NewTailCmd builds the tail alias command.
+// NewTailCmd builds the audit-log pull follow command.
 func NewTailCmd() (*cobra.Command, error) {
-	return newListenCommand(listenCommandSpec{
-		use:              tailUse,
-		short:            tailShort,
-		long:             tailLong,
-		example:          tailExamples,
-		aliases:          nil,
-		forceTailDefault: true,
-	})
+	command := &cobra.Command{
+		Use:     tailUse,
+		Short:   "Follow Konnect organization audit logs",
+		Long:    "Follow Konnect organization audit logs through the audit-log pull API.",
+		Example: "  kongctl tail audit-logs\n  kongctl tail audit-logs --output jsonl",
+		PersistentPreRunE: func(c *cobra.Command, args []string) error {
+			ctx := context.WithValue(c.Context(), verbs.Verb, Verb)
+			ctx = context.WithValue(ctx, products.Product, konnect.Product)
+			c.SetContext(ctx)
+			return bindKonnectFlags(c, args)
+		},
+	}
+	addKonnectTailPersistentFlags(command)
+	konnectAuditLogs.ConfigureTailPullCommand(command, false)
+	addTailPageSizeFlag(command)
+
+	directAuditLogs := &cobra.Command{
+		Use:     konnectAuditLogs.CommandName,
+		Aliases: []string{"audit-log"},
+	}
+	konnectAuditLogs.ConfigureTailPullCommand(directAuditLogs, true)
+	addTailPageSizeFlag(directAuditLogs)
+	command.AddCommand(directAuditLogs)
+
+	konnectCommand := &cobra.Command{
+		Use:     konnect.Product.String(),
+		Short:   "Follow Konnect resources",
+		Aliases: []string{"k", "K"},
+		RunE: func(c *cobra.Command, args []string) error {
+			return cmdpkg.RequireSubcommand(c, args)
+		},
+	}
+	cmdpkg.MarkRequiresSubcommand(konnectCommand)
+	explicitAuditLogs := &cobra.Command{
+		Use:     konnectAuditLogs.CommandName,
+		Aliases: []string{"audit-log"},
+	}
+	konnectAuditLogs.ConfigureTailPullCommand(explicitAuditLogs, true)
+	addTailPageSizeFlag(explicitAuditLogs)
+	konnectCommand.AddCommand(explicitAuditLogs)
+	command.AddCommand(konnectCommand)
+
+	return command, nil
+}
+
+func addKonnectTailPersistentFlags(command *cobra.Command) {
+	command.PersistentFlags().String(common.BaseURLFlagName, "",
+		fmt.Sprintf(`Base URL for Konnect API requests.
+- Config path: [ %s ]
+- Default   : [ %s ]`, common.BaseURLConfigPath, common.BaseURLDefault))
+	command.PersistentFlags().String(common.RegionFlagName, "",
+		fmt.Sprintf(`Konnect region identifier (for example "eu").
+- Config path: [ %s ]`, common.RegionConfigPath))
+	command.PersistentFlags().String(common.PATFlagName, "",
+		fmt.Sprintf(`Konnect Personal Access Token (PAT) used to authenticate the CLI.
+- Config path: [ %s ]`, common.PATConfigPath))
+}
+
+func addTailPageSizeFlag(command *cobra.Command) {
+	command.Flags().Int(common.RequestPageSizeFlagName, konnectAuditLogs.DefaultPullPageSize,
+		fmt.Sprintf(`Maximum audit-log records requested per API page (1..1000).
+- Config path: [ %s ]`, common.RequestPageSizeConfigPath))
 }
 
 func newListenCommand(spec listenCommandSpec) (*cobra.Command, error) {
@@ -197,6 +241,21 @@ func bindKonnectFlags(c *cobra.Command, args []string) error {
 
 	if f := c.Flags().Lookup(common.PATFlagName); f != nil {
 		if err := cfg.BindFlag(common.PATConfigPath, f); err != nil {
+			return err
+		}
+	}
+
+	if f := c.Flags().Lookup(common.RequestPageSizeFlagName); f != nil {
+		if err := cfg.BindFlag(common.RequestPageSizeConfigPath, f); err != nil {
+			return err
+		}
+	}
+
+	if err := jq.BindFlags(cfg, c.Flags()); err != nil {
+		return err
+	}
+	if f := c.Flags().Lookup(cmdcommon.OutputFlagName); f != nil {
+		if err := cfg.BindFlag(cmdcommon.OutputConfigPath, f); err != nil {
 			return err
 		}
 	}

--- a/internal/cmd/root/verbs/listen/listen_test.go
+++ b/internal/cmd/root/verbs/listen/listen_test.go
@@ -1,11 +1,54 @@
 package listen
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNewTailCmdUsesPullAPIAndPreservesListenerChild(t *testing.T) {
+	t.Parallel()
+
+	command, err := NewTailCmd()
+	require.NoError(t, err)
+	require.NotNil(t, command.RunE)
+	require.NotNil(t, command.Flags().Lookup("follow"))
+	require.Equal(t, "true", command.Flags().Lookup("follow").DefValue)
+
+	auditLogs, _, err := command.Find([]string{"audit-logs"})
+	require.NoError(t, err)
+	require.Equal(t, "audit-logs", auditLogs.Name())
+	require.Equal(t, []string{"audit-log"}, auditLogs.Aliases)
+	require.NotNil(t, auditLogs.Flags().Lookup("since"))
+	require.Equal(t, "100", auditLogs.Flags().Lookup("page-size").DefValue)
+
+	listener, _, err := command.Find([]string{"audit-logs", "listener"})
+	require.NoError(t, err)
+	require.Equal(t, "listener", listener.Name())
+	require.NotNil(t, listener.Flags().Lookup("endpoint"))
+	require.NotNil(t, listener.Flags().Lookup("authorization"))
+
+	explicit, _, err := command.Find([]string{"konnect", "audit-logs"})
+	require.NoError(t, err)
+	require.Equal(t, "audit-logs", explicit.Name())
+	require.Equal(t, []string{"audit-log"}, explicit.Aliases)
+	require.Equal(t, "100", explicit.Flags().Lookup("page-size").DefValue)
+}
+
+func TestNewTailCmdHelpDescribesPullBehavior(t *testing.T) {
+	t.Parallel()
+
+	command, err := NewTailCmd()
+	require.NoError(t, err)
+	var output strings.Builder
+	command.SetOut(&output)
+	command.SetArgs([]string{"audit-logs", "--help"})
+	require.NoError(t, command.Execute())
+	require.Contains(t, output.String(), "five-minute audit-log catch-up")
+	require.Contains(t, output.String(), "--output jsonl")
+}
 
 func TestSetTailFlagDefaultIfUnset(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- add finite Konnect organization audit-log retrieval with cursor pagination, time and type filters, limits, and text, JSON, YAML, and JSONL output
- add continuous follow behavior with catch-up, overlap deduplication, retry handling, and clean Ctrl-C shutdown
- preserve the webhook listener under the listener child command and document the updated command UX
- default bare retrieval to the latest 50 events and audit-log API pages to 100 records while leaving explicit time-window queries unlimited

## Reliability

- fail on missing, malformed, or repeated pagination cursors
- preserve complete audit-log records and signatures
- stream JSONL page by page so partial collection is visible with a nonzero exit status
- retry transient follow failures without advancing the collection checkpoint

## Testing

- go fix ./...
- make format
- make build
- make lint
- make test
- make test-integration

Closes #1932