### PR TITLE
fix(declarative): support portal sipr_enabled

### DIFF
--- a/internal/cmd/root/verbs/dump/declarative.go
+++ b/internal/cmd/root/verbs/dump/declarative.go
@@ -847,6 +847,10 @@ func mapPortalToDeclarativeResource(portal kkComps.ListPortalsResponsePortal) de
 		result.RbacEnabled = rbacEnabled
 	}
 
+	if siprEnabled := portal.GetSiprEnabled(); siprEnabled != nil {
+		result.SiprEnabled = siprEnabled
+	}
+
 	if visibility := portal.GetDefaultAPIVisibility(); visibility != "" {
 		apiVisibility := kkComps.DefaultAPIVisibility(visibility)
 		result.DefaultAPIVisibility = &apiVisibility
@@ -883,6 +887,7 @@ func mapPortalResponseToDeclarativeResource(portal kkComps.PortalResponse) declr
 		Description:                      portal.GetDescription(),
 		AuthenticationEnabled:            portal.GetAuthenticationEnabled(),
 		RbacEnabled:                      portal.GetRbacEnabled(),
+		SiprEnabled:                      portal.GetSiprEnabled(),
 		DefaultApplicationAuthStrategyID: portal.GetDefaultApplicationAuthStrategyID(),
 		AutoApproveDevelopers:            portal.GetAutoApproveDevelopers(),
 		AutoApproveApplications:          portal.GetAutoApproveApplications(),

--- a/internal/cmd/root/verbs/dump/dump_declarative_test.go
+++ b/internal/cmd/root/verbs/dump/dump_declarative_test.go
@@ -308,6 +308,7 @@ func TestMapPortalToDeclarativeResource(t *testing.T) {
 	authFalse := false
 	portal.AuthenticationEnabled = &authTrue
 	portal.RbacEnabled = &authTrue
+	portal.SiprEnabled = &authTrue
 	portal.AutoApproveDevelopers = &authTrue
 	portal.AutoApproveApplications = &authFalse
 
@@ -359,6 +360,10 @@ func TestMapPortalToDeclarativeResource(t *testing.T) {
 		t.Fatalf("expected default page visibility public, got %+v", resource.DefaultPageVisibility)
 	}
 
+	if resource.SiprEnabled == nil || !*resource.SiprEnabled {
+		t.Fatalf("expected sipr_enabled to be true")
+	}
+
 	if resource.AutoApproveDevelopers == nil || !*resource.AutoApproveDevelopers {
 		t.Fatalf("expected auto approve developers to be true")
 	}
@@ -387,6 +392,7 @@ func TestMapEventGatewayToDeclarativeResourcePreservesMinRuntimeVersion(t *testi
 func TestCollectDeclarativePortalsUsesPortalDetails(t *testing.T) {
 	listAuthEnabled := false
 	detailAuthEnabled := true
+	detailSIPREnabled := true
 	var getPortalIDs []string
 
 	api := &portalPaginationStub{
@@ -429,6 +435,7 @@ func TestCollectDeclarativePortalsUsesPortalDetails(t *testing.T) {
 					ID:                    id,
 					Name:                  "portal-name",
 					AuthenticationEnabled: &detailAuthEnabled,
+					SiprEnabled:           &detailSIPREnabled,
 				},
 			}, nil
 		},
@@ -446,6 +453,10 @@ func TestCollectDeclarativePortalsUsesPortalDetails(t *testing.T) {
 	if resources[0].AuthenticationEnabled == nil || !*resources[0].AuthenticationEnabled {
 		t.Fatalf("expected authentication_enabled to come from portal detail, got %+v",
 			resources[0].AuthenticationEnabled)
+	}
+
+	if resources[0].SiprEnabled == nil || !*resources[0].SiprEnabled {
+		t.Fatalf("expected sipr_enabled to come from portal detail, got %+v", resources[0].SiprEnabled)
 	}
 
 	if len(getPortalIDs) != 1 || getPortalIDs[0] != "portal-id" {

--- a/internal/declarative/executor/portal_adapter.go
+++ b/internal/declarative/executor/portal_adapter.go
@@ -42,6 +42,7 @@ func (p *PortalAdapter) MapCreateFields(_ context.Context, execCtx *ExecutionCon
 	common.MapOptionalStringFieldToPtr(&create.DisplayName, fields, planner.FieldDisplayName)
 	common.MapOptionalBoolFieldToPtr(&create.AuthenticationEnabled, fields, planner.FieldAuthenticationEnabled)
 	common.MapOptionalBoolFieldToPtr(&create.RbacEnabled, fields, planner.FieldRBACEnabled)
+	common.MapOptionalBoolFieldToPtr(&create.SiprEnabled, fields, planner.FieldSIPREnabled)
 	common.MapOptionalBoolFieldToPtr(&create.AutoApproveDevelopers, fields, planner.FieldAutoApproveDevelopers)
 	common.MapOptionalBoolFieldToPtr(&create.AutoApproveApplications, fields, planner.FieldAutoApproveApplications)
 
@@ -99,6 +100,10 @@ func (p *PortalAdapter) MapUpdateFields(_ context.Context, _ *ExecutionContext, 
 		case planner.FieldRBACEnabled:
 			if rbacEnabled, ok := value.(bool); ok {
 				update.RbacEnabled = &rbacEnabled
+			}
+		case planner.FieldSIPREnabled:
+			if siprEnabled, ok := value.(bool); ok {
+				update.SiprEnabled = &siprEnabled
 			}
 		case planner.FieldAutoApproveDevelopers:
 			if autoApproveDevelopers, ok := value.(bool); ok {

--- a/internal/declarative/executor/portal_adapter_test.go
+++ b/internal/declarative/executor/portal_adapter_test.go
@@ -10,6 +10,49 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestPortalAdapterMapsSIPREnabled(t *testing.T) {
+	tests := []struct {
+		name  string
+		value bool
+	}{
+		{name: "enabled", value: true},
+		{name: "disabled", value: false},
+	}
+
+	adapter := NewPortalAdapter(nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fields := map[string]any{
+				planner.FieldName:        "customer-portal",
+				planner.FieldSIPREnabled: tt.value,
+			}
+
+			create := kkComps.CreatePortal{}
+			err := adapter.MapCreateFields(
+				t.Context(),
+				&ExecutionContext{},
+				fields,
+				&create,
+			)
+			require.NoError(t, err)
+			require.NotNil(t, create.SiprEnabled)
+			assert.Equal(t, tt.value, *create.SiprEnabled)
+
+			update := kkComps.UpdatePortal{}
+			err = adapter.MapUpdateFields(
+				t.Context(),
+				&ExecutionContext{},
+				fields,
+				&update,
+				nil,
+			)
+			require.NoError(t, err)
+			require.NotNil(t, update.SiprEnabled)
+			assert.Equal(t, tt.value, *update.SiprEnabled)
+		})
+	}
+}
+
 func TestPortalAdapterMapUpdateFieldsKeepsPatchPayloadSparse(t *testing.T) {
 	adapter := NewPortalAdapter(nil)
 	update := kkComps.UpdatePortal{}

--- a/internal/declarative/loader/load_schema_test.go
+++ b/internal/declarative/loader/load_schema_test.go
@@ -92,6 +92,46 @@ control_planes:
 	}
 }
 
+func TestDeclarativeLoadSchemaAcceptsPortalSIPREnabled(t *testing.T) {
+	tests := []struct {
+		name  string
+		value bool
+	}{
+		{name: "enabled", value: true},
+		{name: "disabled", value: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := fmt.Sprintf(`
+portals:
+  - ref: customer-portal
+    name: customer-portal
+    sipr_enabled: %t
+`, tt.value)
+
+			resourceSet, err := New().parseYAML(strings.NewReader(input), "manifest.yaml", ".")
+			require.NoError(t, err)
+			require.Len(t, resourceSet.Portals, 1)
+			require.NotNil(t, resourceSet.Portals[0].SiprEnabled)
+			assert.Equal(t, tt.value, *resourceSet.Portals[0].SiprEnabled)
+		})
+	}
+}
+
+func TestDeclarativeLoadSchemaPreservesOmittedPortalSIPREnabled(t *testing.T) {
+	input := `
+portals:
+  - ref: customer-portal
+    name: customer-portal
+`
+
+	resourceSet, err := New().parseYAML(strings.NewReader(input), "manifest.yaml", ".")
+	require.NoError(t, err)
+	require.Len(t, resourceSet.Portals, 1)
+	assert.Nil(t, resourceSet.Portals[0].SiprEnabled)
+}
+
 func TestDeclarativeLoadSchemaSelectsUnionBranch(t *testing.T) {
 	input := `
 application_auth_strategies:

--- a/internal/declarative/planner/constants.go
+++ b/internal/declarative/planner/constants.go
@@ -165,6 +165,7 @@ const (
 	FieldPreview                      = "preview"
 	FieldReplyToEmail                 = "reply_to_email"
 	FieldRBACEnabled                  = "rbac_enabled"
+	FieldSIPREnabled                  = "sipr_enabled"
 	FieldSSL                          = "ssl"
 	FieldRobots                       = "robots"
 	FieldSpecRenderer                 = "spec_renderer"

--- a/internal/declarative/planner/portal_planner.go
+++ b/internal/declarative/planner/portal_planner.go
@@ -312,6 +312,9 @@ func extractPortalFields(resource any) map[string]any {
 	if portal.RbacEnabled != nil {
 		fields[FieldRBACEnabled] = *portal.RbacEnabled
 	}
+	if portal.SiprEnabled != nil {
+		fields[FieldSIPREnabled] = *portal.SiprEnabled
+	}
 	if portal.DefaultAPIVisibility != nil {
 		fields[FieldDefaultAPIVisibility] = string(*portal.DefaultAPIVisibility)
 	}
@@ -523,6 +526,20 @@ func (p *portalPlannerImpl) shouldUpdatePortal(
 			changedFields[FieldRBACEnabled] = FieldChange{
 				Old: oldValue,
 				New: *desired.RbacEnabled,
+			}
+		}
+	}
+
+	if desired.SiprEnabled != nil {
+		if curr := current.GetSiprEnabled(); curr == nil || *curr != *desired.SiprEnabled {
+			updates[FieldSIPREnabled] = *desired.SiprEnabled
+			var oldValue any
+			if curr != nil {
+				oldValue = *curr
+			}
+			changedFields[FieldSIPREnabled] = FieldChange{
+				Old: oldValue,
+				New: *desired.SiprEnabled,
 			}
 		}
 	}

--- a/internal/declarative/planner/portal_planner_test.go
+++ b/internal/declarative/planner/portal_planner_test.go
@@ -1,0 +1,111 @@
+package planner
+
+import (
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/kong/kongctl/internal/declarative/resources"
+	"github.com/kong/kongctl/internal/declarative/state"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractPortalFieldsIncludesSIPREnabled(t *testing.T) {
+	tests := []struct {
+		name  string
+		value bool
+	}{
+		{name: "enabled", value: true},
+		{name: "disabled", value: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			portal := resources.PortalResource{
+				CreatePortal: kkComps.CreatePortal{
+					Name:        "customer-portal",
+					SiprEnabled: &tt.value,
+				},
+			}
+
+			fields := extractPortalFields(portal)
+
+			assert.Equal(t, tt.value, fields[FieldSIPREnabled])
+		})
+	}
+}
+
+func TestShouldUpdatePortalSIPREnabled(t *testing.T) {
+	tests := []struct {
+		name        string
+		current     *bool
+		desired     *bool
+		wantUpdate  bool
+		wantNew     any
+		wantOld     any
+		wantChanged bool
+	}{
+		{
+			name:        "enable",
+			current:     new(false),
+			desired:     new(true),
+			wantUpdate:  true,
+			wantNew:     true,
+			wantOld:     false,
+			wantChanged: true,
+		},
+		{
+			name:        "disable",
+			current:     new(true),
+			desired:     new(false),
+			wantUpdate:  true,
+			wantNew:     false,
+			wantOld:     true,
+			wantChanged: true,
+		},
+		{
+			name:    "unchanged",
+			current: new(true),
+			desired: new(true),
+		},
+		{
+			name:    "omitted preserves current value",
+			current: new(true),
+		},
+		{
+			name:        "missing current value differs from desired",
+			desired:     new(true),
+			wantUpdate:  true,
+			wantNew:     true,
+			wantChanged: true,
+		},
+	}
+
+	planner := &portalPlannerImpl{BasePlanner: &BasePlanner{}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			current := state.Portal{
+				ListPortalsResponsePortal: kkComps.ListPortalsResponsePortal{
+					SiprEnabled: tt.current,
+				},
+			}
+			desired := resources.PortalResource{
+				CreatePortal: kkComps.CreatePortal{SiprEnabled: tt.desired},
+			}
+
+			needsUpdate, updates, changedFields := planner.shouldUpdatePortal(current, desired)
+
+			assert.Equal(t, tt.wantUpdate, needsUpdate)
+			if tt.wantUpdate {
+				assert.Equal(t, tt.wantNew, updates[FieldSIPREnabled])
+			} else {
+				assert.NotContains(t, updates, FieldSIPREnabled)
+			}
+			change, changed := changedFields[FieldSIPREnabled]
+			assert.Equal(t, tt.wantChanged, changed)
+			if tt.wantChanged {
+				assert.Equal(t, tt.wantOld, change.Old)
+				assert.Equal(t, tt.wantNew, change.New)
+			}
+		})
+	}
+}

--- a/internal/declarative/resources/portal.go
+++ b/internal/declarative/resources/portal.go
@@ -510,6 +510,11 @@ func (p *PortalResource) UnmarshalJSON(data []byte) error {
 		if err := json.Unmarshal(encoded, &p.CreatePortal); err != nil {
 			return err
 		}
+		// The SDK applies its false default while decoding even when this field is
+		// absent. Restore nil so the planner can preserve sparse-update semantics.
+		if _, ok := sdkPayload["sipr_enabled"]; !ok {
+			p.SiprEnabled = nil
+		}
 	} else {
 		// Ensure embedded struct is zeroed if no fields were provided.
 		p.CreatePortal = kkComps.CreatePortal{}


### PR DESCRIPTION
## Summary

- carry `sipr_enabled` from portal YAML through planning and SDK create/update payloads
- preserve sparse-update behavior when the field is omitted while retaining explicit `false`
- include the toggle in declarative portal dumps
- add loader, planner, executor, and dump regression coverage

## Rationale

The SDK-backed declarative schema already accepted `sipr_enabled`, but the
portal planner did not add it to planned fields and the executor did not map it
into API requests. As a result, the value was silently dropped and portals
retained the API default of `false`.

The generated SDK decoder also materializes its default when the field is
omitted. The resource decoder now restores omission as `nil` so an absent field
does not unintentionally disable an existing portal setting.

## Validation

- `go fix ./...`
- `make format`
- `make build`
- `make lint`
- `make test`
- `make test-integration`

Closes #2013