### PR TITLE
test(e2e): cover stale deletes after declarative renames

### DIFF
--- a/test/e2e/scenarios/declarative/rename-sync-delete/overlays/002-renamed/config.yaml
+++ b/test/e2e/scenarios/declarative/rename-sync-delete/overlays/002-renamed/config.yaml
@@ -1,0 +1,50 @@
+_defaults:
+  kongctl:
+    namespace: rename-sync-delete-e2e
+
+portals:
+  - ref: rename-sync-portal
+    name: rename-sync-portal-renamed
+    display_name: Rename Sync Portal Renamed
+    description: Portal used to verify rename cleanup
+
+apis:
+  - ref: rename-sync-api
+    name: rename-sync-api-renamed
+    description: API used to verify rename cleanup
+
+ai_gateways:
+  - ref: rename-sync-gateway
+    name: rename-sync-gateway
+    display_name: Rename Sync Gateway
+    model_providers:
+      - ref: rename-sync-provider
+        name: rename-sync-provider
+        type: openai
+        display_name: Rename Sync Provider
+        config:
+          auth:
+            type: basic
+            headers:
+              - name: Authorization
+                value: !secret {source: !env KONGCTL_E2E_RENAME_MODEL_PROVIDER_KEY}
+
+ai_gateway_models:
+  - ref: rename-sync-model
+    ai_gateway: rename-sync-gateway
+    type: model
+    name: rename-sync-model-renamed
+    display_name: Rename Sync Model Renamed
+    config:
+      route: {}
+      model: {}
+    formats:
+      - type: openai
+    targets:
+      - name: gpt-4o
+        provider: rename-sync-provider
+        config:
+          type: openai
+    policies: []
+    capabilities:
+      - generate

--- a/test/e2e/scenarios/declarative/rename-sync-delete/scenario.yaml
+++ b/test/e2e/scenarios/declarative/rename-sync-delete/scenario.yaml
@@ -1,0 +1,138 @@
+baseInputsPath: testdata
+
+test:
+  maturity: beta
+
+env:
+  KONGCTL_E2E_RENAME_MODEL_PROVIDER_KEY: placeholder
+
+defaults:
+  mask:
+    dropKeys:
+      - id
+      - created_at
+      - updated_at
+      - generated_at
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-apply-original-names
+    commands:
+      - name: 000-apply
+        outputFormat: json
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 5
+                failed: 0
+                status: success
+
+  - name: 002-apply-renamed-entities
+    inputOverlayDirs:
+      - overlays/002-renamed
+    commands:
+      - name: 000-apply
+        outputFormat: json
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 3
+                failed: 0
+                status: success
+
+  - name: 003-plan-sync-deletes-stale-entities
+    inputOverlayDirs:
+      - overlays/002-renamed
+    commands:
+      - name: 000-plan-sync
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 3
+                by_action.DELETE: 3
+          - select: >-
+              changes[?resource_type=='portal' && resource_ref=='rename-sync-portal-original'] | [0]
+            expect:
+              fields:
+                action: DELETE
+          - select: >-
+              changes[?resource_type=='api' && resource_ref=='rename-sync-api-original'] | [0]
+            expect:
+              fields:
+                action: DELETE
+          - select: >-
+              changes[?resource_type=='ai_gateway_model' && resource_ref=='rename-sync-model-original'] | [0]
+            expect:
+              fields:
+                action: DELETE
+      - name: 001-sync-delete-stale-entities
+        outputFormat: json
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 3
+                by_action.DELETE: 3
+          - select: summary
+            expect:
+              fields:
+                applied: 3
+                failed: 0
+                status: success
+      - name: 002-get-models-after-sync
+        run:
+          - get
+          - ai-gateway
+          - models
+          - --gateway-name
+          - rename-sync-gateway
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 1
+          - select: "[?name=='rename-sync-model-original']"
+            expect:
+              fields:
+                "length(@)": 0
+          - select: "[?name=='rename-sync-model-renamed'] | [0]"
+            expect:
+              fields:
+                name: rename-sync-model-renamed
+                display_name: Rename Sync Model Renamed
+
+  - name: 004-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true

--- a/test/e2e/scenarios/declarative/rename-sync-delete/testdata/config.yaml
+++ b/test/e2e/scenarios/declarative/rename-sync-delete/testdata/config.yaml
@@ -1,0 +1,50 @@
+_defaults:
+  kongctl:
+    namespace: rename-sync-delete-e2e
+
+portals:
+  - ref: rename-sync-portal
+    name: rename-sync-portal-original
+    display_name: Rename Sync Portal Original
+    description: Portal used to verify rename cleanup
+
+apis:
+  - ref: rename-sync-api
+    name: rename-sync-api-original
+    description: API used to verify rename cleanup
+
+ai_gateways:
+  - ref: rename-sync-gateway
+    name: rename-sync-gateway
+    display_name: Rename Sync Gateway
+    model_providers:
+      - ref: rename-sync-provider
+        name: rename-sync-provider
+        type: openai
+        display_name: Rename Sync Provider
+        config:
+          auth:
+            type: basic
+            headers:
+              - name: Authorization
+                value: !secret {source: !env KONGCTL_E2E_RENAME_MODEL_PROVIDER_KEY}
+
+ai_gateway_models:
+  - ref: rename-sync-model
+    ai_gateway: rename-sync-gateway
+    type: model
+    name: rename-sync-model-original
+    display_name: Rename Sync Model Original
+    config:
+      route: {}
+      model: {}
+    formats:
+      - type: openai
+    targets:
+      - name: gpt-4o
+        provider: rename-sync-provider
+        config:
+          type: openai
+    policies: []
+    capabilities:
+      - generate


### PR DESCRIPTION
## Description

Add an end-to-end declarative scenario covering resource renames followed by sync reconciliation.

The scenario:
- applies original portal, API, and AI Gateway model names
- applies renamed replacements using the same declarative refs
- verifies sync plans DELETE actions for all stale resources
- executes sync and verifies all three deletes succeed
- confirms the stale AI Gateway model is absent and the renamed model remains

## Rationale

Existing coverage tested create and sync-delete independently, but did not exercise the reported apply-rename-sync sequence for AI Gateway models or representative resources in other areas.

## Testing

- go fix ./...
- make format
- make build
- make test
- make test-integration
- make test-e2e-scenarios SCENARIO=declarative/rename-sync-delete

make lint currently reports pre-existing findings in generated portalclient and mock files: 50 line-length findings, four generated misspellings, and two staticcheck findings. No lint finding references this change.