### PR TITLE
feat(declarative): add reusable configuration templates

### DIFF
--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -35,6 +35,30 @@ _defaults:
     protected: false
 ```
 
+## Configuration templates (`_templates` and `_extends`)
+
+Define reusable configuration blocks under the top-level `_templates` key and
+select one from a resource or nested configuration block with `_extends`:
+
+```yaml
+_templates:
+  private-portal:
+    authentication_enabled: true
+    default_api_visibility: private
+
+portals:
+  - _extends: private-portal
+    ref: developer-portal
+    name: Developer Portal
+```
+
+Templates are shared across all sources loaded by one command. Consumer
+configuration blocks recursively override inherited configuration blocks;
+scalars, sequences, explicit `null`, and values of a different type replace the
+inherited value. Sequences never append. See
+[Configuration Templates](declarative.md#configuration-templates) for
+inheritance, discovery, merge, tag, and sync-scope behavior.
+
 ## YAML Tags
 
 Use YAML tags in field values to load files or reference other resources.

--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -13,6 +13,7 @@ For supported resource types and field-level resource definitions see the [Decla
 - [Resource Types](#supported-resource-types)
 - [Configuration Structure](#configuration-structure)
 - [Kongctl Metadata](#kongctl-metadata)
+- [Configuration Templates](#configuration-templates)
 - [YAML Tags](#yaml-tags)
 - [Commands Reference](#commands-reference)
 - [CI/CD Integration](#cicd-integration)
@@ -602,6 +603,163 @@ provider that consumes a populated secret with a Vault reference.
 [config-store-vault-example]:
   examples/declarative/ai-gateway/config-store-vault.yaml
 
+## Configuration Templates
+
+Use a top-level `_templates` configuration block to define named, reusable
+configuration blocks. Add `_extends` to a resource or nested configuration
+block to merge one named template into that block. Both keys are authoring
+constructs: `kongctl` removes them before validation, planning, or sending
+configuration to an API.
+
+Templates apply to any resource configuration block. For example, a shared
+Portal parent configuration and Portal Page child configuration can be used
+together:
+
+```yaml
+_templates:
+  standard-developer-portal:
+    authentication_enabled: true
+    rbac_enabled: true
+    default_api_visibility: private
+    default_page_visibility: private
+    labels:
+      managed-by: kongctl
+      experience: standard
+
+  published-guide-page:
+    visibility: public
+    status: published
+    description: Developer documentation
+
+portals:
+  - _extends: standard-developer-portal
+    ref: payments-portal
+    name: Payments Developer Portal
+    display_name: Payments APIs
+    labels:
+      business-unit: payments
+    pages:
+      - _extends: published-guide-page
+        ref: payments-getting-started
+        slug: getting-started
+        title: Getting Started
+        content: !file ./pages/payments-getting-started.md
+```
+
+The effective Portal labels contain `managed-by`, `experience`, and
+`business-unit`. A child template can also be used in a root-level declaration:
+
+```yaml
+portal_pages:
+  - _extends: published-guide-page
+    ref: payments-authentication
+    portal: payments-portal
+    slug: authentication
+    title: Authentication
+    content: !file ./pages/authentication.md
+```
+
+Expansion is independent of field names and resource types. The following AI
+Gateway example reuses both policy fields and the policy's nested `config`
+configuration block. The `config` key has no special template behavior.
+
+```yaml
+_templates:
+  corporate-oidc-config:
+    issuer: https://auth.example.com
+    auth_methods: [bearer]
+    bearer_token_param_type: [header]
+    consumer_optional: false
+    hide_credentials: true
+
+  standard-oidc-policy:
+    type: openid-connect
+    enabled: true
+    global: false
+    config:
+      _extends: corporate-oidc-config
+
+ai_gateways:
+  - ref: shared-ai-gateway
+    name: shared-ai-gateway
+    display_name: Shared AI Gateway
+    policies:
+      - _extends: standard-oidc-policy
+        ref: payments-oidc
+        name: payments-oidc
+        display_name: Payments OIDC
+        config:
+          groups_required: [payments-api-users]
+
+      - _extends: standard-oidc-policy
+        ref: reporting-oidc
+        name: reporting-oidc
+        display_name: Reporting OIDC
+        config:
+          groups_required: [reporting-api-users]
+```
+
+### Template discovery and inheritance
+
+All files supplied to one command share one template registry. This includes
+explicit files, recursively discovered directory files, standard input, and
+HTTP or HTTPS sources. A template-only file is valid when it is loaded with at
+least one resource file:
+
+```shell
+kongctl plan -f templates.yaml -f portals.yaml
+kongctl plan -f ./configuration --recursive
+```
+
+`kongctl` does not search files outside the supplied source set. Template names
+must be non-empty strings and must be unique across that source set. Duplicate
+names are errors even when the definitions are identical or unused.
+
+A template can extend another template:
+
+```yaml
+_templates:
+  standard-portal:
+    authentication_enabled: true
+    default_api_visibility: private
+
+  restricted-portal:
+    _extends: standard-portal
+    rbac_enabled: true
+```
+
+Each configuration block can extend exactly one template. Circular inheritance
+and unknown template names are errors. Templates may define identity fields
+such as `ref` and `name`, but each consumer must override them when uniqueness
+is required.
+
+### Merge rules
+
+The consumer configuration block takes precedence over the template:
+
+| Template and consumer values | Result |
+| --- | --- |
+| Both configuration blocks | Recursively merge their keys |
+| Consumer scalar | Replace the template value |
+| Consumer sequence | Replace the complete template sequence |
+| Consumer explicit `null` | Replace the template value with `null` |
+| Consumer key omitted | Retain the template value |
+| Different value types | Replace with the consumer value |
+
+Sequences never append or merge by element. A template definition must be a
+configuration block; a sequence can be inherited only as a value within that
+block. Individual configuration blocks inside a sequence can use `_extends`.
+
+Templates are expanded before normal schema validation and sync-scope capture.
+An inherited empty child collection therefore has the same sync behavior as an
+empty collection written directly on the resource. YAML tags in a template use
+the template definition file's context, so a relative `!file` path is relative
+to that file. Deferred `!env` and `!secret` values retain their existing
+behavior after expansion.
+
+`_templates` is separate from `_defaults`: templates are selected explicitly
+and shared across the source set, while defaults remain automatic and
+file-local. `_extends` is not interpreted inside `_defaults`.
 
 ## YAML Tags
 

--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -526,6 +526,9 @@ Important notes for deck integration:
   resources owned by other deck files. kongctl does not inject select tags for you.
 - Relative deck file paths are resolved relative to the declarative config file and must remain within the
   `--base-dir` boundary (default: the config file directory).
+- When `_deck.files` is inherited from a template, its paths remain relative to
+  the file containing the consuming control plane. Unlike a `!file` tag, a deck
+  file path is not resolved in the template definition's context.
 - Plan files store deck base directories relative to the plan file location. When emitting a plan to stdout,
   the base directory is made relative to the current working directory (use `--output-file` for portable plans).
   Applying a plan resolves them from the plan file directory (or the current working directory when using `--plan -`).

--- a/docs/examples/declarative/ai-gateway/README.md
+++ b/docs/examples/declarative/ai-gateway/README.md
@@ -14,6 +14,9 @@ Gateway resources.
 - [openai-llm](openai-llm) creates an AI Gateway, an OpenAI provider, a model,
   and a data plane certificate, then runs a local Docker data plane and sends
   an OpenAI-compatible chat request through it.
+- [templates](templates) centralizes model token costs used by AI Rate Limiting
+  Advanced, then applies the shared costs and policy across multiple AI model
+  resources.
 - [config-store-vault.yaml](config-store-vault.yaml) connects a nested Config
   Store to a Konnect Vault with `!ref`, then uses a Vault reference for an
   OpenAI provider authorization header.

--- a/docs/examples/declarative/ai-gateway/templates/README.md
+++ b/docs/examples/declarative/ai-gateway/templates/README.md
@@ -1,0 +1,81 @@
+# AI Gateway Configuration Templates
+
+This example uses configuration templates to keep OpenAI token costs and an
+AI Rate Limiting Advanced policy in one place.
+
+- `costs.yaml` defines reusable model and policy configuration blocks under
+  `_templates`.
+- `ai-gateway.yaml` defines an OpenAI provider, two models, and a policy that
+  use those templates through `_extends`.
+
+Both model targets inherit the same token costs while retaining their own model
+configuration. Updating a price in `costs.yaml` updates every target that
+extends `gpt-4o-token-costs` the next time the configuration is applied.
+
+The OpenAI authorization header is a deferred secret. `!env` reads
+`OPENAI_API_KEY`, while `!secret` combines it with the `Bearer ` prefix and
+prevents the resulting value from appearing in a plan.
+
+## Preview the configuration
+
+Run the plan with both files so kongctl can discover the templates and the
+resources that use them:
+
+```sh
+kongctl plan \
+  --mode apply \
+  -f costs.yaml \
+  -f ai-gateway.yaml \
+  --output-file template-plan.json
+```
+
+`OPENAI_API_KEY` is not required when creating the plan because secret
+resolution is deferred until apply. Inspect the expanded resources:
+
+```sh
+jq '
+  .changes[]
+  | select(
+      .resource_ref == "customer-support"
+      or .resource_ref == "document-review"
+      or .resource_ref == "hourly-model-cost-budget"
+    )
+  | {resource_ref, fields}
+' template-plan.json
+```
+
+The two models contain the same inherited token costs. `_templates` and
+`_extends` do not appear in the plan.
+
+## Apply the configuration
+
+Set the OpenAI key only when you are ready to apply the configuration:
+
+```sh
+export OPENAI_API_KEY='your-openai-api-key'
+
+kongctl apply \
+  -f costs.yaml \
+  -f ai-gateway.yaml \
+  --write-secrets
+```
+
+Review the plan and confirm the apply when prompted.
+
+## Update a shared price
+
+Change `input_cost` in `gpt-4o-token-costs`, then run a diff with the same
+source set. Both model resources receive the new price without per-model edits:
+
+```sh
+sed 's/input_cost: 2.50/input_cost: 3.00/' \
+  costs.yaml > costs-updated.yaml
+
+kongctl diff \
+  --mode apply \
+  -f costs-updated.yaml \
+  -f ai-gateway.yaml
+```
+
+Use either `costs.yaml` or `costs-updated.yaml` in a command, not both, because
+template identifiers must be unique across the complete source set.

--- a/docs/examples/declarative/ai-gateway/templates/ai-gateway.yaml
+++ b/docs/examples/declarative/ai-gateway/templates/ai-gateway.yaml
@@ -1,0 +1,83 @@
+_defaults:
+  kongctl:
+    namespace: ai-gateway-templates-example
+
+ai_gateways:
+  - ref: shared-cost-gateway
+    name: shared-cost-gateway
+    display_name: Shared Cost Gateway
+    description: Centralizes model token costs for cost-based rate limiting
+    proxy_urls:
+      - host: shared-cost-gateway.example.com
+        port: 443
+        protocol: https
+    labels:
+      example: templates
+
+    model_providers:
+      - ref: openai-provider
+        name: openai-provider
+        display_name: OpenAI
+        type: openai
+        config:
+          auth:
+            type: basic
+            headers:
+              - name: Authorization
+                value: !secret
+                  parts:
+                    - "Bearer "
+                    - !env OPENAI_API_KEY
+
+    models:
+      - ref: customer-support
+        name: customer-support
+        display_name: Customer Support
+        type: model
+        formats:
+          - type: openai
+        config:
+          route:
+            model:
+              body_param: model
+              values:
+                - customer-support
+        targets:
+          - name: gpt-4o
+            provider: openai-provider
+            config:
+              _extends: gpt-4o-token-costs
+              type: openai
+        policies:
+          - !ref hourly-model-cost-budget#name
+        capabilities:
+          - generate
+
+      - ref: document-review
+        name: document-review
+        display_name: Document Review
+        type: model
+        formats:
+          - type: openai
+        config:
+          route:
+            model:
+              body_param: model
+              values:
+                - document-review
+        targets:
+          - name: gpt-4o
+            provider: openai-provider
+            config:
+              type: openai
+              _extends: gpt-4o-token-costs
+        policies:
+          - !ref hourly-model-cost-budget#name
+        capabilities:
+          - generate
+
+    policies:
+      - _extends: hourly-model-cost-budget
+        ref: hourly-model-cost-budget
+        name: hourly-model-cost-budget
+        display_name: Hourly Model Cost Budget

--- a/docs/examples/declarative/ai-gateway/templates/costs.yaml
+++ b/docs/examples/declarative/ai-gateway/templates/costs.yaml
@@ -1,0 +1,25 @@
+_templates:
+  gpt-4o-token-costs:
+    # Illustrative USD cost per one million tokens. Update these values when
+    # the model price changes; every target extending this template is updated.
+    input_cost: 2.50
+    output_cost: 10.00
+
+  hourly-model-cost-budget:
+    type: ai-rate-limiting-advanced
+    enabled: true
+    global: false
+    labels:
+      managed-by: kongctl
+      purpose: model-cost-budget
+    config:
+      strategy: local
+      window_type: sliding
+      policies:
+        - match:
+            - type: model
+              partition_by: true
+          limits:
+            - limit: 25
+              window_size: 3600
+              tokens_count_strategy: cost

--- a/internal/declarative/loader/config_templates.go
+++ b/internal/declarative/loader/config_templates.go
@@ -1,0 +1,433 @@
+package loader
+
+import (
+	"bytes"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"gopkg.in/yaml.v3" //nolint:gomodguard_v2 // yaml.v3 is required to preserve source locations while expanding templates
+)
+
+const (
+	templatesKey = "_templates"
+	extendsKey   = "_extends"
+)
+
+type configTemplate struct {
+	sourcePath string
+	node       *yaml.Node
+}
+
+type configTemplateRegistry struct {
+	definitions  map[string]configTemplate
+	resolved     map[string]*yaml.Node
+	resolvedUses map[string]map[string]configTemplate
+	resolving    map[string]int
+	stack        []string
+	currentUses  map[string]configTemplate
+}
+
+type configTemplateDocument struct {
+	content       []byte
+	sourcePath    string
+	document      yaml.Node
+	usedTemplates map[string]configTemplate
+}
+
+func newConfigTemplateRegistry() *configTemplateRegistry {
+	return &configTemplateRegistry{
+		definitions:  make(map[string]configTemplate),
+		resolved:     make(map[string]*yaml.Node),
+		resolvedUses: make(map[string]map[string]configTemplate),
+		resolving:    make(map[string]int),
+	}
+}
+
+func expandConfigTemplateDocuments(documents []*configTemplateDocument) error {
+	registry := newConfigTemplateRegistry()
+	for _, document := range documents {
+		if err := yaml.Unmarshal(document.content, &document.document); err != nil {
+			return fmt.Errorf("failed to parse YAML for template expansion in %s: %w", document.sourcePath, err)
+		}
+		if err := registry.collect(&document.document, document.sourcePath); err != nil {
+			return err
+		}
+	}
+	if err := registry.resolveDefinitions(); err != nil {
+		return err
+	}
+
+	for _, document := range documents {
+		if isEmptyYAMLDocument(&document.document) {
+			continue
+		}
+		document.usedTemplates = make(map[string]configTemplate)
+		registry.currentUses = document.usedTemplates
+		if err := registry.expandDocument(&document.document, document.sourcePath); err != nil {
+			return err
+		}
+		registry.currentUses = nil
+
+		var result bytes.Buffer
+		encoder := yaml.NewEncoder(&result)
+		encoder.SetIndent(2)
+		if err := encoder.Encode(&document.document); err != nil {
+			return fmt.Errorf("failed to encode expanded YAML in %s: %w", document.sourcePath, err)
+		}
+		document.content = result.Bytes()
+	}
+	return nil
+}
+
+func (r *configTemplateRegistry) resolveDefinitions() error {
+	names := make([]string, 0, len(r.definitions))
+	for name := range r.definitions {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
+	for _, name := range names {
+		definition := r.definitions[name]
+		if _, err := r.resolve(
+			name,
+			definition.sourcePath,
+			[]string{templatesKey, name},
+			definition.node,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *configTemplateRegistry) collect(document *yaml.Node, sourcePath string) error {
+	root, err := documentMapping(document, sourcePath)
+	if err != nil {
+		return err
+	}
+	if root == nil {
+		return nil
+	}
+
+	var registryKey *yaml.Node
+	for i := 0; i+1 < len(root.Content); {
+		if root.Content[i].Value != templatesKey {
+			i += 2
+			continue
+		}
+		if registryKey != nil {
+			return nodeError(
+				root.Content[i],
+				sourcePath,
+				"duplicate %s key; first declared at line %d, column %d",
+				templatesKey,
+				registryKey.Line,
+				registryKey.Column,
+			)
+		}
+		registryKey = root.Content[i]
+
+		templates := root.Content[i+1]
+		if templates.Kind != yaml.MappingNode {
+			return nodeError(templates, sourcePath, "%s must be a configuration block", templatesKey)
+		}
+		for j := 0; j+1 < len(templates.Content); j += 2 {
+			nameNode := templates.Content[j]
+			valueNode := templates.Content[j+1]
+			name := strings.TrimSpace(nameNode.Value)
+			if nameNode.Kind != yaml.ScalarNode || nameNode.Tag != "!!str" || name == "" {
+				return nodeError(nameNode, sourcePath, "template names must be non-empty strings")
+			}
+			if valueNode.Kind != yaml.MappingNode {
+				return nodeError(valueNode, sourcePath, "template %q must be a configuration block", name)
+			}
+			if previous, ok := r.definitions[name]; ok {
+				return nodeError(
+					nameNode,
+					sourcePath,
+					"duplicate template %q; first defined in %s at line %d, column %d",
+					name,
+					previous.sourcePath,
+					previous.node.Line,
+					previous.node.Column,
+				)
+			}
+			r.definitions[name] = configTemplate{sourcePath: sourcePath, node: valueNode}
+		}
+
+		root.Content = append(root.Content[:i], root.Content[i+2:]...)
+	}
+	return nil
+}
+
+func (r *configTemplateRegistry) expandDocument(document *yaml.Node, sourcePath string) error {
+	root, err := documentMapping(document, sourcePath)
+	if err != nil {
+		return err
+	}
+	if root == nil {
+		return nil
+	}
+	if _, _, ok := mappingValue(root, extendsKey); ok {
+		return nodeError(root, sourcePath, "%s is not supported at the document root", extendsKey)
+	}
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		key := root.Content[i].Value
+		if key == "_defaults" {
+			continue
+		}
+		if err := r.expandNode(root.Content[i+1], sourcePath, []string{key}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *configTemplateRegistry) expandNode(node *yaml.Node, sourcePath string, path []string) error {
+	if node == nil {
+		return nil
+	}
+
+	switch node.Kind {
+	case yaml.DocumentNode:
+		for _, child := range node.Content {
+			if err := r.expandNode(child, sourcePath, path); err != nil {
+				return err
+			}
+		}
+	case yaml.SequenceNode:
+		for i, child := range node.Content {
+			if err := r.expandNode(child, sourcePath, append(path, fmt.Sprintf("[%d]", i))); err != nil {
+				return err
+			}
+		}
+	case yaml.MappingNode:
+		if _, nestedTemplates, ok := mappingValue(node, templatesKey); ok {
+			return nodeError(
+				nestedTemplates,
+				sourcePath,
+				"%s is only supported at the document root, not at %s",
+				templatesKey,
+				declarativeTemplatePath(path),
+			)
+		}
+		if keyIndex, extends, ok := mappingValue(node, extendsKey); ok {
+			if extends.Kind != yaml.ScalarNode || extends.Tag != "!!str" || strings.TrimSpace(extends.Value) == "" {
+				return nodeError(
+					extends,
+					sourcePath,
+					"%s at %s must name one template",
+					extendsKey,
+					declarativeTemplatePath(path),
+				)
+			}
+			base, err := r.resolve(strings.TrimSpace(extends.Value), sourcePath, path, extends)
+			if err != nil {
+				return err
+			}
+			local := cloneYAMLNode(node)
+			local.Content = append(local.Content[:keyIndex], local.Content[keyIndex+2:]...)
+			merged, err := mergeTemplateMappings(base, local)
+			if err != nil {
+				return nodeError(node, sourcePath, "failed to merge template at %s: %v", declarativeTemplatePath(path), err)
+			}
+			*node = *merged
+		}
+
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := node.Content[i].Value
+			if err := r.expandNode(node.Content[i+1], sourcePath, append(path, key)); err != nil {
+				return err
+			}
+		}
+	case yaml.ScalarNode, yaml.AliasNode:
+		return nil
+	}
+	return nil
+}
+
+func (r *configTemplateRegistry) resolve(
+	name string,
+	consumerSource string,
+	consumerPath []string,
+	reference *yaml.Node,
+) (*yaml.Node, error) {
+	if resolved, ok := r.resolved[name]; ok {
+		r.recordTemplateUses(name)
+		return cloneYAMLNode(resolved), nil
+	}
+	definition, ok := r.definitions[name]
+	if !ok {
+		return nil, nodeError(
+			reference,
+			consumerSource,
+			"unknown template %q referenced at %s",
+			name,
+			declarativeTemplatePath(consumerPath),
+		)
+	}
+	if start, ok := r.resolving[name]; ok {
+		cycle := append(append([]string(nil), r.stack[start:]...), name)
+		return nil, nodeError(
+			reference,
+			consumerSource,
+			"template inheritance cycle detected: %s",
+			strings.Join(cycle, " -> "),
+		)
+	}
+
+	r.resolving[name] = len(r.stack)
+	r.stack = append(r.stack, name)
+	consumerUses := r.currentUses
+	definitionUses := make(map[string]configTemplate)
+	r.currentUses = definitionUses
+	resolved := cloneYAMLNode(definition.node)
+	err := r.expandNode(resolved, definition.sourcePath, []string{templatesKey, name})
+	r.currentUses = consumerUses
+	r.stack = r.stack[:len(r.stack)-1]
+	delete(r.resolving, name)
+	if err != nil {
+		return nil, err
+	}
+	r.resolved[name] = resolved
+	r.resolvedUses[name] = definitionUses
+	r.recordTemplateUses(name)
+	return cloneYAMLNode(resolved), nil
+}
+
+func (r *configTemplateRegistry) recordTemplateUses(name string) {
+	if r.currentUses == nil {
+		return
+	}
+	if definition, ok := r.definitions[name]; ok {
+		r.currentUses[name] = definition
+	}
+	maps.Copy(r.currentUses, r.resolvedUses[name])
+}
+
+func mergeTemplateMappings(base, local *yaml.Node) (*yaml.Node, error) {
+	if base.Kind != yaml.MappingNode || local.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("template and consumer values must be configuration blocks")
+	}
+
+	result := cloneYAMLNode(base)
+	for i := 0; i+1 < len(local.Content); i += 2 {
+		localKey := local.Content[i]
+		localValue := local.Content[i+1]
+		baseIndex, baseValue, ok := mappingValue(result, localKey.Value)
+		if ok && baseValue.Kind == yaml.MappingNode && localValue.Kind == yaml.MappingNode {
+			merged, err := mergeTemplateMappings(baseValue, localValue)
+			if err != nil {
+				return nil, err
+			}
+			result.Content[baseIndex] = cloneYAMLNode(localKey)
+			result.Content[baseIndex+1] = merged
+			continue
+		}
+		if ok {
+			result.Content[baseIndex] = cloneYAMLNode(localKey)
+			result.Content[baseIndex+1] = cloneYAMLNode(localValue)
+			continue
+		}
+		result.Content = append(result.Content, cloneYAMLNode(localKey), cloneYAMLNode(localValue))
+	}
+	return result, nil
+}
+
+func documentMapping(document *yaml.Node, sourcePath string) (*yaml.Node, error) {
+	if isEmptyYAMLDocument(document) {
+		return nil, nil
+	}
+	if document == nil || document.Kind != yaml.DocumentNode || len(document.Content) != 1 {
+		return nil, fmt.Errorf("declarative document in %s must contain one YAML document", sourcePath)
+	}
+	root := document.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return nil, nodeError(root, sourcePath, "declarative document must be a mapping")
+	}
+	return root, nil
+}
+
+func isEmptyYAMLDocument(document *yaml.Node) bool {
+	if document == nil || document.Kind == 0 || len(document.Content) == 0 {
+		return true
+	}
+	return document.Kind == yaml.DocumentNode && len(document.Content) == 1 &&
+		document.Content[0].Kind == yaml.ScalarNode && document.Content[0].Tag == "!!null"
+}
+
+func mappingValue(mapping *yaml.Node, key string) (int, *yaml.Node, bool) {
+	if mapping == nil || mapping.Kind != yaml.MappingNode {
+		return 0, nil, false
+	}
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			return i, mapping.Content[i+1], true
+		}
+	}
+	return 0, nil, false
+}
+
+func cloneYAMLNode(node *yaml.Node) *yaml.Node {
+	if node == nil {
+		return nil
+	}
+	clone := *node
+	clone.Content = make([]*yaml.Node, len(node.Content))
+	for i, child := range node.Content {
+		clone.Content[i] = cloneYAMLNode(child)
+	}
+	return &clone
+}
+
+func nodeError(node *yaml.Node, sourcePath, format string, args ...any) error {
+	message := fmt.Sprintf(format, args...)
+	if node != nil && node.Line > 0 {
+		return fmt.Errorf("%s in %s at line %d, column %d", message, sourcePath, node.Line, node.Column)
+	}
+	return fmt.Errorf("%s in %s", message, sourcePath)
+}
+
+func declarativeTemplatePath(path []string) string {
+	if len(path) == 0 {
+		return "<document>"
+	}
+	var result strings.Builder
+	for i, part := range path {
+		if strings.HasPrefix(part, "[") {
+			result.WriteString(part)
+			continue
+		}
+		if i > 0 {
+			result.WriteByte('.')
+		}
+		result.WriteString(part)
+	}
+	return result.String()
+}
+
+func templateDefinitionContext(definitions map[string]configTemplate) string {
+	if len(definitions) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(definitions))
+	for name := range definitions {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
+	parts := make([]string, 0, len(names))
+	for _, name := range names {
+		definition := definitions[name]
+		parts = append(parts, fmt.Sprintf(
+			"template %q defined in %s at line %d, column %d",
+			name,
+			definition.sourcePath,
+			definition.node.Line,
+			definition.node.Column,
+		))
+	}
+	return strings.Join(parts, "; ")
+}

--- a/internal/declarative/loader/config_templates.go
+++ b/internal/declarative/loader/config_templates.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/kong/kongctl/internal/declarative/tags"
 	"gopkg.in/yaml.v3" //nolint:gomodguard_v2 // yaml.v3 is required to preserve source locations while expanding templates
 )
 
@@ -54,13 +55,21 @@ func expandConfigTemplateDocuments(documents []*configTemplateDocument) error {
 		if err := registry.collect(&document.document, document.sourcePath); err != nil {
 			return err
 		}
+		document.document = yaml.Node{}
 	}
 	if err := registry.resolveDefinitions(); err != nil {
 		return err
 	}
 
 	for _, document := range documents {
+		if err := yaml.Unmarshal(document.content, &document.document); err != nil {
+			return fmt.Errorf("failed to parse YAML for template expansion in %s: %w", document.sourcePath, err)
+		}
+		if err := stripTemplateDefinitions(&document.document, document.sourcePath); err != nil {
+			return err
+		}
 		if isEmptyYAMLDocument(&document.document) {
+			document.document = yaml.Node{}
 			continue
 		}
 		document.usedTemplates = make(map[string]configTemplate)
@@ -77,6 +86,7 @@ func expandConfigTemplateDocuments(documents []*configTemplateDocument) error {
 			return fmt.Errorf("failed to encode expanded YAML in %s: %w", document.sourcePath, err)
 		}
 		document.content = result.Bytes()
+		document.document = yaml.Node{}
 	}
 	return nil
 }
@@ -154,10 +164,21 @@ func (r *configTemplateRegistry) collect(document *yaml.Node, sourcePath string)
 					previous.node.Column,
 				)
 			}
-			r.definitions[name] = configTemplate{sourcePath: sourcePath, node: valueNode}
+			r.definitions[name] = configTemplate{sourcePath: sourcePath, node: cloneYAMLNode(valueNode)}
 		}
 
 		root.Content = append(root.Content[:i], root.Content[i+2:]...)
+	}
+	return nil
+}
+
+func stripTemplateDefinitions(document *yaml.Node, sourcePath string) error {
+	root, err := documentMapping(document, sourcePath)
+	if err != nil || root == nil {
+		return err
+	}
+	if index, _, ok := mappingValue(root, templatesKey); ok {
+		root.Content = append(root.Content[:index], root.Content[index+2:]...)
 	}
 	return nil
 }
@@ -176,6 +197,15 @@ func (r *configTemplateRegistry) expandDocument(document *yaml.Node, sourcePath 
 	for i := 0; i+1 < len(root.Content); i += 2 {
 		key := root.Content[i].Value
 		if key == "_defaults" {
+			if extends, path, ok := findNestedMappingValue(root.Content[i+1], extendsKey, []string{key}); ok {
+				return nodeError(
+					extends,
+					sourcePath,
+					"%s is not supported inside _defaults at %s",
+					extendsKey,
+					declarativeTemplatePath(path),
+				)
+			}
 			continue
 		}
 		if err := r.expandNode(root.Content[i+1], sourcePath, []string{key}); err != nil {
@@ -214,7 +244,8 @@ func (r *configTemplateRegistry) expandNode(node *yaml.Node, sourcePath string, 
 			)
 		}
 		if keyIndex, extends, ok := mappingValue(node, extendsKey); ok {
-			if extends.Kind != yaml.ScalarNode || extends.Tag != "!!str" || strings.TrimSpace(extends.Value) == "" {
+			if extends.Kind != yaml.ScalarNode || extends.Tag != "!!str" ||
+				strings.TrimSpace(extends.Value) == "" || tags.IsEnvPlaceholder(extends.Value) {
 				return nodeError(
 					extends,
 					sourcePath,
@@ -246,6 +277,44 @@ func (r *configTemplateRegistry) expandNode(node *yaml.Node, sourcePath string, 
 		return nil
 	}
 	return nil
+}
+
+func findNestedMappingValue(node *yaml.Node, key string, path []string) (*yaml.Node, []string, bool) {
+	if node == nil {
+		return nil, nil, false
+	}
+	switch node.Kind {
+	case yaml.DocumentNode:
+		for _, child := range node.Content {
+			if value, valuePath, ok := findNestedMappingValue(child, key, path); ok {
+				return value, valuePath, true
+			}
+		}
+	case yaml.SequenceNode:
+		for i, child := range node.Content {
+			if value, valuePath, ok := findNestedMappingValue(
+				child,
+				key,
+				append(path, fmt.Sprintf("[%d]", i)),
+			); ok {
+				return value, valuePath, true
+			}
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			childKey := node.Content[i].Value
+			childPath := append(path, childKey)
+			if childKey == key {
+				return node.Content[i+1], childPath, true
+			}
+			if value, valuePath, ok := findNestedMappingValue(node.Content[i+1], key, childPath); ok {
+				return value, valuePath, true
+			}
+		}
+	case yaml.ScalarNode, yaml.AliasNode:
+		return nil, nil, false
+	}
+	return nil, nil, false
 }
 
 func (r *configTemplateRegistry) resolve(

--- a/internal/declarative/loader/config_templates_test.go
+++ b/internal/declarative/loader/config_templates_test.go
@@ -1,0 +1,590 @@
+package loader
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoaderExpandsSameFileResourceTemplate(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+_templates:
+  standard-portal:
+    authentication_enabled: true
+    rbac_enabled: true
+    default_api_visibility: private
+    default_page_visibility: private
+    labels:
+      managed-by: kongctl
+
+portals:
+  - ref: payments-portal
+    name: Payments Developer Portal
+    labels:
+      business-unit: payments
+    _extends: standard-portal
+`), 0o600))
+
+	rs, err := NewWithBaseDir(tmpDir).LoadFile(configFile)
+	require.NoError(t, err)
+	require.Len(t, rs.Portals, 1)
+
+	portal := rs.Portals[0]
+	require.NotNil(t, portal.AuthenticationEnabled)
+	assert.True(t, *portal.AuthenticationEnabled)
+	require.NotNil(t, portal.RbacEnabled)
+	assert.True(t, *portal.RbacEnabled)
+	require.NotNil(t, portal.DefaultAPIVisibility)
+	assert.Equal(t, "private", string(*portal.DefaultAPIVisibility))
+	require.NotNil(t, portal.DefaultPageVisibility)
+	assert.Equal(t, "private", string(*portal.DefaultPageVisibility))
+	require.NotNil(t, portal.Labels["managed-by"])
+	assert.Equal(t, "kongctl", *portal.Labels["managed-by"])
+	require.NotNil(t, portal.Labels["business-unit"])
+	assert.Equal(t, "payments", *portal.Labels["business-unit"])
+}
+
+func TestLoaderExpandsTemplateAcrossSourceFiles(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	templatesFile := filepath.Join(tmpDir, "templates.yaml")
+	require.NoError(t, os.WriteFile(templatesFile, []byte(`
+_templates:
+  standard-portal:
+    authentication_enabled: true
+    default_api_visibility: private
+    default_page_visibility: private
+`), 0o600))
+	portalsFile := filepath.Join(tmpDir, "portals.yaml")
+	require.NoError(t, os.WriteFile(portalsFile, []byte(`
+portals:
+  - _extends: standard-portal
+    ref: payments-portal
+    name: Payments Developer Portal
+`), 0o600))
+
+	rs, err := NewWithBaseDir(tmpDir).LoadFromSources([]Source{
+		{Path: templatesFile, Type: SourceTypeFile},
+		{Path: portalsFile, Type: SourceTypeFile},
+	}, false)
+	require.NoError(t, err)
+	require.Len(t, rs.Portals, 1)
+	require.NotNil(t, rs.Portals[0].AuthenticationEnabled)
+	assert.True(t, *rs.Portals[0].AuthenticationEnabled)
+}
+
+func TestLoaderDiscoversTemplatesRecursivelyInDirectorySource(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	sharedDir := filepath.Join(tmpDir, "shared")
+	require.NoError(t, os.MkdirAll(sharedDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(sharedDir, "templates.yaml"), []byte(`
+_templates:
+  standard-portal:
+    rbac_enabled: true
+`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "portals.yaml"), []byte(`
+portals:
+  - _extends: standard-portal
+    ref: docs
+    name: Docs
+`), 0o600))
+
+	rs, err := NewWithBaseDir(tmpDir).LoadFromSources([]Source{
+		{Path: tmpDir, Type: SourceTypeDirectory},
+	}, true)
+	require.NoError(t, err)
+	require.Len(t, rs.Portals, 1)
+	require.NotNil(t, rs.Portals[0].RbacEnabled)
+	assert.True(t, *rs.Portals[0].RbacEnabled)
+}
+
+func TestLoaderUsesTemplatesAcrossFileAndSTDINSources(t *testing.T) {
+	tmpDir := t.TempDir()
+	templatesFile := filepath.Join(tmpDir, "templates.yaml")
+	require.NoError(t, os.WriteFile(templatesFile, []byte(`
+_templates:
+  standard-portal:
+    authentication_enabled: true
+`), 0o600))
+
+	reader, writer, err := os.Pipe()
+	require.NoError(t, err)
+	originalStdin := os.Stdin
+	os.Stdin = reader
+	t.Cleanup(func() {
+		os.Stdin = originalStdin
+		require.NoError(t, reader.Close())
+	})
+	_, err = writer.Write([]byte(`
+portals:
+  - _extends: standard-portal
+    ref: docs
+    name: Docs
+`))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	rs, err := NewWithBaseDir(tmpDir).LoadFromSources([]Source{
+		{Path: templatesFile, Type: SourceTypeFile},
+		{Path: "-", Type: SourceTypeSTDIN},
+	}, false)
+	require.NoError(t, err)
+	require.Len(t, rs.Portals, 1)
+	require.NotNil(t, rs.Portals[0].AuthenticationEnabled)
+	assert.True(t, *rs.Portals[0].AuthenticationEnabled)
+}
+
+func TestLoaderDeepMergesAIGatewayPolicyTemplates(t *testing.T) {
+	t.Parallel()
+
+	path := writeLoaderTestFile(t, `
+_templates:
+  corporate-oidc-config:
+    issuer: https://auth.example.com
+    auth_methods: [session]
+    claims:
+      email: email
+      subject: sub
+    optional_setting: inherited
+    type_conflict:
+      nested: inherited
+  standard-oidc-policy:
+    type: openid-connect
+    enabled: true
+    global: false
+    config:
+      _extends: corporate-oidc-config
+
+ai_gateways:
+  - ref: shared-gateway
+    display_name: Shared Gateway
+    policies:
+      - _extends: standard-oidc-policy
+        ref: payments-oidc
+        name: payments-oidc
+        display_name: Payments OIDC
+        config:
+          auth_methods: [bearer]
+          claims:
+            groups: groups
+          optional_setting: null
+          type_conflict: replaced
+          groups_required: [payments-api-users]
+      - _extends: standard-oidc-policy
+        ref: reporting-oidc
+        name: reporting-oidc
+        display_name: Reporting OIDC
+        config:
+          groups_required: [reporting-api-users]
+`)
+
+	rs, err := New().LoadFromSources([]Source{{Path: path, Type: SourceTypeFile}}, false)
+	require.NoError(t, err)
+	require.Len(t, rs.AIGatewayPolicies, 2)
+
+	payments := rs.AIGatewayPolicies[0].Config
+	assert.Equal(t, "https://auth.example.com", payments["issuer"])
+	assert.Equal(t, []any{"bearer"}, payments["auth_methods"])
+	assert.Equal(t, map[string]any{
+		"email": "email", "subject": "sub", "groups": "groups",
+	}, payments["claims"])
+	assert.Nil(t, payments["optional_setting"])
+	assert.Equal(t, "replaced", payments["type_conflict"])
+	assert.Equal(t, []any{"payments-api-users"}, payments["groups_required"])
+
+	reporting := rs.AIGatewayPolicies[1].Config
+	assert.Equal(t, []any{"session"}, reporting["auth_methods"])
+	assert.Equal(t, "inherited", reporting["optional_setting"])
+	assert.Equal(t, map[string]any{"nested": "inherited"}, reporting["type_conflict"])
+	assert.Equal(t, []any{"reporting-api-users"}, reporting["groups_required"])
+}
+
+func TestLoaderRejectsInvalidTemplateReferences(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{
+			name: "unknown template",
+			input: `
+portals:
+  - _extends: missing-portal
+    ref: docs
+    name: Docs
+`,
+			wantErr: `unknown template "missing-portal" referenced at portals[0]`,
+		},
+		{
+			name: "non-configuration-block template",
+			input: `
+_templates:
+  invalid: [one, two]
+portals:
+  - _extends: invalid
+    ref: docs
+    name: Docs
+`,
+			wantErr: `template "invalid" must be a configuration block`,
+		},
+		{
+			name: "non-string reference",
+			input: `
+_templates:
+  standard: {authentication_enabled: true}
+portals:
+  - _extends: [standard]
+    ref: docs
+    name: Docs
+`,
+			wantErr: `_extends at portals[0] must name one template`,
+		},
+		{
+			name: "nested template registry",
+			input: `
+ai_gateways:
+  - ref: gateway
+    name: gateway
+    display_name: Gateway
+    config:
+      _templates:
+        nested: {enabled: true}
+`,
+			wantErr: `_templates is only supported at the document root, not at ai_gateways[0].config`,
+		},
+		{
+			name: "duplicate template registry",
+			input: `
+_templates:
+  first: {authentication_enabled: true}
+_templates:
+  second: {rbac_enabled: true}
+`,
+			wantErr: `duplicate _templates key`,
+		},
+		{
+			name: "transitive cycle",
+			input: `
+_templates:
+  first:
+    _extends: second
+  second:
+    nested:
+      _extends: third
+  third:
+    _extends: first
+portals:
+  - _extends: first
+    ref: docs
+    name: Docs
+`,
+			wantErr: "template inheritance cycle detected: first -> second -> third -> first",
+		},
+		{
+			name: "unused template with unknown base",
+			input: `
+_templates:
+  unused:
+    _extends: missing
+`,
+			wantErr: `unknown template "missing" referenced at _templates.unused`,
+		},
+		{
+			name: "unused template cycle",
+			input: `
+_templates:
+  first:
+    _extends: second
+  second:
+    _extends: first
+`,
+			wantErr: "template inheritance cycle detected: first -> second -> first",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path := writeLoaderTestFile(t, tt.input)
+			_, err := New().LoadFromSources([]Source{{Path: path, Type: SourceTypeFile}}, false)
+			require.ErrorContains(t, err, tt.wantErr)
+			require.ErrorContains(t, err, path)
+		})
+	}
+}
+
+func TestLoaderRejectsDuplicateTemplatesAcrossSourceFiles(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	first := filepath.Join(tmpDir, "first.yaml")
+	second := filepath.Join(tmpDir, "second.yaml")
+	for _, path := range []string{first, second} {
+		require.NoError(t, os.WriteFile(path, []byte(`
+_templates:
+  standard-portal:
+    authentication_enabled: true
+`), 0o600))
+	}
+
+	_, err := NewWithBaseDir(tmpDir).LoadFromSources([]Source{
+		{Path: first, Type: SourceTypeFile},
+		{Path: second, Type: SourceTypeFile},
+	}, false)
+	require.ErrorContains(t, err, `duplicate template "standard-portal"`)
+	require.ErrorContains(t, err, first)
+	require.ErrorContains(t, err, second)
+}
+
+func TestLoaderRejectsDuplicateTemplatesWithinSourceFile(t *testing.T) {
+	t.Parallel()
+
+	path := writeLoaderTestFile(t, `
+_templates:
+  standard-portal:
+    authentication_enabled: true
+  standard-portal:
+    rbac_enabled: true
+`)
+
+	_, err := New().LoadFromSources([]Source{{Path: path, Type: SourceTypeFile}}, false)
+	require.ErrorContains(t, err, `duplicate template "standard-portal"`)
+	require.ErrorContains(t, err, path)
+}
+
+func TestLoaderReportsTemplateDefinitionForInheritedSchemaError(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	templatesFile := filepath.Join(tmpDir, "templates.yaml")
+	require.NoError(t, os.WriteFile(templatesFile, []byte(`
+_templates:
+  standard-portal:
+    authentication_enabledd: true
+`), 0o600))
+	portalsFile := filepath.Join(tmpDir, "portals.yaml")
+	require.NoError(t, os.WriteFile(portalsFile, []byte(`
+portals:
+  - _extends: standard-portal
+    ref: docs
+    name: Docs
+`), 0o600))
+
+	_, err := NewWithBaseDir(tmpDir).LoadFromSources([]Source{
+		{Path: templatesFile, Type: SourceTypeFile},
+		{Path: portalsFile, Type: SourceTypeFile},
+	}, false)
+	require.ErrorContains(t, err, portalsFile)
+	require.ErrorContains(t, err, `template "standard-portal" defined in `+templatesFile)
+	require.ErrorContains(t, err, "authentication_enabledd")
+}
+
+func TestLoaderReportsTemplateDefinitionForInvalidInheritedEnvField(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	templatesFile := filepath.Join(tmpDir, "templates.yaml")
+	require.NoError(t, os.WriteFile(templatesFile, []byte(`
+_templates:
+  standard-portal:
+    authentication_enabled: !env PORTAL_AUTHENTICATION_ENABLED
+`), 0o600))
+	portalsFile := filepath.Join(tmpDir, "portals.yaml")
+	require.NoError(t, os.WriteFile(portalsFile, []byte(`
+portals:
+  - _extends: standard-portal
+    ref: docs
+    name: Docs
+`), 0o600))
+
+	_, err := NewWithBaseDir(tmpDir).LoadFromSources([]Source{
+		{Path: templatesFile, Type: SourceTypeFile},
+		{Path: portalsFile, Type: SourceTypeFile},
+	}, false)
+	require.ErrorContains(t, err, "!env currently supports string-typed fields only")
+	require.ErrorContains(t, err, `template "standard-portal" defined in `+templatesFile)
+}
+
+func TestLoaderRequiresStringTemplateIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{
+			name: "template name",
+			input: `
+_templates:
+  123:
+    authentication_enabled: true
+`,
+			wantErr: "template names must be non-empty strings",
+		},
+		{
+			name: "extends value",
+			input: `
+_templates:
+  standard:
+    authentication_enabled: true
+portals:
+  - _extends: 123
+    ref: docs
+    name: Docs
+`,
+			wantErr: "_extends at portals[0] must name one template",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path := writeLoaderTestFile(t, tt.input)
+			_, err := New().LoadFromSources([]Source{{Path: path, Type: SourceTypeFile}}, false)
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestLoaderResolvesTemplateTagsInDefinitionContext(t *testing.T) {
+	t.Setenv("PORTAL_DESCRIPTION", "Description from the environment")
+
+	tmpDir := t.TempDir()
+	templateDir := filepath.Join(tmpDir, "shared")
+	consumerDir := filepath.Join(tmpDir, "portals")
+	require.NoError(t, os.MkdirAll(templateDir, 0o700))
+	require.NoError(t, os.MkdirAll(consumerDir, 0o700))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(templateDir, "portal-name.txt"),
+		[]byte("Shared Developer Portal"),
+		0o600,
+	))
+	templatesFile := filepath.Join(templateDir, "templates.yaml")
+	require.NoError(t, os.WriteFile(templatesFile, []byte(`
+_templates:
+  standard-portal:
+    name: !file portal-name.txt
+    description: !env PORTAL_DESCRIPTION
+`), 0o600))
+	portalsFile := filepath.Join(consumerDir, "portals.yaml")
+	require.NoError(t, os.WriteFile(portalsFile, []byte(`
+portals:
+  - _extends: standard-portal
+    ref: docs
+`), 0o600))
+
+	rs, err := NewWithBaseDir(tmpDir).LoadFromSources([]Source{
+		{Path: templatesFile, Type: SourceTypeFile},
+		{Path: portalsFile, Type: SourceTypeFile},
+	}, false)
+	require.NoError(t, err)
+	require.Len(t, rs.Portals, 1)
+	assert.Equal(t, "Shared Developer Portal", rs.Portals[0].Name)
+	require.NotNil(t, rs.Portals[0].Description)
+	assert.Equal(t, "Description from the environment", *rs.Portals[0].Description)
+	assert.Equal(t, "__ENV__:PORTAL_DESCRIPTION", rs.GetEnvSources("docs")["/description"])
+}
+
+func TestLoaderPreservesSecretSourcesInheritedFromTemplate(t *testing.T) {
+	t.Parallel()
+
+	path := writeLoaderTestFile(t, `
+_templates:
+  openai-provider:
+    name: openai
+    type: openai
+    display_name: OpenAI
+    config:
+      auth:
+        type: basic
+        headers:
+          - name: Authorization
+            value: !secret {source: !env OPENAI_API_KEY}
+ai_gateways:
+  - ref: gateway
+    name: gateway
+    display_name: Gateway
+    model_providers:
+      - _extends: openai-provider
+        ref: provider
+`)
+
+	rs, err := New().LoadFromSources([]Source{{Path: path, Type: SourceTypeFile}}, false)
+	require.NoError(t, err)
+	declaration := rs.GetSecretSources("provider")["/config/auth/headers/0/value"]
+	require.Len(t, declaration.Expression.Parts, 1)
+	assert.Equal(t, "OPENAI_API_KEY", declaration.Expression.Parts[0].Source.Reference)
+}
+
+func TestLoaderCapturesChildSyncScopeInheritedFromTemplate(t *testing.T) {
+	t.Parallel()
+
+	path := writeLoaderTestFile(t, `
+_templates:
+  managed-portal:
+    pages: []
+portals:
+  - _extends: managed-portal
+    ref: docs
+    name: Docs
+`)
+
+	rs, err := New().LoadFromSources([]Source{{Path: path, Type: SourceTypeFile}}, false)
+	require.NoError(t, err)
+	require.True(t, rs.SyncScope.ChildInScope(
+		resources.ResourceTypePortal,
+		"docs",
+		resources.ResourceTypePortalPage,
+	))
+}
+
+func TestLoaderExpandsTemplateForNestedAndRootPortalPages(t *testing.T) {
+	t.Parallel()
+
+	path := writeLoaderTestFile(t, `
+_templates:
+  published-page:
+    visibility: public
+    status: published
+    content: Shared page content
+portals:
+  - ref: docs
+    name: Docs
+    pages:
+      - _extends: published-page
+        ref: getting-started
+        slug: getting-started
+        title: Getting Started
+portal_pages:
+  - _extends: published-page
+    ref: authentication
+    portal: docs
+    slug: authentication
+    title: Authentication
+`)
+
+	rs, err := New().LoadFromSources([]Source{{Path: path, Type: SourceTypeFile}}, false)
+	require.NoError(t, err)
+	require.Len(t, rs.PortalPages, 2)
+	for _, page := range rs.PortalPages {
+		assert.Equal(t, "Shared page content", page.Content)
+		require.NotNil(t, page.Visibility)
+		assert.Equal(t, "public", string(*page.Visibility))
+		require.NotNil(t, page.Status)
+		assert.Equal(t, "published", string(*page.Status))
+	}
+}

