### PR TITLE
feat(declarative): manage AI Gateway Config Store secrets

### DIFF
--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -394,8 +394,8 @@ This section covers the root AI Gateway resource backed by the Konnect
 `/v1/ai-gateways` API, AI Gateway Model Providers, AI Gateway Models, AI
 Gateway Auth Strategies, AI Gateway MCP Servers, AI Gateway Agents, AI
 Gateway Consumers, AI Gateway Consumer Credentials, AI Gateway Consumer Groups,
-AI Gateway Config Stores, AI Gateway Vaults, and AI Gateway Data Plane
-Certificates. Use
+AI Gateway Config Stores, AI Gateway Config Store Secrets, AI Gateway Vaults,
+and AI Gateway Data Plane Certificates. Use
 `kongctl explain ai_gateway --output yaml`,
 `kongctl explain ai_gateway_model_provider --output yaml`,
 `kongctl explain ai_gateway_auth_strategy --output yaml`,
@@ -406,6 +406,7 @@ Certificates. Use
 `kongctl explain ai_gateway.models --output yaml`,
 `kongctl explain ai_gateway.mcp_servers --output yaml`,
 `kongctl explain ai_gateway.config_stores --output yaml`,
+`kongctl explain ai_gateway.config_stores.secrets --output yaml`,
 `kongctl explain ai_gateway.vaults --output yaml`, and
 `kongctl explain ai_gateway.data_plane_certificates --output yaml` as the
 authoritative schemas.
@@ -446,23 +447,26 @@ OAuth access-token claim selection and protected-resource metadata. The
 
 For AI Gateway Auth Strategies, Policies, Agents, Consumers, Consumer
 Groups, MCP Servers, Config Stores, Vaults, and Data Plane Certificates,
-root-level
-declarations must include `ai_gateway`, while nested declarations inherit the
-parent gateway. AI Gateway
-Consumer Credentials are children of AI Gateway Consumers; root-level
+root-level declarations must include `ai_gateway`, while nested declarations
+inherit the parent gateway. AI Gateway Consumer Credentials are children of AI
+Gateway Consumers; root-level
 declarations must include `ai_gateway_consumer`, while nested declarations
 inherit the parent consumer. Omit `auth_strategies`, `policies`, `agents`,
 `consumers`, `credentials`, `consumer_groups`, `mcp_servers`, `vaults`, or
 `data_plane_certificates` to leave existing child resources unmanaged during
-sync. Use `auth_strategies: []`, `policies: []`, `agents: []`,
+sync. Config Store Secrets are children of Config Stores; root-level
+declarations must include `ai_gateway_config_store`, while nested declarations
+inherit the parent store. Omit `secrets` to leave existing secrets unmanaged.
+Use `auth_strategies: []`, `policies: []`, `agents: []`,
 `consumers: []`, `credentials: []`, `consumer_groups: []`, `mcp_servers: []`,
-`config_stores: []`, `vaults: []`, or
+`config_stores: []`, `secrets: []`, `vaults: []`, or
 `data_plane_certificates: []` under a specific parent to sync-delete that child
 type. Root-level `ai_gateway_auth_strategies: []`,
 `ai_gateway_policies: []`, `ai_gateway_agents: []`,
 `ai_gateway_consumers: []`, `ai_gateway_consumer_credentials: []`,
 `ai_gateway_consumer_groups: []`, `ai_gateway_mcp_servers: []`,
-`ai_gateway_config_stores: []`, `ai_gateway_vaults: []`, and
+`ai_gateway_config_stores: []`, `ai_gateway_config_store_secrets: []`,
+`ai_gateway_vaults: []`, and
 `ai_gateway_data_plane_certificates: []` are rejected because they do not
 identify a parent resource.
 
@@ -876,12 +880,33 @@ ai_gateway_config_stores:
    ai_gateway: support-gateway
    name: support-store
    display_name: Support-Store
+   secrets:
+    - ref: support-openai-header
+      key: openai-auth-header
+      value: !secret {source: !env OPENAI_AUTH_HEADER}
+```
+
+Secrets can also be declared at the root. The `value` field is write-only and
+must use `!secret` with a deferred source. A declaration or dump may omit
+`value` to represent an existing secret without requesting a write. Creating a
+missing secret without `value` is rejected. Use `--write-secret
+support-openai-header#value` or `--write-secrets` to rotate an existing value.
+
+```yaml
+ai_gateway_config_store_secrets:
+ - ref: support-openai-header
+   ai_gateway_config_store: support-store
+   key: openai-auth-header
+   value: !secret {source: !env OPENAI_AUTH_HEADER}
 ```
 
 Use `kongctl get ai-gateway config-stores --gateway-id <id>` (or
 `--gateway-name <name>`) to list Config Stores. Add a Config Store ID or name
 as the final argument to retrieve one store. Text, JSON, and YAML output are
-supported.
+supported. Use `kongctl get ai-gateway config-stores <store> secrets
+--gateway-id <id>` to list safe secret metadata, and append a secret key to
+retrieve one secret. The `list` verb supports the same secret-list form.
+Secret values are never returned or displayed.
 
 Konnect Vaults can reference a Config Store declared in the same configuration.
 The reference is resolved to the Config Store API ID and orders its creation

--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -591,6 +591,10 @@ ai_gateways:
       - ref: support-config-store
         name: support-config-store
         display_name: Support-Config-Store
+        secrets:
+          - ref: support-openai-header
+            key: openai-auth-header
+            value: !secret {source: !env OPENAI_AUTH_HEADER}
     vaults:
       - ref: support-secrets
         name: support-secrets
@@ -599,9 +603,13 @@ ai_gateways:
           config_store_id: !ref support-config-store#id
 ```
 
-Config Store resources manage the store, but not the secrets it contains. See
-the [Config Store and Vault example][config-store-vault-example] for a model
-provider that consumes a populated secret with a Vault reference.
+Secret values are write-only. New secrets require `value: !secret` with a
+deferred source and are written once during creation. Existing secrets are not
+rotated unless `--write-secret <ref>#value` or `--write-secrets` is supplied
+while planning. Omit `secrets` to leave a store's secrets unmanaged during
+sync, or use `secrets: []` to remove all secrets in that store's sync scope.
+See the [Config Store and Vault example][config-store-vault-example] for a
+complete provider Vault reference.
 
 [config-store-vault-example]:
   examples/declarative/ai-gateway/config-store-vault.yaml

--- a/docs/examples/declarative/ai-gateway/README.md
+++ b/docs/examples/declarative/ai-gateway/README.md
@@ -17,9 +17,9 @@ Gateway resources.
 - [templates](templates) centralizes model token costs used by AI Rate Limiting
   Advanced, then applies the shared costs and policy across multiple AI model
   resources.
-- [config-store-vault.yaml](config-store-vault.yaml) connects a nested Config
-  Store to a Konnect Vault with `!ref`, then uses a Vault reference for an
-  OpenAI provider authorization header.
+- [config-store-vault.yaml](config-store-vault.yaml) creates a secret in a
+  nested Config Store, connects the store to a Konnect Vault with `!ref`, then
+  uses a Vault reference for an OpenAI provider authorization header.
 - [data-plane-certificates.yaml](data-plane-certificates.yaml) defines AI
   Gateway data plane certificates using both nested
   `data_plane_certificates` and root-level
@@ -35,10 +35,9 @@ applying `ai-gateway.yaml` or the federated example. Set `OPENAI_API_KEY` to
 only the token when using `ai-gateway-remote.yaml`; its `!secret` composition
 adds the `Bearer ` prefix.
 
-Before applying `config-store-vault.yaml`, add a secret named
-`openai-auth-header` to `support-config-store`. Its value should be the full
-OpenAI authorization header, for example `Bearer ...`. Config Store resources
-manage the store itself, but do not manage the secrets it contains. The model
-provider uses the literal `{vault://support-secrets/openai-auth-header}` vault
-reference. The reference is public configuration, remains visible in plans,
-and is resolved by Konnect when the provider uses it.
+Set `OPENAI_AUTH_HEADER` to the full OpenAI authorization header before
+applying `config-store-vault.yaml`. kongctl creates the Config Store secret
+from this deferred source without placing its value in the plan. The model
+provider uses the public
+`{vault://support-secrets/openai-auth-header}` reference, which remains visible
+in plans and is resolved by Konnect when the provider uses it.

--- a/docs/examples/declarative/ai-gateway/config-store-vault.yaml
+++ b/docs/examples/declarative/ai-gateway/config-store-vault.yaml
@@ -15,6 +15,10 @@ ai_gateways:
       - ref: support-config-store
         name: support-config-store
         display_name: Support-Config-Store
+        secrets:
+          - ref: support-openai-header
+            key: openai-auth-header
+            value: !secret {source: !env OPENAI_AUTH_HEADER}
     vaults:
       - ref: support-secrets
         name: support-secrets

--- a/docs/examples/declarative/ai-gateway/openai-llm/data-plane.sh
+++ b/docs/examples/declarative/ai-gateway/openai-llm/data-plane.sh
@@ -7,7 +7,7 @@ cert_dir="${script_dir}/certs"
 cert_file="${cert_dir}/data-plane.crt"
 key_file="${cert_dir}/data-plane.key"
 container_name="openai-llm-data-plane"
-image="${KONG_AI_GATEWAY_IMAGE:-kong/kong-ai-gateway:2.0.1}"
+image="${KONG_AI_GATEWAY_IMAGE:-kong/kong-ai-gateway:2.0.2}"
 
 usage() {
   echo "Usage: $0 certs|run|stop"

--- a/internal/cmd/root/products/konnect/aigateway/config_store_secrets.go
+++ b/internal/cmd/root/products/konnect/aigateway/config_store_secrets.go
@@ -1,0 +1,259 @@
+package aigateway
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/table"
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/cmd"
+	cmdCommon "github.com/kong/kongctl/internal/cmd/common"
+	"github.com/kong/kongctl/internal/cmd/output/tableview"
+	"github.com/kong/kongctl/internal/cmd/root/products/konnect/common"
+	"github.com/kong/kongctl/internal/config"
+	"github.com/kong/kongctl/internal/konnect/helpers"
+	"github.com/kong/kongctl/internal/util/pagination"
+	"github.com/segmentio/cli"
+)
+
+type aiGatewayConfigStoreSecretRecord struct {
+	Key              string
+	LocalCreatedTime string
+	LocalUpdatedTime string
+}
+
+func (h aiGatewayConfigStoresHandler) runSecrets(store string, args []string) error {
+	helper := cmd.BuildHelper(h.cmd, append([]string{store, "secrets"}, args...))
+	if len(args) > 1 {
+		return &cmd.ConfigurationError{Err: fmt.Errorf(
+			"too many arguments. Listing AI Gateway Config Store secrets requires a store and optional secret key",
+		)}
+	}
+	store = strings.TrimSpace(store)
+	if store == "" {
+		return &cmd.ConfigurationError{Err: fmt.Errorf("an AI Gateway Config Store ID or name is required")}
+	}
+	cfg, err := helper.GetConfig()
+	if err != nil {
+		return err
+	}
+	logger, err := helper.GetLogger()
+	if err != nil {
+		return err
+	}
+	outType, err := helper.GetOutputFormat()
+	if err != nil {
+		return err
+	}
+	printer, err := cli.Format(outType.String(), helper.GetStreams().Out)
+	if err != nil {
+		return err
+	}
+	defer printer.Flush()
+
+	sdk, err := helper.GetKonnectSDK(cfg, logger)
+	if err != nil {
+		return err
+	}
+	gatewayID, gatewayName := getAIGatewayIdentifiers(cfg)
+	if gatewayID != "" && gatewayName != "" {
+		return &cmd.ConfigurationError{Err: fmt.Errorf(
+			"only one of --%s or --%s can be provided",
+			aiGatewayIDFlagName,
+			aiGatewayNameFlagName,
+		)}
+	}
+	if gatewayID == "" && gatewayName == "" {
+		return &cmd.ConfigurationError{Err: fmt.Errorf(
+			"an AI Gateway identifier is required. Provide --%s or --%s",
+			aiGatewayIDFlagName,
+			aiGatewayNameFlagName,
+		)}
+	}
+	if gatewayID == "" {
+		gatewayID, err = resolveAIGatewayIDByName(gatewayName, sdk.GetAIGatewayAPI(), helper, cfg)
+		if err != nil {
+			return err
+		}
+	}
+	api := sdk.GetAIGatewayConfigStoresAPI()
+	if api == nil {
+		return &cmd.ExecutionError{
+			Msg: "AI Gateway Config Stores client is not available",
+			Err: fmt.Errorf("AI Gateway Config Stores client not configured"),
+		}
+	}
+	if len(args) == 1 {
+		return h.getSingleSecret(helper, api, gatewayID, store, args[0], outType, printer)
+	}
+	return h.listSecrets(helper, api, gatewayID, store, outType, printer, cfg)
+}
+
+func (h aiGatewayConfigStoresHandler) listSecrets(
+	helper cmd.Helper,
+	api helpers.AIGatewayConfigStoresAPI,
+	gatewayID string,
+	store string,
+	outType cmdCommon.OutputFormat,
+	printer cli.PrintFlusher,
+	cfg config.Hook,
+) error {
+	secrets, err := fetchAIGatewayConfigStoreSecrets(helper, api, gatewayID, store, cfg)
+	if err != nil {
+		return err
+	}
+	records := make([]aiGatewayConfigStoreSecretRecord, 0, len(secrets))
+	rows := make([]table.Row, 0, len(secrets))
+	for _, secret := range secrets {
+		record := aiGatewayConfigStoreSecretToRecord(secret)
+		records = append(records, record)
+		rows = append(rows, table.Row{record.Key, record.LocalCreatedTime, record.LocalUpdatedTime})
+	}
+	return tableview.RenderForFormat(
+		helper,
+		false,
+		outType,
+		printer,
+		helper.GetStreams(),
+		records,
+		secrets,
+		"",
+		tableview.WithCustomTable([]string{"KEY", "CREATED", "UPDATED"}, rows),
+		tableview.WithRootLabel("secrets"),
+		tableview.WithDetailHelper(helper),
+		tableview.WithDetailRenderer(func(index int) string {
+			if index < 0 || index >= len(secrets) {
+				return ""
+			}
+			return aiGatewayConfigStoreSecretDetailView(secrets[index])
+		}),
+	)
+}
+
+func (h aiGatewayConfigStoresHandler) getSingleSecret(
+	helper cmd.Helper,
+	api helpers.AIGatewayConfigStoresAPI,
+	gatewayID string,
+	store string,
+	key string,
+	outType cmdCommon.OutputFormat,
+	printer cli.PrintFlusher,
+) error {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return &cmd.ConfigurationError{Err: fmt.Errorf("a Config Store secret key is required")}
+	}
+	res, err := api.GetAiGatewayConfigStoreSecret(
+		helper.GetContext(),
+		kkOps.GetAiGatewayConfigStoreSecretRequest{
+			GatewayID:           gatewayID,
+			ConfigStoreIDOrName: store,
+			Key:                 key,
+		},
+	)
+	if err != nil {
+		return cmd.PrepareExecutionError(
+			"Failed to get AI Gateway Config Store secret",
+			err,
+			helper.GetCmd(),
+			cmd.TryConvertErrorToAttrs(err)...,
+		)
+	}
+	secret := res.GetAIGatewayConfigStoreSecret()
+	if secret == nil {
+		return &cmd.ExecutionError{
+			Msg: "AI Gateway Config Store secret response was empty",
+			Err: fmt.Errorf("no Config Store secret returned for key %s", key),
+		}
+	}
+	record := aiGatewayConfigStoreSecretToRecord(*secret)
+	return tableview.RenderForFormat(
+		helper,
+		false,
+		outType,
+		printer,
+		helper.GetStreams(),
+		record,
+		secret,
+		"",
+		tableview.WithRootLabel("secrets"),
+		tableview.WithDetailHelper(helper),
+		tableview.WithDetailRenderer(func(index int) string {
+			if index == 0 {
+				return aiGatewayConfigStoreSecretDetailView(*secret)
+			}
+			return ""
+		}),
+	)
+}
+
+func fetchAIGatewayConfigStoreSecrets(
+	helper cmd.Helper,
+	api helpers.AIGatewayConfigStoresAPI,
+	gatewayID string,
+	store string,
+	cfg config.Hook,
+) ([]kkComps.AIGatewayConfigStoreSecret, error) {
+	requestPageSize := common.ResolveRequestPageSize(cfg)
+	var pageAfter *string
+	var secrets []kkComps.AIGatewayConfigStoreSecret
+	for {
+		res, err := api.ListAiGatewayConfigStoreSecrets(
+			helper.GetContext(),
+			kkOps.ListAiGatewayConfigStoreSecretsRequest{
+				GatewayID:           gatewayID,
+				ConfigStoreIDOrName: store,
+				PageSize:            &requestPageSize,
+				PageAfter:           pageAfter,
+			},
+		)
+		if err != nil {
+			return nil, cmd.PrepareExecutionError(
+				"Failed to list AI Gateway Config Store secrets",
+				err,
+				helper.GetCmd(),
+				cmd.TryConvertErrorToAttrs(err)...,
+			)
+		}
+		body := res.GetListAIGatewayConfigStoreSecretsResponse()
+		if body == nil {
+			break
+		}
+		secrets = append(secrets, body.Data...)
+		next := pagination.ExtractPageAfterCursor(body.Meta.Page.Next)
+		if next == "" {
+			break
+		}
+		pageAfter = &next
+	}
+	return secrets, nil
+}
+
+func aiGatewayConfigStoreSecretToRecord(
+	secret kkComps.AIGatewayConfigStoreSecret,
+) aiGatewayConfigStoreSecretRecord {
+	record := aiGatewayConfigStoreSecretRecord{
+		Key:              valueOrMissing(secret.Key),
+		LocalCreatedTime: aiGatewayMissingValue,
+		LocalUpdatedTime: aiGatewayMissingValue,
+	}
+	if !secret.CreatedAt.IsZero() {
+		record.LocalCreatedTime = secret.CreatedAt.In(time.Local).Format("2006-01-02 15:04:05")
+	}
+	if !secret.UpdatedAt.IsZero() {
+		record.LocalUpdatedTime = secret.UpdatedAt.In(time.Local).Format("2006-01-02 15:04:05")
+	}
+	return record
+}
+
+func aiGatewayConfigStoreSecretDetailView(secret kkComps.AIGatewayConfigStoreSecret) string {
+	record := aiGatewayConfigStoreSecretToRecord(secret)
+	return fmt.Sprintf(
+		"key: %s\ncreated_at: %s\nupdated_at: %s",
+		record.Key,
+		record.LocalCreatedTime,
+		record.LocalUpdatedTime,
+	)
+}

