### PR TITLE
fix(declarative): sync children of external parents

### DIFF
--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -83,6 +83,9 @@ Use YAML tags in field values to load files or reference other resources.
 - For a one-off unmanaged relationship, use `!lookup`. Use an `_external`
   declaration plus `!ref` when the resource needs a reusable declarative ref
   or owns managed child resources.
+- Sync never changes or deletes an external parent. Its child collections
+  placed in sync scope are still fully reconciled, including stale child
+  deletion. Omitted child collections remain out of scope.
 - Large text/spec fields are commonly loaded with `!file`.
 - `!file` paths are resolved relative to the config file and must remain
   within the configured base directory boundary.

--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -480,6 +480,10 @@ Because kongctl does not own those resources:
   external parent's Konnect ID.
   You do not need to (and cannot) assign a namespace to the external
   definition itself.
+- An external parent is not changed or deleted, but its child collections
+  explicitly included in sync scope are fully reconciled, including stale child
+  deletion. Child collections omitted from the configuration remain out of
+  scope and are not pruned.
 
 Inline lookups use either a `field:value` scalar or a mapping. The target type
 is inferred from the relationship field:

--- a/internal/declarative/planner/ai_gateway_agent_planner.go
+++ b/internal/declarative/planner/ai_gateway_agent_planner.go
@@ -107,7 +107,7 @@ func (p *Planner) planAIGatewayAgentChanges(
 		}
 	}
 
