### PR TITLE
fix(declarative): support catalog services in dumps

### DIFF
--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -1376,6 +1376,14 @@ discovery and YAML filtering are not run. The option affects only
 `dump declarative`; it does not change `plan`, `apply`, `diff`, or
 `dump tf-import` behavior.
 
+Catalog services, including nested custom fields, can be dumped and planned
+again to verify round-trip fidelity:
+
+```shell
+kongctl dump declarative --resources=catalog_services > catalog-services.yaml
+kongctl plan -f catalog-services.yaml --mode apply
+```
+
 For custom dashboards created in the Konnect UI, adopt the dashboard first,
 then dump it with the same namespace:
 

--- a/internal/cmd/root/verbs/dump/common.go
+++ b/internal/cmd/root/verbs/dump/common.go
@@ -31,6 +31,7 @@ const (
 	filterOpContains                  = "contains"
 	resourceAPIs                      = "apis"
 	resourceAnalyticsDashboards       = "analytics.dashboards"
+	resourceCatalogServices           = "catalog_services"
 )
 
 type paginationParams struct {
@@ -160,6 +161,8 @@ func mapResourceName(name string) string {
 		return resourceAnalyticsDashboards
 	case "ai-gateway", "ai-gateways", "ai_gateway", "ai_gateways", "aigw":
 		return "ai_gateways"
+	case "catalog-service", "catalog-services", "catalog_service", resourceCatalogServices:
+		return resourceCatalogServices
 	case "org.team", "org.teams", "organization.team", "organization.teams":
 		return "organization.teams"
 	default:

--- a/internal/cmd/root/verbs/dump/declarative.go
+++ b/internal/cmd/root/verbs/dump/declarative.go
@@ -49,6 +49,7 @@ var declarativeAllowedResources = map[string]struct{}{
 	"portals":                     {},
 	resourceAPIs:                  {},
 	"application_auth_strategies": {},
+	resourceCatalogServices:       {},
 	"dcr_providers":               {},
 	"control_planes":              {},
 	resourceAnalyticsDashboards:   {},
@@ -86,7 +87,7 @@ func newDeclarativeCmd() *cobra.Command {
 	cmd.Flags().String("resources", "",
 		"Comma separated list of resource types to dump "+
 			"(ai_gateways, "+resourceAnalyticsDashboards+", apis, application_auth_strategies, "+
-			"control_planes, dcr_providers, event_gateways, organization.teams, portals).")
+			resourceCatalogServices+", control_planes, dcr_providers, event_gateways, organization.teams, portals).")
 	_ = cmd.MarkFlagRequired("resources")
 
 	cmd.Flags().BoolVar(&opts.includeChildResources, "include-child-resources", false,
@@ -313,6 +314,14 @@ func runDeclarativeDump(helper cmdpkg.Helper, opts declarativeOptions) error {
 				return err
 			}
 			resourceSet.ApplicationAuthStrategies = append(resourceSet.ApplicationAuthStrategies, authStrategies...)
+		case resourceCatalogServices:
+			catalogServices, err := collectDeclarativeCatalogServices(
+				ctx, sdk.GetCatalogServicesAPI(), requestPageSize, opts.filter,
+			)
+			if err != nil {
+				return err
+			}
+			resourceSet.CatalogServices = append(resourceSet.CatalogServices, catalogServices...)
 		case "dcr_providers":
 			dcrProviders, err := collectDeclarativeDCRProviders(
 				ctx, sdk.GetDCRProvidersAPI(), requestPageSize, opts.filter,
@@ -564,6 +573,65 @@ func collectDeclarativeAPIs(
 	}
 
 	slices.SortFunc(results, func(a, b declresources.APIResource) int {
+		if n := cmp.Compare(a.Name, b.Name); n != 0 {
+			return n
+		}
+		return cmp.Compare(a.Ref, b.Ref)
+	})
+
+	return results, nil
+}
+
+func collectDeclarativeCatalogServices(
+	ctx context.Context,
+	api helpers.CatalogServicesAPI,
+	requestPageSize int64,
+	filter filterOptions,
+) ([]declresources.CatalogServiceResource, error) {
+	if api == nil {
+		return nil, fmt.Errorf("catalog services API client is not configured")
+	}
+
+	var results []declresources.CatalogServiceResource
+
+	err := processPaginatedRequests(func(pageNumber int64) (bool, error) {
+		req := kkOps.ListCatalogServicesRequest{
+			PageSize:   &requestPageSize,
+			PageNumber: &pageNumber,
+		}
+
+		if filter.name != "" {
+			req.Filter = &kkComps.CatalogServiceFilterParameters{Name: buildStringFieldFilter(filter.name)}
+		} else if filter.id != "" {
+			req.Filter = &kkComps.CatalogServiceFilterParameters{ID: &kkComps.UUIDFieldFilter{Eq: &filter.id}}
+		}
+
+		resp, err := api.ListCatalogServices(ctx, req)
+		if err != nil {
+			return false, fmt.Errorf("failed to list catalog services: %w", err)
+		}
+
+		if resp == nil || resp.ListCatalogServicesResponse == nil ||
+			len(resp.ListCatalogServicesResponse.Data) == 0 {
+			return false, nil
+		}
+
+		for _, service := range resp.ListCatalogServicesResponse.Data {
+			results = append(results, mapCatalogServiceToDeclarativeResource(service))
+		}
+
+		params := paginationParams{
+			pageSize:   requestPageSize,
+			pageNumber: pageNumber,
+			totalItems: resp.ListCatalogServicesResponse.Meta.Page.Total,
+		}
+		return params.hasMorePages(), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	slices.SortFunc(results, func(a, b declresources.CatalogServiceResource) int {
 		if n := cmp.Compare(a.Name, b.Name); n != 0 {
 			return n
 		}
@@ -918,6 +986,25 @@ func mapAPIToDeclarativeResource(api kkComps.APIResponseSchema) declresources.AP
 	result.Kongctl = kongctlMetaFromLabels(api.Labels)
 
 	normalizeAPIResource(&result)
+
+	return result
+}
+
+func mapCatalogServiceToDeclarativeResource(service kkComps.CatalogService) declresources.CatalogServiceResource {
+	result := declresources.CatalogServiceResource{
+		BaseResource: declresources.BaseResource{Ref: service.ID},
+		CreateCatalogService: kkComps.CreateCatalogService{
+			Name:         service.Name,
+			DisplayName:  service.DisplayName,
+			Description:  service.Description,
+			CustomFields: service.CustomFields,
+		},
+	}
+
+	if labels := decllabels.GetUserLabels(service.Labels); len(labels) > 0 {
+		result.Labels = labels
+	}
+	result.Kongctl = kongctlMetaFromLabels(service.Labels)
 
 	return result
 }

--- a/internal/cmd/root/verbs/dump/dump_declarative_test.go
+++ b/internal/cmd/root/verbs/dump/dump_declarative_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -844,6 +845,10 @@ func TestNormalizeResourceListMapsSupportedAliases(t *testing.T) {
 		{input: "ai-gateways", want: []string{"ai_gateways"}},
 		{input: "aigw", want: []string{"ai_gateways"}},
 		{input: "ai_gateways,analytics.dashboards", want: []string{"ai_gateways", "analytics.dashboards"}},
+		{input: "catalog-service", want: []string{resourceCatalogServices}},
+		{input: "catalog-services", want: []string{resourceCatalogServices}},
+		{input: "catalog_service", want: []string{resourceCatalogServices}},
+		{input: resourceCatalogServices, want: []string{resourceCatalogServices}},
 	}
 
 	for _, tt := range tests {
@@ -856,6 +861,44 @@ func TestNormalizeResourceListMapsSupportedAliases(t *testing.T) {
 				t.Fatalf("expected %v, got %v", tt.want, got)
 			}
 		})
+	}
+}
+
+func TestMapCatalogServiceToDeclarativeResource(t *testing.T) {
+	description := "Catalog service description"
+	service := kkComps.CatalogService{
+		ID:          "service-id",
+		Name:        "payments",
+		DisplayName: "Payments Service",
+		Description: &description,
+		Labels: map[string]string{
+			decllabels.NamespaceKey: "catalog-team",
+			"tier":                  "critical",
+		},
+		CustomFields: map[string]any{
+			"owner": "platform-team",
+			"dashboard": map[string]any{
+				"name": "Payments Dashboard",
+				"link": "https://example.com/dashboard",
+			},
+		},
+	}
+
+	got := mapCatalogServiceToDeclarativeResource(service)
+	if got.Ref != service.ID || got.Name != service.Name || got.DisplayName != service.DisplayName {
+		t.Fatalf("unexpected catalog service identity: %#v", got)
+	}
+	if got.Description == nil || *got.Description != description {
+		t.Fatalf("unexpected catalog service description: %#v", got.Description)
+	}
+	if got.Labels["tier"] != "critical" {
+		t.Fatalf("expected user labels in dump, got %#v", got.Labels)
+	}
+	if got.Kongctl == nil || got.Kongctl.Namespace == nil || *got.Kongctl.Namespace != "catalog-team" {
+		t.Fatalf("expected namespace metadata in dump, got %#v", got.Kongctl)
+	}
+	if !reflect.DeepEqual(got.CustomFields, service.CustomFields) {
+		t.Fatalf("expected custom fields to be preserved, got %#v", got.CustomFields)
 	}
 }
 

--- a/test/e2e/scenarios/catalog/service/scenario.yaml
+++ b/test/e2e/scenarios/catalog/service/scenario.yaml
@@ -330,6 +330,51 @@ steps:
               fields:
                 total_changes: 0
 
+  - name: 004b-dump-and-round-trip
+    skipInputs: true
+    commands:
+      - name: 000-dump-catalog-services
+        run:
+          - dump
+          - declarative
+          - "--resources=catalog_services"
+        outputFormat: none
+        parseAs: yaml
+        stdoutFile: "{{ .workdir }}/dump.yaml"
+        assertions:
+          - select: "catalog_services[?name=='{{ .vars.serviceName }}'] | [0]"
+            expect:
+              fields:
+                display_name: "Payments Service"
+                description: "Updated description for payments service"
+                labels.tier: important
+                labels.domain: payments
+                kongctl.namespace: "{{ .vars.namespace }}"
+                custom_fields.owner: platform-team
+                custom_fields.cost_center: "Platform"
+                custom_fields.product_manager: "Jordan Kim"
+                custom_fields.jira_project.name: "Payments Platform"
+                custom_fields.jira_project.link: "https://jira.example.com/projects/PLATPAY"
+                custom_fields.dashboard.name: "Payments Platform Dashboard"
+                custom_fields.dashboard.link: "https://dashboards.example.com/payments-platform"
+                custom_fields.git_repo.name: "payments-service"
+                custom_fields.git_repo.link: "https://github.com/example/payments"
+                custom_fields.slack_channel.name: "#payments-platform"
+                custom_fields.slack_channel.link: "https://slack.example.com/archives/payments-platform"
+      - name: 001-plan-from-dump
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/dump.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+
   - name: 005-sync-delete-catalog-service
     inputOverlayDirs:
       - overlays/005-sync-delete


### PR DESCRIPTION
## Summary

- add catalog services and common aliases to `dump declarative --resources`
- preserve service fields, user labels, namespace metadata, and nested custom fields in dump output
- expand the existing catalog service E2E scenario with dump assertions and a zero-change plan round-trip
- document the catalog service dump workflow

The issue assumed `catalog_services` was already a supported dump resource because it is a valid declarative sync scope. The targeted scenario showed the dump command rejected it, so this PR adds the missing dump support required by the requested coverage.

## Testing

- `go test ./internal/cmd/root/verbs/dump`
- `make test-e2e-scenarios SCENARIO=catalog/service`
- `go fix ./...`
- `make format`
- `make build`
- `make test`
- `make test-integration`
- `make lint` *(currently fails on pre-existing generated helper/portal-client line-length and misspelling findings plus two generated mock staticcheck findings)*

Closes #1968