--- a/internal/cmd/root/products/konnect/aigateway/config_stores.go
+++ b/internal/cmd/root/products/konnect/aigateway/config_stores.go
@@ -31,7 +31,7 @@ type aiGatewayConfigStoreRecord struct {
 }
 
 var (
-	aiGatewayConfigStoresUse   = "config-stores [config-store-id|config-store-name]"
+	aiGatewayConfigStoresUse   = "config-stores [config-store-id|config-store-name] [secrets [key]]"
 	aiGatewayConfigStoresShort = i18n.T(
 		"root.products.konnect.ai-gateway.configStoresShort",
 		"List or get Config Stores for a Konnect AI Gateway",
@@ -44,6 +44,11 @@ var (
 %[1]s get ai-gateway config-stores --gateway-name "Customer Support Gateway"
 # Get a Config Store by name
 %[1]s get ai-gateway config-stores --gateway-id <gateway-id> support-store
+# List safe secret metadata for a Config Store
+%[1]s get ai-gateway config-stores support-store secrets --gateway-id <gateway-id>
+%[1]s list ai-gateway config-stores support-store secrets --gateway-id <gateway-id>
+# Get one Config Store secret by key (the value is never returned)
+%[1]s get ai-gateway config-stores support-store secrets openai-auth-header --gateway-id <gateway-id>
 `, meta.CLIName))
 )
 
@@ -86,6 +91,9 @@ type aiGatewayConfigStoresHandler struct {
 }
 
 func (h aiGatewayConfigStoresHandler) run(args []string) error {
+	if len(args) >= 2 && (args[1] == "secrets" || args[1] == "secret") {
+		return h.runSecrets(args[0], args[2:])
+	}
 	helper := cmd.BuildHelper(h.cmd, args)
 	if len(args) > 1 {
 		return &cmd.ConfigurationError{Err: fmt.Errorf(

--- a/internal/cmd/root/products/konnect/aigateway/config_stores_test.go
+++ b/internal/cmd/root/products/konnect/aigateway/config_stores_test.go
@@ -25,3 +25,20 @@ func TestAIGatewayConfigStorePresentation(t *testing.T) {
 	require.Equal(t, displayName, record.DisplayName)
 	require.Contains(t, aiGatewayConfigStoreDetailView(store), "display_name: Support-Store")
 }
+
+func TestAIGatewayConfigStoreSecretPresentationContainsOnlyMetadata(t *testing.T) {
+	updatedAt := time.Date(2026, time.August, 25, 12, 30, 0, 0, time.UTC)
+	secret := kkComps.AIGatewayConfigStoreSecret{
+		Key:       "openai-auth-header",
+		CreatedAt: updatedAt.Add(-time.Hour),
+		UpdatedAt: updatedAt,
+	}
+
+	record := aiGatewayConfigStoreSecretToRecord(secret)
+	require.Equal(t, secret.Key, record.Key)
+	detail := aiGatewayConfigStoreSecretDetailView(secret)
+	require.Contains(t, detail, "key: openai-auth-header")
+	require.Contains(t, detail, "created_at:")
+	require.Contains(t, detail, "updated_at:")
+	require.NotContains(t, detail, "value")
+}

--- a/internal/cmd/root/verbs/dump/declarative_children.go
+++ b/internal/cmd/root/verbs/dump/declarative_children.go
@@ -779,10 +779,22 @@ func buildAIGatewayConfigStores(
 	}
 	result := make([]declresources.AIGatewayConfigStoreResource, 0, len(stores))
 	for _, store := range stores {
-		result = append(
-			result,
-			declresources.AIGatewayConfigStoreResourceFromResponse(gatewayRef, store.AIGatewayConfigStore),
-		)
+		resource := declresources.AIGatewayConfigStoreResourceFromResponse(gatewayRef, store.AIGatewayConfigStore)
+		secrets, err := client.ListAIGatewayConfigStoreSecrets(ctx, gatewayID, store.ID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list secrets for AI Gateway Config Store %s: %w", store.Name, err)
+		}
+		resource.Secrets = make([]declresources.AIGatewayConfigStoreSecretResource, 0, len(secrets))
+		for _, secret := range secrets {
+			resource.Secrets = append(
+				resource.Secrets,
+				declresources.AIGatewayConfigStoreSecretResourceFromResponse(resource.Ref, secret.AIGatewayConfigStoreSecret),
+			)
+		}
+		slices.SortFunc(resource.Secrets, func(a, b declresources.AIGatewayConfigStoreSecretResource) int {
+			return cmp.Compare(a.Key, b.Key)
+		})
+		result = append(result, resource)
 	}
 	slices.SortFunc(result, func(a, b declresources.AIGatewayConfigStoreResource) int {
 		if a.Name == b.Name {

--- a/internal/declarative/executor/ai_gateway_config_store_secret_adapter.go
+++ b/internal/declarative/executor/ai_gateway_config_store_secret_adapter.go
@@ -1,0 +1,138 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/kong/kongctl/internal/declarative/state"
+)
+
+// AIGatewayConfigStoreSecretAdapter implements write-only Config Store secret operations.
+type AIGatewayConfigStoreSecretAdapter struct {
+	client *state.Client
+}
+
+func NewAIGatewayConfigStoreSecretAdapter(client *state.Client) *AIGatewayConfigStoreSecretAdapter {
+	return &AIGatewayConfigStoreSecretAdapter{client: client}
+}
+
+func (a *AIGatewayConfigStoreSecretAdapter) MapCreateFields(
+	_ context.Context,
+	_ *ExecutionContext,
+	fields map[string]any,
+	create *kkComps.CreateAIGatewayConfigStoreSecretRequest,
+) error {
+	return mapAIGatewaySDKRequest("AI Gateway Config Store secret create", fields, create)
+}
+
+func (a *AIGatewayConfigStoreSecretAdapter) MapUpdateFields(
+	_ context.Context,
+	_ *ExecutionContext,
+	fields map[string]any,
+	update *kkComps.UpdateAIGatewayConfigStoreSecretRequest,
+	_ map[string]string,
+) error {
+	return mapAIGatewaySDKRequest("AI Gateway Config Store secret update", fields, update)
+}
+
+func (a *AIGatewayConfigStoreSecretAdapter) Create(
+	ctx context.Context,
+	req kkComps.CreateAIGatewayConfigStoreSecretRequest,
+	_ string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	gatewayID, storeID, err := aiGatewayConfigStoreSecretParentIDs(execCtx)
+	if err != nil {
+		return "", err
+	}
+	return a.client.CreateAIGatewayConfigStoreSecret(ctx, gatewayID, storeID, req)
+}
+
+func (a *AIGatewayConfigStoreSecretAdapter) Update(
+	ctx context.Context,
+	key string,
+	req kkComps.UpdateAIGatewayConfigStoreSecretRequest,
+	_ string,
+	execCtx *ExecutionContext,
+) (string, error) {
+	gatewayID, storeID, err := aiGatewayConfigStoreSecretParentIDs(execCtx)
+	if err != nil {
+		return "", err
+	}
+	return a.client.UpdateAIGatewayConfigStoreSecret(ctx, gatewayID, storeID, key, req)
+}
+
+func (a *AIGatewayConfigStoreSecretAdapter) Delete(
+	ctx context.Context,
+	key string,
+	execCtx *ExecutionContext,
+) error {
+	gatewayID, storeID, err := aiGatewayConfigStoreSecretParentIDs(execCtx)
+	if err != nil {
+		return err
+	}
+	return a.client.DeleteAIGatewayConfigStoreSecret(ctx, gatewayID, storeID, key)
+}
+
+func (a *AIGatewayConfigStoreSecretAdapter) GetByID(
+	ctx context.Context,
+	key string,
+	execCtx *ExecutionContext,
+) (ResourceInfo, error) {
+	gatewayID, storeID, err := aiGatewayConfigStoreSecretParentIDs(execCtx)
+	if err != nil {
+		return nil, err
+	}
+	secret, err := a.client.GetAIGatewayConfigStoreSecret(ctx, gatewayID, storeID, key)
+	if err != nil || secret == nil {
+		return nil, err
+	}
+	return &aiGatewayConfigStoreSecretResourceInfo{secret: secret}, nil
+}
+
+func (a *AIGatewayConfigStoreSecretAdapter) GetByName(_ context.Context, _ string) (ResourceInfo, error) {
+	return nil, fmt.Errorf("GetByName not supported for AI Gateway Config Store secrets")
+}
+
+func (a *AIGatewayConfigStoreSecretAdapter) ResourceType() string {
+	return planner.ResourceTypeAIGatewayConfigStoreSecret
+}
+
+func (a *AIGatewayConfigStoreSecretAdapter) RequiredFields() []string {
+	return []string{planner.FieldKey, planner.FieldValue}
+}
+
+func (a *AIGatewayConfigStoreSecretAdapter) SupportsUpdate() bool { return true }
+
+func aiGatewayConfigStoreSecretParentIDs(execCtx *ExecutionContext) (string, string, error) {
+	if execCtx == nil || execCtx.PlannedChange == nil {
+		return "", "", fmt.Errorf("execution context required")
+	}
+	change := execCtx.PlannedChange
+	gateway, ok := change.References[planner.FieldAIGatewayID]
+	if !ok || unresolvedReferenceID(gateway.ID) {
+		return "", "", fmt.Errorf("AI Gateway ID required for Config Store secret operations")
+	}
+	if change.Parent != nil && !unresolvedReferenceID(change.Parent.ID) {
+		return gateway.ID, change.Parent.ID, nil
+	}
+	store, ok := change.References[planner.FieldConfigStoreID]
+	if ok && !unresolvedReferenceID(store.ID) {
+		return gateway.ID, store.ID, nil
+	}
+	return "", "", fmt.Errorf("AI Gateway Config Store ID required for secret operations")
+}
+
+type aiGatewayConfigStoreSecretResourceInfo struct {
+	secret *state.AIGatewayConfigStoreSecret
+}
+
+func (a *aiGatewayConfigStoreSecretResourceInfo) GetID() string { return a.secret.Key }
+
+func (a *aiGatewayConfigStoreSecretResourceInfo) GetName() string { return a.secret.Key }
+
+func (a *aiGatewayConfigStoreSecretResourceInfo) GetLabels() map[string]string { return nil }
+
+func (a *aiGatewayConfigStoreSecretResourceInfo) GetNormalizedLabels() map[string]string { return nil }

--- a/internal/declarative/executor/ai_gateway_config_store_secret_adapter_test.go
+++ b/internal/declarative/executor/ai_gateway_config_store_secret_adapter_test.go
@@ -1,0 +1,85 @@
+package executor
+
+import (
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAIGatewayConfigStoreSecretAdapterMapsSDKRequests(t *testing.T) {
+	adapter := NewAIGatewayConfigStoreSecretAdapter(nil)
+
+	var create kkComps.CreateAIGatewayConfigStoreSecretRequest
+	require.NoError(t, adapter.MapCreateFields(t.Context(), nil, map[string]any{
+		planner.FieldKey:   "openai-auth-header",
+		planner.FieldValue: "secret-value",
+	}, &create))
+	require.Equal(t, "openai-auth-header", create.Key)
+	require.Equal(t, "secret-value", create.Value)
+
+	var update kkComps.UpdateAIGatewayConfigStoreSecretRequest
+	require.NoError(t, adapter.MapUpdateFields(t.Context(), nil, map[string]any{
+		planner.FieldValue: "rotated-secret-value",
+	}, &update, nil))
+	require.Equal(t, "rotated-secret-value", update.Value)
+}
+
+func TestAIGatewayConfigStoreSecretParentIDs(t *testing.T) {
+	change := &planner.PlannedChange{
+		Parent: &planner.ParentInfo{ID: "store-id"},
+		References: map[string]planner.ReferenceInfo{
+			planner.FieldAIGatewayID: {ID: "gateway-id"},
+		},
+	}
+
+	gatewayID, storeID, err := aiGatewayConfigStoreSecretParentIDs(&ExecutionContext{PlannedChange: change})
+	require.NoError(t, err)
+	require.Equal(t, "gateway-id", gatewayID)
+	require.Equal(t, "store-id", storeID)
+}
+
+func TestHydrateKnownReferenceIDsResolvesConfigStoreSecretParents(t *testing.T) {
+	exec := New(nil, nil, false)
+	exec.createdResources["1-create-gateway"] = "gateway-id"
+	exec.createdResources["2-create-store"] = "store-id"
+
+	plan := planner.NewPlan("1.0", "test", planner.PlanModeApply)
+	plan.AddChange(planner.PlannedChange{
+		ID:           "1-create-gateway",
+		ResourceType: planner.ResourceTypeAIGateway,
+		ResourceRef:  "support-gateway",
+		Action:       planner.ActionCreate,
+	})
+	plan.AddChange(planner.PlannedChange{
+		ID:           "2-create-store",
+		ResourceType: planner.ResourceTypeAIGatewayConfigStore,
+		ResourceRef:  "support-store",
+		Action:       planner.ActionCreate,
+	})
+	change := planner.PlannedChange{
+		ID:           "3-create-secret",
+		ResourceType: planner.ResourceTypeAIGatewayConfigStoreSecret,
+		ResourceRef:  "support-api-key",
+		Action:       planner.ActionCreate,
+		DependsOn:    []string{"1-create-gateway", "2-create-store"},
+		References: map[string]planner.ReferenceInfo{
+			planner.FieldAIGatewayID: {
+				Ref: "support-gateway",
+				ID:  resources.UnknownReferenceID,
+			},
+			planner.FieldConfigStoreID: {
+				Ref: "support-store",
+				ID:  resources.UnknownReferenceID,
+			},
+		},
+	}
+	plan.AddChange(change)
+
+	exec.hydrateKnownReferenceIDs(&change, plan)
+
+	require.Equal(t, "gateway-id", change.References[planner.FieldAIGatewayID].ID)
+	require.Equal(t, "store-id", change.References[planner.FieldConfigStoreID].ID)
+}

--- a/internal/declarative/executor/base_executor.go
+++ b/internal/declarative/executor/base_executor.go
@@ -166,7 +166,7 @@ func NewManagedLabelBaseExecutor[TCreate any, TUpdate any](
 func (b *BaseExecutor[TCreate, TUpdate]) Create(ctx context.Context, change planner.PlannedChange) (string, error) {
 	logger := ctx.Value(log.LoggerKey).(*slog.Logger)
 	logger.Debug(fmt.Sprintf("Creating %s", b.ops.ResourceType()),
-		slog.Any("fields", httpclient.RedactSensitiveFields(change.Fields)))
+		slog.Any("fields", redactResourceOperationFields(b.ops.ResourceType(), change.Fields)))
 
 	// Validate required fields
 	if err := common.ValidateRequiredFields(change.Fields, b.ops.RequiredFields()); err != nil {
@@ -206,7 +206,7 @@ func (b *BaseExecutor[TCreate, TUpdate]) Update(ctx context.Context, change plan
 
 	logger := ctx.Value(log.LoggerKey).(*slog.Logger)
 	logger.Debug(fmt.Sprintf("Updating %s", b.ops.ResourceType()),
-		slog.Any("change", httpclient.RedactSensitiveFields(change)))
+		slog.Any("change", redactResourceOperationFields(b.ops.ResourceType(), change)))
 
 	resourceName := common.ExtractResourceName(change.Fields)
 
@@ -260,6 +260,13 @@ func (b *BaseExecutor[TCreate, TUpdate]) Update(ctx context.Context, change plan
 	}
 
 	return id, nil
+}
+
+func redactResourceOperationFields(resourceType string, value any) any {
+	if resourceType == planner.ResourceTypeAIGatewayConfigStoreSecret {
+		return httpclient.RedactSensitiveFieldsWithExactKeys(value, planner.FieldValue)
+	}
+	return httpclient.RedactSensitiveFields(value)
 }
 
 // Delete handles DELETE operations for any resource type

--- a/internal/declarative/executor/base_executor_logging_test.go
+++ b/internal/declarative/executor/base_executor_logging_test.go
@@ -1,0 +1,18 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedactResourceOperationFieldsScopesConfigStoreSecretValue(t *testing.T) {
+	fields := map[string]any{planner.FieldValue: "secret-value"}
+
+	redacted := redactResourceOperationFields(planner.ResourceTypeAIGatewayConfigStoreSecret, fields).(map[string]any)
+	assert.Equal(t, "[REDACTED]", redacted[planner.FieldValue])
+
+	unrelated := redactResourceOperationFields(planner.ResourceTypeAIGatewayConfigStore, fields).(map[string]any)
+	assert.Equal(t, "secret-value", unrelated[planner.FieldValue])
+}

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -86,6 +86,8 @@ type Executor struct {
 		kkComps.CreateAIGatewayMCPServerRequest, kkComps.UpdateAIGatewayMCPServerRequest]
 	aiGatewayConfigStoreExecutor *BaseExecutor[
 		kkComps.CreateAIGatewayConfigStoreRequest, kkComps.UpdateAIGatewayConfigStoreRequest]
+	aiGatewayConfigStoreSecretExecutor *BaseExecutor[
+		kkComps.CreateAIGatewayConfigStoreSecretRequest, kkComps.UpdateAIGatewayConfigStoreSecretRequest]
 	aiGatewayVaultExecutor *BaseExecutor[
 		kkComps.CreateAIGatewayVaultRequest, kkComps.UpdateAIGatewayVaultRequest]
 	aiGatewayDataPlaneCertificateExecutor  *BaseCreateDeleteExecutor[createAIGatewayDataPlaneCertificateRequest]
@@ -348,6 +350,12 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 		client,
 		dryRun,
 	)
+	e.aiGatewayConfigStoreSecretExecutor = NewBaseExecutor[
+		kkComps.CreateAIGatewayConfigStoreSecretRequest, kkComps.UpdateAIGatewayConfigStoreSecretRequest](
+		NewAIGatewayConfigStoreSecretAdapter(client),
+		client,
+		dryRun,
+	)
 	e.aiGatewayDataPlaneCertificateExecutor = NewBaseCreateDeleteExecutor[createAIGatewayDataPlaneCertificateRequest](
 		NewAIGatewayDataPlaneCertificateAdapter(client),
 		dryRun,
@@ -599,6 +607,7 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 		e.aiGatewayModelExecutor,
 		e.aiGatewayMCPServerExecutor,
 		e.aiGatewayConfigStoreExecutor,
+		e.aiGatewayConfigStoreSecretExecutor,
 		e.aiGatewayVaultExecutor,
 		e.aiGatewayDataPlaneCertificateExecutor,
 		e.dashboardExecutor,
@@ -2762,6 +2771,11 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 			return "", err
 		}
 		return e.aiGatewayConfigStoreExecutor.Create(ctx, *change)
+	case planner.ResourceTypeAIGatewayConfigStoreSecret:
+		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
+			return "", err
+		}
+		return e.aiGatewayConfigStoreSecretExecutor.Create(ctx, *change)
 	case planner.ResourceTypeAIGatewayVault:
 		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
 			return "", err
@@ -3406,6 +3420,11 @@ func (e *Executor) updateResource(ctx context.Context, change *planner.PlannedCh
 			return "", err
 		}
 		return e.aiGatewayConfigStoreExecutor.Update(ctx, *change)
+	case planner.ResourceTypeAIGatewayConfigStoreSecret:
+		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
+			return "", err
+		}
+		return e.aiGatewayConfigStoreSecretExecutor.Update(ctx, *change)
 	case planner.ResourceTypeAIGatewayVault:
 		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
 			return "", err
@@ -3925,6 +3944,11 @@ func (e *Executor) deleteResource(ctx context.Context, change *planner.PlannedCh
 			return err
 		}
 		return e.aiGatewayConfigStoreExecutor.Delete(ctx, *change)
+	case planner.ResourceTypeAIGatewayConfigStoreSecret:
+		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
+			return err
+		}
+		return e.aiGatewayConfigStoreSecretExecutor.Delete(ctx, *change)
 	case planner.ResourceTypeAIGatewayVault:
 		if err := e.syncResolvedAIGatewayID(ctx, change); err != nil {
 			return err

--- a/internal/declarative/loader/ai_gateway_config_store_test.go
+++ b/internal/declarative/loader/ai_gateway_config_store_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/tags"
 	"github.com/stretchr/testify/require"
 )
 
@@ -118,4 +119,132 @@ ai_gateways:
 	require.NoError(t, err)
 	config := payload[resources.SchemaFieldConfig].(map[string]any)
 	require.Equal(t, "__REF__:support-store#id", config[resources.SchemaFieldConfigStoreID])
+}
+
+func TestLoaderExtractsNestedAIGatewayConfigStoreSecrets(t *testing.T) {
+	input := `
+ai_gateways:
+  - ref: support-gateway
+    display_name: Support Gateway
+    config_stores:
+      - ref: support-store
+        name: support-store
+        secrets:
+          - ref: support-openai-header
+            key: openai-auth-header
+            value: !secret {source: !env OPENAI_AUTH_HEADER}
+`
+	rs, err := New().LoadFile(writeLoaderTestFile(t, input))
+	require.NoError(t, err)
+	require.Len(t, rs.AIGatewayConfigStoreSecrets, 1)
+	require.Equal(t, "support-store", rs.AIGatewayConfigStoreSecrets[0].AIGatewayConfigStore)
+	require.Equal(t, "openai-auth-header", rs.AIGatewayConfigStoreSecrets[0].Key)
+	require.True(t, tags.IsSecretPlaceholder(rs.AIGatewayConfigStoreSecrets[0].Value))
+	require.Contains(t, rs.GetSecretSources("support-openai-header"), "/value")
+	require.True(t, rs.SyncScope.ChildInScope(
+		resources.ResourceTypeAIGatewayConfigStore,
+		"support-store",
+		resources.ResourceTypeAIGatewayConfigStoreSecret,
+	))
+}
+
+func TestLoaderAcceptsRootAIGatewayConfigStoreSecret(t *testing.T) {
+	rs, err := New().LoadFile(writeLoaderTestFile(t, `
+ai_gateways:
+  - ref: support-gateway
+    display_name: Support Gateway
+ai_gateway_config_stores:
+  - ref: support-store
+    ai_gateway: !ref support-gateway
+    name: support-store
+ai_gateway_config_store_secrets:
+  - ref: support-api-key
+    ai_gateway_config_store: !ref support-store
+    key: support-api-key
+    value: !secret {source: !env SUPPORT_API_KEY}
+`))
+	require.NoError(t, err)
+	require.Len(t, rs.AIGatewayConfigStoreSecrets, 1)
+	require.Equal(t, "support-store", resources.NormalizeResourceRef(
+		rs.AIGatewayConfigStoreSecrets[0].AIGatewayConfigStore,
+	))
+	require.Contains(t, rs.GetSecretSources("support-api-key"), "/value")
+}
+
+func TestLoaderAIGatewayConfigStoreSecretSyncScope(t *testing.T) {
+	t.Run("omitted is unmanaged", func(t *testing.T) {
+		rs, err := New().LoadFile(writeLoaderTestFile(t, `
+ai_gateways:
+  - ref: support-gateway
+    display_name: Support Gateway
+    config_stores:
+      - ref: support-store
+        name: support-store
+`))
+		require.NoError(t, err)
+		require.False(t, rs.SyncScope.ChildInScope(
+			resources.ResourceTypeAIGatewayConfigStore,
+			"support-store",
+			resources.ResourceTypeAIGatewayConfigStoreSecret,
+		))
+	})
+
+	t.Run("explicit empty is managed", func(t *testing.T) {
+		rs, err := New().LoadFile(writeLoaderTestFile(t, `
+ai_gateways:
+  - ref: support-gateway
+    display_name: Support Gateway
+    config_stores:
+      - ref: support-store
+        name: support-store
+        secrets: []
+`))
+		require.NoError(t, err)
+		require.True(t, rs.SyncScope.ChildInScope(
+			resources.ResourceTypeAIGatewayConfigStore,
+			"support-store",
+			resources.ResourceTypeAIGatewayConfigStoreSecret,
+		))
+	})
+
+	t.Run("root empty is rejected", func(t *testing.T) {
+		_, err := New().LoadFile(writeLoaderTestFile(t, "ai_gateway_config_store_secrets: []"))
+		require.ErrorContains(t, err, "ai_gateway_config_store_secrets cannot be empty")
+	})
+}
+
+func TestLoaderRejectsLiteralAIGatewayConfigStoreSecretWithoutEchoingValue(t *testing.T) {
+	secretValue := "must-not-appear"
+	_, err := New().LoadFile(writeLoaderTestFile(t, `
+ai_gateways:
+  - ref: support-gateway
+    display_name: Support Gateway
+    config_stores:
+      - ref: support-store
+        name: support-store
+        secrets:
+          - ref: support-openai-header
+            key: openai-auth-header
+            value: `+secretValue+`
+`))
+	require.ErrorContains(t, err, "field /value")
+	require.NotContains(t, err.Error(), secretValue)
+}
+
+func TestLoaderAcceptsDumpedAIGatewayConfigStoreSecretWithoutValue(t *testing.T) {
+	rs, err := New().LoadFile(writeLoaderTestFile(t, `
+ai_gateways:
+  - ref: support-gateway-id
+    display_name: Support Gateway
+    config_stores:
+      - ref: support-store-id
+        name: support-store
+        secrets:
+          - ref: support-api-key
+            key: support-api-key
+`))
+	require.NoError(t, err)
+	require.Len(t, rs.AIGatewayConfigStoreSecrets, 1)
+	require.Equal(t, "support-api-key", rs.AIGatewayConfigStoreSecrets[0].Key)
+	require.Empty(t, rs.AIGatewayConfigStoreSecrets[0].Value)
 }

--- a/internal/declarative/loader/ai_gateway_config_store_test.go
+++ b/internal/declarative/loader/ai_gateway_config_store_test.go
@@ -171,6 +171,50 @@ ai_gateway_config_store_secrets:
 	require.Contains(t, rs.GetSecretSources("support-api-key"), "/value")
 }
 
+func TestLoaderRejectsDuplicateAIGatewayConfigStoreSecretRefsAcrossStores(t *testing.T) {
+	_, err := New().LoadFile(writeLoaderTestFile(t, `
+ai_gateways:
+  - ref: support-gateway
+    display_name: Support Gateway
+    config_stores:
+      - ref: primary-store
+        name: primary-store
+        secrets:
+          - key: api-key
+            value: !secret {source: !env PRIMARY_API_KEY}
+      - ref: fallback-store
+        name: fallback-store
+        secrets:
+          - key: api-key
+            value: !secret {source: !env FALLBACK_API_KEY}
+`))
+	require.ErrorContains(t, err, "duplicate ref 'api-key'")
+}
+
+func TestValidatorRejectsDuplicateAIGatewayConfigStoreSecretRefsAcrossStores(t *testing.T) {
+	rs := &resources.ResourceSet{
+		AIGatewayConfigStores: []resources.AIGatewayConfigStoreResource{
+			{BaseResource: resources.BaseResource{Ref: "primary-store"}},
+			{BaseResource: resources.BaseResource{Ref: "fallback-store"}},
+		},
+		AIGatewayConfigStoreSecrets: []resources.AIGatewayConfigStoreSecretResource{
+			{
+				BaseResource:         resources.BaseResource{Ref: "api-key"},
+				AIGatewayConfigStore: "primary-store",
+				Key:                  "api-key",
+			},
+			{
+				BaseResource:         resources.BaseResource{Ref: "api-key"},
+				AIGatewayConfigStore: "fallback-store",
+				Key:                  "api-key",
+			},
+		},
+	}
+
+	err := New().validateAIGatewayConfigStoreSecrets(rs)
+	require.ErrorContains(t, err, "duplicate ref 'api-key' (already defined as ai_gateway_config_store_secret)")
+}
+
 func TestLoaderAIGatewayConfigStoreSecretSyncScope(t *testing.T) {
 	t.Run("omitted is unmanaged", func(t *testing.T) {
 		rs, err := New().LoadFile(writeLoaderTestFile(t, `

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -819,6 +819,12 @@ func (l *Loader) extractNestedResources(rs *resources.ResourceSet) {
 		for j := range gateway.ConfigStores {
 			store := gateway.ConfigStores[j]
 			store.AIGateway = gateway.Ref
+			for k := range store.Secrets {
+				secret := store.Secrets[k]
+				secret.AIGatewayConfigStore = store.Ref
+				rs.AIGatewayConfigStoreSecrets = append(rs.AIGatewayConfigStoreSecrets, secret)
+			}
+			store.Secrets = nil
 			rs.AIGatewayConfigStores = append(rs.AIGatewayConfigStores, store)
 		}
 		gateway.ConfigStores = nil
@@ -835,6 +841,16 @@ func (l *Loader) extractNestedResources(rs *resources.ResourceSet) {
 			rs.AIGatewayDataPlaneCertificates = append(rs.AIGatewayDataPlaneCertificates, cert)
 		}
 		gateway.DataPlaneCertificates = nil
+	}
+
+	for i := range rs.AIGatewayConfigStores {
+		store := &rs.AIGatewayConfigStores[i]
+		for j := range store.Secrets {
+			secret := store.Secrets[j]
+			secret.AIGatewayConfigStore = store.Ref
+			rs.AIGatewayConfigStoreSecrets = append(rs.AIGatewayConfigStoreSecrets, secret)
+		}
+		store.Secrets = nil
 	}
 
 	for i := range rs.APIs {

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -853,6 +853,12 @@ func (l *Loader) extractNestedResources(rs *resources.ResourceSet) {
 		store.Secrets = nil
 	}
 
+	// Secret sources are collected before the ResourceSet-wide defaults pass, so
+	// establish default secret refs before indexing their source metadata.
+	for i := range rs.AIGatewayConfigStoreSecrets {
+		rs.AIGatewayConfigStoreSecrets[i].SetDefaults()
+	}
+
 	for i := range rs.APIs {
 		api := &rs.APIs[i]
 

--- a/internal/declarative/loader/ref_resolver.go
+++ b/internal/declarative/loader/ref_resolver.go
@@ -284,6 +284,24 @@ func ResolveReferences(ctx context.Context, rs *resources.ResourceSet) error {
 		processCount++
 	}
 
+	for i := range rs.AIGatewayConfigStoreSecrets {
+		if err := resolveResourceFields(
+			ctx,
+			&rs.AIGatewayConfigStoreSecrets[i],
+			rs,
+			resolver,
+			resolutionPath,
+			logger,
+		); err != nil {
+			return fmt.Errorf(
+				"resolving AI gateway config store secret %s: %w",
+				rs.AIGatewayConfigStoreSecrets[i].GetRef(),
+				err,
+			)
+		}
+		processCount++
+	}
+
 	for i := range rs.AIGatewayVaults {
 		if err := resolveResourceFields(ctx, &rs.AIGatewayVaults[i], rs, resolver, resolutionPath, logger); err != nil {
 			return fmt.Errorf("resolving AI gateway vault %s: %w", rs.AIGatewayVaults[i].GetRef(), err)

--- a/internal/declarative/loader/sync_scope.go
+++ b/internal/declarative/loader/sync_scope.go
@@ -92,6 +92,12 @@ var rootChildCollectionScopes = []childCollectionScope{
 		parentType:   resources.ResourceTypeAIGateway,
 	},
 	{
+		key:          "ai_gateway_config_store_secrets",
+		resourceType: resources.ResourceTypeAIGatewayConfigStoreSecret,
+		parentKey:    resources.SchemaFieldAIGatewayConfigStore,
+		parentType:   resources.ResourceTypeAIGatewayConfigStore,
+	},
+	{
 		key:          "ai_gateway_vaults",
 		resourceType: resources.ResourceTypeAIGatewayVault,
 		parentKey:    resources.SchemaFieldAIGateway,
@@ -533,6 +539,7 @@ func captureSyncScope(content []byte, rs *resources.ResourceSet) error {
 		aiGatewayChildCollectionScopes,
 	)
 	captureNestedAIGatewayConsumerCredentialScopes(scope, raw)
+	captureNestedAIGatewayConfigStoreSecretScopes(scope, raw)
 	captureNestedCollectionScopes(
 		scope,
 		raw,
@@ -603,6 +610,12 @@ func captureRootChildScope(scope *resources.SyncScope, raw map[string]any, entry
 		if entry.resourceType == resources.ResourceTypeAIGatewayConfigStore {
 			return fmt.Errorf("%s cannot be empty because each Config Store must declare an ai_gateway parent", entry.key)
 		}
+		if entry.resourceType == resources.ResourceTypeAIGatewayConfigStoreSecret {
+			return fmt.Errorf(
+				"%s cannot be empty because each secret must declare an ai_gateway_config_store parent",
+				entry.key,
+			)
+		}
 		if entry.resourceType == resources.ResourceTypeAIGatewayVault {
 			return fmt.Errorf("%s cannot be empty because each Vault must declare an ai_gateway parent", entry.key)
 		}
@@ -668,6 +681,46 @@ func captureNestedAIGatewayConsumerCredentialScopes(scope *resources.SyncScope, 
 			continue
 		}
 		captureCredentialsUnderConsumers(scope, gateway["consumers"])
+	}
+}
+
+func captureNestedAIGatewayConfigStoreSecretScopes(scope *resources.SyncScope, raw map[string]any) {
+	captureSecretsUnderConfigStores(scope, raw["ai_gateway_config_stores"])
+
+	gateways, ok := asSlice(raw["ai_gateways"])
+	if !ok {
+		return
+	}
+	for _, item := range gateways {
+		gateway, ok := asMap(item)
+		if !ok {
+			continue
+		}
+		captureSecretsUnderConfigStores(scope, gateway["config_stores"])
+	}
+}
+
+func captureSecretsUnderConfigStores(scope *resources.SyncScope, value any) {
+	stores, ok := asSlice(value)
+	if !ok {
+		return
+	}
+	for _, item := range stores {
+		store, ok := asMap(item)
+		if !ok {
+			continue
+		}
+		storeRef := stringValue(store[resources.SchemaFieldRef])
+		if storeRef == "" {
+			continue
+		}
+		if _, ok := store["secrets"]; ok {
+			scope.AddChild(
+				resources.ResourceTypeAIGatewayConfigStore,
+				storeRef,
+				resources.ResourceTypeAIGatewayConfigStoreSecret,
+			)
+		}
 	}
 }
 

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -1098,11 +1098,20 @@ func (l *Loader) validateAIGatewayConfigStores(rs *resources.ResourceSet) error 
 // validateAIGatewayConfigStoreSecrets validates Config Store child secrets.
 func (l *Loader) validateAIGatewayConfigStoreSecrets(rs *resources.ResourceSet) error {
 	keysByStore := make(map[string]string)
+	refs := make(map[string]struct{})
 	for i := range rs.AIGatewayConfigStoreSecrets {
 		secret := &rs.AIGatewayConfigStoreSecrets[i]
 		if err := secret.Validate(); err != nil {
 			return fmt.Errorf("invalid ai_gateway_config_store_secret %q: %w", secret.GetRef(), err)
 		}
+		if _, exists := refs[secret.GetRef()]; exists {
+			return fmt.Errorf(
+				"duplicate ref '%s' (already defined as %s)",
+				secret.GetRef(),
+				resources.ResourceTypeAIGatewayConfigStoreSecret,
+			)
+		}
+		refs[secret.GetRef()] = struct{}{}
 		if existing, found := rs.GetResourceByRef(secret.GetRef()); found &&
 			existing.GetType() != resources.ResourceTypeAIGatewayConfigStoreSecret {
 			return fmt.Errorf("duplicate ref '%s' (already defined as %s)", secret.GetRef(), existing.GetType())

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -76,6 +76,9 @@ func (l *Loader) validateResourceSet(rs *resources.ResourceSet) error {
 	if err := l.validateAIGatewayConfigStores(rs); err != nil {
 		return err
 	}
+	if err := l.validateAIGatewayConfigStoreSecrets(rs); err != nil {
+		return err
+	}
 	if err := l.validateAIGatewayVaults(rs); err != nil {
 		return err
 	}
@@ -1090,6 +1093,51 @@ func (l *Loader) validateAIGatewayConfigStores(rs *resources.ResourceSet) error 
 		resources.SchemaFieldName,
 		func(store *resources.AIGatewayConfigStoreResource) string { return store.Name },
 	)
+}
+
+// validateAIGatewayConfigStoreSecrets validates Config Store child secrets.
+func (l *Loader) validateAIGatewayConfigStoreSecrets(rs *resources.ResourceSet) error {
+	keysByStore := make(map[string]string)
+	for i := range rs.AIGatewayConfigStoreSecrets {
+		secret := &rs.AIGatewayConfigStoreSecrets[i]
+		if err := secret.Validate(); err != nil {
+			return fmt.Errorf("invalid ai_gateway_config_store_secret %q: %w", secret.GetRef(), err)
+		}
+		if existing, found := rs.GetResourceByRef(secret.GetRef()); found &&
+			existing.GetType() != resources.ResourceTypeAIGatewayConfigStoreSecret {
+			return fmt.Errorf("duplicate ref '%s' (already defined as %s)", secret.GetRef(), existing.GetType())
+		}
+		storeRef := resources.NormalizeResourceRef(secret.AIGatewayConfigStore)
+		store, found := rs.GetResourceByRef(storeRef)
+		if !found {
+			return fmt.Errorf(
+				"ai_gateway_config_store_secret %q references unknown ai_gateway_config_store %q",
+				secret.GetRef(),
+				secret.AIGatewayConfigStore,
+			)
+		}
+		if store.GetType() != resources.ResourceTypeAIGatewayConfigStore {
+			return fmt.Errorf(
+				"ai_gateway_config_store_secret %q references %q which is %s, not ai_gateway_config_store",
+				secret.GetRef(),
+				secret.AIGatewayConfigStore,
+				store.GetType(),
+			)
+		}
+		key := storeRef + "\x00" + secret.Key
+		if existingRef, exists := keysByStore[key]; exists {
+			return fmt.Errorf(
+				"duplicate ai_gateway_config_store_secret key %q for ai_gateway_config_store %q "+
+					"(ref: %s conflicts with ref: %s)",
+				secret.Key,
+				storeRef,
+				secret.GetRef(),
+				existingRef,
+			)
+		}
+		keysByStore[key] = secret.GetRef()
+	}
+	return nil
 }
 
 // validateAIGatewayDataPlaneCertificates validates AI Gateway child data plane certificate resources.

--- a/internal/declarative/planner/ai_gateway_config_store_planner.go
+++ b/internal/declarative/planner/ai_gateway_config_store_planner.go
@@ -32,7 +32,22 @@ func (p *Planner) planAIGatewayConfigStoreChanges(
 			dependsOn = []string{gatewayChangeID}
 		}
 		for _, store := range desired {
-			p.planAIGatewayConfigStoreCreate(namespace, gatewayRef, gatewayName, "", store, dependsOn, plan)
+			storeChangeID := p.planAIGatewayConfigStoreCreate(
+				namespace, gatewayRef, gatewayName, "", store, dependsOn, plan,
+			)
+			secrets := p.resources.GetAIGatewayConfigStoreSecretsForStore(store.Ref)
+			if p.shouldPlanChild(
+				plan,
+				resources.ResourceTypeAIGatewayConfigStore,
+				store.Ref,
+				resources.ResourceTypeAIGatewayConfigStoreSecret,
+			) && (len(secrets) > 0 || plan.Metadata.Mode == PlanModeSync) {
+				if err := p.planAIGatewayConfigStoreSecretChanges(
+					ctx, namespace, gatewayRef, "", store.Ref, "", storeChangeID, secrets, plan,
+				); err != nil {
+					return err
+				}
+			}
 		}
 		return nil
 	}
@@ -51,7 +66,7 @@ func (p *Planner) planAIGatewayConfigStoreChanges(
 			desiredKeys[id] = true
 		}
 		if !exists {
-			p.planAIGatewayConfigStoreCreate(
+			storeChangeID := p.planAIGatewayConfigStoreCreate(
 				namespace,
 				gatewayRef,
 				gatewayName,
@@ -60,6 +75,27 @@ func (p *Planner) planAIGatewayConfigStoreChanges(
 				nil,
 				plan,
 			)
+			secrets := p.resources.GetAIGatewayConfigStoreSecretsForStore(desiredStore.Ref)
+			if p.shouldPlanChild(
+				plan,
+				resources.ResourceTypeAIGatewayConfigStore,
+				desiredStore.Ref,
+				resources.ResourceTypeAIGatewayConfigStoreSecret,
+			) && (len(secrets) > 0 || plan.Metadata.Mode == PlanModeSync) {
+				if err := p.planAIGatewayConfigStoreSecretChanges(
+					ctx,
+					namespace,
+					gatewayRef,
+					gatewayID,
+					desiredStore.Ref,
+					"",
+					storeChangeID,
+					secrets,
+					plan,
+				); err != nil {
+					return err
+				}
+			}
 			continue
 		}
 
@@ -76,29 +112,49 @@ func (p *Planner) planAIGatewayConfigStoreChanges(
 		if resource := p.resources.GetAIGatewayConfigStoreByRef(desiredStore.Ref); resource != nil {
 			resource.SetKonnectID(current.ID)
 		}
-		if desiredStore.DisplayName == nil || stringPointersEqual(desiredStore.DisplayName, current.DisplayName) {
-			continue
+		if desiredStore.DisplayName != nil && !stringPointersEqual(desiredStore.DisplayName, current.DisplayName) {
+			fields := map[string]any{FieldDisplayName: *desiredStore.DisplayName}
+			var oldDisplayName any
+			if current.DisplayName != nil {
+				oldDisplayName = *current.DisplayName
+			}
+			changed := map[string]FieldChange{
+				FieldDisplayName: {Old: oldDisplayName, New: *desiredStore.DisplayName},
+			}
+			plan.AddChange(PlannedChange{
+				ID:            p.nextChangeID(ActionUpdate, ResourceTypeAIGatewayConfigStore, desiredStore.Ref),
+				ResourceType:  ResourceTypeAIGatewayConfigStore,
+				ResourceRef:   desiredStore.Ref,
+				ResourceID:    current.ID,
+				Action:        ActionUpdate,
+				Fields:        fields,
+				ChangedFields: changed,
+				Namespace:     namespace,
+				Parent:        &ParentInfo{Ref: gatewayRef, ID: gatewayID},
+			})
 		}
 
-		fields := map[string]any{FieldDisplayName: *desiredStore.DisplayName}
-		var oldDisplayName any
-		if current.DisplayName != nil {
-			oldDisplayName = *current.DisplayName
+		secrets := p.resources.GetAIGatewayConfigStoreSecretsForStore(desiredStore.Ref)
+		if p.shouldPlanChild(
+			plan,
+			resources.ResourceTypeAIGatewayConfigStore,
+			desiredStore.Ref,
+			resources.ResourceTypeAIGatewayConfigStoreSecret,
+		) && (len(secrets) > 0 || plan.Metadata.Mode == PlanModeSync) {
+			if err := p.planAIGatewayConfigStoreSecretChanges(
+				ctx,
+				namespace,
+				gatewayRef,
+				gatewayID,
+				desiredStore.Ref,
+				current.ID,
+				"",
+				secrets,
+				plan,
+			); err != nil {
+				return err
+			}
 		}
-		changed := map[string]FieldChange{
-			FieldDisplayName: {Old: oldDisplayName, New: *desiredStore.DisplayName},
-		}
-		plan.AddChange(PlannedChange{
-			ID:            p.nextChangeID(ActionUpdate, ResourceTypeAIGatewayConfigStore, desiredStore.Ref),
-			ResourceType:  ResourceTypeAIGatewayConfigStore,
-			ResourceRef:   desiredStore.Ref,
-			ResourceID:    current.ID,
-			Action:        ActionUpdate,
-			Fields:        fields,
-			ChangedFields: changed,
-			Namespace:     namespace,
-			Parent:        &ParentInfo{Ref: gatewayRef, ID: gatewayID},
-		})
 	}
 
 	if plan.Metadata.Mode == PlanModeSync && !p.isAIGatewayExternal(gatewayRef) {
@@ -129,14 +185,14 @@ func (p *Planner) planAIGatewayConfigStoreCreate(
 	store resources.AIGatewayConfigStoreResource,
 	dependsOn []string,
 	plan *Plan,
-) {
+) string {
 	fields, err := store.MutablePayloadMap()
 	if err != nil {
 		plan.AddWarning(
 			store.GetRef(),
 			fmt.Sprintf("failed to build AI Gateway Config Store create payload: %s", err),
 		)
-		return
+		return ""
 	}
 
 	change := PlannedChange{
@@ -161,6 +217,7 @@ func (p *Planner) planAIGatewayConfigStoreCreate(
 		}
 	}
 	plan.AddChange(change)
+	return change.ID
 }
 
 func indexAIGatewayConfigStores(

--- a/internal/declarative/planner/ai_gateway_config_store_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_config_store_planner_test.go
@@ -3,6 +3,7 @@ package planner
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
 	"github.com/kong/kongctl/internal/declarative/resources"
 	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/declarative/tags"
 	"github.com/stretchr/testify/require"
 )
 
@@ -162,6 +164,229 @@ func TestAIGatewayConfigStorePlannerResolvesExistingStoreForVault(t *testing.T) 
 	require.Empty(t, plan.Changes[0].DependsOn)
 }
 
+func TestAIGatewayConfigStoreSecretPlannerCreateNoOpAndRotation(t *testing.T) {
+	t.Run("create includes deferred write", func(t *testing.T) {
+		client := state.NewClient(state.ClientConfig{
+			AIGatewayAPI: &testAIGatewayAPI{gateways: []kkComps.AIGateway{testAIGateway()}},
+			AIGatewayConfigStoresAPI: &testAIGatewayConfigStoreAPI{
+				stores: []kkComps.AIGatewayConfigStore{{ID: "store-id", Name: "support-store"}},
+			},
+		})
+		rs := testAIGatewayConfigStoreResourceSet(resources.AIGatewayConfigStoreResource{
+			BaseResource: resources.BaseResource{Ref: "support-store"},
+			AIGateway:    "support-gateway",
+			Name:         "support-store",
+		})
+		rs.AIGatewayConfigStoreSecrets = []resources.AIGatewayConfigStoreSecretResource{{
+			BaseResource:         resources.BaseResource{Ref: "support-openai-header"},
+			AIGatewayConfigStore: "support-store",
+			Key:                  "openai-auth-header",
+			Value:                testSecretPlaceholder(t),
+		}}
+		addTestConfigStoreSecretSource(rs)
+
+		plan, err := NewPlanner(client, slog.Default()).GeneratePlan(
+			t.Context(), rs, Options{Mode: PlanModeApply},
+		)
+		require.NoError(t, err)
+		require.Len(t, plan.Changes, 1)
+		change := plan.Changes[0]
+		require.Equal(t, ResourceTypeAIGatewayConfigStoreSecret, change.ResourceType)
+		require.Equal(t, ActionCreate, change.Action)
+		require.Equal(t, "openai-auth-header", change.Fields[FieldKey])
+		require.Len(t, change.SecretWrites, 1)
+		require.NotContains(t, fmt.Sprint(change.Fields), "configured-secret-value")
+	})
+
+	t.Run("existing is no-op without selector", func(t *testing.T) {
+		client, rs := testExistingConfigStoreSecret(t)
+		plan, err := NewPlanner(client, slog.Default()).GeneratePlan(
+			t.Context(), rs, Options{Mode: PlanModeApply},
+		)
+		require.NoError(t, err)
+		require.Empty(t, plan.Changes)
+	})
+
+	t.Run("existing declaration without value is no-op", func(t *testing.T) {
+		client, rs := testExistingConfigStoreSecret(t)
+		rs.AIGatewayConfigStoreSecrets[0].Value = ""
+		delete(rs.SecretSources, "support-openai-header")
+
+		plan, err := NewPlanner(client, slog.Default()).GeneratePlan(
+			t.Context(), rs, Options{Mode: PlanModeApply},
+		)
+		require.NoError(t, err)
+		require.Empty(t, plan.Changes)
+	})
+
+	t.Run("selector plans secret-only update", func(t *testing.T) {
+		client, rs := testExistingConfigStoreSecret(t)
+		plan, err := NewPlanner(client, slog.Default()).GeneratePlan(
+			t.Context(),
+			rs,
+			Options{Mode: PlanModeApply, WriteSecretSelectors: []string{"support-openai-header#value"}},
+		)
+		require.NoError(t, err)
+		require.Len(t, plan.Changes, 1)
+		change := plan.Changes[0]
+		require.Equal(t, ActionUpdate, change.Action)
+		require.Equal(t, "openai-auth-header", change.ResourceID)
+		require.NotContains(t, change.Fields, FieldKey)
+		require.Len(t, change.SecretWrites, 1)
+		require.Equal(t, "store-id", change.Parent.ID)
+		require.Equal(t, "gateway-id", change.References[FieldAIGatewayID].ID)
+	})
+
+	t.Run("write-secrets plans secret-only update", func(t *testing.T) {
+		client, rs := testExistingConfigStoreSecret(t)
+		plan, err := NewPlanner(client, slog.Default()).GeneratePlan(
+			t.Context(),
+			rs,
+			Options{Mode: PlanModeApply, WriteSecrets: true},
+		)
+		require.NoError(t, err)
+		require.Len(t, plan.Changes, 1)
+		require.Equal(t, ActionUpdate, plan.Changes[0].Action)
+		require.Len(t, plan.Changes[0].SecretWrites, 1)
+	})
+}
+
+func TestAIGatewayConfigStoreSecretPlannerRequiresValueForMissingSecret(t *testing.T) {
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{gateways: []kkComps.AIGateway{testAIGateway()}},
+		AIGatewayConfigStoresAPI: &testAIGatewayConfigStoreAPI{
+			stores: []kkComps.AIGatewayConfigStore{{ID: "store-id", Name: "support-store"}},
+		},
+	})
+	rs := testAIGatewayConfigStoreResourceSet(resources.AIGatewayConfigStoreResource{
+		BaseResource: resources.BaseResource{Ref: "support-store"},
+		AIGateway:    "support-gateway",
+		Name:         "support-store",
+	})
+	rs.AIGatewayConfigStoreSecrets = []resources.AIGatewayConfigStoreSecretResource{{
+		BaseResource:         resources.BaseResource{Ref: "support-openai-header"},
+		AIGatewayConfigStore: "support-store",
+		Key:                  "openai-auth-header",
+	}}
+
+	_, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+	require.ErrorContains(t, err, "requires value: !secret")
+}
+
+func TestAIGatewayConfigStoreSecretPlannerOrdersSamePlanParentCreates(t *testing.T) {
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI:             &testAIGatewayAPI{},
+		AIGatewayConfigStoresAPI: &testAIGatewayConfigStoreAPI{},
+	})
+	rs := testAIGatewayConfigStoreResourceSet(resources.AIGatewayConfigStoreResource{
+		BaseResource: resources.BaseResource{Ref: "support-store"},
+		AIGateway:    "support-gateway",
+		Name:         "support-store",
+	})
+	rs.AIGatewayConfigStoreSecrets = []resources.AIGatewayConfigStoreSecretResource{{
+		BaseResource:         resources.BaseResource{Ref: "support-openai-header"},
+		AIGatewayConfigStore: "support-store",
+		Key:                  "openai-auth-header",
+		Value:                testSecretPlaceholder(t),
+	}}
+	addTestConfigStoreSecretSource(rs)
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 3)
+
+	changes := make(map[string]*PlannedChange, len(plan.Changes))
+	for i := range plan.Changes {
+		changes[plan.Changes[i].ResourceType] = &plan.Changes[i]
+	}
+	gatewayChange := changes[ResourceTypeAIGateway]
+	storeChange := changes[ResourceTypeAIGatewayConfigStore]
+	secretChange := changes[ResourceTypeAIGatewayConfigStoreSecret]
+	require.NotNil(t, gatewayChange)
+	require.NotNil(t, storeChange)
+	require.NotNil(t, secretChange)
+	require.Contains(t, storeChange.DependsOn, gatewayChange.ID)
+	require.Contains(t, secretChange.DependsOn, storeChange.ID)
+	require.Nil(t, secretChange.Parent)
+	require.Equal(t, "support-store", secretChange.References[FieldConfigStoreID].Ref)
+	require.Equal(t, "support-gateway", secretChange.References[FieldAIGatewayID].Ref)
+	require.Empty(t, secretChange.References[FieldAIGatewayID].ID)
+}
+
+func TestAIGatewayConfigStoreSecretPlannerSyncDeletesExplicitEmptyScope(t *testing.T) {
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{gateways: []kkComps.AIGateway{testAIGateway()}},
+		AIGatewayConfigStoresAPI: &testAIGatewayConfigStoreAPI{
+			stores:  []kkComps.AIGatewayConfigStore{{ID: "store-id", Name: "support-store"}},
+			secrets: []kkComps.AIGatewayConfigStoreSecret{{Key: "stale-key"}},
+		},
+	})
+	rs := testAIGatewayConfigStoreResourceSet(resources.AIGatewayConfigStoreResource{
+		BaseResource: resources.BaseResource{Ref: "support-store"},
+		AIGateway:    "support-gateway",
+		Name:         "support-store",
+	})
+	rs.SyncScope = resources.NewSyncScope()
+	rs.SyncScope.AddRoot(resources.ResourceTypeAIGateway)
+	rs.SyncScope.AddChild(
+		resources.ResourceTypeAIGateway,
+		"support-gateway",
+		resources.ResourceTypeAIGatewayConfigStore,
+	)
+	rs.SyncScope.AddChild(
+		resources.ResourceTypeAIGatewayConfigStore,
+		"support-store",
+		resources.ResourceTypeAIGatewayConfigStoreSecret,
+	)
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeSync})
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	require.Equal(t, ResourceTypeAIGatewayConfigStoreSecret, plan.Changes[0].ResourceType)
+	require.Equal(t, ActionDelete, plan.Changes[0].Action)
+}
+
+func testExistingConfigStoreSecret(
+	t *testing.T,
+) (*state.Client, *resources.ResourceSet) {
+	t.Helper()
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{gateways: []kkComps.AIGateway{testAIGateway()}},
+		AIGatewayConfigStoresAPI: &testAIGatewayConfigStoreAPI{
+			stores:  []kkComps.AIGatewayConfigStore{{ID: "store-id", Name: "support-store"}},
+			secrets: []kkComps.AIGatewayConfigStoreSecret{{Key: "openai-auth-header"}},
+		},
+	})
+	rs := testAIGatewayConfigStoreResourceSet(resources.AIGatewayConfigStoreResource{
+		BaseResource: resources.BaseResource{Ref: "support-store"},
+		AIGateway:    "support-gateway",
+		Name:         "support-store",
+	})
+	rs.AIGatewayConfigStoreSecrets = []resources.AIGatewayConfigStoreSecretResource{{
+		BaseResource:         resources.BaseResource{Ref: "support-openai-header"},
+		AIGatewayConfigStore: "support-store",
+		Key:                  "openai-auth-header",
+		Value:                testSecretPlaceholder(t),
+	}}
+	addTestConfigStoreSecretSource(rs)
+	return client, rs
+}
+
+func addTestConfigStoreSecretSource(rs *resources.ResourceSet) {
+	rs.AddSecretSource("support-openai-header", "/value", tags.SecretExpression{Parts: []tags.SecretPart{{
+		Source: &tags.SecretSource{Kind: "env", Reference: "OPENAI_AUTH_HEADER"},
+	}}}, false)
+}
+
+func testSecretPlaceholder(t *testing.T) string {
+	t.Helper()
+	value, err := tags.BuildSecretPlaceholder(tags.SecretExpression{Parts: []tags.SecretPart{{
+		Source: &tags.SecretSource{Kind: "env", Reference: "OPENAI_AUTH_HEADER"},
+	}}})
+	require.NoError(t, err)
+	return value
+}
+
 func testAIGatewayConfigStoreResourceSet(
 	stores ...resources.AIGatewayConfigStoreResource,
 ) *resources.ResourceSet {
@@ -192,7 +417,8 @@ func testAIGatewayConfigStoreVaultRequest(t *testing.T) kkComps.CreateAIGatewayV
 }
 
 type testAIGatewayConfigStoreAPI struct {
-	stores []kkComps.AIGatewayConfigStore
+	stores  []kkComps.AIGatewayConfigStore
+	secrets []kkComps.AIGatewayConfigStoreSecret
 }
 
 func (t *testAIGatewayConfigStoreAPI) ListAiGatewayConfigStores(
@@ -236,5 +462,47 @@ func (t *testAIGatewayConfigStoreAPI) DeleteAiGatewayConfigStore(
 	kkOps.DeleteAiGatewayConfigStoreRequest,
 	...kkOps.Option,
 ) (*kkOps.DeleteAiGatewayConfigStoreResponse, error) {
+	return nil, nil
+}
+
+func (t *testAIGatewayConfigStoreAPI) ListAiGatewayConfigStoreSecrets(
+	_ context.Context,
+	_ kkOps.ListAiGatewayConfigStoreSecretsRequest,
+	_ ...kkOps.Option,
+) (*kkOps.ListAiGatewayConfigStoreSecretsResponse, error) {
+	return &kkOps.ListAiGatewayConfigStoreSecretsResponse{
+		ListAIGatewayConfigStoreSecretsResponse: &kkComps.ListAIGatewayConfigStoreSecretsResponse{Data: t.secrets},
+	}, nil
+}
+
+func (t *testAIGatewayConfigStoreAPI) CreateAiGatewayConfigStoreSecret(
+	context.Context,
+	kkOps.CreateAiGatewayConfigStoreSecretRequest,
+	...kkOps.Option,
+) (*kkOps.CreateAiGatewayConfigStoreSecretResponse, error) {
+	return nil, nil
+}
+
+func (t *testAIGatewayConfigStoreAPI) GetAiGatewayConfigStoreSecret(
+	context.Context,
+	kkOps.GetAiGatewayConfigStoreSecretRequest,
+	...kkOps.Option,
+) (*kkOps.GetAiGatewayConfigStoreSecretResponse, error) {
+	return nil, nil
+}
+
+func (t *testAIGatewayConfigStoreAPI) UpdateAiGatewayConfigStoreSecret(
+	context.Context,
+	kkOps.UpdateAiGatewayConfigStoreSecretRequest,
+	...kkOps.Option,
+) (*kkOps.UpdateAiGatewayConfigStoreSecretResponse, error) {
+	return nil, nil
+}
+
+func (t *testAIGatewayConfigStoreAPI) DeleteAiGatewayConfigStoreSecret(
+	context.Context,
+	kkOps.DeleteAiGatewayConfigStoreSecretRequest,
+	...kkOps.Option,
+) (*kkOps.DeleteAiGatewayConfigStoreSecretResponse, error) {
 	return nil, nil
 }

--- a/internal/declarative/planner/ai_gateway_config_store_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_config_store_planner_test.go
@@ -417,8 +417,10 @@ func testAIGatewayConfigStoreVaultRequest(t *testing.T) kkComps.CreateAIGatewayV
 }
 
 type testAIGatewayConfigStoreAPI struct {
-	stores  []kkComps.AIGatewayConfigStore
-	secrets []kkComps.AIGatewayConfigStoreSecret
+	stores            []kkComps.AIGatewayConfigStore
+	secrets           []kkComps.AIGatewayConfigStoreSecret
+	getSecret         *kkComps.AIGatewayConfigStoreSecret
+	getSecretRequests []kkOps.GetAiGatewayConfigStoreSecretRequest
 }
 
 func (t *testAIGatewayConfigStoreAPI) ListAiGatewayConfigStores(
@@ -484,11 +486,15 @@ func (t *testAIGatewayConfigStoreAPI) CreateAiGatewayConfigStoreSecret(
 }
 
 func (t *testAIGatewayConfigStoreAPI) GetAiGatewayConfigStoreSecret(
-	context.Context,
-	kkOps.GetAiGatewayConfigStoreSecretRequest,
-	...kkOps.Option,
+	_ context.Context,
+	request kkOps.GetAiGatewayConfigStoreSecretRequest,
+	_ ...kkOps.Option,
 ) (*kkOps.GetAiGatewayConfigStoreSecretResponse, error) {
-	return nil, nil
+	t.getSecretRequests = append(t.getSecretRequests, request)
+	if t.getSecret == nil {
+		return nil, nil
+	}
+	return &kkOps.GetAiGatewayConfigStoreSecretResponse{AIGatewayConfigStoreSecret: t.getSecret}, nil
 }
 
 func (t *testAIGatewayConfigStoreAPI) UpdateAiGatewayConfigStoreSecret(

--- a/internal/declarative/planner/ai_gateway_config_store_secret_planner.go
+++ b/internal/declarative/planner/ai_gateway_config_store_secret_planner.go
@@ -1,0 +1,155 @@
+package planner
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+)
+
+func (p *Planner) planAIGatewayConfigStoreSecretChanges(
+	ctx context.Context,
+	namespace string,
+	gatewayRef string,
+	gatewayID string,
+	storeRef string,
+	storeID string,
+	storeChangeID string,
+	desired []resources.AIGatewayConfigStoreSecretResource,
+	plan *Plan,
+) error {
+	p.logger.Debug(
+		"Planning AI Gateway Config Store secret changes",
+		slog.String("gateway_ref", gatewayRef),
+		slog.String("config_store_ref", storeRef),
+		slog.String("config_store_id", storeID),
+		slog.Int("desired_count", len(desired)),
+	)
+	if storeID == "" {
+		for _, secret := range desired {
+			if !p.aiGatewayConfigStoreSecretHasValueSource(secret.Ref) {
+				return missingAIGatewayConfigStoreSecretValueError(secret.Ref)
+			}
+			p.planAIGatewayConfigStoreSecretCreate(
+				namespace,
+				gatewayRef,
+				gatewayID,
+				storeRef,
+				"",
+				secret,
+				[]string{storeChangeID},
+				plan,
+			)
+		}
+		return nil
+	}
+
+	currentSecrets, err := p.client.ListAIGatewayConfigStoreSecrets(ctx, gatewayID, storeID)
+	if err != nil {
+		return fmt.Errorf("failed to list secrets for AI Gateway Config Store %s: %w", storeRef, err)
+	}
+	currentByKey := make(map[string]state.AIGatewayConfigStoreSecret, len(currentSecrets))
+	for _, secret := range currentSecrets {
+		currentByKey[secret.Key] = secret
+	}
+	desiredKeys := make(map[string]bool, len(desired))
+	for _, desiredSecret := range desired {
+		desiredKeys[desiredSecret.Key] = true
+		if _, exists := currentByKey[desiredSecret.Key]; !exists {
+			if !p.aiGatewayConfigStoreSecretHasValueSource(desiredSecret.Ref) {
+				return missingAIGatewayConfigStoreSecretValueError(desiredSecret.Ref)
+			}
+			p.planAIGatewayConfigStoreSecretCreate(
+				namespace,
+				gatewayRef,
+				gatewayID,
+				storeRef,
+				storeID,
+				desiredSecret,
+				nil,
+				plan,
+			)
+			continue
+		}
+		if resource := p.resources.GetAIGatewayConfigStoreSecretByRef(desiredSecret.Ref); resource != nil {
+			resource.SetKonnectID(desiredSecret.Key)
+		}
+	}
+
+	if plan.Metadata.Mode == PlanModeSync && p.shouldPlanChild(
+		plan,
+		resources.ResourceTypeAIGatewayConfigStore,
+		storeRef,
+		resources.ResourceTypeAIGatewayConfigStoreSecret,
+	) {
+		for _, current := range currentSecrets {
+			if desiredKeys[current.Key] {
+				continue
+			}
+			plan.AddChange(PlannedChange{
+				ID:           p.nextChangeID(ActionDelete, ResourceTypeAIGatewayConfigStoreSecret, current.Key),
+				ResourceType: ResourceTypeAIGatewayConfigStoreSecret,
+				ResourceRef:  current.Key,
+				ResourceID:   current.Key,
+				Action:       ActionDelete,
+				Namespace:    namespace,
+				Fields:       map[string]any{FieldKey: current.Key},
+				Parent:       &ParentInfo{Ref: storeRef, ID: storeID},
+				References: map[string]ReferenceInfo{
+					FieldAIGatewayID: {Ref: gatewayRef, ID: gatewayID},
+				},
+			})
+		}
+	}
+	return nil
+}
+
+func (p *Planner) planAIGatewayConfigStoreSecretCreate(
+	namespace string,
+	gatewayRef string,
+	gatewayID string,
+	storeRef string,
+	storeID string,
+	secret resources.AIGatewayConfigStoreSecretResource,
+	dependsOn []string,
+	plan *Plan,
+) {
+	change := PlannedChange{
+		ID:           p.nextChangeID(ActionCreate, ResourceTypeAIGatewayConfigStoreSecret, secret.Ref),
+		ResourceType: ResourceTypeAIGatewayConfigStoreSecret,
+		ResourceRef:  secret.Ref,
+		Action:       ActionCreate,
+		Fields:       map[string]any{FieldKey: secret.Key},
+		Namespace:    namespace,
+		DependsOn:    dependsOn,
+		References: map[string]ReferenceInfo{
+			FieldAIGatewayID: {Ref: gatewayRef, ID: gatewayID},
+		},
+	}
+	if storeID != "" {
+		change.Parent = &ParentInfo{Ref: storeRef, ID: storeID}
+	} else {
+		change.References[FieldConfigStoreID] = ReferenceInfo{
+			Ref: storeRef,
+			LookupFields: map[string]string{
+				FieldName: storeRef,
+			},
+		}
+	}
+	plan.AddChange(change)
+}
+
+func (p *Planner) aiGatewayConfigStoreSecretHasValueSource(ref string) bool {
+	declarations := p.resources.SecretSources[ref]
+	_, ok := declarations["/value"]
+	return ok
+}
+
+func missingAIGatewayConfigStoreSecretValueError(ref string) error {
+	return fmt.Errorf(
+		"AI Gateway Config Store secret %q does not exist and requires value: !secret with a deferred source",
+		ref,
+	)
+}

--- a/internal/declarative/planner/constants.go
+++ b/internal/declarative/planner/constants.go
@@ -70,6 +70,7 @@ const (
 	FieldVersion        = "version"
 	FieldSpec           = "spec"
 	FieldSlug           = "slug"
+	FieldKey            = "key"
 	FieldValue          = "value"
 	FieldAPIKey         = "api_key"
 	FieldClientID       = "client_id"
@@ -239,6 +240,7 @@ const (
 	ResourceTypeAIGatewayModel                   = string(resources.ResourceTypeAIGatewayModel)
 	ResourceTypeAIGatewayMCPServer               = string(resources.ResourceTypeAIGatewayMCPServer)
 	ResourceTypeAIGatewayConfigStore             = string(resources.ResourceTypeAIGatewayConfigStore)
+	ResourceTypeAIGatewayConfigStoreSecret       = string(resources.ResourceTypeAIGatewayConfigStoreSecret)
 	ResourceTypeAIGatewayVault                   = string(resources.ResourceTypeAIGatewayVault)
 	ResourceTypeAIGatewayDataPlaneCertificate    = string(resources.ResourceTypeAIGatewayDataPlaneCertificate)
 	ResourceTypeDashboard                        = string(resources.ResourceTypeDashboard)

--- a/internal/declarative/planner/dependencies.go
+++ b/internal/declarative/planner/dependencies.go
@@ -243,6 +243,7 @@ func aiGatewayChildSerializationParentKey(change PlannedChange) string {
 		ResourceTypeAIGatewayModel,
 		ResourceTypeAIGatewayMCPServer,
 		ResourceTypeAIGatewayConfigStore,
+		ResourceTypeAIGatewayConfigStoreSecret,
 		ResourceTypeAIGatewayVault,
 		ResourceTypeAIGatewayDataPlaneCertificate:
 	default:
@@ -382,6 +383,8 @@ func (d *DependencyResolver) getParentType(childType string) string {
 		return ResourceTypeAIGateway
 	case ResourceTypeAIGatewayConsumerCredential:
 		return ResourceTypeAIGatewayConsumer
+	case ResourceTypeAIGatewayConfigStoreSecret:
+		return ResourceTypeAIGatewayConfigStore
 	default:
 		return ""
 	}

--- a/internal/declarative/planner/secret_writes.go
+++ b/internal/declarative/planner/secret_writes.go
@@ -776,6 +776,25 @@ func (p *Planner) resolveSecretResourceID(
 				return resources.AIGatewayVaultID(candidate.AIGatewayVault), nil
 			}
 		}
+	case *resources.AIGatewayConfigStoreSecretResource:
+		parent := secretResourceParent(rs, resource)
+		if parent == nil || parent.ID == "" {
+			return "", fmt.Errorf("AI Gateway Config Store secret %q has no resolved Config Store", typed.Ref)
+		}
+		gatewayReference := secretResourceReferences(rs, resource)[FieldAIGatewayID]
+		if gatewayReference.ID == "" {
+			return "", fmt.Errorf("AI Gateway Config Store secret %q has no resolved gateway", typed.Ref)
+		}
+		current, err := p.client.GetAIGatewayConfigStoreSecret(
+			ctx,
+			gatewayReference.ID,
+			parent.ID,
+			typed.Key,
+		)
+		if err != nil || current == nil {
+			return "", err
+		}
+		return current.Key, nil
 	case *resources.EventGatewaySchemaRegistryResource:
 		parent := secretResourceParent(rs, resource)
 		if parent == nil || parent.ID == "" {

--- a/internal/declarative/planner/secret_writes.go
+++ b/internal/declarative/planner/secret_writes.go
@@ -111,6 +111,7 @@ func (p *Planner) applySecretWriteIntents(
 				Fields:       fields,
 				Namespace:    secretResourceNamespace(rs, resource),
 				Parent:       secretResourceParent(rs, resource),
+				References:   secretResourceReferences(rs, resource),
 			}
 			plan.AddChange(*change)
 			change = &plan.Changes[len(plan.Changes)-1]
@@ -388,6 +389,9 @@ func secretResourceFields(resource resources.Resource, action ActionType) (map[s
 	}
 	if resource.GetType() == resources.ResourceTypePortalIdentityProvider && action == ActionUpdate {
 		delete(fields, FieldType)
+	}
+	if resource.GetType() == resources.ResourceTypeAIGatewayConfigStoreSecret && action == ActionUpdate {
+		delete(fields, FieldKey)
 	}
 	return fields, nil
 }
@@ -687,6 +691,30 @@ func secretResourceParent(rs *resources.ResourceSet, resource resources.Resource
 		return &ParentInfo{Ref: parentRef.Ref}
 	}
 	return &ParentInfo{Ref: parentRef.Ref, ID: parent.GetKonnectID()}
+}
+
+func secretResourceReferences(rs *resources.ResourceSet, resource resources.Resource) map[string]ReferenceInfo {
+	secret, ok := resource.(*resources.AIGatewayConfigStoreSecretResource)
+	if !ok {
+		return nil
+	}
+	store := rs.GetAIGatewayConfigStoreByRef(resources.NormalizeResourceRef(secret.AIGatewayConfigStore))
+	if store == nil {
+		return nil
+	}
+	gateway := rs.GetAIGatewayByRef(resources.NormalizeResourceRef(store.AIGateway))
+	if gateway == nil {
+		return nil
+	}
+	return map[string]ReferenceInfo{
+		FieldAIGatewayID: {
+			Ref: gateway.GetRef(),
+			ID:  gateway.GetKonnectID(),
+			LookupFields: map[string]string{
+				FieldName: gateway.GetRef(),
+			},
+		},
+	}
 }
 
 func (p *Planner) resolveSecretResourceID(

--- a/internal/declarative/planner/secret_writes_test.go
+++ b/internal/declarative/planner/secret_writes_test.go
@@ -131,6 +131,42 @@ func TestSecretResourceFieldsUsesMutablePayloadContract(t *testing.T) {
 	assert.NotContains(t, fields, resources.SchemaFieldAIGateway)
 }
 
+func TestResolveSecretResourceIDLooksUpAIGatewayConfigStoreSecretByKey(t *testing.T) {
+	api := &testAIGatewayConfigStoreAPI{
+		getSecret: &kkComps.AIGatewayConfigStoreSecret{Key: "openai-auth-header"},
+	}
+	client := state.NewClient(state.ClientConfig{AIGatewayConfigStoresAPI: api})
+	gateway := resources.AIGatewayResource{BaseResource: resources.BaseResource{Ref: "support-gateway"}}
+	gateway.SetKonnectID("gateway-id")
+	store := resources.AIGatewayConfigStoreResource{
+		BaseResource: resources.BaseResource{Ref: "support-store"},
+		AIGateway:    "support-gateway",
+		Name:         "support-store",
+	}
+	store.SetKonnectID("store-id")
+	rs := &resources.ResourceSet{
+		AIGateways:            []resources.AIGatewayResource{gateway},
+		AIGatewayConfigStores: []resources.AIGatewayConfigStoreResource{store},
+		AIGatewayConfigStoreSecrets: []resources.AIGatewayConfigStoreSecretResource{{
+			BaseResource:         resources.BaseResource{Ref: "support-openai-header"},
+			AIGatewayConfigStore: "support-store",
+			Key:                  "openai-auth-header",
+		}},
+	}
+
+	id, err := (&Planner{client: client}).resolveSecretResourceID(
+		t.Context(),
+		rs,
+		&rs.AIGatewayConfigStoreSecrets[0],
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "openai-auth-header", id)
+	require.Len(t, api.getSecretRequests, 1)
+	assert.Equal(t, "gateway-id", api.getSecretRequests[0].GatewayID)
+	assert.Equal(t, "store-id", api.getSecretRequests[0].ConfigStoreIDOrName)
+	assert.Equal(t, "openai-auth-header", api.getSecretRequests[0].Key)
+}
+
 func TestSecretResourceFieldsUsesPortalIdentityProviderUpdateContract(t *testing.T) {
 	providerType := kkComps.IdentityProviderTypeOidc
 	provider := resources.PortalIdentityProviderResource{

--- a/internal/declarative/planner/sync_scope.go
+++ b/internal/declarative/planner/sync_scope.go
@@ -231,6 +231,13 @@ func addAIGatewayChildScopes(scope *resources.SyncScope, rs *resources.ResourceS
 			resources.ResourceTypeAIGatewayConfigStore,
 		)
 	}
+	for _, child := range rs.AIGatewayConfigStoreSecrets {
+		scope.AddChild(
+			resources.ResourceTypeAIGatewayConfigStore,
+			resources.NormalizeResourceRef(child.AIGatewayConfigStore),
+			resources.ResourceTypeAIGatewayConfigStoreSecret,
+		)
+	}
 	for _, child := range rs.AIGatewayVaults {
 		scope.AddChild(
 			resources.ResourceTypeAIGateway,

--- a/internal/declarative/planner/sync_scope_test.go
+++ b/internal/declarative/planner/sync_scope_test.go
@@ -256,6 +256,31 @@ func TestEnsurePlanningSyncScopeInfersPortalTeamRolesWithTeams(t *testing.T) {
 	))
 }
 
+func TestEnsurePlanningSyncScopeInfersAIGatewayConfigStoreSecrets(t *testing.T) {
+	rs := &resources.ResourceSet{
+		AIGateways: []resources.AIGatewayResource{{
+			BaseResource: resources.BaseResource{Ref: "support-gateway"},
+		}},
+		AIGatewayConfigStores: []resources.AIGatewayConfigStoreResource{{
+			BaseResource: resources.BaseResource{Ref: "support-store"},
+			AIGateway:    "support-gateway",
+		}},
+		AIGatewayConfigStoreSecrets: []resources.AIGatewayConfigStoreSecretResource{{
+			BaseResource:         resources.BaseResource{Ref: "support-api-key"},
+			AIGatewayConfigStore: "support-store",
+			Key:                  "api-key",
+		}},
+	}
+
+	ensurePlanningSyncScope(rs)
+	require.NotNil(t, rs.SyncScope)
+	assert.True(t, rs.SyncScope.ChildInScope(
+		resources.ResourceTypeAIGatewayConfigStore,
+		"support-store",
+		resources.ResourceTypeAIGatewayConfigStoreSecret,
+	))
+}
+
 func TestEnsurePlanningSyncScopeInfersOrganizationAssignmentScope(t *testing.T) {
 	rs := &resources.ResourceSet{
 		Organization: &resources.OrganizationResource{

--- a/internal/declarative/protection/lookup.go
+++ b/internal/declarative/protection/lookup.go
@@ -164,6 +164,7 @@ func IsManagedResourceProtected(
 		resources.ResourceTypeAIGatewayModel,
 		resources.ResourceTypeAIGatewayMCPServer,
 		resources.ResourceTypeAIGatewayConfigStore,
+		resources.ResourceTypeAIGatewayConfigStoreSecret,
 		resources.ResourceTypeAIGatewayVault,
 		resources.ResourceTypeAIGatewayDataPlaneCertificate:
 		return false, nil

--- a/internal/declarative/resources/ai_gateway_config_store.go
+++ b/internal/declarative/resources/ai_gateway_config_store.go
@@ -32,9 +32,10 @@ func init() {
 // AIGatewayConfigStoreResource represents a Config Store nested under a Konnect AI Gateway.
 type AIGatewayConfigStoreResource struct {
 	BaseResource `yaml:",inline" json:",inline"`
-	AIGateway    string  `yaml:"ai_gateway,omitempty" json:"ai_gateway,omitempty"`
-	Name         string  `yaml:"name"                 json:"name"`
-	DisplayName  *string `yaml:"display_name,omitempty" json:"display_name,omitempty"`
+	AIGateway    string                               `yaml:"ai_gateway,omitempty" json:"ai_gateway,omitempty"`
+	Name         string                               `yaml:"name"                 json:"name"`
+	DisplayName  *string                              `yaml:"display_name,omitempty" json:"display_name,omitempty"`
+	Secrets      []AIGatewayConfigStoreSecretResource `yaml:"secrets,omitempty" json:"secrets,omitempty"`
 }
 
 func (a AIGatewayConfigStoreResource) GetType() ResourceType {
@@ -186,6 +187,12 @@ func aiGatewayConfigStoreExplainNode(_ ExplainBuildContext) (*ExplainNode, error
 		explainRefField(SchemaFieldAIGateway, ResourceTypeAIGateway, true),
 		explainField(SchemaFieldName, explainStringNode("my-config-store"), true, true),
 		explainField(SchemaFieldDisplayName, explainStringNode("My-Config-Store"), false, true),
+		explainField(
+			"secrets",
+			&ExplainNode{Kind: explainKindArray, Items: aiGatewayConfigStoreSecretInlineExplainNode()},
+			false,
+			false,
+		),
 	), nil
 }
 

--- a/internal/declarative/resources/ai_gateway_config_store_secret.go
+++ b/internal/declarative/resources/ai_gateway_config_store_secret.go
@@ -1,0 +1,169 @@
+package resources
+
+import (
+	"fmt"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+)
+
+const (
+	aiGatewayConfigStoreSecretFieldKey   = "key"
+	aiGatewayConfigStoreSecretFieldValue = "value"
+)
+
+func init() {
+	registerResourceType(
+		ResourceTypeAIGatewayConfigStoreSecret,
+		func(rs *ResourceSet) *[]AIGatewayConfigStoreSecretResource {
+			return &rs.AIGatewayConfigStoreSecrets
+		},
+		AutoExplain[AIGatewayConfigStoreSecretResource](
+			WithExplainAliases(
+				"ai_gateway_config_store_secrets",
+				"ai-gateway-config-store-secret",
+				"ai-gateway-config-store-secrets",
+				"ai_gateway.config_stores.secrets",
+				"aigw-config-store-secret",
+			),
+			WithExplainRecommendedFields(
+				SchemaFieldRef,
+				SchemaFieldAIGatewayConfigStore,
+				aiGatewayConfigStoreSecretFieldKey,
+				aiGatewayConfigStoreSecretFieldValue,
+			),
+			WithExplainSchemaBuilder(aiGatewayConfigStoreSecretExplainNode),
+		),
+		WithMaturity(aiGatewayMaturity),
+	)
+}
+
+// AIGatewayConfigStoreSecretResource represents a write-only secret in an AI Gateway Config Store.
+type AIGatewayConfigStoreSecretResource struct {
+	BaseResource         `yaml:",inline" json:",inline"`
+	AIGatewayConfigStore string `yaml:"ai_gateway_config_store,omitempty" json:"ai_gateway_config_store,omitempty"`
+	Key                  string `yaml:"key" json:"key"`
+	Value                string `yaml:"value,omitempty" json:"value,omitempty"`
+}
+
+func (a AIGatewayConfigStoreSecretResource) GetType() ResourceType {
+	return ResourceTypeAIGatewayConfigStoreSecret
+}
+
+func (a AIGatewayConfigStoreSecretResource) GetMoniker() string { return a.Key }
+
+func (a AIGatewayConfigStoreSecretResource) GetDependencies() []ResourceRef {
+	if a.AIGatewayConfigStore == "" {
+		return nil
+	}
+	return []ResourceRef{{
+		Kind: ResourceTypeAIGatewayConfigStore,
+		Ref:  NormalizeResourceRef(a.AIGatewayConfigStore),
+	}}
+}
+
+func (a AIGatewayConfigStoreSecretResource) GetParentRef() *ResourceRef {
+	if a.AIGatewayConfigStore == "" {
+		return nil
+	}
+	return &ResourceRef{
+		Kind: ResourceTypeAIGatewayConfigStore,
+		Ref:  NormalizeResourceRef(a.AIGatewayConfigStore),
+	}
+}
+
+func (a AIGatewayConfigStoreSecretResource) GetReferenceFieldMappings() map[string]string {
+	if a.AIGatewayConfigStore == "" {
+		return nil
+	}
+	return map[string]string{SchemaFieldAIGatewayConfigStore: string(ResourceTypeAIGatewayConfigStore)}
+}
+
+func (a AIGatewayConfigStoreSecretResource) Validate() error {
+	if err := ValidateRef(a.Ref); err != nil {
+		return fmt.Errorf("invalid AI Gateway Config Store Secret ref: %w", err)
+	}
+	if a.Kongctl != nil {
+		return fmt.Errorf("kongctl metadata not supported on AI Gateway Config Store Secret %s", a.Ref)
+	}
+	if a.AIGatewayConfigStore == "" {
+		return fmt.Errorf("ai_gateway_config_store is required for AI Gateway Config Store Secret %s", a.Ref)
+	}
+	if a.Key == "" {
+		return fmt.Errorf("key is required for AI Gateway Config Store Secret %s", a.Ref)
+	}
+	return nil
+}
+
+func (a *AIGatewayConfigStoreSecretResource) SetDefaults() {
+	if a == nil {
+		return
+	}
+	if a.Ref == "" {
+		a.Ref = a.Key
+	}
+}
+
+func (a AIGatewayConfigStoreSecretResource) GetKonnectMonikerFilter() string { return a.Key }
+
+func (a *AIGatewayConfigStoreSecretResource) TryMatchKonnectResource(resource any) bool {
+	var key string
+	switch typed := resource.(type) {
+	case kkComps.AIGatewayConfigStoreSecret:
+		key = typed.Key
+	case *kkComps.AIGatewayConfigStoreSecret:
+		if typed != nil {
+			key = typed.Key
+		}
+	}
+	if key == "" || key != a.Key {
+		return false
+	}
+	a.SetKonnectID(key)
+	return true
+}
+
+func (a AIGatewayConfigStoreSecretResource) PayloadMap() (map[string]any, error) {
+	payload := map[string]any{aiGatewayConfigStoreSecretFieldKey: a.Key}
+	if a.Value != "" {
+		payload[aiGatewayConfigStoreSecretFieldValue] = a.Value
+	}
+	return payload, nil
+}
+
+func (a AIGatewayConfigStoreSecretResource) MutablePayloadMap() (map[string]any, error) {
+	return a.PayloadMap()
+}
+
+// AIGatewayConfigStoreSecretResourceFromResponse maps public secret metadata to declarative form.
+func AIGatewayConfigStoreSecretResourceFromResponse(
+	storeRef string,
+	secret kkComps.AIGatewayConfigStoreSecret,
+) AIGatewayConfigStoreSecretResource {
+	return AIGatewayConfigStoreSecretResource{
+		BaseResource:         BaseResource{Ref: secret.Key},
+		AIGatewayConfigStore: storeRef,
+		Key:                  secret.Key,
+	}
+}
+
+func aiGatewayConfigStoreSecretExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
+	return explainObject(
+		explainResourceRefField(),
+		explainRefField(SchemaFieldAIGatewayConfigStore, ResourceTypeAIGatewayConfigStore, true),
+		explainField(aiGatewayConfigStoreSecretFieldKey, explainStringNode("openai-auth-header"), true, true),
+		explainField(
+			aiGatewayConfigStoreSecretFieldValue,
+			explainSecretEnvNode("OPENAI_AUTH_HEADER"),
+			false,
+			false,
+		),
+	), nil
+}
+
+func aiGatewayConfigStoreSecretInlineExplainNode() *ExplainNode {
+	node, err := aiGatewayConfigStoreSecretExplainNode(ExplainBuildContext{})
+	if err != nil {
+		return explainObject()
+	}
+	return node
+}

--- a/internal/declarative/resources/ai_gateway_maturity_test.go
+++ b/internal/declarative/resources/ai_gateway_maturity_test.go
@@ -21,6 +21,7 @@ func TestAIGatewayResourcesAreBeta(t *testing.T) {
 		ResourceTypeAIGatewayModel,
 		ResourceTypeAIGatewayMCPServer,
 		ResourceTypeAIGatewayConfigStore,
+		ResourceTypeAIGatewayConfigStoreSecret,
 		ResourceTypeAIGatewayVault,
 		ResourceTypeAIGatewayDataPlaneCertificate,
 	}

--- a/internal/declarative/resources/relationships.go
+++ b/internal/declarative/resources/relationships.go
@@ -161,6 +161,10 @@ func init() {
 			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
 		}}
 	}
+	relationshipDescriptors[ResourceTypeAIGatewayConfigStoreSecret] = []RelationshipDescriptor{{
+		FieldPath: SchemaFieldAIGatewayConfigStore, TargetType: ResourceTypeAIGatewayConfigStore,
+		Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
+	}}
 	relationshipDescriptors[ResourceTypeAIGatewayVault] = append(
 		relationshipDescriptors[ResourceTypeAIGatewayVault],
 		RelationshipDescriptor{

--- a/internal/declarative/resources/testdata/dump_defaults_inventory.yaml
+++ b/internal/declarative/resources/testdata/dump_defaults_inventory.yaml
@@ -565,6 +565,10 @@ resources:
     defaults: []
     overrides: []
     exclusions: []
+  - resource_type: ai_gateway_config_store_secret
+    defaults: []
+    overrides: []
+    exclusions: []
   - resource_type: ai_gateway_consumer
     defaults:
       - path: credentials.ttl

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -28,6 +28,7 @@ const (
 	ResourceTypeAIGatewayModel                          ResourceType = "ai_gateway_model"
 	ResourceTypeAIGatewayMCPServer                      ResourceType = "ai_gateway_mcp_server"
 	ResourceTypeAIGatewayConfigStore                    ResourceType = "ai_gateway_config_store"
+	ResourceTypeAIGatewayConfigStoreSecret              ResourceType = "ai_gateway_config_store_secret"
 	ResourceTypeAIGatewayVault                          ResourceType = "ai_gateway_vault"
 	ResourceTypeAIGatewayDataPlaneCertificate           ResourceType = "ai_gateway_data_plane_certificate"
 	ResourceTypeDashboard                               ResourceType = "dashboard"
@@ -84,28 +85,29 @@ const (
 )
 
 const (
-	SchemaFieldRef               = "ref"
-	SchemaFieldName              = "name"
-	SchemaFieldPortal            = "portal"
-	SchemaFieldOrganization      = "organization"
-	SchemaFieldTeams             = "teams"
-	SchemaFieldRoles             = "roles"
-	SchemaFieldUser              = "user"
-	SchemaFieldSystemAccount     = "system_account"
-	SchemaFieldAIGateway         = "ai_gateway"
-	SchemaFieldAIGatewayConsumer = "ai_gateway_consumer"
-	SchemaFieldDisplayName       = "display_name"
-	SchemaFieldAccess            = "access"
-	SchemaFieldAuthStrategies    = "auth_strategies"
-	SchemaFieldIdentityProviders = "identity_providers"
-	SchemaFieldConfig            = "config"
-	SchemaFieldConfigStoreID     = "config_store_id"
-	SchemaFieldKongctl           = "kongctl"
-	SchemaFieldID                = "id"
-	SchemaFieldCreatedAt         = "created_at"
-	SchemaFieldUpdatedAt         = "updated_at"
-	authenticationTypeBasic      = "basic"
-	jsonNullLiteral              = "null"
+	SchemaFieldRef                  = "ref"
+	SchemaFieldName                 = "name"
+	SchemaFieldPortal               = "portal"
+	SchemaFieldOrganization         = "organization"
+	SchemaFieldTeams                = "teams"
+	SchemaFieldRoles                = "roles"
+	SchemaFieldUser                 = "user"
+	SchemaFieldSystemAccount        = "system_account"
+	SchemaFieldAIGateway            = "ai_gateway"
+	SchemaFieldAIGatewayConsumer    = "ai_gateway_consumer"
+	SchemaFieldAIGatewayConfigStore = "ai_gateway_config_store"
+	SchemaFieldDisplayName          = "display_name"
+	SchemaFieldAccess               = "access"
+	SchemaFieldAuthStrategies       = "auth_strategies"
+	SchemaFieldIdentityProviders    = "identity_providers"
+	SchemaFieldConfig               = "config"
+	SchemaFieldConfigStoreID        = "config_store_id"
+	SchemaFieldKongctl              = "kongctl"
+	SchemaFieldID                   = "id"
+	SchemaFieldCreatedAt            = "created_at"
+	SchemaFieldUpdatedAt            = "updated_at"
+	authenticationTypeBasic         = "basic"
+	jsonNullLiteral                 = "null"
 )
 
 // ResourceRef represents a reference to another resource
@@ -146,6 +148,7 @@ type ResourceSet struct {
 	AIGatewayModels                   []AIGatewayModelResource                   `yaml:"ai_gateway_models,omitempty"                              json:"ai_gateway_models,omitempty"`                     //nolint:lll
 	AIGatewayMCPServers               []AIGatewayMCPServerResource               `yaml:"ai_gateway_mcp_servers,omitempty"                         json:"ai_gateway_mcp_servers,omitempty"`                //nolint:lll
 	AIGatewayConfigStores             []AIGatewayConfigStoreResource             `yaml:"ai_gateway_config_stores,omitempty"                       json:"ai_gateway_config_stores,omitempty"`              //nolint:lll
+	AIGatewayConfigStoreSecrets       []AIGatewayConfigStoreSecretResource       `yaml:"ai_gateway_config_store_secrets,omitempty"                json:"ai_gateway_config_store_secrets,omitempty"`       //nolint:lll
 	AIGatewayVaults                   []AIGatewayVaultResource                   `yaml:"ai_gateway_vaults,omitempty"                              json:"ai_gateway_vaults,omitempty"`                     //nolint:lll
 	AIGatewayDataPlaneCertificates    []AIGatewayDataPlaneCertificateResource    `yaml:"ai_gateway_data_plane_certificates,omitempty"              json:"ai_gateway_data_plane_certificates,omitempty"`   //nolint:lll
 	APIs                              []APIResource                              `yaml:"apis,omitempty"                                           json:"apis,omitempty"`                                  //nolint:lll
@@ -536,6 +539,16 @@ func (rs *ResourceSet) GetAIGatewayConfigStoreByRef(ref string) *AIGatewayConfig
 	for i := range rs.AIGatewayConfigStores {
 		if rs.AIGatewayConfigStores[i].GetRef() == ref {
 			return &rs.AIGatewayConfigStores[i]
+		}
+	}
+	return nil
+}
+
+// GetAIGatewayConfigStoreSecretByRef returns an AI Gateway Config Store Secret resource by its ref.
+func (rs *ResourceSet) GetAIGatewayConfigStoreSecretByRef(ref string) *AIGatewayConfigStoreSecretResource {
+	for i := range rs.AIGatewayConfigStoreSecrets {
+		if rs.AIGatewayConfigStoreSecrets[i].GetRef() == ref {
+			return &rs.AIGatewayConfigStoreSecrets[i]
 		}
 	}
 	return nil
@@ -1948,6 +1961,20 @@ func (rs *ResourceSet) GetAIGatewayConfigStoresForGateway(gatewayRef string) []A
 		}
 	}
 	return stores
+}
+
+// GetAIGatewayConfigStoreSecretsForStore returns all secrets for a Config Store ref.
+func (rs *ResourceSet) GetAIGatewayConfigStoreSecretsForStore(
+	storeRef string,
+) []AIGatewayConfigStoreSecretResource {
+	var secrets []AIGatewayConfigStoreSecretResource
+	storeRef = NormalizeResourceRef(storeRef)
+	for _, secret := range rs.AIGatewayConfigStoreSecrets {
+		if NormalizeResourceRef(secret.AIGatewayConfigStore) == storeRef {
+			secrets = append(secrets, secret)
+		}
+	}
+	return secrets
 }
 
 // GetAIGatewayDataPlaneCertificatesForGateway returns all AI Gateway data plane

--- a/internal/declarative/secrets/catalog.go
+++ b/internal/declarative/secrets/catalog.go
@@ -34,6 +34,7 @@ var capabilities = []Capability{
 	{resources.ResourceTypeAIGatewayVault, "/config/secret_id", true, true},
 	{resources.ResourceTypeEventGatewaySchemaRegistry, "/config/authentication/password", true, true},
 	{resources.ResourceTypeAIGatewayConsumerCredential, "/api_key", true, false},
+	{resources.ResourceTypeAIGatewayConfigStoreSecret, "/value", true, true},
 }
 
 // Match returns the reviewed capability for a concrete resource field path.

--- a/internal/declarative/state/ai_gateway_config_store_secrets.go
+++ b/internal/declarative/state/ai_gateway_config_store_secrets.go
@@ -1,0 +1,199 @@
+package state
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/log"
+	"github.com/kong/kongctl/internal/util/pagination"
+)
+
+func (c *Client) ListAIGatewayConfigStoreSecrets(
+	ctx context.Context,
+	gatewayID string,
+	configStoreIDOrName string,
+) ([]AIGatewayConfigStoreSecret, error) {
+	logAIGatewayConfigStoreSecretOperation(
+		ctx, "listing AI Gateway Config Store secrets", gatewayID, configStoreIDOrName, "",
+	)
+	if err := ValidateAPIClient(c.aiGatewayConfigStoresAPI, "AI Gateway Config Stores API"); err != nil {
+		return nil, err
+	}
+
+	var secrets []AIGatewayConfigStoreSecret
+	var pageAfter *string
+	pageSize := int64(100)
+	for {
+		resp, err := c.aiGatewayConfigStoresAPI.ListAiGatewayConfigStoreSecrets(
+			ctx,
+			kkOps.ListAiGatewayConfigStoreSecretsRequest{
+				GatewayID:           gatewayID,
+				ConfigStoreIDOrName: configStoreIDOrName,
+				PageSize:            &pageSize,
+				PageAfter:           pageAfter,
+			},
+		)
+		if err != nil {
+			return nil, WrapAPIError(err, "list AI Gateway Config Store secrets", nil)
+		}
+		if resp == nil || resp.ListAIGatewayConfigStoreSecretsResponse == nil {
+			break
+		}
+		for _, secret := range resp.ListAIGatewayConfigStoreSecretsResponse.Data {
+			secrets = append(secrets, AIGatewayConfigStoreSecret{AIGatewayConfigStoreSecret: secret})
+		}
+		next := pagination.ExtractPageAfterCursor(resp.ListAIGatewayConfigStoreSecretsResponse.Meta.Page.Next)
+		if next == "" {
+			break
+		}
+		pageAfter = &next
+	}
+	return secrets, nil
+}
+
+func (c *Client) GetAIGatewayConfigStoreSecret(
+	ctx context.Context,
+	gatewayID string,
+	configStoreIDOrName string,
+	key string,
+) (*AIGatewayConfigStoreSecret, error) {
+	if err := ValidateAPIClient(c.aiGatewayConfigStoresAPI, "AI Gateway Config Stores API"); err != nil {
+		return nil, err
+	}
+	resp, err := c.aiGatewayConfigStoresAPI.GetAiGatewayConfigStoreSecret(
+		ctx,
+		kkOps.GetAiGatewayConfigStoreSecretRequest{
+			GatewayID:           gatewayID,
+			ConfigStoreIDOrName: configStoreIDOrName,
+			Key:                 key,
+		},
+	)
+	if err != nil {
+		return nil, WrapAPIError(err, "get AI Gateway Config Store secret", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeAIGatewayConfigStoreSecret),
+			ResourceName: key,
+			UseEnhanced:  true,
+		})
+	}
+	if resp == nil || resp.AIGatewayConfigStoreSecret == nil {
+		return nil, nil
+	}
+	return &AIGatewayConfigStoreSecret{AIGatewayConfigStoreSecret: *resp.AIGatewayConfigStoreSecret}, nil
+}
+
+func (c *Client) CreateAIGatewayConfigStoreSecret(
+	ctx context.Context,
+	gatewayID string,
+	configStoreIDOrName string,
+	req kkComps.CreateAIGatewayConfigStoreSecretRequest,
+) (string, error) {
+	logAIGatewayConfigStoreSecretOperation(
+		ctx, "creating AI Gateway Config Store secret", gatewayID, configStoreIDOrName, req.Key,
+	)
+	if err := ValidateAPIClient(c.aiGatewayConfigStoresAPI, "AI Gateway Config Stores API"); err != nil {
+		return "", err
+	}
+	resp, err := c.aiGatewayConfigStoresAPI.CreateAiGatewayConfigStoreSecret(
+		ctx,
+		kkOps.CreateAiGatewayConfigStoreSecretRequest{
+			GatewayID:                               gatewayID,
+			ConfigStoreIDOrName:                     configStoreIDOrName,
+			CreateAIGatewayConfigStoreSecretRequest: req,
+		},
+	)
+	if err != nil {
+		return "", WrapAPIError(err, "create AI Gateway Config Store secret", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeAIGatewayConfigStoreSecret),
+			ResourceName: req.Key,
+			UseEnhanced:  true,
+		})
+	}
+	if resp == nil || resp.AIGatewayConfigStoreSecret == nil {
+		return "", fmt.Errorf("create AI Gateway Config Store secret response missing data")
+	}
+	return resp.AIGatewayConfigStoreSecret.Key, nil
+}
+
+func (c *Client) UpdateAIGatewayConfigStoreSecret(
+	ctx context.Context,
+	gatewayID string,
+	configStoreIDOrName string,
+	key string,
+	req kkComps.UpdateAIGatewayConfigStoreSecretRequest,
+) (string, error) {
+	logAIGatewayConfigStoreSecretOperation(
+		ctx, "updating AI Gateway Config Store secret", gatewayID, configStoreIDOrName, key,
+	)
+	if err := ValidateAPIClient(c.aiGatewayConfigStoresAPI, "AI Gateway Config Stores API"); err != nil {
+		return "", err
+	}
+	resp, err := c.aiGatewayConfigStoresAPI.UpdateAiGatewayConfigStoreSecret(
+		ctx,
+		kkOps.UpdateAiGatewayConfigStoreSecretRequest{
+			GatewayID:                               gatewayID,
+			ConfigStoreIDOrName:                     configStoreIDOrName,
+			Key:                                     key,
+			UpdateAIGatewayConfigStoreSecretRequest: req,
+		},
+	)
+	if err != nil {
+		return "", WrapAPIError(err, "update AI Gateway Config Store secret", &ErrorWrapperOptions{
+			ResourceType: string(resources.ResourceTypeAIGatewayConfigStoreSecret),
+			ResourceName: key,
+			UseEnhanced:  true,
+		})
+	}
+	if resp == nil || resp.AIGatewayConfigStoreSecret == nil {
+		return "", fmt.Errorf("update AI Gateway Config Store secret response missing data")
+	}
+	return resp.AIGatewayConfigStoreSecret.Key, nil
+}
+
+func (c *Client) DeleteAIGatewayConfigStoreSecret(
+	ctx context.Context,
+	gatewayID string,
+	configStoreIDOrName string,
+	key string,
+) error {
+	logAIGatewayConfigStoreSecretOperation(
+		ctx, "deleting AI Gateway Config Store secret", gatewayID, configStoreIDOrName, key,
+	)
+	if err := ValidateAPIClient(c.aiGatewayConfigStoresAPI, "AI Gateway Config Stores API"); err != nil {
+		return err
+	}
+	_, err := c.aiGatewayConfigStoresAPI.DeleteAiGatewayConfigStoreSecret(
+		ctx,
+		kkOps.DeleteAiGatewayConfigStoreSecretRequest{
+			GatewayID:           gatewayID,
+			ConfigStoreIDOrName: configStoreIDOrName,
+			Key:                 key,
+		},
+	)
+	if err != nil {
+		return WrapAPIError(err, "delete AI Gateway Config Store secret", nil)
+	}
+	return nil
+}
+
+func logAIGatewayConfigStoreSecretOperation(
+	ctx context.Context,
+	message string,
+	gatewayID string,
+	configStore string,
+	key string,
+) {
+	logger, ok := ctx.Value(log.LoggerKey).(*slog.Logger)
+	if !ok || logger == nil {
+		return
+	}
+	logger.Debug(
+		message,
+		slog.String("gateway_id", gatewayID),
+		slog.String("config_store", configStore),
+		slog.String("key", key),
+	)
+}

--- a/internal/declarative/state/ai_gateway_config_stores_test.go
+++ b/internal/declarative/state/ai_gateway_config_stores_test.go
@@ -69,3 +69,43 @@ func (failingAIGatewayConfigStoreUpdateAPI) DeleteAiGatewayConfigStore(
 ) (*kkOps.DeleteAiGatewayConfigStoreResponse, error) {
 	return nil, nil
 }
+
+func (failingAIGatewayConfigStoreUpdateAPI) ListAiGatewayConfigStoreSecrets(
+	context.Context,
+	kkOps.ListAiGatewayConfigStoreSecretsRequest,
+	...kkOps.Option,
+) (*kkOps.ListAiGatewayConfigStoreSecretsResponse, error) {
+	return nil, nil
+}
+
+func (failingAIGatewayConfigStoreUpdateAPI) CreateAiGatewayConfigStoreSecret(
+	context.Context,
+	kkOps.CreateAiGatewayConfigStoreSecretRequest,
+	...kkOps.Option,
+) (*kkOps.CreateAiGatewayConfigStoreSecretResponse, error) {
+	return nil, nil
+}
+
+func (failingAIGatewayConfigStoreUpdateAPI) GetAiGatewayConfigStoreSecret(
+	context.Context,
+	kkOps.GetAiGatewayConfigStoreSecretRequest,
+	...kkOps.Option,
+) (*kkOps.GetAiGatewayConfigStoreSecretResponse, error) {
+	return nil, nil
+}
+
+func (failingAIGatewayConfigStoreUpdateAPI) UpdateAiGatewayConfigStoreSecret(
+	context.Context,
+	kkOps.UpdateAiGatewayConfigStoreSecretRequest,
+	...kkOps.Option,
+) (*kkOps.UpdateAiGatewayConfigStoreSecretResponse, error) {
+	return nil, nil
+}
+
+func (failingAIGatewayConfigStoreUpdateAPI) DeleteAiGatewayConfigStoreSecret(
+	context.Context,
+	kkOps.DeleteAiGatewayConfigStoreSecretRequest,
+	...kkOps.Option,
+) (*kkOps.DeleteAiGatewayConfigStoreSecretResponse, error) {
+	return nil, nil
+}

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -361,6 +361,11 @@ type AIGatewayConfigStore struct {
 	kkComps.AIGatewayConfigStore
 }
 
+// AIGatewayConfigStoreSecret represents public metadata for a write-only Config Store secret.
+type AIGatewayConfigStoreSecret struct {
+	kkComps.AIGatewayConfigStoreSecret
+}
+
 // AIGatewayVault represents a Konnect AI Gateway Vault for internal use.
 type AIGatewayVault struct {
 	kkComps.AIGatewayVault

--- a/internal/konnect/helpers/ai_gateway_config_stores.go
+++ b/internal/konnect/helpers/ai_gateway_config_stores.go
@@ -37,6 +37,31 @@ type AIGatewayConfigStoresAPI interface {
 		kkOps.DeleteAiGatewayConfigStoreRequest,
 		...kkOps.Option,
 	) (*kkOps.DeleteAiGatewayConfigStoreResponse, error)
+	ListAiGatewayConfigStoreSecrets(
+		context.Context,
+		kkOps.ListAiGatewayConfigStoreSecretsRequest,
+		...kkOps.Option,
+	) (*kkOps.ListAiGatewayConfigStoreSecretsResponse, error)
+	CreateAiGatewayConfigStoreSecret(
+		context.Context,
+		kkOps.CreateAiGatewayConfigStoreSecretRequest,
+		...kkOps.Option,
+	) (*kkOps.CreateAiGatewayConfigStoreSecretResponse, error)
+	GetAiGatewayConfigStoreSecret(
+		context.Context,
+		kkOps.GetAiGatewayConfigStoreSecretRequest,
+		...kkOps.Option,
+	) (*kkOps.GetAiGatewayConfigStoreSecretResponse, error)
+	UpdateAiGatewayConfigStoreSecret(
+		context.Context,
+		kkOps.UpdateAiGatewayConfigStoreSecretRequest,
+		...kkOps.Option,
+	) (*kkOps.UpdateAiGatewayConfigStoreSecretResponse, error)
+	DeleteAiGatewayConfigStoreSecret(
+		context.Context,
+		kkOps.DeleteAiGatewayConfigStoreSecretRequest,
+		...kkOps.Option,
+	) (*kkOps.DeleteAiGatewayConfigStoreSecretResponse, error)
 }
 
 // AIGatewayConfigStoresAPIImpl provides the SDK implementation.
@@ -84,4 +109,44 @@ func (a *AIGatewayConfigStoresAPIImpl) DeleteAiGatewayConfigStore(
 	opts ...kkOps.Option,
 ) (*kkOps.DeleteAiGatewayConfigStoreResponse, error) {
 	return a.SDK.AIGatewayConfigStores.DeleteAiGatewayConfigStore(ctx, request, opts...)
+}
+
+func (a *AIGatewayConfigStoresAPIImpl) ListAiGatewayConfigStoreSecrets(
+	ctx context.Context,
+	request kkOps.ListAiGatewayConfigStoreSecretsRequest,
+	opts ...kkOps.Option,
+) (*kkOps.ListAiGatewayConfigStoreSecretsResponse, error) {
+	return a.SDK.AIGatewayConfigStores.ListAiGatewayConfigStoreSecrets(ctx, request, opts...)
+}
+
+func (a *AIGatewayConfigStoresAPIImpl) CreateAiGatewayConfigStoreSecret(
+	ctx context.Context,
+	request kkOps.CreateAiGatewayConfigStoreSecretRequest,
+	opts ...kkOps.Option,
+) (*kkOps.CreateAiGatewayConfigStoreSecretResponse, error) {
+	return a.SDK.AIGatewayConfigStores.CreateAiGatewayConfigStoreSecret(ctx, request, opts...)
+}
+
+func (a *AIGatewayConfigStoresAPIImpl) GetAiGatewayConfigStoreSecret(
+	ctx context.Context,
+	request kkOps.GetAiGatewayConfigStoreSecretRequest,
+	opts ...kkOps.Option,
+) (*kkOps.GetAiGatewayConfigStoreSecretResponse, error) {
+	return a.SDK.AIGatewayConfigStores.GetAiGatewayConfigStoreSecret(ctx, request, opts...)
+}
+
+func (a *AIGatewayConfigStoresAPIImpl) UpdateAiGatewayConfigStoreSecret(
+	ctx context.Context,
+	request kkOps.UpdateAiGatewayConfigStoreSecretRequest,
+	opts ...kkOps.Option,
+) (*kkOps.UpdateAiGatewayConfigStoreSecretResponse, error) {
+	return a.SDK.AIGatewayConfigStores.UpdateAiGatewayConfigStoreSecret(ctx, request, opts...)
+}
+
+func (a *AIGatewayConfigStoresAPIImpl) DeleteAiGatewayConfigStoreSecret(
+	ctx context.Context,
+	request kkOps.DeleteAiGatewayConfigStoreSecretRequest,
+	opts ...kkOps.Option,
+) (*kkOps.DeleteAiGatewayConfigStoreSecretResponse, error) {
+	return a.SDK.AIGatewayConfigStores.DeleteAiGatewayConfigStoreSecret(ctx, request, opts...)
 }

--- a/internal/konnect/httpclient/logging.go
+++ b/internal/konnect/httpclient/logging.go
@@ -73,7 +73,6 @@ var sensitiveExactFieldKeys = map[string]struct{}{
 	"passphrase":           {},
 	"client_secret":        {},
 	"service_account_json": {},
-	"value":                {},
 	"set_cookie":           {},
 	"konnectaccesstoken":   {},
 	"konnectrefreshtoken":  {},
@@ -86,7 +85,12 @@ var nonSensitiveTokenFieldKeys = map[string]struct{}{
 
 // RedactSensitiveFields returns a copy of value with known sensitive fields redacted.
 func RedactSensitiveFields(value any) any {
-	return redactSensitiveValue(cloneLogValue(value))
+	return RedactSensitiveFieldsWithExactKeys(value)
+}
+
+// RedactSensitiveFieldsWithExactKeys redacts known sensitive fields plus caller-scoped exact field keys.
+func RedactSensitiveFieldsWithExactKeys(value any, exactKeys ...string) any {
+	return redactSensitiveValue(cloneLogValue(value), normalizedKeySet(exactKeys))
 }
 
 // LoggingHTTPClient wraps an HTTP client to add centralized request/response logging.
@@ -202,7 +206,7 @@ func (c *LoggingHTTPClient) logRequest(
 		if bodyErr != nil {
 			attrs = append(attrs, slog.String("request_body_error", bodyErr.Error()))
 		} else if len(body) > 0 {
-			attrs = append(attrs, slog.String("request_body", redactBody(body, contentType)))
+			attrs = append(attrs, slog.String("request_body", redactBodyForURL(body, contentType, req.URL)))
 		}
 	}
 
@@ -287,7 +291,11 @@ func (c *LoggingHTTPClient) logResponse(
 		if bodyErr != nil {
 			attrs = append(attrs, slog.String("response_body_error", bodyErr.Error()))
 		} else if len(body) > 0 {
-			attrs = append(attrs, slog.String("response_body", redactBody(body, contentType)))
+			var responseURL *url.URL
+			if resp.Request != nil {
+				responseURL = resp.Request.URL
+			}
+			attrs = append(attrs, slog.String("response_body", redactBodyForURL(body, contentType, responseURL)))
 		}
 	}
 
@@ -440,6 +448,19 @@ func normalizeKey(key string) string {
 	return strings.Trim(string(out), "_")
 }
 
+func normalizedKeySet(keys []string) map[string]struct{} {
+	if len(keys) == 0 {
+		return nil
+	}
+	result := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		if normalized := normalizeKey(key); normalized != "" {
+			result[normalized] = struct{}{}
+		}
+	}
+	return result
+}
+
 func (c *LoggingHTTPClient) peekRequestBody(req *http.Request) ([]byte, error) {
 	if req == nil || req.Body == nil || req.Body == http.NoBody {
 		return nil, nil
@@ -474,6 +495,18 @@ func (c *LoggingHTTPClient) peekResponseBody(resp *http.Response) ([]byte, error
 }
 
 func redactBody(body []byte, contentType string) string {
+	return redactBodyWithExactKeys(body, contentType, nil)
+}
+
+func redactBodyForURL(body []byte, contentType string, parsedURL *url.URL) string {
+	var exactKeys map[string]struct{}
+	if isConfigStoreSecretRoute(routeFromURL(parsedURL)) {
+		exactKeys = normalizedKeySet([]string{"value"})
+	}
+	return redactBodyWithExactKeys(body, contentType, exactKeys)
+}
+
+func redactBodyWithExactKeys(body []byte, contentType string, exactKeys map[string]struct{}) string {
 	if len(body) == 0 {
 		return ""
 	}
@@ -484,18 +517,23 @@ func redactBody(body []byte, contentType string) string {
 
 	contentType = normalizeContentType(contentType)
 	if strings.Contains(contentType, "json") {
-		if redacted, ok := redactJSONBody(body); ok {
+		if redacted, ok := redactJSONBody(body, exactKeys); ok {
 			return truncateBody(redacted)
 		}
 	}
 	if strings.Contains(contentType, "x-www-form-urlencoded") {
-		if redacted, ok := redactFormBody(body); ok {
+		if redacted, ok := redactFormBody(body, exactKeys); ok {
 			return truncateBody(redacted)
 		}
 	}
 
 	redacted := redactPlainTextBody(string(body))
 	return truncateBody(redacted)
+}
+
+func isConfigStoreSecretRoute(route string) bool {
+	return strings.Contains(route, "/config-stores/") &&
+		(strings.HasSuffix(route, "/secrets") || strings.Contains(route, "/secrets/"))
 }
 
 func isTextualBody(body []byte, contentType string) bool {
@@ -534,7 +572,7 @@ func normalizeContentType(contentType string) string {
 	return strings.ToLower(strings.TrimSpace(contentType))
 }
 
-func redactJSONBody(body []byte) (string, bool) {
+func redactJSONBody(body []byte, exactKeys map[string]struct{}) (string, bool) {
 	var payload any
 	decoder := json.NewDecoder(bytes.NewReader(body))
 	decoder.UseNumber()
@@ -542,7 +580,7 @@ func redactJSONBody(body []byte) (string, bool) {
 		return "", false
 	}
 
-	payload = redactJSONValue(payload)
+	payload = redactJSONValue(payload, exactKeys)
 	redactedBody, err := json.Marshal(payload)
 	if err != nil {
 		return "", false
@@ -551,29 +589,35 @@ func redactJSONBody(body []byte) (string, bool) {
 	return string(redactedBody), true
 }
 
-func redactJSONValue(value any) any {
-	return redactSensitiveValue(value)
+func redactJSONValue(value any, exactKeys map[string]struct{}) any {
+	return redactSensitiveValue(value, exactKeys)
 }
 
-func redactSensitiveValue(value any) any {
-	return redactSensitiveValueAt(value, "", false)
+func redactSensitiveValue(value any, exactKeys map[string]struct{}) any {
+	return redactSensitiveValueAt(value, "", false, exactKeys)
 }
 
-func redactSensitiveValueAt(value any, parentKey string, insideConfig bool) any {
+func redactSensitiveValueAt(
+	value any,
+	parentKey string,
+	insideConfig bool,
+	exactKeys map[string]struct{},
+) any {
 	switch typed := value.(type) {
 	case map[string]any:
 		for key, nested := range typed {
 			normalizedKey := normalizeKey(key)
-			if isSensitiveFieldKey(key) || (insideConfig && normalizedKey == "key") ||
+			_, exactMatch := exactKeys[normalizedKey]
+			if isSensitiveFieldKey(key) || exactMatch || (insideConfig && normalizedKey == "key") ||
 				(normalizeKey(parentKey) == "headers" && normalizedKey == "value") {
 				typed[key] = redactedValue
 				continue
 			}
-			typed[key] = redactSensitiveValueAt(nested, key, insideConfig || normalizedKey == "config")
+			typed[key] = redactSensitiveValueAt(nested, key, insideConfig || normalizedKey == "config", exactKeys)
 		}
 	case []any:
 		for idx, nested := range typed {
-			typed[idx] = redactSensitiveValueAt(nested, parentKey, insideConfig)
+			typed[idx] = redactSensitiveValueAt(nested, parentKey, insideConfig, exactKeys)
 		}
 	}
 	return value
@@ -594,13 +638,14 @@ func cloneLogValue(value any) any {
 	return cloned
 }
 
-func redactFormBody(body []byte) (string, bool) {
+func redactFormBody(body []byte, exactKeys map[string]struct{}) (string, bool) {
 	values, err := url.ParseQuery(string(body))
 	if err != nil {
 		return "", false
 	}
 	for key := range values {
-		if isSensitiveFieldKey(key) {
+		_, exactMatch := exactKeys[normalizeKey(key)]
+		if isSensitiveFieldKey(key) || exactMatch {
 			values[key] = []string{redactedValue}
 		}
 	}

--- a/internal/konnect/httpclient/logging.go
+++ b/internal/konnect/httpclient/logging.go
@@ -73,6 +73,7 @@ var sensitiveExactFieldKeys = map[string]struct{}{
 	"passphrase":           {},
 	"client_secret":        {},
 	"service_account_json": {},
+	"value":                {},
 	"set_cookie":           {},
 	"konnectaccesstoken":   {},
 	"konnectrefreshtoken":  {},

--- a/internal/konnect/httpclient/logging_test.go
+++ b/internal/konnect/httpclient/logging_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kong/kongctl/internal/declarative/resources"
 	"github.com/kong/kongctl/internal/declarative/secrets"
 	"github.com/kong/kongctl/internal/log"
 	"github.com/stretchr/testify/assert"
@@ -150,7 +151,8 @@ func TestLoggingHTTPClient_TraceLogsBodiesAndRedactsSensitiveFields(t *testing.T
 
 func TestRedactSensitiveFieldsClonesAndRedactsNestedFields(t *testing.T) {
 	input := map[string]any{
-		"name": "demo",
+		"name":  "demo",
+		"value": "diagnostic-value",
 		"config": map[string]any{
 			"client_secret": "secret-value",
 			"token_type":    "Bearer",
@@ -169,6 +171,7 @@ func TestRedactSensitiveFieldsClonesAndRedactsNestedFields(t *testing.T) {
 	}
 
 	redacted := RedactSensitiveFields(input).(map[string]any)
+	require.Equal(t, "diagnostic-value", redacted["value"])
 	config := redacted["config"].(map[string]any)
 	require.Equal(t, redactedValue, config["client_secret"])
 	require.Equal(t, "Bearer", config["token_type"])
@@ -192,6 +195,9 @@ func TestReviewedDeclarativeSecretCatalogIsCoveredByHTTPRedaction(t *testing.T) 
 		t.Run(string(capability.ResourceType)+capability.PathPattern, func(t *testing.T) {
 			payload := secretCatalogPatternValue(strings.Split(strings.Trim(capability.PathPattern, "/"), "/"), sentinel)
 			redacted := RedactSensitiveFields(payload)
+			if capability.ResourceType == resources.ResourceTypeAIGatewayConfigStoreSecret {
+				redacted = RedactSensitiveFieldsWithExactKeys(payload, "value")
+			}
 			data, err := json.Marshal(redacted)
 			require.NoError(t, err)
 			assert.NotContains(t, string(data), sentinel)
@@ -201,6 +207,25 @@ func TestReviewedDeclarativeSecretCatalogIsCoveredByHTTPRedaction(t *testing.T) 
 			assert.Contains(t, string(original), sentinel)
 		})
 	}
+}
+
+func TestRedactBodyForURLScopesConfigStoreSecretValue(t *testing.T) {
+	body := []byte(`{"key":"api-key","value":"secret-value"}`)
+
+	configStoreSecretURL, err := url.Parse(
+		"https://global.api.konghq.com/v1/ai-gateways/gateway/config-stores/store/secrets",
+	)
+	require.NoError(t, err)
+
+	redacted := redactBodyForURL(body, "application/json", configStoreSecretURL)
+	assert.Contains(t, redacted, `"value":"`+redactedValue+`"`)
+	assert.NotContains(t, redacted, "secret-value")
+
+	unrelatedURL, err := url.Parse("https://global.api.konghq.com/v1/ai-gateways/gateway/providers")
+	require.NoError(t, err)
+
+	unredacted := redactBodyForURL(body, "application/json", unrelatedURL)
+	assert.Contains(t, unredacted, `"value":"secret-value"`)
 }
 
 func secretCatalogPatternValue(segments []string, value string) any {

--- a/site/src/content/lessons/federated-api-platform-management/run-a-data-plane.md
+++ b/site/src/content/lessons/federated-api-platform-management/run-a-data-plane.md
@@ -115,7 +115,7 @@ docker run --detach --rm --name federated-aigw-dp \
   --volume "$PWD/platform/certs:/etc/kong/certs:ro" \
   --publish 8000:8000 \
   --publish 8443:8443 \
-  kong/kong-ai-gateway:2.0.1
+  kong/kong-ai-gateway:2.0.2
 ```
 
 The image runs as the non-root `kong` user. `--group-add` gives that user

--- a/site/src/content/lessons/quickstarts/consumer-credentials.md
+++ b/site/src/content/lessons/quickstarts/consumer-credentials.md
@@ -254,7 +254,7 @@ docker run --detach --rm --name consumer-credential-data-plane \
   --volume "$PWD/certs:/etc/kong/certs:ro" \
   --publish 8000:8000 \
   --publish 8443:8443 \
-  kong/kong-ai-gateway:2.0.1
+  kong/kong-ai-gateway:2.0.2
 ```
 
 The container exposes the local HTTP proxy on port `8000` and the HTTPS proxy

--- a/site/src/content/lessons/quickstarts/route-openai-requests.md
+++ b/site/src/content/lessons/quickstarts/route-openai-requests.md
@@ -212,7 +212,7 @@ docker run --detach --rm --name openai-llm-data-plane \
   --volume "$PWD/certs:/etc/kong/certs:ro" \
   --publish 8000:8000 \
   --publish 8443:8443 \
-  kong/kong-ai-gateway:2.0.1
+  kong/kong-ai-gateway:2.0.2
 ```
 
 The container exposes the local HTTP proxy on port `8000` and the HTTPS proxy

--- a/site/src/content/lessons/quickstarts/vault-backed-openai.md
+++ b/site/src/content/lessons/quickstarts/vault-backed-openai.md
@@ -1,0 +1,367 @@
+---
+title: "AI Gateway: Vault-backed OpenAI"
+summary: >-
+  Route Consumer-authenticated LLM requests while keeping the OpenAI credential
+  in a Config Store-backed Konnect Vault.
+order: 3
+related:
+  - label: Declarative configuration documentation
+    url: https://developer.konghq.com/kongctl/declarative/
+  - label: Kong Gateway secrets management
+    url: https://developer.konghq.com/gateway/entities/vault/
+  - label: Kong Gateway authentication
+    url: https://developer.konghq.com/gateway/authentication/
+---
+
+## Goal
+
+You will use `kongctl` to create an AI Gateway that routes requests to OpenAI
+and requires clients to authenticate as an AI Gateway Consumer. The same
+declarative configuration will create a Config Store secret, connect the
+Config Store to a Konnect Vault, and configure the OpenAI provider to read its
+upstream credential from that Vault.
+
+This lesson uses two separate credentials:
+
+- `OPENAI_API_KEY` authenticates the AI Gateway to OpenAI. `kongctl` writes it
+  to the Config Store, and the provider retains only a Vault reference.
+- `CONSUMER_API_KEY` authenticates your client to the AI Gateway.
+
+The data plane consumes the client credential before routing the request. It
+does not forward that credential to OpenAI. The model provider resolves the
+OpenAI authorization header from the Vault and adds it to the upstream
+request.
+
+## Prerequisites
+
+Before you begin, you need:
+
+- A [Kong Konnect account](https://konghq.com/products/kong-konnect/register)
+  with permission to manage AI Gateway resources.
+- `kongctl` installed and authenticated. Complete
+  [Konnect Authentication](../../installation/authenticate/) first.
+- A running [Docker](https://docs.docker.com/get-started/get-docker/) daemon.
+- `openssl` and `curl` available in your terminal.
+- An [OpenAI API key](https://platform.openai.com/api-keys) with access to
+  `gpt-5.4-nano` and available API quota.
+
+Keep the same terminal open throughout the lesson. The exported variables are
+used by later commands.
+
+## Set the API keys
+
+Export your OpenAI API key, replacing `<openai-api-key>` with the real value:
+
+```shell label="Set the OpenAI API key"
+export OPENAI_API_KEY="<openai-api-key>"
+```
+
+Set a harmless, known value for the Consumer credential. This value only
+authenticates requests to your local data plane:
+
+```shell label="Set the Consumer API key"
+export CONSUMER_API_KEY="vault-quickstart-consumer"
+```
+
+Keep both values in the environment. Do not write them directly into the
+declarative configuration.
+
+## Create a working directory
+
+Create an isolated directory for the configuration and certificate files:
+
+```shell label="Create the working directory"
+mkdir -p vault-backed-openai/certs
+cd vault-backed-openai
+```
+
+## Generate a data plane certificate
+
+The local data plane uses a certificate and private key to authenticate to
+Konnect. Generate a self-signed pair:
+
+```shell label="Generate the certificate and key"
+openssl req -new -x509 -nodes -newkey rsa:2048 -days 365 \
+  -subj "/CN=vault-backed-openai-data-plane/C=US" \
+  -keyout certs/data-plane.key \
+  -out certs/data-plane.crt
+```
+
+Keep the private key readable only by its owner and group. The Docker
+container joins that group in a later step:
+
+```shell label="Protect the private key"
+chgrp "$(id -g)" certs/data-plane.key
+chmod 640 certs/data-plane.key
+```
+
+Only the public certificate is registered with Konnect. Keep
+`certs/data-plane.key` local and do not commit it.
+
+## Create the declarative configuration
+
+Write the complete gateway configuration to `ai-gateway.yaml`:
+
+```shell label="Create ai-gateway.yaml"
+cat > ai-gateway.yaml <<'YAML'
+_defaults:
+  kongctl:
+    namespace: vault-backed-openai-quickstart
+
+ai_gateways:
+  - ref: vault-backed-openai-gateway
+    name: vault-backed-openai-gateway
+    display_name: Vault-backed OpenAI Gateway
+    description: Routes authenticated LLM requests with a vaulted OpenAI key
+    deployment_type: hybrid
+    proxy_urls:
+      - host: localhost
+        port: 8000
+        protocol: http
+    labels:
+      example: vault-backed-openai
+    data_plane_certificates:
+      - ref: vault-backed-openai-data-plane
+        title: vault-backed-openai-data-plane
+        description: Local Docker data plane
+        cert: !file ./certs/data-plane.crt
+    config_stores:
+      - ref: openai-config-store
+        name: openai-config-store
+        display_name: OpenAI-Config-Store
+        secrets:
+          - ref: openai-auth-header
+            key: openai-auth-header
+            value: !secret
+              parts:
+                - "Bearer "
+                - !env OPENAI_API_KEY
+    vaults:
+      - ref: openai-vault
+        name: openai-vault
+        type: konnect
+        description: Resolves credentials from the OpenAI Config Store
+        config:
+          config_store_id: !ref openai-config-store#id
+    model_providers:
+      - ref: openai
+        name: openai
+        display_name: OpenAI
+        type: openai
+        config:
+          auth:
+            type: basic
+            headers:
+              - name: Authorization
+                value: "{vault://openai-vault/openai-auth-header}"
+    auth_strategies:
+      - ref: consumer-key-auth
+        name: consumer-key-auth
+        display_name: Consumer Key Authentication
+        type: key-auth
+        config:
+          key_names:
+            - apikey
+          hide_credentials: true
+    consumers:
+      - ref: vault-quickstart-consumer
+        name: vault-quickstart-consumer
+        display_name: Vault Quickstart Consumer
+        custom_id: vault-quickstart-consumer
+        type: api-key
+        credentials:
+          - ref: vault-quickstart-consumer-key
+            name: vault-quickstart-consumer-key
+            display_name: Vault Quickstart Consumer Key
+            type: api-key
+            ttl: 0
+            api_key: !secret {source: !env CONSUMER_API_KEY}
+    models:
+      - ref: vaulted-openai-model
+        name: vaulted-openai-model
+        display_name: Vaulted OpenAI Model
+        type: model
+        enabled: true
+        access:
+          auth_strategies:
+            - !ref consumer-key-auth
+        formats:
+          - type: openai
+        config:
+          route:
+            paths:
+              - /v1
+            model:
+              body_param: model
+              values:
+                - vaulted-openai-model
+        targets:
+          - name: gpt-5.4-nano
+            provider: openai
+            config:
+              type: openai
+        policies: []
+        capabilities:
+          - generate
+YAML
+```
+
+This one input file describes every remote resource used by the request path.
+During execution, `kongctl` builds the `Bearer` authorization value from
+`OPENAI_API_KEY` and writes it to the `openai-config-store` Config Store. The
+`openai-vault` Vault uses the Config Store ID resolved by `!ref`, and the
+provider stores only the public
+`{vault://openai-vault/openai-auth-header}` reference.
+
+The Consumer credential is separate. Its `api_key` is also write-only, and
+`!env CONSUMER_API_KEY` resolves its value only during execution. Neither
+credential value is stored in the configuration or generated plan.
+
+## Create the AI Gateway
+
+Apply the configuration:
+
+```shell label="Create the Konnect resources"
+kongctl apply -f ai-gateway.yaml
+```
+
+Review the proposed changes displayed by `kongctl`. Confirm the apply when the
+resources and actions match the configuration you created. The apply creates
+the AI Gateway, certificate, Config Store and secret, Vault, provider, auth
+strategy, Consumer and credential, and model.
+
+## Run a local data plane
+
+The local data plane needs the gateway's configuration and telemetry endpoint
+hostnames to connect to Konnect. Read them into environment variables:
+
+```shell label="Set the configuration endpoint"
+export AIGW_CONTROL_PLANE="$(kongctl get ai-gateway \
+  "Vault-backed OpenAI Gateway" --output json --jq \
+  '.endpoints.configuration | sub("^https://"; "") | sub(":443$"; "")' \
+  --jq-raw-output)"
+```
+
+```shell label="Set the telemetry endpoint"
+export AIGW_TELEMETRY="$(kongctl get ai-gateway \
+  "Vault-backed OpenAI Gateway" --output json --jq \
+  '.endpoints.telemetry | sub("^https://"; "") | sub(":443$"; "")' \
+  --jq-raw-output)"
+```
+
+Confirm that both variables contain hostnames without a URL scheme or port:
+
+```shell label="Show the endpoint hostnames"
+echo "Configuration: ${AIGW_CONTROL_PLANE}"
+echo "Telemetry:     ${AIGW_TELEMETRY}"
+```
+
+### Start the data plane
+
+Start Kong AI Gateway in Docker and mount the certificate pair read-only:
+
+```shell label="Start the data plane"
+docker run --detach --rm --name vault-backed-openai-data-plane \
+  --group-add "$(id -g)" \
+  --env "KONG_ROLE=data_plane" \
+  --env "KONG_DATABASE=off" \
+  --env "KONG_VITALS=off" \
+  --env "KONG_CLUSTER_MTLS=pki" \
+  --env "KONG_CLUSTER_CONTROL_PLANE=${AIGW_CONTROL_PLANE}:443" \
+  --env "KONG_CLUSTER_SERVER_NAME=${AIGW_CONTROL_PLANE}" \
+  --env "KONG_CLUSTER_TELEMETRY_ENDPOINT=${AIGW_TELEMETRY}:443" \
+  --env "KONG_CLUSTER_TELEMETRY_SERVER_NAME=${AIGW_TELEMETRY}" \
+  --env "KONG_CLUSTER_CERT=/etc/kong/certs/data-plane.crt" \
+  --env "KONG_CLUSTER_CERT_KEY=/etc/kong/certs/data-plane.key" \
+  --env "KONG_LUA_SSL_TRUSTED_CERTIFICATE=system" \
+  --env "KONG_KONNECT_MODE=on" \
+  --volume "$PWD/certs:/etc/kong/certs:ro" \
+  --publish 8000:8000 \
+  --publish 8443:8443 \
+  kong/kong-ai-gateway:2.0.1
+```
+
+The container exposes the local HTTP proxy on port `8000` and the HTTPS proxy
+on port `8443`.
+
+## Verify the data plane connection
+
+Allow the container a few seconds to connect, then list the gateway nodes:
+
+```shell label="Verify the data plane"
+kongctl get ai-gateway nodes \
+  --gateway-name "Vault-backed OpenAI Gateway"
+```
+
+The output should include the new data plane node. If it appears, continue to
+the credential checks.
+
+### Troubleshoot the connection (optional)
+
+Only inspect the container logs if the data plane node does not appear:
+
+```shell label="Inspect the data plane logs"
+docker logs vault-backed-openai-data-plane
+```
+
+## Route an authenticated LLM request
+
+First, send a request without a Consumer key:
+
+```shell label="Send a request without a Consumer key"
+curl -i --no-progress-meter \
+  --request POST http://localhost:8000/v1/chat/completions \
+  --header 'Content-Type: application/json' \
+  --json '{
+    "model": "vaulted-openai-model",
+    "messages": [
+      {"role": "user", "content": "Reply with only OK."}
+    ]
+  }'
+```
+
+The request should return `HTTP/1.1 401 Unauthorized`. The data plane rejects
+it before calling OpenAI because it has no Consumer credential.
+
+Now send the exact Consumer key that `kongctl` read from
+`CONSUMER_API_KEY`:
+
+```shell label="Send the configured Consumer key"
+curl -i --no-progress-meter --fail-with-body \
+  --request POST http://localhost:8000/v1/chat/completions \
+  --header "apikey: ${CONSUMER_API_KEY}" \
+  --header 'Content-Type: application/json' \
+  --json '{
+    "model": "vaulted-openai-model",
+    "messages": [
+      {"role": "user", "content": "Reply with only OK."}
+    ]
+  }'
+```
+
+The request should return `HTTP/1.1 200 OK` and an assistant message from
+OpenAI. This confirms both credential paths: the client authenticated with the
+Consumer key, and the provider resolved its OpenAI authorization header from
+the Config Store-backed Vault.
+
+## Clean up
+
+> **Warning:** The following commands stop the local data plane and delete the
+> AI Gateway resources created by this lesson.
+
+Stop the Docker container. Because it was started with `--rm`, Docker removes
+the container after it stops:
+
+```shell label="Stop the data plane"
+docker stop vault-backed-openai-data-plane
+```
+
+Delete the AI Gateway and its child resources from Konnect:
+
+```shell label="Delete the Konnect resources"
+kongctl delete -f ai-gateway.yaml
+```
+
+Review the delete plan before confirming it. The configuration, public
+certificate, and private key remain in the local `vault-backed-openai`
+directory.

--- a/site/src/content/lessons/quickstarts/vault-backed-openai.md
+++ b/site/src/content/lessons/quickstarts/vault-backed-openai.md
@@ -278,7 +278,7 @@ docker run --detach --rm --name vault-backed-openai-data-plane \
   --volume "$PWD/certs:/etc/kong/certs:ro" \
   --publish 8000:8000 \
   --publish 8443:8443 \
-  kong/kong-ai-gateway:2.0.1
+  kong/kong-ai-gateway:2.0.2
 ```
 
 The container exposes the local HTTP proxy on port `8000` and the HTTPS proxy

--- a/site/tests/e2e/learning.spec.ts
+++ b/site/tests/e2e/learning.spec.ts
@@ -754,10 +754,10 @@ test("persists explicit completion and continues to the next lesson", async ({
   await page.getByRole("link", { name: "Mark complete and continue" }).click();
 
   await expect(page).toHaveURL(/\/kongctl\/installation\/authenticate\/$/);
-  await expect(page.getByText("1 of 35", { exact: true })).toBeVisible();
+  await expect(page.getByText("1 of 36", { exact: true })).toBeVisible();
 
   await page.reload();
-  await expect(page.getByText("1 of 35", { exact: true })).toBeVisible();
+  await expect(page.getByText("1 of 36", { exact: true })).toBeVisible();
 });
 
 test("persists a chosen color theme", async ({ page }) => {

--- a/site/tests/e2e/learning.spec.ts
+++ b/site/tests/e2e/learning.spec.ts
@@ -66,7 +66,7 @@ test("routes OpenAI requests through a local AI Gateway", async ({ page }) => {
   ).toBeVisible();
   await expect(lesson).toContainText("!env OPENAI_API_KEY");
   await expect(lesson).toContainText("openssl req -new -x509");
-  await expect(lesson).toContainText("kong/kong-ai-gateway:2.0.1");
+  await expect(lesson).toContainText("kong/kong-ai-gateway:2.0.2");
   await expect(lesson).toContainText(
     "http://localhost:8000/v1/chat/completions",
   );
@@ -113,7 +113,7 @@ test("protects an AI Gateway model with Consumer credentials", async ({
   await expect(lesson).toContainText("apikey: ${CONSUMER_API_KEY}");
   await expect(lesson).toContainText("HTTP/1.1 401 Unauthorized");
   await expect(lesson).toContainText("HTTP/1.1 200 OK");
-  await expect(lesson).toContainText("kong/kong-ai-gateway:2.0.1");
+  await expect(lesson).toContainText("kong/kong-ai-gateway:2.0.2");
   await expect(lesson).toContainText(
     "docker stop consumer-credential-data-plane",
   );

--- a/site/tests/e2e/learning.spec.ts
+++ b/site/tests/e2e/learning.spec.ts
@@ -80,13 +80,18 @@ test("protects an AI Gateway model with Consumer credentials", async ({
 }) => {
   await page.goto("quickstarts/");
   const quickstarts = page.locator(".chapter-lessons");
-  await expect(quickstarts.locator(":scope > li")).toHaveCount(2);
+  await expect(quickstarts.locator(":scope > li")).toHaveCount(3);
   await expect(
     quickstarts.getByRole("link", { name: /AI Gateway: Route OpenAI/ }),
   ).toBeVisible();
   await expect(
     quickstarts.getByRole("link", {
       name: /AI Gateway: Consumer Credentials/,
+    }),
+  ).toBeVisible();
+  await expect(
+    quickstarts.getByRole("link", {
+      name: /AI Gateway: Vault-backed OpenAI/,
     }),
   ).toBeVisible();
 
@@ -112,6 +117,35 @@ test("protects an AI Gateway model with Consumer credentials", async ({
   await expect(lesson).toContainText(
     "docker stop consumer-credential-data-plane",
   );
+});
+
+test("routes Consumer requests with a vaulted OpenAI credential", async ({
+  page,
+}) => {
+  await page.goto("quickstarts/vault-backed-openai/");
+  const lesson = page.locator(".lesson-body");
+
+  await expect(
+    page.getByRole("heading", {
+      name: "AI Gateway: Vault-backed OpenAI",
+    }),
+  ).toBeVisible();
+  await expect(lesson).toContainText("config_stores:");
+  await expect(lesson).toContainText("openai-auth-header");
+  await expect(lesson).toContainText("!env OPENAI_API_KEY");
+  await expect(lesson).toContainText(
+    "config_store_id: !ref openai-config-store#id",
+  );
+  await expect(lesson).toContainText(
+    "{vault://openai-vault/openai-auth-header}",
+  );
+  await expect(lesson).toContainText("!env CONSUMER_API_KEY");
+  await expect(lesson).toContainText("auth_strategies:");
+  await expect(lesson).toContainText("apikey: ${CONSUMER_API_KEY}");
+  await expect(lesson).toContainText("HTTP/1.1 401 Unauthorized");
+  await expect(lesson).toContainText("HTTP/1.1 200 OK");
+  await expect(lesson).toContainText("kongctl apply -f ai-gateway.yaml");
+  await expect(lesson).toContainText("kongctl delete -f ai-gateway.yaml");
 });
 
 test("presents the federated management journey", async ({ page }) => {

--- a/test/e2e/scenarios/ai-gateway/config-store/overlays/002-sync-delete-vault/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/config-store/overlays/002-sync-delete-vault/config.yaml
@@ -9,4 +9,5 @@ ai_gateways:
       - ref: support-store
         name: support-store
         display_name: Support-Store-Updated
+        secrets: []
     vaults: []

--- a/test/e2e/scenarios/ai-gateway/config-store/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/config-store/scenario.yaml
@@ -3,6 +3,9 @@ baseInputsPath: testdata
 test:
   maturity: beta
 
+env:
+  KONGCTL_E2E_CONFIG_STORE_SECRET: kongctl-config-store-secret-value
+
 vars:
   namespace: ai-gateway-config-store-e2e
   gateway_name: AI Gateway Config Store E2E
@@ -51,6 +54,23 @@ steps:
             expect:
               fields:
                 '"x-kongctl-root-key"': ai_gateway_config_stores
+      - name: 003-explain-secret
+        run: [explain, ai_gateway_config_store_secret, -o, json]
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                type: object
+                '"x-kongctl-root-key"': ai_gateway_config_store_secrets
+      - name: 004-scaffold-secret
+        run: [scaffold, ai_gateway_config_store_secret]
+        outputFormat: disable
+        parseAs: raw
+        assertions:
+          - expect:
+              fields:
+                "contains(stdout, 'ai_gateway_config_store_secrets:')": true
+                "contains(stdout, 'value: !secret')": true
 
   - name: 002-create-and-read
     commands:
@@ -62,8 +82,8 @@ steps:
           - select: summary
             expect:
               fields:
-                total_changes: 3
-                by_action.CREATE: 3
+                total_changes: 5
+                by_action.CREATE: 5
       - name: 001-apply
         outputFormat: json
         run: [apply, --plan, "{{ .workdir }}/plan-create.json", --auto-approve]
@@ -71,7 +91,7 @@ steps:
           - select: summary
             expect:
               fields:
-                applied: 3
+                applied: 5
                 failed: 0
       - name: 002-list
         run:
@@ -122,8 +142,100 @@ steps:
             expect:
               fields:
                 "@": "{{ .vars.store_name }}"
+      - name: 005-list-secrets
+        run:
+          - list
+          - ai-gateway
+          - config-stores
+          - "{{ .vars.store_name }}"
+          - secrets
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - -o
+          - json
+        assertions:
+          - select: "[?key=='support-api-key'] | [0]"
+            expect:
+              fields:
+                key: support-api-key
+                "contains(keys(@), 'value')": false
+      - name: 006-get-secret
+        run:
+          - get
+          - ai-gateway
+          - config-stores
+          - "{{ .vars.store_name }}"
+          - secrets
+          - support-api-key
+          - --gateway-name
+          - "{{ .vars.gateway_name }}"
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                key: support-api-key
+                "contains(keys(@), 'value')": false
 
-  - name: 003-update-and-dump
+  - name: 003-rotate-secret
+    commands:
+      - name: 000-plan-rotation
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-rotation.json"
+        env:
+          KONGCTL_E2E_CONFIG_STORE_SECRET: rotated-config-store-secret-value
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+          - --write-secret
+          - support-api-key#value
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.UPDATE: 1
+                secret_writes: 1
+          - select: changes[0]
+            expect:
+              fields:
+                resource_type: ai_gateway_config_store_secret
+                resource_ref: support-api-key
+                secret_writes[0].field: /value
+      - name: 001-diff-rotation
+        outputFormat: text
+        parseAs: raw
+        run:
+          - diff
+          - --plan
+          - "{{ .workdir }}/plan-rotation.json"
+        assertions:
+          - select: stdout
+            expect:
+              fields:
+                "contains(@, '[redacted from !env]')": true
+                "contains(@, 'rotated-config-store-secret-value')": false
+      - name: 002-apply-rotation
+        outputFormat: json
+        env:
+          KONGCTL_E2E_CONFIG_STORE_SECRET: rotated-config-store-secret-value
+        run:
+          - apply
+          - --plan
+          - "{{ .workdir }}/plan-rotation.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+
+  - name: 004-update-and-dump
     inputOverlayDirs: [overlays/001-update]
     commands:
       - name: 000-plan-update
@@ -170,8 +282,10 @@ steps:
               fields:
                 name: "{{ .vars.store_name }}"
                 display_name: Support-Store-Updated
+                "secrets[0].key": support-api-key
+                "contains(keys(secrets[0]), 'value')": false
 
-  - name: 004-sync-delete-vault
+  - name: 005-sync-delete-secret-and-vault
     inputOverlayDirs: [overlays/002-sync-delete-vault]
     commands:
       - name: 000-sync
@@ -181,10 +295,10 @@ steps:
           - select: summary
             expect:
               fields:
-                applied: 1
+                applied: 2
                 failed: 0
 
-  - name: 005-sync-delete-store
+  - name: 006-sync-delete-store
     inputOverlayDirs: [overlays/003-sync-delete-store]
     commands:
       - name: 000-sync
@@ -197,7 +311,7 @@ steps:
                 applied: 1
                 failed: 0
 
-  - name: 006-sync-delete-gateway
+  - name: 007-sync-delete-gateway
     inputOverlayDirs: [overlays/004-sync-delete-gateway]
     commands:
       - name: 000-sync

--- a/test/e2e/scenarios/ai-gateway/config-store/testdata/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/config-store/testdata/config.yaml
@@ -9,9 +9,23 @@ ai_gateways:
       - ref: support-store
         name: support-store
         display_name: Support-Store
+        secrets:
+          - ref: support-api-key
+            key: support-api-key
+            value: !secret {source: !env KONGCTL_E2E_CONFIG_STORE_SECRET}
     vaults:
       - ref: support-vault
         type: konnect
         name: support-vault
         config:
           config_store_id: !ref support-store#id
+    model_providers:
+      - ref: support-openai
+        name: support-openai
+        type: openai
+        config:
+          auth:
+            type: basic
+            headers:
+              - name: Authorization
+                value: "{vault://support-vault/support-api-key}"

--- a/test/integration/declarative/ai_gateway_explain_conformance_test.go
+++ b/test/integration/declarative/ai_gateway_explain_conformance_test.go
@@ -96,6 +96,13 @@ func validateAIGatewayScenarioExplainSchemas(t *testing.T, resourceSet *resource
 			&resourceSet.AIGatewayConfigStores[i],
 		)
 	}
+	for i := range resourceSet.AIGatewayConfigStoreSecrets {
+		validateResourceAgainstExplainSchema(
+			t,
+			string(resources.ResourceTypeAIGatewayConfigStoreSecret),
+			&resourceSet.AIGatewayConfigStoreSecrets[i],
+		)
+	}
 	for i := range resourceSet.AIGatewayDataPlaneCertificates {
 		validateResourceAgainstExplainSchema(
 			t,

--- a/test/integration/declarative/ai_gateway_sdk_mapping_test.go
+++ b/test/integration/declarative/ai_gateway_sdk_mapping_test.go
@@ -148,6 +148,15 @@ func mapAIGatewayScenarioCreatePayloads(t *testing.T, resourceSet *resources.Res
 			executor.NewAIGatewayConfigStoreAdapter(nil).MapCreateFields(t.Context(), nil, fields, &request),
 		)
 	}
+	for _, resource := range resourceSet.AIGatewayConfigStoreSecrets {
+		fields, err := resource.MutablePayloadMap()
+		require.NoError(t, err)
+		var request kkComps.CreateAIGatewayConfigStoreSecretRequest
+		require.NoError(
+			t,
+			executor.NewAIGatewayConfigStoreSecretAdapter(nil).MapCreateFields(t.Context(), nil, fields, &request),
+		)
+	}
 	for _, resource := range resourceSet.AIGatewayDataPlaneCertificates {
 		var request kkComps.CreateAIGatewayDataPlaneCertificateRequest
 		require.NoError(


### PR DESCRIPTION
## Summary

- add first-class nested and root-level declarative support for AI Gateway Config Store secrets
- implement safe create, explicit rotation, sync deletion, same-plan dependency resolution, dump, and HTTP redaction behavior
- add imperative list/get metadata commands, Explain/scaffold schemas, documentation, and unit/integration/E2E coverage
- add Consumer credential and vault-backed OpenAI Learn-site quickstarts
- demonstrate one declarative input that creates the Config Store secret, Konnect Vault, provider, Consumer credential, protected model, and data plane certificate

## Testing

- `go fix ./...`
- `make format`
- `make build`
- `make lint`
- `make test`
- `make test-integration`
- `cd site && npm run check`
- `cd site && npm test`
- `cd site && npm run build`
- `cd site && npm run test:e2e` (28 passed)

The live Konnect E2E scenario was not executed locally because it resets the configured Konnect organization.

Closes #1974