-	if plan.Metadata.Mode == PlanModeSync && !p.isAIGatewayExternal(gatewayRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for _, current := range currentAgents {
 			agentID := resources.AIGatewayAgentID(current.AIGatewayAgent)
 			agentName := resources.AIGatewayAgentName(current.AIGatewayAgent)

--- a/internal/declarative/planner/ai_gateway_auth_strategy_planner.go
+++ b/internal/declarative/planner/ai_gateway_auth_strategy_planner.go
@@ -93,7 +93,7 @@ func (p *Planner) planAIGatewayAuthStrategyChanges(
 		)
 	}
 
-	if plan.Metadata.Mode == PlanModeSync && !p.isAIGatewayExternal(gatewayRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for _, current := range currentProviders {
 			if desiredKeys[current.ID] || desiredKeys[current.Name] {
 				continue

--- a/internal/declarative/planner/ai_gateway_config_store_planner.go
+++ b/internal/declarative/planner/ai_gateway_config_store_planner.go
@@ -157,7 +157,7 @@ func (p *Planner) planAIGatewayConfigStoreChanges(
 		}
 	}
 
-	if plan.Metadata.Mode == PlanModeSync && !p.isAIGatewayExternal(gatewayRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for _, current := range currentStores {
 			if desiredKeys[current.ID] || desiredKeys[current.Name] {
 				continue

--- a/internal/declarative/planner/ai_gateway_consumer_credential_planner.go
+++ b/internal/declarative/planner/ai_gateway_consumer_credential_planner.go
@@ -103,7 +103,7 @@ func (p *Planner) planAIGatewayConsumerCredentialChanges(
 		)
 	}
 
-	if plan.Metadata.Mode == PlanModeSync && !p.isAIGatewayExternal(gatewayRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for _, current := range currentCredentials {
 			credentialID := resources.AIGatewayConsumerCredentialID(current.AIGatewayConsumerCredential)
 			credentialName := resources.AIGatewayConsumerCredentialName(current.AIGatewayConsumerCredential)

--- a/internal/declarative/planner/ai_gateway_consumer_group_planner.go
+++ b/internal/declarative/planner/ai_gateway_consumer_group_planner.go
@@ -133,7 +133,7 @@ func (p *Planner) planAIGatewayConsumerGroupChanges(
 		}
 	}
 
-	if plan.Metadata.Mode == PlanModeSync && !p.isAIGatewayExternal(gatewayRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for _, current := range currentGroups {
 			groupID := resources.AIGatewayConsumerGroupID(current.AIGatewayConsumerGroup)
 			groupName := resources.AIGatewayConsumerGroupName(current.AIGatewayConsumerGroup)

--- a/internal/declarative/planner/ai_gateway_consumer_planner.go
+++ b/internal/declarative/planner/ai_gateway_consumer_planner.go
@@ -164,7 +164,7 @@ func (p *Planner) planAIGatewayConsumerChanges(
 		}
 	}
 
-	if plan.Metadata.Mode == PlanModeSync && !p.isAIGatewayExternal(gatewayRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for _, current := range currentConsumers {
 			consumerID := resources.AIGatewayConsumerID(current.AIGatewayConsumer)
 			consumerName := resources.AIGatewayConsumerName(current.AIGatewayConsumer)

--- a/internal/declarative/planner/ai_gateway_data_plane_certificate_planner.go
+++ b/internal/declarative/planner/ai_gateway_data_plane_certificate_planner.go
@@ -90,7 +90,7 @@ func (p *Planner) planAIGatewayDataPlaneCertificateChanges(
 		)
 	}
 
-	if plan.Metadata.Mode == PlanModeSync && !p.isAIGatewayExternal(gatewayRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for _, current := range currentCerts {
 			title := resources.AIGatewayDataPlaneCertificateTitle(current.AIGatewayDataPlaneClientCertificate)
 			if desiredTitles[title] {

--- a/internal/declarative/planner/ai_gateway_mcp_server_planner.go
+++ b/internal/declarative/planner/ai_gateway_mcp_server_planner.go
@@ -107,7 +107,7 @@ func (p *Planner) planAIGatewayMCPServerChanges(
 		}
 	}
 
-	if plan.Metadata.Mode == PlanModeSync && !p.isAIGatewayExternal(gatewayRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for _, current := range orderCurrentAIGatewayMCPServersForDeletion(currentServers) {
 			serverID := resources.AIGatewayMCPServerID(current.AIGatewayMCPServer)
 			serverName := resources.AIGatewayMCPServerName(current.AIGatewayMCPServer)

--- a/internal/declarative/planner/ai_gateway_model_planner.go
+++ b/internal/declarative/planner/ai_gateway_model_planner.go
@@ -109,7 +109,7 @@ func (p *Planner) planAIGatewayModelChanges(
 		}
 	}
 
-	if plan.Metadata.Mode == PlanModeSync && !p.isAIGatewayExternal(gatewayRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for _, current := range currentModels {
 			modelID := resources.AIGatewayModelID(current.AIGatewayModel)
 			modelName := resources.AIGatewayModelName(current.AIGatewayModel)

--- a/internal/declarative/planner/ai_gateway_model_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_model_planner_test.go
@@ -168,6 +168,76 @@ func TestAIGatewayModelPlannerSyncDeletesScopedModels(t *testing.T) {
 	require.Equal(t, "gateway-id", change.Parent.ID)
 }
 
+func TestAIGatewayModelPlannerSyncDeletesStaleModelThroughExternalLookup(t *testing.T) {
+	gateway := testAIGateway()
+	gateway.Name = "bedrock-gateway"
+	gateway.DisplayName = "Amazon Bedrock AI Gateway"
+	gateway.Labels[labels.NamespaceKey] = "bedrock-ai-gateway"
+
+	desiredModel := testAIGatewayModelResource(t)
+	desiredModel.Ref = "proxy-sonet"
+	desiredModel.AIGateway = namedExternalPlaceholder(t, tags.TagLookup, "bedrock-gateway")
+	desiredModel.AIGatewayModelModel.Name = "proxy-sonet"
+	desiredModel.AIGatewayModelModel.DisplayName = "AI Proxy baseline (sonet)"
+
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{gateways: []kkComps.AIGateway{gateway}},
+		AIGatewayModelAPI: &testAIGatewayModelAPI{
+			models: []kkComps.AIGatewayModel{testAIGatewayModel("stale-model-id", "proxy-haiku")},
+		},
+	})
+	rs := &resources.ResourceSet{
+		AIGateways: []resources.AIGatewayResource{{
+			BaseResource: resources.BaseResource{
+				Ref:     "bedrock-ai-gateway",
+				Kongctl: &resources.KongctlMeta{Namespace: new("bedrock-ai-gateway")},
+			},
+			CreateAIGatewayRequest: kkComps.CreateAIGatewayRequest{
+				Name:        "bedrock-gateway",
+				DisplayName: "Amazon Bedrock AI Gateway",
+			},
+		}},
+		AIGatewayModels:   []resources.AIGatewayModelResource{desiredModel},
+		DefaultNamespaces: []string{"bedrock-ai-gateway", "ai-gateway-feature-tests"},
+	}
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeSync})
+	require.NoError(t, err)
+	change := findAIGatewayModelTestChange(t, plan, ResourceTypeAIGatewayModel, "proxy-haiku")
+	require.Equal(t, ActionDelete, change.Action)
+	require.Equal(t, "stale-model-id", change.ResourceID)
+	require.NotNil(t, change.Parent)
+	require.Equal(t, "gateway-id", change.Parent.ID)
+}
+
+func TestAIGatewayModelPlannerSyncDeletesLastModelFromExternalGateway(t *testing.T) {
+	gateway := resources.AIGatewayResource{
+		BaseResource: resources.BaseResource{Ref: "external-gateway"},
+		External:     &resources.ExternalBlock{ID: "gateway-id"},
+	}
+	gateway.SetKonnectID("gateway-id")
+	scope := resources.NewSyncScope()
+	scope.AddRoot(resources.ResourceTypeAIGateway)
+	scope.AddChild(resources.ResourceTypeAIGateway, gateway.Ref, resources.ResourceTypeAIGatewayModel)
+
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{gateways: []kkComps.AIGateway{testAIGateway()}},
+		AIGatewayModelAPI: &testAIGatewayModelAPI{
+			models: []kkComps.AIGatewayModel{testAIGatewayModel("model-id", "last-model")},
+		},
+	})
+	rs := &resources.ResourceSet{
+		AIGateways: []resources.AIGatewayResource{gateway},
+		SyncScope:  scope,
+	}
+
+	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeSync})
+	require.NoError(t, err)
+	change := findAIGatewayModelTestChange(t, plan, ResourceTypeAIGatewayModel, "last-model")
+	require.Equal(t, ActionDelete, change.Action)
+	require.Equal(t, "model-id", change.ResourceID)
+}
+
 func TestAIGatewayModelPlannerIgnoresAPIDefaults(t *testing.T) {
 	model := testAIGatewayModelResource(t)
 	var current kkComps.AIGatewayModel

--- a/internal/declarative/planner/ai_gateway_planner.go
+++ b/internal/declarative/planner/ai_gateway_planner.go
@@ -431,7 +431,7 @@ func (p *Planner) planExternalAIGatewayChildren(
 		resources.ResourceTypeAIGateway,
 		desiredGateway.Ref,
 		resources.ResourceTypeAIGatewayConfigStore,
-	) && len(configStores) > 0 {
+	) && (len(configStores) > 0 || plan.Metadata.Mode == PlanModeSync) {
 		if err := p.planAIGatewayConfigStoreChanges(
 			ctx,
 			namespace,
@@ -452,7 +452,7 @@ func (p *Planner) planExternalAIGatewayChildren(
 		resources.ResourceTypeAIGateway,
 		desiredGateway.Ref,
 		resources.ResourceTypeAIGatewayVault,
-	) && len(vaults) > 0 {
+	) && (len(vaults) > 0 || plan.Metadata.Mode == PlanModeSync) {
 		if err := p.planAIGatewayVaultChanges(
 			ctx,
 			namespace,
@@ -473,7 +473,7 @@ func (p *Planner) planExternalAIGatewayChildren(
 		resources.ResourceTypeAIGateway,
 		desiredGateway.Ref,
 		resources.ResourceTypeAIGatewayDataPlaneCertificate,
-	) && len(dataPlaneCertificates) > 0 {
+	) && (len(dataPlaneCertificates) > 0 || plan.Metadata.Mode == PlanModeSync) {
 		if err := p.planAIGatewayDataPlaneCertificateChanges(
 			ctx,
 			namespace,
@@ -494,7 +494,7 @@ func (p *Planner) planExternalAIGatewayChildren(
 		resources.ResourceTypeAIGateway,
 		desiredGateway.Ref,
 		resources.ResourceTypeAIGatewayProvider,
-	) && len(providers) > 0 {
+	) && (len(providers) > 0 || plan.Metadata.Mode == PlanModeSync) {
 		if err := p.planAIGatewayProviderChanges(
 			ctx, plannerCtx, namespace, desiredGateway.DisplayName, gatewayID, desiredGateway.Ref, "", providers, plan,
 		); err != nil {
@@ -509,7 +509,7 @@ func (p *Planner) planExternalAIGatewayChildren(
 		resources.ResourceTypeAIGateway,
 		desiredGateway.Ref,
 		resources.ResourceTypeAIGatewayAuthStrategy,
-	) && len(authStrategies) > 0 {
+	) && (len(authStrategies) > 0 || plan.Metadata.Mode == PlanModeSync) {
 		if err := p.planAIGatewayAuthStrategyChanges(
 			ctx, plannerCtx, namespace, desiredGateway.DisplayName, gatewayID, desiredGateway.Ref, "", authStrategies, plan,
 		); err != nil {
@@ -523,7 +523,7 @@ func (p *Planner) planExternalAIGatewayChildren(
 		resources.ResourceTypeAIGateway,
 		desiredGateway.Ref,
 		resources.ResourceTypeAIGatewayPolicy,
-	) && len(policies) > 0 {
+	) && (len(policies) > 0 || plan.Metadata.Mode == PlanModeSync) {
 		if err := p.planAIGatewayPolicyChanges(
 			ctx,
 			namespace,
@@ -545,7 +545,7 @@ func (p *Planner) planExternalAIGatewayChildren(
 		resources.ResourceTypeAIGateway,
 		desiredGateway.Ref,
 		resources.ResourceTypeAIGatewayAgent,
-	) && len(agents) > 0 {
+	) && (len(agents) > 0 || plan.Metadata.Mode == PlanModeSync) {
 		if err := p.planAIGatewayAgentChanges(
 			ctx,
 			namespace,
@@ -567,7 +567,7 @@ func (p *Planner) planExternalAIGatewayChildren(
 		resources.ResourceTypeAIGateway,
 		desiredGateway.Ref,
 		resources.ResourceTypeAIGatewayConsumer,
-	) && len(consumers) > 0 {
+	) && (len(consumers) > 0 || plan.Metadata.Mode == PlanModeSync) {
 		if err := p.planAIGatewayConsumerChanges(
 			ctx,
 			namespace,
@@ -589,7 +589,7 @@ func (p *Planner) planExternalAIGatewayChildren(
 		resources.ResourceTypeAIGateway,
 		desiredGateway.Ref,
 		resources.ResourceTypeAIGatewayConsumerGroup,
-	) && len(consumerGroups) > 0 {
+	) && (len(consumerGroups) > 0 || plan.Metadata.Mode == PlanModeSync) {
 		if err := p.planAIGatewayConsumerGroupChanges(
 			ctx,
 			namespace,
@@ -611,7 +611,7 @@ func (p *Planner) planExternalAIGatewayChildren(
 		resources.ResourceTypeAIGateway,
 		desiredGateway.Ref,
 		resources.ResourceTypeAIGatewayModel,
-	) && len(models) > 0 {
+	) && (len(models) > 0 || plan.Metadata.Mode == PlanModeSync) {
 		if err := p.planAIGatewayModelChanges(
 			ctx,
 			namespace,
@@ -634,7 +634,7 @@ func (p *Planner) planExternalAIGatewayChildren(
 		resources.ResourceTypeAIGateway,
 		desiredGateway.Ref,
 		resources.ResourceTypeAIGatewayMCPServer,
-	) && len(mcpServers) > 0 {
+	) && (len(mcpServers) > 0 || plan.Metadata.Mode == PlanModeSync) {
 		if err := p.planAIGatewayMCPServerChanges(
 			ctx,
 			namespace,
@@ -651,14 +651,6 @@ func (p *Planner) planExternalAIGatewayChildren(
 	}
 
 	return nil
-}
-
-func (p *Planner) isAIGatewayExternal(gatewayRef string) bool {
-	if p == nil || p.resources == nil {
-		return false
-	}
-	gateway := p.resources.GetAIGatewayByRef(gatewayRef)
-	return gateway != nil && gateway.IsExternal()
 }
 
 func (p *Planner) shouldUpdateAIGateway(

--- a/internal/declarative/planner/ai_gateway_policy_planner.go
+++ b/internal/declarative/planner/ai_gateway_policy_planner.go
@@ -86,7 +86,7 @@ func (p *Planner) planAIGatewayPolicyChanges(
 		}
 	}
 
-	if plan.Metadata.Mode == PlanModeSync && !p.isAIGatewayExternal(gatewayRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for _, current := range currentPolicies {
 			policyID := resources.AIGatewayPolicyID(current.AIGatewayPolicy)
 			policyName := resources.AIGatewayPolicyName(current.AIGatewayPolicy)

--- a/internal/declarative/planner/ai_gateway_provider_planner.go
+++ b/internal/declarative/planner/ai_gateway_provider_planner.go
@@ -85,7 +85,7 @@ func (p *Planner) planAIGatewayProviderChanges(
 		)
 	}
 
-	if plan.Metadata.Mode == PlanModeSync && !p.isAIGatewayExternal(gatewayRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for _, current := range currentProviders {
 			if desiredKeys[current.ID] || desiredKeys[current.Name] {
 				continue

--- a/internal/declarative/planner/ai_gateway_vault_planner.go
+++ b/internal/declarative/planner/ai_gateway_vault_planner.go
@@ -88,7 +88,7 @@ func (p *Planner) planAIGatewayVaultChanges(
 		}
 	}
 
-	if plan.Metadata.Mode == PlanModeSync && !p.isAIGatewayExternal(gatewayRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for _, current := range currentVaults {
 			vaultID := resources.AIGatewayVaultID(current.AIGatewayVault)
 			vaultName := resources.AIGatewayVaultName(current.AIGatewayVault)

--- a/internal/declarative/planner/api_planner.go
+++ b/internal/declarative/planner/api_planner.go
@@ -777,7 +777,7 @@ func (p *Planner) getAPIVersionsForAPI(api resources.APIResource) []resources.AP
 		seen[version.GetRef()] = struct{}{}
 	}
 	for _, version := range p.resources.APIVersions {
-		if version.API != api.GetRef() {
+		if !apiChildParentMatches(api, version.API) {
 			continue
 		}
 		if _, ok := seen[version.GetRef()]; ok {
@@ -797,7 +797,7 @@ func (p *Planner) getAPIPublicationsForAPI(api resources.APIResource) []resource
 		seen[pub.GetRef()] = struct{}{}
 	}
 	for _, pub := range p.resources.APIPublications {
-		if pub.API != api.GetRef() {
+		if !apiChildParentMatches(api, pub.API) {
 			continue
 		}
 		if _, ok := seen[pub.GetRef()]; ok {
@@ -817,7 +817,7 @@ func (p *Planner) getAPIImplementationsForAPI(api resources.APIResource) []resou
 		seen[impl.GetRef()] = struct{}{}
 	}
 	for _, impl := range p.resources.APIImplementations {
-		if impl.API != api.GetRef() {
+		if !apiChildParentMatches(api, impl.API) {
 			continue
 		}
 		if _, ok := seen[impl.GetRef()]; ok {
@@ -837,7 +837,7 @@ func (p *Planner) getAPIDocumentsForAPI(api resources.APIResource) []resources.A
 		seen[doc.GetRef()] = struct{}{}
 	}
 	for _, doc := range p.resources.APIDocuments {
-		if doc.API != api.GetRef() {
+		if !apiChildParentMatches(api, doc.API) {
 			continue
 		}
 		if _, ok := seen[doc.GetRef()]; ok {
@@ -847,6 +847,14 @@ func (p *Planner) getAPIDocumentsForAPI(api resources.APIResource) []resources.A
 		seen[doc.GetRef()] = struct{}{}
 	}
 	return result
+}
+
+func apiChildParentMatches(api resources.APIResource, parent string) bool {
+	return apiChildParentValueMatches(api.GetRef(), api.GetKonnectID(), parent)
+}
+
+func apiChildParentValueMatches(apiRef, apiID, parent string) bool {
+	return parent == apiRef || apiID != "" && parent == apiID
 }
 
 // planAPIChildResourceChanges plans changes for child resources of an existing API
@@ -949,13 +957,10 @@ func (p *Planner) planAPIVersionChanges(
 
 	// In sync mode, delete unmanaged versions
 	if plan.Metadata.Mode == PlanModeSync {
-		if p.isExternalAPI(apiRef) {
-			return nil
-		}
 		// Check if there are extracted versions for this API that will be processed later
 		hasExtractedVersions := false
-		for _, ver := range p.resources.GetAPIVersionsByNamespace(parentNamespace) {
-			if ver.API == apiRef {
+		for _, ver := range p.resources.APIVersions {
+			if apiChildParentValueMatches(apiRef, apiID, ver.API) {
 				hasExtractedVersions = true
 				break
 			}
@@ -1220,13 +1225,10 @@ func (p *Planner) planAPIPublicationChanges(
 
 	// In sync mode, delete unmanaged publications
 	if plan.Metadata.Mode == PlanModeSync {
-		if p.isExternalAPI(apiRef) {
-			return nil
-		}
 		// Check if there are extracted publications for this API that will be processed later
 		hasExtractedPublications := false
-		for _, pub := range p.resources.GetAPIPublicationsByNamespace(parentNamespace) {
-			if pub.API == apiRef {
+		for _, pub := range p.resources.APIPublications {
+			if apiChildParentValueMatches(apiRef, apiID, pub.API) {
 				hasExtractedPublications = true
 				break
 			}
@@ -1711,13 +1713,10 @@ func (p *Planner) planAPIImplementationChanges(
 
 	// In sync mode, delete unmanaged implementations
 	if plan.Metadata.Mode == PlanModeSync {
-		if p.isExternalAPI(apiRef) {
-			return nil
-		}
 		// Check if there are extracted implementations for this API that will be processed later
 		hasExtractedImplementations := false
-		for _, impl := range p.resources.GetAPIImplementationsByNamespace(parentNamespace) {
-			if impl.API == apiRef {
+		for _, impl := range p.resources.APIImplementations {
+			if apiChildParentValueMatches(apiRef, apiID, impl.API) {
 				hasExtractedImplementations = true
 				break
 			}
@@ -1937,9 +1936,17 @@ func (p *Planner) planAPIDocumentChanges(
 
 	// In sync mode, delete unmanaged documents
 	if plan.Metadata.Mode == PlanModeSync {
-		if p.isExternalAPI(apiRef) {
-			return nil
+		for _, doc := range p.resources.APIDocuments {
+			if apiChildParentValueMatches(apiRef, apiID, doc.API) && len(desired) == 0 {
+				p.logger.Debug(
+					"Skipping document deletion - extracted documents exist",
+					slog.String("api", apiRef),
+					slog.Int("current_count", len(currentDocuments)),
+				)
+				return nil
+			}
 		}
+
 		remaining := stateIndex.unprocessed()
 		for path, current := range remaining {
 			p.planAPIDocumentDelete(parentNamespace, apiRef, apiID, current.ID, path, plan)
@@ -1947,11 +1954,6 @@ func (p *Planner) planAPIDocumentChanges(
 	}
 
 	return nil
-}
-
-func (p *Planner) isExternalAPI(apiRef string) bool {
-	api := p.resources.GetAPIByRef(apiRef)
-	return api != nil && api.IsExternal()
 }
 
 func (p *Planner) shouldUpdateAPIDocument(current state.APIDocument, desired resources.APIDocumentResource) bool {

--- a/internal/declarative/planner/api_planner_test.go
+++ b/internal/declarative/planner/api_planner_test.go
@@ -78,7 +78,7 @@ func TestPlanAPIChangesExternalParentDeletesOnlyDeclaredChild(t *testing.T) {
 	require.Equal(t, "api-id", plan.Changes[0].Parent.ID)
 }
 
-func TestPlanAPIChangesExternalParentSyncDoesNotDeleteOutOfBandChildren(t *testing.T) {
+func TestPlanAPIChangesExternalParentSyncDeletesStaleVersions(t *testing.T) {
 	t.Parallel()
 
 	versionName := "v1"
@@ -112,10 +112,190 @@ func TestPlanAPIChangesExternalParentSyncDoesNotDeleteOutOfBandChildren(t *testi
 		t.Context(), &Config{Namespace: resources.NamespaceExternal}, []resources.APIResource{externalAPI}, plan,
 	)
 	require.NoError(t, err)
-	require.Len(t, plan.Changes, 1)
+	require.Len(t, plan.Changes, 2)
 	require.Equal(t, ResourceTypeAPIVersion, plan.Changes[0].ResourceType)
 	require.Equal(t, ActionCreate, plan.Changes[0].Action)
 	require.Equal(t, "v1", plan.Changes[0].ResourceRef)
+	require.Equal(t, ResourceTypeAPIVersion, plan.Changes[1].ResourceType)
+	require.Equal(t, ActionDelete, plan.Changes[1].Action)
+	require.Equal(t, "out-of-band-version-id", plan.Changes[1].ResourceID)
+	require.Equal(t, "api-id", plan.Changes[1].Parent.ID)
+}
+
+func TestPlanAPIChangesExternalParentSyncRetainsExtractedDesiredVersion(t *testing.T) {
+	t.Parallel()
+
+	versionName := "v1"
+	externalAPI := resources.APIResource{
+		BaseResource: resources.BaseResource{Ref: "shared-api"},
+		External:     &resources.ExternalBlock{ID: "api-id"},
+	}
+	externalAPI.SetKonnectID("api-id")
+	planner := NewPlanner(state.NewClient(state.ClientConfig{
+		APIVersionAPI: &stubAPIVersionAPI{
+			response: &kkOps.ListAPIVersionsResponse{
+				ListAPIVersionResponse: &kkComps.ListAPIVersionResponse{
+					Data: []kkComps.ListAPIVersionResponseAPIVersionSummary{
+						{ID: "version-id", Version: versionName},
+						{ID: "stale-version-id", Version: "v2"},
+					},
+					Meta: kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: 2}},
+				},
+			},
+			fetchResponse: &kkOps.FetchAPIVersionResponse{
+				APIVersionResponse: &kkComps.APIVersionResponse{ID: "version-id", Version: versionName},
+			},
+		},
+	}), slog.Default())
+	planner.resources = &resources.ResourceSet{
+		APIs: []resources.APIResource{externalAPI},
+		APIVersions: []resources.APIVersionResource{{
+			Ref:                     "v1",
+			API:                     "shared-api",
+			CreateAPIVersionRequest: kkComps.CreateAPIVersionRequest{Version: &versionName},
+		}},
+	}
+	planner.resources.EnsureSyncScope().AddChild(
+		resources.ResourceTypeAPI,
+		externalAPI.GetRef(),
+		resources.ResourceTypeAPIVersion,
+	)
+	plan := NewPlan(CurrentPlanVersion, "test", PlanModeSync)
+
+	err := planner.planAPIChanges(
+		t.Context(), &Config{Namespace: resources.NamespaceExternal}, []resources.APIResource{externalAPI}, plan,
+	)
+	require.NoError(t, err)
+	err = planner.planAPIVersionsChanges(
+		t.Context(),
+		&Config{Namespace: resources.NamespaceExternal},
+		planner.resources.APIVersions,
+		plan,
+	)
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	require.Equal(t, ResourceTypeAPIVersion, plan.Changes[0].ResourceType)
+	require.Equal(t, ActionDelete, plan.Changes[0].Action)
+	require.Equal(t, "stale-version-id", plan.Changes[0].ResourceID)
+}
+
+func TestPlanAPIChangesExternalParentSyncDeletesStalePublications(t *testing.T) {
+	t.Parallel()
+
+	externalAPI := resources.APIResource{
+		BaseResource: resources.BaseResource{Ref: "shared-api"},
+		External:     &resources.ExternalBlock{ID: "api-id"},
+	}
+	externalAPI.SetKonnectID("api-id")
+	planner := NewPlanner(state.NewClient(state.ClientConfig{
+		APIPublicationAPI: &stubAPIPublicationAPI{response: &kkOps.ListAPIPublicationsResponse{
+			ListAPIPublicationResponse: &kkComps.ListAPIPublicationResponse{
+				Data: []kkComps.APIPublicationListItem{{APIID: "api-id", PortalID: "portal-id"}},
+				Meta: kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: 1}},
+			},
+		}},
+	}), slog.Default())
+	planner.resources = &resources.ResourceSet{APIs: []resources.APIResource{externalAPI}}
+	planner.resources.EnsureSyncScope().AddChild(
+		resources.ResourceTypeAPI,
+		externalAPI.GetRef(),
+		resources.ResourceTypeAPIPublication,
+	)
+	plan := NewPlan(CurrentPlanVersion, "test", PlanModeSync)
+
+	err := planner.planAPIChanges(
+		t.Context(), &Config{Namespace: resources.NamespaceExternal}, []resources.APIResource{externalAPI}, plan,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	require.Equal(t, ResourceTypeAPIPublication, plan.Changes[0].ResourceType)
+	require.Equal(t, ActionDelete, plan.Changes[0].Action)
+	require.Equal(t, "shared-api-to-portal-id", plan.Changes[0].ResourceRef)
+	require.Equal(t, "api-id", plan.Changes[0].Parent.ID)
+}
+
+func TestPlanAPIChangesExternalParentSyncDeletesStaleImplementations(t *testing.T) {
+	t.Parallel()
+
+	externalAPI := resources.APIResource{
+		BaseResource: resources.BaseResource{Ref: "shared-api"},
+		External:     &resources.ExternalBlock{ID: "api-id"},
+	}
+	externalAPI.SetKonnectID("api-id")
+	planner := NewPlanner(state.NewClient(state.ClientConfig{
+		APIImplementationAPI: &stubAPIImplementationAPI{response: &kkOps.ListAPIImplementationsResponse{
+			ListAPIImplementationsResponse: &kkComps.ListAPIImplementationsResponse{
+				Data: []kkComps.APIImplementationListItem{
+					kkComps.CreateAPIImplementationListItemAPIImplementationListItemGatewayServiceEntity(
+						kkComps.APIImplementationListItemGatewayServiceEntity{
+							ID:    "implementation-id",
+							APIID: "api-id",
+							Service: &kkComps.APIImplementationService{
+								ID: "service-id", ControlPlaneID: "control-plane-id",
+							},
+						},
+					),
+				},
+				Meta: kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: 1}},
+			},
+		}},
+	}), slog.Default())
+	planner.resources = &resources.ResourceSet{APIs: []resources.APIResource{externalAPI}}
+	planner.resources.EnsureSyncScope().AddChild(
+		resources.ResourceTypeAPI,
+		externalAPI.GetRef(),
+		resources.ResourceTypeAPIImplementation,
+	)
+	plan := NewPlan(CurrentPlanVersion, "test", PlanModeSync)
+
+	err := planner.planAPIChanges(
+		t.Context(), &Config{Namespace: resources.NamespaceExternal}, []resources.APIResource{externalAPI}, plan,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	require.Equal(t, ResourceTypeAPIImplementation, plan.Changes[0].ResourceType)
+	require.Equal(t, ActionDelete, plan.Changes[0].Action)
+	require.Equal(t, "implementation-id", plan.Changes[0].ResourceID)
+	require.Equal(t, "api-id", plan.Changes[0].Parent.ID)
+}
+
+func TestPlanAPIChangesExternalParentSyncDeletesStaleDocuments(t *testing.T) {
+	t.Parallel()
+
+	externalAPI := resources.APIResource{
+		BaseResource: resources.BaseResource{Ref: "shared-api"},
+		External:     &resources.ExternalBlock{ID: "api-id"},
+	}
+	externalAPI.SetKonnectID("api-id")
+	planner := NewPlanner(state.NewClient(state.ClientConfig{
+		APIDocumentAPI: &stubAPIDocumentAPI{response: &kkOps.ListAPIDocumentsResponse{
+			ListAPIDocumentResponse: &kkComps.ListAPIDocumentResponse{
+				Data: []kkComps.APIDocumentSummaryWithChildren{
+					{ID: "document-id", Slug: "stale-document", Title: "Stale document"},
+				},
+			},
+		}},
+	}), slog.Default())
+	planner.resources = &resources.ResourceSet{APIs: []resources.APIResource{externalAPI}}
+	planner.resources.EnsureSyncScope().AddChild(
+		resources.ResourceTypeAPI,
+		externalAPI.GetRef(),
+		resources.ResourceTypeAPIDocument,
+	)
+	plan := NewPlan(CurrentPlanVersion, "test", PlanModeSync)
+
+	err := planner.planAPIChanges(
+		t.Context(), &Config{Namespace: resources.NamespaceExternal}, []resources.APIResource{externalAPI}, plan,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	require.Equal(t, ResourceTypeAPIDocument, plan.Changes[0].ResourceType)
+	require.Equal(t, ActionDelete, plan.Changes[0].Action)
+	require.Equal(t, "document-id", plan.Changes[0].ResourceID)
+	require.Equal(t, "api-id", plan.Changes[0].Parent.ID)
 }
 
 func TestValidateNoExternalResourceChangesRejectsAPIChange(t *testing.T) {

--- a/internal/declarative/planner/event_gateway_backend_cluster_planner.go
+++ b/internal/declarative/planner/event_gateway_backend_cluster_planner.go
@@ -129,7 +129,7 @@ func (p *Planner) planBackendClusterChangesForExistingGateway(
 	}
 
 	// 4. SYNC MODE: Delete unmanaged clusters
-	if plan.Metadata.Mode == PlanModeSync && !p.isEventGatewayExternal(gatewayRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for name, current := range currentByName {
 			if !desiredNames[name] {
 				p.logger.Debug(

--- a/internal/declarative/planner/event_gateway_cluster_policy_planner.go
+++ b/internal/declarative/planner/event_gateway_cluster_policy_planner.go
@@ -136,7 +136,7 @@ func (p *Planner) planClusterPolicyChangesForExistingVirtualCluster(
 	}
 
 	// 4. SYNC MODE: Delete unmanaged policies
-	if plan.Metadata.Mode == PlanModeSync && !p.isEventGatewayVirtualClusterExternal(virtualClusterRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for name, current := range currentByName {
 			if !desiredNames[name] {
 				p.logger.Debug(

--- a/internal/declarative/planner/event_gateway_consume_policy_planner.go
+++ b/internal/declarative/planner/event_gateway_consume_policy_planner.go
@@ -155,7 +155,7 @@ func (p *Planner) planConsumePolicyChangesForExistingVirtualCluster(
 	}
 
 	// 4. SYNC MODE: Delete policies no longer in desired state
-	if plan.Metadata.Mode == PlanModeSync && !p.isEventGatewayVirtualClusterExternal(virtualClusterRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for name, current := range currentByName {
 			if !desiredNames[name] {
 				p.logger.Debug(

--- a/internal/declarative/planner/event_gateway_data_plane_certificate_planner.go
+++ b/internal/declarative/planner/event_gateway_data_plane_certificate_planner.go
@@ -124,7 +124,7 @@ func (p *Planner) planDataPlaneCertificateChangesForExistingGateway(
 	}
 
 	// 4. SYNC MODE: Delete unmanaged certificates
-	if plan.Metadata.Mode == PlanModeSync && !p.isEventGatewayExternal(gatewayRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for name, current := range currentByName {
 			if !desiredNames[name] {
 				p.logger.Debug(

--- a/internal/declarative/planner/event_gateway_external.go
+++ b/internal/declarative/planner/event_gateway_external.go
@@ -7,22 +7,6 @@ import (
 	"github.com/kong/kongctl/internal/declarative/state"
 )
 
-func (p *Planner) isEventGatewayExternal(gatewayRef string) bool {
-	if p == nil || p.resources == nil {
-		return false
-	}
-	eventGateway := p.resources.GetEventGatewayControlPlaneByRef(gatewayRef)
-	return eventGateway != nil && eventGateway.IsExternal()
-}
-
-func (p *Planner) isEventGatewayVirtualClusterExternal(virtualClusterRef string) bool {
-	if p == nil || p.resources == nil {
-		return false
-	}
-	virtualCluster := p.resources.GetVirtualClusterByRef(virtualClusterRef)
-	return virtualCluster != nil && virtualCluster.IsExternal()
-}
-
 func matchExternalEventGatewayVirtualCluster(
 	virtualCluster *resources.EventGatewayVirtualClusterResource,
 	available []state.EventGatewayVirtualCluster,

--- a/internal/declarative/planner/event_gateway_external_test.go
+++ b/internal/declarative/planner/event_gateway_external_test.go
@@ -388,7 +388,7 @@ func TestPlanner_ExternalEventGateway_MissingResolvedIDFailsBeforeChildPlanning(
 	require.Empty(t, plan.Changes)
 }
 
-func TestPlanner_ExternalEventGateway_SyncDoesNotDeleteExistingBackendClusters(t *testing.T) {
+func TestPlanner_ExternalEventGateway_SyncDeletesExistingBackendClusters(t *testing.T) {
 	t.Parallel()
 
 	planner := &Planner{
@@ -418,10 +418,10 @@ func TestPlanner_ExternalEventGateway_SyncDoesNotDeleteExistingBackendClusters(t
 		plan,
 	)
 	require.NoError(t, err)
-	requireNoDeleteChange(t, plan, ResourceTypeEventGatewayBackendCluster)
+	requireDeleteChange(t, plan, ResourceTypeEventGatewayBackendCluster)
 }
 
-func TestPlanner_ExternalEventGateway_SyncDoesNotDeleteExistingVirtualClusters(t *testing.T) {
+func TestPlanner_ExternalEventGateway_SyncDeletesExistingVirtualClusters(t *testing.T) {
 	t.Parallel()
 
 	planner := &Planner{
@@ -451,10 +451,10 @@ func TestPlanner_ExternalEventGateway_SyncDoesNotDeleteExistingVirtualClusters(t
 		plan,
 	)
 	require.NoError(t, err)
-	requireNoDeleteChange(t, plan, ResourceTypeEventGatewayVirtualCluster)
+	requireDeleteChange(t, plan, ResourceTypeEventGatewayVirtualCluster)
 }
 
-func TestPlanner_ExternalEventGatewayVirtualCluster_SyncDoesNotDeleteExistingClusterPolicies(t *testing.T) {
+func TestPlanner_ExternalEventGatewayVirtualCluster_SyncDeletesExistingClusterPolicies(t *testing.T) {
 	t.Parallel()
 
 	policyName := "external-policy"
@@ -492,7 +492,7 @@ func TestPlanner_ExternalEventGatewayVirtualCluster_SyncDoesNotDeleteExistingClu
 		plan,
 	)
 	require.NoError(t, err)
-	requireNoDeleteChange(t, plan, ResourceTypeEventGatewayClusterPolicy)
+	requireDeleteChange(t, plan, ResourceTypeEventGatewayClusterPolicy)
 }
 
 func externalEventGatewayResourceSet() *resources.ResourceSet {
@@ -556,14 +556,15 @@ func externalEventGatewayVirtualClusterResource() resources.EventGatewayVirtualC
 	}
 }
 
-func requireNoDeleteChange(t *testing.T, plan *Plan, resourceType string) {
+func requireDeleteChange(t *testing.T, plan *Plan, resourceType string) {
 	t.Helper()
 
 	for _, change := range plan.Changes {
 		if change.ResourceType == resourceType && change.Action == ActionDelete {
-			t.Fatalf("unexpected %s delete planned for external event gateway: %+v", resourceType, change)
+			return
 		}
 	}
+	t.Fatalf("expected %s delete under external event gateway, got: %+v", resourceType, plan.Changes)
 }
 
 func eventGatewayExternalCursorMeta() *kkComps.CursorMeta {

--- a/internal/declarative/planner/event_gateway_listener_planner.go
+++ b/internal/declarative/planner/event_gateway_listener_planner.go
@@ -160,7 +160,7 @@ func (p *Planner) planListenerChangesForExistingGateway(
 	}
 
 	// 4. SYNC MODE: Delete unmanaged listeners
-	if plan.Metadata.Mode == PlanModeSync && !p.isEventGatewayExternal(gatewayRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for name, current := range currentByName {
 			if !desiredNames[name] {
 				p.logger.Debug(

--- a/internal/declarative/planner/event_gateway_listener_policy_planner.go
+++ b/internal/declarative/planner/event_gateway_listener_policy_planner.go
@@ -136,7 +136,7 @@ func (p *Planner) planListenerPolicyChangesForExistingListener(
 	}
 
 	// 4. SYNC MODE: Delete unmanaged policies
-	if plan.Metadata.Mode == PlanModeSync && !p.isEventGatewayExternal(gatewayRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for name, current := range currentByName {
 			if !desiredNames[name] {
 				p.logger.Debug(

--- a/internal/declarative/planner/event_gateway_produce_policy_planner.go
+++ b/internal/declarative/planner/event_gateway_produce_policy_planner.go
@@ -139,7 +139,7 @@ func (p *Planner) planProducePolicyChangesForExistingVirtualCluster(
 		}
 	}
 
-	if plan.Metadata.Mode == PlanModeSync && !p.isEventGatewayVirtualClusterExternal(virtualClusterRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for name, current := range currentByName {
 			if !desiredNames[name] {
 				p.logger.Debug(

--- a/internal/declarative/planner/event_gateway_schema_registry_planner.go
+++ b/internal/declarative/planner/event_gateway_schema_registry_planner.go
@@ -119,7 +119,7 @@ func (p *Planner) planSchemaRegistryChangesForExistingGateway(
 	}
 
 	// SYNC MODE: Delete unmanaged registries
-	if plan.Metadata.Mode == PlanModeSync && !p.isEventGatewayExternal(gatewayRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for name, current := range currentByName {
 			if !desiredNames[name] {
 				p.logger.Debug(

--- a/internal/declarative/planner/event_gateway_static_key_planner.go
+++ b/internal/declarative/planner/event_gateway_static_key_planner.go
@@ -116,7 +116,7 @@ func (p *Planner) planStaticKeyChangesForExistingGateway(
 	}
 
 	// 4. SYNC MODE: Delete unmanaged static keys
-	if plan.Metadata.Mode == PlanModeSync && !p.isEventGatewayExternal(gatewayRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for name, current := range currentByName {
 			if !desiredNames[name] {
 				p.logger.Debug(

--- a/internal/declarative/planner/event_gateway_tls_trust_bundle_planner.go
+++ b/internal/declarative/planner/event_gateway_tls_trust_bundle_planner.go
@@ -117,7 +117,7 @@ func (p *Planner) planTrustBundleChangesForExistingGateway(
 	}
 
 	// SYNC MODE: Delete unmanaged trust bundles
-	if plan.Metadata.Mode == PlanModeSync && !p.isEventGatewayExternal(gatewayRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for name, current := range currentByName {
 			if !desiredNames[name] {
 				p.logger.Debug(

--- a/internal/declarative/planner/event_gateway_virtual_cluster_planner.go
+++ b/internal/declarative/planner/event_gateway_virtual_cluster_planner.go
@@ -320,7 +320,7 @@ func (p *Planner) planVirtualClusterChangesForExistingGateway(
 	}
 
 	// 4. SYNC MODE: Delete unmanaged clusters
-	if plan.Metadata.Mode == PlanModeSync && !p.isEventGatewayExternal(gatewayRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for name, current := range currentByName {
 			if !desiredNames[name] {
 				p.logger.Debug(

--- a/internal/declarative/planner/organization_team_planner.go
+++ b/internal/declarative/planner/organization_team_planner.go
@@ -337,7 +337,6 @@ func (t *OrganizationTeamPlannerImpl) planOrganizationTeamRoleChanges(
 	for _, team := range desiredTeams {
 		teamByRef[team.Ref] = team
 		if plan.Metadata.Mode == PlanModeSync &&
-			!team.IsExternal() &&
 			t.planner.shouldPlanChild(
 				plan,
 				resources.ResourceTypeOrganizationTeam,
@@ -433,7 +432,7 @@ func (t *OrganizationTeamPlannerImpl) planOrganizationTeamRoleChanges(
 			t.planOrganizationTeamRoleCreate(namespace, teamRef, teamName, teamID, role, plan)
 		}
 
-		if plan.Metadata.Mode == PlanModeSync && teamID != "" && !team.IsExternal() {
+		if plan.Metadata.Mode == PlanModeSync && teamID != "" {
 			for key, existingRole := range existingRoles {
 				if !desiredKeys[key] {
 					t.planOrganizationTeamRoleDelete(namespace, teamRef, teamName, teamID, existingRole, plan)

--- a/internal/declarative/planner/organization_team_planner_test.go
+++ b/internal/declarative/planner/organization_team_planner_test.go
@@ -282,8 +282,8 @@ func assignedRoleCollection(roles ...kkComps.AssignedRole) *kkComps.AssignedRole
 	}
 }
 
-func assignedRole(id, roleName, entityID, entityTypeName, entityRegion string) kkComps.AssignedRole {
-	region := kkComps.AssignedRoleEntityRegion(entityRegion)
+func assignedRole(id, roleName, entityID, entityTypeName string) kkComps.AssignedRole {
+	region := kkComps.AssignedRoleEntityRegion("us")
 	return kkComps.AssignedRole{
 		ID:             &id,
 		RoleName:       &roleName,
@@ -317,6 +317,64 @@ func TestOrganizationTeamExternalConfigContributesExternalNamespace(t *testing.T
 
 	namespaces := planner.getResourceNamespaces(rs)
 	require.Equal(t, []string{resources.NamespaceExternal}, namespaces)
+}
+
+func TestOrganizationTeamRoleSyncDeletesStaleRoleFromExternalTeam(t *testing.T) {
+	const (
+		teamRef = "external-team"
+		teamID  = "team-123"
+	)
+
+	team := resources.OrganizationTeamResource{
+		BaseResource: resources.BaseResource{Ref: teamRef},
+		CreateTeam:   kkComps.CreateTeam{Name: "External Team"},
+		External:     &resources.ExternalBlock{ID: teamID},
+	}
+	scope := resources.NewSyncScope()
+	scope.AddChild(
+		resources.ResourceTypeOrganizationTeam,
+		teamRef,
+		resources.ResourceTypeOrganizationTeamRole,
+	)
+	resourceSet := &resources.ResourceSet{
+		OrganizationTeams: []resources.OrganizationTeamResource{team},
+		SyncScope:         scope,
+	}
+	client := state.NewClient(state.ClientConfig{
+		OrganizationTeamRolesAPI: &organizationTeamRolesAPIStub{
+			listTeamRoles: func(
+				_ context.Context,
+				gotTeamID string,
+				_ *kkOps.ListTeamRolesQueryParamFilter,
+				_ ...kkOps.Option,
+			) (*kkOps.ListTeamRolesResponse, error) {
+				require.Equal(t, teamID, gotTeamID)
+				return &kkOps.ListTeamRolesResponse{
+					AssignedRoleCollection: assignedRoleCollection(
+						assignedRole("stale-role-123", "Admin", "*", "APIs"),
+					),
+				}, nil
+			},
+		},
+	})
+	planner := NewPlanner(client, discardPlannerLogger())
+	planner.resources = resourceSet
+	teamPlanner := NewOrganizationTeamPlanner(NewBasePlanner(planner)).(*OrganizationTeamPlannerImpl)
+	plan := NewPlan("1.0", "test", PlanModeSync)
+
+	err := teamPlanner.planOrganizationTeamRoleChanges(
+		t.Context(),
+		resources.NamespaceExternal,
+		resourceSet.OrganizationTeams,
+		map[string]state.OrganizationTeam{},
+		plan,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	require.Equal(t, ActionDelete, plan.Changes[0].Action)
+	require.Equal(t, ResourceTypeOrganizationTeamRole, plan.Changes[0].ResourceType)
+	require.Equal(t, teamID, plan.Changes[0].Parent.ID)
 }
 
 func TestOrganizationTeamRoleDeleteUsesUniqueCompositeRef(t *testing.T) {
@@ -583,7 +641,7 @@ func TestOrganizationTeamRolePortalEntityRefMatchesExistingRole(t *testing.T) {
 				require.Equal(t, teamID, gotTeamID)
 				return &kkOps.ListTeamRolesResponse{
 					AssignedRoleCollection: assignedRoleCollection(
-						assignedRole("role-123", "Viewer", portalID, "Portals", "us"),
+						assignedRole("role-123", "Viewer", portalID, "Portals"),
 					),
 				}, nil
 			},
@@ -652,7 +710,7 @@ func TestOrganizationUserRolePortalEntityRefMatchesExistingRoleInSyncScope(t *te
 				require.Equal(t, userID, gotUserID)
 				return &kkOps.ListUserRolesResponse{
 					AssignedRoleCollection: assignedRoleCollection(
-						assignedRole("role-123", "Viewer", portalID, "Portals", "us"),
+						assignedRole("role-123", "Viewer", portalID, "Portals"),
 					),
 				}, nil
 			},
@@ -715,7 +773,7 @@ func TestOrganizationSystemAccountRolePortalEntityRefMatchesExistingRoleInSyncSc
 				require.Equal(t, accountID, gotAccountID)
 				return &kkOps.GetSystemAccountsAccountIDAssignedRolesResponse{
 					AssignedRoleCollection: assignedRoleCollection(
-						assignedRole("role-123", "Viewer", portalID, "Portals", "us"),
+						assignedRole("role-123", "Viewer", portalID, "Portals"),
 					),
 				}, nil
 			},

--- a/internal/declarative/planner/planner_test.go
+++ b/internal/declarative/planner/planner_test.go
@@ -110,7 +110,8 @@ func (s *stubAPIPublicationAPI) ListAPIPublications(
 }
 
 type stubAPIVersionAPI struct {
-	response *kkOps.ListAPIVersionsResponse
+	response      *kkOps.ListAPIVersionsResponse
+	fetchResponse *kkOps.FetchAPIVersionResponse
 }
 
 func (s *stubAPIVersionAPI) CreateAPIVersion(
@@ -163,16 +164,24 @@ func (s *stubAPIVersionAPI) FetchAPIVersion(
 	_ string,
 	_ ...kkOps.Option,
 ) (*kkOps.FetchAPIVersionResponse, error) {
+	if s.fetchResponse != nil {
+		return s.fetchResponse, nil
+	}
 	return nil, fmt.Errorf("FetchAPIVersion not implemented")
 }
 
-type stubAPIImplementationAPI struct{}
+type stubAPIImplementationAPI struct {
+	response *kkOps.ListAPIImplementationsResponse
+}
 
 func (s *stubAPIImplementationAPI) ListAPIImplementations(
 	_ context.Context,
 	_ kkOps.ListAPIImplementationsRequest,
 	_ ...kkOps.Option,
 ) (*kkOps.ListAPIImplementationsResponse, error) {
+	if s.response != nil {
+		return s.response, nil
+	}
 	return &kkOps.ListAPIImplementationsResponse{
 		ListAPIImplementationsResponse: &kkComps.ListAPIImplementationsResponse{
 			Data: []kkComps.APIImplementationListItem{},

--- a/internal/declarative/planner/portal_child_planner.go
+++ b/internal/declarative/planner/portal_child_planner.go
@@ -295,7 +295,7 @@ func (p *Planner) planPortalIPAllowListsChanges(
 	if err != nil {
 		var apiErr *state.APIClientError
 		if errors.As(err, &apiErr) && apiErr.ClientType == "portal IP allow list API" {
-			if plan.Metadata.Mode == PlanModeSync && !p.isPortalExternal(portalRef) {
+			if plan.Metadata.Mode == PlanModeSync {
 				plan.AddWarning(
 					"",
 					fmt.Sprintf(
@@ -316,7 +316,7 @@ func (p *Planner) planPortalIPAllowListsChanges(
 	}
 
 	if desiredAllowList == nil {
-		if plan.Metadata.Mode == PlanModeSync && !p.isPortalExternal(portalRef) {
+		if plan.Metadata.Mode == PlanModeSync {
 			for i := range currentEntries {
 				p.planPortalIPAllowListDelete(
 					parentNamespace,
@@ -358,7 +358,7 @@ func (p *Planner) planPortalIPAllowListsChanges(
 		)
 	}
 
-	if plan.Metadata.Mode == PlanModeSync && !p.isPortalExternal(portalRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for i := range currentEntries {
 			if i == selectedIndex {
 				continue
@@ -859,7 +859,7 @@ func (p *Planner) planPortalIdentityProvidersChanges(
 		p.planPortalIdentityProviderCreate(parentNamespace, provider, portalID, plan)
 	}
 
-	if plan.Metadata.Mode == PlanModeSync && !p.isPortalExternal(portalRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for providerType, current := range existingProviders {
 			if !desiredTypes[providerType] {
 				p.planPortalIdentityProviderDelete(parentNamespace, portalRef, portalID, current, plan)
@@ -1590,7 +1590,7 @@ func (p *Planner) planPortalCustomDomainsChanges(
 	}
 
 	if desiredDomain == nil {
-		if currentDomain != nil && plan.Metadata.Mode == PlanModeSync && !p.isPortalExternal(portalRef) {
+		if currentDomain != nil && plan.Metadata.Mode == PlanModeSync {
 			p.planPortalCustomDomainDelete(parentNamespace, portalRef, portalID, portalName, currentDomain, "", plan)
 		}
 		return nil
@@ -2274,7 +2274,7 @@ func (p *Planner) planPortalEmailConfigsChanges(
 	}
 
 	if desiredCfg == nil {
-		if currentCfg != nil && plan.Metadata.Mode == PlanModeSync && !p.isPortalExternal(portalRef) {
+		if currentCfg != nil && plan.Metadata.Mode == PlanModeSync {
 			p.planPortalEmailConfigDelete(parentNamespace, portalRef, portalID, portalName, plan)
 		}
 		return nil
@@ -2372,7 +2372,7 @@ func (p *Planner) planPortalAuditLogWebhooksChanges(
 	}
 
 	if desiredWebhook == nil {
-		if currentWebhook != nil && plan.Metadata.Mode == PlanModeSync && !p.isPortalExternal(portalRef) {
+		if currentWebhook != nil && plan.Metadata.Mode == PlanModeSync {
 			p.planPortalAuditLogWebhookDelete(parentNamespace, portalRef, portalID, portalName, plan)
 		}
 		return nil
@@ -2926,7 +2926,7 @@ func (p *Planner) planPortalEmailTemplatesChanges(
 		}
 	}
 
-	if plan.Metadata.Mode == PlanModeSync && portalID != "" && !p.isPortalExternal(portalRef) {
+	if plan.Metadata.Mode == PlanModeSync && portalID != "" {
 		for name, tpl := range existing {
 			if _, ok := desiredByName[name]; ok {
 				continue
@@ -3375,9 +3375,8 @@ func (p *Planner) planPortalPagesChanges(
 		}
 	}
 
-	// In sync mode, delete unmanaged pages only for managed portals.
-	// External portals are managed elsewhere, so we avoid destructive pruning.
-	if plan.Metadata.Mode == PlanModeSync && !p.isPortalExternal(portalRef) {
+	// In sync mode, delete pages absent from the desired in-scope collection.
+	if plan.Metadata.Mode == PlanModeSync {
 		// Build set of desired page paths
 		desiredPaths := make(map[string]bool)
 		for _, desiredPage := range desired {
@@ -3902,9 +3901,8 @@ func (p *Planner) planPortalSnippetsChanges(
 		}
 	}
 
-	// In sync mode, delete undeclared snippets only for managed portals.
-	// External portals are managed elsewhere, so we avoid destructive pruning.
-	if plan.Metadata.Mode == PlanModeSync && !p.isPortalExternal(portalRef) {
+	// In sync mode, delete snippets absent from the desired in-scope collection.
+	if plan.Metadata.Mode == PlanModeSync {
 		for _, existingSnippet := range existingSnippets {
 			if !desiredNames[existingSnippet.Name] {
 				p.planPortalSnippetDelete(parentNamespace, portalRef, portalID, existingSnippet, plan)
@@ -4260,7 +4258,7 @@ func (p *Planner) planPortalTeamsChanges(
 	}
 
 	// In SYNC mode: Delete teams not in desired state
-	if plan.Metadata.Mode == PlanModeSync && !p.isPortalExternal(portalRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for _, existingTeam := range existingTeams {
 			if !desiredNames[existingTeam.Name] {
 				p.planPortalTeamDelete(parentNamespace, portalRef, portalID, existingTeam, plan)
@@ -4833,7 +4831,7 @@ func (p *Planner) planPortalTeamRolesChanges(
 		}
 	}
 
-	if plan.Metadata.Mode == PlanModeSync && !p.isPortalExternal(portalRef) {
+	if plan.Metadata.Mode == PlanModeSync {
 		for teamRef := range teamByRef {
 			if _, ok := rolesByTeam[teamRef]; !ok {
 				rolesByTeam[teamRef] = []resources.PortalTeamRoleResource{}
@@ -4947,7 +4945,7 @@ func (p *Planner) planPortalTeamRolesChanges(
 			)
 		}
 
-		if plan.Metadata.Mode == PlanModeSync && teamID != "" && !p.isPortalExternal(portalRef) {
+		if plan.Metadata.Mode == PlanModeSync && teamID != "" {
 			for key, existingRole := range existingRoles {
 				if !desiredKeys[key] {
 					p.planPortalTeamRoleDelete(

--- a/internal/declarative/planner/portal_external_child_deletes_test.go
+++ b/internal/declarative/planner/portal_external_child_deletes_test.go
@@ -173,7 +173,7 @@ func (s *stubExternalPortalTeamRolesAPI) RemoveRoleFromPortalTeam(
 	return &kkOps.RemoveRoleFromPortalTeamResponse{}, nil
 }
 
-func TestPlanPortalCustomDomain_ExternalPortalSyncSkipsDeleteWhenOmitted(t *testing.T) {
+func TestPlanPortalCustomDomain_ExternalPortalSyncDeletesWhenOmitted(t *testing.T) {
 	t.Parallel()
 
 	stub := &stubPortalCustomDomainAPI{
@@ -211,10 +211,10 @@ func TestPlanPortalCustomDomain_ExternalPortalSyncSkipsDeleteWhenOmitted(t *test
 		plan,
 	)
 	assert.NoError(t, err)
-	assert.Empty(t, plan.Changes)
+	assertDeleteChangeForResourceType(t, plan, ResourceTypePortalCustomDomain)
 }
 
-func TestPlanPortalEmailConfig_ExternalPortalSyncSkipsDeleteWhenOmitted(t *testing.T) {
+func TestPlanPortalEmailConfig_ExternalPortalSyncDeletesWhenOmitted(t *testing.T) {
 	t.Parallel()
 
 	planner := &Planner{
@@ -236,10 +236,10 @@ func TestPlanPortalEmailConfig_ExternalPortalSyncSkipsDeleteWhenOmitted(t *testi
 		plan,
 	)
 	assert.NoError(t, err)
-	assert.Empty(t, plan.Changes)
+	assertDeleteChangeForResourceType(t, plan, ResourceTypePortalEmailConfig)
 }
 
-func TestPlanPortalEmailTemplates_ExternalPortalSyncSkipsDeleteWhenOmitted(t *testing.T) {
+func TestPlanPortalEmailTemplates_ExternalPortalSyncDeletesWhenOmitted(t *testing.T) {
 	t.Parallel()
 
 	planner := &Planner{
@@ -268,10 +268,10 @@ func TestPlanPortalEmailTemplates_ExternalPortalSyncSkipsDeleteWhenOmitted(t *te
 		plan,
 	)
 	assert.NoError(t, err)
-	assert.Empty(t, plan.Changes)
+	assertDeleteChangeForResourceType(t, plan, ResourceTypePortalEmailTemplate)
 }
 
-func TestPlanPortalTeams_ExternalPortalSyncSkipsDeleteWhenOmitted(t *testing.T) {
+func TestPlanPortalTeams_ExternalPortalSyncDeletesWhenOmitted(t *testing.T) {
 	t.Parallel()
 
 	planner := &Planner{
@@ -306,10 +306,10 @@ func TestPlanPortalTeams_ExternalPortalSyncSkipsDeleteWhenOmitted(t *testing.T) 
 		plan,
 	)
 	assert.NoError(t, err)
-	assertNoDeleteChangeForResourceType(t, plan, ResourceTypePortalTeam)
+	assertDeleteChangeForResourceType(t, plan, ResourceTypePortalTeam)
 }
 
-func TestPlanPortalTeamRoles_ExternalPortalSyncSkipsDeleteWhenOmitted(t *testing.T) {
+func TestPlanPortalTeamRoles_ExternalPortalSyncDeletesWhenOmitted(t *testing.T) {
 	t.Parallel()
 
 	region := kkComps.EntityRegion("us")
@@ -390,7 +390,7 @@ func TestPlanPortalTeamRoles_ExternalPortalSyncSkipsDeleteWhenOmitted(t *testing
 		plan,
 	)
 	assert.NoError(t, err)
-	assertNoDeleteChangeForResourceType(t, plan, ResourceTypePortalTeamRole)
+	assertDeleteChangeForResourceType(t, plan, ResourceTypePortalTeamRole)
 }
 
 func externalPortalResource() resources.PortalResource {
@@ -401,12 +401,13 @@ func externalPortalResource() resources.PortalResource {
 	}
 }
 
-func assertNoDeleteChangeForResourceType(t *testing.T, plan *Plan, resourceType string) {
+func assertDeleteChangeForResourceType(t *testing.T, plan *Plan, resourceType string) {
 	t.Helper()
 
 	for _, change := range plan.Changes {
 		if change.ResourceType == resourceType && change.Action == ActionDelete {
-			t.Fatalf("unexpected %s delete planned for external portal: %+v", resourceType, change)
+			return
 		}
 	}
+	t.Fatalf("expected %s delete under external portal, got: %+v", resourceType, plan.Changes)
 }

--- a/internal/declarative/planner/portal_external_children_test.go
+++ b/internal/declarative/planner/portal_external_children_test.go
@@ -495,7 +495,7 @@ func TestPlanner_ExternalPortal_PlansChildren(t *testing.T) {
 	assert.True(t, foundSnippet, "expected a portal_snippet create change")
 }
 
-func TestPlanner_ExternalPortal_SyncDoesNotDeleteExistingPages(t *testing.T) {
+func TestPlanner_ExternalPortal_SyncDoesNotDeleteUnscopedExistingPages(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()

--- a/internal/declarative/planner/portal_planner.go
+++ b/internal/declarative/planner/portal_planner.go
@@ -75,7 +75,6 @@ func (p *portalPlannerImpl) PlanChanges(ctx context.Context, plannerCtx *Config,
 		// We still plan their child resources based on the resolved Konnect ID when available.
 		if desiredPortal.IsExternal() {
 			// If we have a resolved Konnect ID, plan full child diffs.
-			// Sync-mode pruning is skipped for external portal children.
 			if portalID := desiredPortal.GetKonnectID(); portalID != "" {
 				// Build a minimal current portal for child planning
 				current := state.Portal{

--- a/test/e2e/scenarios/event-gateway/external-sync/scenario.yaml
+++ b/test/e2e/scenarios/event-gateway/external-sync/scenario.yaml
@@ -179,7 +179,7 @@ steps:
     inputOverlayDirs:
       - overlays/006-remove-root-level-lookup-policy
     commands:
-      - name: 000-sync-no-deletions
+      - name: 000-sync-delete-omitted-policy
         run:
           - sync
           - -f
@@ -189,12 +189,13 @@ steps:
           - select: plan.summary
             expect:
               fields:
-                total_changes: 0
+                total_changes: 1
+                by_action.DELETE: 1
           - select: >-
               plan.changes[?resource_type=='event_gateway_virtual_cluster_cluster_policy' && action=='DELETE']
             expect:
               fields:
-                "length(@)": 0
+                "length(@)": 1
           - select: plan.changes[?resource_type=='event_gateway_virtual_cluster' && action=='DELETE']
             expect:
               fields:
@@ -212,11 +213,10 @@ steps:
           - -o
           - json
         assertions:
-          - select: "[?name=='{{ .vars.lookup_cluster_policy_name }}'] | [0]"
+          - select: "[?name=='{{ .vars.lookup_cluster_policy_name }}']"
             expect:
               fields:
-                name: "{{ .vars.lookup_cluster_policy_name }}"
-                description: "{{ .vars.lookup_cluster_policy_description }}"
+                "length(@)": 0
 
   - name: 006-sync-with-declarative-cluster-policy
     inputOverlayDirs:
@@ -286,9 +286,9 @@ steps:
               fields:
                 total_changes: 0
 
-  - name: 008-sync-remove-declarative-cluster-policy
+  - name: 008-sync-with-cluster-policy-collection-omitted
     commands:
-      - name: 000-sync-no-deletions
+      - name: 000-sync-omitted-collection
         run:
           - sync
           - -f
@@ -623,9 +623,9 @@ steps:
               fields:
                 "length(@)": 0
 
-  - name: 015-cleanup-declarative-policies
+  - name: 015-sync-with-policy-collections-omitted
     commands:
-      - name: 000-sync-no-deletions
+      - name: 000-sync-omitted-collections
         run:
           - sync
           - -f
@@ -657,17 +657,16 @@ steps:
           - select: "length(@)"
             expect:
               fields:
-                "@": 2
+                "@": 1
           - select: "[?name=='{{ .vars.cluster_policy_name }}'] | [0]"
             expect:
               fields:
                 name: "{{ .vars.cluster_policy_name }}"
                 description: "External sync cluster policy"
-          - select: "[?name=='{{ .vars.lookup_cluster_policy_name }}'] | [0]"
+          - select: "[?name=='{{ .vars.lookup_cluster_policy_name }}']"
             expect:
               fields:
-                name: "{{ .vars.lookup_cluster_policy_name }}"
-                description: "{{ .vars.lookup_cluster_policy_description }}"
+                "length(@)": 0
 
       - name: 002-get-produce-policies-after-cleanup
         run:

--- a/test/e2e/scenarios/external/ai-gateway-parent/scenario.yaml
+++ b/test/e2e/scenarios/external/ai-gateway-parent/scenario.yaml
@@ -102,11 +102,11 @@ steps:
               fields:
                 "@": 0
 
-  - name: 004-sync-does-not-prune-external-children
+  - name: 004-sync-prunes-external-children
     inputOverlayDirs:
       - overlays/001-retain-one-provider
     commands:
-      - name: 000-sync-one-provider
+      - name: 000-sync-delete-omitted-provider
         run:
           - sync
           - -f
@@ -116,13 +116,23 @@ steps:
           - select: plan.summary
             expect:
               fields:
-                total_changes: 0
-          - select: >-
-              plan.changes[?resource_type=='ai_gateway' ||
-                           resource_type=='ai_gateway_model_provider']
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: plan.changes[?resource_type=='ai_gateway_model_provider'] | [0]
+            expect:
+              fields:
+                action: DELETE
+                resource_ref: lookup-openai-provider
+          - select: plan.changes[?resource_type=='ai_gateway']
             expect:
               fields:
                 "length(@)": 0
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+                status: success
 
       - name: 001-get-providers
         run:
@@ -137,7 +147,15 @@ steps:
           - select: "length(@)"
             expect:
               fields:
-                "@": 2
+                "@": 1
+          - select: "[?name=='external-openai-provider'] | [0]"
+            expect:
+              fields:
+                name: external-openai-provider
+          - select: "[?name=='lookup-openai-provider']"
+            expect:
+              fields:
+                "length(@)": 0
 
   - name: 005-verify-external-gateway-remains
     skipInputs: true

--- a/test/e2e/scenarios/external/api-parent/overlays/002-empty-api-children/external-api.yaml
+++ b/test/e2e/scenarios/external/api-parent/overlays/002-empty-api-children/external-api.yaml
@@ -1,0 +1,8 @@
+apis:
+  - ref: external-parent-api
+    _external:
+      selector:
+        matchFields:
+          name: External Parent API
+    versions: []
+    publications: []

--- a/test/e2e/scenarios/external/api-parent/scenario.yaml
+++ b/test/e2e/scenarios/external/api-parent/scenario.yaml
@@ -106,7 +106,66 @@ steps:
                 failed: 0
                 status: success
 
-  - name: 004-reset-org
+  - name: 004-sync-delete-children-under-external-api
+    inputOverlayDirs:
+      - overlays/002-empty-api-children
+    commands:
+      - name: 000-sync
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/external-api.yaml"
+          - --auto-approve
+        assertions:
+          - select: "plan.changes[?resource_type=='api']"
+            expect:
+              fields:
+                "length(@)": 0
+          - select: "plan.changes[?resource_type=='api_version' && action=='DELETE']"
+            expect:
+              fields:
+                "length(@)": 1
+          - select: "plan.changes[?resource_type=='api_publication' && action=='DELETE']"
+            expect:
+              fields:
+                "length(@)": 1
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 2
+                by_action.DELETE: 2
+          - select: summary
+            expect:
+              fields:
+                applied: 2
+                failed: 0
+                status: success
+
+      - name: 001-get-api-versions
+        run: ["get", "api", "versions", "--api-name", "{{ .vars.api_name }}", "-o", "json"]
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                "length(@)": 0
+
+      - name: 002-get-api-publications
+        run: ["get", "api", "publications", "--api-name", "{{ .vars.api_name }}", "-o", "json"]
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                "length(@)": 0
+
+      - name: 003-get-external-api
+        run: ["get", "apis", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.api_name }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.api_name }}"
+
+  - name: 005-reset-org
     skipInputs: true
     commands:
       - resetOrg: true

--- a/test/e2e/scenarios/org/teams/external-role/overlays/002-remove-role/config.yaml
+++ b/test/e2e/scenarios/org/teams/external-role/overlays/002-remove-role/config.yaml
@@ -1,0 +1,9 @@
+organization:
+  teams:
+    - ref: external-role-team
+      name: e2e-external-role-team
+      _external:
+        selector:
+          matchFields:
+            name: e2e-external-role-team
+      roles: []

--- a/test/e2e/scenarios/org/teams/external-role/scenario.yaml
+++ b/test/e2e/scenarios/org/teams/external-role/scenario.yaml
@@ -160,7 +160,64 @@ steps:
               fields:
                 total_changes: 0
 
-  - name: 005-reset-cleanup
+  - name: 005-sync-delete-role-from-external-team
+    inputOverlayDirs:
+      - overlays/002-remove-role
+    commands:
+      - name: 000-sync-delete-role
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+                by_resource.organization_team_role: 1
+          - select: >-
+              plan.changes[?resource_type=='organization_team_role' && action=='DELETE']
+            expect:
+              fields:
+                "length(@)": 1
+          - select: plan.changes[?resource_type=='organization_team']
+            expect:
+              fields:
+                "length(@)": 0
+          - select: summary
+            expect:
+              fields:
+                applied: 1
+                failed: 0
+                status: success
+
+      - name: 001-get-team-roles-after-sync
+        run:
+          - get
+          - org
+          - team
+          - roles
+          - --team-name
+          - "{{ .vars.teamName }}"
+          - -o
+          - json
+        assertions:
+          - select: "[?role_name=='Admin' && entity_id=='*' && entity_type_name=='APIs']"
+            expect:
+              fields:
+                "length(@)": 0
+
+      - name: 002-get-external-team-after-sync
+        run: ["get", "org", "teams", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.teamName }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.teamName }}"
+
+  - name: 006-reset-cleanup
     skipInputs: true
     commands:
       - resetOrg: true

--- a/test/e2e/scenarios/portal/external-sync/overlays/004-empty-pages/external-portal.yaml
+++ b/test/e2e/scenarios/portal/external-sync/overlays/004-empty-pages/external-portal.yaml
@@ -1,0 +1,7 @@
+portals:
+  - ref: external-sync-portal
+    _external:
+      selector:
+        matchFields:
+          name: "external-sync-portal"
+    pages: []

--- a/test/e2e/scenarios/portal/external-sync/scenario.yaml
+++ b/test/e2e/scenarios/portal/external-sync/scenario.yaml
@@ -83,16 +83,17 @@ steps:
           - select: plan.summary
             expect:
               fields:
-                total_changes: 1
+                total_changes: 3
                 by_action.CREATE: 1
+                by_action.DELETE: 2
           - select: plan.changes[?resource_type=='portal_page' && action=='DELETE']
             expect:
               fields:
-                "length(@)": 0
+                "length(@)": 2
           - select: summary
             expect:
               fields:
-                applied: 1
+                applied: 3
                 failed: 0
 
       - name: 001-get-portal-pages
@@ -110,14 +111,14 @@ steps:
               fields:
                 slug: declarative-page
                 title: "Declarative Page"
-          - select: "[?slug=='getting-started'] | [0]"
+          - select: "[?slug=='getting-started']"
             expect:
               fields:
-                slug: getting-started
-          - select: "[?slug=='guides'] | [0]"
+                "length(@)": 0
+          - select: "[?slug=='guides']"
             expect:
               fields:
-                slug: guides
+                "length(@)": 0
 
   - name: 004-sync-idempotency
     inputOverlayDirs:
@@ -135,9 +136,9 @@ steps:
               fields:
                 total_changes: 0
 
-  - name: 005-sync-remove-declarative-page
+  - name: 005-sync-with-page-collection-omitted
     commands:
-      - name: 000-sync-no-deletions
+      - name: 000-sync-omitted-collection
         run:
           - sync
           - -f
@@ -149,7 +150,7 @@ steps:
               fields:
                 total_changes: 0
 
-      - name: 001-get-portal-pages-after-sync
+      - name: 001-get-portal-pages-after-omitted-collection
         run:
           - get
           - portal
@@ -163,14 +164,14 @@ steps:
             expect:
               fields:
                 slug: declarative-page
-          - select: "[?slug=='getting-started'] | [0]"
+          - select: "[?slug=='getting-started']"
             expect:
               fields:
-                slug: getting-started
-          - select: "[?slug=='guides'] | [0]"
+                "length(@)": 0
+          - select: "[?slug=='guides']"
             expect:
               fields:
-                slug: guides
+                "length(@)": 0
 
   - name: 006-sync-update-declarative-page
     inputOverlayDirs:
@@ -220,14 +221,14 @@ steps:
                 title: "Updated Declarative Page"
                 visibility: "private"
                 status: "unpublished"
-          - select: "[?slug=='getting-started'] | [0]"
+          - select: "[?slug=='getting-started']"
             expect:
               fields:
-                slug: getting-started
-          - select: "[?slug=='guides'] | [0]"
+                "length(@)": 0
+          - select: "[?slug=='guides']"
             expect:
               fields:
-                slug: guides
+                "length(@)": 0
 
   - name: 007-sync-update-idempotency
     inputOverlayDirs:
@@ -296,14 +297,14 @@ steps:
               fields:
                 total_changes: 0
 
-  - name: 009-delete-declarative-page
+  - name: 009-sync-delete-pages-from-external-portal
     inputOverlayDirs:
-      - overlays/003-update-page
+      - overlays/004-empty-pages
     commands:
-      - name: 000-delete-page
+      - name: 000-sync-delete-pages
         outputFormat: json
         run:
-          - delete
+          - sync
           - -f
           - "{{ .workdir }}/external-portal.yaml"
           - --auto-approve
@@ -311,18 +312,17 @@ steps:
           - select: plan.metadata
             expect:
               fields:
-                mode: delete
+                mode: sync
           - select: plan.summary
             expect:
               fields:
                 total_changes: 1
                 by_action.DELETE: 1
                 by_resource.portal_page: 1
-          - select: >-
-              plan.changes[?resource_type=='portal_page' && resource_ref=='declarative-page'] | [0]
+          - select: plan.changes[?resource_type=='portal_page' && action=='DELETE']
             expect:
               fields:
-                action: DELETE
+                "length(@)": 1
           - select: summary
             expect:
               fields:
@@ -343,16 +343,14 @@ steps:
             expect:
               fields:
                 "length(@)": 0
-          - select: "[?slug=='getting-started'] | [0]"
+          - select: "[?slug=='getting-started']"
             expect:
               fields:
-                slug: getting-started
-                title: "Getting Started"
-          - select: "[?slug=='guides'] | [0]"
+                "length(@)": 0
+          - select: "[?slug=='guides']"
             expect:
               fields:
-                slug: guides
-                title: "Guides"
+                "length(@)": 0
 
       - name: 002-get-external-portal-after-delete
         run:


### PR DESCRIPTION
## Summary

- reconcile explicitly scoped children beneath external AI Gateway, Event Gateway, Portal, organization team, and API parents
- preserve protection of external parents and leave omitted child collections outside sync scope
- support sync deletion for API versions, publications, implementations, and documents beneath externally resolved APIs
- preserve extracted API children during normal and idempotent sync, then prune them only when their child collection is explicitly empty
- add unit and E2E coverage for stale child deletion, including the AI Gateway lookup reproduction and API external-parent lifecycle
- document external-parent sync semantics

PR #2012 is merged into `main` and provides the external-resource registry, API external-parent support, and portal-owned round-trip fix used here.

Closes #2008

## Validation

- `go fix ./...`
- `make format`
- `make build`
- `make test`
- `make test-integration`
- E2E: `dump/portal-owned`
- E2E: `external/ai-gateway-parent`
- E2E: `event-gateway/external-sync`
- E2E: `portal/external-sync`
- E2E: `org/teams/external-role`
- E2E: `external/api-parent`

`make lint` reports the existing 56 generated/mock-file findings (50 line-length, 4 spelling, and 2 staticcheck); this change introduces no lint findings.