### PR TITLE
test(e2e): cover control plane implementation sync-delete

### DIFF
--- a/test/e2e/scenarios/apis/control-plane-implementation/overlays/001-remove-implementation/resources.yaml
+++ b/test/e2e/scenarios/apis/control-plane-implementation/overlays/001-remove-implementation/resources.yaml
@@ -1,3 +1,19 @@
+_defaults:
+  kongctl:
+    namespace: api-control-plane-implementation
+
+control_planes:
+  - ref: api-implementation-cp
+    name: "e2e-api-implementation-cp"
+    description: "Control plane implementation E2E"
+    cluster_type: "CLUSTER_TYPE_SERVERLESS"
+    cloud_gateway: false
+    _deck:
+      files:
+        - "ace.yaml"
+      flags:
+        - "--analytics=false"
+
 apis:
   - ref: control-plane-api
     name: "E2E Control Plane Implementation API"

--- a/test/e2e/scenarios/apis/control-plane-implementation/overlays/001-remove-implementation/resources.yaml
+++ b/test/e2e/scenarios/apis/control-plane-implementation/overlays/001-remove-implementation/resources.yaml
@@ -1,0 +1,4 @@
+apis:
+  - ref: control-plane-api
+    name: "E2E Control Plane Implementation API"
+    implementations: []

--- a/test/e2e/scenarios/apis/control-plane-implementation/scenario.yaml
+++ b/test/e2e/scenarios/apis/control-plane-implementation/scenario.yaml
@@ -93,7 +93,70 @@ steps:
               fields:
                 total_changes: 0
 
-  - name: 004-reset-org
+  - name: 004-sync-delete-implementation
+    inputOverlayDirs:
+      - overlays/001-remove-implementation
+    commands:
+      - name: 000-sync-delete
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/resources.yaml"
+          - --auto-approve
+        assertions:
+          - select: plan.summary
+            expect:
+              fields:
+                total_changes: 1
+                by_action.DELETE: 1
+          - select: "plan.changes[?resource_type=='api_implementation'] | [0]"
+            expect:
+              fields:
+                action: DELETE
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success
+      - name: 001-get-implementations
+        run:
+          - get
+          - api
+          - implementations
+          - --api-name
+          - "E2E Control Plane Implementation API"
+          - -o
+          - json
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                "length(@)": 0
+      - name: 002-get-api
+        run:
+          - get
+          - apis
+          - -o
+          - json
+        assertions:
+          - select: "[?name=='E2E Control Plane Implementation API']"
+            expect:
+              fields:
+                "length(@)": 1
+      - name: 003-get-control-plane
+        run:
+          - get
+          - gateway
+          - control-planes
+          - -o
+          - json
+        assertions:
+          - select: "[?name=='e2e-api-implementation-cp']"
+            expect:
+              fields:
+                "length(@)": 1
+
+  - name: 005-reset-org
     skipInputs: true
     commands:
       - resetOrg: true


### PR DESCRIPTION
## Summary

- add a sync-delete step for control-plane API implementations
- verify the implementation is removed after sync
- verify the parent API and control plane remain

## Testing

- `go fix ./...`
- `make format`
- `make build`
- `make test`
- `make lint` *(fails on pre-existing generated portal client line-length/misspelling findings and two pre-existing staticcheck findings)*

Closes #2005