### PR TITLE
fix(declarative): require explicit AI Gateway policy display name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,6 +331,9 @@ after making changes to catch regressions.
   another user-supplied field.
 - Only documented, literal API defaults may be applied automatically. Hidden
   cross-field defaults are prohibited.
+- Existing `name`-from-`ref` fallbacks are legacy behavior, not a pattern to
+  copy. Changes to those fallbacks require separately scoped compatibility
+  work.
 
 ## Testing Guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,6 +324,14 @@ after making changes to catch regressions.
   JSON/YAML tags, and external schema field names as literals unless they are
   also used as an internal contract identifier.
 
+### Declarative Defaults
+
+- Required API fields must be explicitly stated in declarative manifests.
+- `SetDefaults()` must not derive a required field from `ref`, `name`, or
+  another user-supplied field.
+- Only documented, literal API defaults may be applied automatically. Hidden
+  cross-field defaults are prohibited.
+
 ## Testing Guidelines
 
 - Place tests in `*_test.go` with `TestXxx` functions.

--- a/docs/contributor/declarative-resource-implementation-guide.md
+++ b/docs/contributor/declarative-resource-implementation-guide.md
@@ -118,6 +118,17 @@ Saved plans are not migrated between payload contracts. Kongctl accepts only
 the current plan version and rejects structurally incompatible plans before
 execution with guidance to regenerate the plan.
 
+### DECLARATIVE DEFAULTS
+
+Required API fields must be explicitly stated in the manifest. `SetDefaults()`
+must not derive a required field from `ref`, `name`, or another user-supplied
+field. Hidden cross-field defaults make incomplete manifests appear valid and
+can cause kongctl to differ from an equivalent direct API request.
+
+Only documented, literal API defaults may be applied automatically. For
+example, a documented `enabled: true` default is eligible; copying `name` into
+`display_name` is not.
+
 ### LOGGING & DIAGNOSTICS
 - Always add verbose `slog` debug statements when introducing a new planner or executor path. Helpful patterns:
   - Planner: log when you fetch existing resources, how many desired items you saw, and each change you enqueue.

--- a/docs/contributor/declarative-resource-implementation-guide.md
+++ b/docs/contributor/declarative-resource-implementation-guide.md
@@ -129,6 +129,11 @@ Only documented, literal API defaults may be applied automatically. For
 example, a documented `enabled: true` default is eligible; copying `name` into
 `display_name` is not.
 
+Some existing resources default `name` from `ref` for compatibility. Treat
+that as legacy behavior, not an implementation pattern. Removing those
+fallbacks requires separately scoped compatibility work; do not copy them into
+new or expanded declarative resources.
+
 ### LOGGING & DIAGNOSTICS
 - Always add verbose `slog` debug statements when introducing a new planner or executor path. Helpful patterns:
   - Planner: log when you fetch existing resources, how many desired items you saw, and each change you enqueue.

--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -399,6 +399,10 @@ inherit
 management scope from their parent resource and do not accept `kongctl`
 metadata.
 
+For AI Gateway Policies, `display_name` must be explicitly provided in both
+nested and root-level declarations; kongctl does not infer it from `name` or
+`ref`.
+
 For AI Gateway Models, `targets[].provider` must match an AI Gateway
 Model Provider `name` under the parent gateway. The model provider can already
 exist or be declared in the same gateway configuration.
@@ -654,8 +658,6 @@ ai_gateway_identity_providers:
 
 AI Gateway Policies can also be declared as root resources. Root-level policy
 declarations must identify the parent AI Gateway with `ai_gateway`.
-The `display_name` field must be explicitly provided; kongctl does not infer it
-from `name` or `ref`.
 
 ```yaml
 ai_gateway_policies:

--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -654,6 +654,8 @@ ai_gateway_identity_providers:
 
 AI Gateway Policies can also be declared as root resources. Root-level policy
 declarations must identify the parent AI Gateway with `ai_gateway`.
+The `display_name` field must be explicitly provided; kongctl does not infer it
+from `name` or `ref`.
 
 ```yaml
 ai_gateway_policies:

--- a/internal/declarative/loader/ai_gateway_policy_test.go
+++ b/internal/declarative/loader/ai_gateway_policy_test.go
@@ -41,6 +41,34 @@ func TestLoaderExtractsNestedAIGatewayPolicies(t *testing.T) {
 	))
 }
 
+func TestLoaderRejectsAIGatewayPolicyWithoutDisplayName(t *testing.T) {
+	tests := map[string]string{
+		"omitted": "",
+		"empty":   "        display_name: ''\n",
+	}
+
+	for name, displayName := range tests {
+		t.Run(name, func(t *testing.T) {
+			input := `
+ai_gateways:
+  - ref: support-gateway
+    display_name: Support Gateway
+    policies:
+      - ref: post-function
+        name: post-function
+        type: post-function
+` + displayName + `        config:
+          access:
+            - 'kong.log.info("hello world")'
+`
+
+			_, err := New().LoadFromSources([]Source{{Path: writeLoaderTestFile(t, input), Type: SourceTypeFile}}, false)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "display_name is required for AI Gateway policy post-function")
+		})
+	}
+}
+
 func TestLoaderValidatesAIGatewayPolicyParentAndDuplicates(t *testing.T) {
 	rootOnly := `
 ai_gateway_policies:

--- a/internal/declarative/planner/ai_gateway_policy_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_policy_planner_test.go
@@ -47,6 +47,7 @@ func TestAIGatewayPolicyPlannerCreatesChildForExistingGateway(t *testing.T) {
 	require.Equal(t, "gateway-id", change.Parent.ID)
 	require.Equal(t, "support-gateway", change.Parent.Ref)
 	require.Equal(t, "ai-sanitizer", change.Fields[FieldType])
+	require.Equal(t, "Mask Sensitive Data", change.Fields[FieldDisplayName])
 }
 
 func TestAIGatewayPolicyPlannerUpdatesExistingPolicy(t *testing.T) {

--- a/internal/declarative/resources/ai_gateway_policy.go
+++ b/internal/declarative/resources/ai_gateway_policy.go
@@ -119,9 +119,6 @@ func (a *AIGatewayPolicyResource) SetDefaults() {
 	if a.Name == "" {
 		a.Name = a.Ref
 	}
-	if a.DisplayName == "" {
-		a.DisplayName = a.Name
-	}
 	enabled := true
 	if a.Enabled == nil {
 		a.Enabled = &enabled

--- a/internal/declarative/resources/ai_gateway_policy_test.go
+++ b/internal/declarative/resources/ai_gateway_policy_test.go
@@ -53,7 +53,8 @@ func TestAIGatewayPolicyResourceDefaults(t *testing.T) {
 	policy.SetDefaults()
 
 	require.Equal(t, "mask-sensitive-data", policy.Name)
-	require.Equal(t, "mask-sensitive-data", policy.DisplayName)
+	require.Empty(t, policy.DisplayName)
+	require.ErrorContains(t, policy.Validate(), "display_name is required")
 	require.NotNil(t, policy.Enabled)
 	require.True(t, *policy.Enabled)
 	require.NotNil(t, policy.Global)


### PR DESCRIPTION
## Summary

- stop deriving AI Gateway policy display_name from name
- reject omitted or empty display_name during declarative loading
- document the prohibition on hidden cross-field defaults

## Rationale

Konnect requires display_name, but kongctl previously synthesized it before validation. Requiring the manifest to state the value keeps declarative behavior aligned with the API contract.

## Testing

- go fix ./...
- make format
- make build
- make test-all

Closes #1971