### PR TITLE
test(e2e): cover hybrid Event Gateway secret fields

### DIFF
--- a/test/e2e/scenarios/event-gateway/backend-cluster/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/backend-cluster/scenario.yaml
@@ -245,6 +245,8 @@ steps:
                   - "egw-backend-1.example.com:9094"
                   - "egw-backend-2.example.com:9095"
                 authentication.type: "sasl_plain"
+                authentication.username: '${env["updated-username"]}'
+                authentication.password: '${env["updated-password"]}'
                 tls.enabled: true
                 tls.tls_versions:
                   - "tls12"
@@ -303,6 +305,8 @@ steps:
                 name: "{{ .vars.bcRef }}"
                 authentication.type: sasl_scram
                 authentication.algorithm: sha512
+                authentication.username: '${env["scram-username"]}'
+                authentication.password: '${env["scram-password"]}'
       - name: 004-idempotency-check
         outputFormat: disable
         run:

--- a/test/e2e/scenarios/event-gateway/dump/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/dump/scenario.yaml
@@ -21,6 +21,7 @@ vars:
   schemaRegistryName: default-schema-registry-name-for-dump-test
   staticKeyRef: default-static-key
   staticKeyName: default-static-key-name-for-dump-test
+  literalStaticKeyName: literal-static-key-name-for-dump-test
   trustBundleRef: default-tls-trust-bundle-ref-dump
   trustBundleName: default-tls-trust-bundle-name-dump
   listenerRef: default-listener-for-dump-test-ref
@@ -58,7 +59,7 @@ steps:
           - select: summary
             expect:
               fields:
-                applied: 13
+                applied: 14
                 failed: 0
 
   # Dump event_gateways with child resources and validate the output structure.
@@ -133,6 +134,14 @@ steps:
             expect:
               fields:
                 name: "{{ .vars.staticKeyName }}"
+                value: '${env["STATIC_KEY_VALUE"]}'
+          - name: literal-static-key-omits-plaintext
+            select: >-
+              event_gateways[?name=='{{ .vars.egwName }}'] | [0].static_keys[?name=='{{ .vars.literalStaticKeyName }}'] | [0]
+            expect:
+              fields:
+                name: "{{ .vars.literalStaticKeyName }}"
+                value: ""
           - name: trust-bundle-present
             select: >-
               event_gateways[?name=='{{ .vars.egwName }}'] | [0].tls_trust_bundles[?name=='{{ .vars.trustBundleName }}'] | [0]

--- a/test/e2e/scenarios/event-gateway/dump/testdata/config.yaml
+++ b/test/e2e/scenarios/event-gateway/dump/testdata/config.yaml
@@ -134,6 +134,10 @@ event_gateways:
         name: default-static-key-name-for-dump-test
         description: "Default Static Key description for Dump Test"
         value: "${env[\"STATIC_KEY_VALUE\"]}"
+      - ref: literal-static-key
+        name: literal-static-key-name-for-dump-test
+        description: "Literal Static Key description for Dump Test"
+        value: "YXNkZmdoamthc2RmZ2hqa2FzZGZnaGprYXNkZmdoams="
     tls_trust_bundles:
       - ref: default-tls-trust-bundle-ref-dump
         name: default-tls-trust-bundle-name-dump

--- a/test/e2e/scenarios/event-gateway/static-key/overlays/002-update-template-expression/config.yaml
+++ b/test/e2e/scenarios/event-gateway/static-key/overlays/002-update-template-expression/config.yaml
@@ -10,4 +10,4 @@ event_gateways:
       - ref: default-static-key-ref
         name: default-static-key-name
         description: "Default Static Key description"
-        value: '${env["STATIC_KEY_VALUE"]}'
+        value: '${env["STATIC_KEY_VALUE_V2"]}'

--- a/test/e2e/scenarios/event-gateway/static-key/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/static-key/scenario.yaml
@@ -89,8 +89,26 @@ steps:
               fields:
                 name: "{{ .vars.staticKeyName }}"
                 description: "Default Static Key description"
+                "contains(keys(@), 'value')": false
+      - name: 004-verify-create-by-name
+        run:
+          - get
+          - event-gateway
+          - static-keys
+          - "{{ .vars.staticKeyName }}"
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                name: "{{ .vars.staticKeyName }}"
+                description: "Default Static Key description"
+                "contains(keys(@), 'value')": false
   - name: 002-plan-sync-replace
