### PR TITLE
feat(declarative): expand external resource lookups

### DIFF
--- a/docs/contributor/declarative-resource-implementation-guide.md
+++ b/docs/contributor/declarative-resource-implementation-guide.md
@@ -1860,15 +1860,23 @@ Resource types that support `_external` or inline lookup targets must:
 2. Use `registerExternalResourceType` (or its slice-accessor variant) so the
    capability is enforced by the generic registration constraint.
 3. Register supported selectors and any parent resource type.
-4. Provide exactly one planner lookup adapter.
+4. Provide exactly one unrestricted planner lookup adapter. Managed-label
+   filtered list operations are not valid for external identity lookup.
 5. Add unit, integration, and E2E coverage for selector, ambiguity, missing
    scope, caching, and unmanaged lifecycle behavior.
 
 Cross-resource YAML fields use static `RelationshipDescriptor` metadata. Mark
 API schema IDs as `api_foreign_key` and kongctl-added root parent fields as
-`kongctl_parent_selector`. Include the target type, scope field, and root-only
-placement. This metadata drives planner inference and `kongctl explain`; do not
-add field-name switches to individual planners.
+`kongctl_parent_selector`. Include the target type (or discriminator), scalar
+or list cardinality, result field, scope field, and root-only placement. This
+metadata drives planner inference and `kongctl explain`; do not add field-name
+switches to individual planners.
+
+Every relationship target must register either external resolution or a
+specific `WithExternalUnsupportedReason`. The relationship contract test
+enforces that disposition. Registry external registration supplies generic
+materialization, including scoped parent fields, so planner code must not add
+resource-type construction switches.
 
 Keep execution dependencies separate from relationship metadata. Dependencies
 control operation ordering, while relationship descriptors define the YAML

--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -95,7 +95,7 @@ inside `!secret`:
 portal_id: !lookup
   name: !env PORTAL_NAME
 
-control_plane: !external {name: !env CONTROL_PLANE_NAME}
+control_plane: !lookup {name: !env CONTROL_PLANE_NAME}
 ```
 
 | Outer tag | Supported inner tags |
@@ -142,11 +142,12 @@ selectors such as `ai_gateway` retain their established names. They share the
 same relationship resolution behavior. Parent selectors are omitted when the
 child is nested and the parent can be inferred.
 
-Initially, inline lookup targets are the resource types that already support
-`_external`: portals, control planes, gateway services, AI gateways, audit-log
-webhook destinations, organization teams, Event Gateway control planes, and
-Event Gateway virtual clusters. Run `kongctl explain` to see selectors and
-scope requirements for a specific field.
+Inline lookup targets are the resource types that support `_external`:
+Catalog APIs, application auth strategies, portals, control planes, gateway
+services, AI gateways, audit-log webhook destinations, organization teams,
+Event Gateway control planes, and Event Gateway virtual clusters. Run
+`kongctl explain` to see selectors and scope requirements for a specific
+field.
 
 ## Audit Logs
 
@@ -178,6 +179,8 @@ created, updated, or deleted by declarative apply.
 apis:
   - ref: string
     name: string required (1-255 chars)
+    _external: # alternative to managed API fields
+      id: string # API UUID, or use selector.matchFields.name
     description: string (nullable)
     version: string (1-255 chars, nullable)
     slug: string (pattern: ^[\w-]+$, nullable)
@@ -226,6 +229,12 @@ API specifications must be declared on API versions with `versions[].spec` or
 root-level `api_versions[].spec`; `apis[].spec_content` is not supported in
 declarative configuration.
 
+An external API can own managed versions, publications, implementations, and
+documents in the same manifest. kongctl resolves the API identity and plans
+only its declared children; it never creates, updates, or deletes the API.
+Root-level API children can use `api: !lookup name:Shared API` as the anonymous
+equivalent.
+
 Each API implementation must define exactly one of `service` or
 `control_plane`. When `type` is present, it must match the selected payload.
 
@@ -233,6 +242,25 @@ Each API implementation must define exactly one of `service` or
 
 [API Specification](https://developer.konghq.com/api/konnect/application-auth-strategies/v2/#/operations/create-app-auth-strategy)
 [Example](examples/declarative/portal/auth-strategies.yaml)
+
+```yaml
+application_auth_strategies:
+ - ref: string
+   _external: # alternative to managed strategy fields
+     id: string # strategy UUID, or use selector by name/display_name
+```
+
+External application auth strategies are identity-only declarations. They can
+be referenced from `portals[].default_application_auth_strategy_id` and
+`apis[].publications[].auth_strategy_ids`. For a one-off relationship, use
+`!lookup`, for example:
+
+```yaml
+auth_strategy_ids:
+  - !lookup name:Shared Auth
+```
+
+Managed application auth strategies use the following fields:
 
 ```yaml
 application_auth_strategies:

--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -447,12 +447,37 @@ portals:
           name: "Shared Developer Portal"
 ```
 
+Catalog APIs and application auth strategies can also be declared external.
+An external API may contain managed versions, publications, implementations,
+and documents:
+
+```yaml
+apis:
+  - ref: shared-api
+    _external:
+      selector:
+        matchFields:
+          name: Shared API
+    versions:
+      - ref: shared-api-v2
+        version: v2
+        spec: !file ./openapi.yaml
+```
+
+The API itself remains outside kongctl management. The declared version is
+managed beneath the resolved API ID.
+
 Because kongctl does not own those resources:
-- External resources **cannot** declare `kongctl` metadata. Supplying `kongctl.namespace` or `kongctl.protected`
-  on an external resource results in a parsing error. File-level defaults are ignored for externals.
-- External references do **not** add their namespaces to sync planning. Only namespaces from managed parent
-  resources are considered when sync mode calculates deletes.
-- Child resources (portal pages, customizations, etc.) are still planned by resolving the external parent's Konnect ID.
+
+- External resources **cannot** declare `kongctl` metadata. Supplying
+  `kongctl.namespace` or `kongctl.protected` on an external resource results
+  in a parsing error. File-level defaults are ignored for externals.
+- External references do **not** add their namespaces to sync planning. Only
+  namespaces from managed parent resources are considered when sync mode
+  calculates deletes.
+- Child resources (portal pages, API versions, publications,
+  implementations, documents, etc.) are still planned by resolving the
+  external parent's Konnect ID.
   You do not need to (and cannot) assign a namespace to the external
   definition itself.
 
@@ -802,7 +827,7 @@ portal_id: !lookup
   name: !env PORTAL_NAME
 
 # Compact flow syntax
-control_plane: !external {name: !env CONTROL_PLANE_NAME}
+control_plane: !lookup {name: !env CONTROL_PLANE_NAME}
 ```
 
 Both scalar and map forms of the nested `!env` tag are supported. Multiple

--- a/docs/examples/declarative/external/api-parent/README.md
+++ b/docs/examples/declarative/external/api-parent/README.md
@@ -1,0 +1,16 @@
+# External API Parent
+
+This example resolves an existing Catalog API by name and manages an API
+version beneath it. The API itself remains external and never receives a
+create, update, or delete operation.
+
+Create an API named `Shared API` in Konnect, then preview or apply the example:
+
+```bash
+kongctl plan -f external-api-version.yaml --mode apply
+kongctl apply -f external-api-version.yaml
+```
+
+The scalar `!lookup name:Shared API` form keeps the example concise. Mapping
+syntax is available when selector values need YAML composition; `!external`
+is supported as an exact alias for `!lookup`.

--- a/docs/examples/declarative/external/api-parent/external-api-version.yaml
+++ b/docs/examples/declarative/external/api-parent/external-api-version.yaml
@@ -1,0 +1,11 @@
+# The API must already exist in Konnect. kongctl manages only this version.
+api_versions:
+  - ref: shared-api-v2
+    api: !lookup name:Shared API
+    version: v2
+    spec:
+      openapi: 3.0.0
+      info:
+        title: Shared API
+        version: v2
+      paths: {}

--- a/internal/declarative/executor/api_publication_adapter_test.go
+++ b/internal/declarative/executor/api_publication_adapter_test.go
@@ -189,6 +189,59 @@ func TestExecutorCreateAPIPublicationAcceptsResolvedAuthStrategyUUID(t *testing.
 	}
 }
 
+func TestExecutorCreateAPIPublicationUsesRecreatedAuthStrategyForDumpedUUIDRef(t *testing.T) {
+	t.Parallel()
+
+	const (
+		dumpedAuthStrategyRef   = "a86aec1e-f67f-4624-919f-b11292b11159"
+		recreatedAuthStrategyID = "92f2a7e6-3d5d-4df7-ac2e-3391bb2257cf"
+	)
+	authAPI := &stubAppAuthStrategiesAPI{t: t}
+	publicationAPI := &stubAPIPublicationAPI{t: t}
+	client := state.NewClient(state.ClientConfig{
+		AppAuthAPI:        authAPI,
+		APIPublicationAPI: publicationAPI,
+	})
+	exec := New(client, nil, false)
+	exec.setRef(planner.ResourceTypeApplicationAuthStrategy, dumpedAuthStrategyRef, recreatedAuthStrategyID)
+	change := planner.PlannedChange{
+		ID:           "2:c:api_publication:dumped-publication",
+		ResourceType: planner.ResourceTypeAPIPublication,
+		ResourceRef:  "dumped-publication",
+		Action:       planner.ActionCreate,
+		Fields: map[string]any{
+			planner.FieldAuthStrategyIDs: []string{dumpedAuthStrategyRef},
+			planner.FieldVisibility:      "public",
+		},
+		Parent: &planner.ParentInfo{Ref: "dumped-api", ID: "api-123"},
+		References: map[string]planner.ReferenceInfo{
+			planner.FieldAPIID:    {Ref: "dumped-api", ID: "api-123"},
+			planner.FieldPortalID: {Ref: "dumped-portal", ID: "portal-456"},
+			planner.FieldAuthStrategyIDs: {
+				Refs:         []string{dumpedAuthStrategyRef},
+				IsArray:      true,
+				LookupArrays: map[string][]string{"names": {"key-auth"}},
+			},
+		},
+	}
+
+	_, err := exec.createResource(t.Context(), &change)
+	if err != nil {
+		t.Fatalf("createResource() error = %v", err)
+	}
+	if authAPI.listCalls != 0 {
+		t.Fatalf("ListAppAuthStrategies() calls = %d, want 0", authAPI.listCalls)
+	}
+	if len(publicationAPI.publishReq.AuthStrategyIds) != 1 ||
+		publicationAPI.publishReq.AuthStrategyIds[0] != recreatedAuthStrategyID {
+		t.Fatalf(
+			"PublishAPIToPortal() auth strategy IDs = %v, want [%s]",
+			publicationAPI.publishReq.AuthStrategyIds,
+			recreatedAuthStrategyID,
+		)
+	}
+}
+
 func TestAPIPublicationAdapterDeleteFallsBackToCompositeResourceID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/declarative/executor/api_publication_adapter_test.go
+++ b/internal/declarative/executor/api_publication_adapter_test.go
@@ -134,6 +134,61 @@ func TestAPIPublicationAdapterCreatePublishesAPIToResolvedPortal(t *testing.T) {
 	}
 }
 
+func TestExecutorCreateAPIPublicationAcceptsResolvedAuthStrategyUUID(t *testing.T) {
+	t.Parallel()
+
+	const authStrategyID = "a86aec1e-f67f-4624-919f-b11292b11159"
+	authAPI := &stubAppAuthStrategiesAPI{t: t}
+	publicationAPI := &stubAPIPublicationAPI{t: t}
+	client := state.NewClient(state.ClientConfig{
+		AppAuthAPI:        authAPI,
+		APIPublicationAPI: publicationAPI,
+	})
+	exec := New(client, nil, false)
+	change := planner.PlannedChange{
+		ID:           "1:c:api_publication:external-parent-publication",
+		ResourceType: planner.ResourceTypeAPIPublication,
+		ResourceRef:  "external-parent-publication",
+		Action:       planner.ActionCreate,
+		Fields: map[string]any{
+			planner.FieldAuthStrategyIDs: []string{authStrategyID},
+			planner.FieldVisibility:      "public",
+		},
+		Parent: &planner.ParentInfo{Ref: "external-parent-api", ID: "api-123"},
+		References: map[string]planner.ReferenceInfo{
+			planner.FieldAPIID: {
+				Ref: "external-parent-api",
+				ID:  "api-123",
+			},
+			planner.FieldPortalID: {
+				Ref: "portal-456",
+				ID:  "portal-456",
+			},
+			planner.FieldAuthStrategyIDs: {
+				Refs:         []string{authStrategyID},
+				IsArray:      true,
+				LookupArrays: map[string][]string{"names": {""}},
+			},
+		},
+	}
+
+	_, err := exec.createResource(context.Background(), &change)
+	if err != nil {
+		t.Fatalf("createResource() error = %v", err)
+	}
+	if authAPI.listCalls != 0 {
+		t.Fatalf("ListAppAuthStrategies() calls = %d, want 0", authAPI.listCalls)
+	}
+	if len(publicationAPI.publishReq.AuthStrategyIds) != 1 ||
+		publicationAPI.publishReq.AuthStrategyIds[0] != authStrategyID {
+		t.Fatalf(
+			"PublishAPIToPortal() auth strategy IDs = %v, want [%s]",
+			publicationAPI.publishReq.AuthStrategyIds,
+			authStrategyID,
+		)
+	}
+}
+
 func TestAPIPublicationAdapterDeleteFallsBackToCompositeResourceID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -1649,6 +1649,16 @@ func (e *Executor) syncResolvedAPIPublicationAuthStrategyIDs(
 		if resolvedIDs[i] != "" {
 			continue
 		}
+		lookupRef := ref
+		if tags.IsRefPlaceholder(lookupRef) {
+			if parsedRef, _, ok := tags.ParseRefPlaceholder(lookupRef); ok && parsedRef != "" {
+				lookupRef = parsedRef
+			}
+		}
+		if id, ok := e.getRefAny(planner.ResourceTypeApplicationAuthStrategy, lookupRef, ref); ok {
+			resolvedIDs[i] = id
+			continue
+		}
 		if util.IsValidUUID(ref) {
 			resolvedIDs[i] = ref
 			continue

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kong/kongctl/internal/declarative/state"
 	"github.com/kong/kongctl/internal/declarative/tags"
 	"github.com/kong/kongctl/internal/log"
+	"github.com/kong/kongctl/internal/util"
 	"github.com/kong/kongctl/internal/util/normalizers"
 	"golang.org/x/sync/errgroup"
 )
@@ -1633,6 +1634,45 @@ func (e *Executor) syncResolvedPortalDefaultAuthStrategyID(
 	)
 }
 
+func (e *Executor) syncResolvedAPIPublicationAuthStrategyIDs(
+	ctx context.Context,
+	change *planner.PlannedChange,
+) error {
+	authStrategyRefs, ok := change.References[planner.FieldAuthStrategyIDs]
+	if !ok || !authStrategyRefs.IsArray {
+		return nil
+	}
+
+	resolvedIDs := make([]string, len(authStrategyRefs.Refs))
+	copy(resolvedIDs, authStrategyRefs.ResolvedIDs)
+	for i, ref := range authStrategyRefs.Refs {
+		if resolvedIDs[i] != "" {
+			continue
+		}
+		if util.IsValidUUID(ref) {
+			resolvedIDs[i] = ref
+			continue
+		}
+
+		refInfo := planner.ReferenceInfo{Ref: ref}
+		if names := authStrategyRefs.LookupArrays["names"]; i < len(names) && names[i] != "" {
+			refInfo.LookupFields = map[string]string{planner.FieldName: names[i]}
+		}
+		resolvedID, err := e.resolveAuthStrategyRef(ctx, refInfo)
+		if err != nil {
+			return fmt.Errorf("failed to resolve auth strategy reference %q: %w", ref, err)
+		}
+		if resolvedID == "" {
+			return fmt.Errorf("failed to resolve auth strategy reference %q", ref)
+		}
+		resolvedIDs[i] = resolvedID
+	}
+
+	authStrategyRefs.ResolvedIDs = resolvedIDs
+	change.References[planner.FieldAuthStrategyIDs] = authStrategyRefs
+	return nil
+}
+
 func (e *Executor) syncResolvedAIGatewayID(
 	ctx context.Context,
 	change *planner.PlannedChange,
@@ -2823,46 +2863,8 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 			portalRef.ID = portalID
 			change.References[planner.FieldPortalID] = portalRef
 		}
