### PR TITLE
fix(declarative): require effective API document titles

### DIFF
--- a/internal/declarative/executor/api_document_adapter.go
+++ b/internal/declarative/executor/api_document_adapter.go
@@ -25,12 +25,10 @@ func (a *APIDocumentAdapter) MapCreateFields(
 	_ context.Context, execCtx *ExecutionContext, fields map[string]any,
 	create *kkComps.CreateAPIDocumentRequest,
 ) error {
-	// Required fields
-	title, ok := fields[planner.FieldTitle].(string)
-	if !ok {
-		return fmt.Errorf("title is required")
+	// Optional fields
+	if title, ok := fields[planner.FieldTitle].(string); ok {
+		create.Title = &title
 	}
-	create.Title = &title
 
 	content, ok := fields[planner.FieldContent].(string)
 	if !ok {
@@ -38,7 +36,6 @@ func (a *APIDocumentAdapter) MapCreateFields(
 	}
 	create.Content = content
 
-	// Optional fields
 	if slug, ok := fields[planner.FieldSlug].(string); ok {
 		create.Slug = &slug
 	}
@@ -183,7 +180,7 @@ func (a *APIDocumentAdapter) ResourceType() string {
 
 // RequiredFields returns the required fields for creation
 func (a *APIDocumentAdapter) RequiredFields() []string {
-	return []string{planner.FieldTitle, planner.FieldContent}
+	return []string{planner.FieldContent}
 }
 
 // SupportsUpdate returns true as documents support updates

--- a/internal/declarative/executor/api_document_adapter.go
+++ b/internal/declarative/executor/api_document_adapter.go
@@ -25,10 +25,12 @@ func (a *APIDocumentAdapter) MapCreateFields(
 	_ context.Context, execCtx *ExecutionContext, fields map[string]any,
 	create *kkComps.CreateAPIDocumentRequest,
 ) error {
-	// Optional fields
-	if title, ok := fields[planner.FieldTitle].(string); ok {
-		create.Title = &title
+	// Required fields
+	title, ok := fields[planner.FieldTitle].(string)
+	if !ok {
+		return fmt.Errorf("title is required")
 	}
+	create.Title = &title
 
 	content, ok := fields[planner.FieldContent].(string)
 	if !ok {
@@ -36,6 +38,7 @@ func (a *APIDocumentAdapter) MapCreateFields(
 	}
 	create.Content = content
 
+	// Optional fields
 	if slug, ok := fields[planner.FieldSlug].(string); ok {
 		create.Slug = &slug
 	}
@@ -180,7 +183,7 @@ func (a *APIDocumentAdapter) ResourceType() string {
 
 // RequiredFields returns the required fields for creation
 func (a *APIDocumentAdapter) RequiredFields() []string {
-	return []string{planner.FieldContent}
+	return []string{planner.FieldTitle, planner.FieldContent}
 }
 
 // SupportsUpdate returns true as documents support updates

--- a/internal/declarative/executor/api_document_adapter_test.go
+++ b/internal/declarative/executor/api_document_adapter_test.go
@@ -1,0 +1,28 @@
+package executor
+
+import (
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/common"
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIDocumentAdapterAllowsCreateWithoutTitle(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewAPIDocumentAdapter(nil)
+	fields := map[string]any{
+		planner.FieldContent: "API documentation",
+	}
+
+	require.Equal(t, []string{planner.FieldContent}, adapter.RequiredFields())
+	require.NoError(t, common.ValidateRequiredFields(fields, adapter.RequiredFields()))
+
+	var request kkComps.CreateAPIDocumentRequest
+	require.NoError(t, adapter.MapCreateFields(t.Context(), nil, fields, &request))
+	assert.Nil(t, request.Title)
+	assert.Equal(t, "API documentation", request.Content)
+}

--- a/internal/declarative/executor/api_document_adapter_test.go
+++ b/internal/declarative/executor/api_document_adapter_test.go
@@ -6,11 +6,10 @@ import (
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/kong/kongctl/internal/declarative/common"
 	"github.com/kong/kongctl/internal/declarative/planner"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestAPIDocumentAdapterAllowsCreateWithoutTitle(t *testing.T) {
+func TestAPIDocumentAdapterRequiresEffectiveTitle(t *testing.T) {
 	t.Parallel()
 
 	adapter := NewAPIDocumentAdapter(nil)
@@ -18,11 +17,13 @@ func TestAPIDocumentAdapterAllowsCreateWithoutTitle(t *testing.T) {
 		planner.FieldContent: "API documentation",
 	}
 
-	require.Equal(t, []string{planner.FieldContent}, adapter.RequiredFields())
-	require.NoError(t, common.ValidateRequiredFields(fields, adapter.RequiredFields()))
+	require.Equal(t, []string{planner.FieldTitle, planner.FieldContent}, adapter.RequiredFields())
+	require.ErrorContains(
+		t,
+		common.ValidateRequiredFields(fields, adapter.RequiredFields()),
+		"required field 'title' is missing",
+	)
 
 	var request kkComps.CreateAPIDocumentRequest
-	require.NoError(t, adapter.MapCreateFields(t.Context(), nil, fields, &request))
-	assert.Nil(t, request.Title)
-	assert.Equal(t, "API documentation", request.Content)
+	require.ErrorContains(t, adapter.MapCreateFields(t.Context(), nil, fields, &request), "title is required")
 }

--- a/internal/declarative/loader/content_metadata_test.go
+++ b/internal/declarative/loader/content_metadata_test.go
@@ -130,6 +130,23 @@ apis:
 	assert.Equal(t, "api-guide", *doc.Slug)
 }
 
+func TestLoaderRejectsAPIDocumentWithoutEffectiveTitle(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadContentMetadataConfigErr(t, `
+apis:
+  - ref: api-1
+    name: API 1
+    documents:
+      - ref: doc-1
+        content: "# Missing title"
+        slug: missing-title
+`)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API document title is required either in title or content frontmatter")
+}
+
 func TestLoaderDoesNotDerivePortalPageSlugFromFrontmatterTitle(t *testing.T) {
 	t.Parallel()
 

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -1229,6 +1229,23 @@ func (l *Loader) validateAPIs(apis []resources.APIResource, rs *resources.Resour
 				}
 			}
 		}
+
+		// Validate documents retained under their parent API after flattening.
+		for j := range api.Documents {
+			document := &api.Documents[j]
+			if err := document.Validate(); err != nil {
+				return fmt.Errorf("invalid api_document %q in api %q: %w", document.GetRef(), api.GetRef(), err)
+			}
+			if existing, found := rs.GetResourceByRef(document.GetRef()); found {
+				if existing.GetType() != resources.ResourceTypeAPIDocument {
+					return fmt.Errorf(
+						"duplicate ref '%s' (already defined as %s)",
+						document.GetRef(),
+						existing.GetType(),
+					)
+				}
+			}
+		}
 	}
 
 	return nil

--- a/internal/declarative/planner/planner_test.go
+++ b/internal/declarative/planner/planner_test.go
@@ -202,7 +202,8 @@ func (s *stubAPIImplementationAPI) DeleteAPIImplementation(
 }
 
 type stubAPIDocumentAPI struct {
-	response *kkOps.ListAPIDocumentsResponse
+	response      *kkOps.ListAPIDocumentsResponse
+	fetchResponse *kkOps.FetchAPIDocumentResponse
 }
 
 func (s *stubAPIDocumentAPI) CreateAPIDocument(
@@ -255,7 +256,55 @@ func (s *stubAPIDocumentAPI) FetchAPIDocument(
 	_ string,
 	_ ...kkOps.Option,
 ) (*kkOps.FetchAPIDocumentResponse, error) {
+	if s.fetchResponse != nil {
+		return s.fetchResponse, nil
+	}
 	return nil, fmt.Errorf("FetchAPIDocument not implemented")
+}
+
+func TestPlanAPIDocumentChangesMatchesTitlelessDocumentByDefaultedSlug(t *testing.T) {
+	t.Parallel()
+
+	status := kkComps.APIDocumentStatusPublished
+	api := &stubAPIDocumentAPI{
+		response: &kkOps.ListAPIDocumentsResponse{
+			ListAPIDocumentResponse: &kkComps.ListAPIDocumentResponse{
+				Data: []kkComps.APIDocumentSummaryWithChildren{
+					{
+						ID:     "document-123",
+						Slug:   "getting-started",
+						Status: &status,
+					},
+				},
+			},
+		},
+		fetchResponse: &kkOps.FetchAPIDocumentResponse{
+			APIDocumentResponse: &kkComps.APIDocumentResponse{
+				ID:      "document-123",
+				Content: "Old content",
+				Slug:    "getting-started",
+				Status:  &status,
+			},
+		},
+	}
+	document := resources.APIDocumentResource{
+		Ref: "getting-started",
+		CreateAPIDocumentRequest: kkComps.CreateAPIDocumentRequest{
+			Content: "Updated content",
+		},
+	}
+	document.SetDefaults()
+
+	client := state.NewClient(state.ClientConfig{APIDocumentAPI: api})
+	plan := NewPlan("1.0", "test", PlanModeApply)
+	err := NewPlanner(client, slog.Default()).planAPIDocumentChanges(
+		t.Context(), NewConfig(DefaultNamespace), DefaultNamespace, "api-123", "", []resources.APIDocumentResource{document},
+		plan,
+	)
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	assert.Equal(t, ActionUpdate, plan.Changes[0].Action)
+	assert.Equal(t, "document-123", plan.Changes[0].ResourceID)
 }
 
 func TestGeneratePlan_CreatePortal(t *testing.T) {

--- a/internal/declarative/planner/planner_test.go
+++ b/internal/declarative/planner/planner_test.go
@@ -202,8 +202,7 @@ func (s *stubAPIImplementationAPI) DeleteAPIImplementation(
 }
 
 type stubAPIDocumentAPI struct {
-	response      *kkOps.ListAPIDocumentsResponse
-	fetchResponse *kkOps.FetchAPIDocumentResponse
+	response *kkOps.ListAPIDocumentsResponse
 }
 
 func (s *stubAPIDocumentAPI) CreateAPIDocument(
@@ -256,55 +255,27 @@ func (s *stubAPIDocumentAPI) FetchAPIDocument(
 	_ string,
 	_ ...kkOps.Option,
 ) (*kkOps.FetchAPIDocumentResponse, error) {
-	if s.fetchResponse != nil {
-		return s.fetchResponse, nil
-	}
 	return nil, fmt.Errorf("FetchAPIDocument not implemented")
 }
 
-func TestPlanAPIDocumentChangesMatchesTitlelessDocumentByDefaultedSlug(t *testing.T) {
+func TestPlanAPIDocumentCreateIncludesEffectiveTitle(t *testing.T) {
 	t.Parallel()
 
-	status := kkComps.APIDocumentStatusPublished
-	api := &stubAPIDocumentAPI{
-		response: &kkOps.ListAPIDocumentsResponse{
-			ListAPIDocumentResponse: &kkComps.ListAPIDocumentResponse{
-				Data: []kkComps.APIDocumentSummaryWithChildren{
-					{
-						ID:     "document-123",
-						Slug:   "getting-started",
-						Status: &status,
-					},
-				},
-			},
-		},
-		fetchResponse: &kkOps.FetchAPIDocumentResponse{
-			APIDocumentResponse: &kkComps.APIDocumentResponse{
-				ID:      "document-123",
-				Content: "Old content",
-				Slug:    "getting-started",
-				Status:  &status,
-			},
-		},
-	}
+	title := "Frontmatter Title"
 	document := resources.APIDocumentResource{
 		Ref: "getting-started",
 		CreateAPIDocumentRequest: kkComps.CreateAPIDocumentRequest{
-			Content: "Updated content",
+			Content: "---\ntitle: Frontmatter Title\n---\n\n# Guide",
+			Title:   &title,
 		},
 	}
-	document.SetDefaults()
 
-	client := state.NewClient(state.ClientConfig{APIDocumentAPI: api})
 	plan := NewPlan("1.0", "test", PlanModeApply)
-	err := NewPlanner(client, slog.Default()).planAPIDocumentChanges(
-		t.Context(), NewConfig(DefaultNamespace), DefaultNamespace, "api-123", "", []resources.APIDocumentResource{document},
-		plan,
+	new(Planner).planAPIDocumentCreate(
+		DefaultNamespace, "", "api-123", document, nil, apiDocumentLookup{}, plan,
 	)
-	require.NoError(t, err)
 	require.Len(t, plan.Changes, 1)
-	assert.Equal(t, ActionUpdate, plan.Changes[0].Action)
-	assert.Equal(t, "document-123", plan.Changes[0].ResourceID)
+	assert.Equal(t, "Frontmatter Title", plan.Changes[0].Fields[FieldTitle])
 }
 
 func TestGeneratePlan_CreatePortal(t *testing.T) {

--- a/internal/declarative/resources/api_document.go
+++ b/internal/declarative/resources/api_document.go
@@ -116,11 +116,19 @@ func (d *APIDocumentResource) SetDefaults() {
 		d.Status = &status
 	}
 
-	// If slug is not set but title is provided, generate slug from title
-	// This matches the Konnect API behavior: "defaults to slugify(title)"
-	if d.Slug == nil && d.Title != nil && *d.Title != "" {
-		slug := util.GenerateSlug(*d.Title)
-		d.Slug = &slug
+	// Konnect defaults slug to slugify(title). Fall back to the declarative ref
+	// when title is omitted so the document retains a stable reconciliation key.
+	if d.Slug == nil {
+		slug := ""
+		if d.Title != nil {
+			slug = util.GenerateSlug(*d.Title)
+		}
+		if slug == "" {
+			slug = util.GenerateSlug(d.Ref)
+		}
+		if slug != "" {
+			d.Slug = &slug
+		}
 	}
 
 	for i := range d.Children {

--- a/internal/declarative/resources/api_document.go
+++ b/internal/declarative/resources/api_document.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strings"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/kong/kongctl/internal/util"
@@ -14,7 +15,15 @@ func init() {
 	registerResourceType(
 		ResourceTypeAPIDocument,
 		func(rs *ResourceSet) *[]APIDocumentResource { return &rs.APIDocuments },
-		AutoExplain[APIDocumentResource](),
+		AutoExplain[APIDocumentResource](
+			WithExplainFieldHint("title", ExplainFieldHint{
+				Description: "The document title. Required here unless content YAML frontmatter provides title.",
+				Recommended: new(true),
+				Notes: []string{
+					"A title must be provided either in this field or in the content YAML frontmatter.",
+				},
+			}),
+		),
 	)
 }
 
@@ -82,6 +91,9 @@ func (d APIDocumentResource) Validate() error {
 	if d.Content == "" {
 		return fmt.Errorf("API document content is required")
 	}
+	if d.Title == nil || strings.TrimSpace(*d.Title) == "" {
+		return fmt.Errorf("API document title is required either in title or content frontmatter")
+	}
 
 	// Validate slug format using Konnect's regex pattern
 	if d.Slug != nil && *d.Slug != "" {
@@ -116,19 +128,11 @@ func (d *APIDocumentResource) SetDefaults() {
 		d.Status = &status
 	}
 
-	// Konnect defaults slug to slugify(title). Fall back to the declarative ref
-	// when title is omitted so the document retains a stable reconciliation key.
-	if d.Slug == nil {
-		slug := ""
-		if d.Title != nil {
-			slug = util.GenerateSlug(*d.Title)
-		}
-		if slug == "" {
-			slug = util.GenerateSlug(d.Ref)
-		}
-		if slug != "" {
-			d.Slug = &slug
-		}
+	// If slug is not set but title is provided, generate slug from title
+	// This matches the Konnect API behavior: "defaults to slugify(title)"
+	if d.Slug == nil && d.Title != nil && *d.Title != "" {
+		slug := util.GenerateSlug(*d.Title)
+		d.Slug = &slug
 	}
 
 	for i := range d.Children {

--- a/internal/declarative/resources/api_document_defaults_test.go
+++ b/internal/declarative/resources/api_document_defaults_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAPIDocumentResource_SetDefaults(t *testing.T) {
@@ -44,17 +45,6 @@ func TestAPIDocumentResource_SetDefaults(t *testing.T) {
 				},
 			},
 			expectSlugSet: false,
-		},
-		{
-			name: "generates slug from ref when title is nil",
-			doc: &APIDocumentResource{
-				Ref: "api.guide",
-				CreateAPIDocumentRequest: kkComps.CreateAPIDocumentRequest{
-					Content: "Content here",
-				},
-			},
-			expectedSlug:  "apiguide",
-			expectSlugSet: true,
 		},
 		{
 			name: "does not generate slug when title is empty",
@@ -102,4 +92,20 @@ func TestAPIDocumentResource_SetDefaults(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAPIDocumentResourceValidateRequiresEffectiveTitle(t *testing.T) {
+	t.Parallel()
+
+	document := APIDocumentResource{
+		Ref: "guide",
+		CreateAPIDocumentRequest: kkComps.CreateAPIDocumentRequest{
+			Content: "# Guide",
+		},
+	}
+
+	require.ErrorContains(t, document.Validate(), "title is required either in title or content frontmatter")
+
+	document.Title = new("Guide")
+	require.NoError(t, document.Validate())
 }

--- a/internal/declarative/resources/api_document_defaults_test.go
+++ b/internal/declarative/resources/api_document_defaults_test.go
@@ -46,6 +46,17 @@ func TestAPIDocumentResource_SetDefaults(t *testing.T) {
 			expectSlugSet: false,
 		},
 		{
+			name: "generates slug from ref when title is nil",
+			doc: &APIDocumentResource{
+				Ref: "api.guide",
+				CreateAPIDocumentRequest: kkComps.CreateAPIDocumentRequest{
+					Content: "Content here",
+				},
+			},
+			expectedSlug:  "apiguide",
+			expectSlugSet: true,
+		},
+		{
 			name: "does not generate slug when title is empty",
 			doc: &APIDocumentResource{
 				CreateAPIDocumentRequest: kkComps.CreateAPIDocumentRequest{

--- a/internal/declarative/resources/explain_test.go
+++ b/internal/declarative/resources/explain_test.go
@@ -589,6 +589,27 @@ func TestRenderScaffoldYAML_APIVersionSpecUsesFileScalar(t *testing.T) {
 	}
 }
 
+func TestAPIDocumentExplainAndScaffoldGuideEffectiveTitle(t *testing.T) {
+	t.Parallel()
+
+	title, err := ResolveExplainSubject("api.documents.title")
+	require.NoError(t, err)
+	assert.False(t, title.FieldRequired)
+	assert.True(t, title.FieldRecommended)
+	assert.Contains(
+		t,
+		title.Node.Notes,
+		"A title must be provided either in this field or in the content YAML frontmatter.",
+	)
+
+	document, err := ResolveExplainSubject("api.documents")
+	require.NoError(t, err)
+	scaffold, err := RenderScaffoldYAML(document)
+	require.NoError(t, err)
+	assert.Contains(t, scaffold, "        title: value")
+	assert.NotContains(t, scaffold, "        # title: value")
+}
+
 func TestRenderScaffoldYAML_ApplicationAuthStrategyUnion(t *testing.T) {
 	subject, err := ResolveExplainSubject("application_auth_strategies")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- recommend an explicit API document title in explain and scaffold output
- accept titles normalized from content YAML frontmatter
- reject nested and root API documents with no effective title before planning
- preserve title as a required planner-to-executor create field

## Rationale

Konnect requires a document title either in the request body or in Markdown frontmatter. kongctl already normalizes frontmatter metadata, but its explain/scaffold guidance and resource validation allowed plain content without a title to produce a plan that apply later rejected.

This change makes scaffold output valid by default and enforces the effective-title invariant after frontmatter normalization, before planning.

Fixes #1947

## Testing

- `go fix ./...`
- `make format`
- `make build`
- `make test`
- `make test-integration`
- `golangci-lint run ./internal/declarative/resources/... ./internal/declarative/loader/... ./internal/declarative/planner/... ./internal/declarative/executor/...`
- manual `kongctl scaffold api.documents` and `kongctl explain api.documents.title -o json` inspection

Full `make lint` currently reports unrelated existing findings in generated portal-client code and two mock files.