### PR TITLE
fix(declarative): prevent AI Gateway perpetual drift

### DIFF
--- a/internal/declarative/planner/ai_gateway_auth_strategy_planner.go
+++ b/internal/declarative/planner/ai_gateway_auth_strategy_planner.go
@@ -297,9 +297,10 @@ func shouldUpdateAIGatewayAuthStrategy(
 	}
 
 	if desired.Config != nil && aiGatewayAuthStrategyConfigChanged(current.Config, desired.Config) {
+		currentConfig, desiredConfig := comparableAIGatewayAuthStrategyConfigs(current.Config, desired.Config)
 		changedFields[FieldConfig] = FieldChange{
-			Old: scrubAIGatewayAuthStrategySecretFields(normalizeAuthStrategyConfigForCompare(current.Config)),
-			New: scrubAIGatewayAuthStrategySecretFields(normalizeAuthStrategyConfigForCompare(desired.Config)),
+			Old: currentConfig,
+			New: desiredConfig,
 		}
 	}
 
@@ -343,17 +344,28 @@ func extractAIGatewayAuthStrategyFields(provider resources.AIGatewayAuthStrategy
 }
 
 func aiGatewayAuthStrategyConfigChanged(current, desired map[string]any) bool {
+	currentComparable, desiredComparable := comparableAIGatewayAuthStrategyConfigs(current, desired)
+	return !reflect.DeepEqual(currentComparable, desiredComparable)
+}
+
+func comparableAIGatewayAuthStrategyConfigs(current, desired map[string]any) (map[string]any, map[string]any) {
+	return comparableAIGatewayWriteOnlyPayloads(
+		current,
+		desired,
+		normalizeAIGatewayAuthStrategyConfigsForComparison,
+		scrubAIGatewayAuthStrategySecretFields,
+		isAIGatewayAuthStrategySecretField,
+	)
+}
+
+func normalizeAIGatewayAuthStrategyConfigsForComparison(
+	current map[string]any,
+	desired map[string]any,
+) (map[string]any, map[string]any) {
 	currentComparable := normalizeAuthStrategyConfigForCompare(current)
 	desiredComparable := normalizeAuthStrategyConfigForCompare(desired)
 	projectAIGatewayAuthStrategyConfigForComparison(currentComparable, desiredComparable)
-	currentComparable = scrubAIGatewayAuthStrategySecretFields(currentComparable).(map[string]any)
-	desiredComparable = scrubAIGatewayAuthStrategySecretFields(desiredComparable).(map[string]any)
-	pruneUnpairedAIGatewayWriteOnlyReferences(
-		currentComparable,
-		desiredComparable,
-		isAIGatewayAuthStrategySecretField,
-	)
-	return !reflect.DeepEqual(currentComparable, desiredComparable)
+	return currentComparable, desiredComparable
 }
 
 func projectAIGatewayAuthStrategyConfigForComparison(currentCompare map[string]any, desiredCompare map[string]any) {

--- a/internal/declarative/planner/ai_gateway_auth_strategy_planner.go
+++ b/internal/declarative/planner/ai_gateway_auth_strategy_planner.go
@@ -348,6 +348,11 @@ func aiGatewayAuthStrategyConfigChanged(current, desired map[string]any) bool {
 	projectAIGatewayAuthStrategyConfigForComparison(currentComparable, desiredComparable)
 	currentComparable = scrubAIGatewayAuthStrategySecretFields(currentComparable).(map[string]any)
 	desiredComparable = scrubAIGatewayAuthStrategySecretFields(desiredComparable).(map[string]any)
+	pruneUnpairedAIGatewayWriteOnlyReferences(
+		currentComparable,
+		desiredComparable,
+		isAIGatewayAuthStrategySecretField,
+	)
 	return !reflect.DeepEqual(currentComparable, desiredComparable)
 }
 

--- a/internal/declarative/planner/ai_gateway_auth_strategy_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_auth_strategy_planner_test.go
@@ -70,6 +70,24 @@ func TestAIGatewayAuthStrategyConfigChangedComparesPublicVaultReferences(t *test
 	))
 }
 
