### PR TITLE
test(e2e): verify port mapping listener policy fields

### DIFF
--- a/test/e2e/scenarios/event-gateway/dependency-order/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/dependency-order/scenario.yaml
@@ -86,10 +86,18 @@ steps:
             expect:
               fields:
                 "@": 1
-          - select: "[0].name"
+          - select: "[0]"
             expect:
               fields:
-                "@": storefront-forward
+                name: storefront-forward
+                type: forward_to_virtual_cluster
+                config:
+                  type: port_mapping
+                  advertised_host: host.docker.internal
+                  bootstrap_port: at_start
+                  min_broker_id: 0
+                  destination:
+                    name: storefront
 
   - name: 003-idempotency-check
     commands:

--- a/test/e2e/scenarios/event-gateway/dependency-order/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/dependency-order/scenario.yaml
@@ -91,13 +91,11 @@ steps:
               fields:
                 name: storefront-forward
                 type: forward_to_virtual_cluster
-                config:
-                  type: port_mapping
-                  advertised_host: host.docker.internal
-                  bootstrap_port: at_start
-                  min_broker_id: 0
-                  destination:
-                    name: storefront
+                config.type: port_mapping
+                config.advertised_host: host.docker.internal
+                config.bootstrap_port: at_start
+                config.min_broker_id: 0
+                config.destination.name: storefront
 
   - name: 003-idempotency-check
     commands:


### PR DESCRIPTION
## Summary

- expand the Event Gateway dependency-order verification for the port-mapping listener policy
- assert the policy type and port-mapping configuration, including its virtual-cluster destination

Closes #1994

## Testing

- `go fix ./...`
- `make format`
- `make build`
- `make test`
- `yq eval . test/e2e/scenarios/event-gateway/dependency-order/scenario.yaml`
- `make lint` *(fails on pre-existing generated portal client line-length/misspelling findings and two generated mock staticcheck findings)*