-		// Resolve auth_strategy_ids array references if needed
-		if authStrategyRefs, ok := change.References[planner.FieldAuthStrategyIDs]; ok && authStrategyRefs.IsArray {
-			resolvedIDs := make([]string, 0, len(authStrategyRefs.Refs))
-
-			for i, ref := range authStrategyRefs.Refs {
-				var resolvedID string
-				var err error
-
-				// Check if already resolved
-				if authStrategyRefs.ResolvedIDs != nil && i < len(authStrategyRefs.ResolvedIDs) &&
-					authStrategyRefs.ResolvedIDs[i] != "" {
-					resolvedID = authStrategyRefs.ResolvedIDs[i]
-				} else {
-					// Construct ReferenceInfo for the auth strategy
-					refInfo := planner.ReferenceInfo{
-						Ref: ref,
-					}
-					// Add lookup fields if available
-					if names, ok := authStrategyRefs.LookupArrays["names"]; ok && i < len(names) {
-						refInfo.LookupFields = map[string]string{
-							planner.FieldName: names[i],
-						}
-					}
-
-					resolvedID, err = e.resolveAuthStrategyRef(ctx, refInfo)
-					if err != nil {
-						return "", fmt.Errorf("failed to resolve auth strategy reference %q: %w", ref, err)
-					}
-				}
-
-				if resolvedID == "" {
-					return "", fmt.Errorf("failed to resolve auth strategy reference %q", ref)
-				}
-
-				resolvedIDs = append(resolvedIDs, resolvedID)
-			}
-
-			// Update the reference with resolved IDs
-			authStrategyRefs.ResolvedIDs = resolvedIDs
-			change.References[planner.FieldAuthStrategyIDs] = authStrategyRefs
+		if err := e.syncResolvedAPIPublicationAuthStrategyIDs(ctx, change); err != nil {
+			return "", err
 		}
 		return e.apiPublicationExecutor.Create(ctx, *change)
 	case planner.ResourceTypeAPIImplementation:
@@ -3482,33 +3484,8 @@ func (e *Executor) updateResource(ctx context.Context, change *planner.PlannedCh
 			portalRef.ID = portalID
 			change.References[planner.FieldPortalID] = portalRef
 		}
-		// Resolve auth strategy references if present
-		if authStrategyRefs, ok := change.References[planner.FieldAuthStrategyIDs]; ok && authStrategyRefs.IsArray {
-			resolvedIDs := make([]string, 0, len(authStrategyRefs.Refs))
-			for _, ref := range authStrategyRefs.Refs {
-				strategyRef := planner.ReferenceInfo{
-					Ref:          ref,
-					LookupFields: make(map[string]string),
-				}
-				// Copy lookup fields if available
-				if authStrategyRefs.LookupArrays != nil && len(authStrategyRefs.LookupArrays["names"]) > 0 {
-					// Find corresponding name for this ref
-					for i, r := range authStrategyRefs.Refs {
-						if r == ref && i < len(authStrategyRefs.LookupArrays["names"]) {
-							strategyRef.LookupFields[planner.FieldName] = authStrategyRefs.LookupArrays["names"][i]
-							break
-						}
-					}
-				}
-				resolvedID, err := e.resolveAuthStrategyRef(ctx, strategyRef)
-				if err != nil {
-					return "", fmt.Errorf("failed to resolve auth strategy reference %q: %w", ref, err)
-				}
-				resolvedIDs = append(resolvedIDs, resolvedID)
-			}
-			// Update the reference with resolved IDs
-			authStrategyRefs.ResolvedIDs = resolvedIDs
-			change.References[planner.FieldAuthStrategyIDs] = authStrategyRefs
+		if err := e.syncResolvedAPIPublicationAuthStrategyIDs(ctx, change); err != nil {
+			return "", err
 		}
 		// Use Create method which handles PUT (both create and update)
 		return e.apiPublicationExecutor.Create(ctx, *change)

--- a/internal/declarative/planner/api_planner.go
+++ b/internal/declarative/planner/api_planner.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/kong/kongctl/internal/declarative/attributes"
 	"github.com/kong/kongctl/internal/declarative/labels"
 	"github.com/kong/kongctl/internal/declarative/resources"
@@ -98,7 +99,11 @@ func (p *Planner) planAPIChanges(
 
 	// Fetch current managed APIs from the specific namespace
 	namespaceFilter := []string{namespace}
-	currentAPIs, err := p.listManagedAPIs(ctx, namespaceFilter)
+	var currentAPIs []state.API
+	var err error
+	if namespace != resources.NamespaceExternal {
+		currentAPIs, err = p.listManagedAPIs(ctx, namespaceFilter)
+	}
 	if err != nil {
 		// If API client is not configured, skip API planning
 		if err.Error() == "API client not configured" {
@@ -117,6 +122,16 @@ func (p *Planner) planAPIChanges(
 	if plan.Metadata.Mode == PlanModeDelete {
 		var protectionErrors []error
 		for _, desiredAPI := range desired {
+			if desiredAPI.IsExternal() {
+				apiID := desiredAPI.GetKonnectID()
+				if apiID == "" {
+					return fmt.Errorf("external API %q does not have a resolved Konnect ID", desiredAPI.GetRef())
+				}
+				if err := p.planExternalAPIChildDeletes(ctx, desiredAPI, apiID, plan); err != nil {
+					return fmt.Errorf("failed to plan deletes beneath external API %q: %w", desiredAPI.GetRef(), err)
+				}
+				continue
+			}
 			current, exists := currentByName[desiredAPI.Name]
 			if !exists {
 				plan.AddWarning("", fmt.Sprintf(
@@ -148,6 +163,16 @@ func (p *Planner) planAPIChanges(
 
 	// Compare each desired API
 	for _, desiredAPI := range desired {
+		if desiredAPI.IsExternal() {
+			if desiredAPI.GetKonnectID() == "" {
+				return fmt.Errorf("external API %q does not have a resolved Konnect ID", desiredAPI.GetRef())
+			}
+			current := state.API{APIResponseSchema: kkComps.APIResponseSchema{ID: desiredAPI.GetKonnectID()}}
+			if err := p.planAPIChildResourceChanges(ctx, plannerCtx, current, desiredAPI, plan); err != nil {
+				return err
+			}
+			continue
+		}
 		current, exists := currentByName[desiredAPI.Name]
 
 		if !exists {
@@ -222,7 +247,9 @@ func (p *Planner) planAPIChanges(
 		// Build set of desired API names
 		desiredNames := make(map[string]bool)
 		for _, api := range desired {
-			desiredNames[api.Name] = true
+			if !api.IsExternal() {
+				desiredNames[api.Name] = true
+			}
 		}
 
 		// Find managed APIs not in desired state
@@ -249,6 +276,126 @@ func (p *Planner) planAPIChanges(
 	}
 
 	return nil
+}
+
+// planExternalAPIChildDeletes deletes only descendants explicitly present in a
+// delete manifest. The external API itself remains outside kongctl's lifecycle.
+func (p *Planner) planExternalAPIChildDeletes(
+	ctx context.Context,
+	desiredAPI resources.APIResource,
+	apiID string,
+	plan *Plan,
+) error {
+	parentNamespace := DefaultNamespace
+	if desiredAPI.Kongctl != nil && desiredAPI.Kongctl.Namespace != nil {
+		parentNamespace = *desiredAPI.Kongctl.Namespace
+	}
+	apiRef := desiredAPI.GetRef()
+
+	desiredVersions := p.getAPIVersionsForAPI(desiredAPI)
+	if len(desiredVersions) > 0 {
+		currentVersions, err := p.client.ListAPIVersions(ctx, apiID)
+		if err != nil {
+			return fmt.Errorf("failed to list API versions: %w", err)
+		}
+		versionsByName := make(map[string]state.APIVersion, len(currentVersions))
+		for _, version := range currentVersions {
+			versionsByName[version.Version] = version
+		}
+		for _, desired := range desiredVersions {
+			if desired.Version == nil {
+				continue
+			}
+			if current, ok := versionsByName[*desired.Version]; ok {
+				p.planAPIVersionDelete(parentNamespace, apiRef, apiID, current.ID, current.Version, plan)
+			}
+		}
+	}
+
+	desiredPublications := p.getAPIPublicationsForAPI(desiredAPI)
+	if len(desiredPublications) > 0 {
+		currentPublications, err := p.client.ListAPIPublications(ctx, apiID)
+		if err != nil {
+			return fmt.Errorf("failed to list API publications: %w", err)
+		}
+		publicationsByPortalID := make(map[string]state.APIPublication, len(currentPublications))
+		for _, publication := range currentPublications {
+			publicationsByPortalID[publication.PortalID] = publication
+		}
+		for _, desired := range desiredPublications {
+			portalID, portalRef := p.resolveDesiredPublicationPortal(desired)
+			if current, ok := publicationsByPortalID[portalID]; ok {
+				p.planAPIPublicationDelete(parentNamespace, apiRef, apiID, portalID, portalRef, current, plan)
+			}
+		}
+	}
+
+	desiredImplementations := p.getAPIImplementationsForAPI(desiredAPI)
+	if len(desiredImplementations) > 0 {
+		currentImplementations, err := p.client.ListAPIImplementations(ctx, apiID)
+		if err != nil {
+			return fmt.Errorf("failed to list API implementations: %w", err)
+		}
+		implementationsByService := make(map[string]state.APIImplementation)
+		implementationsByControlPlane := make(map[string]state.APIImplementation)
+		for _, implementation := range currentImplementations {
+			if implementation.Service != nil {
+				key := fmt.Sprintf("%s:%s", implementation.Service.ID, implementation.Service.ControlPlaneID)
+				implementationsByService[key] = implementation
+			}
+			if implementation.ControlPlane != nil {
+				implementationsByControlPlane[implementation.ControlPlane.ID] = implementation
+			}
+		}
+		for _, desired := range desiredImplementations {
+			if service := desired.ServiceReference.GetService(); service != nil {
+				key := fmt.Sprintf("%s:%s", service.ID, service.ControlPlaneID)
+				if current, ok := implementationsByService[key]; ok {
+					p.planAPIImplementationDelete(parentNamespace, apiRef, apiID, current, plan)
+				}
+			}
+			if controlPlane := desired.ControlPlaneReference.GetControlPlane(); controlPlane != nil {
+				if current, ok := implementationsByControlPlane[controlPlane.ID]; ok {
+					p.planAPIImplementationDelete(parentNamespace, apiRef, apiID, current, plan)
+				}
+			}
+		}
+	}
+
+	desiredDocuments := p.getAPIDocumentsForAPI(desiredAPI)
+	if len(desiredDocuments) > 0 {
+		currentDocuments, err := p.client.ListAPIDocuments(ctx, apiID)
+		if err != nil {
+			return fmt.Errorf("failed to list API documents: %w", err)
+		}
+		documentLookup := p.buildAPIDocumentLookup(desiredDocuments)
+		documentIndex := newAPIDocumentStateIndex(currentDocuments)
+		for _, desired := range desiredDocuments {
+			path := documentLookup.paths[desired.GetRef()]
+			if path == "" && desired.Slug != nil {
+				path = strings.TrimPrefix(*desired.Slug, "/")
+			}
+			if current, ok := documentIndex.getByPath(path); ok {
+				p.planAPIDocumentDelete(parentNamespace, apiRef, apiID, current.ID, path, plan)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (p *Planner) resolveDesiredPublicationPortal(
+	publication resources.APIPublicationResource,
+) (portalID string, portalRef string) {
+	portalID = publication.PortalID
+	portalRef = publication.PortalID
+	if parsedRef, _, ok := tags.ParseRefPlaceholder(publication.PortalID); ok {
+		portalRef = parsedRef
+	}
+	if portal := p.resources.GetPortalByRef(portalRef); portal != nil && portal.GetKonnectID() != "" {
+		portalID = portal.GetKonnectID()
+	}
+	return portalID, portalRef
 }
 
 // extractAPIFields extracts fields from an API resource for planner operations
@@ -802,6 +949,9 @@ func (p *Planner) planAPIVersionChanges(
 
 	// In sync mode, delete unmanaged versions
 	if plan.Metadata.Mode == PlanModeSync {
+		if p.isExternalAPI(apiRef) {
+			return nil
+		}
 		// Check if there are extracted versions for this API that will be processed later
 		hasExtractedVersions := false
 		for _, ver := range p.resources.GetAPIVersionsByNamespace(parentNamespace) {
@@ -1070,6 +1220,9 @@ func (p *Planner) planAPIPublicationChanges(
 
 	// In sync mode, delete unmanaged publications
 	if plan.Metadata.Mode == PlanModeSync {
+		if p.isExternalAPI(apiRef) {
+			return nil
+		}
 		// Check if there are extracted publications for this API that will be processed later
 		hasExtractedPublications := false
 		for _, pub := range p.resources.GetAPIPublicationsByNamespace(parentNamespace) {
@@ -1559,6 +1712,9 @@ func (p *Planner) planAPIImplementationChanges(
 
 	// In sync mode, delete unmanaged implementations
 	if plan.Metadata.Mode == PlanModeSync {
+		if p.isExternalAPI(apiRef) {
+			return nil
+		}
 		// Check if there are extracted implementations for this API that will be processed later
 		hasExtractedImplementations := false
 		for _, impl := range p.resources.GetAPIImplementationsByNamespace(parentNamespace) {
@@ -1782,6 +1938,9 @@ func (p *Planner) planAPIDocumentChanges(
 
 	// In sync mode, delete unmanaged documents
 	if plan.Metadata.Mode == PlanModeSync {
+		if p.isExternalAPI(apiRef) {
+			return nil
+		}
 		remaining := stateIndex.unprocessed()
 		for path, current := range remaining {
 			p.planAPIDocumentDelete(parentNamespace, apiRef, apiID, current.ID, path, plan)
@@ -1789,6 +1948,11 @@ func (p *Planner) planAPIDocumentChanges(
 	}
 
 	return nil
+}
+
+func (p *Planner) isExternalAPI(apiRef string) bool {
+	api := p.resources.GetAPIByRef(apiRef)
+	return api != nil && api.IsExternal()
 }
 
 func (p *Planner) shouldUpdateAPIDocument(current state.APIDocument, desired resources.APIDocumentResource) bool {

--- a/internal/declarative/planner/api_planner.go
+++ b/internal/declarative/planner/api_planner.go
@@ -1368,23 +1368,12 @@ func (p *Planner) planAPIPublicationCreate(
 
 	// Set up auth_strategy_ids references (array)
 	if len(publication.AuthStrategyIds) > 0 {
-		// Look up names for each auth strategy reference
-		var authStrategyNames []string
-		for _, ref := range publication.AuthStrategyIds {
-			// Find the auth strategy in desired state using global lookup
-			var strategyName string
-			if strategy := p.resources.GetAuthStrategyByRef(ref); strategy != nil {
-				strategyName = p.getAuthStrategyName(*strategy)
-			}
-			authStrategyNames = append(authStrategyNames, strategyName)
-		}
-
 		// Set up array reference with lookup names
 		change.References[FieldAuthStrategyIDs] = ReferenceInfo{
 			Refs:    publication.AuthStrategyIds,
 			IsArray: true,
 			LookupArrays: map[string][]string{
-				"names": authStrategyNames,
+				"names": p.authStrategyLookupNames(publication.AuthStrategyIds),
 			},
 		}
 	}
@@ -1505,26 +1494,36 @@ func (p *Planner) planAPIPublicationUpdate(
 
 	// Handle auth strategy references if they are being updated
 	if authStrategyIDs, ok := updateFields[FieldAuthStrategyIDs].([]string); ok && len(authStrategyIDs) > 0 {
-		// Extract auth strategy names for lookup
-		authStrategyNames := make([]string, 0, len(authStrategyIDs))
-		for _, strategyRef := range authStrategyIDs {
-			// Find the auth strategy by ref to get its name using global lookup
-			if strategy := p.resources.GetAuthStrategyByRef(strategyRef); strategy != nil {
-				authStrategyNames = append(authStrategyNames, p.getAuthStrategyName(*strategy))
-			}
-		}
-
 		// Set auth strategy array reference
 		change.References[FieldAuthStrategyIDs] = ReferenceInfo{
 			Refs:    authStrategyIDs,
 			IsArray: true,
 			LookupArrays: map[string][]string{
-				"names": authStrategyNames,
+				"names": p.authStrategyLookupNames(authStrategyIDs),
 			},
 		}
 	}
 
 	plan.AddChange(change)
+}
+
+func (p *Planner) authStrategyLookupNames(refs []string) []string {
+	names := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		lookupRef := ref
+		if tags.IsRefPlaceholder(lookupRef) {
+			if parsedRef, _, ok := tags.ParseRefPlaceholder(lookupRef); ok && parsedRef != "" {
+				lookupRef = parsedRef
+			}
+		}
+
+		name := ""
+		if strategy := p.resources.GetAuthStrategyByRef(lookupRef); strategy != nil {
+			name = p.getAuthStrategyName(*strategy)
+		}
+		names = append(names, name)
+	}
+	return names
 }
 
 // shouldUpdateAPIPublication compares current and desired API publication to determine if update is needed

--- a/internal/declarative/planner/api_planner_test.go
+++ b/internal/declarative/planner/api_planner_test.go
@@ -421,3 +421,43 @@ func TestShouldUpdateAPIPublicationIgnoresAuthStrategyWhenUnset(t *testing.T) {
 	assert.Empty(t, fields)
 	assert.Empty(t, changedFields)
 }
+
+func TestPlanAPIPublicationUpdateAlignsAuthStrategyLookupNames(t *testing.T) {
+	t.Parallel()
+
+	authStrategy := resources.ApplicationAuthStrategyResource{
+		CreateAppAuthStrategyRequest: kkComps.CreateCreateAppAuthStrategyRequestKeyAuth(
+			kkComps.AppAuthStrategyKeyAuthRequest{
+				Name:         "my-api-key-auth",
+				StrategyType: kkComps.StrategyTypeKeyAuth,
+			},
+		),
+		BaseResource: resources.BaseResource{Ref: "key-auth"},
+	}
+	planner := &Planner{
+		resources: &resources.ResourceSet{
+			ApplicationAuthStrategies: []resources.ApplicationAuthStrategyResource{authStrategy},
+		},
+	}
+	authStrategyIDs := []string{
+		"a86aec1e-f67f-4624-919f-b11292b11159",
+		tags.RefPlaceholderPrefix + "key-auth#id",
+	}
+	plan := NewPlan(CurrentPlanVersion, "test", PlanModeApply)
+
+	planner.planAPIPublicationUpdate(
+		DefaultNamespace,
+		"api",
+		"api-id",
+		state.APIPublication{PortalID: "portal-id"},
+		resources.APIPublicationResource{Ref: "publication", PortalID: "portal-id"},
+		map[string]any{FieldAuthStrategyIDs: authStrategyIDs},
+		map[string]FieldChange{},
+		plan,
+	)
+
+	require.Len(t, plan.Changes, 1)
+	reference := plan.Changes[0].References[FieldAuthStrategyIDs]
+	require.Equal(t, authStrategyIDs, reference.Refs)
+	require.Equal(t, []string{"", "my-api-key-auth"}, reference.LookupArrays["names"])
+}

--- a/internal/declarative/planner/api_planner_test.go
+++ b/internal/declarative/planner/api_planner_test.go
@@ -1,15 +1,142 @@
 package planner
 
 import (
+	"log/slog"
 	"testing"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
 	"github.com/kong/kongctl/internal/declarative/resources"
 	"github.com/kong/kongctl/internal/declarative/state"
 	"github.com/kong/kongctl/internal/declarative/tags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPlanAPIChangesExternalParentPlansChildWithoutAPIChange(t *testing.T) {
+	t.Parallel()
+
+	versionName := "v1"
+	externalAPI := resources.APIResource{
+		BaseResource: resources.BaseResource{Ref: "shared-api"},
+		External:     &resources.ExternalBlock{ID: "api-id"},
+		Versions: []resources.APIVersionResource{{
+			Ref: "v1", CreateAPIVersionRequest: kkComps.CreateAPIVersionRequest{Version: &versionName},
+		}},
+	}
+	externalAPI.SetKonnectID("api-id")
+	planner := NewPlanner(state.NewClient(state.ClientConfig{
+		APIVersionAPI: &stubAPIVersionAPI{},
+	}), slog.Default())
+	planner.resources = &resources.ResourceSet{APIs: []resources.APIResource{externalAPI}}
+	plan := NewPlan(CurrentPlanVersion, "test", PlanModeApply)
+
+	err := planner.planAPIChanges(
+		t.Context(), &Config{Namespace: resources.NamespaceExternal}, []resources.APIResource{externalAPI}, plan,
+	)
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	require.Equal(t, ResourceTypeAPIVersion, plan.Changes[0].ResourceType)
+	require.Equal(t, ActionCreate, plan.Changes[0].Action)
+	require.Equal(t, "api-id", plan.Changes[0].Parent.ID)
+}
+
+func TestPlanAPIChangesExternalParentDeletesOnlyDeclaredChild(t *testing.T) {
+	t.Parallel()
+
+	versionName := "v1"
+	externalAPI := resources.APIResource{
+		BaseResource: resources.BaseResource{Ref: "shared-api"},
+		External:     &resources.ExternalBlock{ID: "api-id"},
+		Versions: []resources.APIVersionResource{{
+			Ref: "v1", CreateAPIVersionRequest: kkComps.CreateAPIVersionRequest{Version: &versionName},
+		}},
+	}
+	externalAPI.SetKonnectID("api-id")
+	planner := NewPlanner(state.NewClient(state.ClientConfig{
+		APIVersionAPI: &stubAPIVersionAPI{response: &kkOps.ListAPIVersionsResponse{
+			ListAPIVersionResponse: &kkComps.ListAPIVersionResponse{
+				Data: []kkComps.ListAPIVersionResponseAPIVersionSummary{
+					{ID: "version-id", Version: "v1"},
+					{ID: "out-of-band-version-id", Version: "v2"},
+				},
+				Meta: kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: 2}},
+			},
+		}},
+	}), slog.Default())
+	planner.resources = &resources.ResourceSet{APIs: []resources.APIResource{externalAPI}}
+	plan := NewPlan(CurrentPlanVersion, "test", PlanModeDelete)
+
+	err := planner.planAPIChanges(
+		t.Context(), &Config{Namespace: resources.NamespaceExternal}, []resources.APIResource{externalAPI}, plan,
+	)
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	require.Equal(t, ResourceTypeAPIVersion, plan.Changes[0].ResourceType)
+	require.Equal(t, ActionDelete, plan.Changes[0].Action)
+	require.Equal(t, "version-id", plan.Changes[0].ResourceID)
+	require.Equal(t, "api-id", plan.Changes[0].Parent.ID)
+}
+
+func TestPlanAPIChangesExternalParentSyncDoesNotDeleteOutOfBandChildren(t *testing.T) {
+	t.Parallel()
+
+	versionName := "v1"
+	externalAPI := resources.APIResource{
+		BaseResource: resources.BaseResource{Ref: "shared-api"},
+		External:     &resources.ExternalBlock{ID: "api-id"},
+		Versions: []resources.APIVersionResource{{
+			Ref: "v1", CreateAPIVersionRequest: kkComps.CreateAPIVersionRequest{Version: &versionName},
+		}},
+	}
+	externalAPI.SetKonnectID("api-id")
+	planner := NewPlanner(state.NewClient(state.ClientConfig{
+		APIVersionAPI: &stubAPIVersionAPI{response: &kkOps.ListAPIVersionsResponse{
+			ListAPIVersionResponse: &kkComps.ListAPIVersionResponse{
+				Data: []kkComps.ListAPIVersionResponseAPIVersionSummary{
+					{ID: "out-of-band-version-id", Version: "v2"},
+				},
+				Meta: kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: 1}},
+			},
+		}},
+	}), slog.Default())
+	planner.resources = &resources.ResourceSet{APIs: []resources.APIResource{externalAPI}}
+	planner.resources.EnsureSyncScope().AddChild(
+		resources.ResourceTypeAPI,
+		externalAPI.GetRef(),
+		resources.ResourceTypeAPIVersion,
+	)
+	plan := NewPlan(CurrentPlanVersion, "test", PlanModeSync)
+
+	err := planner.planAPIChanges(
+		t.Context(), &Config{Namespace: resources.NamespaceExternal}, []resources.APIResource{externalAPI}, plan,
+	)
+	require.NoError(t, err)
+	require.Len(t, plan.Changes, 1)
+	require.Equal(t, ResourceTypeAPIVersion, plan.Changes[0].ResourceType)
+	require.Equal(t, ActionCreate, plan.Changes[0].Action)
+	require.Equal(t, "v1", plan.Changes[0].ResourceRef)
+}
+
+func TestValidateNoExternalResourceChangesRejectsAPIChange(t *testing.T) {
+	t.Parallel()
+
+	api := resources.APIResource{
+		BaseResource: resources.BaseResource{Ref: "shared-api"},
+		External:     &resources.ExternalBlock{ID: "api-id"},
+	}
+	api.SetKonnectID("api-id")
+	plan := NewPlan(CurrentPlanVersion, "test", PlanModeApply)
+	plan.AddChange(PlannedChange{
+		ResourceType: ResourceTypeAPI,
+		ResourceRef:  "shared-api",
+		ResourceID:   "api-id",
+		Action:       ActionUpdate,
+	})
+
+	err := validateNoExternalResourceChanges(plan, &resources.ResourceSet{APIs: []resources.APIResource{api}})
+	require.ErrorContains(t, err, "external api \"shared-api\" received UPDATE change")
+}
 
 // TestAPIVersionConstraintValidation tests that the loader properly validates API version constraints
 func TestAPIVersionConstraintValidation(t *testing.T) {

--- a/internal/declarative/planner/auth_strategy_planner.go
+++ b/internal/declarative/planner/auth_strategy_planner.go
@@ -35,6 +35,9 @@ func (p *authStrategyPlannerImpl) PlanChanges(ctx context.Context, plannerCtx *C
 	// Get namespace from planner context
 	namespace := plannerCtx.Namespace
 	desired := p.GetDesiredAuthStrategies(namespace)
+	if namespace == resources.NamespaceExternal {
+		return nil
+	}
 
 	// Skip if no auth strategies to plan and not in sync mode
 	if len(desired) == 0 && plan.Metadata.Mode != PlanModeSync {

--- a/internal/declarative/planner/external_lookup.go
+++ b/internal/declarative/planner/external_lookup.go
@@ -56,6 +56,8 @@ func newExternalLookupResolver(planner *Planner) *externalLookupResolver {
 		cache:   make(map[string]externalLookupCacheEntry),
 	}
 	r.adapters = map[resources.ResourceType]externalLookupAdapter{
+		resources.ResourceTypeAPI:                        r.lookupAPI,
+		resources.ResourceTypeApplicationAuthStrategy:    r.lookupApplicationAuthStrategy,
 		resources.ResourceTypePortal:                     r.lookupPortal,
 		resources.ResourceTypeControlPlane:               r.lookupControlPlane,
 		resources.ResourceTypeGatewayService:             r.lookupGatewayService,
@@ -164,13 +166,7 @@ func (r *externalLookupResolver) resolveDeclarations(ctx context.Context, rs *re
 	}
 
 	// Resolve unscoped resources first so scoped resources can consume their IDs.
-	for _, resourceType := range []resources.ResourceType{
-		resources.ResourceTypeControlPlane,
-		resources.ResourceTypeEventGatewayControlPlane,
-		resources.ResourceTypePortal,
-		resources.ResourceTypeAIGateway,
-		resources.ResourceTypeOrganizationTeam,
-	} {
+	for _, resourceType := range resources.ExternalResolvableTypesByScope(false) {
 		for _, item := range rs.AllResourcesByType(resourceType) {
 			external, ok := item.(resources.ExternallyResolvableResource)
 			if !ok || external.GetExternalBlock() == nil || item.GetKonnectID() != "" {
@@ -183,22 +179,6 @@ func (r *externalLookupResolver) resolveDeclarations(ctx context.Context, rs *re
 				return err
 			}
 			external.SetKonnectID(id)
-		}
-	}
-
-	if rs.AuditLogs != nil {
-		for i := range rs.AuditLogs.Destinations {
-			destination := &rs.AuditLogs.Destinations[i]
-			if destination.GetKonnectID() != "" {
-				continue
-			}
-			id, err := r.resolve(ctx, externalRequest(
-				destination.GetType(), destination.External, "", externalDeclarationSource(destination),
-			))
-			if err != nil {
-				return err
-			}
-			destination.SetKonnectID(id)
 		}
 	}
 
@@ -215,54 +195,85 @@ func (r *externalLookupResolver) resolveScopedDeclarations(ctx context.Context, 
 		controlPlaneByRef[rs.ControlPlanes[i].GetRef()] = &rs.ControlPlanes[i]
 	}
 	deckControlPlanes := deckControlPlaneRefs(rs.ControlPlanes)
-	for i := range rs.GatewayServices {
-		service := &rs.GatewayServices[i]
-		if !service.IsExternal() || service.GetKonnectID() != "" {
-			continue
-		}
-		parentID, err := r.planner.resolveGatewayServiceControlPlaneID(service, controlPlaneByRef)
-		if err != nil {
-			return err
-		}
-		usesDeck := controlPlaneHasDeck(service, deckControlPlanes)
-		if parentID == "" && usesDeck {
-			continue
-		}
-		id, err := r.resolve(ctx, externalRequest(
-			service.GetType(), service.External, parentID, externalDeclarationSource(service),
-		))
-		if err != nil {
-			if usesDeck {
+	for _, resourceType := range resources.ExternalResolvableTypesByScope(true) {
+		capability, _ := resources.ExternalResolutionFor(resourceType)
+		for _, item := range rs.AllResourcesByType(resourceType) {
+			external, ok := item.(resources.ExternallyResolvableResource)
+			if !ok || external.GetExternalBlock() == nil || item.GetKonnectID() != "" {
 				continue
 			}
-			return err
-		}
-		service.SetKonnectID(id)
-		service.SetResolvedControlPlaneID(parentID)
-	}
 
-	eventGatewayByRef := make(map[string]*resources.EventGatewayControlPlaneResource, len(rs.EventGatewayControlPlanes))
-	for i := range rs.EventGatewayControlPlanes {
-		eventGatewayByRef[rs.EventGatewayControlPlanes[i].GetRef()] = &rs.EventGatewayControlPlanes[i]
-	}
-	for i := range rs.EventGatewayVirtualClusters {
-		cluster := &rs.EventGatewayVirtualClusters[i]
-		if !cluster.IsExternal() || cluster.GetKonnectID() != "" {
-			continue
+			parentID, deferred, err := r.scopedDeclarationParentID(
+				rs, item, capability, controlPlaneByRef, deckControlPlanes,
+			)
+			if err != nil {
+				return err
+			}
+			if deferred {
+				continue
+			}
+			id, err := r.resolve(ctx, externalRequest(
+				item.GetType(), external.GetExternalBlock(), parentID, externalDeclarationSource(item),
+			))
+			if err != nil {
+				if service, ok := item.(*resources.GatewayServiceResource); ok &&
+					controlPlaneHasDeck(service, deckControlPlanes) {
+					continue
+				}
+				return err
+			}
+			external.SetKonnectID(id)
+			if service, ok := item.(*resources.GatewayServiceResource); ok {
+				service.SetResolvedControlPlaneID(parentID)
+			}
 		}
-		parentID, err := resolveScopedParentID(cluster.EventGateway, eventGatewayByRef)
-		if err != nil {
-			return fmt.Errorf("event_gateway_virtual_cluster %q: %w", cluster.GetRef(), err)
-		}
-		id, err := r.resolve(ctx, externalRequest(
-			cluster.GetType(), cluster.External, parentID, externalDeclarationSource(cluster),
-		))
-		if err != nil {
-			return err
-		}
-		cluster.SetKonnectID(id)
 	}
 	return nil
+}
+
+func (r *externalLookupResolver) scopedDeclarationParentID(
+	rs *resources.ResourceSet,
+	item resources.Resource,
+	capability resources.ExternalResolutionRegistration,
+	controlPlaneByRef map[string]*resources.ControlPlaneResource,
+	deckControlPlanes map[string]bool,
+) (parentID string, deferred bool, err error) {
+	if service, ok := item.(*resources.GatewayServiceResource); ok {
+		parentID, err := r.planner.resolveGatewayServiceControlPlaneID(service, controlPlaneByRef)
+		if err != nil {
+			return "", false, err
+		}
+		return parentID, parentID == "" && controlPlaneHasDeck(service, deckControlPlanes), nil
+	}
+
+	parentValue, err := stringFieldByPath(item, capability.ParentFieldPath)
+	if err != nil {
+		return "", false, fmt.Errorf("%s %q: resolve parent scope: %w", item.GetType(), item.GetRef(), err)
+	}
+	if tags.IsRefPlaceholder(parentValue) {
+		ref, field, ok := tags.ParseRefPlaceholder(parentValue)
+		if !ok || field != FieldID {
+			return "", false, fmt.Errorf("%s %q: invalid parent reference %q", item.GetType(), item.GetRef(), parentValue)
+		}
+		parentValue = ref
+	}
+	if util.IsValidUUID(parentValue) {
+		return parentValue, false, nil
+	}
+	parent, ok := rs.GetResourceByRef(parentValue)
+	if !ok || parent.GetType() != capability.ParentType {
+		return "", false, fmt.Errorf(
+			"%s %q: referenced %s parent %q not found",
+			item.GetType(), item.GetRef(), capability.ParentType, parentValue,
+		)
+	}
+	if parent.GetKonnectID() == "" {
+		return "", false, fmt.Errorf(
+			"%s %q: parent %s %q does not have a resolved Konnect ID",
+			item.GetType(), item.GetRef(), capability.ParentType, parentValue,
+		)
+	}
+	return parent.GetKonnectID(), false, nil
 }
 
 func (r *externalLookupResolver) resolveInlineLookups(
@@ -281,60 +292,72 @@ func (r *externalLookupResolver) resolveInlineLookups(
 		for _, relationship := range resources.RelationshipDescriptorsFor(resource) {
 			fieldPath := relationship.FieldPath
 			targetType := relationship.TargetType
+			if relationship.TargetTypeResolver != nil {
+				discriminator, err := stringFieldByPath(resource, relationship.TargetDiscriminatorFieldPath)
+				if err != nil {
+					resolutionErr = fmt.Errorf(
+						"%s %q field %s: resolve target discriminator: %w",
+						resource.GetType(), resource.GetRef(), fieldPath, err,
+					)
+					return false
+				}
+				var ok bool
+				targetType, ok = relationship.TargetTypeResolver(discriminator)
+				if !ok {
+					continue
+				}
+			}
 			if _, selected := targetSet[targetType]; !selected {
 				continue
 			}
-			value, err := stringFieldByPath(resource, fieldPath)
-			if err != nil {
-				resolutionErr = fmt.Errorf("%s %q field %s: %w", resource.GetType(), resource.GetRef(), fieldPath, err)
-				return false
-			}
-			lookup, isLookup := tags.ParseExternalPlaceholder(value)
-			if !isLookup {
-				continue
-			}
+			err := visitStringFieldsByPath(resource, fieldPath, func(value string, set func(string)) error {
+				lookup, isLookup := tags.ParseExternalPlaceholder(value)
+				if !isLookup {
+					return nil
+				}
 
-			parent, err := r.inlineLookupParent(rs, resource, relationship)
-			if err != nil {
-				resolutionErr = fmt.Errorf("%s %q field %s: %w", resource.GetType(), resource.GetRef(), fieldPath, err)
-				return false
-			}
-			source := fmt.Sprintf("%s %q field %s", resource.GetType(), resource.GetRef(), fieldPath)
-			if lookup.Line > 0 {
-				source += fmt.Sprintf(" (line %d, column %d)", lookup.Line, lookup.Column)
-			}
-			id, err := r.resolve(ctx, externalLookupRequest{
-				ResourceType:    targetType,
-				MatchFields:     lookup.MatchFields,
-				SensitiveFields: lookup.SensitiveFields,
-				ParentID:        parent.id,
-				Source:          source,
+				parent, err := r.inlineLookupParent(rs, resource, relationship)
+				if err != nil {
+					return err
+				}
+				source := fmt.Sprintf("%s %q field %s", resource.GetType(), resource.GetRef(), fieldPath)
+				if lookup.Line > 0 {
+					source += fmt.Sprintf(" (line %d, column %d)", lookup.Line, lookup.Column)
+				}
+				id, err := r.resolve(ctx, externalLookupRequest{
+					ResourceType:    targetType,
+					MatchFields:     lookup.MatchFields,
+					SensitiveFields: lookup.SensitiveFields,
+					ParentID:        parent.id,
+					Source:          source,
+				})
+				if err != nil {
+					return err
+				}
+				resolvedRef := id
+				if relationship.ResultField == resources.RelationshipResultFieldRef {
+					resolvedRef = inlineExternalResourceRef(rs, targetType, id)
+				}
+				set(resolvedRef)
+				if relationship.ResultField == resources.RelationshipResultFieldRef {
+					r.hasInlineParents = true
+					if rs.SyncScope != nil {
+						rs.SyncScope.RebindChildParent(targetType, value, resolvedRef)
+					}
+					key := string(targetType) + "|" + resolvedRef
+					inlineParents[key] = inlineExternalParent{
+						resourceType: targetType,
+						id:           id,
+						ref:          resolvedRef,
+						parentID:     parent.id,
+						parentRef:    parent.ref,
+					}
+				}
+				return nil
 			})
 			if err != nil {
-				resolutionErr = err
+				resolutionErr = fmt.Errorf("%s %q field %s: %w", resource.GetType(), resource.GetRef(), fieldPath, err)
 				return false
-			}
-			resolvedRef := id
-			if relationship.Kind == resources.RelationshipKindKongctlParentSelector {
-				resolvedRef = inlineExternalResourceRef(rs, targetType, id)
-			}
-			if err := setStringFieldByPath(resource, fieldPath, resolvedRef); err != nil {
-				resolutionErr = fmt.Errorf("%s: bind resolved external reference: %w", source, err)
-				return false
-			}
-			if relationship.Kind == resources.RelationshipKindKongctlParentSelector {
-				r.hasInlineParents = true
-				if rs.SyncScope != nil {
-					rs.SyncScope.RebindChildParent(targetType, value, resolvedRef)
-				}
-				key := string(targetType) + "|" + resolvedRef
-				inlineParents[key] = inlineExternalParent{
-					resourceType: targetType,
-					id:           id,
-					ref:          resolvedRef,
-					parentID:     parent.id,
-					parentRef:    parent.ref,
-				}
 			}
 		}
 		return true
@@ -375,57 +398,8 @@ func ensureInlineExternalParent(rs *resources.ResourceSet, parent inlineExternal
 		return nil
 	}
 
-	external := &resources.ExternalBlock{ID: parent.id}
-	// Only registered parent-capable external types can reach this switch.
-	//nolint:exhaustive
-	switch parent.resourceType {
-	case resources.ResourceTypePortal:
-		rs.Portals = append(rs.Portals, resources.PortalResource{
-			BaseResource: resources.BaseResource{Ref: parent.ref},
-			External:     external,
-		})
-		rs.Portals[len(rs.Portals)-1].SetKonnectID(parent.id)
-	case resources.ResourceTypeControlPlane:
-		rs.ControlPlanes = append(rs.ControlPlanes, resources.ControlPlaneResource{
-			BaseResource: resources.BaseResource{Ref: parent.ref},
-			External:     external,
-		})
-		rs.ControlPlanes[len(rs.ControlPlanes)-1].SetKonnectID(parent.id)
-	case resources.ResourceTypeAIGateway:
-		rs.AIGateways = append(rs.AIGateways, resources.AIGatewayResource{
-			BaseResource: resources.BaseResource{Ref: parent.ref},
-			External:     external,
-		})
-		rs.AIGateways[len(rs.AIGateways)-1].SetKonnectID(parent.id)
-	case resources.ResourceTypeOrganizationTeam:
-		rs.OrganizationTeams = append(rs.OrganizationTeams, resources.OrganizationTeamResource{
-			BaseResource: resources.BaseResource{Ref: parent.ref},
-			External:     external,
-		})
-		rs.OrganizationTeams[len(rs.OrganizationTeams)-1].SetKonnectID(parent.id)
-	case resources.ResourceTypeEventGatewayControlPlane:
-		rs.EventGatewayControlPlanes = append(
-			rs.EventGatewayControlPlanes,
-			resources.EventGatewayControlPlaneResource{
-				BaseResource: resources.BaseResource{Ref: parent.ref},
-				External:     external,
-			},
-		)
-		rs.EventGatewayControlPlanes[len(rs.EventGatewayControlPlanes)-1].SetKonnectID(parent.id)
-	case resources.ResourceTypeEventGatewayVirtualCluster:
-		rs.EventGatewayVirtualClusters = append(
-			rs.EventGatewayVirtualClusters,
-			resources.EventGatewayVirtualClusterResource{
-				Ref:          parent.ref,
-				EventGateway: parent.parentRef,
-				External:     external,
-			},
-		)
-		rs.EventGatewayVirtualClusters[len(rs.EventGatewayVirtualClusters)-1].SetKonnectID(parent.id)
-	default:
-		return fmt.Errorf("cannot materialize inline external parent for %s", parent.resourceType)
-	}
-	return nil
+	_, err := resources.MaterializeExternalResource(rs, parent.resourceType, parent.ref, parent.id, parent.parentRef)
+	return err
 }
 
 func ensureInlineExternalTraversal(rs *resources.ResourceSet, parent inlineExternalParent) error {
@@ -609,27 +583,6 @@ func deckControlPlaneRefs(controlPlanes []resources.ControlPlaneResource) map[st
 	return result
 }
 
-func resolveScopedParentID[T resources.Resource](value string, byRef map[string]T) (string, error) {
-	if tags.IsRefPlaceholder(value) {
-		ref, field, ok := tags.ParseRefPlaceholder(value)
-		if !ok || field != FieldID {
-			return "", fmt.Errorf("invalid parent reference %q", value)
-		}
-		value = ref
-	}
-	if util.IsValidUUID(value) {
-		return value, nil
-	}
-	parent, ok := byRef[value]
-	if !ok {
-		return "", fmt.Errorf("parent resource %q not found", value)
-	}
-	if parent.GetKonnectID() == "" {
-		return "", fmt.Errorf("parent resource %q does not have a resolved Konnect ID", value)
-	}
-	return parent.GetKonnectID(), nil
-}
-
 func matchExternalCandidates[T any](
 	req externalLookupRequest,
 	candidates []T,
@@ -668,6 +621,25 @@ func (r *externalLookupResolver) lookupPortal(ctx context.Context, req externalL
 		return "", fmt.Errorf("%s: list portals: %w", req.Source, err)
 	}
 	return matchExternalCandidates(req, items, func(item state.Portal) string { return item.ID })
+}
+
+func (r *externalLookupResolver) lookupAPI(ctx context.Context, req externalLookupRequest) (string, error) {
+	items, err := r.planner.client.ListAllAPIs(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%s: list APIs: %w", req.Source, err)
+	}
+	return matchExternalCandidates(req, items, func(item state.API) string { return item.ID })
+}
+
+func (r *externalLookupResolver) lookupApplicationAuthStrategy(
+	ctx context.Context,
+	req externalLookupRequest,
+) (string, error) {
+	items, err := r.planner.client.ListAllApplicationAuthStrategies(ctx)
+	if err != nil {
+		return "", fmt.Errorf("%s: list application auth strategies: %w", req.Source, err)
+	}
+	return matchExternalCandidates(req, items, func(item state.ApplicationAuthStrategy) string { return item.ID })
 }
 
 func (r *externalLookupResolver) lookupControlPlane(ctx context.Context, req externalLookupRequest) (string, error) {
@@ -832,6 +804,57 @@ func stringFieldByPath(resource resources.Resource, path string) (string, error)
 		return "", fmt.Errorf("field %s is not a string", path)
 	}
 	return current.String(), nil
+}
+
+func visitStringFieldsByPath(resource resources.Resource, path string, visit func(string, func(string)) error) error {
+	if implementation, ok := resource.(*resources.APIImplementationResource); ok {
+		value, err := stringFieldByPath(resource, path)
+		if err != nil || value == "" {
+			return err
+		}
+		return visit(value, func(resolved string) {
+			_ = setStringFieldByPath(implementation, path, resolved)
+		})
+	}
+
+	current := reflect.ValueOf(resource)
+	for part := range strings.SplitSeq(path, ".") {
+		for current.Kind() == reflect.Pointer {
+			if current.IsNil() {
+				return nil
+			}
+			current = current.Elem()
+		}
+		current = findSettableTaggedField(current, part)
+		if !current.IsValid() {
+			return fmt.Errorf("field %s not found", path)
+		}
+	}
+	for current.Kind() == reflect.Pointer {
+		if current.IsNil() {
+			return nil
+		}
+		current = current.Elem()
+	}
+
+	//exhaustive:ignore reflect.Kind is validated by the default branch.
+	switch current.Kind() {
+	case reflect.String:
+		return visit(current.String(), func(resolved string) { current.SetString(resolved) })
+	case reflect.Slice, reflect.Array:
+		for i := range current.Len() {
+			item := current.Index(i)
+			if item.Kind() != reflect.String || !item.CanSet() {
+				return fmt.Errorf("field %s item %d is not a settable string", path, i)
+			}
+			if err := visit(item.String(), func(resolved string) { item.SetString(resolved) }); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("field %s is not a string or string list", path)
+	}
 }
 
 func findSettableTaggedField(value reflect.Value, name string) reflect.Value {

--- a/internal/declarative/planner/external_lookup_test.go
+++ b/internal/declarative/planner/external_lookup_test.go
@@ -44,12 +44,121 @@ func TestExternalLookupResolverInlineAliasesShareCache(t *testing.T) {
 	portalAPI.AssertExpectations(t)
 }
 
+func TestExternalLookupResolverMaterializesAPIParent(t *testing.T) {
+	t.Parallel()
+
+	apiAPI := &MockAPIAPI{}
+	apiAPI.On("ListApis", mock.Anything, mock.Anything).Return(&kkOps.ListApisResponse{
+		ListAPIResponse: &kkComps.ListAPIResponse{
+			Data: []kkComps.APIResponseSchema{{ID: "api-id", Name: "Shared API"}},
+			Meta: kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: 1}},
+		},
+	}, nil).Once()
+
+	resolver := newExternalLookupResolver(NewPlanner(
+		state.NewClient(state.ClientConfig{APIAPI: apiAPI}),
+		slog.Default(),
+	))
+	rs := &resources.ResourceSet{APIVersions: []resources.APIVersionResource{{
+		Ref: "v1", API: namedExternalPlaceholder(t, "!lookup", "Shared API"),
+	}}}
+
+	require.NoError(t, resolver.resolveInlineLookups(t.Context(), rs, resources.ResourceTypeAPI))
+	require.Equal(t, "api-id", rs.APIVersions[0].API)
+	require.Len(t, rs.APIs, 1)
+	require.Equal(t, "api-id", rs.APIs[0].GetKonnectID())
+	require.True(t, rs.APIs[0].IsExternal())
+	apiAPI.AssertExpectations(t)
+}
+
+func TestExternalLookupResolverResolvesRBACAPIEntity(t *testing.T) {
+	t.Parallel()
+
+	apiAPI := &MockAPIAPI{}
+	apiAPI.On("ListApis", mock.Anything, mock.Anything).Return(&kkOps.ListApisResponse{
+		ListAPIResponse: &kkComps.ListAPIResponse{
+			Data: []kkComps.APIResponseSchema{{ID: "api-id", Name: "Shared API"}},
+			Meta: kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: 1}},
+		},
+	}, nil).Once()
+
+	resolver := newExternalLookupResolver(NewPlanner(
+		state.NewClient(state.ClientConfig{APIAPI: apiAPI}),
+		slog.Default(),
+	))
+	rs := &resources.ResourceSet{OrganizationUserRoles: []resources.OrganizationUserRoleResource{{
+		Ref: "viewer", EntityID: namedExternalPlaceholder(t, "!lookup", "Shared API"), EntityTypeName: "API Products",
+	}}}
+
+	require.NoError(t, resolver.resolveInlineLookups(t.Context(), rs, resources.ResourceTypeAPI))
+	require.Equal(t, "api-id", rs.OrganizationUserRoles[0].EntityID)
+	apiAPI.AssertExpectations(t)
+}
+
+func TestExternalLookupResolverResolvesPortalTeamRoleAPIEntity(t *testing.T) {
+	t.Parallel()
+
+	apiAPI := &MockAPIAPI{}
+	apiAPI.On("ListApis", mock.Anything, mock.Anything).Return(&kkOps.ListApisResponse{
+		ListAPIResponse: &kkComps.ListAPIResponse{
+			Data: []kkComps.APIResponseSchema{{ID: "api-id", Name: "Shared API"}},
+			Meta: kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: 1}},
+		},
+	}, nil).Once()
+
+	resolver := newExternalLookupResolver(NewPlanner(
+		state.NewClient(state.ClientConfig{APIAPI: apiAPI}),
+		slog.Default(),
+	))
+	rs := &resources.ResourceSet{PortalTeamRoles: []resources.PortalTeamRoleResource{{
+		Ref: "viewer", EntityID: namedExternalPlaceholder(t, "!lookup", "Shared API"), EntityTypeName: "API Products",
+	}}}
+
+	require.NoError(t, resolver.resolveInlineLookups(t.Context(), rs, resources.ResourceTypeAPI))
+	require.Equal(t, "api-id", rs.PortalTeamRoles[0].EntityID)
+	apiAPI.AssertExpectations(t)
+}
+
+func TestExternalLookupResolverResolvesAuthStrategyListInOrder(t *testing.T) {
+	t.Parallel()
+
+	authAPI := &MockAppAuthStrategiesAPI{}
+	authResponse := &kkComps.AppAuthStrategyKeyAuthResponseAppAuthStrategyKeyAuthResponse{
+		ID: "auth-id", Name: "Shared Auth", DisplayName: "Shared Authentication",
+	}
+	authAPI.On("ListAppAuthStrategies", mock.Anything, mock.Anything).Return(&kkOps.ListAppAuthStrategiesResponse{
+		ListAppAuthStrategiesResponse: &kkComps.ListAppAuthStrategiesResponse{
+			Data: []kkComps.AppAuthStrategy{{
+				AppAuthStrategyKeyAuthResponseAppAuthStrategyKeyAuthResponse: authResponse,
+			}},
+			Meta: kkComps.PaginatedMeta{Page: kkComps.PageMeta{Total: 1}},
+		},
+	}, nil).Once()
+
+	resolver := newExternalLookupResolver(NewPlanner(
+		state.NewClient(state.ClientConfig{AppAuthAPI: authAPI}),
+		slog.Default(),
+	))
+	rs := &resources.ResourceSet{APIPublications: []resources.APIPublicationResource{{
+		Ref: "publication",
+		APIPublication: kkComps.APIPublication{
+			AuthStrategyIds: []string{"literal-id", namedExternalPlaceholder(t, "!lookup", "Shared Auth")},
+		},
+	}}}
+
+	require.NoError(t, resolver.resolveInlineLookups(
+		t.Context(), rs, resources.ResourceTypeApplicationAuthStrategy,
+	))
+	require.Equal(t, []string{"literal-id", "auth-id"}, rs.APIPublications[0].AuthStrategyIds)
+	authAPI.AssertExpectations(t)
+}
+
 func TestExternalLookupResolverRejectsUnsupportedPlacement(t *testing.T) {
 	t.Parallel()
 
 	resolver := newExternalLookupResolver(NewPlanner(state.NewClient(state.ClientConfig{}), slog.Default()))
 	_, err := resolver.resolve(context.Background(), externalLookupRequest{
-		ResourceType: resources.ResourceTypeAPI,
+		ResourceType: resources.ResourceTypeDCRProvider,
 		MatchFields:  map[string]string{"name": "products"},
 		Source:       "api_publication products field portal_id",
 	})

--- a/internal/declarative/planner/planner.go
+++ b/internal/declarative/planner/planner.go
@@ -486,8 +486,49 @@ func (p *Planner) GeneratePlan(ctx context.Context, rs *resources.ResourceSet, o
 
 	p.addUnresolvedReferenceWarnings(basePlan, rs)
 	p.applyDeferredEnvPlaceholders(basePlan, rs)
+	if err := validateNoExternalResourceChanges(basePlan, rs); err != nil {
+		return nil, err
+	}
 
 	return basePlan, nil
+}
+
+func validateNoExternalResourceChanges(plan *Plan, rs *resources.ResourceSet) error {
+	if plan == nil || rs == nil {
+		return nil
+	}
+	externalRefs := make(map[string]struct{})
+	externalIDs := make(map[string]struct{})
+	rs.ForEachResource(func(resource resources.Resource) bool {
+		external, ok := resource.(resources.ExternallyResolvableResource)
+		if !ok || external.GetExternalBlock() == nil {
+			return true
+		}
+		keyPrefix := string(resource.GetType()) + "|"
+		externalRefs[keyPrefix+resource.GetRef()] = struct{}{}
+		if resource.GetKonnectID() != "" {
+			externalIDs[keyPrefix+resource.GetKonnectID()] = struct{}{}
+		}
+		return true
+	})
+
+	for _, change := range plan.Changes {
+		if change.Action == ActionExternalTool {
+			continue
+		}
+		keyPrefix := change.ResourceType + "|"
+		_, refMatch := externalRefs[keyPrefix+change.ResourceRef]
+		_, idMatch := externalIDs[keyPrefix+change.ResourceID]
+		if refMatch || (change.ResourceID != "" && idMatch) {
+			return fmt.Errorf(
+				"planner invariant violated: external %s %q received %s change",
+				change.ResourceType,
+				change.ResourceRef,
+				change.Action,
+			)
+		}
+	}
+	return nil
 }
 
 func withPlannerHTTPLogContext(
@@ -974,12 +1015,7 @@ func (p *Planner) resolveResourceIdentities(ctx context.Context, rs *resources.R
 	if err := p.externalResolver.resolveInlineLookups(
 		ctx,
 		rs,
-		resources.ResourceTypeControlPlane,
-		resources.ResourceTypeEventGatewayControlPlane,
-		resources.ResourceTypePortal,
-		resources.ResourceTypeAIGateway,
-		resources.ResourceTypeAuditLogWebhookDestination,
-		resources.ResourceTypeOrganizationTeam,
+		resources.ExternalResolvableTypesByScope(false)...,
 	); err != nil {
 		return fmt.Errorf("failed to resolve inline external lookups: %w", err)
 	}
@@ -999,8 +1035,7 @@ func (p *Planner) resolveResourceIdentities(ctx context.Context, rs *resources.R
 	if err := p.externalResolver.resolveInlineLookups(
 		ctx,
 		rs,
-		resources.ResourceTypeGatewayService,
-		resources.ResourceTypeEventGatewayVirtualCluster,
+		resources.ExternalResolvableTypesByScope(true)...,
 	); err != nil {
 		return fmt.Errorf("failed to resolve scoped inline external lookups: %w", err)
 	}
@@ -2634,29 +2669,14 @@ func (p *Planner) resolveAuthStrategyIdentities(
 // getResourceNamespaces extracts all unique namespaces from the desired resources
 func (p *Planner) getResourceNamespaces(rs *resources.ResourceSet) []string {
 	namespaceSet := make(map[string]bool)
-	hasExternalPortals := false
-	hasExternalControlPlanes := false
-	hasExternalEventGateways := false
-	hasExternalAIGateways := false
-	hasExternalOrganizationTeams := false
+	hasExternalResources := false
 
 	// External portals, control planes, event gateways, AI gateways, and
 	// organization teams all map to the external namespace instead of
 	// contributing their own.
 	_ = rs.ForEachNamespaceParticipant(func(pt resources.NamespaceParticipant) error {
 		if pt.External {
-			switch pt.Type { //nolint:exhaustive // only external-capable types set pt.External
-			case resources.ResourceTypePortal:
-				hasExternalPortals = true
-			case resources.ResourceTypeControlPlane:
-				hasExternalControlPlanes = true
-			case resources.ResourceTypeEventGatewayControlPlane:
-				hasExternalEventGateways = true
-			case resources.ResourceTypeAIGateway:
-				hasExternalAIGateways = true
-			case resources.ResourceTypeOrganizationTeam:
-				hasExternalOrganizationTeams = true
-			}
+			hasExternalResources = true
 			return nil
 		}
 		namespaceSet[resources.GetNamespace(*pt.Meta)] = true
@@ -2672,11 +2692,7 @@ func (p *Planner) getResourceNamespaces(rs *resources.ResourceSet) []string {
 	// Sort for consistent processing order
 	sort.Strings(namespaces)
 
-	if hasExternalPortals ||
-		hasExternalControlPlanes ||
-		hasExternalEventGateways ||
-		hasExternalAIGateways ||
-		hasExternalOrganizationTeams ||
+	if hasExternalResources ||
 		(p.externalResolver != nil && p.externalResolver.hasInlineParents) {
 		namespaces = append(namespaces, resources.NamespaceExternal)
 	}

--- a/internal/declarative/planner/resolver.go
+++ b/internal/declarative/planner/resolver.go
@@ -249,6 +249,13 @@ func (r *ReferenceResolver) getResourceTypeForField(fieldName string) string {
 func (r *ReferenceResolver) getResourceTypeForChangeField(change PlannedChange, fieldName string) string {
 	for _, descriptor := range resources.RelationshipDescriptorsForType(resources.ResourceType(change.ResourceType)) {
 		if descriptor.FieldPath == fieldName || strings.HasPrefix(fieldName, descriptor.FieldPath+".") {
+			if descriptor.TargetTypeResolver != nil {
+				discriminator, _ := change.Fields[descriptor.TargetDiscriminatorFieldPath].(string)
+				if resourceType, ok := descriptor.TargetTypeResolver(discriminator); ok {
+					return string(resourceType)
+				}
+				continue
+			}
 			return string(descriptor.TargetType)
 		}
 	}

--- a/internal/declarative/planner/sync_scope.go
+++ b/internal/declarative/planner/sync_scope.go
@@ -415,7 +415,8 @@ func syncRootParentType(rt resources.ResourceType) bool {
 func syncParentTypeSupportsExternal(rt resources.ResourceType) bool {
 	//nolint:exhaustive
 	switch rt {
-	case resources.ResourceTypePortal,
+	case resources.ResourceTypeAPI,
+		resources.ResourceTypePortal,
 		resources.ResourceTypeControlPlane,
 		resources.ResourceTypeAIGateway,
 		resources.ResourceTypeEventGatewayControlPlane,

--- a/internal/declarative/resources/ai_gateway_auth_strategy.go
+++ b/internal/declarative/resources/ai_gateway_auth_strategy.go
@@ -33,6 +33,7 @@ func init() {
 			WithExplainSchemaBuilder(aiGatewayAuthStrategyExplainNode),
 		),
 		WithMaturity(aiGatewayMaturity),
+		WithExternalUnsupportedReason("scoped AI Gateway auth strategy lookup is planned for domain enablement"),
 	)
 }
 

--- a/internal/declarative/resources/ai_gateway_config_store.go
+++ b/internal/declarative/resources/ai_gateway_config_store.go
@@ -26,6 +26,7 @@ func init() {
 			WithExplainSchemaBuilder(aiGatewayConfigStoreExplainNode),
 		),
 		WithMaturity(aiGatewayMaturity),
+		WithExternalUnsupportedReason("scoped AI Gateway config store lookup is planned for domain enablement"),
 	)
 }
 

--- a/internal/declarative/resources/ai_gateway_consumer.go
+++ b/internal/declarative/resources/ai_gateway_consumer.go
@@ -44,6 +44,7 @@ func init() {
 			WithExplainSchemaBuilder(aiGatewayConsumerExplainNode),
 		),
 		WithMaturity(aiGatewayMaturity),
+		WithExternalUnsupportedReason("scoped AI Gateway consumer lookup is planned for domain enablement"),
 	)
 }
 

--- a/internal/declarative/resources/ai_gateway_vault.go
+++ b/internal/declarative/resources/ai_gateway_vault.go
@@ -455,11 +455,11 @@ func aiGatewayVaultExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
 func aiGatewayConfigStoreIDExplainNode() *ExplainNode {
 	node := explainStringNode("config-store-id")
 	node.RefKind = string(ResourceTypeAIGatewayConfigStore)
-	node.PreferredTag = "!ref"
+	node.PreferredTag = yamlTagRef
 	node.Relationship = &ExplainRelationship{
 		Target:       ResourceTypeAIGatewayConfigStore,
 		Kind:         RelationshipKindAPIForeignKey,
-		AcceptedTags: []string{"!ref"},
+		AcceptedTags: []string{yamlTagRef},
 	}
 	return node
 }

--- a/internal/declarative/resources/api.go
+++ b/internal/declarative/resources/api.go
@@ -9,19 +9,23 @@ import (
 )
 
 func init() {
-	registerResourceType(
+	registerExternalResourceType(
 		ResourceTypeAPI,
 		func(rs *ResourceSet) *[]APIResource { return &rs.APIs },
 		AutoExplain[APIResource](
 			WithExplainSchemaBuilder(apiExplainNode),
 		),
+		ExternalResolutionRegistration{Selectors: []string{SchemaFieldName}},
 	)
 }
+
+func (a *APIResource) GetExternalBlock() *ExternalBlock { return a.External }
 
 // APIResource represents an API in declarative configuration
 type APIResource struct {
 	BaseResource
 	kkComps.CreateAPIRequest `yaml:",inline" json:",inline"`
+	External                 *ExternalBlock `yaml:"_external,omitempty" json:"_external,omitempty"`
 
 	// Nested child resources
 	Versions        []APIVersionResource        `yaml:"versions,omitempty"        json:"versions,omitempty"`
@@ -88,16 +92,22 @@ func (a APIResource) Validate() error {
 	if err := ValidateRef(a.Ref); err != nil {
 		return fmt.Errorf("invalid API ref: %w", err)
 	}
+	if err := a.External.Validate(); err != nil {
+		return fmt.Errorf("invalid _external block: %w", err)
+	}
 	return nil
 }
 
 // SetDefaults applies default values to API resource
 func (a *APIResource) SetDefaults() {
 	// If Name is not set, use ref as default
-	if a.Name == "" {
+	if !a.IsExternal() && a.Name == "" {
 		a.Name = a.Ref
 	}
 }
+
+// IsExternal returns true when the API is resolved but not managed by kongctl.
+func (a APIResource) IsExternal() bool { return a.External.IsExternal() }
 
 // GetKonnectMonikerFilter returns the filter string for Konnect API lookup
 func (a APIResource) GetKonnectMonikerFilter() string {
@@ -106,5 +116,14 @@ func (a APIResource) GetKonnectMonikerFilter() string {
 
 // TryMatchKonnectResource attempts to match this resource with a Konnect resource.
 func (a *APIResource) TryMatchKonnectResource(konnectResource any) bool {
-	return a.TryMatchByName(a.Name, konnectResource, matchOptions{sdkType: "APIResponseSchema"})
+	id, ok := tryMatchByNameWithExternal(
+		a.Name,
+		konnectResource,
+		matchOptions{sdkType: "APIResponseSchema"},
+		a.External,
+	)
+	if ok {
+		a.SetKonnectID(id)
+	}
+	return ok
 }

--- a/internal/declarative/resources/api_document.go
+++ b/internal/declarative/resources/api_document.go
@@ -24,6 +24,7 @@ func init() {
 				},
 			}),
 		),
+		WithExternalUnsupportedReason("scoped API document lookup is planned for API domain enablement"),
 	)
 }
 

--- a/internal/declarative/resources/api_test.go
+++ b/internal/declarative/resources/api_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAPIResourceInterface(t *testing.T) {
@@ -33,6 +34,21 @@ func TestAPIResourceInterface(t *testing.T) {
 	if deps := api.GetDependencies(); len(deps) != 0 {
 		t.Errorf("GetDependencies() = %v, want empty", deps)
 	}
+}
+
+func TestAPIResourceExternalDoesNotDefaultManagedName(t *testing.T) {
+	t.Parallel()
+
+	api := APIResource{
+		BaseResource: BaseResource{Ref: "shared-api"},
+		External: &ExternalBlock{Selector: &ExternalSelector{
+			MatchFields: map[string]string{"name": "Shared API"},
+		}},
+	}
+	api.SetDefaults()
+	require.True(t, api.IsExternal())
+	require.Empty(t, api.Name)
+	require.NoError(t, api.Validate())
 }
 
 func TestAPIResourceLabels(t *testing.T) {

--- a/internal/declarative/resources/auth_strategy.go
+++ b/internal/declarative/resources/auth_strategy.go
@@ -11,20 +11,24 @@ import (
 )
 
 func init() {
-	registerResourceType(
+	registerExternalResourceType(
 		ResourceTypeApplicationAuthStrategy,
 		func(rs *ResourceSet) *[]ApplicationAuthStrategyResource { return &rs.ApplicationAuthStrategies },
 		AutoExplain[ApplicationAuthStrategyResource](
 			WithExplainSchemaBuilder(applicationAuthStrategyExplainNode),
 		),
+		ExternalResolutionRegistration{Selectors: []string{SchemaFieldName, "display_name"}},
 	)
 }
+
+func (a *ApplicationAuthStrategyResource) GetExternalBlock() *ExternalBlock { return a.External }
 
 // ApplicationAuthStrategyResource represents an application auth strategy in declarative configuration
 type ApplicationAuthStrategyResource struct {
 	BaseResource
 	DCRProviderID                        *string `yaml:"dcr_provider_id,omitempty" json:"dcr_provider_id,omitempty"`
 	kkComps.CreateAppAuthStrategyRequest `yaml:",inline" json:",inline"`
+	External                             *ExternalBlock `yaml:"_external,omitempty" json:"_external,omitempty"`
 }
 
 // GetType returns the resource type
@@ -87,6 +91,9 @@ func (a ApplicationAuthStrategyResource) Validate() error {
 	if err := ValidateRef(a.Ref); err != nil {
 		return fmt.Errorf("invalid application auth strategy ref: %w", err)
 	}
+	if err := a.External.Validate(); err != nil {
+		return fmt.Errorf("invalid _external block: %w", err)
+	}
 	if providerID := a.GetDCRProviderID(); providerID != "" && !a.allowsDCRProviderID() {
 		return fmt.Errorf("dcr_provider_id is only supported for openid_connect auth strategies")
 	}
@@ -120,8 +127,15 @@ func (a ApplicationAuthStrategyResource) GetKonnectMonikerFilter() string {
 
 // TryMatchKonnectResource attempts to match this resource with a Konnect resource
 func (a *ApplicationAuthStrategyResource) TryMatchKonnectResource(konnectResource any) bool {
-	return a.TryMatchByName(a.GetMoniker(), konnectResource, matchOptions{})
+	id, ok := tryMatchByNameWithExternal(a.GetMoniker(), konnectResource, matchOptions{}, a.External)
+	if ok {
+		a.SetKonnectID(id)
+	}
+	return ok
 }
+
+// IsExternal returns true when the strategy is resolved but not managed by kongctl.
+func (a ApplicationAuthStrategyResource) IsExternal() bool { return a.External.IsExternal() }
 
 // UnmarshalJSON implements custom JSON unmarshaling to handle SDK union types
 // (sigs.k8s.io/yaml uses JSON unmarshaling internally)
@@ -136,6 +150,7 @@ func (a *ApplicationAuthStrategyResource) UnmarshalJSON(data []byte) error {
 		DcrProviderID *string           `json:"dcr_provider_id,omitempty"`
 		Labels        map[string]string `json:"labels,omitempty"`
 		Kongctl       *KongctlMeta      `json:"kongctl,omitempty"`
+		External      *ExternalBlock    `json:"_external,omitempty"`
 	}
 
 	// Use a decoder with DisallowUnknownFields to catch typos
@@ -150,6 +165,14 @@ func (a *ApplicationAuthStrategyResource) UnmarshalJSON(data []byte) error {
 	a.Ref = temp.Ref
 	a.Kongctl = temp.Kongctl
 	a.DCRProviderID = temp.DcrProviderID
+	a.External = temp.External
+	if a.External != nil {
+		if temp.StrategyType != "" || temp.Name != "" || temp.DisplayName != "" || len(temp.Configs) > 0 ||
+			temp.DcrProviderID != nil || len(temp.Labels) > 0 {
+			return fmt.Errorf("external application auth strategy %q cannot define managed payload fields", temp.Ref)
+		}
+		return nil
+	}
 
 	// Based on strategy_type, create the appropriate SDK union type
 	switch temp.StrategyType {
@@ -219,6 +242,10 @@ func remarshalConfig(configData any, target any, configType string) error {
 
 // MarshalJSON ensures the ref field is always included alongside the union payload
 func (a ApplicationAuthStrategyResource) MarshalJSON() ([]byte, error) {
+	if a.External != nil {
+		payload := map[string]any{"ref": a.Ref, "_external": a.External}
+		return json.Marshal(payload)
+	}
 	// Marshal the union portion to capture the strategy-specific fields
 	unionBytes, err := json.Marshal(a.CreateAppAuthStrategyRequest)
 	if err != nil {

--- a/internal/declarative/resources/auth_strategy_unmarshal_test.go
+++ b/internal/declarative/resources/auth_strategy_unmarshal_test.go
@@ -54,6 +54,27 @@ configs:
 	}
 }
 
+func TestApplicationAuthStrategyResourceExternalRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var strategy ApplicationAuthStrategyResource
+	require.NoError(t, yaml.Unmarshal([]byte(`
+ref: shared-auth
+_external:
+  selector:
+    matchFields:
+      display_name: Shared Authentication
+`), &strategy))
+	require.True(t, strategy.IsExternal())
+	require.Equal(t, "Shared Authentication", strategy.External.Selector.MatchFields["display_name"])
+	require.NoError(t, strategy.Validate())
+
+	payload, err := yaml.Marshal(strategy)
+	require.NoError(t, err)
+	require.Contains(t, string(payload), "_external:")
+	require.NotContains(t, string(payload), "strategy_type:")
+}
+
 func TestApplicationAuthStrategyResource_UnmarshalJSON_OIDCConfigAliases(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/declarative/resources/dcr_provider.go
+++ b/internal/declarative/resources/dcr_provider.go
@@ -17,6 +17,9 @@ func init() {
 			WithExplainFieldHint("dcr_config.dcr_token", secretExplainFieldHint("DCR_TOKEN")),
 			WithExplainFieldHint("dcr_config.api_key", secretExplainFieldHint("DCR_API_KEY")),
 		),
+		WithExternalUnsupportedReason(
+			"DCR provider lookup is deferred until write-only configuration can be separated from identity",
+		),
 	)
 }
 

--- a/internal/declarative/resources/event_gateway_cluster_policy.go
+++ b/internal/declarative/resources/event_gateway_cluster_policy.go
@@ -143,7 +143,7 @@ func (e EventGatewayClusterPolicyResource) MarshalJSON() ([]byte, error) {
 		result["virtual_cluster"] = e.VirtualCluster
 	}
 	if e.EventGateway != "" {
-		result["event_gateway"] = e.EventGateway
+		result[SchemaFieldEventGateway] = e.EventGateway
 	}
 
 	return json.Marshal(result)

--- a/internal/declarative/resources/event_gateway_consume_policy.go
+++ b/internal/declarative/resources/event_gateway_consume_policy.go
@@ -167,7 +167,7 @@ func (e EventGatewayConsumePolicyResource) MarshalJSON() ([]byte, error) {
 		result["virtual_cluster"] = e.VirtualCluster
 	}
 	if e.EventGateway != "" {
-		result["event_gateway"] = e.EventGateway
+		result[SchemaFieldEventGateway] = e.EventGateway
 	}
 
 	return json.Marshal(result)

--- a/internal/declarative/resources/event_gateway_listener.go
+++ b/internal/declarative/resources/event_gateway_listener.go
@@ -13,6 +13,7 @@ func init() {
 		ResourceTypeEventGatewayListener,
 		func(rs *ResourceSet) *[]EventGatewayListenerResource { return &rs.EventGatewayListeners },
 		AutoExplain[EventGatewayListenerResource](),
+		WithExternalUnsupportedReason("listener lookup requires an Event Gateway-scoped list adapter"),
 	)
 }
 

--- a/internal/declarative/resources/event_gateway_produce_policy.go
+++ b/internal/declarative/resources/event_gateway_produce_policy.go
@@ -177,7 +177,7 @@ func (e EventGatewayProducePolicyResource) MarshalJSON() ([]byte, error) {
 		result["virtual_cluster"] = e.VirtualCluster
 	}
 	if e.EventGateway != "" {
-		result["event_gateway"] = e.EventGateway
+		result[SchemaFieldEventGateway] = e.EventGateway
 	}
 
 	return json.Marshal(result)

--- a/internal/declarative/resources/event_gateway_schema_registry.go
+++ b/internal/declarative/resources/event_gateway_schema_registry.go
@@ -120,7 +120,7 @@ func (e EventGatewaySchemaRegistryResource) MarshalJSON() ([]byte, error) {
 
 	result["ref"] = e.Ref
 	if e.EventGateway != "" {
-		result["event_gateway"] = e.EventGateway
+		result[SchemaFieldEventGateway] = e.EventGateway
 	}
 	removeEmptySchemaRegistryPassword(result)
 

--- a/internal/declarative/resources/event_gateway_virtual_cluster.go
+++ b/internal/declarative/resources/event_gateway_virtual_cluster.go
@@ -15,7 +15,9 @@ func init() {
 			WithExplainSchemaBuilder(eventGatewayVirtualClusterExplainNode),
 		),
 		ExternalResolutionRegistration{
-			ParentType: ResourceTypeEventGatewayControlPlane, AllowAnyStringSelector: true,
+			ParentType:             ResourceTypeEventGatewayControlPlane,
+			ParentFieldPath:        SchemaFieldEventGateway,
+			AllowAnyStringSelector: true,
 		},
 	)
 }

--- a/internal/declarative/resources/explain.go
+++ b/internal/declarative/resources/explain.go
@@ -18,6 +18,9 @@ const (
 	explainKindObject     = "object"
 	explainKindString     = "string"
 	explainKindInteger    = "integer"
+	yamlTagRef            = "!ref"
+	yamlTagExternal       = "!external"
+	yamlTagLookup         = "!lookup"
 	explainKindBoolean    = "boolean"
 
 	explainResourceClassTopLevel = "top-level"
@@ -179,12 +182,16 @@ func (s *JSONSchema) LoadRejectedFieldMessage(name string) string {
 
 // ExplainRelationship describes the user-visible contract of a resource relationship field.
 type ExplainRelationship struct {
-	Target       ResourceType     `json:"target" yaml:"target"`
-	Kind         RelationshipKind `json:"kind" yaml:"kind"`
-	AcceptedTags []string         `json:"accepted_tags,omitempty" yaml:"accepted_tags,omitempty"`
-	Selectors    []string         `json:"selectors,omitempty" yaml:"selectors,omitempty"`
-	ScopeField   string           `json:"scope_field,omitempty" yaml:"scope_field,omitempty"`
-	RootOnly     bool             `json:"root_only,omitempty" yaml:"root_only,omitempty"`
+	Target              ResourceType            `json:"target,omitempty" yaml:"target,omitempty"`
+	Targets             []ResourceType          `json:"targets,omitempty" yaml:"targets,omitempty"`
+	TargetDiscriminator string                  `json:"target_discriminator,omitempty" yaml:"target_discriminator,omitempty"` //nolint:lll
+	Kind                RelationshipKind        `json:"kind" yaml:"kind"`
+	Cardinality         RelationshipCardinality `json:"cardinality" yaml:"cardinality"`
+	ResultField         RelationshipResultField `json:"result_field" yaml:"result_field"`
+	AcceptedTags        []string                `json:"accepted_tags,omitempty" yaml:"accepted_tags,omitempty"`
+	Selectors           []string                `json:"selectors,omitempty" yaml:"selectors,omitempty"`
+	ScopeField          string                  `json:"scope_field,omitempty" yaml:"scope_field,omitempty"`
+	RootOnly            bool                    `json:"root_only,omitempty" yaml:"root_only,omitempty"`
 }
 
 type ExplainSchemaSubject struct {
@@ -1016,31 +1023,59 @@ func applyRelationshipHints(rt ResourceType, node *ExplainNode) {
 			continue
 		}
 		metadata := &ExplainRelationship{
-			Target:     relationship.TargetType,
-			Kind:       relationship.Kind,
-			ScopeField: relationship.ScopeFieldPath,
-			RootOnly:   relationship.RootOnly,
+			Target:              relationship.TargetType,
+			Targets:             append([]ResourceType(nil), relationship.TargetTypes...),
+			TargetDiscriminator: relationship.TargetDiscriminatorFieldPath,
+			Kind:                relationship.Kind,
+			Cardinality:         relationship.Cardinality,
+			ResultField:         relationship.ResultField,
+			ScopeField:          relationship.ScopeFieldPath,
+			RootOnly:            relationship.RootOnly,
 		}
-		capability, supportsExternal := ExternalResolutionFor(relationship.TargetType)
+		capability, supportsExternal := relationshipExternalCapability(relationship)
 		if supportsExternal {
-			metadata.AcceptedTags = []string{"!ref", "!external", "!lookup"}
+			metadata.AcceptedTags = []string{yamlTagRef, yamlTagExternal, yamlTagLookup}
 			metadata.Selectors = append([]string(nil), capability.Selectors...)
 			if capability.AllowAnyStringSelector {
 				metadata.Selectors = []string{"<string field>"}
 			}
 		} else {
-			metadata.AcceptedTags = []string{"!ref"}
+			metadata.AcceptedTags = []string{yamlTagRef}
 		}
 		fieldNode.Relationship = metadata
 		fieldNode.RefKind = string(relationship.TargetType)
 		if fieldNode.PreferredTag == "" {
-			fieldNode.PreferredTag = "!ref"
+			fieldNode.PreferredTag = yamlTagRef
 		}
 		fieldNode.Notes = append(
 			fieldNode.Notes,
 			relationshipExplainNote(relationship.Kind, supportsExternal),
 		)
 	}
+}
+
+func relationshipExternalCapability(relationship RelationshipDescriptor) (ExternalResolutionRegistration, bool) {
+	if relationship.TargetType != "" {
+		return ExternalResolutionFor(relationship.TargetType)
+	}
+	if len(relationship.TargetTypes) == 0 {
+		return ExternalResolutionRegistration{}, false
+	}
+	var common []string
+	for i, targetType := range relationship.TargetTypes {
+		capability, ok := ExternalResolutionFor(targetType)
+		if !ok || capability.AllowAnyStringSelector {
+			return ExternalResolutionRegistration{}, false
+		}
+		if i == 0 {
+			common = append([]string(nil), capability.Selectors...)
+			continue
+		}
+		common = slices.DeleteFunc(common, func(selector string) bool {
+			return !slices.Contains(capability.Selectors, selector)
+		})
+	}
+	return ExternalResolutionRegistration{Selectors: common}, true
 }
 
 func relationshipExplainNote(kind RelationshipKind, supportsExternal bool) string {
@@ -1085,7 +1120,7 @@ func applyReferenceHints(rt ResourceType, node *ExplainNode) {
 			if fieldNode, ok := node.lookup(strings.Split(path, ".")); ok {
 				fieldNode.RefKind = kind
 				if fieldNode.PreferredTag == "" {
-					fieldNode.PreferredTag = "!ref"
+					fieldNode.PreferredTag = yamlTagRef
 				}
 				if fieldNode.Literal == "" {
 					fieldNode.Literal = fmt.Sprintf("!ref my-%s", strings.ReplaceAll(kind, "_", "-"))

--- a/internal/declarative/resources/explain_test.go
+++ b/internal/declarative/resources/explain_test.go
@@ -267,7 +267,7 @@ func TestRenderExplainSchema_ApplicationAuthStrategyUnion(t *testing.T) {
 
 	schema := RenderExplainSchema(subject)
 	require.NotNil(t, schema)
-	require.Len(t, schema.OneOf, 2)
+	require.Len(t, schema.OneOf, 3)
 	assert.Nil(t, schema.Properties)
 	assert.Nil(t, schema.Additional)
 
@@ -290,7 +290,7 @@ func TestRenderExplainSchema_ApplicationAuthStrategyUnionField(t *testing.T) {
 	subject, err := ResolveExplainSubject("application_auth_strategies.strategy_type")
 	require.NoError(t, err)
 
-	assert.True(t, subject.FieldRequired)
+	assert.False(t, subject.FieldRequired)
 	schema := RenderExplainSchema(subject)
 	require.NotNil(t, schema)
 	require.Len(t, schema.OneOf, 2)
@@ -298,14 +298,14 @@ func TestRenderExplainSchema_ApplicationAuthStrategyUnionField(t *testing.T) {
 	assert.Equal(t, "key_auth", schema.OneOf[0].Const)
 	assert.Equal(t, "openid_connect", schema.OneOf[1].Const)
 	require.NotNil(t, schema.XSubject)
-	assert.True(t, *schema.XSubject.Required)
+	assert.False(t, *schema.XSubject.Required)
 }
 
 func TestRenderExplainSchema_ApplicationAuthStrategyConfigsUnionField(t *testing.T) {
 	subject, err := ResolveExplainSubject("application_auth_strategies.configs")
 	require.NoError(t, err)
 
-	assert.True(t, subject.FieldRequired)
+	assert.False(t, subject.FieldRequired)
 	schema := RenderExplainSchema(subject)
 	require.NotNil(t, schema)
 	require.Len(t, schema.OneOf, 2)
@@ -313,7 +313,7 @@ func TestRenderExplainSchema_ApplicationAuthStrategyConfigsUnionField(t *testing
 	assert.Contains(t, schema.OneOf[0].Properties, "key-auth")
 	assert.Contains(t, schema.OneOf[1].Properties, "openid-connect")
 	require.NotNil(t, schema.XSubject)
-	assert.True(t, *schema.XSubject.Required)
+	assert.False(t, *schema.XSubject.Required)
 }
 
 func TestRenderExplainSchema_PortalAuthSettingsOmitsDeprecatedFields(t *testing.T) {
@@ -636,7 +636,7 @@ func TestRenderScaffoldYAML_ApplicationAuthStrategyUnion(t *testing.T) {
 	assert.Contains(t, scaffold, "# strategy_type: openid_connect")
 	assert.Contains(t, scaffold, "# openid-connect:")
 	assert.NotContains(t, scaffold, "# ref: my-resource")
-	assert.NotContains(t, scaffold, "# name: my-resource")
+	assert.Contains(t, scaffold, "# _external:")
 	assert.NotContains(t, scaffold, "app_auth_strategy_key_auth_request")
 	assert.NotContains(t, scaffold, "app_auth_strategy_open_i_d_connect_request")
 }

--- a/internal/declarative/resources/explain_union_schemas.go
+++ b/internal/declarative/resources/explain_union_schemas.go
@@ -118,7 +118,7 @@ func explainConstStringNode(value string) *ExplainNode {
 func explainRefField(name string, kind ResourceType, required bool) *ExplainField {
 	node := explainStringNode(fmt.Sprintf("!ref my-%s", stringsForResourceRef(kind)))
 	node.RefKind = string(kind)
-	node.PreferredTag = "!ref"
+	node.PreferredTag = yamlTagRef
 	return explainField(name, node, required, required)
 }
 
@@ -586,7 +586,7 @@ func applicationAuthStrategyExplainNode(_ ExplainBuildContext) (*ExplainNode, er
 	hints := defaultExplainHints(ResourceTypeApplicationAuthStrategy)
 	hints["name"] = ExplainFieldHint{DefaultFrom: SchemaFieldRef, Literal: "my-resource", Recommended: new(true)}
 	hints["dcr_provider_id"] = ExplainFieldHint{
-		PreferredTag: "!ref",
+		PreferredTag: yamlTagRef,
 		RefKind:      string(ResourceTypeDCRProvider),
 		Literal:      "!ref my-dcr-provider",
 	}
@@ -608,11 +608,20 @@ func applicationAuthStrategyExplainNode(_ ExplainBuildContext) (*ExplainNode, er
 	explainSetPathRequired(oidc, []string{"configs", "openid-connect", "scopes"})
 	explainSetPathRequired(oidc, []string{"configs", "openid-connect", "auth_methods"})
 	explainAddPropertyAlias(oidc, []string{"configs"}, "openid-connect", "openid_connect")
+	external, err := autoExplainConcreteNode[ExternalBlock](nil)
+	if err != nil {
+		return nil, err
+	}
+	externalBranch := explainObject(
+		explainResourceRefField(),
+		explainField("_external", external, true, true),
+	)
 
 	common := []*ExplainField{explainResourceRefField(), explainKongctlField()}
 	return explainUnionNode(
 		explainWithCommonFields(keyAuth, common...),
 		explainWithCommonFields(oidc, common...),
+		externalBranch,
 	), nil
 }
 
@@ -681,7 +690,7 @@ func eventGatewaySchemaRegistryExplainNode(_ ExplainBuildContext) (*ExplainNode,
 	return explainUnionNode(explainWithCommonFields(
 		confluent,
 		explainResourceRefField(),
-		explainRefField("event_gateway", ResourceTypeEventGatewayControlPlane, false),
+		explainRefField(SchemaFieldEventGateway, ResourceTypeEventGatewayControlPlane, false),
 	)), nil
 }
 
@@ -695,7 +704,7 @@ func eventGatewayClusterPolicyExplainNode(_ ExplainBuildContext) (*ExplainNode, 
 		acls,
 		explainResourceRefField(),
 		explainRefField("virtual_cluster", ResourceTypeEventGatewayVirtualCluster, false),
-		explainRefField("event_gateway", ResourceTypeEventGatewayControlPlane, false),
+		explainRefField(SchemaFieldEventGateway, ResourceTypeEventGatewayControlPlane, false),
 	)), nil
 }
 
@@ -775,7 +784,7 @@ func eventGatewayVirtualClusterPolicyUnion(branches ...*ExplainNode) *ExplainNod
 	common := []*ExplainField{
 		explainResourceRefField(),
 		explainRefField("virtual_cluster", ResourceTypeEventGatewayVirtualCluster, false),
-		explainRefField("event_gateway", ResourceTypeEventGatewayControlPlane, false),
+		explainRefField(SchemaFieldEventGateway, ResourceTypeEventGatewayControlPlane, false),
 	}
 	withCommon := make([]*ExplainNode, 0, len(branches))
 	for _, branch := range branches {
@@ -815,7 +824,7 @@ func eventGatewayListenerPolicyExplainNode(_ ExplainBuildContext) (*ExplainNode,
 	common := []*ExplainField{
 		explainResourceRefField(),
 		explainRefField("listener", ResourceTypeEventGatewayListener, false),
-		explainRefField("event_gateway", ResourceTypeEventGatewayControlPlane, false),
+		explainRefField(SchemaFieldEventGateway, ResourceTypeEventGatewayControlPlane, false),
 	}
 	return explainUnionNode(
 		explainWithCommonFields(tlsServer, common...),

--- a/internal/declarative/resources/gateway_service.go
+++ b/internal/declarative/resources/gateway_service.go
@@ -15,7 +15,11 @@ func init() {
 		ResourceTypeGatewayService,
 		func(rs *ResourceSet) *[]GatewayServiceResource { return &rs.GatewayServices },
 		AutoExplain[GatewayServiceResource](),
-		ExternalResolutionRegistration{Selectors: []string{SchemaFieldName}, ParentType: ResourceTypeControlPlane},
+		ExternalResolutionRegistration{
+			Selectors:       []string{SchemaFieldName},
+			ParentType:      ResourceTypeControlPlane,
+			ParentFieldPath: "control_plane",
+		},
 	)
 }
 

--- a/internal/declarative/resources/load_schema_test.go
+++ b/internal/declarative/resources/load_schema_test.go
@@ -64,9 +64,13 @@ func TestRenderLoadSchemaRetainsOnlyUnionDiscriminatorScalars(t *testing.T) {
 	require.NoError(t, err)
 
 	authStrategy := schema.Defs[string(ResourceTypeApplicationAuthStrategy)]
-	require.Len(t, authStrategy.OneOf, 2)
+	require.Len(t, authStrategy.OneOf, 3)
 	for _, branch := range authStrategy.OneOf {
 		strategyType := branch.Properties["strategy_type"]
+		if strategyType == nil {
+			require.Contains(t, branch.Properties, "_external")
+			continue
+		}
 		require.NotNil(t, strategyType)
 		assert.NotNil(t, strategyType.Const)
 		assert.Contains(t, branch.Required, "strategy_type")

--- a/internal/declarative/resources/namespace_participants.go
+++ b/internal/declarative/resources/namespace_participants.go
@@ -46,7 +46,7 @@ func (rs *ResourceSet) ForEachNamespaceParticipant(fn func(NamespaceParticipant)
 	}
 	for i := range rs.APIs {
 		if err := fn(NamespaceParticipant{
-			Type: ResourceTypeAPI, Ref: rs.APIs[i].Ref,
+			Type: ResourceTypeAPI, Ref: rs.APIs[i].Ref, External: rs.APIs[i].IsExternal(),
 			SupportsProtected: true, Label: "api", Meta: &rs.APIs[i].Kongctl,
 		}); err != nil {
 			return err
@@ -75,7 +75,7 @@ func (rs *ResourceSet) ForEachNamespaceParticipant(fn func(NamespaceParticipant)
 		if err := fn(NamespaceParticipant{
 			Type: ResourceTypeEventGatewayControlPlane, Ref: rs.EventGatewayControlPlanes[i].Ref,
 			External: rs.EventGatewayControlPlanes[i].IsExternal(), SupportsProtected: true,
-			Label: "event_gateway", Meta: &rs.EventGatewayControlPlanes[i].Kongctl,
+			Label: SchemaFieldEventGateway, Meta: &rs.EventGatewayControlPlanes[i].Kongctl,
 		}); err != nil {
 			return err
 		}
@@ -83,6 +83,7 @@ func (rs *ResourceSet) ForEachNamespaceParticipant(fn func(NamespaceParticipant)
 	for i := range rs.ApplicationAuthStrategies {
 		if err := fn(NamespaceParticipant{
 			Type: ResourceTypeApplicationAuthStrategy, Ref: rs.ApplicationAuthStrategies[i].Ref,
+			External:          rs.ApplicationAuthStrategies[i].IsExternal(),
 			SupportsProtected: true, Label: "application_auth_strategy",
 			Meta: &rs.ApplicationAuthStrategies[i].Kongctl,
 		}); err != nil {

--- a/internal/declarative/resources/portal_page.go
+++ b/internal/declarative/resources/portal_page.go
@@ -13,6 +13,7 @@ func init() {
 		ResourceTypePortalPage,
 		func(rs *ResourceSet) *[]PortalPageResource { return &rs.PortalPages },
 		AutoExplain[PortalPageResource](),
+		WithExternalUnsupportedReason("scoped portal page lookup is planned for Portal domain enablement"),
 	)
 	registerResourceType(
 		ResourceTypePortalSnippet,

--- a/internal/declarative/resources/portal_team.go
+++ b/internal/declarative/resources/portal_team.go
@@ -12,6 +12,7 @@ func init() {
 		ResourceTypePortalTeam,
 		func(rs *ResourceSet) *[]PortalTeamResource { return &rs.PortalTeams },
 		AutoExplain[PortalTeamResource](),
+		WithExternalUnsupportedReason("portal team lookup requires a portal-scoped list adapter"),
 	)
 }
 

--- a/internal/declarative/resources/portal_team_group_mapping.go
+++ b/internal/declarative/resources/portal_team_group_mapping.go
@@ -110,7 +110,7 @@ func (p *PortalTeamGroupMappingResource) UnmarshalJSON(data []byte) error {
 	allowedKeys := map[string]struct{}{
 		SchemaFieldRef:    {},
 		SchemaFieldPortal: {},
-		"team":            {},
+		SchemaFieldTeam:   {},
 		"groups":          {},
 		"kongctl":         {},
 	}

--- a/internal/declarative/resources/registry.go
+++ b/internal/declarative/resources/registry.go
@@ -1,6 +1,13 @@
 package resources
 
-import "github.com/kong/kongctl/internal/maturity"
+import (
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+
+	"github.com/kong/kongctl/internal/maturity"
+)
 
 // ResourceRegistry provides a central lookup for resource type metadata and iteration.
 // This enables adding new resources without modifying switch statements across the codebase.
@@ -13,15 +20,17 @@ import "github.com/kong/kongctl/internal/maturity"
 
 // resourceOps provides operations for a specific resource type within a ResourceSet.
 type resourceOps struct {
-	get               func(rs *ResourceSet) []Resource
-	append            func(dest, src *ResourceSet)
-	forEach           func(rs *ResourceSet, fn func(Resource) bool) bool
-	count             func(rs *ResourceSet) int
-	explain           ExplainRegistration
-	dumpDefaultRules  map[string]dumpDefaultRule
-	maturity          *maturity.Metadata
-	operationMaturity map[Operation]maturity.Metadata
-	external          *ExternalResolutionRegistration
+	get                       func(rs *ResourceSet) []Resource
+	append                    func(dest, src *ResourceSet)
+	forEach                   func(rs *ResourceSet, fn func(Resource) bool) bool
+	count                     func(rs *ResourceSet) int
+	explain                   ExplainRegistration
+	dumpDefaultRules          map[string]dumpDefaultRule
+	maturity                  *maturity.Metadata
+	operationMaturity         map[Operation]maturity.Metadata
+	external                  *ExternalResolutionRegistration
+	materializeExternal       func(rs *ResourceSet, ref, id, parentRef string) (Resource, error)
+	externalUnsupportedReason string
 }
 
 // ExternalResolutionRegistration describes the selectors and scope supported
@@ -29,7 +38,25 @@ type resourceOps struct {
 type ExternalResolutionRegistration struct {
 	Selectors              []string
 	ParentType             ResourceType
+	ParentFieldPath        string
 	AllowAnyStringSelector bool
+}
+
+// WithExternalUnsupportedReason records why a relationship target cannot yet
+// participate in external resolution. Relationship contract tests require
+// either this option or an external capability registration for every target.
+func WithExternalUnsupportedReason(reason string) ResourceRegistrationOption {
+	return func(ops *resourceOps) error {
+		reason = strings.TrimSpace(reason)
+		if reason == "" {
+			return fmt.Errorf("external unsupported reason cannot be empty")
+		}
+		if ops.external != nil {
+			return fmt.Errorf("external capability and unsupported reason are mutually exclusive")
+		}
+		ops.externalUnsupportedReason = reason
+		return nil
+	}
 }
 
 // registry maps resource types to their operations.
@@ -72,7 +99,11 @@ func registerExternalResourceType[R any, RPtr interface {
 ) {
 	registerResourceTypeWithSliceAccessors[R, RPtr](rt, getSlicePtr, getSlicePtr, explain, options...)
 	ops := registry[rt]
+	if ops.externalUnsupportedReason != "" {
+		panic("register resource type " + string(rt) + ": external capability and unsupported reason are mutually exclusive")
+	}
 	ops.external = &external
+	ops.materializeExternal = externalMaterializer[R, RPtr](rt, getSlicePtr, external)
 	registry[rt] = ops
 }
 
@@ -88,8 +119,140 @@ func registerExternalResourceTypeWithSliceAccessors[R any, RPtr interface {
 ) {
 	registerResourceTypeWithSliceAccessors[R, RPtr](rt, getSlicePtr, ensureSlicePtr, explain, options...)
 	ops := registry[rt]
+	if ops.externalUnsupportedReason != "" {
+		panic("register resource type " + string(rt) + ": external capability and unsupported reason are mutually exclusive")
+	}
 	ops.external = &external
+	ops.materializeExternal = externalMaterializer[R, RPtr](rt, ensureSlicePtr, external)
 	registry[rt] = ops
+}
+
+func externalMaterializer[R any, RPtr interface {
+	*R
+	ExternallyResolvableResource
+}](
+	rt ResourceType,
+	ensureSlicePtr func(*ResourceSet) *[]R,
+	external ExternalResolutionRegistration,
+) func(*ResourceSet, string, string, string) (Resource, error) {
+	return func(rs *ResourceSet, ref, id, parentRef string) (Resource, error) {
+		if rs == nil {
+			return nil, fmt.Errorf("cannot materialize external %s in a nil resource set", rt)
+		}
+		if strings.TrimSpace(ref) == "" || strings.TrimSpace(id) == "" {
+			return nil, fmt.Errorf("cannot materialize external %s without ref and ID", rt)
+		}
+		if existing, ok := rs.GetResourceByRef(ref); ok {
+			if existing.GetType() != rt {
+				return nil, fmt.Errorf("external ref %q is already used by %s, expected %s", ref, existing.GetType(), rt)
+			}
+			if existing.GetKonnectID() != "" && existing.GetKonnectID() != id {
+				return nil, fmt.Errorf(
+					"external %s %q has Konnect ID %q, expected %q",
+					rt,
+					ref,
+					existing.GetKonnectID(),
+					id,
+				)
+			}
+			return existing, nil
+		}
+
+		var value R
+		resource := RPtr(&value)
+		if err := setMaterializedField(resource, SchemaFieldRef, ref); err != nil {
+			return nil, fmt.Errorf("materialize external %s ref: %w", rt, err)
+		}
+		if err := setMaterializedExternalBlock(resource, &ExternalBlock{ID: id}); err != nil {
+			return nil, fmt.Errorf("materialize external %s block: %w", rt, err)
+		}
+		if external.ParentType != "" {
+			if external.ParentFieldPath == "" {
+				return nil, fmt.Errorf("external %s registration has parent type %s without parent field", rt, external.ParentType)
+			}
+			if strings.TrimSpace(parentRef) == "" {
+				return nil, fmt.Errorf("cannot materialize external %s without %s parent ref", rt, external.ParentType)
+			}
+			if err := setMaterializedField(resource, external.ParentFieldPath, parentRef); err != nil {
+				return nil, fmt.Errorf("materialize external %s parent: %w", rt, err)
+			}
+		}
+		resource.SetKonnectID(id)
+		slice := ensureSlicePtr(rs)
+		*slice = append(*slice, value)
+		materialized := RPtr(&(*slice)[len(*slice)-1])
+		return materialized, nil
+	}
+}
+
+func setMaterializedExternalBlock(resource Resource, external *ExternalBlock) error {
+	field, err := materializedFieldByPath(resource, "_external")
+	if err != nil {
+		return err
+	}
+	if field.Type() != reflect.TypeFor[*ExternalBlock]() || !field.CanSet() {
+		return fmt.Errorf("field _external is not a settable external block")
+	}
+	field.Set(reflect.ValueOf(external))
+	return nil
+}
+
+func setMaterializedField(resource Resource, path, value string) error {
+	field, err := materializedFieldByPath(resource, path)
+	if err != nil {
+		return err
+	}
+	if field.Kind() != reflect.String || !field.CanSet() {
+		return fmt.Errorf("field %s is not a settable string", path)
+	}
+	field.SetString(value)
+	return nil
+}
+
+func materializedFieldByPath(resource Resource, path string) (reflect.Value, error) {
+	current := reflect.ValueOf(resource)
+	for part := range strings.SplitSeq(path, ".") {
+		for current.Kind() == reflect.Pointer {
+			if current.IsNil() {
+				return reflect.Value{}, fmt.Errorf("field %s is nil", path)
+			}
+			current = current.Elem()
+		}
+		current = materializedTaggedField(current, part)
+		if !current.IsValid() {
+			return reflect.Value{}, fmt.Errorf("field %s not found", path)
+		}
+	}
+	return current, nil
+}
+
+func materializedTaggedField(value reflect.Value, name string) reflect.Value {
+	if value.Kind() != reflect.Struct {
+		return reflect.Value{}
+	}
+	typ := value.Type()
+	for i := range value.NumField() {
+		field := typ.Field(i)
+		for _, tagName := range []string{"yaml", "json"} {
+			tag, _, _ := strings.Cut(field.Tag.Get(tagName), ",")
+			if tag == name {
+				return value.Field(i)
+			}
+		}
+	}
+	for i := range value.NumField() {
+		if !typ.Field(i).Anonymous {
+			continue
+		}
+		field := value.Field(i)
+		for field.Kind() == reflect.Pointer && !field.IsNil() {
+			field = field.Elem()
+		}
+		if result := materializedTaggedField(field, name); result.IsValid() {
+			return result
+		}
+	}
+	return reflect.Value{}
 }
 
 func registerResourceTypeWithSliceAccessors[R any, RPtr interface {
@@ -262,12 +425,52 @@ func ExternalResolutionFor(rt ResourceType) (ExternalResolutionRegistration, boo
 	return result, true
 }
 
+// MaterializeExternalResource adds an externally managed resource identity to
+// the ResourceSet using the constructor registered for its resource type.
+func MaterializeExternalResource(
+	rs *ResourceSet,
+	rt ResourceType,
+	ref string,
+	id string,
+	parentRef string,
+) (Resource, error) {
+	ops, ok := registry[rt]
+	if !ok || ops.external == nil || ops.materializeExternal == nil {
+		return nil, fmt.Errorf("resource type %s does not support external materialization", rt)
+	}
+	return ops.materializeExternal(rs, ref, id, parentRef)
+}
+
+// ExternalUnsupportedReason reports the reviewed reason a relationship target
+// does not currently support external resolution.
+func ExternalUnsupportedReason(rt ResourceType) (string, bool) {
+	ops, ok := registry[rt]
+	if !ok || strings.TrimSpace(ops.externalUnsupportedReason) == "" {
+		return "", false
+	}
+	return ops.externalUnsupportedReason, true
+}
+
 // ExternalResolvableTypes returns all resource types with the external capability contract.
 func ExternalResolvableTypes() []ResourceType {
 	result := make([]ResourceType, 0)
 	for rt, ops := range registry {
 		if ops.external != nil {
 			result = append(result, rt)
+		}
+	}
+	slices.Sort(result)
+	return result
+}
+
+// ExternalResolvableTypesByScope returns capabilities partitioned by whether
+// their lookup requires a resolved parent identity.
+func ExternalResolvableTypesByScope(scoped bool) []ResourceType {
+	result := make([]ResourceType, 0)
+	for _, resourceType := range ExternalResolvableTypes() {
+		capability, _ := ExternalResolutionFor(resourceType)
+		if (capability.ParentType != "") == scoped {
+			result = append(result, resourceType)
 		}
 	}
 	return result

--- a/internal/declarative/resources/registry_test.go
+++ b/internal/declarative/resources/registry_test.go
@@ -35,6 +35,19 @@ func TestAllResources(t *testing.T) {
 	})
 }
 
+func TestMaterializeExternalAPI(t *testing.T) {
+	t.Parallel()
+
+	rs := &ResourceSet{}
+	resource, err := MaterializeExternalResource(rs, ResourceTypeAPI, "shared-api", "api-id", "")
+	require.NoError(t, err)
+	require.Equal(t, "shared-api", resource.GetRef())
+	require.Equal(t, "api-id", resource.GetKonnectID())
+	require.Len(t, rs.APIs, 1)
+	require.True(t, rs.APIs[0].IsExternal())
+	require.Equal(t, "api-id", rs.APIs[0].External.ID)
+}
+
 func TestResourceCount(t *testing.T) {
 	t.Run("matches AllResources length", func(t *testing.T) {
 		rs := &ResourceSet{

--- a/internal/declarative/resources/relationships.go
+++ b/internal/declarative/resources/relationships.go
@@ -1,30 +1,52 @@
 package resources
 
-import "strings"
+import "slices"
 
 // RelationshipKind distinguishes API schema foreign keys from kongctl-added
 // root-level parent selectors while giving both the same reference semantics.
 type RelationshipKind string
 
+type RelationshipCardinality string
+
+type RelationshipResultField string
+
 const (
-	RelationshipKindAPIForeignKey         RelationshipKind = "api_foreign_key"
-	RelationshipKindKongctlParentSelector RelationshipKind = "kongctl_parent_selector"
+	RelationshipKindAPIForeignKey         RelationshipKind        = "api_foreign_key"
+	RelationshipKindKongctlParentSelector RelationshipKind        = "kongctl_parent_selector"
+	RelationshipCardinalityScalar         RelationshipCardinality = "scalar"
+	RelationshipCardinalityList           RelationshipCardinality = "list"
+	RelationshipResultFieldID             RelationshipResultField = "id"
+	RelationshipResultFieldRef            RelationshipResultField = "ref"
 )
 
 // RelationshipDescriptor is static schema metadata for a cross-resource field.
 type RelationshipDescriptor struct {
-	FieldPath      string
-	TargetType     ResourceType
-	Kind           RelationshipKind
-	ScopeFieldPath string
-	RootOnly       bool
+	FieldPath                    string
+	TargetType                   ResourceType
+	TargetTypes                  []ResourceType
+	TargetDiscriminatorFieldPath string
+	TargetTypeResolver           func(string) (ResourceType, bool)
+	Kind                         RelationshipKind
+	Cardinality                  RelationshipCardinality
+	ResultField                  RelationshipResultField
+	ScopeFieldPath               string
+	RootOnly                     bool
 }
 
 var relationshipDescriptors = map[ResourceType][]RelationshipDescriptor{
+	ResourceTypeAPIVersion: {
+		{FieldPath: "api", TargetType: ResourceTypeAPI, Kind: RelationshipKindKongctlParentSelector, RootOnly: true},
+	},
 	ResourceTypeAPIPublication: {
+		{FieldPath: "api", TargetType: ResourceTypeAPI, Kind: RelationshipKindKongctlParentSelector, RootOnly: true},
 		{FieldPath: "portal_id", TargetType: ResourceTypePortal, Kind: RelationshipKindAPIForeignKey},
+		{
+			FieldPath: "auth_strategy_ids", TargetType: ResourceTypeApplicationAuthStrategy,
+			Kind: RelationshipKindAPIForeignKey, Cardinality: RelationshipCardinalityList,
+		},
 	},
 	ResourceTypeAPIImplementation: {
+		{FieldPath: "api", TargetType: ResourceTypeAPI, Kind: RelationshipKindKongctlParentSelector, RootOnly: true},
 		{
 			FieldPath:  "control_plane.control_plane_id",
 			TargetType: ResourceTypeControlPlane,
@@ -38,6 +60,52 @@ var relationshipDescriptors = map[ResourceType][]RelationshipDescriptor{
 		{
 			FieldPath: "service.id", TargetType: ResourceTypeGatewayService, Kind: RelationshipKindAPIForeignKey,
 			ScopeFieldPath: "service.control_plane_id",
+		},
+	},
+	ResourceTypeAPIDocument: {
+		{FieldPath: "api", TargetType: ResourceTypeAPI, Kind: RelationshipKindKongctlParentSelector, RootOnly: true},
+		{
+			FieldPath: "parent_document_ref", TargetType: ResourceTypeAPIDocument,
+			Kind: RelationshipKindKongctlParentSelector, ScopeFieldPath: "api",
+		},
+	},
+	ResourceTypePortal: {
+		{
+			FieldPath: "default_application_auth_strategy_id", TargetType: ResourceTypeApplicationAuthStrategy,
+			Kind: RelationshipKindAPIForeignKey,
+		},
+	},
+	ResourceTypeApplicationAuthStrategy: {
+		{FieldPath: "dcr_provider_id", TargetType: ResourceTypeDCRProvider, Kind: RelationshipKindAPIForeignKey},
+	},
+	ResourceTypePortalPage: {
+		{
+			FieldPath: "parent_page_ref", TargetType: ResourceTypePortalPage,
+			Kind: RelationshipKindKongctlParentSelector, ScopeFieldPath: "portal",
+		},
+	},
+	ResourceTypePortalTeamGroupMapping: {
+		{
+			FieldPath: SchemaFieldTeam, TargetType: ResourceTypePortalTeam,
+			Kind: RelationshipKindKongctlParentSelector, ScopeFieldPath: SchemaFieldPortal, RootOnly: true,
+		},
+	},
+	ResourceTypePortalTeamRole: {
+		{
+			FieldPath: SchemaFieldTeam, TargetType: ResourceTypePortalTeam,
+			Kind: RelationshipKindKongctlParentSelector, ScopeFieldPath: SchemaFieldPortal, RootOnly: true,
+		},
+		{
+			FieldPath: "entity_id", TargetDiscriminatorFieldPath: "entity_type_name",
+			TargetTypeResolver: RoleEntityResourceType,
+			TargetTypes:        []ResourceType{ResourceTypeAPI, ResourceTypePortal, ResourceTypeControlPlane},
+			Kind:               RelationshipKindAPIForeignKey,
+		},
+	},
+	ResourceTypeAIGatewayConsumerCredential: {
+		{
+			FieldPath: SchemaFieldAIGatewayConsumer, TargetType: ResourceTypeAIGatewayConsumer,
+			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
 		},
 	},
 	ResourceTypeGatewayService: {
@@ -64,56 +132,84 @@ var relationshipDescriptors = map[ResourceType][]RelationshipDescriptor{
 	},
 	ResourceTypeOrganizationTeamRole: {
 		{
-			FieldPath: "team", TargetType: ResourceTypeOrganizationTeam,
+			FieldPath: SchemaFieldTeam, TargetType: ResourceTypeOrganizationTeam,
 			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
+		},
+		{
+			FieldPath: "entity_id", TargetDiscriminatorFieldPath: "entity_type_name",
+			TargetTypeResolver: RoleEntityResourceType,
+			TargetTypes:        []ResourceType{ResourceTypeAPI, ResourceTypePortal, ResourceTypeControlPlane},
+			Kind:               RelationshipKindAPIForeignKey,
+		},
+	},
+	ResourceTypeOrganizationUserRole: {
+		{
+			FieldPath: "entity_id", TargetDiscriminatorFieldPath: "entity_type_name",
+			TargetTypeResolver: RoleEntityResourceType,
+			TargetTypes:        []ResourceType{ResourceTypeAPI, ResourceTypePortal, ResourceTypeControlPlane},
+			Kind:               RelationshipKindAPIForeignKey,
+		},
+	},
+	ResourceTypeOrganizationSystemAccountRole: {
+		{
+			FieldPath: "entity_id", TargetDiscriminatorFieldPath: "entity_type_name",
+			TargetTypeResolver: RoleEntityResourceType,
+			TargetTypes:        []ResourceType{ResourceTypeAPI, ResourceTypePortal, ResourceTypeControlPlane},
+			Kind:               RelationshipKindAPIForeignKey,
 		},
 	},
 	ResourceTypeOrganizationUserTeamMembership: {
 		{
-			FieldPath: "team", TargetType: ResourceTypeOrganizationTeam,
+			FieldPath: SchemaFieldTeam, TargetType: ResourceTypeOrganizationTeam,
 			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
 		},
 	},
 	ResourceTypeOrganizationSystemAccountTeamMembership: {
 		{
-			FieldPath: "team", TargetType: ResourceTypeOrganizationTeam,
+			FieldPath: SchemaFieldTeam, TargetType: ResourceTypeOrganizationTeam,
 			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
 		},
 	},
 	ResourceTypeEventGatewayVirtualCluster: {
 		{
-			FieldPath: "event_gateway", TargetType: ResourceTypeEventGatewayControlPlane,
+			FieldPath: SchemaFieldEventGateway, TargetType: ResourceTypeEventGatewayControlPlane,
 			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
 		},
 	},
 	ResourceTypeEventGatewayClusterPolicy: {
 		{
-			FieldPath: "event_gateway", TargetType: ResourceTypeEventGatewayControlPlane,
+			FieldPath: SchemaFieldEventGateway, TargetType: ResourceTypeEventGatewayControlPlane,
 			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
 		},
 		{
 			FieldPath: "virtual_cluster", TargetType: ResourceTypeEventGatewayVirtualCluster,
-			Kind: RelationshipKindKongctlParentSelector, ScopeFieldPath: "event_gateway", RootOnly: true,
+			Kind: RelationshipKindKongctlParentSelector, ScopeFieldPath: SchemaFieldEventGateway, RootOnly: true,
 		},
 	},
 	ResourceTypeEventGatewayProducePolicy: {
 		{
-			FieldPath: "event_gateway", TargetType: ResourceTypeEventGatewayControlPlane,
+			FieldPath: SchemaFieldEventGateway, TargetType: ResourceTypeEventGatewayControlPlane,
 			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
 		},
 		{
 			FieldPath: "virtual_cluster", TargetType: ResourceTypeEventGatewayVirtualCluster,
-			Kind: RelationshipKindKongctlParentSelector, ScopeFieldPath: "event_gateway", RootOnly: true,
+			Kind: RelationshipKindKongctlParentSelector, ScopeFieldPath: SchemaFieldEventGateway, RootOnly: true,
 		},
 	},
 	ResourceTypeEventGatewayConsumePolicy: {
 		{
-			FieldPath: "event_gateway", TargetType: ResourceTypeEventGatewayControlPlane,
+			FieldPath: SchemaFieldEventGateway, TargetType: ResourceTypeEventGatewayControlPlane,
 			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
 		},
 		{
 			FieldPath: "virtual_cluster", TargetType: ResourceTypeEventGatewayVirtualCluster,
-			Kind: RelationshipKindKongctlParentSelector, ScopeFieldPath: "event_gateway", RootOnly: true,
+			Kind: RelationshipKindKongctlParentSelector, ScopeFieldPath: SchemaFieldEventGateway, RootOnly: true,
+		},
+	},
+	ResourceTypeEventGatewayListenerPolicy: {
+		{
+			FieldPath: "listener", TargetType: ResourceTypeEventGatewayListener,
+			Kind: RelationshipKindKongctlParentSelector, ScopeFieldPath: SchemaFieldEventGateway, RootOnly: true,
 		},
 	},
 }
@@ -161,10 +257,10 @@ var eventGatewayChildTypes = []ResourceType{
 
 func init() {
 	for _, resourceType := range aiGatewayChildTypes {
-		relationshipDescriptors[resourceType] = []RelationshipDescriptor{{
+		relationshipDescriptors[resourceType] = append(relationshipDescriptors[resourceType], RelationshipDescriptor{
 			FieldPath: SchemaFieldAIGateway, TargetType: ResourceTypeAIGateway,
 			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
-		}}
+		})
 	}
 	relationshipDescriptors[ResourceTypeAIGatewayConfigStoreSecret] = []RelationshipDescriptor{{
 		FieldPath: SchemaFieldAIGatewayConfigStore, TargetType: ResourceTypeAIGatewayConfigStore,
@@ -189,54 +285,64 @@ func init() {
 				FieldPath:      SchemaFieldAccess + "." + SchemaFieldAuthStrategies,
 				TargetType:     ResourceTypeAIGatewayAuthStrategy,
 				Kind:           RelationshipKindAPIForeignKey,
+				Cardinality:    RelationshipCardinalityList,
 				ScopeFieldPath: SchemaFieldAIGateway,
 			},
 		)
 	}
 	for _, resourceType := range portalChildTypes {
-		relationshipDescriptors[resourceType] = []RelationshipDescriptor{{
+		relationshipDescriptors[resourceType] = append(relationshipDescriptors[resourceType], RelationshipDescriptor{
 			FieldPath: SchemaFieldPortal, TargetType: ResourceTypePortal,
 			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
-		}}
+		})
 	}
 	for _, resourceType := range eventGatewayChildTypes {
-		relationshipDescriptors[resourceType] = []RelationshipDescriptor{{
-			FieldPath: "event_gateway", TargetType: ResourceTypeEventGatewayControlPlane,
+		relationshipDescriptors[resourceType] = append(relationshipDescriptors[resourceType], RelationshipDescriptor{
+			FieldPath: SchemaFieldEventGateway, TargetType: ResourceTypeEventGatewayControlPlane,
 			Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
-		}}
+		})
 	}
 }
 
 // RelationshipDescriptorsForType returns static relationship schema metadata.
 func RelationshipDescriptorsForType(resourceType ResourceType) []RelationshipDescriptor {
-	return append([]RelationshipDescriptor(nil), relationshipDescriptors[resourceType]...)
+	result := append([]RelationshipDescriptor(nil), relationshipDescriptors[resourceType]...)
+	for i := range result {
+		if result[i].Cardinality == "" {
+			result[i].Cardinality = RelationshipCardinalityScalar
+		}
+		if result[i].ResultField == "" {
+			result[i].ResultField = RelationshipResultFieldID
+			if result[i].Kind == RelationshipKindKongctlParentSelector {
+				result[i].ResultField = RelationshipResultFieldRef
+			}
+		}
+	}
+	return result
 }
 
-// RelationshipDescriptorsFor returns static descriptors plus compatibility
-// mappings for fields not yet backfilled into the static schema registry.
+// RelationshipDescriptorsFor returns authoritative relationship metadata for a resource.
 func RelationshipDescriptorsFor(resource Resource) []RelationshipDescriptor {
-	result := RelationshipDescriptorsForType(resource.GetType())
-	seen := make(map[string]struct{}, len(result))
-	for _, descriptor := range result {
-		seen[descriptor.FieldPath] = struct{}{}
-	}
-	mapping, ok := resource.(ReferenceMapping)
-	if !ok {
-		return result
-	}
-	for fieldPath, target := range mapping.GetReferenceFieldMappings() {
-		if _, exists := seen[fieldPath]; exists {
-			continue
+	return RelationshipDescriptorsForType(resource.GetType())
+}
+
+// RelationshipTargetTypes returns every target declared by relationship metadata.
+func RelationshipTargetTypes() []ResourceType {
+	seen := make(map[ResourceType]struct{})
+	for _, descriptors := range relationshipDescriptors {
+		for _, descriptor := range descriptors {
+			if descriptor.TargetType != "" {
+				seen[descriptor.TargetType] = struct{}{}
+			}
+			for _, targetType := range descriptor.TargetTypes {
+				seen[targetType] = struct{}{}
+			}
 		}
-		kind := RelationshipKindKongctlParentSelector
-		if strings.HasSuffix(fieldPath, "_id") || strings.Contains(fieldPath, ".id") {
-			kind = RelationshipKindAPIForeignKey
-		}
-		result = append(result, RelationshipDescriptor{
-			FieldPath:  fieldPath,
-			TargetType: ResourceType(target),
-			Kind:       kind,
-		})
 	}
+	result := make([]ResourceType, 0, len(seen))
+	for resourceType := range seen {
+		result = append(result, resourceType)
+	}
+	slices.Sort(result)
 	return result
 }

--- a/internal/declarative/resources/relationships_test.go
+++ b/internal/declarative/resources/relationships_test.go
@@ -12,31 +12,36 @@ func TestRelationshipDescriptorsDistinguishFieldOrigins(t *testing.T) {
 	publication := RelationshipDescriptorsForType(ResourceTypeAPIPublication)
 	require.Contains(t, publication, RelationshipDescriptor{
 		FieldPath: "portal_id", TargetType: ResourceTypePortal, Kind: RelationshipKindAPIForeignKey,
+		Cardinality: RelationshipCardinalityScalar, ResultField: RelationshipResultFieldID,
 	})
 
 	model := RelationshipDescriptorsForType(ResourceTypeAIGatewayModel)
 	require.Contains(t, model, RelationshipDescriptor{
 		FieldPath: SchemaFieldAIGateway, TargetType: ResourceTypeAIGateway,
-		Kind: RelationshipKindKongctlParentSelector, RootOnly: true,
+		Kind: RelationshipKindKongctlParentSelector, Cardinality: RelationshipCardinalityScalar,
+		ResultField: RelationshipResultFieldRef, RootOnly: true,
 	})
 	require.Contains(t, model, RelationshipDescriptor{
 		FieldPath:  SchemaFieldAccess + "." + SchemaFieldAuthStrategies,
 		TargetType: ResourceTypeAIGatewayAuthStrategy,
-		Kind:       RelationshipKindAPIForeignKey, ScopeFieldPath: SchemaFieldAIGateway,
+		Kind:       RelationshipKindAPIForeignKey, Cardinality: RelationshipCardinalityList,
+		ResultField: RelationshipResultFieldID, ScopeFieldPath: SchemaFieldAIGateway,
 	})
 
 	agent := RelationshipDescriptorsForType(ResourceTypeAIGatewayAgent)
 	require.Contains(t, agent, RelationshipDescriptor{
 		FieldPath:  SchemaFieldAccess + "." + SchemaFieldAuthStrategies,
 		TargetType: ResourceTypeAIGatewayAuthStrategy,
-		Kind:       RelationshipKindAPIForeignKey, ScopeFieldPath: SchemaFieldAIGateway,
+		Kind:       RelationshipKindAPIForeignKey, Cardinality: RelationshipCardinalityList,
+		ResultField: RelationshipResultFieldID, ScopeFieldPath: SchemaFieldAIGateway,
 	})
 
 	mcpServer := RelationshipDescriptorsForType(ResourceTypeAIGatewayMCPServer)
 	require.Contains(t, mcpServer, RelationshipDescriptor{
 		FieldPath:  SchemaFieldAccess + "." + SchemaFieldAuthStrategies,
 		TargetType: ResourceTypeAIGatewayAuthStrategy,
-		Kind:       RelationshipKindAPIForeignKey, ScopeFieldPath: SchemaFieldAIGateway,
+		Kind:       RelationshipKindAPIForeignKey, Cardinality: RelationshipCardinalityList,
+		ResultField: RelationshipResultFieldID, ScopeFieldPath: SchemaFieldAIGateway,
 	})
 }
 
@@ -85,4 +90,42 @@ func TestRelationshipExplainNoteMatchesExternalCapability(t *testing.T) {
 	require.Contains(t, note, "use !ref")
 	require.NotContains(t, note, "!lookup")
 	require.NotContains(t, note, "!external")
+}
+
+func TestEveryRelationshipTargetDeclaresExternalCapabilityOrExclusion(t *testing.T) {
+	t.Parallel()
+
+	for _, targetType := range RelationshipTargetTypes() {
+		_, supported := ExternalResolutionFor(targetType)
+		_, excluded := ExternalUnsupportedReason(targetType)
+		require.NotEqualf(
+			t,
+			supported,
+			excluded,
+			"relationship target %s must declare exactly one external-resolution disposition",
+			targetType,
+		)
+	}
+}
+
+func TestRBACRelationshipExplainUsesDiscriminatorContract(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		"organization.users.roles.entity_id",
+		"portal.teams.roles.entity_id",
+	} {
+		subject, err := ResolveExplainSubject(path)
+		require.NoError(t, err)
+		schema := RenderExplainSchema(subject)
+		require.NotNil(t, schema.XRelationship)
+		require.Equal(t, "entity_type_name", schema.XRelationship.TargetDiscriminator)
+		require.ElementsMatch(
+			t,
+			[]ResourceType{ResourceTypeAPI, ResourceTypePortal, ResourceTypeControlPlane},
+			schema.XRelationship.Targets,
+		)
+		require.Equal(t, []string{"!ref", "!external", "!lookup"}, schema.XRelationship.AcceptedTags)
+		require.Equal(t, []string{"name"}, schema.XRelationship.Selectors)
+	}
 }

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -89,11 +89,13 @@ const (
 	SchemaFieldName                 = "name"
 	SchemaFieldPortal               = "portal"
 	SchemaFieldOrganization         = "organization"
+	SchemaFieldTeam                 = "team"
 	SchemaFieldTeams                = "teams"
 	SchemaFieldRoles                = "roles"
 	SchemaFieldUser                 = "user"
 	SchemaFieldSystemAccount        = "system_account"
 	SchemaFieldAIGateway            = "ai_gateway"
+	SchemaFieldEventGateway         = "event_gateway"
 	SchemaFieldAIGatewayConsumer    = "ai_gateway_consumer"
 	SchemaFieldAIGatewayConfigStore = "ai_gateway_config_store"
 	SchemaFieldDisplayName          = "display_name"
@@ -887,6 +889,12 @@ func (rs *ResourceSet) GetAIGatewayDataPlaneCertificatesByNamespace(
 func (rs *ResourceSet) GetAPIsByNamespace(namespace string) []APIResource {
 	var filtered []APIResource
 	for _, api := range rs.APIs {
+		if api.IsExternal() {
+			if namespace == NamespaceExternal {
+				filtered = append(filtered, api)
+			}
+			continue
+		}
 		if GetNamespace(api.Kongctl) == namespace {
 			filtered = append(filtered, api)
 		}
@@ -909,6 +917,12 @@ func (rs *ResourceSet) GetDashboardsByNamespace(namespace string) []DashboardRes
 func (rs *ResourceSet) GetAuthStrategiesByNamespace(namespace string) []ApplicationAuthStrategyResource {
 	var filtered []ApplicationAuthStrategyResource
 	for _, strategy := range rs.ApplicationAuthStrategies {
+		if strategy.IsExternal() {
+			if namespace == NamespaceExternal {
+				filtered = append(filtered, strategy)
+			}
+			continue
+		}
 		if GetNamespace(strategy.Kongctl) == namespace {
 			filtered = append(filtered, strategy)
 		}
@@ -932,7 +946,8 @@ func (rs *ResourceSet) GetAPIVersionsByNamespace(namespace string) []APIVersionR
 	var filtered []APIVersionResource
 	for _, version := range rs.APIVersions {
 		// Check if parent API is in the namespace
-		if api := rs.GetAPIByRef(version.API); api != nil && GetNamespace(api.Kongctl) == namespace {
+		api := rs.GetAPIByRef(version.API)
+		if api != nil && resourceNamespaceMatches(api.IsExternal(), api.Kongctl, namespace) {
 			filtered = append(filtered, version)
 		}
 	}
@@ -944,7 +959,7 @@ func (rs *ResourceSet) GetAPIPublicationsByNamespace(namespace string) []APIPubl
 	var filtered []APIPublicationResource
 	for _, pub := range rs.APIPublications {
 		// Check if parent API is in the namespace
-		if api := rs.GetAPIByRef(pub.API); api != nil && GetNamespace(api.Kongctl) == namespace {
+		if api := rs.GetAPIByRef(pub.API); api != nil && resourceNamespaceMatches(api.IsExternal(), api.Kongctl, namespace) {
 			filtered = append(filtered, pub)
 		}
 	}
@@ -956,7 +971,7 @@ func (rs *ResourceSet) GetAPIImplementationsByNamespace(namespace string) []APII
 	var filtered []APIImplementationResource
 	for _, impl := range rs.APIImplementations {
 		// Check if parent API is in the namespace
-		if api := rs.GetAPIByRef(impl.API); api != nil && GetNamespace(api.Kongctl) == namespace {
+		if api := rs.GetAPIByRef(impl.API); api != nil && resourceNamespaceMatches(api.IsExternal(), api.Kongctl, namespace) {
 			filtered = append(filtered, impl)
 		}
 	}
@@ -968,11 +983,18 @@ func (rs *ResourceSet) GetAPIDocumentsByNamespace(namespace string) []APIDocumen
 	var filtered []APIDocumentResource
 	for _, doc := range rs.APIDocuments {
 		// Check if parent API is in the namespace
-		if api := rs.GetAPIByRef(doc.API); api != nil && GetNamespace(api.Kongctl) == namespace {
+		if api := rs.GetAPIByRef(doc.API); api != nil && resourceNamespaceMatches(api.IsExternal(), api.Kongctl, namespace) {
 			filtered = append(filtered, doc)
 		}
 	}
 	return filtered
+}
+
+func resourceNamespaceMatches(external bool, meta *KongctlMeta, namespace string) bool {
+	if external {
+		return namespace == NamespaceExternal
+	}
+	return GetNamespace(meta) == namespace
 }
 
 // GetPortalCustomizationsByNamespace returns all portal customization resources from the specified namespace

--- a/internal/declarative/state/client.go
+++ b/internal/declarative/state/client.go
@@ -2962,6 +2962,37 @@ func (c *Client) ListManagedAuthStrategies(
 	return PaginateAll(ctx, lister)
 }
 
+// ListAllApplicationAuthStrategies returns all application auth strategies,
+// including resources not managed by kongctl.
+func (c *Client) ListAllApplicationAuthStrategies(ctx context.Context) ([]ApplicationAuthStrategy, error) {
+	if err := ValidateAPIClient(c.appAuthAPI, "app auth API"); err != nil {
+		return nil, err
+	}
+
+	lister := func(ctx context.Context, pageSize, pageNumber int64) ([]ApplicationAuthStrategy, *PageMeta, error) {
+		resp, err := c.appAuthAPI.ListAppAuthStrategies(ctx, kkOps.ListAppAuthStrategiesRequest{
+			PageSize:   &pageSize,
+			PageNumber: &pageNumber,
+		})
+		if err != nil {
+			return nil, nil, WrapAPIError(err, "list application auth strategies", nil)
+		}
+		if resp.ListAppAuthStrategiesResponse == nil {
+			return []ApplicationAuthStrategy{}, &PageMeta{Total: 0}, nil
+		}
+
+		strategies := make([]ApplicationAuthStrategy, 0, len(resp.ListAppAuthStrategiesResponse.Data))
+		for _, candidate := range resp.ListAppAuthStrategiesResponse.Data {
+			if strategy := c.extractAuthStrategyFromUnion(candidate); strategy != nil {
+				strategies = append(strategies, *strategy)
+			}
+		}
+		return strategies, &PageMeta{Total: resp.ListAppAuthStrategiesResponse.Meta.Page.Total}, nil
+	}
+
+	return PaginateAll(ctx, lister)
+}
+
 // extractAuthStrategyFromUnion extracts a normalized auth strategy from the SDK union type
 func (c *Client) extractAuthStrategyFromUnion(s kkComps.AppAuthStrategy) *ApplicationAuthStrategy {
 	if s.AppAuthStrategyKeyAuthResponseAppAuthStrategyKeyAuthResponse != nil {

--- a/test/e2e/scenarios/external/api-parent/scenario.yaml
+++ b/test/e2e/scenarios/external/api-parent/scenario.yaml
@@ -1,0 +1,112 @@
+baseInputsPath: testdata
+
+vars:
+  api_name: External Parent API
+  portal_name: External Parent Portal
+  auth_strategy_name: external-parent-auth
+  team_name: external-api-consumers
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-bootstrap-external-resources
+    skipInputs: true
+    commands:
+      - name: 000-create-api
+        create:
+          resource: api
+          payload:
+            inline:
+              name: "{{ .vars.api_name }}"
+              description: API owned outside kongctl declarative management
+          recordVar:
+            name: api_id
+            responsePath: id
+      - name: 001-create-portal
+        create:
+          resource: portal
+          payload:
+            inline:
+              name: "{{ .vars.portal_name }}"
+              display_name: External Parent Portal
+          recordVar:
+            name: portal_id
+            responsePath: id
+      - name: 002-create-auth-strategy
+        create:
+          resource: auth_strategy
+          payload:
+            inline:
+              name: "{{ .vars.auth_strategy_name }}"
+              display_name: External Parent Auth
+              strategy_type: key_auth
+              configs:
+                key-auth:
+                  key_names:
+                    - X-API-Key
+          recordVar:
+            name: auth_strategy_id
+            responsePath: id
+
+  - name: 002-sync-version-under-external-api
+    commands:
+      - name: 000-sync
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/external-api.yaml"
+          - --auto-approve
+        assertions:
+          - select: "plan.changes[?resource_type=='api']"
+            expect:
+              fields:
+                "length(@)": 0
+          - select: "plan.changes[?resource_type=='api_version'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+                parent.id: "{{ .vars.api_id }}"
+          - select: "plan.changes[?resource_type=='api_publication'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+                parent.id: "{{ .vars.api_id }}"
+                "fields.auth_strategy_ids[0]": "{{ .vars.auth_strategy_id }}"
+          - select: "plan.changes[?resource_type=='organization_team_role'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+                fields.entity_id: "{{ .vars.api_id }}"
+                fields.entity_type_name: APIs
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success
+
+  - name: 003-sync-idempotent
+    commands:
+      - name: 000-sync
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/external-api.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 0
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success
+
+  - name: 004-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true

--- a/test/e2e/scenarios/external/api-parent/testdata/external-api.yaml
+++ b/test/e2e/scenarios/external/api-parent/testdata/external-api.yaml
@@ -1,0 +1,33 @@
+apis:
+  - ref: external-parent-api
+    _external:
+      selector:
+        matchFields:
+          name: External Parent API
+    versions:
+      - ref: external-parent-api-v1
+        version: v1
+        spec:
+          openapi: 3.0.0
+          info:
+            title: External Parent API
+            version: v1
+          paths: {}
+    publications:
+      - ref: external-parent-publication
+        portal_id: !lookup name:External Parent Portal
+        visibility: public
+        auth_strategy_ids:
+          - !lookup name:external-parent-auth
+
+organization:
+  teams:
+    - ref: external-api-consumers
+      name: external-api-consumers
+      description: Team with access to an externally managed API
+      roles:
+        - ref: external-api-viewer
+          role_name: Viewer
+          entity_id: !lookup name:External Parent API
+          entity_type_name: APIs
+          entity_region: us

--- a/test/integration/declarative/external_lookup_test.go
+++ b/test/integration/declarative/external_lookup_test.go
@@ -79,3 +79,68 @@ gateway_services:
 	require.Equal(t, map[string]string{"name": "Flow Control Plane"}, parentLookup.MatchFields)
 	require.Equal(t, []string{"name"}, parentLookup.SensitiveFields)
 }
+
+func TestExpandedExternalLookupTargetsLoad(t *testing.T) {
+	t.Parallel()
+
+	configFile := filepath.Join(t.TempDir(), "expanded-external-lookups.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+apis:
+  - ref: shared-api
+    _external:
+      selector:
+        matchFields:
+          name: Shared API
+    versions:
+      - ref: shared-api-v1
+        version: v1
+        spec:
+          openapi: 3.0.0
+          info: {title: Shared API, version: v1}
+          paths: {}
+
+application_auth_strategies:
+  - ref: shared-auth
+    _external:
+      selector:
+        matchFields:
+          display_name: Shared Authentication
+
+api_publications:
+  - ref: shared-publication
+    api: !lookup name:Shared API
+    portal_id: 00000000-0000-4000-8000-000000000001
+    auth_strategy_ids:
+      - !lookup name:Shared Auth
+    visibility: private
+
+organization:
+  users:
+    - ref: reader
+      email: reader@example.com
+      roles:
+        - ref: api-viewer
+          role_name: Viewer
+          entity_id: !lookup name:Shared API
+          entity_type_name: API Products
+          entity_region: us
+`), 0o600))
+
+	rs, err := loader.New().LoadFile(configFile)
+	require.NoError(t, err)
+	require.Len(t, rs.APIs, 1)
+	require.True(t, rs.APIs[0].IsExternal())
+	require.Len(t, rs.APIVersions, 1)
+	require.Equal(t, "shared-api", rs.APIVersions[0].API)
+	require.Len(t, rs.ApplicationAuthStrategies, 1)
+	require.True(t, rs.ApplicationAuthStrategies[0].IsExternal())
+	require.Len(t, rs.APIPublications, 1)
+	_, ok := tags.ParseExternalPlaceholder(rs.APIPublications[0].API)
+	require.True(t, ok)
+	require.Len(t, rs.APIPublications[0].AuthStrategyIds, 1)
+	_, ok = tags.ParseExternalPlaceholder(rs.APIPublications[0].AuthStrategyIds[0])
+	require.True(t, ok)
+	require.Len(t, rs.OrganizationUserRoles, 1)
+	_, ok = tags.ParseExternalPlaceholder(rs.OrganizationUserRoles[0].EntityID)
+	require.True(t, ok)
+}


### PR DESCRIPTION
## Summary

- centralize declarative external lookup capabilities and relationship metadata
- expand external lookup support across eligible resource types, including APIs and authentication strategies
- allow managed API children and role assignments to resolve external API parents without placing those parents in apply or sync scope
- resolve dumped API publication auth strategy refs to resources recreated earlier in the same sync instead of reusing stale UUIDs
- document lookup contracts and add declarative, integration, unit, and end-to-end coverage

## Validation

- `go fix ./...`
- `make format`
- `make build`
- `make test`
- `make test-integration`
- E2E: `dump/portal-owned`

`make lint` reports the existing 56 generated/mock-file findings (50 line-length, 4 spelling, and 2 staticcheck); this change introduces no lint findings.

Closes #1674