+func TestAIGatewayAuthStrategyConfigChangedIgnoresVaultReferenceMissingFromResponse(t *testing.T) {
+	t.Parallel()
+
+	current := map[string]any{
+		"auth_methods": []any{"bearer"},
+		"client_id":    []any{"primary-client"},
+		"issuer":       "https://issuer.example.com",
+	}
+	desired := map[string]any{
+		"auth_methods":  []any{"bearer"},
+		"client_id":     []any{"primary-client"},
+		"client_secret": []any{"{vault://support-secrets/primary}"},
+		"issuer":        "https://issuer.example.com",
+	}
+
+	require.False(t, aiGatewayAuthStrategyConfigChanged(current, desired))
+}
+
 func TestAIGatewayAuthStrategyMatchPrefersIDOverName(t *testing.T) {
 	t.Parallel()
 

--- a/internal/declarative/planner/ai_gateway_auth_strategy_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_auth_strategy_planner_test.go
@@ -192,6 +192,32 @@ func TestAIGatewayAuthStrategyChangedFieldsScrubClientSecret(t *testing.T) {
 	require.NotContains(t, changedFields[FieldConfig].New, "client_secret")
 }
 
+func TestAIGatewayAuthStrategyChangedFieldsPruneUnpairedVaultReference(t *testing.T) {
+	t.Parallel()
+
+	needsUpdate, _, changedFields, err := shouldUpdateAIGatewayAuthStrategy(
+		state.AIGatewayAuthStrategy{
+			Type:        "openid-connect",
+			DisplayName: "Support OIDC",
+			Config: map[string]any{
+				"issuer": "https://issuer.example.com",
+			},
+		},
+		resources.AIGatewayAuthStrategyResource{
+			Type:        "openid-connect",
+			DisplayName: "Support OIDC",
+			Config: map[string]any{
+				"issuer":          "https://issuer-updated.example.com",
+				FieldClientSecret: []any{"{vault://support-secrets/primary}"},
+			},
+		},
+	)
+
+	require.NoError(t, err)
+	require.True(t, needsUpdate)
+	require.NotContains(t, changedFields[FieldConfig].New, FieldClientSecret)
+}
+
 func TestAIGatewayAuthStrategyUpdatePreservesUndeclaredSecurityConfig(t *testing.T) {
 	t.Parallel()
 

--- a/internal/declarative/planner/ai_gateway_config_store_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_config_store_planner_test.go
@@ -164,6 +164,39 @@ func TestAIGatewayConfigStorePlannerResolvesExistingStoreForVault(t *testing.T) 
 	require.Empty(t, plan.Changes[0].DependsOn)
 }
 
+func TestAIGatewayConfigStorePlannerTreatsResolvedVaultStoreReferenceAsUnchanged(t *testing.T) {
+	var currentVault kkComps.AIGatewayVault
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"id": "vault-id",
+		"type": "konnect",
+		"name": "support-vault",
+		"config": {"config_store_id": "existing-store-id"},
+		"created_at": "2026-01-01T00:00:00Z",
+		"updated_at": "2026-01-01T00:00:00Z"
+	}`), &currentVault))
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{gateways: []kkComps.AIGateway{testAIGateway()}},
+		AIGatewayConfigStoresAPI: &testAIGatewayConfigStoreAPI{
+			stores: []kkComps.AIGatewayConfigStore{{ID: "existing-store-id", Name: "support-store"}},
+		},
+		AIGatewayVaultsAPI: &testAIGatewayVaultAPI{vaults: []kkComps.AIGatewayVault{currentVault}},
+	})
+	rs := testAIGatewayConfigStoreResourceSet(resources.AIGatewayConfigStoreResource{
+		BaseResource: resources.BaseResource{Ref: "support-store"},
+		AIGateway:    "support-gateway",
+		Name:         "support-store",
+	})
+	rs.AIGatewayVaults = []resources.AIGatewayVaultResource{{
+		BaseResource:                resources.BaseResource{Ref: "support-vault"},
+		AIGateway:                   "support-gateway",
+		CreateAIGatewayVaultRequest: testAIGatewayConfigStoreVaultRequest(t),
+	}}
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
+	require.NoError(t, err)
+	require.Empty(t, plan.Changes)
+}
+
 func TestAIGatewayConfigStoreSecretPlannerCreateNoOpAndRotation(t *testing.T) {
 	t.Run("create includes deferred write", func(t *testing.T) {
 		client := state.NewClient(state.ClientConfig{

--- a/internal/declarative/planner/ai_gateway_payload_compare.go
+++ b/internal/declarative/planner/ai_gateway_payload_compare.go
@@ -103,6 +103,35 @@ func scrubAIGatewayUpstreamWriteOnlyFields(value any) any {
 	}
 }
 
+type aiGatewayPayloadPairNormalizer func(map[string]any, map[string]any) (map[string]any, map[string]any)
+
+func scrubbedAIGatewayWriteOnlyPayloads(
+	current map[string]any,
+	desired map[string]any,
+	normalize aiGatewayPayloadPairNormalizer,
+	scrub func(any) any,
+) (map[string]any, map[string]any) {
+	currentComparable, desiredComparable := normalize(current, desired)
+	return scrub(currentComparable).(map[string]any), scrub(desiredComparable).(map[string]any)
+}
+
+func comparableAIGatewayWriteOnlyPayloads(
+	current map[string]any,
+	desired map[string]any,
+	normalize aiGatewayPayloadPairNormalizer,
+	scrub func(any) any,
+	isWriteOnlyField func(string) bool,
+) (map[string]any, map[string]any) {
+	currentComparable, desiredComparable := scrubbedAIGatewayWriteOnlyPayloads(
+		current,
+		desired,
+		normalize,
+		scrub,
+	)
+	pruneUnpairedAIGatewayWriteOnlyReferences(currentComparable, desiredComparable, isWriteOnlyField)
+	return currentComparable, desiredComparable
+}
+
 func pruneUnpairedAIGatewayWriteOnlyReferences(
 	current any,
 	desired any,

--- a/internal/declarative/planner/ai_gateway_payload_compare.go
+++ b/internal/declarative/planner/ai_gateway_payload_compare.go
@@ -103,6 +103,47 @@ func scrubAIGatewayUpstreamWriteOnlyFields(value any) any {
 	}
 }
 
+func pruneUnpairedAIGatewayWriteOnlyReferences(
+	current any,
+	desired any,
+	isWriteOnlyField func(string) bool,
+) {
+	switch currentTyped := current.(type) {
+	case map[string]any:
+		desiredTyped, ok := desired.(map[string]any)
+		if !ok {
+			return
+		}
+		for key, currentValue := range currentTyped {
+			desiredValue, desiredHasKey := desiredTyped[key]
+			if isWriteOnlyField(key) {
+				if !desiredHasKey {
+					delete(currentTyped, key)
+				}
+				continue
+			}
+			if desiredHasKey {
+				pruneUnpairedAIGatewayWriteOnlyReferences(currentValue, desiredValue, isWriteOnlyField)
+			}
+		}
+		for key := range desiredTyped {
+			if isWriteOnlyField(key) {
+				if _, currentHasKey := currentTyped[key]; !currentHasKey {
+					delete(desiredTyped, key)
+				}
+			}
+		}
+	case []any:
+		desiredTyped, ok := desired.([]any)
+		if !ok {
+			return
+		}
+		for i := range min(len(currentTyped), len(desiredTyped)) {
+			pruneUnpairedAIGatewayWriteOnlyReferences(currentTyped[i], desiredTyped[i], isWriteOnlyField)
+		}
+	}
+}
+
 func pruneNilValues(value any) any {
 	switch typed := value.(type) {
 	case map[string]any:

--- a/internal/declarative/planner/ai_gateway_provider_planner.go
+++ b/internal/declarative/planner/ai_gateway_provider_planner.go
@@ -284,7 +284,12 @@ func shouldUpdateAIGatewayProvider(
 	}
 
 	if desired.Config != nil && aiGatewayProviderConfigChanged(current.Config, desired.Config) {
-		currentConfig, desiredConfig := comparableAIGatewayProviderConfigs(current.Config, desired.Config)
+		currentConfig, desiredConfig := scrubbedAIGatewayWriteOnlyPayloads(
+			current.Config,
+			desired.Config,
+			normalizeAIGatewayPayloadsForComparison,
+			scrubAIGatewayProviderSecretFields,
+		)
 		changedFields[FieldConfig] = FieldChange{
 			Old: currentConfig,
 			New: desiredConfig,
@@ -321,15 +326,13 @@ func aiGatewayProviderConfigChanged(current, desired map[string]any) bool {
 }
 
 func comparableAIGatewayProviderConfigs(current, desired map[string]any) (map[string]any, map[string]any) {
-	currentComparable, desiredComparable := normalizeAIGatewayPayloadsForComparison(current, desired)
-	currentComparable = scrubAIGatewayProviderSecretFields(currentComparable).(map[string]any)
-	desiredComparable = scrubAIGatewayProviderSecretFields(desiredComparable).(map[string]any)
-	pruneUnpairedAIGatewayWriteOnlyReferences(
-		currentComparable,
-		desiredComparable,
+	return comparableAIGatewayWriteOnlyPayloads(
+		current,
+		desired,
+		normalizeAIGatewayPayloadsForComparison,
+		scrubAIGatewayProviderSecretFields,
 		isAIGatewayProviderSecretField,
 	)
-	return currentComparable, desiredComparable
 }
 
 func scrubAIGatewayProviderSecretFields(value any) any {

--- a/internal/declarative/planner/ai_gateway_provider_planner.go
+++ b/internal/declarative/planner/ai_gateway_provider_planner.go
@@ -284,9 +284,10 @@ func shouldUpdateAIGatewayProvider(
 	}
 
 	if desired.Config != nil && aiGatewayProviderConfigChanged(current.Config, desired.Config) {
+		currentConfig, desiredConfig := comparableAIGatewayProviderConfigs(current.Config, desired.Config)
 		changedFields[FieldConfig] = FieldChange{
-			Old: scrubAIGatewayProviderSecretFields(normalizeProviderConfigForCompare(current.Config)),
-			New: scrubAIGatewayProviderSecretFields(normalizeProviderConfigForCompare(desired.Config)),
+			Old: currentConfig,
+			New: desiredConfig,
 		}
 	}
 
@@ -315,14 +316,20 @@ func extractAIGatewayProviderFields(provider resources.AIGatewayProviderResource
 }
 
 func aiGatewayProviderConfigChanged(current, desired map[string]any) bool {
-	currentComparable, desiredComparable := normalizeAIGatewayPayloadsForComparison(current, desired)
-	currentComparable = scrubAIGatewayProviderSecretFields(currentComparable).(map[string]any)
-	desiredComparable = scrubAIGatewayProviderSecretFields(desiredComparable).(map[string]any)
+	currentComparable, desiredComparable := comparableAIGatewayProviderConfigs(current, desired)
 	return !reflect.DeepEqual(currentComparable, desiredComparable)
 }
 
-func normalizeProviderConfigForCompare(config map[string]any) map[string]any {
-	return normalizeAIGatewayJSONMap(config)
+func comparableAIGatewayProviderConfigs(current, desired map[string]any) (map[string]any, map[string]any) {
+	currentComparable, desiredComparable := normalizeAIGatewayPayloadsForComparison(current, desired)
+	currentComparable = scrubAIGatewayProviderSecretFields(currentComparable).(map[string]any)
+	desiredComparable = scrubAIGatewayProviderSecretFields(desiredComparable).(map[string]any)
+	pruneUnpairedAIGatewayWriteOnlyReferences(
+		currentComparable,
+		desiredComparable,
+		isAIGatewayProviderSecretField,
+	)
+	return currentComparable, desiredComparable
 }
 
 func scrubAIGatewayProviderSecretFields(value any) any {

--- a/internal/declarative/planner/ai_gateway_provider_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_provider_planner_test.go
@@ -148,6 +148,35 @@ func TestShouldUpdateAIGatewayProviderIncludesChangedPublicVaultReference(t *tes
 	require.Equal(t, newReference, diffHeader[FieldValue])
 }
 
+func TestShouldUpdateAIGatewayProviderDisplaysUnpairedVaultReferenceOnObservableConfigChange(t *testing.T) {
+	t.Parallel()
+
+	const reference = "{vault://support-secrets/oauth-client-secret}"
+	needsUpdate, fields, changedFields, err := shouldUpdateAIGatewayProvider(
+		state.AIGatewayProvider{
+			Type:        "openai",
+			DisplayName: "OpenAI Provider",
+			Config:      map[string]any{"auth": map[string]any{"type": "basic"}},
+		},
+		resources.AIGatewayProviderResource{
+			Type:        "openai",
+			DisplayName: "OpenAI Provider",
+			Config: map[string]any{"auth": map[string]any{
+				"type": "oauth2", FieldClientSecret: reference,
+			}},
+		},
+	)
+
+	require.NoError(t, err)
+	require.True(t, needsUpdate)
+	require.Equal(t, reference, fields[FieldConfig].(map[string]any)["auth"].(map[string]any)[FieldClientSecret])
+	require.Equal(
+		t,
+		reference,
+		changedFields[FieldConfig].New.(map[string]any)["auth"].(map[string]any)[FieldClientSecret],
+	)
+}
+
 func TestAIGatewayProviderCreatePlanKeepsPublicVaultReferenceOutOfSecretWrites(t *testing.T) {
 	t.Parallel()
 

--- a/internal/declarative/planner/ai_gateway_provider_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_provider_planner_test.go
@@ -83,6 +83,32 @@ func TestAIGatewayProviderConfigChangedComparesPublicVaultReferences(t *testing.
 	))
 }
 
+func TestAIGatewayProviderConfigChangedIgnoresVaultReferenceMissingFromResponse(t *testing.T) {
+	t.Parallel()
+
+	current := map[string]any{
+		"auth": map[string]any{
+			"type": "basic",
+			"headers": []any{
+				map[string]any{"name": "Authorization"},
+			},
+		},
+	}
+	desired := map[string]any{
+		"auth": map[string]any{
+			"type": "basic",
+			"headers": []any{
+				map[string]any{
+					"name":  "Authorization",
+					"value": "{vault://support-secrets/openai-token}",
+				},
+			},
+		},
+	}
+
+	require.False(t, aiGatewayProviderConfigChanged(current, desired))
+}
+
 func TestShouldUpdateAIGatewayProviderIncludesChangedPublicVaultReference(t *testing.T) {
 	t.Parallel()
 

--- a/internal/declarative/planner/ai_gateway_vault_planner.go
+++ b/internal/declarative/planner/ai_gateway_vault_planner.go
@@ -241,15 +241,13 @@ func shouldUpdateAIGatewayVault(
 }
 
 func comparableAIGatewayVaultPayloads(current, desired map[string]any) (map[string]any, map[string]any) {
-	currentComparable, desiredComparable := normalizeAIGatewayPayloadsForComparison(current, desired)
-	currentComparable = scrubAIGatewayVaultWriteOnlyFields(currentComparable).(map[string]any)
-	desiredComparable = scrubAIGatewayVaultWriteOnlyFields(desiredComparable).(map[string]any)
-	pruneUnpairedAIGatewayWriteOnlyReferences(
-		currentComparable,
-		desiredComparable,
+	return comparableAIGatewayWriteOnlyPayloads(
+		current,
+		desired,
+		normalizeAIGatewayPayloadsForComparison,
+		scrubAIGatewayVaultWriteOnlyFields,
 		isAIGatewayVaultWriteOnlyField,
 	)
-	return currentComparable, desiredComparable
 }
 
 func normalizeAIGatewayVaultConfigStoreReferenceForComparison(

--- a/internal/declarative/planner/ai_gateway_vault_planner.go
+++ b/internal/declarative/planner/ai_gateway_vault_planner.go
@@ -65,7 +65,11 @@ func (p *Planner) planAIGatewayVaultChanges(
 			continue
 		}
 
-		needsUpdate, updateFields, changedFields, err := shouldUpdateAIGatewayVault(*fullVault, desiredVault)
+		needsUpdate, updateFields, changedFields, err := shouldUpdateAIGatewayVault(
+			*fullVault,
+			desiredVault,
+			p.resources,
+		)
 		if err != nil {
 			return err
 		}
@@ -211,6 +215,7 @@ func (p *Planner) planAIGatewayVaultDelete(
 func shouldUpdateAIGatewayVault(
 	current state.AIGatewayVault,
 	desired resources.AIGatewayVaultResource,
+	resourceSet *resources.ResourceSet,
 ) (bool, map[string]any, map[string]FieldChange, error) {
 	currentPayload, err := resources.AIGatewayVaultMutablePayloadMap(current.AIGatewayVault)
 	if err != nil {
@@ -221,9 +226,8 @@ func shouldUpdateAIGatewayVault(
 		return false, nil, nil, fmt.Errorf("failed to normalize desired AI Gateway Vault %q: %w", desired.Ref, err)
 	}
 
-	currentCompare, desiredCompare := normalizeAIGatewayPayloadsForComparison(currentPayload, desiredPayload)
-	currentCompare = scrubAIGatewayVaultWriteOnlyFields(currentCompare).(map[string]any)
-	desiredCompare = scrubAIGatewayVaultWriteOnlyFields(desiredCompare).(map[string]any)
+	currentCompare, desiredCompare := comparableAIGatewayVaultPayloads(currentPayload, desiredPayload)
+	normalizeAIGatewayVaultConfigStoreReferenceForComparison(desiredCompare, resourceSet)
 
 	currentPlanPayload := scrubAIGatewayVaultWriteOnlyFields(currentPayload).(map[string]any)
 	desiredPlanPayload := scrubAIGatewayVaultWriteOnlyFields(desiredPayload).(map[string]any)
@@ -234,6 +238,40 @@ func shouldUpdateAIGatewayVault(
 	}
 
 	return true, desiredPayload, changedFields, nil
+}
+
+func comparableAIGatewayVaultPayloads(current, desired map[string]any) (map[string]any, map[string]any) {
+	currentComparable, desiredComparable := normalizeAIGatewayPayloadsForComparison(current, desired)
+	currentComparable = scrubAIGatewayVaultWriteOnlyFields(currentComparable).(map[string]any)
+	desiredComparable = scrubAIGatewayVaultWriteOnlyFields(desiredComparable).(map[string]any)
+	pruneUnpairedAIGatewayWriteOnlyReferences(
+		currentComparable,
+		desiredComparable,
+		isAIGatewayVaultWriteOnlyField,
+	)
+	return currentComparable, desiredComparable
+}
+
+func normalizeAIGatewayVaultConfigStoreReferenceForComparison(
+	payload map[string]any,
+	resourceSet *resources.ResourceSet,
+) {
+	if resourceSet == nil {
+		return
+	}
+	config, ok := payload[FieldConfig].(map[string]any)
+	if !ok {
+		return
+	}
+	configuredID, ok := config[FieldConfigStoreID].(string)
+	if !ok || configuredID == "" {
+		return
+	}
+	store := resourceSet.GetAIGatewayConfigStoreByRef(resources.NormalizeResourceRef(configuredID))
+	if store == nil || store.GetKonnectID() == "" {
+		return
+	}
+	config[FieldConfigStoreID] = store.GetKonnectID()
 }
 
 func scrubAIGatewayVaultWriteOnlyFields(value any) any {
@@ -263,7 +301,7 @@ func scrubAIGatewayVaultWriteOnlyFields(value any) any {
 
 func isAIGatewayVaultWriteOnlyField(key string) bool {
 	switch strings.ToLower(key) {
-	case FieldAPIKey, FieldClientSecret, "key", "secret_access_key", "secret_id", "token":
+	case FieldAPIKey, FieldClientSecret, "key", "secret_access_key", "secret_id", FieldToken:
 		return true
 	default:
 		return false

--- a/internal/declarative/planner/ai_gateway_vault_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_vault_planner_test.go
@@ -151,6 +151,31 @@ func TestAIGatewayVaultPlannerComparesPublicVaultReferences(t *testing.T) {
 	)
 }
 
+func TestAIGatewayVaultPlannerIgnoresVaultReferenceMissingFromResponse(t *testing.T) {
+	currentPayload := map[string]any{
+		FieldType: "hcv",
+		FieldName: "support-hcv",
+		FieldConfig: map[string]any{
+			"auth_method": "token",
+			"host":        "vault.example.test",
+			"port":        float64(8200),
+		},
+	}
+	desiredPayload := map[string]any{
+		FieldType: "hcv",
+		FieldName: "support-hcv",
+		FieldConfig: map[string]any{
+			"auth_method": "token",
+			"host":        "vault.example.test",
+			"port":        float64(8200),
+			"token":       "{vault://support-secrets/hcv-token}",
+		},
+	}
+
+	currentCompare, desiredCompare := comparableAIGatewayVaultPayloads(currentPayload, desiredPayload)
+	require.Equal(t, currentCompare, desiredCompare)
+}
+
 func TestAIGatewayVaultPlannerSendsWriteOnlySecretsOnObservableUpdate(t *testing.T) {
 	var currentVault kkComps.AIGatewayVault
 	require.NoError(t, json.Unmarshal([]byte(`{
@@ -178,7 +203,7 @@ func TestAIGatewayVaultPlannerSendsWriteOnlySecretsOnObservableUpdate(t *testing
 		}
 	}`), &desired))
 
-	needsUpdate, fields, changedFields, err := shouldUpdateAIGatewayVault(current, desired)
+	needsUpdate, fields, changedFields, err := shouldUpdateAIGatewayVault(current, desired, nil)
 	require.NoError(t, err)
 	require.True(t, needsUpdate)
 	require.Equal(t, "super-secret-token", fields[FieldConfig].(map[string]any)["token"])

--- a/internal/declarative/planner/constants.go
+++ b/internal/declarative/planner/constants.go
@@ -75,6 +75,7 @@ const (
 	FieldAPIKey         = "api_key"
 	FieldClientID       = "client_id"
 	FieldClientSecret   = "client_secret"
+	FieldToken          = "token"
 	FieldMetadata       = "metadata"
 	FieldDataURL        = "data_url"
 	FieldDeckBaseDir    = "deck_base_dir"

--- a/internal/declarative/planner/secret_writes_test.go
+++ b/internal/declarative/planner/secret_writes_test.go
@@ -3,15 +3,19 @@ package planner
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/secrets"
 	"github.com/kong/kongctl/internal/declarative/state"
 	"github.com/kong/kongctl/internal/declarative/tags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const testAIGatewaySecretRef = "gateway"
 
 func TestApplySecretWriteIntentsCreatesSecretOnlyUpdate(t *testing.T) {
 	resourceSet := dcrSecretResourceSet(t)
@@ -33,6 +37,259 @@ func TestApplySecretWriteIntentsCreatesSecretOnlyUpdate(t *testing.T) {
 	assert.Equal(t, "http", change.Fields[FieldDCRProviderUpdateType])
 	assert.NotContains(t, change.Fields, FieldDCRProviderProviderType)
 	assert.Equal(t, 1, plan.Summary.SecretWrites)
+}
+
+func TestAIGatewayWriteOnlyFieldsPlanSecretOnlyUpdates(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name         string
+		resourceType resources.ResourceType
+		resourceRef  string
+		field        string
+		selector     string
+		resourceSet  func(*testing.T, string) *resources.ResourceSet
+	}
+
+	provider := func(config func(string) map[string]any) func(*testing.T, string) *resources.ResourceSet {
+		return func(t *testing.T, placeholder string) *resources.ResourceSet {
+			t.Helper()
+			resource := resources.AIGatewayProviderResource{
+				BaseResource: resources.BaseResource{Ref: "provider"},
+				AIGateway:    testAIGatewaySecretRef,
+				Name:         "provider",
+				Type:         "openai",
+				DisplayName:  "Provider",
+				Config:       config(placeholder),
+			}
+			resource.SetKonnectID("remote-id")
+			return aiGatewaySecretResourceSet(&resource)
+		}
+	}
+	authStrategy := func(config func(string) map[string]any) func(*testing.T, string) *resources.ResourceSet {
+		return func(t *testing.T, placeholder string) *resources.ResourceSet {
+			t.Helper()
+			resource := resources.AIGatewayAuthStrategyResource{
+				BaseResource: resources.BaseResource{Ref: "auth-strategy"},
+				AIGateway:    testAIGatewaySecretRef,
+				Name:         "auth-strategy",
+				Type:         "openid-connect",
+				DisplayName:  "Auth Strategy",
+				Config:       config(placeholder),
+			}
+			resource.SetKonnectID("remote-id")
+			return aiGatewaySecretResourceSet(&resource)
+		}
+	}
+	vault := func(config func(string) map[string]any, vaultType string) func(*testing.T, string) *resources.ResourceSet {
+		return func(t *testing.T, placeholder string) *resources.ResourceSet {
+			t.Helper()
+			payload := map[string]any{
+				"ref":        "vault",
+				"ai_gateway": testAIGatewaySecretRef,
+				"type":       vaultType,
+				"name":       "vault",
+				"config":     config(placeholder),
+			}
+			data, err := json.Marshal(payload)
+			require.NoError(t, err)
+			var resource resources.AIGatewayVaultResource
+			require.NoError(t, json.Unmarshal(data, &resource))
+			resource.SetKonnectID("remote-id")
+			return aiGatewaySecretResourceSet(&resource)
+		}
+	}
+
+	cases := []testCase{
+		{
+			name: "provider header value", resourceType: resources.ResourceTypeAIGatewayProvider,
+			resourceRef: "provider", field: "/config/auth/headers/0/value",
+			selector: "config.auth.headers[].value",
+			resourceSet: provider(func(secret string) map[string]any {
+				return map[string]any{"auth": map[string]any{
+					"type": "basic", "headers": []any{map[string]any{"name": "Authorization", "value": secret}},
+				}}
+			}),
+		},
+		{
+			name: "provider client secret", resourceType: resources.ResourceTypeAIGatewayProvider,
+			resourceRef: "provider", field: "/config/auth/client_secret", selector: "config.auth.client_secret",
+			resourceSet: provider(func(secret string) map[string]any {
+				return map[string]any{"auth": map[string]any{"type": "oauth2", FieldClientSecret: secret}}
+			}),
+		},
+		{
+			name: "provider AWS secret access key", resourceType: resources.ResourceTypeAIGatewayProvider,
+			resourceRef: "provider", field: "/config/auth/secret_access_key",
+			selector: "config.auth.secret_access_key",
+			resourceSet: provider(func(secret string) map[string]any {
+				return map[string]any{"auth": map[string]any{"type": "aws", "secret_access_key": secret}}
+			}),
+		},
+		{
+			name: "provider nested AWS secret access key", resourceType: resources.ResourceTypeAIGatewayProvider,
+			resourceRef: "provider", field: "/config/auth/aws/secret_access_key",
+			selector: "config.auth.aws.secret_access_key",
+			resourceSet: provider(func(secret string) map[string]any {
+				return map[string]any{"auth": map[string]any{
+					"type": "aws", "aws": map[string]any{"secret_access_key": secret},
+				}}
+			}),
+		},
+		{
+			name: "provider GCP service account", resourceType: resources.ResourceTypeAIGatewayProvider,
+			resourceRef: "provider", field: "/config/auth/service_account_json",
+			selector: "config.auth.service_account_json",
+			resourceSet: provider(func(secret string) map[string]any {
+				return map[string]any{"auth": map[string]any{"type": "gcp", "service_account_json": secret}}
+			}),
+		},
+		{
+			name: "auth strategy client secret array", resourceType: resources.ResourceTypeAIGatewayAuthStrategy,
+			resourceRef: "auth-strategy", field: "/config/client_secret/0", selector: "config.client_secret[]",
+			resourceSet: authStrategy(func(secret string) map[string]any {
+				return map[string]any{"issuer": "https://issuer.example.test", FieldClientSecret: []any{secret}}
+			}),
+		},
+		{
+			name: "auth strategy scalar client secret", resourceType: resources.ResourceTypeAIGatewayAuthStrategy,
+			resourceRef: "auth-strategy", field: "/config/client_secret", selector: "config.client_secret",
+			resourceSet: authStrategy(func(secret string) map[string]any {
+				return map[string]any{"issuer": "https://issuer.example.test", FieldClientSecret: secret}
+			}),
+		},
+		{
+			name: "Conjur vault API key", resourceType: resources.ResourceTypeAIGatewayVault,
+			resourceRef: "vault", field: "/config/api_key", selector: "config.api_key",
+			resourceSet: vault(func(secret string) map[string]any {
+				return map[string]any{
+					"account": "account", "endpoint_url": "https://conjur.example.test", "login": "login",
+					"api_key": secret,
+				}
+			}, "conjur"),
+		},
+		{
+			name: "HashiCorp vault token", resourceType: resources.ResourceTypeAIGatewayVault,
+			resourceRef: "vault", field: "/config/token", selector: "config.token",
+			resourceSet: vault(func(secret string) map[string]any {
+				return map[string]any{
+					"auth_method": "token", "host": "vault.example.test", "port": 8200, "token": secret,
+				}
+			}, "hcv"),
+		},
+		{
+			name: "HashiCorp vault OAuth client secret", resourceType: resources.ResourceTypeAIGatewayVault,
+			resourceRef: "vault", field: "/config/client_secret", selector: "config.client_secret",
+			resourceSet: vault(func(secret string) map[string]any {
+				config := map[string]any{ //nolint:gosec // Non-secret OAuth test fixture values.
+					"auth_method": "jwt", "host": "vault.example.test", "port": 8200, "role": "role",
+					"token_endpoint": "https://issuer.example.test/token", "client_id": "client",
+				}
+				config[FieldClientSecret] = secret
+				return config
+			}, "hcv"),
+		},
+		{
+			name: "HashiCorp vault AWS secret access key", resourceType: resources.ResourceTypeAIGatewayVault,
+			resourceRef: "vault", field: "/config/secret_access_key", selector: "config.secret_access_key",
+			resourceSet: vault(func(secret string) map[string]any {
+				return map[string]any{
+					"auth_method": "aws_iam", "host": "vault.example.test", "port": 8200, "role": "role",
+					"region": "us-east-1", "access_key_id": "access-key", "secret_access_key": secret,
+				}
+			}, "hcv"),
+		},
+		{
+			name: "HashiCorp vault AppRole secret ID", resourceType: resources.ResourceTypeAIGatewayVault,
+			resourceRef: "vault", field: "/config/secret_id", selector: "config.secret_id",
+			resourceSet: vault(func(secret string) map[string]any {
+				return map[string]any{
+					"auth_method": "approle", "host": "vault.example.test", "port": 8200,
+					"role_id": "role", "secret_id": secret,
+				}
+			}, "hcv"),
+		},
+		{
+			name: "config store secret value", resourceType: resources.ResourceTypeAIGatewayConfigStoreSecret,
+			resourceRef: "config-store-secret", field: "/value", selector: "value",
+			resourceSet: func(t *testing.T, placeholder string) *resources.ResourceSet {
+				t.Helper()
+				secret := resources.AIGatewayConfigStoreSecretResource{
+					BaseResource:         resources.BaseResource{Ref: "config-store-secret"},
+					AIGatewayConfigStore: "config-store", Key: "secret", Value: placeholder,
+				}
+				secret.SetKonnectID("remote-id")
+				store := resources.AIGatewayConfigStoreResource{
+					BaseResource: resources.BaseResource{Ref: "config-store"},
+					AIGateway:    testAIGatewaySecretRef,
+					Name:         "store",
+				}
+				store.SetKonnectID("store-id")
+				rs := aiGatewaySecretResourceSet(&secret)
+				rs.AIGatewayConfigStores = []resources.AIGatewayConfigStoreResource{store}
+				return rs
+			},
+		},
+	}
+	coveredCapabilities := make(map[string]bool, len(cases))
+	for _, tc := range cases {
+		capability, ok := secrets.Match(tc.resourceType, tc.field)
+		require.True(t, ok, "%s is not in the reviewed secret catalog", tc.field)
+		coveredCapabilities[string(capability.ResourceType)+":"+capability.PathPattern] = true
+	}
+	expectedCapabilities := make(map[string]bool)
+	for _, capability := range secrets.Capabilities() {
+		if capability.Update && strings.HasPrefix(string(capability.ResourceType), "ai_gateway") {
+			expectedCapabilities[string(capability.ResourceType)+":"+capability.PathPattern] = true
+		}
+	}
+	require.Equal(t, expectedCapabilities, coveredCapabilities)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			for _, mode := range []struct {
+				name    string
+				options Options
+			}{
+				{name: "without write flag", options: Options{Mode: PlanModeApply}},
+				{name: "with --write-secret", options: Options{
+					Mode: PlanModeApply, WriteSecretSelectors: []string{tc.resourceRef + "#" + tc.selector},
+				}},
+				{name: "with --write-secrets", options: Options{Mode: PlanModeApply, WriteSecrets: true}},
+			} {
+				t.Run(mode.name, func(t *testing.T) {
+					t.Parallel()
+					expression := envSecretExpression("AI_GATEWAY_SECRET")
+					placeholder, err := tags.BuildSecretPlaceholder(expression)
+					require.NoError(t, err)
+					rs := tc.resourceSet(t, placeholder)
+					rs.AddSecretSource(tc.resourceRef, tc.field, expression, false)
+					plan := NewPlan(CurrentPlanVersion, "test", PlanModeApply)
+
+					err = (&Planner{}).applySecretWriteIntents(t.Context(), plan, rs, mode.options)
+					require.NoError(t, err)
+					if mode.name == "without write flag" {
+						require.Empty(t, plan.Changes)
+						return
+					}
+
+					require.Len(t, plan.Changes, 1)
+					change := plan.Changes[0]
+					require.Equal(t, ActionUpdate, change.Action)
+					require.Equal(t, string(tc.resourceType), change.ResourceType)
+					require.Equal(t, tc.resourceRef, change.ResourceRef)
+					require.Equal(t, "remote-id", change.ResourceID)
+					require.Len(t, change.SecretWrites, 1)
+					require.Equal(t, tc.field, change.SecretWrites[0].Field)
+					require.Equal(t, 1, plan.Summary.SecretWrites)
+					data, err := json.Marshal(plan)
+					require.NoError(t, err)
+					require.NotContains(t, string(data), placeholder)
+				})
+			}
+		})
+	}
 }
 
 func TestApplySecretWriteIntentsMergesIntoOrdinaryUpdate(t *testing.T) {
@@ -497,4 +754,21 @@ func envSecretExpression(reference string) tags.SecretExpression {
 	return tags.SecretExpression{Parts: []tags.SecretPart{{Source: &tags.SecretSource{
 		Kind: "env", Reference: reference,
 	}}}}
+}
+
+func aiGatewaySecretResourceSet(resource resources.Resource) *resources.ResourceSet {
+	gateway := resources.AIGatewayResource{BaseResource: resources.BaseResource{Ref: testAIGatewaySecretRef}}
+	gateway.SetKonnectID("gateway-id")
+	rs := &resources.ResourceSet{AIGateways: []resources.AIGatewayResource{gateway}}
+	switch typed := resource.(type) {
+	case *resources.AIGatewayProviderResource:
+		rs.AIGatewayProviders = []resources.AIGatewayProviderResource{*typed}
+	case *resources.AIGatewayAuthStrategyResource:
+		rs.AIGatewayAuthStrategies = []resources.AIGatewayAuthStrategyResource{*typed}
+	case *resources.AIGatewayVaultResource:
+		rs.AIGatewayVaults = []resources.AIGatewayVaultResource{*typed}
+	case *resources.AIGatewayConfigStoreSecretResource:
+		rs.AIGatewayConfigStoreSecrets = []resources.AIGatewayConfigStoreSecretResource{*typed}
+	}
+	return rs
 }

--- a/test/e2e/scenarios/ai-gateway/config-store/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/config-store/scenario.yaml
@@ -93,7 +93,26 @@ steps:
               fields:
                 applied: 5
                 failed: 0
-      - name: 002-list
+      - name: 002-reapply-identical-config-is-no-op
+        outputFormat: json
+        run: [apply, -f, "{{ .workdir }}/config.yaml", --auto-approve]
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 0
+          - select: plan.changes
+            expect:
+              fields:
+                "length(@)": 0
+          - select: summary
+            expect:
+              fields:
+                applied: 0
+                failed: 0
+                total_changes: 0
+                status: success
+      - name: 003-list
         run:
           - get
           - ai-gateway
@@ -111,7 +130,7 @@ steps:
               fields:
                 name: "{{ .vars.store_name }}"
                 display_name: Support-Store
-      - name: 003-get-by-name
+      - name: 004-get-by-name
         run:
           - get
           - ai-gateway
@@ -127,7 +146,7 @@ steps:
             expect:
               fields:
                 name: "{{ .vars.store_name }}"
-      - name: 004-get-by-id
+      - name: 005-get-by-id
         run:
           - get
           - ai-gateway
@@ -142,12 +161,12 @@ steps:
             expect:
               fields:
                 "@": "{{ .vars.store_name }}"
-      - name: 005-list-secrets
+      - name: 006-list-secrets
         run:
           - list
           - ai-gateway
           - config-stores
-          - "{{ .vars.store_name }}"
+          - "{{ .vars.store_id }}"
           - secrets
           - --gateway-name
           - "{{ .vars.gateway_name }}"
@@ -159,12 +178,12 @@ steps:
               fields:
                 key: support-api-key
                 "contains(keys(@), 'value')": false
-      - name: 006-get-secret
+      - name: 007-get-secret
         run:
           - get
           - ai-gateway
           - config-stores
-          - "{{ .vars.store_name }}"
+          - "{{ .vars.store_id }}"
           - secrets
           - support-api-key
           - --gateway-name
@@ -217,7 +236,7 @@ steps:
           - select: stdout
             expect:
               fields:
-                "contains(@, '[redacted from !env]')": true
+                "contains(@, 'write requested (current value unavailable; deferred source)')": true
                 "contains(@, 'rotated-config-store-secret-value')": false
       - name: 002-apply-rotation
         outputFormat: json


### PR DESCRIPTION
## Summary

- treat AI Gateway write-only values omitted from API responses as unknown during comparison
- normalize declarative config-store references to resolved Konnect IDs before comparing vault configuration
- preserve comparison of vault references when both desired and current payloads expose them
- add reapply convergence coverage and catalog-wide secret-write planning tests

## Testing

- go fix ./...
- make format
- make build
- make test
- golangci-lint run ./internal/declarative/planner/...
- make test-e2e-scenarios SCENARIO=ai-gateway/config-store

Closes #1987