### PR TITLE
fix(declarative): support control plane API implementations

### DIFF
--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -198,10 +198,15 @@ apis:
         visibility: One of (public | private)
     implementations: # https://developer.konghq.com/api/konnect/api-builder/v3/#/operations/create-api-implementation
       - ref: string
-        type: service
+        type: service # optional when the service payload is present
         service:
           id: string required (uuid) # prefer: !ref <gateway-service-ref>
           control_plane_id: string required (uuid) # prefer: !ref <control-plane-ref>
+      - ref: string
+        type: control_plane # optional when the control_plane payload is present
+        control_plane:
+          # prefer: !ref <control-plane-ref>
+          control_plane_id: string required (uuid)
     documents: # https://developer.konghq.com/api/konnect/api-builder/v3/#/operations/create-api-document
       - ref: string
         content: string required (markdown) # prefer: !file ./docs/page.md
@@ -220,6 +225,9 @@ apis:
 API specifications must be declared on API versions with `versions[].spec` or
 root-level `api_versions[].spec`; `apis[].spec_content` is not supported in
 declarative configuration.
+
+Each API implementation must define exactly one of `service` or
+`control_plane`. When `type` is present, it must match the selected payload.
 
 ## Application Auth Strategies
 

--- a/internal/cmd/root/verbs/dump/declarative_children.go
+++ b/internal/cmd/root/verbs/dump/declarative_children.go
@@ -1977,26 +1977,42 @@ func buildAPIImplementations(
 
 	results := make([]declresources.APIImplementationResource, 0, len(implementations))
 	for _, impl := range implementations {
-		if impl.Service == nil || strings.TrimSpace(impl.Service.ID) == "" ||
-			strings.TrimSpace(impl.Service.ControlPlaneID) == "" {
-			logWarn(logger, "API implementation missing service reference; skipping", apiID, apiName, nil)
+		res, ok := apiImplementationResourceFromState(impl)
+		if !ok {
+			logWarn(logger, "API implementation missing implementation reference; skipping", apiID, apiName, nil)
 			continue
 		}
-
-		service := kkComps.APIImplementationService{
-			ID:             impl.Service.ID,
-			ControlPlaneID: impl.Service.ControlPlaneID,
-		}
-		ref := kkComps.ServiceReference{Service: &service}
-		res := declresources.APIImplementationResource{
-			Ref:               impl.ID,
-			APIImplementation: kkComps.CreateAPIImplementationServiceReference(ref),
-		}
-
 		results = append(results, res)
 	}
 
 	return results, nil
+}
+
+func apiImplementationResourceFromState(
+	impl declstate.APIImplementation,
+) (declresources.APIImplementationResource, bool) {
+	var implementation kkComps.APIImplementation
+	switch {
+	case impl.Service != nil && strings.TrimSpace(impl.Service.ID) != "" &&
+		strings.TrimSpace(impl.Service.ControlPlaneID) != "":
+		service := kkComps.APIImplementationService{
+			ID:             impl.Service.ID,
+			ControlPlaneID: impl.Service.ControlPlaneID,
+		}
+		implementation = kkComps.CreateAPIImplementationServiceReference(
+			kkComps.ServiceReference{Service: &service},
+		)
+	case impl.ControlPlane != nil && strings.TrimSpace(impl.ControlPlane.ID) != "":
+		implementation = kkComps.CreateAPIImplementationControlPlaneReference(kkComps.ControlPlaneReference{
+			ControlPlane: &kkComps.APIImplementationControlPlaneInput{ID: impl.ControlPlane.ID},
+		})
+	default:
+		return declresources.APIImplementationResource{}, false
+	}
+	return declresources.APIImplementationResource{
+		Ref:               impl.ID,
+		APIImplementation: implementation,
+	}, true
 }
 
 func buildAPIDocuments(

--- a/internal/cmd/root/verbs/dump/declarative_children_test.go
+++ b/internal/cmd/root/verbs/dump/declarative_children_test.go
@@ -8,6 +8,7 @@ import (
 	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
 	declresources "github.com/kong/kongctl/internal/declarative/resources"
 	declstate "github.com/kong/kongctl/internal/declarative/state"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -85,6 +86,19 @@ func TestNormalizePortalPageSlug(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAPIImplementationResourceFromStateControlPlane(t *testing.T) {
+	resource, ok := apiImplementationResourceFromState(declstate.APIImplementation{
+		ID: "implementation-id",
+		ControlPlane: &struct{ ID string }{
+			ID: "control-plane-id",
+		},
+	})
+	require.True(t, ok)
+	assert.Equal(t, "implementation-id", resource.Ref)
+	require.NotNil(t, resource.ControlPlaneReference)
+	assert.Equal(t, "control-plane-id", resource.ControlPlaneReference.GetControlPlane().ID)
 }
 
 func TestMapPortalPageToResourceOmitsMetadataPresentInFrontmatter(t *testing.T) {

--- a/internal/declarative/executor/api_implementation_adapter.go
+++ b/internal/declarative/executor/api_implementation_adapter.go
@@ -28,34 +28,42 @@ func (a *APIImplementationAdapter) MapCreateFields(
 		return fmt.Errorf("create request must not be nil")
 	}
 
-	serviceValue, ok := fields[planner.FieldService]
+	serviceValue, hasService := fields[planner.FieldService]
+	controlPlaneValue, hasControlPlane := fields[planner.FieldControlPlane]
+	if hasService == hasControlPlane {
+		return fmt.Errorf("exactly one of service or control_plane is required for API implementations")
+	}
+
+	if hasService {
+		serviceMap, ok := serviceValue.(map[string]any)
+		if !ok {
+			return fmt.Errorf("service must be an object")
+		}
+		serviceID, err := getStringField(serviceMap, planner.FieldID)
+		if err != nil {
+			return fmt.Errorf("service.id is required: %w", err)
+		}
+		controlPlaneID, err := getStringField(serviceMap, planner.FieldControlPlaneID)
+		if err != nil {
+			return fmt.Errorf("service.control_plane_id is required: %w", err)
+		}
+		*create = kkComps.CreateAPIImplementationServiceReference(kkComps.ServiceReference{
+			Service: &kkComps.APIImplementationService{ID: serviceID, ControlPlaneID: controlPlaneID},
+		})
+		return nil
+	}
+
+	controlPlaneMap, ok := controlPlaneValue.(map[string]any)
 	if !ok {
-		return fmt.Errorf("service is required for API implementations")
+		return fmt.Errorf("control_plane must be an object")
 	}
-
-	serviceMap, ok := serviceValue.(map[string]any)
-	if !ok {
-		return fmt.Errorf("service must be an object")
-	}
-
-	serviceID, err := getStringField(serviceMap, "id")
+	controlPlaneID, err := getStringField(controlPlaneMap, planner.FieldControlPlaneID)
 	if err != nil {
-		return fmt.Errorf("service.id is required: %w", err)
+		return fmt.Errorf("control_plane.control_plane_id is required: %w", err)
 	}
-
-	controlPlaneID, err := getStringField(serviceMap, "control_plane_id")
-	if err != nil {
-		return fmt.Errorf("service.control_plane_id is required: %w", err)
-	}
-
-	create.ServiceReference = &kkComps.ServiceReference{
-		Service: &kkComps.APIImplementationService{
-			ID:             serviceID,
-			ControlPlaneID: controlPlaneID,
-		},
-	}
-	create.Type = kkComps.APIImplementationTypeServiceReference
-
+	*create = kkComps.CreateAPIImplementationControlPlaneReference(kkComps.ControlPlaneReference{
+		ControlPlane: &kkComps.APIImplementationControlPlaneInput{ID: controlPlaneID},
+	})
 	return nil
 }
 
@@ -79,6 +87,9 @@ func (a *APIImplementationAdapter) Create(ctx context.Context, req kkComps.APIIm
 
 	if sr := resp.APIImplementationResponseServiceReference; sr != nil {
 		return sr.GetID(), nil
+	}
+	if cp := resp.APIImplementationResponseControlPlaneReference; cp != nil {
+		return cp.GetID(), nil
 	}
 
 	return "", fmt.Errorf("unexpected API implementation response format")
@@ -111,7 +122,7 @@ func (a *APIImplementationAdapter) ResourceType() string {
 
 // RequiredFields lists the required fields for creation.
 func (a *APIImplementationAdapter) RequiredFields() []string {
-	return []string{planner.FieldService}
+	return nil
 }
 
 // MapUpdateFields reports that updates are not supported.

--- a/internal/declarative/executor/api_implementation_adapter_test.go
+++ b/internal/declarative/executor/api_implementation_adapter_test.go
@@ -1,0 +1,59 @@
+package executor
+
+import (
+	"context"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/planner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIImplementationAdapterMapCreateFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		fields   map[string]any
+		wantType kkComps.APIImplementationType
+		wantErr  string
+	}{
+		{
+			name: "service",
+			fields: map[string]any{planner.FieldService: map[string]any{
+				planner.FieldID: "service-id", planner.FieldControlPlaneID: "control-plane-id",
+			}},
+			wantType: kkComps.APIImplementationTypeServiceReference,
+		},
+		{
+			name: "control plane",
+			fields: map[string]any{planner.FieldControlPlane: map[string]any{
+				planner.FieldControlPlaneID: "control-plane-id",
+			}},
+			wantType: kkComps.APIImplementationTypeControlPlaneReference,
+		},
+		{name: "neither", fields: map[string]any{}, wantErr: "exactly one"},
+		{
+			name: "both",
+			fields: map[string]any{
+				planner.FieldService:      map[string]any{},
+				planner.FieldControlPlane: map[string]any{},
+			},
+			wantErr: "exactly one",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var request kkComps.APIImplementation
+			err := NewAPIImplementationAdapter(nil).MapCreateFields(
+				context.Background(), nil, tt.fields, &request,
+			)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantType, request.Type)
+		})
+	}
+}

--- a/internal/declarative/loader/load_schema.go
+++ b/internal/declarative/loader/load_schema.go
@@ -443,11 +443,12 @@ func resolveDeclarativeSchemaRef(root *resources.JSONSchema, schema *resources.J
 func suggestDeclarativeField(field string, candidates []string) string {
 	field = strings.ToLower(field)
 	legacy := map[string]string{
-		"lables":            "labels",
-		"label":             "labels",
-		"strategytype":      "strategy_type",
-		"integration":       "integrations",
-		"service_reference": "service",
+		"lables":                  "labels",
+		"label":                   "labels",
+		"strategytype":            "strategy_type",
+		"integration":             "integrations",
+		"service_reference":       "service",
+		"control_plane_reference": "control_plane",
 	}
 	if candidate := legacy[field]; candidate != "" && slices.Contains(candidates, candidate) {
 		return candidate

--- a/internal/declarative/loader/load_schema.go
+++ b/internal/declarative/loader/load_schema.go
@@ -262,7 +262,7 @@ func firstDeclarativeValidationLeaf(validationErr *jsonschema.ValidationError) *
 		}
 	}
 	collect(validationErr)
-	sort.Slice(leaves, func(i, j int) bool {
+	sort.SliceStable(leaves, func(i, j int) bool {
 		return declarativePath(leaves[i].InstanceLocation) < declarativePath(leaves[j].InstanceLocation)
 	})
 	return leaves[0]

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -1135,6 +1135,7 @@ func (l *Loader) suggestFieldName(fieldName string) string {
 		"publications":    {"publication", "publish", "published"},
 		"implementations": {"implementation", "impl", "service"},
 		"service":         {"service_reference", "service-reference"},
+		"control_plane":   {"control_plane_reference", "control-plane-reference"},
 
 		// Auth strategy fields
 		"strategy_type": {"type", "auth_type", "strategy-type", "strategytype"},

--- a/internal/declarative/loader/loader_test.go
+++ b/internal/declarative/loader/loader_test.go
@@ -1219,7 +1219,7 @@ apis:
 	assert.Contains(t, err.Error(), "Did you mean 'service'?")
 }
 
-func TestLoader_LoadFile_APIImplementationRejectsUnsupportedType(t *testing.T) {
+func TestLoader_LoadFile_APIImplementationRejectsMismatchedType(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
 	err := os.WriteFile(path, []byte(`
@@ -1237,7 +1237,29 @@ apis:
 
 	_, err = New().LoadFile(path)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "API implementation type must be service")
+	assert.Contains(t, err.Error(), "missing required union selector control_plane")
+}
+
+func TestLoader_LoadFile_APIImplementationControlPlane(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(path, []byte(`
+apis:
+  - ref: users-api
+    name: Users API
+    implementations:
+      - ref: users-api-impl
+        control_plane:
+          control_plane_id: users-control-plane
+`), 0o600)
+	require.NoError(t, err)
+
+	rs, err := New().LoadFile(path)
+	require.NoError(t, err)
+	require.Len(t, rs.APIImplementations, 1)
+	controlPlane := rs.APIImplementations[0].ControlPlaneReference.GetControlPlane()
+	require.NotNil(t, controlPlane)
+	assert.Equal(t, "users-control-plane", controlPlane.ID)
 }
 
 func TestLoader_LoadFile_RejectsAPISpecContent(t *testing.T) {

--- a/internal/declarative/loader/ref_resolver.go
+++ b/internal/declarative/loader/ref_resolver.go
@@ -446,10 +446,11 @@ func ResolveReferences(ctx context.Context, rs *resources.ResourceSet) error {
 	}
 
 	implCount := len(rs.APIImplementations)
-	implMissingService := 0
+	implMissingPayload := 0
 	for i := range rs.APIImplementations {
-		if rs.APIImplementations[i].ServiceReference.GetService() == nil {
-			implMissingService++
+		if rs.APIImplementations[i].ServiceReference.GetService() == nil &&
+			rs.APIImplementations[i].ControlPlaneReference.GetControlPlane() == nil {
+			implMissingPayload++
 		}
 	}
 
@@ -457,7 +458,7 @@ func ResolveReferences(ctx context.Context, rs *resources.ResourceSet) error {
 		ctx, slog.LevelDebug, "Reference resolution completed",
 		slog.Int("resources_processed", processCount),
 		slog.Int("api_implementations", implCount),
-		slog.Int("api_implementations_missing_service", implMissingService),
+		slog.Int("api_implementations_missing_payload", implMissingPayload),
 	)
 
 	return nil

--- a/internal/declarative/planner/api_implementation_control_plane_test.go
+++ b/internal/declarative/planner/api_implementation_control_plane_test.go
@@ -1,0 +1,69 @@
+package planner
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/kong/kongctl/internal/declarative/tags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlanAPIImplementationCreateControlPlane(t *testing.T) {
+	planner := NewPlanner(nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	planner.resources = &resources.ResourceSet{}
+	plan := NewPlan(CurrentPlanVersion, "test", PlanModeApply)
+	implementation := resources.APIImplementationResource{
+		Ref: "implementation",
+		APIImplementation: kkComps.CreateAPIImplementationControlPlaneReference(kkComps.ControlPlaneReference{
+			ControlPlane: &kkComps.APIImplementationControlPlaneInput{ID: "control-plane-id"},
+		}),
+	}
+
+	planner.planAPIImplementationCreate("default", "api", "api-id", implementation, nil, plan)
+	require.Len(t, plan.Changes, 1)
+	controlPlane := plan.Changes[0].Fields[FieldControlPlane].(map[string]any)
+	assert.Equal(t, "control-plane-id", controlPlane[FieldControlPlaneID])
+}
+
+func TestPlanAPIImplementationDeleteControlPlane(t *testing.T) {
+	planner := NewPlanner(nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	plan := NewPlan(CurrentPlanVersion, "test", PlanModeSync)
+	implementation := state.APIImplementation{
+		ID: "implementation-id",
+		ControlPlane: &struct{ ID string }{
+			ID: "control-plane-id",
+		},
+	}
+
+	planner.planAPIImplementationDelete("default", "api", "api-id", implementation, plan)
+	require.Len(t, plan.Changes, 1)
+	assert.Equal(t, ActionDelete, plan.Changes[0].Action)
+	controlPlane := plan.Changes[0].Fields[FieldControlPlane].(map[string]any)
+	assert.Equal(t, "control-plane-id", controlPlane[FieldControlPlaneID])
+}
+
+func TestResolveAPIImplementationControlPlaneReferencePreservesForwardReference(t *testing.T) {
+	planner := NewPlanner(nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	controlPlane := resources.ControlPlaneResource{BaseResource: resources.BaseResource{Ref: "control-plane"}}
+
+	resolved, err := planner.resolveAPIImplementationControlPlaneReference(
+		fmt.Sprintf("%scontrol-plane#id", tags.RefPlaceholderPrefix),
+		map[string]*resources.ControlPlaneResource{"control-plane": &controlPlane},
+		"implementation",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("%scontrol-plane#id", tags.RefPlaceholderPrefix), resolved)
+}
+
+func TestDeckControlPlaneRefFromFields(t *testing.T) {
+	fields := map[string]any{FieldControlPlane: map[string]any{
+		FieldControlPlaneID: fmt.Sprintf("%scontrol-plane#id", tags.RefPlaceholderPrefix),
+	}}
+	assert.Equal(t, "control-plane", deckControlPlaneRefFromFields(fields, map[string]string{"control-plane": "deck"}))
+}

--- a/internal/declarative/planner/api_planner.go
+++ b/internal/declarative/planner/api_planner.go
@@ -1495,24 +1495,30 @@ func (p *Planner) planAPIImplementationChanges(
 		slog.Int("current_count", len(currentImplementations)),
 	)
 
-	// Index current implementations by service ID + control plane ID
+	// Index current implementations by their variant-specific identity.
 	currentByService := make(map[string]state.APIImplementation)
+	currentByControlPlane := make(map[string]state.APIImplementation)
 	currentWithService := 0
-	currentMissingService := 0
+	currentWithControlPlane := 0
+	currentMissingPayload := 0
 	for _, i := range currentImplementations {
 		if i.Service != nil {
 			currentWithService++
 			key := fmt.Sprintf("%s:%s", i.Service.ID, i.Service.ControlPlaneID)
 			currentByService[key] = i
+		} else if i.ControlPlane != nil {
+			currentWithControlPlane++
+			currentByControlPlane[i.ControlPlane.ID] = i
 		} else {
-			currentMissingService++
+			currentMissingPayload++
 		}
 	}
 	p.logger.Debug(
 		"Indexed current api_implementations by service",
 		slog.String("api_ref", apiRef),
 		slog.Int("current_with_service", currentWithService),
-		slog.Int("current_missing_service", currentMissingService),
+		slog.Int("current_with_control_plane", currentWithControlPlane),
+		slog.Int("current_missing_payload", currentMissingPayload),
 	)
 
 	// Compare desired implementations
@@ -1532,9 +1538,19 @@ func (p *Planner) planAPIImplementationChanges(
 				p.planAPIImplementationCreate(parentNamespace, apiRef, apiID, desiredImpl, []string{}, plan)
 			}
 			// Note: Implementation IDs are managed by the SDK
+		} else if controlPlane := desiredImpl.ControlPlaneReference.GetControlPlane(); controlPlane != nil {
+			if _, exists := currentByControlPlane[controlPlane.ID]; !exists {
+				p.logger.Debug(
+					"Planning api_implementation CREATE (control plane not found)",
+					slog.String("api_ref", apiRef),
+					slog.String("api_implementation_ref", desiredImpl.GetRef()),
+					slog.String("control_plane_id", controlPlane.ID),
+				)
+				p.planAPIImplementationCreate(parentNamespace, apiRef, apiID, desiredImpl, []string{}, plan)
+			}
 		} else {
 			p.logger.Debug(
-				"Desired api_implementation missing service reference; skipping match",
+				"Desired api_implementation missing implementation payload; skipping match",
 				slog.String("api_ref", apiRef),
 				slog.String("api_implementation_ref", desiredImpl.GetRef()),
 			)
@@ -1557,16 +1573,20 @@ func (p *Planner) planAPIImplementationChanges(
 			p.logger.Debug(
 				"Skipping implementation deletion - extracted implementations exist",
 				slog.String("api", apiRef),
-				slog.Int("current_count", len(currentByService)),
+				slog.Int("current_count", len(currentByService)+len(currentByControlPlane)),
 			)
 			return nil
 		}
 
 		desiredServices := make(map[string]bool)
+		desiredControlPlanes := make(map[string]bool)
 		for _, impl := range desired {
 			if service := impl.ServiceReference.GetService(); service != nil {
 				key := fmt.Sprintf("%s:%s", service.ID, service.ControlPlaneID)
 				desiredServices[key] = true
+			}
+			if controlPlane := impl.ControlPlaneReference.GetControlPlane(); controlPlane != nil {
+				desiredControlPlanes[controlPlane.ID] = true
 			}
 		}
 
@@ -1575,6 +1595,8 @@ func (p *Planner) planAPIImplementationChanges(
 			slog.String("api_ref", apiRef),
 			slog.Int("desired_services", len(desiredServices)),
 			slog.Int("current_services", len(currentByService)),
+			slog.Int("desired_control_planes", len(desiredControlPlanes)),
+			slog.Int("current_control_planes", len(currentByControlPlane)),
 		)
 
 		for serviceKey, current := range currentByService {
@@ -1583,6 +1605,17 @@ func (p *Planner) planAPIImplementationChanges(
 					"Planning api_implementation DELETE (service not desired)",
 					slog.String("api_ref", apiRef),
 					slog.String("service_key", serviceKey),
+					slog.String("implementation_id", current.ID),
+				)
+				p.planAPIImplementationDelete(parentNamespace, apiRef, apiID, current, plan)
+			}
+		}
+		for controlPlaneID, current := range currentByControlPlane {
+			if !desiredControlPlanes[controlPlaneID] {
+				p.logger.Debug(
+					"Planning api_implementation DELETE (control plane not desired)",
+					slog.String("api_ref", apiRef),
+					slog.String("control_plane_id", controlPlaneID),
 					slog.String("implementation_id", current.ID),
 				)
 				p.planAPIImplementationDelete(parentNamespace, apiRef, apiID, current, plan)
@@ -1598,11 +1631,15 @@ func (p *Planner) planAPIImplementationCreate(
 	implementation resources.APIImplementationResource, dependsOn []string, plan *Plan,
 ) {
 	fields := make(map[string]any)
-	// APIImplementation only has Service field in the SDK
 	if service := implementation.ServiceReference.GetService(); service != nil {
 		fields[FieldService] = map[string]any{
 			FieldID:             service.ID,
 			FieldControlPlaneID: service.ControlPlaneID,
+		}
+	}
+	if controlPlane := implementation.ControlPlaneReference.GetControlPlane(); controlPlane != nil {
+		fields[FieldControlPlane] = map[string]any{
+			FieldControlPlaneID: controlPlane.ID,
 		}
 	}
 
@@ -1651,6 +1688,9 @@ func (p *Planner) planAPIImplementationDelete(
 	if ref == "" && implementation.Service != nil {
 		ref = fmt.Sprintf("%s:%s", implementation.Service.ID, implementation.Service.ControlPlaneID)
 	}
+	if ref == "" && implementation.ControlPlane != nil {
+		ref = implementation.ControlPlane.ID
+	}
 
 	fields := map[string]any{
 		FieldAPIID: apiID,
@@ -1659,6 +1699,11 @@ func (p *Planner) planAPIImplementationDelete(
 		fields[FieldService] = map[string]any{
 			FieldID:             implementation.Service.ID,
 			FieldControlPlaneID: implementation.Service.ControlPlaneID,
+		}
+	}
+	if implementation.ControlPlane != nil {
+		fields[FieldControlPlane] = map[string]any{
+			FieldControlPlaneID: implementation.ControlPlane.ID,
 		}
 	}
 

--- a/internal/declarative/planner/constants.go
+++ b/internal/declarative/planner/constants.go
@@ -120,6 +120,7 @@ const (
 	FieldParentPolicyID               = "parent_policy_id"
 	FieldPortalID                     = "portal_id"
 	FieldRoleName                     = "role_name"
+	FieldControlPlane                 = "control_plane"
 	FieldService                      = "service"
 	FieldSlugPath                     = "slug_path"
 	FieldTeamID                       = "team_id"

--- a/internal/declarative/planner/control_plane_api_implementation_dependencies_test.go
+++ b/internal/declarative/planner/control_plane_api_implementation_dependencies_test.go
@@ -77,4 +77,29 @@ func TestAdjustControlPlaneAPIImplementationDeleteDependencies(t *testing.T) {
 		adjustControlPlaneAPIImplementationDeleteDependencies(changes, nil)
 		require.Equal(t, []string{"implementation-delete"}, changes[1].DependsOn)
 	})
+
+	t.Run("control plane implementation delete precedes control plane delete", func(t *testing.T) {
+		t.Parallel()
+
+		const controlPlaneID = "3285a0db-a0e6-4c18-8620-c9753c6b96ad"
+		changes := []PlannedChange{
+			{
+				ID:           "implementation-delete",
+				ResourceType: ResourceTypeAPIImplementation,
+				Action:       ActionDelete,
+				Fields: map[string]any{
+					FieldControlPlane: map[string]any{FieldControlPlaneID: controlPlaneID},
+				},
+			},
+			{
+				ID:           "control-plane-delete",
+				ResourceType: ResourceTypeControlPlane,
+				ResourceID:   controlPlaneID,
+				Action:       ActionDelete,
+			},
+		}
+
+		adjustControlPlaneAPIImplementationDeleteDependencies(changes, nil)
+		require.Equal(t, []string{"implementation-delete"}, changes[1].DependsOn)
+	})
 }

--- a/internal/declarative/planner/deck_requirements.go
+++ b/internal/declarative/planner/deck_requirements.go
@@ -112,6 +112,9 @@ func (p *Planner) planDeckDependencies(ctx context.Context, rs *resources.Resour
 
 		plan.AddChange(change)
 		deckChangeIDs[cpRef] = change.ID
+		if cpID != "" {
+			deckChangeIDs[cpID] = change.ID
+		}
 
 		for _, svc := range postResolutionTargets {
 			if svc.ResourceRef == "" {
@@ -142,16 +145,27 @@ func (p *Planner) planDeckDependencies(ctx context.Context, rs *resources.Resour
 			(change.Action != ActionCreate && change.Action != ActionUpdate) {
 			continue
 		}
-		ref := deckServiceRefFromFields(change.Fields, serviceToDeckChange)
-		if ref == "" {
+		dependencyID := ""
+		logField := ""
+		logValue := ""
+		if ref := deckServiceRefFromFields(change.Fields, serviceToDeckChange); ref != "" {
+			dependencyID = serviceToDeckChange[ref]
+			logField = "gateway_service_ref"
+			logValue = ref
+		} else if ref := deckControlPlaneRefFromFields(change.Fields, deckChangeIDs); ref != "" {
+			dependencyID = deckChangeIDs[ref]
+			logField = "control_plane_ref"
+			logValue = ref
+		}
+		if dependencyID == "" {
 			continue
 		}
-		change.DependsOn = appendDependsOn(change.DependsOn, serviceToDeckChange[ref])
+		change.DependsOn = appendDependsOn(change.DependsOn, dependencyID)
 
 		p.logger.Debug(
 			"Added deck dependency to api_implementation",
 			slog.String("api_implementation_ref", change.ResourceRef),
-			slog.String("gateway_service_ref", ref),
+			slog.String(logField, logValue),
 		)
 	}
 
@@ -271,6 +285,29 @@ func deckServiceRefFromFields(fields map[string]any, deckChangeIDs map[string]st
 		return idValue
 	}
 
+	return ""
+}
+
+func deckControlPlaneRefFromFields(fields map[string]any, deckChangeIDs map[string]string) string {
+	controlPlaneValue, ok := fields[FieldControlPlane]
+	if !ok {
+		return ""
+	}
+	controlPlaneMap, ok := controlPlaneValue.(map[string]any)
+	if !ok {
+		return ""
+	}
+	id, _ := controlPlaneMap[FieldControlPlaneID].(string)
+	if tags.IsRefPlaceholder(id) {
+		ref, field, ok := tags.ParseRefPlaceholder(id)
+		if ok && field == FieldID && deckChangeIDs[ref] != "" {
+			return ref
+		}
+		return ""
+	}
+	if deckChangeIDs[id] != "" {
+		return id
+	}
 	return ""
 }
 

--- a/internal/declarative/planner/deck_requirements_test.go
+++ b/internal/declarative/planner/deck_requirements_test.go
@@ -206,6 +206,43 @@ func TestPlanDeckDependenciesAdded(t *testing.T) {
 	require.Contains(t, apiChange.DependsOn, deckChange.ID)
 }
 
+func TestPlanDeckDependenciesAddedToControlPlaneImplementation(t *testing.T) {
+	const controlPlaneID = "11111111-1111-1111-1111-111111111111"
+	cp := resources.ControlPlaneResource{
+		CreateControlPlaneRequest: kkComps.CreateControlPlaneRequest{Name: "cp"},
+		BaseResource:              resources.BaseResource{Ref: "cp"},
+		Deck:                      &resources.DeckConfig{Files: []string{"ace.yaml"}},
+	}
+	cp.SetKonnectID(controlPlaneID)
+	cp.SetDeckBaseDir(t.TempDir())
+	rs := &resources.ResourceSet{ControlPlanes: []resources.ControlPlaneResource{cp}}
+	plan := NewPlan(CurrentPlanVersion, "test", PlanModeApply)
+	plan.AddChange(PlannedChange{
+		ID:           "implementation-create",
+		ResourceType: ResourceTypeAPIImplementation,
+		ResourceRef:  "implementation",
+		Action:       ActionCreate,
+		Fields: map[string]any{
+			FieldControlPlane: map[string]any{FieldControlPlaneID: controlPlaneID},
+		},
+	})
+	runner := &stubDeckRunner{result: &deck.RunResult{
+		Stdout: `{"summary":{"creating":1,"updating":0,"deleting":0,"total":1},"errors":[]}`,
+	}}
+	planner := NewPlanner(nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	err := planner.planDeckDependencies(context.Background(), rs, plan, Options{
+		Mode: PlanModeApply,
+		Deck: DeckOptions{
+			Runner: runner, KonnectToken: "token", KonnectAddress: "https://api.konghq.com",
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 2)
+	require.Equal(t, ResourceTypeDeck, plan.Changes[1].ResourceType)
+	require.Contains(t, plan.Changes[0].DependsOn, plan.Changes[1].ID)
+}
+
 func TestDeckDiffHasChangesNormalizesBareMaskedDeckEnvValues(t *testing.T) {
 	runner := &stubDeckRunner{
 		result: &deck.RunResult{

--- a/internal/declarative/planner/external_lookup.go
+++ b/internal/declarative/planner/external_lookup.go
@@ -756,6 +756,13 @@ func setStringFieldByPath(resource resources.Resource, path, value string) error
 				service.ControlPlaneID = value
 			}
 			return nil
+		case "control_plane.control_plane_id":
+			controlPlane := implementation.ControlPlaneReference.GetControlPlane()
+			if controlPlane == nil {
+				return fmt.Errorf("control_plane is not configured")
+			}
+			controlPlane.ID = value
+			return nil
 		}
 	}
 
@@ -808,6 +815,12 @@ func stringFieldByPath(resource resources.Resource, path string) (string, error)
 				return service.ID, nil
 			}
 			return service.ControlPlaneID, nil
+		case "control_plane.control_plane_id":
+			controlPlane := implementation.ControlPlaneReference.GetControlPlane()
+			if controlPlane == nil {
+				return "", nil
+			}
+			return controlPlane.ID, nil
 		}
 	}
 

--- a/internal/declarative/planner/planner.go
+++ b/internal/declarative/planner/planner.go
@@ -639,11 +639,13 @@ func adjustControlPlaneAPIImplementationDeleteDependencies(changes []PlannedChan
 		if change.Action != ActionDelete || change.ResourceType != ResourceTypeAPIImplementation {
 			continue
 		}
-		service, ok := change.Fields[FieldService].(map[string]any)
-		if !ok {
-			continue
+		var controlPlaneID string
+		if service, ok := change.Fields[FieldService].(map[string]any); ok {
+			controlPlaneID, _ = service[FieldControlPlaneID].(string)
 		}
-		controlPlaneID, _ := service[FieldControlPlaneID].(string)
+		if controlPlane, ok := change.Fields[FieldControlPlane].(map[string]any); ok {
+			controlPlaneID, _ = controlPlane[FieldControlPlaneID].(string)
+		}
 		if controlPlaneDelete := controlPlaneDeletes[controlPlaneID]; controlPlaneDelete != nil {
 			controlPlaneDelete.DependsOn = appendDependsOn(controlPlaneDelete.DependsOn, change.ID)
 		}
@@ -654,14 +656,14 @@ func adjustControlPlaneAPIImplementationDeleteDependencies(changes []PlannedChan
 	}
 	for i := range rs.APIImplementations {
 		implementation := &rs.APIImplementations[i]
-		if implementation.ServiceReference == nil {
-			continue
+		var controlPlaneID string
+		if service := implementation.ServiceReference.GetService(); service != nil {
+			controlPlaneID = service.ControlPlaneID
 		}
-		service := implementation.ServiceReference.GetService()
-		if service == nil {
-			continue
+		if controlPlane := implementation.ControlPlaneReference.GetControlPlane(); controlPlane != nil {
+			controlPlaneID = controlPlane.ID
 		}
-		controlPlaneDelete := controlPlaneDeletes[normalizeControlPlaneRef(service.ControlPlaneID)]
+		controlPlaneDelete := controlPlaneDeletes[normalizeControlPlaneRef(controlPlaneID)]
 		apiDelete := apiDeletes[resources.NormalizeResourceRef(implementation.API)]
 		if controlPlaneDelete != nil && apiDelete != nil {
 			controlPlaneDelete.DependsOn = appendDependsOn(controlPlaneDelete.DependsOn, apiDelete.ID)
@@ -1013,8 +1015,8 @@ func (p *Planner) resolveResourceIdentities(ctx context.Context, rs *resources.R
 		}
 	}
 
-	if err := p.resolveAPIImplementationServiceReferences(rs); err != nil {
-		return fmt.Errorf("failed to resolve API implementation services: %w", err)
+	if err := p.resolveAPIImplementationReferences(rs); err != nil {
+		return fmt.Errorf("failed to resolve API implementation references: %w", err)
 	}
 
 	if err := p.resolveCatalogServiceIdentities(ctx, rs.CatalogServices); err != nil {
@@ -1933,7 +1935,7 @@ func (p *Planner) matchGatewayService(
 	return nil, fmt.Errorf("external gateway_service %s: invalid _external configuration", service.GetRef())
 }
 
-func (p *Planner) resolveAPIImplementationServiceReferences(rs *resources.ResourceSet) error {
+func (p *Planner) resolveAPIImplementationReferences(rs *resources.ResourceSet) error {
 	if len(rs.APIImplementations) == 0 {
 		return nil
 	}
@@ -1952,6 +1954,16 @@ func (p *Planner) resolveAPIImplementationServiceReferences(rs *resources.Resour
 
 	for i := range rs.APIImplementations {
 		impl := &rs.APIImplementations[i]
+		if controlPlane := impl.ControlPlaneReference.GetControlPlane(); controlPlane != nil {
+			resolved, err := p.resolveAPIImplementationControlPlaneReference(
+				strings.TrimSpace(controlPlane.ID), controlPlaneByRef, impl.GetRef(),
+			)
+			if err != nil {
+				return err
+			}
+			controlPlane.ID = resolved
+			continue
+		}
 		service := impl.ServiceReference.GetService()
 		if service == nil {
 			p.logger.Debug(
@@ -1990,6 +2002,37 @@ func (p *Planner) resolveAPIImplementationServiceReferences(rs *resources.Resour
 	}
 
 	return nil
+}
+
+func (p *Planner) resolveAPIImplementationControlPlaneReference(
+	value string,
+	controlPlaneByRef map[string]*resources.ControlPlaneResource,
+	implRef string,
+) (string, error) {
+	if value == "" {
+		return "", fmt.Errorf("api_implementation %s: control_plane.control_plane_id is required", implRef)
+	}
+	if util.IsValidUUID(value) {
+		return value, nil
+	}
+
+	ref := value
+	if tags.IsRefPlaceholder(value) {
+		var field string
+		var ok bool
+		ref, field, ok = tags.ParseRefPlaceholder(value)
+		if !ok || field != FieldID {
+			return "", fmt.Errorf("api_implementation %s: control_plane references support '#id' only", implRef)
+		}
+	}
+	cp, ok := controlPlaneByRef[ref]
+	if !ok {
+		return "", fmt.Errorf("api_implementation %s: control_plane %s not found", implRef, ref)
+	}
+	if cp.GetKonnectID() != "" {
+		return cp.GetKonnectID(), nil
+	}
+	return fmt.Sprintf("%s%s#id", tags.RefPlaceholderPrefix, cp.GetRef()), nil
 }
 
 func (p *Planner) normalizeAPIImplementationService(

--- a/internal/declarative/planner/resolver.go
+++ b/internal/declarative/planner/resolver.go
@@ -211,7 +211,8 @@ func (r *ReferenceResolver) isReferenceField(fieldName string) bool {
 		if fieldName == rf ||
 			fieldName == "gateway_service."+rf ||
 			fieldName == "gateway_service.service_id" ||
-			fieldName == "service."+rf {
+			fieldName == "service."+rf ||
+			fieldName == "control_plane."+rf {
 			return true
 		}
 	}
@@ -227,7 +228,8 @@ func (r *ReferenceResolver) getResourceTypeForField(fieldName string) string {
 		return ResourceTypeAuditLogWebhookDestination
 	case FieldDCRProviderID:
 		return ResourceTypeDCRProvider
-	case "control_plane_id", "gateway_service.control_plane_id", "service.control_plane_id":
+	case "control_plane_id", "gateway_service.control_plane_id", "service.control_plane_id",
+		"control_plane.control_plane_id":
 		return ResourceTypeControlPlane
 	case FieldPortalID:
 		return ResourceTypePortal

--- a/internal/declarative/resources/api_child_resources_test.go
+++ b/internal/declarative/resources/api_child_resources_test.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"testing"
 
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -92,6 +93,29 @@ func TestAPIImplementationResource_Interfaces(t *testing.T) {
 	assert.Equal(t, "my-api", parentRef.Ref)
 }
 
+func TestAPIImplementationResource_ControlPlaneReferencesAndMatching(t *testing.T) {
+	implementation := &APIImplementationResource{
+		Ref: "implementation",
+		APIImplementation: kkComps.CreateAPIImplementationControlPlaneReference(kkComps.ControlPlaneReference{
+			ControlPlane: &kkComps.APIImplementationControlPlaneInput{ID: "control-plane-ref"},
+		}),
+	}
+
+	assert.Equal(t, map[string]string{
+		"control_plane.control_plane_id": string(ResourceTypeControlPlane),
+	}, implementation.GetReferenceFieldMappings())
+	assert.True(t, implementation.TryMatchKonnectResource(struct {
+		ID           string
+		ControlPlane *struct{ ID string }
+	}{
+		ID: "implementation-id",
+		ControlPlane: &struct{ ID string }{
+			ID: "control-plane-ref",
+		},
+	}))
+	assert.Equal(t, "implementation-id", implementation.GetKonnectID())
+}
+
 func TestAPIChildResources_Validation(t *testing.T) {
 	// Test version validation
 	version := APIVersionResource{}
@@ -126,5 +150,10 @@ func TestAPIChildResources_Validation(t *testing.T) {
 
 	impl.Ref = "impl1"
 	err = impl.Validate()
-	assert.NoError(t, err)
+	assert.ErrorContains(t, err, "exactly one of service or control_plane")
+
+	impl.APIImplementation = kkComps.CreateAPIImplementationControlPlaneReference(kkComps.ControlPlaneReference{
+		ControlPlane: &kkComps.APIImplementationControlPlaneInput{ID: "control-plane"},
+	})
+	assert.NoError(t, impl.Validate())
 }

--- a/internal/declarative/resources/api_implementation.go
+++ b/internal/declarative/resources/api_implementation.go
@@ -11,6 +11,11 @@ import (
 	"github.com/kong/kongctl/internal/util"
 )
 
+const (
+	apiImplementationTypeService      = "service"
+	apiImplementationTypeControlPlane = "control_plane"
+)
+
 func init() {
 	registerResourceType(
 		ResourceTypeAPIImplementation,
@@ -55,6 +60,13 @@ func (i APIImplementationResource) getService() *kkComps.APIImplementationServic
 	return i.ServiceReference.GetService()
 }
 
+func (i APIImplementationResource) getControlPlane() *kkComps.APIImplementationControlPlaneInput {
+	if i.ControlPlaneReference == nil {
+		return nil
+	}
+	return i.ControlPlaneReference.GetControlPlane()
+}
+
 // GetDependencies returns references to other resources this API implementation depends on
 func (i APIImplementationResource) GetDependencies() []ResourceRef {
 	deps := []ResourceRef{}
@@ -75,13 +87,19 @@ func (i APIImplementationResource) GetReferenceFieldMappings() map[string]string
 		// Check if control_plane_id is a UUID - if so, it's an external reference
 		if !util.IsValidUUID(service.ControlPlaneID) {
 			// Not a UUID, so it's a reference to a declarative control plane
-			mappings["service.control_plane_id"] = "control_plane"
+			mappings["service.control_plane_id"] = string(ResourceTypeControlPlane)
 		}
 	}
 
 	if service := i.getService(); service != nil && service.ID != "" {
 		if !util.IsValidUUID(service.ID) && !tags.IsRefPlaceholder(service.ID) {
 			mappings["service.id"] = string(ResourceTypeGatewayService)
+		}
+	}
+
+	if controlPlane := i.getControlPlane(); controlPlane != nil && controlPlane.ID != "" {
+		if !util.IsValidUUID(controlPlane.ID) {
+			mappings["control_plane.control_plane_id"] = string(ResourceTypeControlPlane)
 		}
 	}
 
@@ -94,8 +112,16 @@ func (i APIImplementationResource) Validate() error {
 		return fmt.Errorf("invalid API implementation ref: %w", err)
 	}
 
-	// Validate service information if present.
-	if service := i.getService(); service != nil {
+	service := i.getService()
+	controlPlane := i.getControlPlane()
+	if service != nil && controlPlane != nil {
+		return fmt.Errorf("API implementation must define exactly one of service or control_plane")
+	}
+	if service == nil && controlPlane == nil {
+		return fmt.Errorf("API implementation must define exactly one of service or control_plane")
+	}
+
+	if service != nil {
 		if service.ID == "" {
 			return fmt.Errorf("API implementation service.id is required")
 		}
@@ -104,8 +130,18 @@ func (i APIImplementationResource) Validate() error {
 			return fmt.Errorf("API implementation service.control_plane_id is required")
 		}
 
-		// control_plane_id can be either a UUID (external) or a reference (declarative)
-		// Both are valid - no additional validation needed here
+		if i.Type != "" && i.Type != kkComps.APIImplementationTypeServiceReference {
+			return fmt.Errorf("API implementation type does not match service payload")
+		}
+	}
+
+	if controlPlane != nil {
+		if controlPlane.ID == "" {
+			return fmt.Errorf("API implementation control_plane.control_plane_id is required")
+		}
+		if i.Type != "" && i.Type != kkComps.APIImplementationTypeControlPlaneReference {
+			return fmt.Errorf("API implementation type does not match control_plane payload")
+		}
 	}
 
 	return nil
@@ -129,71 +165,75 @@ func (i APIImplementationResource) GetKonnectMonikerFilter() string {
 
 // TryMatchKonnectResource attempts to match this resource with a Konnect resource
 func (i *APIImplementationResource) TryMatchKonnectResource(konnectResource any) bool {
-	// For API implementations, we match by service ID + control plane ID
-	// Use reflection to access fields from state.APIImplementation
-	v := reflect.ValueOf(konnectResource)
-
-	// Handle pointer types
-	if v.Kind() == reflect.Pointer {
-		v = v.Elem()
-	}
-
-	// Ensure we have a struct
-	if v.Kind() != reflect.Struct {
+	v, ok := implementationStructValue(reflect.ValueOf(konnectResource))
+	if !ok {
 		return false
 	}
+	id := implementationStringField(v, "ID")
 
-	// Look for Service and ID fields
-	serviceField := v.FieldByName("Service")
-	idField := v.FieldByName("ID")
-
-	if serviceField.IsValid() && serviceField.Kind() == reflect.Pointer && !serviceField.IsNil() && idField.IsValid() {
-		// Service is a pointer to struct
-		svc := serviceField.Elem()
-		if svc.Kind() == reflect.Struct {
-			svcIDField := svc.FieldByName("ID")
-			cpIDField := svc.FieldByName("ControlPlaneID")
-
-			if svcIDField.IsValid() && cpIDField.IsValid() {
-				if service := i.getService(); service != nil &&
-					svcIDField.String() == service.ID &&
-					cpIDField.String() == service.ControlPlaneID {
-					i.konnectID = idField.String()
-					return true
-				}
+	if service := i.getService(); service != nil {
+		for _, path := range [][]string{{"Service"}, {"ServiceReference", "Service"}} {
+			remote, found := implementationNestedStruct(v, path...)
+			if !found {
+				continue
+			}
+			serviceID := implementationStringField(remote, "ID")
+			controlPlaneID := implementationStringField(remote, "ControlPlaneID")
+			if serviceID == service.ID && controlPlaneID == service.ControlPlaneID {
+				i.konnectID = id
+				return true
 			}
 		}
 	}
 
-	// Handle nested ServiceReference for newer SDK models.
-	serviceRefField := v.FieldByName("ServiceReference")
-	if serviceRefField.IsValid() &&
-		serviceRefField.Kind() == reflect.Pointer &&
-		!serviceRefField.IsNil() &&
-		idField.IsValid() {
-		ref := serviceRefField.Elem()
-		if ref.Kind() == reflect.Struct {
-			serviceField = ref.FieldByName("Service")
-			if serviceField.IsValid() && serviceField.Kind() == reflect.Pointer && !serviceField.IsNil() {
-				svc := serviceField.Elem()
-				if svc.Kind() == reflect.Struct {
-					svcIDField := svc.FieldByName("ID")
-					cpIDField := svc.FieldByName("ControlPlaneID")
-
-					if svcIDField.IsValid() && cpIDField.IsValid() {
-						if service := i.getService(); service != nil &&
-							svcIDField.String() == service.ID &&
-							cpIDField.String() == service.ControlPlaneID {
-							i.konnectID = idField.String()
-							return true
-						}
-					}
-				}
+	if controlPlane := i.getControlPlane(); controlPlane != nil {
+		for _, path := range [][]string{{"ControlPlane"}, {"ControlPlaneReference", "ControlPlane"}} {
+			remote, found := implementationNestedStruct(v, path...)
+			if !found {
+				continue
+			}
+			controlPlaneID := implementationStringField(remote, "ID")
+			if controlPlaneID == controlPlane.ID {
+				i.konnectID = id
+				return true
 			}
 		}
 	}
 
 	return false
+}
+
+func implementationNestedStruct(value reflect.Value, path ...string) (reflect.Value, bool) {
+	current, ok := implementationStructValue(value)
+	if !ok {
+		return reflect.Value{}, false
+	}
+	for _, fieldName := range path {
+		current = current.FieldByName(fieldName)
+		current, ok = implementationStructValue(current)
+		if !ok {
+			return reflect.Value{}, false
+		}
+	}
+	return current, true
+}
+
+func implementationStructValue(value reflect.Value) (reflect.Value, bool) {
+	for value.IsValid() && value.Kind() == reflect.Pointer {
+		if value.IsNil() {
+			return reflect.Value{}, false
+		}
+		value = value.Elem()
+	}
+	return value, value.IsValid() && value.Kind() == reflect.Struct
+}
+
+func implementationStringField(value reflect.Value, name string) string {
+	field := value.FieldByName(name)
+	if !field.IsValid() || field.Kind() != reflect.String {
+		return ""
+	}
+	return field.String()
 }
 
 // GetParentRef returns the parent API reference for ResourceWithParent interface
@@ -207,6 +247,10 @@ func (i APIImplementationResource) GetParentRef() *ResourceRef {
 // MarshalJSON ensures implementation metadata (ref, api) are included.
 // Without this, the embedded APIImplementation's MarshalJSON is promoted and drops metadata fields.
 func (i APIImplementationResource) MarshalJSON() ([]byte, error) {
+	if i.ServiceReference != nil && i.ControlPlaneReference != nil {
+		return nil, fmt.Errorf("API implementation must define exactly one of service or control_plane")
+	}
+
 	payload := make(map[string]any)
 
 	implBytes, err := json.Marshal(i.APIImplementation)
@@ -220,6 +264,12 @@ func (i APIImplementationResource) MarshalJSON() ([]byte, error) {
 	payload["ref"] = i.Ref
 	if i.API != "" {
 		payload["api"] = i.API
+	}
+	if i.ServiceReference != nil {
+		payload["type"] = apiImplementationTypeService
+	}
+	if i.ControlPlaneReference != nil {
+		payload["type"] = apiImplementationTypeControlPlane
 	}
 
 	return json.Marshal(payload)
@@ -237,6 +287,9 @@ func (i *APIImplementationResource) UnmarshalJSON(data []byte) error {
 			ID             string `json:"id"`
 			ControlPlaneID string `json:"control_plane_id"`
 		} `json:"service,omitempty"`
+		ControlPlane *struct {
+			ControlPlaneID string `json:"control_plane_id"`
+		} `json:"control_plane,omitempty"`
 		Kongctl any `json:"kongctl,omitempty"`
 	}
 
@@ -252,8 +305,9 @@ func (i *APIImplementationResource) UnmarshalJSON(data []byte) error {
 	i.Ref = temp.Ref
 	i.API = temp.API
 
-	if temp.Type != "" && temp.Type != "service" {
-		return fmt.Errorf("API implementation type must be service (got %q)", temp.Type)
+	if temp.Type != "" && temp.Type != apiImplementationTypeService &&
+		temp.Type != apiImplementationTypeControlPlane {
+		return fmt.Errorf("API implementation type must be service or control_plane (got %q)", temp.Type)
 	}
 
 	// Check if kongctl field was provided and reject it
@@ -261,29 +315,31 @@ func (i *APIImplementationResource) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("kongctl metadata is not supported on child resources (API implementations)")
 	}
 
-	// Map to SDK fields embedded in APIImplementation
-	sdkData := map[string]any{}
-
-	if temp.ImplementationURL != "" {
-		sdkData["implementation_url"] = temp.ImplementationURL
+	if temp.Service != nil && temp.ControlPlane != nil {
+		return fmt.Errorf("API implementation must define exactly one of service or control_plane")
 	}
-
 	if temp.Service != nil {
-		sdkData["service"] = map[string]any{
-			"id":               temp.Service.ID,
-			"control_plane_id": temp.Service.ControlPlaneID,
+		if temp.Type == apiImplementationTypeControlPlane {
+			return fmt.Errorf("API implementation type control_plane does not match service payload")
 		}
+		i.APIImplementation = kkComps.CreateAPIImplementationServiceReference(kkComps.ServiceReference{
+			Service: &kkComps.APIImplementationService{
+				ID:             temp.Service.ID,
+				ControlPlaneID: temp.Service.ControlPlaneID,
+			},
+		})
+		return nil
+	}
+	if temp.ControlPlane != nil {
+		if temp.Type == apiImplementationTypeService {
+			return fmt.Errorf("API implementation type service does not match control_plane payload")
+		}
+		i.APIImplementation = kkComps.CreateAPIImplementationControlPlaneReference(kkComps.ControlPlaneReference{
+			ControlPlane: &kkComps.APIImplementationControlPlaneInput{ID: temp.ControlPlane.ControlPlaneID},
+		})
+		return nil
 	}
 
-	sdkBytes, err := json.Marshal(sdkData)
-	if err != nil {
-		return err
-	}
-
-	// Unmarshal into the embedded SDK type
-	if err := json.Unmarshal(sdkBytes, &i.APIImplementation); err != nil {
-		return err
-	}
-
+	i.APIImplementation = kkComps.APIImplementation{}
 	return nil
 }

--- a/internal/declarative/resources/api_implementation_marshal_test.go
+++ b/internal/declarative/resources/api_implementation_marshal_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAPIImplementationResourceMarshalJSONIncludesMetadata(t *testing.T) {
@@ -36,6 +38,7 @@ func TestAPIImplementationResourceMarshalJSONIncludesMetadata(t *testing.T) {
 	if payload["api"] != "api-ref" {
 		t.Fatalf("expected api %q, got %v", "api-ref", payload["api"])
 	}
+	assert.Equal(t, apiImplementationTypeService, payload["type"])
 
 	serviceVal, ok := payload["service"].(map[string]any)
 	if !ok {
@@ -46,5 +49,81 @@ func TestAPIImplementationResourceMarshalJSONIncludesMetadata(t *testing.T) {
 	}
 	if serviceVal["control_plane_id"] != "cp-id" {
 		t.Fatalf("expected control_plane_id %q, got %v", "cp-id", serviceVal["control_plane_id"])
+	}
+}
+
+func TestAPIImplementationResourceMarshalJSONControlPlane(t *testing.T) {
+	resource := APIImplementationResource{
+		APIImplementation: kkComps.CreateAPIImplementationControlPlaneReference(kkComps.ControlPlaneReference{
+			ControlPlane: &kkComps.APIImplementationControlPlaneInput{ID: "cp-id"},
+		}),
+		Ref: "impl-ref",
+		API: "api-ref",
+	}
+
+	raw, err := json.Marshal(resource)
+	require.NoError(t, err)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(raw, &payload))
+	assert.Equal(t, apiImplementationTypeControlPlane, payload["type"])
+	assert.Equal(t, "cp-id", payload["control_plane"].(map[string]any)["control_plane_id"])
+}
+
+func TestAPIImplementationResourceUnmarshalJSONVariants(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantType  kkComps.APIImplementationType
+		wantCPID  string
+		wantSvcID string
+		wantErr   string
+	}{
+		{
+			name:     "control plane with type",
+			input:    `{"ref":"impl","type":"control_plane","control_plane":{"control_plane_id":"cp"}}`,
+			wantType: kkComps.APIImplementationTypeControlPlaneReference,
+			wantCPID: "cp",
+		},
+		{
+			name:     "control plane without type",
+			input:    `{"ref":"impl","control_plane":{"control_plane_id":"cp"}}`,
+			wantType: kkComps.APIImplementationTypeControlPlaneReference,
+			wantCPID: "cp",
+		},
+		{
+			name:      "service without type",
+			input:     `{"ref":"impl","service":{"id":"svc","control_plane_id":"cp"}}`,
+			wantType:  kkComps.APIImplementationTypeServiceReference,
+			wantSvcID: "svc",
+		},
+		{
+			name:    "mismatched type",
+			input:   `{"ref":"impl","type":"service","control_plane":{"control_plane_id":"cp"}}`,
+			wantErr: "does not match",
+		},
+		{
+			name: "both payloads",
+			input: `{"ref":"impl","service":{"id":"svc","control_plane_id":"cp"},` +
+				`"control_plane":{"control_plane_id":"cp"}}`,
+			wantErr: "exactly one",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var resource APIImplementationResource
+			err := json.Unmarshal([]byte(tt.input), &resource)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantType, resource.Type)
+			if tt.wantCPID != "" {
+				assert.Equal(t, tt.wantCPID, resource.getControlPlane().ID)
+			}
+			if tt.wantSvcID != "" {
+				assert.Equal(t, tt.wantSvcID, resource.getService().ID)
+			}
+		})
 	}
 }

--- a/internal/declarative/resources/explain_test.go
+++ b/internal/declarative/resources/explain_test.go
@@ -357,24 +357,32 @@ func TestRenderExplainSchema_AnalyticsDashboardDiscriminators(t *testing.T) {
 	assert.Equal(t, "top_n", chart.OneOf[7].Properties["type"].Const)
 }
 
-func TestRenderExplainSchema_APIImplementationServiceShape(t *testing.T) {
+func TestRenderExplainSchema_APIImplementationShapes(t *testing.T) {
 	subject, err := ResolveExplainSubject("api.implementations")
 	require.NoError(t, err)
 
 	schema := RenderExplainSchema(subject)
 	require.NotNil(t, schema)
 
-	assert.Contains(t, schema.Properties, "service")
-	assert.Contains(t, schema.Properties, "type")
-	assert.NotContains(t, schema.Properties, "service_reference")
-	assert.NotContains(t, schema.Properties, "control_plane_reference")
+	require.Len(t, schema.OneOf, 2)
+	serviceBranch := schema.OneOf[0]
+	controlPlaneBranch := schema.OneOf[1]
+	assert.Equal(t, apiImplementationTypeService, serviceBranch.Properties["type"].Const)
+	assert.Equal(t, apiImplementationTypeControlPlane, controlPlaneBranch.Properties["type"].Const)
+	assert.NotContains(t, serviceBranch.Properties, "service_reference")
+	assert.NotContains(t, controlPlaneBranch.Properties, "control_plane_reference")
 
-	service := schema.Properties["service"]
+	service := serviceBranch.Properties["service"]
 	require.NotNil(t, service)
 	require.NotNil(t, service.Properties["id"])
 	require.NotNil(t, service.Properties["control_plane_id"])
 	assert.Equal(t, "gateway_service", service.Properties["id"].XRefKind)
 	assert.Equal(t, "control_plane", service.Properties["control_plane_id"].XRefKind)
+
+	controlPlane := controlPlaneBranch.Properties["control_plane"]
+	require.NotNil(t, controlPlane)
+	require.NotNil(t, controlPlane.Properties["control_plane_id"])
+	assert.Equal(t, "control_plane", controlPlane.Properties["control_plane_id"].XRefKind)
 }
 
 func TestAutoExplainInlineSDKUnionUsesPayloadFields(t *testing.T) {
@@ -551,6 +559,8 @@ func TestRenderScaffoldYAML_RootResource(t *testing.T) {
 	assert.Contains(t, scaffold, "# versions:")
 	assert.Contains(t, scaffold, "# type: service")
 	assert.Contains(t, scaffold, "# service:")
+	assert.Contains(t, scaffold, "# oneOf option: type=control_plane")
+	assert.Contains(t, scaffold, "# control_plane:")
 	assert.NotContains(t, scaffold, "service_reference")
 	assert.NotContains(t, scaffold, "control_plane_reference")
 	assert.NotContains(t, scaffold, "spec_content")

--- a/internal/declarative/resources/explain_union_schemas.go
+++ b/internal/declarative/resources/explain_union_schemas.go
@@ -383,16 +383,25 @@ func apiExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
 }
 
 func apiImplementationExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
-	return explainObject(
+	commonFields := []*ExplainField{
 		explainField(SchemaFieldRef, explainStringNode("my-resource"), true, true),
 		explainField("api", explainStringNode("my-api"), false, false),
-		explainField("type", explainConstStringNode("service"), false, true),
 		explainField("implementation_url", explainStringNode("https://api.example.com"), false, false),
+	}
+	service := explainWithCommonFields(explainObject(
+		explainField("type", explainConstStringNode(apiImplementationTypeService), false, true),
 		explainField("service", explainObject(
 			explainRefField("id", ResourceTypeGatewayService, true),
 			explainRefField("control_plane_id", ResourceTypeControlPlane, true),
 		), true, true),
-	), nil
+	), commonFields...)
+	controlPlane := explainWithCommonFields(explainObject(
+		explainField("type", explainConstStringNode(apiImplementationTypeControlPlane), false, true),
+		explainField("control_plane", explainObject(
+			explainRefField("control_plane_id", ResourceTypeControlPlane, true),
+		), true, true),
+	), commonFields...)
+	return explainUnionNode(service, controlPlane), nil
 }
 
 func dashboardExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {

--- a/internal/declarative/resources/load_schema_test.go
+++ b/internal/declarative/resources/load_schema_test.go
@@ -74,8 +74,11 @@ func TestRenderLoadSchemaRetainsOnlyUnionDiscriminatorScalars(t *testing.T) {
 
 	implementation := schema.Defs[string(ResourceTypeAPIImplementation)]
 	require.NotNil(t, implementation)
-	assert.Nil(t, implementation.Properties["type"].Const)
-	assert.Nil(t, implementation.Properties["type"].Type)
+	require.Len(t, implementation.OneOf, 2)
+	for _, branch := range implementation.OneOf {
+		assert.NotNil(t, branch.Properties["type"].Const)
+		assert.NotContains(t, branch.Required, "type")
+	}
 }
 
 func TestRenderShapeSchemaRetainsScalarTypesOnlyForUnionBranches(t *testing.T) {

--- a/internal/declarative/resources/relationships.go
+++ b/internal/declarative/resources/relationships.go
@@ -26,6 +26,11 @@ var relationshipDescriptors = map[ResourceType][]RelationshipDescriptor{
 	},
 	ResourceTypeAPIImplementation: {
 		{
+			FieldPath:  "control_plane.control_plane_id",
+			TargetType: ResourceTypeControlPlane,
+			Kind:       RelationshipKindAPIForeignKey,
+		},
+		{
 			FieldPath:  "service.control_plane_id",
 			TargetType: ResourceTypeControlPlane,
 			Kind:       RelationshipKindAPIForeignKey,

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -403,9 +403,13 @@ type APIPublication struct {
 type APIImplementation struct {
 	ID                string
 	ImplementationURL string
+	Type              kkComps.APIImplementationType
 	Service           *struct {
 		ID             string
 		ControlPlaneID string
+	}
+	ControlPlane *struct {
+		ID string
 	}
 }
 
@@ -2656,26 +2660,33 @@ func (c *Client) ListAPIImplementations(ctx context.Context, apiID string) ([]AP
 
 		for _, item := range resp.ListAPIImplementationsResponse.Data {
 			entity := item.APIImplementationListItemGatewayServiceEntity
-			if entity == nil {
+			if entity != nil {
+				impl := APIImplementation{ID: entity.GetID(), Type: kkComps.APIImplementationTypeServiceReference}
+				if svc := entity.GetService(); svc != nil {
+					impl.Service = &struct {
+						ID             string
+						ControlPlaneID string
+					}{
+						ID:             svc.GetID(),
+						ControlPlaneID: svc.GetControlPlaneID(),
+					}
+				}
+				allImplementations = append(allImplementations, impl)
 				continue
 			}
 
-			impl := APIImplementation{
-				ID: entity.GetID(),
-			}
-
-			// ImplementationURL not available in list response
-			if svc := entity.GetService(); svc != nil {
-				impl.Service = &struct {
-					ID             string
-					ControlPlaneID string
-				}{
-					ID:             svc.GetID(),
-					ControlPlaneID: svc.GetControlPlaneID(),
+			controlPlaneEntity := item.APIImplementationListItemControlPlaneEntity
+			if controlPlaneEntity != nil {
+				controlPlane := controlPlaneEntity.GetControlPlane()
+				impl := APIImplementation{
+					ID:   controlPlaneEntity.GetID(),
+					Type: kkComps.APIImplementationTypeControlPlaneReference,
+					ControlPlane: &struct {
+						ID string
+					}{ID: controlPlane.GetID()},
 				}
+				allImplementations = append(allImplementations, impl)
 			}
-
-			allImplementations = append(allImplementations, impl)
 		}
 
 		// Check if we've fetched all pages

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -403,7 +403,6 @@ type APIPublication struct {
 type APIImplementation struct {
 	ID                string
 	ImplementationURL string
-	Type              kkComps.APIImplementationType
 	Service           *struct {
 		ID             string
 		ControlPlaneID string
@@ -2661,7 +2660,7 @@ func (c *Client) ListAPIImplementations(ctx context.Context, apiID string) ([]AP
 		for _, item := range resp.ListAPIImplementationsResponse.Data {
 			entity := item.APIImplementationListItemGatewayServiceEntity
 			if entity != nil {
-				impl := APIImplementation{ID: entity.GetID(), Type: kkComps.APIImplementationTypeServiceReference}
+				impl := APIImplementation{ID: entity.GetID()}
 				if svc := entity.GetService(); svc != nil {
 					impl.Service = &struct {
 						ID             string
@@ -2679,8 +2678,7 @@ func (c *Client) ListAPIImplementations(ctx context.Context, apiID string) ([]AP
 			if controlPlaneEntity != nil {
 				controlPlane := controlPlaneEntity.GetControlPlane()
 				impl := APIImplementation{
-					ID:   controlPlaneEntity.GetID(),
-					Type: kkComps.APIImplementationTypeControlPlaneReference,
+					ID: controlPlaneEntity.GetID(),
 					ControlPlane: &struct {
 						ID string
 					}{ID: controlPlane.GetID()},

--- a/internal/declarative/state/client_pagination_test.go
+++ b/internal/declarative/state/client_pagination_test.go
@@ -502,6 +502,37 @@ func TestListAPIImplementations_ExactPageBoundaryRequestsSecondPage(t *testing.T
 	assert.Equal(t, "service-2-100", implementations[199].Service.ID)
 }
 
+func TestListAPIImplementations_NormalizesControlPlaneVariant(t *testing.T) {
+	client := NewClient(ClientConfig{
+		APIImplementationAPI: &mockAPIImplementationAPI{
+			listAPIImplementationsFunc: func(
+				_ context.Context, _ kkOps.ListAPIImplementationsRequest,
+			) (*kkOps.ListAPIImplementationsResponse, error) {
+				return &kkOps.ListAPIImplementationsResponse{
+					ListAPIImplementationsResponse: &kkComps.ListAPIImplementationsResponse{
+						Data: []kkComps.APIImplementationListItem{{
+							APIImplementationListItemControlPlaneEntity: &kkComps.APIImplementationListItemControlPlaneEntity{
+								ID: "implementation-id",
+								ControlPlane: kkComps.APIImplementationControlPlane{
+									ID: "control-plane-id",
+								},
+							},
+						}},
+						Meta: kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: 1}},
+					},
+				}, nil
+			},
+		},
+	})
+
+	implementations, err := client.ListAPIImplementations(testContextWithLogger(), "api-id")
+	require.NoError(t, err)
+	require.Len(t, implementations, 1)
+	assert.Equal(t, kkComps.APIImplementationTypeControlPlaneReference, implementations[0].Type)
+	require.NotNil(t, implementations[0].ControlPlane)
+	assert.Equal(t, "control-plane-id", implementations[0].ControlPlane.ID)
+}
+
 func TestListPortalSnippets_ExactPageBoundaryRequestsSecondPage(t *testing.T) {
 	ctx := testContextWithLogger()
 	var requestedPages []int64

--- a/internal/declarative/state/client_pagination_test.go
+++ b/internal/declarative/state/client_pagination_test.go
@@ -528,7 +528,6 @@ func TestListAPIImplementations_NormalizesControlPlaneVariant(t *testing.T) {
 	implementations, err := client.ListAPIImplementations(testContextWithLogger(), "api-id")
 	require.NoError(t, err)
 	require.Len(t, implementations, 1)
-	assert.Equal(t, kkComps.APIImplementationTypeControlPlaneReference, implementations[0].Type)
 	require.NotNil(t, implementations[0].ControlPlane)
 	assert.Equal(t, "control-plane-id", implementations[0].ControlPlane.ID)
 }

--- a/test/e2e/scenarios/apis/control-plane-implementation/scenario.yaml
+++ b/test/e2e/scenarios/apis/control-plane-implementation/scenario.yaml
@@ -1,0 +1,99 @@
+baseInputsPath: testdata
+
+defaults:
+  mask:
+    dropKeys:
+      - resource_id
+      - change_id
+      - created_at
+      - updated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-apply-control-plane-implementation
+    commands:
+      - name: 000-apply
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/resources.yaml"
+          - --auto-approve
+        assertions:
+          - select: >-
+              plan.changes[?resource_type=='api_implementation' &&
+                           resource_ref=='control-plane-implementation'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                "length(fields.control_plane.control_plane_id) > `0`": true
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success
+      - name: 001-get-control-plane
+        run:
+          - get
+          - gateway
+          - control-planes
+          - -o
+          - json
+        recordVar:
+          name: apiImplementationCPID
+          responsePath: "[?name=='e2e-api-implementation-cp'] | [0].id"
+
+  - name: 002-repeat-is-noop
+    commands:
+      - name: 000-apply
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/resources.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 0
+
+  - name: 003-dump-and-round-trip
+    skipInputs: true
+    commands:
+      - name: 000-dump
+        run:
+          - dump
+          - declarative
+          - "--resources=apis"
+          - --include-child-resources
+        outputFormat: none
+        parseAs: yaml
+        stdoutFile: "{{ .workdir }}/dump.yaml"
+        assertions:
+          - select: >-
+              apis[?name=='E2E Control Plane Implementation API'] | [0].implementations[0]
+            expect:
+              fields:
+                type: control_plane
+                control_plane.control_plane_id: "{{ .vars.apiImplementationCPID }}"
+      - name: 001-plan-dump
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/dump.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+
+  - name: 004-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true

--- a/test/e2e/scenarios/apis/control-plane-implementation/testdata/ace.yaml
+++ b/test/e2e/scenarios/apis/control-plane-implementation/testdata/ace.yaml
@@ -1,0 +1,4 @@
+_format_version: "3.0"
+
+plugins:
+  - name: ace

--- a/test/e2e/scenarios/apis/control-plane-implementation/testdata/resources.yaml
+++ b/test/e2e/scenarios/apis/control-plane-implementation/testdata/resources.yaml
@@ -1,0 +1,24 @@
+_defaults:
+  kongctl:
+    namespace: api-control-plane-implementation
+
+control_planes:
+  - ref: api-implementation-cp
+    name: "e2e-api-implementation-cp"
+    description: "Control plane implementation E2E"
+    cluster_type: "CLUSTER_TYPE_SERVERLESS"
+    cloud_gateway: false
+    _deck:
+      files:
+        - "ace.yaml"
+      flags:
+        - "--analytics=false"
+
+apis:
+  - ref: control-plane-api
+    name: "E2E Control Plane Implementation API"
+    implementations:
+      - ref: control-plane-implementation
+        type: control_plane
+        control_plane:
+          control_plane_id: !ref api-implementation-cp#id

--- a/test/integration/declarative/api_test.go
+++ b/test/integration/declarative/api_test.go
@@ -1021,6 +1021,10 @@ apis:
         service:
           id: "12345678-1234-1234-1234-123456789012"
           control_plane_id: "87654321-4321-4321-4321-210987654321"
+      - ref: kong-control-plane-impl
+        type: control_plane
+        control_plane:
+          control_plane_id: "87654321-4321-4321-4321-210987654321"
 `
 
 	err := os.WriteFile(configFile, []byte(configContent), 0o600)
@@ -1087,7 +1091,14 @@ apis:
 			},
 		}, nil).Maybe()
 
-	mockAPIAPI.On("CreateAPIImplementation", mock.Anything, "api-impl-123", mock.Anything).
+	mockAPIAPI.On(
+		"CreateAPIImplementation",
+		mock.Anything,
+		"api-impl-123",
+		mock.MatchedBy(func(implementation kkComps.APIImplementation) bool {
+			return implementation.Type == kkComps.APIImplementationTypeServiceReference
+		}),
+	).
 		Return(&kkOps.CreateAPIImplementationResponse{
 			StatusCode: 201,
 			APIImplementationResponse: func() *kkComps.APIImplementationResponse {
@@ -1105,6 +1116,30 @@ apis:
 				return &response
 			}(),
 		}, nil).Once()
+
+	mockAPIAPI.On(
+		"CreateAPIImplementation",
+		mock.Anything,
+		"api-impl-123",
+		mock.MatchedBy(func(implementation kkComps.APIImplementation) bool {
+			return implementation.Type == kkComps.APIImplementationTypeControlPlaneReference
+		}),
+	).Return(&kkOps.CreateAPIImplementationResponse{
+		StatusCode: 201,
+		APIImplementationResponse: func() *kkComps.APIImplementationResponse {
+			response := kkComps.CreateAPIImplementationResponseAPIImplementationResponseControlPlaneReference(
+				kkComps.APIImplementationResponseControlPlaneReference{
+					ID:        "control-plane-impl-123",
+					CreatedAt: time.Now(),
+					UpdatedAt: time.Now(),
+					ControlPlane: &kkComps.APIImplementationControlPlane{
+						ID: "87654321-4321-4321-4321-210987654321",
+					},
+				},
+			)
+			return &response
+		}(),
+	}, nil).Once()
 
 	// Create state client and planner
 	mockPortalAPI := GetMockPortalAPI(ctx, t)
@@ -1127,7 +1162,7 @@ apis:
 	require.NotNil(t, plan)
 
 	// Verify both API and implementation are planned
-	require.Len(t, plan.Changes, 2)
+	require.Len(t, plan.Changes, 3)
 	for i, change := range plan.Changes {
 		t.Logf(
 			"plan change %d: %s %s ref=%s deps=%v",
@@ -1140,6 +1175,7 @@ apis:
 	}
 	assert.Equal(t, "api", plan.Changes[0].ResourceType)
 	assert.Equal(t, "api_implementation", plan.Changes[1].ResourceType)
+	assert.Equal(t, "api_implementation", plan.Changes[2].ResourceType)
 
 	// Execute plan
 	exec := executor.New(stateClient, nil, false)
@@ -1166,7 +1202,7 @@ apis:
 	require.NoError(t, err)
 	assert.Equal(t, 0, report.FailureCount)
 	assert.Equal(t, 0, report.SkippedCount)
-	assert.Equal(t, 2, report.SuccessCount+report.FailureCount+report.SkippedCount)
+	assert.Equal(t, 3, report.SuccessCount+report.FailureCount+report.SkippedCount)
 	// assert.Equal(t, 2, report.SuccessCount)
 
 	mockAPIAPI.AssertExpectations(t)


### PR DESCRIPTION
## Summary

- support the control_plane API implementation union branch throughout declarative loading, validation, planning, execution, state matching, and dump
- preserve omitted type compatibility while emitting canonical type values in scaffold and dump output
- account for control-plane implementations in reference resolution, delete ordering, and deck/ACE dependencies
- document both implementation variants and add unit, integration, and E2E round-trip coverage

## Testing

- go fix ./...
- make format
- make build
- make test
- make test-integration
- focused golangci-lint for changed packages: zero issues
- E2E packages compile and the new scenario parses successfully; live execution requires a Konnect PAT

## Known repository lint baseline

The repository-wide make lint command still reports pre-existing generated portal-client line-length and spelling findings plus two existing mock staticcheck findings. The changed packages pass focused lint with zero issues.

Closes #1534