### PR TITLE
refactor(simplify): reduce planner and validation boilerplate

### DIFF
--- a/internal/cmd/root/products/konnect/aigateway/child_common.go
+++ b/internal/cmd/root/products/konnect/aigateway/child_common.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kong/kongctl/internal/cmd"
 	"github.com/kong/kongctl/internal/config"
+	"github.com/kong/kongctl/internal/konnect/helpers"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -300,6 +301,32 @@ func bindAIGatewayChildFlags(c *cobra.Command, args []string) error {
 
 func getAIGatewayIdentifiers(cfg config.Hook) (id string, name string) {
 	return getPairedAIGatewayIdentifiers(cfg, aiGatewayIDConfigPath, aiGatewayNameConfigPath)
+}
+
+func resolveRequiredAIGatewayID(
+	cfg config.Hook,
+	gatewayAPI helpers.AIGatewayAPI,
+	helper cmd.Helper,
+) (string, error) {
+	gatewayID, gatewayName := getAIGatewayIdentifiers(cfg)
+	if gatewayID != "" && gatewayName != "" {
+		return "", &cmd.ConfigurationError{Err: fmt.Errorf(
+			"only one of --%s or --%s can be provided",
+			aiGatewayIDFlagName,
+			aiGatewayNameFlagName,
+		)}
+	}
+	if gatewayID == "" && gatewayName == "" {
+		return "", &cmd.ConfigurationError{Err: fmt.Errorf(
+			"an AI Gateway identifier is required. Provide --%s or --%s",
+			aiGatewayIDFlagName,
+			aiGatewayNameFlagName,
+		)}
+	}
+	if gatewayID != "" {
+		return gatewayID, nil
+	}
+	return resolveAIGatewayIDByName(gatewayName, gatewayAPI, helper, cfg)
 }
 
 func addAIGatewayProviderFlags(c *cobra.Command) {

--- a/internal/cmd/root/products/konnect/aigateway/config_store_secrets.go
+++ b/internal/cmd/root/products/konnect/aigateway/config_store_secrets.go
@@ -57,26 +57,9 @@ func (h aiGatewayConfigStoresHandler) runSecrets(store string, args []string) er
 	if err != nil {
 		return err
 	}
-	gatewayID, gatewayName := getAIGatewayIdentifiers(cfg)
-	if gatewayID != "" && gatewayName != "" {
-		return &cmd.ConfigurationError{Err: fmt.Errorf(
-			"only one of --%s or --%s can be provided",
-			aiGatewayIDFlagName,
-			aiGatewayNameFlagName,
-		)}
-	}
-	if gatewayID == "" && gatewayName == "" {
-		return &cmd.ConfigurationError{Err: fmt.Errorf(
-			"an AI Gateway identifier is required. Provide --%s or --%s",
-			aiGatewayIDFlagName,
-			aiGatewayNameFlagName,
-		)}
-	}
-	if gatewayID == "" {
-		gatewayID, err = resolveAIGatewayIDByName(gatewayName, sdk.GetAIGatewayAPI(), helper, cfg)
-		if err != nil {
-			return err
-		}
+	gatewayID, err := resolveRequiredAIGatewayID(cfg, sdk.GetAIGatewayAPI(), helper)
+	if err != nil {
+		return err
 	}
 	api := sdk.GetAIGatewayConfigStoresAPI()
 	if api == nil {

--- a/internal/cmd/root/products/konnect/aigateway/config_stores.go
+++ b/internal/cmd/root/products/konnect/aigateway/config_stores.go
@@ -131,26 +131,9 @@ func (h aiGatewayConfigStoresHandler) run(args []string) error {
 	if err != nil {
 		return err
 	}
-	gatewayID, gatewayName := getAIGatewayIdentifiers(cfg)
-	if gatewayID != "" && gatewayName != "" {
-		return &cmd.ConfigurationError{Err: fmt.Errorf(
-			"only one of --%s or --%s can be provided",
-			aiGatewayIDFlagName,
-			aiGatewayNameFlagName,
-		)}
-	}
-	if gatewayID == "" && gatewayName == "" {
-		return &cmd.ConfigurationError{Err: fmt.Errorf(
-			"an AI Gateway identifier is required. Provide --%s or --%s",
-			aiGatewayIDFlagName,
-			aiGatewayNameFlagName,
-		)}
-	}
-	if gatewayID == "" {
-		gatewayID, err = resolveAIGatewayIDByName(gatewayName, sdk.GetAIGatewayAPI(), helper, cfg)
-		if err != nil {
-			return err
-		}
+	gatewayID, err := resolveRequiredAIGatewayID(cfg, sdk.GetAIGatewayAPI(), helper)
+	if err != nil {
+		return err
 	}
 	api := sdk.GetAIGatewayConfigStoresAPI()
 	if api == nil {

--- a/internal/cmd/root/products/konnect/auditlogs/pull.go
+++ b/internal/cmd/root/products/konnect/auditlogs/pull.go
@@ -584,8 +584,7 @@ func resolveAuditLogHeadersAndRows(helper cmd.Helper, records []json.RawMessage)
 		return nil, nil, err
 	}
 	if len(selected) > 0 {
-		headers, rows, err := columns.Project(records, selected)
-		return headers, rows, err
+		return columns.Project(records, selected)
 	}
 
 	headers := []string{"TIMESTAMP", "TYPE", "PRINCIPAL", "ACTION", "RESULT", "TRACE ID"}

--- a/internal/declarative/planner/ai_gateway_auth_strategy_planner.go
+++ b/internal/declarative/planner/ai_gateway_auth_strategy_planner.go
@@ -2,7 +2,6 @@ package planner
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"reflect"
@@ -353,7 +352,6 @@ func comparableAIGatewayAuthStrategyConfigs(current, desired map[string]any) (ma
 		current,
 		desired,
 		normalizeAIGatewayAuthStrategyConfigsForComparison,
-		scrubAIGatewayAuthStrategySecretFields,
 		isAIGatewayAuthStrategySecretField,
 	)
 }
@@ -362,8 +360,8 @@ func normalizeAIGatewayAuthStrategyConfigsForComparison(
 	current map[string]any,
 	desired map[string]any,
 ) (map[string]any, map[string]any) {
-	currentComparable := normalizeAuthStrategyConfigForCompare(current)
-	desiredComparable := normalizeAuthStrategyConfigForCompare(desired)
+	currentComparable := normalizeAIGatewayJSONMap(current)
+	desiredComparable := normalizeAIGatewayJSONMap(desired)
 	projectAIGatewayAuthStrategyConfigForComparison(currentComparable, desiredComparable)
 	return currentComparable, desiredComparable
 }
@@ -387,11 +385,11 @@ func projectAIGatewayAuthStrategyConfigForComparison(currentCompare map[string]a
 }
 
 func mergeAIGatewayAuthStrategyConfig(current, desired map[string]any) map[string]any {
-	merged := normalizeAuthStrategyConfigForCompare(current)
+	merged := normalizeAIGatewayJSONMap(current)
 	if merged == nil {
 		merged = make(map[string]any)
 	}
-	mergeAIGatewayAuthStrategyConfigValues(merged, normalizeAuthStrategyConfigForCompare(desired))
+	mergeAIGatewayAuthStrategyConfigValues(merged, normalizeAIGatewayJSONMap(desired))
 	return merged
 }
 
@@ -404,46 +402,6 @@ func mergeAIGatewayAuthStrategyConfigValues(current, desired map[string]any) {
 			continue
 		}
 		current[key] = desiredValue
-	}
-}
-
-func normalizeAuthStrategyConfigForCompare(config map[string]any) map[string]any {
-	if config == nil {
-		return nil
-	}
-	data, err := json.Marshal(config)
-	if err != nil {
-		return config
-	}
-	var normalized map[string]any
-	if err := json.Unmarshal(data, &normalized); err != nil {
-		return config
-	}
-	return normalized
-}
-
-func scrubAIGatewayAuthStrategySecretFields(value any) any {
-	switch typed := value.(type) {
-	case map[string]any:
-		result := make(map[string]any, len(typed))
-		for key, val := range typed {
-			if isAIGatewayAuthStrategySecretField(key) {
-				if references, ok := projectPublicVaultReferences(val); ok {
-					result[key] = references
-				}
-				continue
-			}
-			result[key] = scrubAIGatewayAuthStrategySecretFields(val)
-		}
-		return result
-	case []any:
-		result := make([]any, len(typed))
-		for i := range typed {
-			result[i] = scrubAIGatewayAuthStrategySecretFields(typed[i])
-		}
-		return result
-	default:
-		return value
 	}
 }
 

--- a/internal/declarative/planner/ai_gateway_config_store_planner.go
+++ b/internal/declarative/planner/ai_gateway_config_store_planner.go
@@ -35,18 +35,10 @@ func (p *Planner) planAIGatewayConfigStoreChanges(
 			storeChangeID := p.planAIGatewayConfigStoreCreate(
 				namespace, gatewayRef, gatewayName, "", store, dependsOn, plan,
 			)
-			secrets := p.resources.GetAIGatewayConfigStoreSecretsForStore(store.Ref)
-			if p.shouldPlanChild(
-				plan,
-				resources.ResourceTypeAIGatewayConfigStore,
-				store.Ref,
-				resources.ResourceTypeAIGatewayConfigStoreSecret,
-			) && (len(secrets) > 0 || plan.Metadata.Mode == PlanModeSync) {
-				if err := p.planAIGatewayConfigStoreSecretChanges(
-					ctx, namespace, gatewayRef, "", store.Ref, "", storeChangeID, secrets, plan,
-				); err != nil {
-					return err
-				}
+			if err := p.planAIGatewayConfigStoreSecretChangesIfNeeded(
+				ctx, namespace, gatewayRef, "", store.Ref, "", storeChangeID, plan,
+			); err != nil {
+				return err
 			}
 		}
 		return nil
@@ -75,26 +67,10 @@ func (p *Planner) planAIGatewayConfigStoreChanges(
 				nil,
 				plan,
 			)
-			secrets := p.resources.GetAIGatewayConfigStoreSecretsForStore(desiredStore.Ref)
-			if p.shouldPlanChild(
-				plan,
-				resources.ResourceTypeAIGatewayConfigStore,
-				desiredStore.Ref,
-				resources.ResourceTypeAIGatewayConfigStoreSecret,
-			) && (len(secrets) > 0 || plan.Metadata.Mode == PlanModeSync) {
-				if err := p.planAIGatewayConfigStoreSecretChanges(
-					ctx,
-					namespace,
-					gatewayRef,
-					gatewayID,
-					desiredStore.Ref,
-					"",
-					storeChangeID,
-					secrets,
-					plan,
-				); err != nil {
-					return err
-				}
+			if err := p.planAIGatewayConfigStoreSecretChangesIfNeeded(
+				ctx, namespace, gatewayRef, gatewayID, desiredStore.Ref, "", storeChangeID, plan,
+			); err != nil {
+				return err
 			}
 			continue
 		}
@@ -134,26 +110,10 @@ func (p *Planner) planAIGatewayConfigStoreChanges(
 			})
 		}
 
-		secrets := p.resources.GetAIGatewayConfigStoreSecretsForStore(desiredStore.Ref)
-		if p.shouldPlanChild(
-			plan,
-			resources.ResourceTypeAIGatewayConfigStore,
-			desiredStore.Ref,
-			resources.ResourceTypeAIGatewayConfigStoreSecret,
-		) && (len(secrets) > 0 || plan.Metadata.Mode == PlanModeSync) {
-			if err := p.planAIGatewayConfigStoreSecretChanges(
-				ctx,
-				namespace,
-				gatewayRef,
-				gatewayID,
-				desiredStore.Ref,
-				current.ID,
-				"",
-				secrets,
-				plan,
-			); err != nil {
-				return err
-			}
+		if err := p.planAIGatewayConfigStoreSecretChangesIfNeeded(
+			ctx, namespace, gatewayRef, gatewayID, desiredStore.Ref, current.ID, "", plan,
+		); err != nil {
+			return err
 		}
 	}
 
@@ -175,6 +135,30 @@ func (p *Planner) planAIGatewayConfigStoreChanges(
 		}
 	}
 	return nil
+}
+
+func (p *Planner) planAIGatewayConfigStoreSecretChangesIfNeeded(
+	ctx context.Context,
+	namespace string,
+	gatewayRef string,
+	gatewayID string,
+	storeRef string,
+	storeID string,
+	storeChangeID string,
+	plan *Plan,
+) error {
+	secrets := p.resources.GetAIGatewayConfigStoreSecretsForStore(storeRef)
+	if !p.shouldPlanChild(
+		plan,
+		resources.ResourceTypeAIGatewayConfigStore,
+		storeRef,
+		resources.ResourceTypeAIGatewayConfigStoreSecret,
+	) || (len(secrets) == 0 && plan.Metadata.Mode != PlanModeSync) {
+		return nil
+	}
+	return p.planAIGatewayConfigStoreSecretChanges(
+		ctx, namespace, gatewayRef, gatewayID, storeRef, storeID, storeChangeID, secrets, plan,
+	)
 }
 
 func (p *Planner) planAIGatewayConfigStoreCreate(

--- a/internal/declarative/planner/ai_gateway_payload_compare.go
+++ b/internal/declarative/planner/ai_gateway_payload_compare.go
@@ -79,6 +79,31 @@ func normalizeAIGatewayJSONMap(payload map[string]any) map[string]any {
 	return normalized
 }
 
+func scrubAIGatewayWriteOnlyFields(value any, isWriteOnly func(string) bool) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		result := make(map[string]any, len(typed))
+		for key, child := range typed {
+			if isWriteOnly(key) {
+				if references, ok := projectPublicVaultReferences(child); ok {
+					result[key] = references
+				}
+				continue
+			}
+			result[key] = scrubAIGatewayWriteOnlyFields(child, isWriteOnly)
+		}
+		return result
+	case []any:
+		result := make([]any, len(typed))
+		for i := range typed {
+			result[i] = scrubAIGatewayWriteOnlyFields(typed[i], isWriteOnly)
+		}
+		return result
+	default:
+		return value
+	}
+}
+
 func scrubAIGatewayUpstreamWriteOnlyFields(value any) any {
 	switch typed := value.(type) {
 	case map[string]any:
@@ -119,15 +144,11 @@ func comparableAIGatewayWriteOnlyPayloads(
 	current map[string]any,
 	desired map[string]any,
 	normalize aiGatewayPayloadPairNormalizer,
-	scrub func(any) any,
 	isWriteOnlyField func(string) bool,
 ) (map[string]any, map[string]any) {
-	currentComparable, desiredComparable := scrubbedAIGatewayWriteOnlyPayloads(
-		current,
-		desired,
-		normalize,
-		scrub,
-	)
+	currentComparable, desiredComparable := normalize(current, desired)
+	currentComparable = scrubAIGatewayWriteOnlyFields(currentComparable, isWriteOnlyField).(map[string]any)
+	desiredComparable = scrubAIGatewayWriteOnlyFields(desiredComparable, isWriteOnlyField).(map[string]any)
 	pruneUnpairedAIGatewayWriteOnlyReferences(currentComparable, desiredComparable, isWriteOnlyField)
 	return currentComparable, desiredComparable
 }

--- a/internal/declarative/planner/ai_gateway_provider_planner.go
+++ b/internal/declarative/planner/ai_gateway_provider_planner.go
@@ -330,34 +330,12 @@ func comparableAIGatewayProviderConfigs(current, desired map[string]any) (map[st
 		current,
 		desired,
 		normalizeAIGatewayPayloadsForComparison,
-		scrubAIGatewayProviderSecretFields,
 		isAIGatewayProviderSecretField,
 	)
 }
 
 func scrubAIGatewayProviderSecretFields(value any) any {
-	switch typed := value.(type) {
-	case map[string]any:
-		result := make(map[string]any, len(typed))
-		for key, val := range typed {
-			if isAIGatewayProviderSecretField(key) {
-				if references, ok := projectPublicVaultReferences(val); ok {
-					result[key] = references
-				}
-				continue
-			}
-			result[key] = scrubAIGatewayProviderSecretFields(val)
-		}
-		return result
-	case []any:
-		result := make([]any, len(typed))
-		for i := range typed {
-			result[i] = scrubAIGatewayProviderSecretFields(typed[i])
-		}
-		return result
-	default:
-		return value
-	}
+	return scrubAIGatewayWriteOnlyFields(value, isAIGatewayProviderSecretField)
 }
 
 func isAIGatewayProviderSecretField(key string) bool {

--- a/internal/declarative/planner/ai_gateway_vault_planner.go
+++ b/internal/declarative/planner/ai_gateway_vault_planner.go
@@ -245,7 +245,6 @@ func comparableAIGatewayVaultPayloads(current, desired map[string]any) (map[stri
 		current,
 		desired,
 		normalizeAIGatewayPayloadsForComparison,
-		scrubAIGatewayVaultWriteOnlyFields,
 		isAIGatewayVaultWriteOnlyField,
 	)
 }
@@ -273,28 +272,7 @@ func normalizeAIGatewayVaultConfigStoreReferenceForComparison(
 }
 
 func scrubAIGatewayVaultWriteOnlyFields(value any) any {
-	switch typed := value.(type) {
-	case map[string]any:
-		result := make(map[string]any, len(typed))
-		for key, val := range typed {
-			if isAIGatewayVaultWriteOnlyField(key) {
-				if references, ok := projectPublicVaultReferences(val); ok {
-					result[key] = references
-				}
-				continue
-			}
-			result[key] = scrubAIGatewayVaultWriteOnlyFields(val)
-		}
-		return result
-	case []any:
-		result := make([]any, len(typed))
-		for i := range typed {
-			result[i] = scrubAIGatewayVaultWriteOnlyFields(typed[i])
-		}
-		return result
-	default:
-		return value
-	}
+	return scrubAIGatewayWriteOnlyFields(value, isAIGatewayVaultWriteOnlyField)
 }
 
 func isAIGatewayVaultWriteOnlyField(key string) bool {

--- a/internal/declarative/planner/deck_requirements.go
+++ b/internal/declarative/planner/deck_requirements.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 
 	"github.com/kong/kongctl/internal/declarative/deck"
@@ -59,8 +60,8 @@ func (p *Planner) planDeckDependencies(ctx context.Context, rs *resources.Resour
 			cpName = resolved
 		}
 
-		deckFiles := cloneStringSlice(cp.Deck.Files)
-		deckFlags := cloneStringSlice(cp.Deck.Flags)
+		deckFiles := slices.Clone(cp.Deck.Files)
+		deckFlags := slices.Clone(cp.Deck.Flags)
 		deckBaseDir := strings.TrimSpace(cp.DeckBaseDir())
 
 		if cpCreateID == "" && cpID != "" {
@@ -494,15 +495,6 @@ func (p *Planner) resolveDeckControlPlaneName(ctx context.Context, controlPlaneI
 	}
 
 	return cp.Name, nil
-}
-
-func cloneStringSlice(values []string) []string {
-	if len(values) == 0 {
-		return nil
-	}
-	out := make([]string, len(values))
-	copy(out, values)
-	return out
 }
 
 func deckRunErrorSuffix(result *deck.RunResult) string {

--- a/internal/declarative/resources/api_implementation.go
+++ b/internal/declarative/resources/api_implementation.go
@@ -114,10 +114,7 @@ func (i APIImplementationResource) Validate() error {
 
 	service := i.getService()
 	controlPlane := i.getControlPlane()
-	if service != nil && controlPlane != nil {
-		return fmt.Errorf("API implementation must define exactly one of service or control_plane")
-	}
-	if service == nil && controlPlane == nil {
+	if (service == nil) == (controlPlane == nil) {
 		return fmt.Errorf("API implementation must define exactly one of service or control_plane")
 	}
 


### PR DESCRIPTION
## Summary

- consolidate required AI Gateway identifier validation for Config Stores
- centralize Config Store secret-planning guards and write-only payload scrubbing
- reuse shared JSON normalization and Go slice cloning idioms
- simplify audit-log projection and API implementation validation

## Testing

- `go fix ./...`
- `make format`
- `make build`
- `make test-installer`
- `make test`
- `make test-integration`
- `make lint` (fails on pre-existing generated portal client and mock findings;
  no changed files are reported)

Closes #1993
Closes #2004