--- a/internal/declarative/loader/config_templates_test.go
+++ b/internal/declarative/loader/config_templates_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/tags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -80,6 +81,37 @@ portals:
 	require.Len(t, rs.Portals, 1)
 	require.NotNil(t, rs.Portals[0].AuthenticationEnabled)
 	assert.True(t, *rs.Portals[0].AuthenticationEnabled)
+}
+
+func TestExpandConfigTemplateDocumentsReleasesParsedTrees(t *testing.T) {
+	t.Parallel()
+
+	documents := []*configTemplateDocument{
+		{
+			content: []byte(`
+_templates:
+  standard:
+    authentication_enabled: true
+`),
+			sourcePath: "templates.yaml",
+		},
+		{
+			content: []byte(`
+portals:
+  - _extends: standard
+    ref: docs
+    name: Docs
+`),
+			sourcePath: "portals.yaml",
+		},
+	}
+
+	require.NoError(t, expandConfigTemplateDocuments(documents))
+	for _, document := range documents {
+		assert.Zero(t, document.document.Kind)
+		assert.NotContains(t, string(document.content), templatesKey)
+		assert.NotContains(t, string(document.content), extendsKey)
+	}
 }
 
 func TestLoaderDiscoversTemplatesRecursivelyInDirectorySource(t *testing.T) {
@@ -253,6 +285,27 @@ portals:
 			wantErr: `_extends at portals[0] must name one template`,
 		},
 		{
+			name: "extends in defaults",
+			input: `
+_templates:
+  standard: {namespace: shared}
+_defaults:
+  _extends: standard
+`,
+			wantErr: `_extends is not supported inside _defaults at _defaults._extends`,
+		},
+		{
+			name: "extends in nested defaults",
+			input: `
+_templates:
+  standard: {namespace: shared}
+_defaults:
+  kongctl:
+    _extends: standard
+`,
+			wantErr: `_extends is not supported inside _defaults at _defaults.kongctl._extends`,
+		},
+		{
 			name: "nested template registry",
 			input: `
 ai_gateways:
@@ -324,6 +377,21 @@ _templates:
 			require.ErrorContains(t, err, path)
 		})
 	}
+}
+
+func TestLoaderRejectsEnvironmentTemplateReferenceWithoutLeakingPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	path := writeLoaderTestFile(t, `
+portals:
+  - _extends: !env TEMPLATE_NAME
+    ref: docs
+    name: Docs
+`)
+
+	_, err := New().LoadFromSources([]Source{{Path: path, Type: SourceTypeFile}}, false)
+	require.ErrorContains(t, err, `_extends at portals[0] must name one template`)
+	assert.NotContains(t, err.Error(), tags.EnvPlaceholderPrefix)
 }
 
 func TestLoaderRejectsDuplicateTemplatesAcrossSourceFiles(t *testing.T) {

--- a/internal/declarative/loader/documentation_examples_test.go
+++ b/internal/declarative/loader/documentation_examples_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/kong/kongctl/internal/declarative/tags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -57,4 +58,49 @@ func TestLoaderLoadsOpenAILLMDocumentationExample(t *testing.T) {
 	require.Len(t, providerSecret.Expression.Parts, 2)
 	assert.Equal(t, "Bearer ", *providerSecret.Expression.Parts[0].Literal)
 	assert.Equal(t, "OPENAI_API_KEY", providerSecret.Expression.Parts[1].Source.Reference)
+}
+
+func TestLoaderLoadsAIGatewayTemplatesDocumentationExample(t *testing.T) {
+	baseDir := filepath.Join("..", "..", "..", "docs", "examples", "declarative", "ai-gateway", "templates")
+
+	rs, err := NewWithBaseDir(baseDir).LoadFromSources([]Source{
+		{Path: filepath.Join(baseDir, "costs.yaml"), Type: SourceTypeFile},
+		{Path: filepath.Join(baseDir, "ai-gateway.yaml"), Type: SourceTypeFile},
+	}, false)
+	require.NoError(t, err)
+	require.Len(t, rs.AIGateways, 1)
+	require.Len(t, rs.AIGatewayProviders, 1)
+	require.Len(t, rs.AIGatewayModels, 2)
+	require.Len(t, rs.AIGatewayPolicies, 1)
+
+	providerSecret := rs.GetSecretSources("openai-provider")["/config/auth/headers/0/value"]
+	require.Len(t, providerSecret.Expression.Parts, 2)
+	assert.Equal(t, "Bearer ", *providerSecret.Expression.Parts[0].Literal)
+	assert.Equal(t, "OPENAI_API_KEY", providerSecret.Expression.Parts[1].Source.Reference)
+
+	for _, model := range rs.AIGatewayModels {
+		require.NotNil(t, model.AIGatewayModelModel)
+		require.Len(t, model.AIGatewayModelModel.Targets, 1)
+		assert.Equal(
+			t,
+			[]string{tags.RefPlaceholderPrefix + "hourly-model-cost-budget#name"},
+			model.AIGatewayModelModel.Policies,
+		)
+
+		config := model.AIGatewayModelModel.Targets[0].GetConfigOpenai()
+		require.NotNil(t, config)
+		require.NotNil(t, config.InputCost)
+		assert.InDelta(t, 2.5, *config.InputCost, 0.001)
+		require.NotNil(t, config.OutputCost)
+		assert.InDelta(t, 10.0, *config.OutputCost, 0.001)
+	}
+
+	policy := rs.AIGatewayPolicies[0]
+	assert.Equal(t, "ai-rate-limiting-advanced", policy.Type)
+	assert.Equal(t, "local", policy.Config["strategy"])
+	policies := policy.Config["policies"].([]any)
+	limits := policies[0].(map[string]any)["limits"].([]any)
+	limit := limits[0].(map[string]any)
+	assert.Equal(t, "cost", limit["tokens_count_strategy"])
+	assert.InDelta(t, 25, limit["limit"], 0.0001)
 }

--- a/internal/declarative/loader/env_validation.go
+++ b/internal/declarative/loader/env_validation.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/kong/kongctl/internal/declarative/tags"
 	"gopkg.in/yaml.v3" //nolint:gomodguard_v2 // yaml.v3 required for custom tag inspection
 )
 
@@ -50,7 +51,7 @@ func validateEnvNode(node *yaml.Node, targetType reflect.Type, path []string) er
 				}
 
 				nextPath := append(path, keyNode.Value)
-				if valueNode.Tag == "!env" {
+				if isEnvValidationNode(valueNode) {
 					if !isEnvStringCompatibleType(fieldType) {
 						return fmt.Errorf(
 							"!env currently supports string-typed fields only (field: %s)",
@@ -70,7 +71,7 @@ func validateEnvNode(node *yaml.Node, targetType reflect.Type, path []string) er
 				keyNode := node.Content[i]
 				valueNode := node.Content[i+1]
 				nextPath := append(path, keyNode.Value)
-				if valueNode.Tag == "!env" {
+				if isEnvValidationNode(valueNode) {
 					if !isEnvStringCompatibleType(elemType) {
 						return fmt.Errorf(
 							"!env currently supports string-typed fields only (field: %s)",
@@ -93,7 +94,7 @@ func validateEnvNode(node *yaml.Node, targetType reflect.Type, path []string) er
 
 		elemType := derefType(targetType.Elem())
 		for _, child := range node.Content {
-			if child.Tag == "!env" {
+			if isEnvValidationNode(child) {
 				if !isEnvStringCompatibleType(elemType) {
 					return fmt.Errorf(
 						"!env currently supports string-typed fields only (field: %s)",
@@ -130,7 +131,7 @@ func validateDynamicEnvNode(node *yaml.Node, path []string) error {
 		for i := 0; i+1 < len(node.Content); i += 2 {
 			keyNode := node.Content[i]
 			valueNode := node.Content[i+1]
-			if valueNode.Tag == "!env" {
+			if isEnvValidationNode(valueNode) {
 				continue
 			}
 			if err := validateDynamicEnvNode(valueNode, append(path, keyNode.Value)); err != nil {
@@ -139,7 +140,7 @@ func validateDynamicEnvNode(node *yaml.Node, path []string) error {
 		}
 	case yaml.SequenceNode:
 		for _, child := range node.Content {
-			if child.Tag == "!env" {
+			if isEnvValidationNode(child) {
 				continue
 			}
 			if err := validateDynamicEnvNode(child, path); err != nil {
@@ -153,6 +154,11 @@ func validateDynamicEnvNode(node *yaml.Node, path []string) error {
 	}
 
 	return nil
+}
+
+func isEnvValidationNode(node *yaml.Node) bool {
+	return node != nil && (node.Tag == tags.TagEnv ||
+		(node.Kind == yaml.ScalarNode && tags.IsEnvPlaceholder(node.Value)))
 }
 
 func lookupStructFieldType(targetType reflect.Type, name string) (reflect.Type, bool) {

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -103,7 +103,7 @@ func (l *Loader) LoadFromSourcesWithContext(ctx context.Context, sources []Sourc
 	}
 	preparedDocuments := make([]*preparedYAML, 0, len(documents))
 	templateDocuments := make([]*configTemplateDocument, 0, len(documents))
-	for _, document := range documents {
+	for i, document := range documents {
 		prepared, err := l.prepareYAML(document.content, document.sourcePath, document.rootDir)
 		if err != nil {
 			return nil, err
@@ -112,13 +112,17 @@ func (l *Loader) LoadFromSourcesWithContext(ctx context.Context, sources []Sourc
 		templateDocuments = append(templateDocuments, &configTemplateDocument{
 			content: prepared.content, sourcePath: prepared.sourcePath,
 		})
+		prepared.content = nil
+		documents[i].content = nil
 	}
+	documents = nil
 	if err := expandConfigTemplateDocuments(templateDocuments); err != nil {
 		return nil, fmt.Errorf("failed to expand templates: %w", err)
 	}
 	for i, prepared := range preparedDocuments {
 		prepared.content = templateDocuments[i].content
 		prepared.templateDefinitions = templateDocuments[i].usedTemplates
+		templateDocuments[i] = nil
 		prepared.hasEnvTags = prepared.hasEnvTags ||
 			strings.Contains(string(prepared.content), tags.EnvPlaceholderPrefix)
 		rs, err := l.parsePreparedYAML(prepared)
@@ -128,6 +132,7 @@ func (l *Loader) LoadFromSourcesWithContext(ctx context.Context, sources []Sourc
 		if err := l.appendResourcesWithDuplicateCheck(&allResources, rs, prepared.sourcePath, refIndex); err != nil {
 			return nil, err
 		}
+		preparedDocuments[i] = nil
 	}
 
 	if err := l.normalizeContentMetadata(&allResources); err != nil {

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -115,7 +115,6 @@ func (l *Loader) LoadFromSourcesWithContext(ctx context.Context, sources []Sourc
 		prepared.content = nil
 		documents[i].content = nil
 	}
-	documents = nil
 	if err := expandConfigTemplateDocuments(templateDocuments); err != nil {
 		return nil, fmt.Errorf("failed to expand templates: %w", err)
 	}

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -1,7 +1,6 @@
 package loader
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -13,7 +12,6 @@ import (
 	"strings"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
-	decerrors "github.com/kong/kongctl/internal/declarative/errors"
 	"github.com/kong/kongctl/internal/declarative/resources"
 	"github.com/kong/kongctl/internal/declarative/tags"
 	"sigs.k8s.io/yaml"
@@ -97,31 +95,37 @@ func (l *Loader) LoadFromSourcesWithContext(ctx context.Context, sources []Sourc
 	recursive bool,
 ) (*resources.ResourceSet, error) {
 	var allResources resources.ResourceSet
-	// Running index of refs for O(1) duplicate checking across files
 	refIndex := make(map[string]resources.ResourceType)
 
-	for _, source := range sources {
-		var err error
-		rootDir := l.resolveSourceRoot(source)
-
-		switch source.Type {
-		case SourceTypeFile:
-			err = l.loadSingleFileWithContext(ctx, source.Path, rootDir, &allResources, refIndex)
-		case SourceTypeDirectory:
-			err = l.loadDirectorySourceWithContext(ctx, source.Path, rootDir, recursive, &allResources, refIndex)
-		case SourceTypeSTDIN:
-			err = l.loadSTDINWithContext(ctx, rootDir, &allResources, refIndex)
-		case SourceTypeURL:
-			err = l.loadURLWithContext(ctx, source.Path, rootDir, &allResources, refIndex)
-		default:
-			return nil, decerrors.FormatConfigurationError(
-				source.Path,
-				0,
-				fmt.Sprintf("unknown source type: %v", source.Type),
-			)
-		}
-
+	documents, err := l.readSourceDocuments(ctx, sources, recursive)
+	if err != nil {
+		return nil, err
+	}
+	preparedDocuments := make([]*preparedYAML, 0, len(documents))
+	templateDocuments := make([]*configTemplateDocument, 0, len(documents))
+	for _, document := range documents {
+		prepared, err := l.prepareYAML(document.content, document.sourcePath, document.rootDir)
 		if err != nil {
+			return nil, err
+		}
+		preparedDocuments = append(preparedDocuments, prepared)
+		templateDocuments = append(templateDocuments, &configTemplateDocument{
+			content: prepared.content, sourcePath: prepared.sourcePath,
+		})
+	}
+	if err := expandConfigTemplateDocuments(templateDocuments); err != nil {
+		return nil, fmt.Errorf("failed to expand templates: %w", err)
+	}
+	for i, prepared := range preparedDocuments {
+		prepared.content = templateDocuments[i].content
+		prepared.templateDefinitions = templateDocuments[i].usedTemplates
+		prepared.hasEnvTags = prepared.hasEnvTags ||
+			strings.Contains(string(prepared.content), tags.EnvPlaceholderPrefix)
+		rs, err := l.parsePreparedYAML(prepared)
+		if err != nil {
+			return nil, err
+		}
+		if err := l.appendResourcesWithDuplicateCheck(&allResources, rs, prepared.sourcePath, refIndex); err != nil {
 			return nil, err
 		}
 	}
@@ -204,35 +208,36 @@ func (l *Loader) loadSingleFile(
 	return l.appendResourcesWithDuplicateCheck(accumulated, rs, path, refIndex)
 }
 
-func (l *Loader) loadURLWithContext(
-	ctx context.Context,
-	rawURL string,
-	rootDir string,
-	accumulated *resources.ResourceSet,
-	refIndex map[string]resources.ResourceType,
-) error {
-	content, err := FetchURLWithOptions(ctx, rawURL, l.urlFetchOptions)
-	if err != nil {
-		return err
-	}
-
-	rs, err := l.parseYAML(bytes.NewReader(content), rawURL, rootDir)
-	if err != nil {
-		return err
-	}
-
-	return l.appendResourcesWithDuplicateCheck(accumulated, rs, rawURL, refIndex)
+type preparedYAML struct {
+	content             []byte
+	sourcePath          string
+	baseDir             string
+	tagRootDir          string
+	hasEnvTags          bool
+	templateDefinitions map[string]configTemplate
 }
 
-// parseYAML parses YAML content into ResourceSet
+// parseYAML parses YAML content into ResourceSet.
 func (l *Loader) parseYAML(r io.Reader, sourcePath string, rootDir string) (*resources.ResourceSet, error) {
-	var temp temporaryParseResult
-	var placeholderTemp temporaryParseResult
-
 	rawContent, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read content from %s: %w", sourcePath, err)
 	}
+	prepared, err := l.prepareYAML(rawContent, sourcePath, rootDir)
+	if err != nil {
+		return nil, err
+	}
+	templateDocument := &configTemplateDocument{content: prepared.content, sourcePath: sourcePath}
+	if err := expandConfigTemplateDocuments([]*configTemplateDocument{templateDocument}); err != nil {
+		return nil, fmt.Errorf("failed to expand templates in %s: %w", sourcePath, err)
+	}
+	prepared.content = templateDocument.content
+	prepared.templateDefinitions = templateDocument.usedTemplates
+	prepared.hasEnvTags = prepared.hasEnvTags || strings.Contains(string(prepared.content), tags.EnvPlaceholderPrefix)
+	return l.parsePreparedYAML(prepared)
+}
+
+func (l *Loader) prepareYAML(rawContent []byte, sourcePath string, rootDir string) (*preparedYAML, error) {
 	hasEnvTags := strings.Contains(string(rawContent), "!env")
 	if hasEnvTags {
 		if err := validateEnvTagStringFields(rawContent); err != nil {
@@ -274,8 +279,31 @@ func (l *Loader) parseYAML(r io.Reader, sourcePath string, rootDir string) (*res
 	if err != nil {
 		return nil, fmt.Errorf("failed to process placeholder tags in %s: %w", sourcePath, err)
 	}
+	return &preparedYAML{
+		content:    placeholderContent,
+		sourcePath: sourcePath,
+		baseDir:    baseDir,
+		tagRootDir: tagRootDir,
+		hasEnvTags: hasEnvTags,
+	}, nil
+}
+
+func (l *Loader) parsePreparedYAML(prepared *preparedYAML) (*resources.ResourceSet, error) {
+	var temp temporaryParseResult
+	var placeholderTemp temporaryParseResult
+
+	placeholderContent := prepared.content
+	sourcePath := prepared.sourcePath
+	if prepared.hasEnvTags {
+		if err := validateEnvTagStringFields(placeholderContent); err != nil {
+			return nil, withTemplateDefinitionContext(
+				fmt.Errorf("failed to parse deferred !env tags in %s: %w", sourcePath, err),
+				prepared.templateDefinitions,
+			)
+		}
+	}
 	if err := validateDeclarativeDocumentShape(placeholderContent, sourcePath); err != nil {
-		return nil, err
+		return nil, withTemplateDefinitionContext(err, prepared.templateDefinitions)
 	}
 
 	// Decode the placeholder representation twice. The execution representation
@@ -285,22 +313,33 @@ func (l *Loader) parseYAML(r io.Reader, sourcePath string, rootDir string) (*res
 	placeholderErr := yaml.UnmarshalStrict(placeholderContent, &placeholderTemp)
 
 	if parseErr != nil {
-		if hasEnvTags && isDeferredEnvStringOnlyError(placeholderErr) {
-			return nil, fmt.Errorf(
-				"failed to parse deferred !env tags in %s: !env currently supports string-typed fields only: %w",
-				sourcePath,
-				placeholderErr,
+		if prepared.hasEnvTags && isDeferredEnvStringOnlyError(placeholderErr) {
+			return nil, withTemplateDefinitionContext(
+				fmt.Errorf(
+					"failed to parse deferred !env tags in %s: "+
+						"!env currently supports string-typed fields only: %w",
+					sourcePath,
+					placeholderErr,
+				),
+				prepared.templateDefinitions,
 			)
 		}
-		return nil, formatYAMLParseError(l, sourcePath, parseErr)
+		return nil, withTemplateDefinitionContext(
+			formatYAMLParseError(l, sourcePath, parseErr),
+			prepared.templateDefinitions,
+		)
 	}
 
 	if placeholderErr != nil {
-		if hasEnvTags && isDeferredEnvStringOnlyError(placeholderErr) {
-			return nil, fmt.Errorf(
-				"failed to parse deferred !env tags in %s: !env currently supports string-typed fields only: %w",
-				sourcePath,
-				placeholderErr,
+		if prepared.hasEnvTags && isDeferredEnvStringOnlyError(placeholderErr) {
+			return nil, withTemplateDefinitionContext(
+				fmt.Errorf(
+					"failed to parse deferred !env tags in %s: "+
+						"!env currently supports string-typed fields only: %w",
+					sourcePath,
+					placeholderErr,
+				),
+				prepared.templateDefinitions,
 			)
 		}
 		return nil, fmt.Errorf("failed to parse deferred !env tags in %s: %w", sourcePath, placeholderErr)
@@ -331,7 +370,7 @@ func (l *Loader) parseYAML(r io.Reader, sourcePath string, rootDir string) (*res
 		return nil, fmt.Errorf("failed to resolve !env tags in %s: %w", sourcePath, err)
 	}
 	// Resolve deck config paths relative to the source file.
-	if err := l.resolveDeckConfigPaths(&rs, baseDir, tagRootDir); err != nil {
+	if err := l.resolveDeckConfigPaths(&rs, prepared.baseDir, prepared.tagRootDir); err != nil {
 		return nil, fmt.Errorf("failed to resolve deck config paths in %s: %w", sourcePath, err)
 	}
 
@@ -347,6 +386,14 @@ func (l *Loader) parseYAML(r io.Reader, sourcePath string, rootDir string) (*res
 	// loadDirectory will validate the merged result.
 
 	return &rs, nil
+}
+
+func withTemplateDefinitionContext(err error, definitions map[string]configTemplate) error {
+	context := templateDefinitionContext(definitions)
+	if err == nil || context == "" {
+		return err
+	}
+	return fmt.Errorf("%w (%s)", err, context)
 }
 
 func isDeferredEnvStringOnlyError(err error) bool {
@@ -409,103 +456,6 @@ func dashboardUnionParseError(sourcePath string, errMsg string) string {
 	default:
 		return ""
 	}
-}
-
-// loadSTDIN loads configuration from stdin
-func (l *Loader) loadSTDIN(
-	rootDir string,
-	accumulated *resources.ResourceSet,
-	refIndex map[string]resources.ResourceType,
-) error {
-	// Check if stdin has data
-	stat, err := os.Stdin.Stat()
-	if err != nil {
-		return fmt.Errorf("failed to stat stdin: %w", err)
-	}
-
-	if (stat.Mode() & os.ModeCharDevice) != 0 {
-		return fmt.Errorf("no data provided on stdin")
-	}
-
-	rs, err := l.parseYAML(os.Stdin, "stdin", rootDir)
-	if err != nil {
-		return err
-	}
-
-	// Append resources with duplicate checking
-	return l.appendResourcesWithDuplicateCheck(accumulated, rs, "stdin", refIndex)
-}
-
-// loadDirectorySource loads YAML files from a directory
-func (l *Loader) loadDirectorySource(
-	dirPath string,
-	rootDir string,
-	recursive bool,
-	accumulated *resources.ResourceSet,
-	refIndex map[string]resources.ResourceType,
-) error {
-	yamlCount := 0
-	subdirCount := 0
-
-	// First, check direct YAML files in the directory
-	entries, err := os.ReadDir(dirPath)
-	if err != nil {
-		return fmt.Errorf("failed to read directory %s: %w", dirPath, err)
-	}
-
-	for _, entry := range entries {
-		path := filepath.Join(dirPath, entry.Name())
-
-		if entry.IsDir() {
-			subdirCount++
-			if recursive {
-				// Recursively load subdirectory
-				if err := l.loadDirectorySource(path, rootDir, recursive, accumulated, refIndex); err != nil {
-					return err
-				}
-			}
-			continue
-		}
-
-		// Skip non-YAML files
-		if !ValidateYAMLFile(path) {
-			continue
-		}
-
-		yamlCount++
-
-		// Load file without validation (will validate merged result later)
-		file, err := os.Open(path)
-		if err != nil {
-			return fmt.Errorf("failed to open %s: %w", path, err)
-		}
-
-		rs, err := l.parseYAML(file, path, rootDir)
-		file.Close()
-		if err != nil {
-			return fmt.Errorf("failed to parse %s: %w", path, err)
-		}
-
-		// Append resources with duplicate checking
-		if err := l.appendResourcesWithDuplicateCheck(accumulated, rs, path, refIndex); err != nil {
-			return err
-		}
-
-	}
-
-	// Provide helpful error if no YAML files found
-	if yamlCount == 0 && subdirCount > 0 && !recursive {
-		return fmt.Errorf("no YAML files found in directory '%s'. Found %d subdirectories. "+
-			"Use -R to search subdirectories", dirPath, subdirCount)
-	} else if yamlCount == 0 {
-		// Check if accumulated has any resources using the registry
-		if accumulated.IsEmpty() {
-			// Only error if no files were found at all (not just empty files)
-			return fmt.Errorf("no YAML files found in directory '%s'", dirPath)
-		}
-	}
-
-	return nil
 }
 
 // appendResourcesWithDuplicateCheck appends resources from source to accumulated with global duplicate checking.
@@ -1221,41 +1171,4 @@ func abs(n int) int {
 		return -n
 	}
 	return n
-}
-
-// Context-aware wrapper methods for internal use
-func (l *Loader) loadSingleFileWithContext(
-	_ context.Context,
-	path string,
-	rootDir string,
-	accumulated *resources.ResourceSet,
-	refIndex map[string]resources.ResourceType,
-) error {
-	// For now, we just call the non-context version
-	// The context will be used by ResolveReferences in LoadFromSourcesWithContext
-	return l.loadSingleFile(path, rootDir, accumulated, refIndex)
-}
-
-func (l *Loader) loadDirectorySourceWithContext(
-	_ context.Context,
-	dirPath string,
-	rootDir string,
-	recursive bool,
-	accumulated *resources.ResourceSet,
-	refIndex map[string]resources.ResourceType,
-) error {
-	// For now, we just call the non-context version
-	// The context will be used by ResolveReferences in LoadFromSourcesWithContext
-	return l.loadDirectorySource(dirPath, rootDir, recursive, accumulated, refIndex)
-}
-
-func (l *Loader) loadSTDINWithContext(
-	_ context.Context,
-	rootDir string,
-	accumulated *resources.ResourceSet,
-	refIndex map[string]resources.ResourceType,
-) error {
-	// For now, we just call the non-context version
-	// The context will be used by ResolveReferences in LoadFromSourcesWithContext
-	return l.loadSTDIN(rootDir, accumulated, refIndex)
 }

--- a/internal/declarative/loader/source_documents.go
+++ b/internal/declarative/loader/source_documents.go
@@ -1,0 +1,163 @@
+package loader
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	decerrors "github.com/kong/kongctl/internal/declarative/errors"
+)
+
+type sourceDocument struct {
+	content    []byte
+	sourcePath string
+	rootDir    string
+}
+
+func (l *Loader) readSourceDocuments(
+	ctx context.Context,
+	sources []Source,
+	recursive bool,
+) ([]sourceDocument, error) {
+	documents := make([]sourceDocument, 0, len(sources))
+	for _, source := range sources {
+		rootDir := l.resolveSourceRoot(source)
+		switch source.Type {
+		case SourceTypeFile:
+			document, err := readFileSourceDocument(source.Path, rootDir)
+			if err != nil {
+				return nil, err
+			}
+			documents = append(documents, document)
+		case SourceTypeDirectory:
+			directoryDocuments, err := readDirectorySourceDocuments(source.Path, rootDir, recursive)
+			if err != nil {
+				return nil, err
+			}
+			documents = append(documents, directoryDocuments...)
+		case SourceTypeSTDIN:
+			document, err := readSTDINSourceDocument(rootDir)
+			if err != nil {
+				return nil, err
+			}
+			documents = append(documents, document)
+		case SourceTypeURL:
+			content, err := FetchURLWithOptions(ctx, source.Path, l.urlFetchOptions)
+			if err != nil {
+				return nil, err
+			}
+			documents = append(documents, sourceDocument{
+				content: content, sourcePath: source.Path, rootDir: rootDir,
+			})
+		default:
+			return nil, decerrors.FormatConfigurationError(
+				source.Path,
+				0,
+				fmt.Sprintf("unknown source type: %v", source.Type),
+			)
+		}
+	}
+	return documents, nil
+}
+
+func readFileSourceDocument(path, rootDir string) (sourceDocument, error) {
+	if !ValidateYAMLFile(path) {
+		return sourceDocument{}, fmt.Errorf("file %s does not have .yaml or .yml extension", path)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return sourceDocument{}, fmt.Errorf("failed to read file %s: %w", path, err)
+	}
+	return sourceDocument{content: content, sourcePath: path, rootDir: rootDir}, nil
+}
+
+func readDirectorySourceDocuments(dirPath, rootDir string, recursive bool) ([]sourceDocument, error) {
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read directory %s: %w", dirPath, err)
+	}
+
+	documents := make([]sourceDocument, 0)
+	subdirectoryCount := 0
+	for _, entry := range entries {
+		path := filepath.Join(dirPath, entry.Name())
+		if entry.IsDir() {
+			subdirectoryCount++
+			if !recursive {
+				continue
+			}
+			nested, err := readDirectorySourceDocumentsIfPresent(path, rootDir)
+			if err != nil {
+				return nil, err
+			}
+			documents = append(documents, nested...)
+			continue
+		}
+		if !ValidateYAMLFile(path) {
+			continue
+		}
+		document, err := readFileSourceDocument(path, rootDir)
+		if err != nil {
+			return nil, err
+		}
+		documents = append(documents, document)
+	}
+
+	if len(documents) == 0 {
+		if subdirectoryCount > 0 && !recursive {
+			return nil, fmt.Errorf(
+				"no YAML files found in directory '%s'. Found %d subdirectories. Use -R to search subdirectories",
+				dirPath,
+				subdirectoryCount,
+			)
+		}
+		return nil, fmt.Errorf("no YAML files found in directory '%s'", dirPath)
+	}
+	return documents, nil
+}
+
+func readDirectorySourceDocumentsIfPresent(dirPath, rootDir string) ([]sourceDocument, error) {
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read directory %s: %w", dirPath, err)
+	}
+
+	documents := make([]sourceDocument, 0)
+	for _, entry := range entries {
+		path := filepath.Join(dirPath, entry.Name())
+		if entry.IsDir() {
+			nested, err := readDirectorySourceDocumentsIfPresent(path, rootDir)
+			if err != nil {
+				return nil, err
+			}
+			documents = append(documents, nested...)
+			continue
+		}
+		if !ValidateYAMLFile(path) {
+			continue
+		}
+		document, err := readFileSourceDocument(path, rootDir)
+		if err != nil {
+			return nil, err
+		}
+		documents = append(documents, document)
+	}
+	return documents, nil
+}
+
+func readSTDINSourceDocument(rootDir string) (sourceDocument, error) {
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return sourceDocument{}, fmt.Errorf("failed to stat stdin: %w", err)
+	}
+	if (stat.Mode() & os.ModeCharDevice) != 0 {
+		return sourceDocument{}, fmt.Errorf("no data provided on stdin")
+	}
+	content, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return sourceDocument{}, fmt.Errorf("failed to read stdin: %w", err)
+	}
+	return sourceDocument{content: content, sourcePath: "stdin", rootDir: rootDir}, nil
+}

--- a/internal/declarative/loader/url_fetcher_test.go
+++ b/internal/declarative/loader/url_fetcher_test.go
@@ -347,6 +347,36 @@ apis:
 	assert.Equal(t, "loaded from base dir", *rs.APIs[0].Description)
 }
 
+func TestLoader_LoadFromSources_UsesTemplatesFromURLSources(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(`
+_templates:
+  remote-portal:
+    authentication_enabled: true
+`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	consumerPath := filepath.Join(dir, "portal.yaml")
+	require.NoError(t, os.WriteFile(consumerPath, []byte(`
+portals:
+  - _extends: remote-portal
+    ref: docs
+    name: Docs
+`), 0o600))
+
+	rs, err := NewWithBaseDir(dir).LoadFromSourcesWithContext(t.Context(), []Source{
+		{Path: server.URL + "/templates.yaml", Type: SourceTypeURL},
+		{Path: consumerPath, Type: SourceTypeFile},
+	}, false)
+	require.NoError(t, err)
+	require.Len(t, rs.Portals, 1)
+	require.NotNil(t, rs.Portals[0].AuthenticationEnabled)
+	assert.True(t, *rs.Portals[0].AuthenticationEnabled)
+}
+
 func TestFetchURLRejectsInvalidURL(t *testing.T) {
 	tests := []string{
 		"file:///tmp/config.yaml",

--- a/site/src/content/lessons/declarative-configuration/adopt-existing-resources.md
+++ b/site/src/content/lessons/declarative-configuration/adopt-existing-resources.md
@@ -1,7 +1,7 @@
 ---
 title: Adopt Existing Resources
 summary: Bring existing Konnect resources under declarative management.
-order: 7
+order: 8
 related:
   - label: Declarative configuration documentation
     url: https://developer.konghq.com/kongctl/declarative/

--- a/site/src/content/lessons/declarative-configuration/configuration-templates.md
+++ b/site/src/content/lessons/declarative-configuration/configuration-templates.md
@@ -1,0 +1,302 @@
+---
+title: Configuration Templates
+summary: Reuse declarative configuration across resources and files.
+order: 7
+related:
+  - label: Declarative configuration examples
+    url: https://github.com/Kong/kongctl/tree/main/docs/examples/declarative
+  - label: AI Rate Limiting Advanced documentation
+    url: https://developer.konghq.com/plugins/ai-rate-limiting-advanced/
+---
+
+## Goal
+
+You will define named configuration templates, extend them from resources in a
+different file, and observe how inherited and local values merge. Shared
+OpenAI model prices provide the working example.
+
+## How templates work
+
+Define reusable configuration blocks under the top-level `_templates` key. Add
+`_extends` to a resource or nested configuration block to inherit one named
+template. The configuration block containing `_extends` can add fields or
+override inherited values.
+
+Templates are shared across all sources supplied to one command. They can
+therefore live in a dedicated file while the resources that extend them live
+elsewhere.
+
+## Prerequisites
+
+Complete [Konnect Authentication](../../installation/authenticate/) and make
+sure the active profile can create AI Gateway resources.
+
+You can complete all planning steps without an OpenAI key. The key is only
+needed if you apply the configuration.
+
+## Why centralize model costs?
+
+AI Rate Limiting Advanced can enforce limits based on model cost. Those limits
+depend on the input and output token prices configured for each model target.
+If several model resources use the same target, repeating its prices makes
+updates easy to miss.
+
+A model template provides one place to update the price. Every resource that
+extends it receives the updated configuration on the next plan or apply.
+
+## Define the templates
+
+Create and enter a working directory:
+
+```shell label="run this..."
+mkdir -p aigw-templates && cd aigw-templates
+```
+
+Create `costs.yaml`:
+
+```shell label="run this..."
+cat > costs.yaml <<'YAML'
+_templates:
+  gpt-4o-token-costs:
+    # Illustrative USD cost per one million tokens.
+    input_cost: 2.50
+    output_cost: 10.00
+
+  hourly-model-cost-budget:
+    type: ai-rate-limiting-advanced
+    enabled: true
+    global: false
+    labels:
+      managed-by: kongctl
+      purpose: model-cost-budget
+    config:
+      strategy: local
+      window_type: sliding
+      policies:
+        - match:
+            - type: model
+              partition_by: true
+          limits:
+            - limit: 25
+              window_size: 3600
+              tokens_count_strategy: cost
+YAML
+```
+
+The first template contains the shared OpenAI token costs. The policy template
+sets a shared hourly cost limit. Defining these templates does not create
+resources by itself.
+
+## Extend the templates
+
+Create `ai-gateway.yaml`:
+
+```shell label="run this..."
+cat > ai-gateway.yaml <<'YAML'
+_defaults:
+  kongctl:
+    namespace: aigw-templates-learning
+
+ai_gateways:
+  - ref: shared-cost-gateway
+    name: shared-cost-gateway
+    display_name: Shared Cost Gateway
+    description: Centralizes model token costs for cost-based rate limiting
+    proxy_urls:
+      - host: shared-cost-gateway.example.com
+        port: 443
+        protocol: https
+
+    model_providers:
+      - ref: openai-provider
+        name: openai-provider
+        display_name: OpenAI
+        type: openai
+        config:
+          auth:
+            type: basic
+            headers:
+              - name: Authorization
+                value: !secret
+                  parts:
+                    - "Bearer "
+                    - !env OPENAI_API_KEY
+
+    models:
+      - ref: customer-support
+        name: customer-support
+        display_name: Customer Support
+        type: model
+        formats:
+          - type: openai
+        config:
+          route:
+            model:
+              body_param: model
+              values:
+                - customer-support
+        targets:
+          - name: gpt-4o
+            provider: openai-provider
+            config:
+              _extends: gpt-4o-token-costs
+              type: openai
+        policies:
+          - !ref hourly-model-cost-budget#name
+        capabilities:
+          - generate
+
+      - ref: document-review
+        name: document-review
+        display_name: Document Review
+        type: model
+        formats:
+          - type: openai
+        config:
+          route:
+            model:
+              body_param: model
+              values:
+                - document-review
+        targets:
+          - name: gpt-4o
+            provider: openai-provider
+            config:
+              type: openai
+              _extends: gpt-4o-token-costs
+        policies:
+          - !ref hourly-model-cost-budget#name
+        capabilities:
+          - generate
+
+    policies:
+      - _extends: hourly-model-cost-budget
+        ref: hourly-model-cost-budget
+        name: hourly-model-cost-budget
+        display_name: Hourly Model Cost Budget
+YAML
+```
+
+The provider uses `!env` to identify the environment variable and `!secret` to
+compose the full authorization header. The value is deferred until apply and
+does not appear in a plan.
+
+Both model targets inherit the shared costs while retaining their own model
+configuration. The policy resource inherits its complete configuration from
+`hourly-model-cost-budget`.
+
+## Preview the expanded configuration
+
+Supply both files to the same command. A resource can extend a template defined
+in any file in the command's source set:
+
+```shell label="run this..."
+kongctl plan \
+  --mode apply \
+  -f costs.yaml \
+  -f ai-gateway.yaml \
+  --output-file template-plan.json
+```
+
+Inspect the materialized models and policy:
+
+```shell label="run this..."
+jq '
+  .changes[]
+  | select(
+      .resource_ref == "customer-support"
+      or .resource_ref == "document-review"
+      or .resource_ref == "hourly-model-cost-budget"
+    )
+  | {resource_ref, fields}
+' template-plan.json
+```
+
+Both models contain the inherited input and output costs, as well as their
+local route. The policy contains the inherited cost limit. `_templates` and
+`_extends` do not appear in the plan.
+
+Try planning only the resource file:
+
+```shell label="run this..."
+kongctl diff --mode apply -f ai-gateway.yaml
+```
+
+The command fails with an unknown-template error. Template discovery is
+cross-file, but it is limited to files, directories, standard input, and URLs
+supplied to that command.
+
+## Understand the merge rules
+
+The configuration block containing `_extends` is the consumer. Its values
+override the selected template:
+
+| Template and consumer values  | Effective value                         |
+| ----------------------------- | --------------------------------------- |
+| Both are configuration blocks | Recursively merge their keys.           |
+| Consumer key is omitted       | Keep the template value.                |
+| Consumer scalar               | Replace the template value.             |
+| Consumer array                | Replace the whole template array.       |
+| Consumer value is `null`      | Replace the template value with `null`. |
+| Value types differ            | Replace with the consumer value.        |
+
+In this example, `_extends` is used inside each target's `config` configuration
+block and on the policy resource itself. Its position among the other keys in a
+configuration block does not affect the result. Arrays do not append: a local
+array replaces the complete inherited array at the same key.
+
+Each configuration block can extend one template. Template identifiers must be
+unique in the complete source set. Unknown names, duplicate names, and circular
+inheritance are errors.
+
+## Apply the configuration
+
+Skip this section if you only want to inspect expansion. Otherwise, set the
+OpenAI key and apply the same source set:
+
+```shell label="run this..."
+export OPENAI_API_KEY='your-openai-api-key'
+
+kongctl apply \
+  -f costs.yaml \
+  -f ai-gateway.yaml \
+  --write-secrets
+```
+
+Review the plan and confirm the apply when prompted.
+
+## Update a shared price
+
+Create a new template file with the input price changed:
+
+```shell label="run this..."
+sed 's/input_cost: 2.50/input_cost: 3.00/' \
+  costs.yaml > costs-updated.yaml
+```
+
+Use the updated file instead of the original so only one definition of each
+template is present:
+
+```shell label="run this..."
+kongctl diff \
+  --mode apply \
+  -f costs-updated.yaml \
+  -f ai-gateway.yaml
+```
+
+If you applied the initial configuration, the diff updates both
+`customer-support` and `document-review`. Neither resource was edited; both
+receive the new price from `gpt-4o-token-costs`.
+
+## Delete the resources
+
+If you applied the example, delete the resources represented by the files:
+
+```shell label="run this..."
+kongctl delete \
+  -f costs-updated.yaml \
+  -f ai-gateway.yaml
+```
+
+The template file remains necessary because the resource file contains
+`_extends`. Delete mode targets only the resources produced after expansion.

--- a/site/src/content/lessons/declarative-configuration/discovering-schemas.md
+++ b/site/src/content/lessons/declarative-configuration/discovering-schemas.md
@@ -1,7 +1,7 @@
 ---
 title: Discovering Declarative Schemas
 summary: Explore supported resources and generate starter YAML.
-order: 8
+order: 9
 related:
   - label: Declarative resource reference
     url: https://developer.konghq.com/kongctl/supported-resources/

--- a/site/tests/e2e/learning.spec.ts
+++ b/site/tests/e2e/learning.spec.ts
@@ -377,7 +377,7 @@ test("presents the declarative configuration journey", async ({ page }) => {
   await page.goto("declarative-configuration/");
   const lessons = page.locator(".chapter-lessons");
 
-  await expect(lessons.locator(":scope > li")).toHaveCount(8);
+  await expect(lessons.locator(":scope > li")).toHaveCount(9);
   await expect(
     lessons.getByRole("link", { name: /Plan-Based Configuration/ }),
   ).toBeVisible();
@@ -395,10 +395,31 @@ test("presents the declarative configuration journey", async ({ page }) => {
   ).toBeVisible();
   await expect(lessons.getByRole("link", { name: /Sync Scope/ })).toBeVisible();
   await expect(
+    lessons.getByRole("link", { name: /Configuration Templates/ }),
+  ).toBeVisible();
+  await expect(lessons.locator(":scope > li").nth(6)).toContainText(
+    "Configuration Templates",
+  );
+  await expect(
     lessons.getByRole("link", { name: /Adopt Existing Resources/ }),
   ).toBeVisible();
   await expect(
     lessons.getByRole("link", { name: /Discovering Declarative Schemas/ }),
+  ).toBeVisible();
+});
+
+test("teaches reusable configuration templates", async ({ page }) => {
+  await page.goto("declarative-configuration/configuration-templates/");
+  const lesson = page.locator(".lesson-body");
+
+  await expect(
+    lesson.getByRole("heading", { name: "Why centralize model costs?" }),
+  ).toBeVisible();
+  await expect(
+    lesson.getByText("_extends: gpt-4o-token-costs", { exact: true }).first(),
+  ).toBeVisible();
+  await expect(
+    lesson.getByText("-f costs-updated.yaml", { exact: true }).first(),
   ).toBeVisible();
 });
 

--- a/site/tests/e2e/learning.spec.ts
+++ b/site/tests/e2e/learning.spec.ts
@@ -418,9 +418,7 @@ test("teaches reusable configuration templates", async ({ page }) => {
   await expect(
     lesson.getByText("_extends: gpt-4o-token-costs", { exact: true }).first(),
   ).toBeVisible();
-  await expect(
-    lesson.getByText("-f costs-updated.yaml", { exact: true }).first(),
-  ).toBeVisible();
+  await expect(lesson).toContainText("-f costs-updated.yaml");
 });
 
 test("explains plan modes and mode-matched execution", async ({ page }) => {
@@ -683,10 +681,10 @@ test("persists explicit completion and continues to the next lesson", async ({
   await page.getByRole("link", { name: "Mark complete and continue" }).click();
 
   await expect(page).toHaveURL(/\/kongctl\/installation\/authenticate\/$/);
-  await expect(page.getByText("1 of 33", { exact: true })).toBeVisible();
+  await expect(page.getByText("1 of 34", { exact: true })).toBeVisible();
 
   await page.reload();
-  await expect(page.getByText("1 of 33", { exact: true })).toBeVisible();
+  await expect(page.getByText("1 of 34", { exact: true })).toBeVisible();
 });
 
 test("persists a chosen color theme", async ({ page }) => {

--- a/test/integration/declarative/config_templates_test.go
+++ b/test/integration/declarative/config_templates_test.go
@@ -1,0 +1,169 @@
+//go:build integration
+
+package declarative_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/declarative"
+	"github.com/kong/kongctl/internal/declarative/labels"
+	"github.com/kong/kongctl/internal/declarative/loader"
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/kong/kongctl/internal/konnect/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigTemplatesExpandAcrossFilesAndResourceLevels(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	templatesPath := filepath.Join(dir, "templates.yaml")
+	require.NoError(t, os.WriteFile(templatesPath, []byte(`
+_templates:
+  standard-portal:
+    authentication_enabled: true
+    labels:
+      managed-by: kongctl
+  oidc-config:
+    issuer: https://auth.example.com
+    auth_methods: [session]
+  oidc-policy:
+    type: openid-connect
+    enabled: true
+    global: false
+    config:
+      _extends: oidc-config
+`), 0o600))
+
+	resourcesPath := filepath.Join(dir, "resources.yaml")
+	require.NoError(t, os.WriteFile(resourcesPath, []byte(`
+portals:
+  - _extends: standard-portal
+    ref: payments-portal
+    name: Payments Developer Portal
+    labels:
+      business-unit: payments
+ai_gateways:
+  - ref: shared-gateway
+    name: shared-gateway
+    display_name: Shared Gateway
+    policies:
+      - _extends: oidc-policy
+        ref: payments-oidc
+        name: payments-oidc
+        display_name: Payments OIDC
+        config:
+          auth_methods: [bearer]
+          groups_required: [payments-api-users]
+`), 0o600))
+
+	rs, err := loader.NewWithBaseDir(dir).LoadFromSources([]loader.Source{
+		{Path: templatesPath, Type: loader.SourceTypeFile},
+		{Path: resourcesPath, Type: loader.SourceTypeFile},
+	}, false)
+	require.NoError(t, err)
+
+	require.Len(t, rs.Portals, 1)
+	require.NotNil(t, rs.Portals[0].AuthenticationEnabled)
+	assert.True(t, *rs.Portals[0].AuthenticationEnabled)
+	assert.Equal(t, "kongctl", *rs.Portals[0].Labels["managed-by"])
+	assert.Equal(t, "payments", *rs.Portals[0].Labels["business-unit"])
+
+	require.Len(t, rs.AIGatewayPolicies, 1)
+	policy := rs.AIGatewayPolicies[0]
+	assert.Equal(t, "openid-connect", policy.Type)
+	assert.Equal(t, "https://auth.example.com", policy.Config["issuer"])
+	assert.Equal(t, []any{"bearer"}, policy.Config["auth_methods"])
+	assert.Equal(t, []any{"payments-api-users"}, policy.Config["groups_required"])
+}
+
+func TestConfigTemplateChangePlansUpdatesForEveryConsumer(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "portals.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+_templates:
+  shared-portal:
+    description: Updated shared description
+portals:
+  - _extends: shared-portal
+    ref: payments-portal
+    name: Payments Portal
+  - _extends: shared-portal
+    ref: reporting-portal
+    name: Reporting Portal
+`), 0o600))
+
+	ctx := SetupTestContext(t)
+	sdkFactory := ctx.Value(helpers.SDKAPIFactoryKey).(helpers.SDKAPIFactory)
+	konnectSDK, err := sdkFactory(GetTestConfig(), nil)
+	require.NoError(t, err)
+	mockSDK := konnectSDK.(*helpers.MockKonnectSDK)
+	mockPortalAPI := mockSDK.GetPortalAPI().(*MockPortalAPI)
+	oldDescription := "Old shared description"
+	mockPortalAPI.On("ListPortals", mock.Anything, mock.Anything).Return(&kkOps.ListPortalsResponse{
+		ListPortalsResponse: &kkComps.ListPortalsResponse{
+			Data: []kkComps.ListPortalsResponsePortal{
+				{
+					ID: "payments-id", Name: "Payments Portal", Description: &oldDescription,
+					Labels: map[string]string{labels.NamespaceKey: "default"},
+				},
+				{
+					ID: "reporting-id", Name: "Reporting Portal", Description: &oldDescription,
+					Labels: map[string]string{labels.NamespaceKey: "default"},
+				},
+			},
+			Meta: kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: 2}},
+		},
+	}, nil)
+	mockSDK.GetAppAuthStrategiesAPI().(*MockAppAuthStrategiesAPI).
+		On("ListAppAuthStrategies", mock.Anything, mock.Anything).
+		Return(&kkOps.ListAppAuthStrategiesResponse{
+			StatusCode: 200,
+			ListAppAuthStrategiesResponse: &kkComps.ListAppAuthStrategiesResponse{
+				Data: []kkComps.AppAuthStrategy{},
+			},
+		}, nil).
+		Maybe()
+	mockSDK.GetAPIAPI().(*MockAPIAPI).
+		On("ListApis", mock.Anything, mock.Anything).
+		Return(&kkOps.ListApisResponse{
+			StatusCode: 200,
+			ListAPIResponse: &kkComps.ListAPIResponse{
+				Data: []kkComps.APIResponseSchema{},
+				Meta: kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: 0}},
+			},
+		}, nil).
+		Maybe()
+
+	planCmd, err := declarative.NewDeclarativeCmd("plan")
+	require.NoError(t, err)
+	planCmd.SetContext(ctx)
+	var output bytes.Buffer
+	planCmd.SetOut(&output)
+	planCmd.SetErr(&output)
+	planPath := filepath.Join(dir, "plan.json")
+	planCmd.SetArgs([]string{"-f", configPath, "--output-file", planPath})
+	require.NoError(t, planCmd.Execute(), output.String())
+
+	planData, err := os.ReadFile(planPath)
+	require.NoError(t, err)
+	var generatedPlan planner.Plan
+	require.NoError(t, json.Unmarshal(planData, &generatedPlan))
+	require.Len(t, generatedPlan.Changes, 2)
+	for _, change := range generatedPlan.Changes {
+		assert.Equal(t, planner.ActionUpdate, change.Action)
+		assert.Equal(t, "Updated shared description", change.Fields["description"])
+	}
+	assert.ElementsMatch(t, []string{"payments-portal", "reporting-portal"}, []string{
+		generatedPlan.Changes[0].ResourceRef,
+		generatedPlan.Changes[1].ResourceRef,
+	})
+}


### PR DESCRIPTION
## Summary

- add source-set-wide `_templates` discovery and `_extends` expansion for any
  declarative configuration block
- implement recursive configuration-block merging, template inheritance,
  cycle detection, duplicate detection, and source-aware diagnostics
- preserve per-source tag context so templates compose safely with `!file`,
  `!env`, references, and deferred secrets
- document the complete merge contract and add Portal and AI Gateway examples
- add a Learn lesson and an OpenAI cost-management example using `!secret` and
  `!env OPENAI_API_KEY`

## Testing

- `go fix ./...`
- `make format`
- `make build`
- `make test`
- `make test-integration`
- `npm test -- --run` (from `site`)
- `npm exec prettier -- --check .` (from `site`)
- `make lint` *(currently fails on pre-existing line-length, misspelling, and
  staticcheck findings in generated/mock files outside this change)*

Closes #1774
