### PR TITLE
fix(cmd): support control plane API implementation get

### DIFF
--- a/internal/cmd/root/products/konnect/api/implementations.go
+++ b/internal/cmd/root/products/konnect/api/implementations.go
@@ -208,7 +208,7 @@ func (h apiImplementationsHandler) run(args []string) error {
 		implementations,
 		"",
 		tableview.WithTitle("Implementations"),
-		tableview.WithCustomTable([]string{"IMPLEMENTATION", "SERVICE", "CONTROL PLANE"}, tableRows),
+		apiImplementationTableOption(tableRows),
 		tableview.WithDetailRenderer(detailFn),
 		tableview.WithRootLabel(helper.GetCmd().Name()),
 		tableview.WithDetailContext(common.ViewParentAPIImplementation, func(index int) any {
@@ -219,6 +219,10 @@ func (h apiImplementationsHandler) run(args []string) error {
 		}),
 		tableview.WithDetailHelper(helper),
 	)
+}
+
+func apiImplementationTableOption(rows []table.Row) tableview.Option {
+	return tableview.WithExactCustomTable([]string{"IMPLEMENTATION", "SERVICE", "CONTROL PLANE"}, rows)
 }
 
 func fetchImplementations(

--- a/internal/cmd/root/products/konnect/api/implementations.go
+++ b/internal/cmd/root/products/konnect/api/implementations.go
@@ -34,6 +34,15 @@ type apiImplementationRecord struct {
 	LocalUpdatedTime string
 }
 
+type apiImplementationFields struct {
+	id             string
+	apiID          string
+	serviceID      string
+	controlPlaneID string
+	createdAt      time.Time
+	updatedAt      time.Time
+}
+
 var (
 	implementationsUse = implementationsCommandName
 
@@ -179,7 +188,7 @@ func (h apiImplementationsHandler) run(args []string) error {
 	for i := range implementations {
 		record := implementationToRecord(implementations[i])
 		displayRecords = append(displayRecords, record)
-		tableRows = append(tableRows, table.Row{record.ImplementationID, record.ServiceID})
+		tableRows = append(tableRows, table.Row{record.ImplementationID, record.ServiceID, record.ControlPlaneID})
 	}
 
 	detailFn := func(index int) string {
@@ -199,7 +208,7 @@ func (h apiImplementationsHandler) run(args []string) error {
 		implementations,
 		"",
 		tableview.WithTitle("Implementations"),
-		tableview.WithCustomTable([]string{"IMPLEMENTATION", "SERVICE"}, tableRows),
+		tableview.WithCustomTable([]string{"IMPLEMENTATION", "SERVICE", "CONTROL PLANE"}, tableRows),
 		tableview.WithDetailRenderer(detailFn),
 		tableview.WithRootLabel(helper.GetCmd().Name()),
 		tableview.WithDetailContext(common.ViewParentAPIImplementation, func(index int) any {
@@ -262,19 +271,12 @@ func filterImplementations(
 	implementations []kkComps.APIImplementationListItem,
 	identifier string,
 ) []kkComps.APIImplementationListItem {
-	lowered := strings.ToLower(identifier)
-
 	matches := make([]kkComps.APIImplementationListItem, 0)
 	for _, implementation := range implementations {
-		if item := implementation.APIImplementationListItemGatewayServiceEntity; item != nil {
-			if strings.ToLower(item.GetID()) == lowered {
-				matches = append(matches, implementation)
-				continue
-			}
-			if svc := item.GetService(); svc != nil && strings.ToLower(svc.GetID()) == lowered {
-				matches = append(matches, implementation)
-				continue
-			}
+		fields, ok := getAPIImplementationFields(implementation)
+		if ok && (strings.EqualFold(fields.id, identifier) ||
+			(fields.serviceID != "" && strings.EqualFold(fields.serviceID, identifier))) {
+			matches = append(matches, implementation)
 		}
 	}
 
@@ -282,28 +284,28 @@ func filterImplementations(
 }
 
 func implementationToRecord(implementation kkComps.APIImplementationListItem) apiImplementationRecord {
-	entity := implementation.APIImplementationListItemGatewayServiceEntity
-	if entity == nil {
+	const missing = "n/a"
+
+	fields, ok := getAPIImplementationFields(implementation)
+	if !ok {
 		return apiImplementationRecord{}
 	}
 
-	serviceID := "n/a"
-	controlPlaneID := "n/a"
-	if svc := entity.GetService(); svc != nil {
-		if id := svc.GetID(); id != "" {
-			serviceID = id
-		}
-		if cp := svc.GetControlPlaneID(); cp != "" {
-			controlPlaneID = cp
-		}
+	serviceID := fields.serviceID
+	if serviceID == "" {
+		serviceID = missing
+	}
+	controlPlaneID := fields.controlPlaneID
+	if controlPlaneID == "" {
+		controlPlaneID = missing
 	}
 
 	return apiImplementationRecord{
-		ImplementationID: entity.GetID(),
+		ImplementationID: fields.id,
 		ServiceID:        serviceID,
 		ControlPlaneID:   controlPlaneID,
-		LocalCreatedTime: entity.GetCreatedAt().In(time.Local).Format("2006-01-02 15:04:05"),
-		LocalUpdatedTime: entity.GetUpdatedAt().In(time.Local).Format("2006-01-02 15:04:05"),
+		LocalCreatedTime: fields.createdAt.In(time.Local).Format("2006-01-02 15:04:05"),
+		LocalUpdatedTime: fields.updatedAt.In(time.Local).Format("2006-01-02 15:04:05"),
 	}
 }
 
@@ -312,30 +314,28 @@ func implementationDetailView(implementation *kkComps.APIImplementationListItem)
 		return ""
 	}
 
-	entity := implementation.APIImplementationListItemGatewayServiceEntity
-	if entity == nil {
+	const missing = "n/a"
+
+	implementationFields, ok := getAPIImplementationFields(*implementation)
+	if !ok {
 		return ""
 	}
 
-	const missing = "n/a"
-
-	serviceID := missing
-	controlPlaneID := missing
-	if svc := entity.GetService(); svc != nil {
-		if id := svc.GetID(); id != "" {
-			serviceID = id
-		}
-		if cp := svc.GetControlPlaneID(); cp != "" {
-			controlPlaneID = cp
-		}
+	serviceID := implementationFields.serviceID
+	if serviceID == "" {
+		serviceID = missing
+	}
+	controlPlaneID := implementationFields.controlPlaneID
+	if controlPlaneID == "" {
+		controlPlaneID = missing
 	}
 
 	fields := map[string]string{
-		"api_id":           entity.GetAPIID(),
+		"api_id":           implementationFields.apiID,
 		"control_plane_id": controlPlaneID,
-		"created_at":       entity.GetCreatedAt().In(time.Local).Format("2006-01-02 15:04:05"),
+		"created_at":       implementationFields.createdAt.In(time.Local).Format("2006-01-02 15:04:05"),
 		"service_id":       serviceID,
-		"updated_at":       entity.GetUpdatedAt().In(time.Local).Format("2006-01-02 15:04:05"),
+		"updated_at":       implementationFields.updatedAt.In(time.Local).Format("2006-01-02 15:04:05"),
 	}
 
 	keys := make([]string, 0, len(fields))
@@ -345,10 +345,41 @@ func implementationDetailView(implementation *kkComps.APIImplementationListItem)
 	sort.Strings(keys)
 
 	var b strings.Builder
-	fmt.Fprintf(&b, "id: %s\n", entity.GetID())
+	fmt.Fprintf(&b, "id: %s\n", implementationFields.id)
 	for _, key := range keys {
 		fmt.Fprintf(&b, "%s: %s\n", key, fields[key])
 	}
 
 	return strings.TrimRight(b.String(), "\n")
+}
+
+func getAPIImplementationFields(
+	implementation kkComps.APIImplementationListItem,
+) (apiImplementationFields, bool) {
+	if entity := implementation.APIImplementationListItemGatewayServiceEntity; entity != nil {
+		fields := apiImplementationFields{
+			id:        entity.GetID(),
+			apiID:     entity.GetAPIID(),
+			createdAt: entity.GetCreatedAt(),
+			updatedAt: entity.GetUpdatedAt(),
+		}
+		if service := entity.GetService(); service != nil {
+			fields.serviceID = service.GetID()
+			fields.controlPlaneID = service.GetControlPlaneID()
+		}
+		return fields, true
+	}
+
+	if entity := implementation.APIImplementationListItemControlPlaneEntity; entity != nil {
+		controlPlane := entity.GetControlPlane()
+		return apiImplementationFields{
+			id:             entity.GetID(),
+			apiID:          entity.GetAPIID(),
+			controlPlaneID: controlPlane.GetID(),
+			createdAt:      entity.GetCreatedAt(),
+			updatedAt:      entity.GetUpdatedAt(),
+		}, true
+	}
+
+	return apiImplementationFields{}, false
 }

--- a/internal/cmd/root/products/konnect/api/implementations_test.go
+++ b/internal/cmd/root/products/konnect/api/implementations_test.go
@@ -4,7 +4,11 @@ import (
 	"testing"
 	"time"
 
+	"charm.land/bubbles/v2/table"
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	cmdCommon "github.com/kong/kongctl/internal/cmd/common"
+	"github.com/kong/kongctl/internal/cmd/output/tableview"
+	"github.com/kong/kongctl/internal/iostreams"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -49,6 +53,27 @@ func TestControlPlaneImplementationFormatting(t *testing.T) {
 	assert.Contains(t, detail, "api_id: api-id")
 	assert.Contains(t, detail, "control_plane_id: control-plane-id")
 	assert.Contains(t, detail, "service_id: n/a")
+}
+
+func TestAPIImplementationTablePreservesControlPlaneColumn(t *testing.T) {
+	streams, _, out, _ := iostreams.NewTestIOStreams()
+	record := implementationToRecord(newControlPlaneImplementation())
+	rows := []table.Row{{record.ImplementationID, record.ServiceID, record.ControlPlaneID}}
+
+	err := tableview.RenderForFormat(
+		nil,
+		false,
+		cmdCommon.TEXT,
+		nil,
+		streams,
+		[]apiImplementationRecord{record},
+		nil,
+		"",
+		apiImplementationTableOption(rows),
+	)
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "CONTROL PLANE")
+	assert.Contains(t, out.String(), "control-plane-id")
 }
 
 func newControlPlaneImplementation() kkComps.APIImplementationListItem {

--- a/internal/cmd/root/products/konnect/api/implementations_test.go
+++ b/internal/cmd/root/products/konnect/api/implementations_test.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterImplementations(t *testing.T) {
+	controlPlaneImplementation := newControlPlaneImplementation()
+	serviceImplementation := kkComps.CreateAPIImplementationListItemAPIImplementationListItemGatewayServiceEntity(
+		kkComps.APIImplementationListItemGatewayServiceEntity{
+			ID: "service-implementation-id",
+			Service: &kkComps.APIImplementationService{
+				ID: "service-id",
+			},
+		},
+	)
+	implementations := []kkComps.APIImplementationListItem{controlPlaneImplementation, serviceImplementation}
+
+	tests := map[string]string{
+		"control plane implementation ID": "CONTROL-PLANE-IMPLEMENTATION-ID",
+		"service implementation ID":       "SERVICE-IMPLEMENTATION-ID",
+		"service ID":                      "SERVICE-ID",
+	}
+	for name, identifier := range tests {
+		t.Run(name, func(t *testing.T) {
+			matches := filterImplementations(implementations, identifier)
+			require.Len(t, matches, 1)
+		})
+	}
+
+	assert.Empty(t, filterImplementations(implementations, "missing"))
+}
+
+func TestControlPlaneImplementationFormatting(t *testing.T) {
+	implementation := newControlPlaneImplementation()
+
+	record := implementationToRecord(implementation)
+	assert.Equal(t, "control-plane-implementation-id", record.ImplementationID)
+	assert.Equal(t, "n/a", record.ServiceID)
+	assert.Equal(t, "control-plane-id", record.ControlPlaneID)
+
+	detail := implementationDetailView(&implementation)
+	assert.Contains(t, detail, "id: control-plane-implementation-id")
+	assert.Contains(t, detail, "api_id: api-id")
+	assert.Contains(t, detail, "control_plane_id: control-plane-id")
+	assert.Contains(t, detail, "service_id: n/a")
+}
+
+func newControlPlaneImplementation() kkComps.APIImplementationListItem {
+	createdAt := time.Date(2026, time.August, 29, 12, 30, 0, 0, time.UTC)
+	updatedAt := createdAt.Add(time.Hour)
+	return kkComps.CreateAPIImplementationListItemAPIImplementationListItemControlPlaneEntity(
+		kkComps.APIImplementationListItemControlPlaneEntity{
+			ID:        "control-plane-implementation-id",
+			APIID:     "api-id",
+			CreatedAt: createdAt,
+			UpdatedAt: updatedAt,
+			ControlPlane: kkComps.APIImplementationControlPlane{
+				ID: "control-plane-id",
+			},
+		},
+	)
+}

--- a/internal/cmd/root/products/konnect/api/interactive_children.go
+++ b/internal/cmd/root/products/konnect/api/interactive_children.go
@@ -269,7 +269,7 @@ func loadAPIImplementations(_ context.Context, helper cmd.Helper, parent any) (t
 	rows := make([]table.Row, len(implementations))
 	for i := range implementations {
 		record := implementationToRecord(implementations[i])
-		rows[i] = table.Row{record.ImplementationID, record.ServiceID}
+		rows[i] = table.Row{record.ImplementationID, record.ServiceID, record.ControlPlaneID}
 	}
 
 	detail := func(index int) string {
@@ -280,7 +280,7 @@ func loadAPIImplementations(_ context.Context, helper cmd.Helper, parent any) (t
 	}
 
 	return tableview.ChildView{
-		Headers:        []string{"IMPLEMENTATION", "SERVICE"},
+		Headers:        []string{"IMPLEMENTATION", "SERVICE", "CONTROL PLANE"},
 		Rows:           rows,
 		DetailRenderer: detail,
 		Title:          "Implementations",

--- a/test/e2e/scenarios/apis/control-plane-implementation/scenario.yaml
+++ b/test/e2e/scenarios/apis/control-plane-implementation/scenario.yaml
@@ -45,6 +45,57 @@ steps:
         recordVar:
           name: apiImplementationCPID
           responsePath: "[?name=='e2e-api-implementation-cp'] | [0].id"
+      - name: 002-list-implementations
+        run:
+          - get
+          - api
+          - implementations
+          - --api-name
+          - "E2E Control Plane Implementation API"
+          - -o
+          - json
+        recordVar:
+          name: apiImplementationID
+          responsePath: "[0].id"
+        assertions:
+          - select: "@"
+            expect:
+              fields:
+                "length(@)": 1
+          - select: "[0]"
+            expect:
+              fields:
+                "length(id) > `0`": true
+                control_plane.control_plane_id: "{{ .vars.apiImplementationCPID }}"
+      - name: 003-get-implementation-by-id
+        run:
+          - get
+          - api
+          - implementations
+          - --api-name
+          - "E2E Control Plane Implementation API"
+          - "{{ .vars.apiImplementationID }}"
+          - -o
+          - json
+        assertions:
+          - select: "[0]"
+            expect:
+              fields:
+                id: "{{ .vars.apiImplementationID }}"
+                control_plane.control_plane_id: "{{ .vars.apiImplementationCPID }}"
+      - name: 004-get-implementation-not-found
+        run:
+          - get
+          - api
+          - implementations
+          - --api-name
+          - "E2E Control Plane Implementation API"
+          - nonexistent-impl-xyz
+          - -o
+          - json
+        expectFailure:
+          exitCode: 1
+          contains: "not found"
 
   - name: 002-repeat-is-noop
     commands:


### PR DESCRIPTION
## Summary

- support control-plane implementation union values when filtering by implementation ID
- populate control-plane implementation table rows and detail views
- add unit coverage for control-plane formatting and both implementation variants
- expand the E2E scenario with list, get-by-ID, and not-found coverage

## Testing

- `go fix ./...`
- `make format`
- `make build`
- `make test`
- `golangci-lint run ./internal/cmd/root/products/konnect/api`
- `make lint` *(fails on pre-existing generated mock/portal-client line-length and misspelling findings, plus two pre-existing staticcheck findings)*

Closes #2006