-    # Static keys do not support update – changing description triggers DELETE+CREATE.
+    # Static keys do not support update – changing value triggers DELETE+CREATE.
     inputOverlayDirs:
       - overlays/001-update-fields
     commands:
@@ -126,7 +144,7 @@ steps:
               fields:
                 action: CREATE
                 resource_ref: "{{ .vars.staticKeyRef }}"
-                "fields.value": "YXNkZmdoamthc2RmZ2hqa2FzZGZnaGprYXNkZmdoams="
+                "fields.value": '${env["STATIC_KEY_VALUE"]}'
       - name: 002-apply-replace
         outputFormat: json
         run:
@@ -159,8 +177,122 @@ steps:
             expect:
               fields:
                 name: "{{ .vars.staticKeyName }}"
-                description: "Updated Static Key description"
-  - name: 003-sync-delete
+                description: "Default Static Key description"
+                value: '${env["STATIC_KEY_VALUE"]}'
+
+      - name: 004-verify-replacement-by-name
+        run:
+          - get
+          - event-gateway
+          - static-keys
+          - "{{ .vars.staticKeyName }}"
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                name: "{{ .vars.staticKeyName }}"
+                description: "Default Static Key description"
+                value: '${env["STATIC_KEY_VALUE"]}'
+
+      - name: 005-plan-unchanged-template-expression
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-unchanged-template-expression.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+  - name: 003-plan-sync-replace-template-expression
+    inputOverlayDirs:
+      - overlays/002-update-template-expression
+    commands:
+      - name: 001-plan-replace-template-expression
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-replace-template-expression.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 2
+                by_action.DELETE: 1
+                by_action.CREATE: 1
+          - select: >-
+              changes[?resource_type=='event_gateway_static_key' && action=='DELETE'] | [0]
+            expect:
+              fields:
+                action: DELETE
+                resource_type: "event_gateway_static_key"
+          - select: >-
+              changes[?resource_type=='event_gateway_static_key' && action=='CREATE'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.staticKeyRef }}"
+                "fields.value": '${env["STATIC_KEY_VALUE_V2"]}'
+
+      - name: 002-apply-replace-template-expression
+        outputFormat: json
+        run:
+          - sync
+          - --plan
+          - "{{ .workdir }}/plan-replace-template-expression.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 2
+                failed: 0
+
+      - name: 003-verify-replaced-template-expression
+        run:
+          - get
+          - event-gateway
+          - static-keys
+          - "{{ .vars.staticKeyName }}"
+          - --gateway-name
+          - "{{ .vars.egwName }}"
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                name: "{{ .vars.staticKeyName }}"
+                value: '${env["STATIC_KEY_VALUE_V2"]}'
+
+      - name: 004-plan-unchanged-template-expression
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-unchanged-template-expression.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+
+  - name: 004-sync-delete
     inputOverlayDirs:
       - overlays/002-sync-delete
     commands:
@@ -217,7 +349,7 @@ steps:
             expect:
               fields:
                 "@": 0
-  - name: 004-root-level-declaration
+  - name: 005-root-level-declaration
     inputOverlayDirs:
       - overlays/003-root-level-declaration
     commands:
@@ -280,7 +412,7 @@ steps:
               fields:
                 name: default-static-key-name
                 description: "Default root level Static Key description"
-  - name: 005-sync-delete-root-level
+  - name: 006-sync-delete-root-level
     inputOverlayDirs:
       - overlays/004-sync-delete-root-level-declaration
     commands:


### PR DESCRIPTION
## Summary

- verify plaintext static-key values are omitted from list and get output
- verify Event Gateway template expressions are returned and reconciled across replacement lifecycles
- cover dump redaction, expression preservation, and zero-change round trips
- assert returned backend-cluster authentication expressions

Closes #1989

## Testing

- make test-e2e-scenarios SCENARIO=event-gateway/static-key
- make test-e2e-scenarios SCENARIO=event-gateway/dump
- make test-e2e-scenarios SCENARIO=event-gateway/backend-cluster
- make build
- make test
- git diff --check

## Known baseline

- make lint reports existing generated portal client line-length and misspelling findings, plus two unrelated staticcheck findings; none are in the changed files.