### PR TITLE
refactor(simplify): reduce validation and rendering boilerplate

### DIFF
--- a/internal/cmd/root/products/konnect/auditlogs/pull.go
+++ b/internal/cmd/root/products/konnect/auditlogs/pull.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -572,16 +571,21 @@ func renderAuditLogJSONLines(helper cmd.Helper, records []json.RawMessage) error
 }
 
 func renderAuditLogText(helper cmd.Helper, records []json.RawMessage) error {
-	selected, err := columns.Resolve(helper.GetCmd(), cmdcommon.TEXT)
+	headers, rows, err := resolveAuditLogHeadersAndRows(helper, records)
 	if err != nil {
 		return &cmd.ConfigurationError{Err: err}
 	}
+	return columns.RenderAutoWidth(helper.GetStreams().Out, headers, rows)
+}
+
+func resolveAuditLogHeadersAndRows(helper cmd.Helper, records []json.RawMessage) ([]string, [][]string, error) {
+	selected, err := columns.Resolve(helper.GetCmd(), cmdcommon.TEXT)
+	if err != nil {
+		return nil, nil, err
+	}
 	if len(selected) > 0 {
 		headers, rows, err := columns.Project(records, selected)
-		if err != nil {
-			return err
-		}
-		return columns.RenderAutoWidth(helper.GetStreams().Out, headers, rows)
+		return headers, rows, err
 	}
 
 	headers := []string{"TIMESTAMP", "TYPE", "PRINCIPAL", "ACTION", "RESULT", "TRACE ID"}
@@ -589,7 +593,7 @@ func renderAuditLogText(helper cmd.Helper, records []json.RawMessage) error {
 	for _, record := range records {
 		rows = append(rows, defaultAuditLogRow(record))
 	}
-	return columns.RenderAutoWidth(helper.GetStreams().Out, headers, rows)
+	return headers, rows, nil
 }
 
 func defaultAuditLogRow(raw json.RawMessage) []string {
@@ -832,8 +836,8 @@ func auditLogRecordTime(record json.RawMessage, fallback time.Time) time.Time {
 }
 
 func sortAuditLogRecords(records []json.RawMessage) {
-	sort.SliceStable(records, func(i, j int) bool {
-		return auditLogRecordTime(records[i], time.Time{}).Before(auditLogRecordTime(records[j], time.Time{}))
+	slices.SortStableFunc(records, func(a, b json.RawMessage) int {
+		return auditLogRecordTime(a, time.Time{}).Compare(auditLogRecordTime(b, time.Time{}))
 	})
 }
 
@@ -846,23 +850,9 @@ func expireAuditLogDedup(seen map[string]time.Time, before time.Time) {
 }
 
 func renderFollowText(helper cmd.Helper, records []json.RawMessage, headerWritten *bool) error {
-	selected, err := columns.Resolve(helper.GetCmd(), cmdcommon.TEXT)
+	headers, rows, err := resolveAuditLogHeadersAndRows(helper, records)
 	if err != nil {
 		return err
-	}
-	var headers []string
-	var rows [][]string
-	if len(selected) > 0 {
-		headers, rows, err = columns.Project(records, selected)
-		if err != nil {
-			return err
-		}
-	} else {
-		headers = []string{"TIMESTAMP", "TYPE", "PRINCIPAL", "ACTION", "RESULT", "TRACE ID"}
-		rows = make([][]string, 0, len(records))
-		for _, record := range records {
-			rows = append(rows, defaultAuditLogRow(record))
-		}
 	}
 	if *headerWritten {
 		return renderRowsWithoutHeader(helper.GetStreams().Out, rows)

--- a/internal/cmd/root/products/konnect/declarative/declarative.go
+++ b/internal/cmd/root/products/konnect/declarative/declarative.go
@@ -2099,13 +2099,7 @@ func runExecution(command *cobra.Command, args []string, verb verbs.VerbValue, p
 	command.SetContext(ctx)
 
 	// Validate plan mode and actions before handling an empty plan or executing changes.
-	if err := validateExecutionPlan(
-		plan,
-		planFile,
-		string(planMode),
-		planMode,
-		allowedActionsForPlanMode(planMode),
-	); err != nil {
+	if err := validateExecutionPlan(plan, planFile, planMode); err != nil {
 		return err
 	}
 	if outputFormat != textOutputFormat {
@@ -2203,42 +2197,24 @@ func runExecution(command *cobra.Command, args []string, verb verbs.VerbValue, p
 }
 
 func validateApplyPlan(plan *planner.Plan, planFile string) error {
-	return validateExecutionPlan(
-		plan,
-		planFile,
-		"apply",
-		planner.PlanModeApply,
-		allowedActionsForPlanMode(planner.PlanModeApply),
-	)
+	return validateExecutionPlan(plan, planFile, planner.PlanModeApply)
 }
 
 func validateSyncPlan(plan *planner.Plan, planFile string) error {
-	return validateExecutionPlan(
-		plan,
-		planFile,
-		"sync",
-		planner.PlanModeSync,
-		allowedActionsForPlanMode(planner.PlanModeSync),
-	)
+	return validateExecutionPlan(plan, planFile, planner.PlanModeSync)
 }
 
 func validateDeletePlan(plan *planner.Plan, planFile string) error {
-	return validateExecutionPlan(
-		plan,
-		planFile,
-		"delete",
-		planner.PlanModeDelete,
-		allowedActionsForPlanMode(planner.PlanModeDelete),
-	)
+	return validateExecutionPlan(plan, planFile, planner.PlanModeDelete)
 }
 
 func validateExecutionPlan(
 	plan *planner.Plan,
 	planFile string,
-	commandName string,
 	requiredMode planner.PlanMode,
-	allowedActions []planner.ActionType,
 ) error {
+	commandName := string(requiredMode)
+	allowedActions := allowedActionsForPlanMode(requiredMode)
 	planDescription := describePlanSource(planFile)
 	if plan == nil {
 		return fmt.Errorf("%s could not be loaded for the %s command", planDescription, commandName)

--- a/internal/declarative/loader/config_templates.go
+++ b/internal/declarative/loader/config_templates.go
@@ -92,11 +92,7 @@ func expandConfigTemplateDocuments(documents []*configTemplateDocument) error {
 }
 
 func (r *configTemplateRegistry) resolveDefinitions() error {
-	names := make([]string, 0, len(r.definitions))
-	for name := range r.definitions {
-		names = append(names, name)
-	}
-	slices.Sort(names)
+	names := slices.Sorted(maps.Keys(r.definitions))
 
 	for _, name := range names {
 		definition := r.definitions[name]
@@ -481,11 +477,7 @@ func templateDefinitionContext(definitions map[string]configTemplate) string {
 	if len(definitions) == 0 {
 		return ""
 	}
-	names := make([]string, 0, len(definitions))
-	for name := range definitions {
-		names = append(names, name)
-	}
-	slices.Sort(names)
+	names := slices.Sorted(maps.Keys(definitions))
 
 	parts := make([]string, 0, len(names))
 	for _, name := range names {


### PR DESCRIPTION
## Summary

- derive execution-plan validation details from the required plan mode
- share audit-log header and row resolution across pull and follow rendering
- adopt Go 1.26 slice and map iterator helpers
- leave the existing test suite unchanged

Closes #1967
Closes #1980

## Validation

- `go fix ./...`
- `make format`
- `make build`
- `make test-installer` (passed; shellcheck unavailable locally)
- `make test`
- `make test-integration`
- `golangci-lint run ./internal/cmd/root/products/konnect/auditlogs ./internal/cmd/root/products/konnect/declarative ./internal/declarative/loader`

`make test-all` reaches the repository-wide lint step and fails on unchanged baseline findings in generated portal client/test code and generated mocks. The three changed packages lint with zero issues.