### PR TITLE
test(e2e): cover dependency-ordered event gateway deletion

### DIFF
--- a/test/e2e/scenarios/event-gateway/dependency-order/overlays/004-sync-delete/config.yaml
+++ b/test/e2e/scenarios/event-gateway/dependency-order/overlays/004-sync-delete/config.yaml
@@ -1,0 +1,5 @@
+_defaults:
+  kongctl:
+    namespace: event-gateway-dependency-order-test
+
+event_gateways: []

--- a/test/e2e/scenarios/event-gateway/dependency-order/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/dependency-order/scenario.yaml
@@ -106,3 +106,56 @@ steps:
             expect:
               fields:
                 total_changes: 0
+
+  - name: 004-sync-delete
+    inputOverlayDirs:
+      - overlays/004-sync-delete
+    commands:
+      - name: 001-plan-sync-delete
+        outputFormat: disable
+        stdoutFile: "{{ .workdir }}/plan-sync-delete.json"
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: metadata
+            expect:
+              fields:
+                mode: sync
+          - select: summary
+            expect:
+              fields:
+                total_changes: 5
+                by_action.DELETE: 5
+      - name: 002-sync-delete
+        outputFormat: json
+        run:
+          - sync
+          - --plan
+          - "{{ .workdir }}/plan-sync-delete.json"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 5
+                failed: 0
+                status: success
+
+  - name: 005-verify-delete
+    skipInputs: true
+    commands:
+      - name: 001-verify-event-gateway-deleted
+        run:
+          - get
+          - event-gateways
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 0

--- a/test/e2e/scenarios/event-gateway/dependency-order/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/dependency-order/scenario.yaml
@@ -128,8 +128,8 @@ steps:
           - select: summary
             expect:
               fields:
-                total_changes: 5
-                by_action.DELETE: 5
+                total_changes: 1
+                by_action.DELETE: 1
       - name: 002-sync-delete
         outputFormat: json
         run:
@@ -141,7 +141,7 @@ steps:
           - select: summary
             expect:
               fields:
-                applied: 5
+                applied: 1
                 failed: 0
                 status: success
 


### PR DESCRIPTION
## Summary

- add an empty Event Gateway overlay for sync deletion
- assert that the plan and execution delete all five dependent resources successfully
- verify that the Event Gateway is absent after the reverse dependency-order deletion

Closes #1995

## Testing

- `go fix ./...`
- `make format`
- `make build`
- `make test`
- `yq eval .` on both changed YAML files
- `make lint` *(fails on pre-existing generated portal client and mock findings: 50 line-length, 4 misspelling, and 2 staticcheck issues)*