### PR TITLE
refactor(simplify): reduce planner and display boilerplate

### DIFF
--- a/internal/cmd/root/products/konnect/api/implementations.go
+++ b/internal/cmd/root/products/konnect/api/implementations.go
@@ -2,7 +2,8 @@ package api
 
 import (
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"strings"
 	"time"
 
@@ -41,6 +42,20 @@ type apiImplementationFields struct {
 	controlPlaneID string
 	createdAt      time.Time
 	updatedAt      time.Time
+}
+
+func (f apiImplementationFields) displayServiceID() string {
+	if f.serviceID == "" {
+		return "n/a"
+	}
+	return f.serviceID
+}
+
+func (f apiImplementationFields) displayControlPlaneID() string {
+	if f.controlPlaneID == "" {
+		return "n/a"
+	}
+	return f.controlPlaneID
 }
 
 var (
@@ -288,26 +303,15 @@ func filterImplementations(
 }
 
 func implementationToRecord(implementation kkComps.APIImplementationListItem) apiImplementationRecord {
-	const missing = "n/a"
-
 	fields, ok := getAPIImplementationFields(implementation)
 	if !ok {
 		return apiImplementationRecord{}
 	}
 
-	serviceID := fields.serviceID
-	if serviceID == "" {
-		serviceID = missing
-	}
-	controlPlaneID := fields.controlPlaneID
-	if controlPlaneID == "" {
-		controlPlaneID = missing
-	}
-
 	return apiImplementationRecord{
 		ImplementationID: fields.id,
-		ServiceID:        serviceID,
-		ControlPlaneID:   controlPlaneID,
+		ServiceID:        fields.displayServiceID(),
+		ControlPlaneID:   fields.displayControlPlaneID(),
 		LocalCreatedTime: fields.createdAt.In(time.Local).Format("2006-01-02 15:04:05"),
 		LocalUpdatedTime: fields.updatedAt.In(time.Local).Format("2006-01-02 15:04:05"),
 	}
@@ -318,35 +322,20 @@ func implementationDetailView(implementation *kkComps.APIImplementationListItem)
 		return ""
 	}
 
-	const missing = "n/a"
-
 	implementationFields, ok := getAPIImplementationFields(*implementation)
 	if !ok {
 		return ""
 	}
 
-	serviceID := implementationFields.serviceID
-	if serviceID == "" {
-		serviceID = missing
-	}
-	controlPlaneID := implementationFields.controlPlaneID
-	if controlPlaneID == "" {
-		controlPlaneID = missing
-	}
-
 	fields := map[string]string{
 		"api_id":           implementationFields.apiID,
-		"control_plane_id": controlPlaneID,
+		"control_plane_id": implementationFields.displayControlPlaneID(),
 		"created_at":       implementationFields.createdAt.In(time.Local).Format("2006-01-02 15:04:05"),
-		"service_id":       serviceID,
+		"service_id":       implementationFields.displayServiceID(),
 		"updated_at":       implementationFields.updatedAt.In(time.Local).Format("2006-01-02 15:04:05"),
 	}
 
-	keys := make([]string, 0, len(fields))
-	for key := range fields {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
+	keys := slices.Sorted(maps.Keys(fields))
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "id: %s\n", implementationFields.id)

--- a/internal/declarative/planner/ai_gateway_payload_compare.go
+++ b/internal/declarative/planner/ai_gateway_payload_compare.go
@@ -105,40 +105,19 @@ func scrubAIGatewayWriteOnlyFields(value any, isWriteOnly func(string) bool) any
 }
 
 func scrubAIGatewayUpstreamWriteOnlyFields(value any) any {
-	switch typed := value.(type) {
-	case map[string]any:
-		result := make(map[string]any, len(typed))
-		for key, child := range typed {
-			switch strings.ToLower(key) {
-			case "secret_access_key", "session_token":
-				continue
-			default:
-				result[key] = scrubAIGatewayUpstreamWriteOnlyFields(child)
-			}
-		}
-		return result
-	case []any:
-		result := make([]any, len(typed))
-		for i := range typed {
-			result[i] = scrubAIGatewayUpstreamWriteOnlyFields(typed[i])
-		}
-		return result
+	return scrubAIGatewayWriteOnlyFields(value, isAIGatewayUpstreamWriteOnlyField)
+}
+
+func isAIGatewayUpstreamWriteOnlyField(key string) bool {
+	switch strings.ToLower(key) {
+	case "secret_access_key", "session_token":
+		return true
 	default:
-		return value
+		return false
 	}
 }
 
 type aiGatewayPayloadPairNormalizer func(map[string]any, map[string]any) (map[string]any, map[string]any)
-
-func scrubbedAIGatewayWriteOnlyPayloads(
-	current map[string]any,
-	desired map[string]any,
-	normalize aiGatewayPayloadPairNormalizer,
-	scrub func(any) any,
-) (map[string]any, map[string]any) {
-	currentComparable, desiredComparable := normalize(current, desired)
-	return scrub(currentComparable).(map[string]any), scrub(desiredComparable).(map[string]any)
-}
 
 func comparableAIGatewayWriteOnlyPayloads(
 	current map[string]any,

--- a/internal/declarative/planner/ai_gateway_provider_planner.go
+++ b/internal/declarative/planner/ai_gateway_provider_planner.go
@@ -284,12 +284,9 @@ func shouldUpdateAIGatewayProvider(
 	}
 
 	if desired.Config != nil && aiGatewayProviderConfigChanged(current.Config, desired.Config) {
-		currentConfig, desiredConfig := scrubbedAIGatewayWriteOnlyPayloads(
-			current.Config,
-			desired.Config,
-			normalizeAIGatewayPayloadsForComparison,
-			scrubAIGatewayProviderSecretFields,
-		)
+		currentConfig, desiredConfig := normalizeAIGatewayPayloadsForComparison(current.Config, desired.Config)
+		currentConfig = scrubAIGatewayWriteOnlyFields(currentConfig, isAIGatewayProviderSecretField).(map[string]any)
+		desiredConfig = scrubAIGatewayWriteOnlyFields(desiredConfig, isAIGatewayProviderSecretField).(map[string]any)
 		changedFields[FieldConfig] = FieldChange{
 			Old: currentConfig,
 			New: desiredConfig,
@@ -332,10 +329,6 @@ func comparableAIGatewayProviderConfigs(current, desired map[string]any) (map[st
 		normalizeAIGatewayPayloadsForComparison,
 		isAIGatewayProviderSecretField,
 	)
-}
-
-func scrubAIGatewayProviderSecretFields(value any) any {
-	return scrubAIGatewayWriteOnlyFields(value, isAIGatewayProviderSecretField)
 }
 
 func isAIGatewayProviderSecretField(key string) bool {

--- a/internal/declarative/planner/api_planner.go
+++ b/internal/declarative/planner/api_planner.go
@@ -854,7 +854,7 @@ func apiChildParentMatches(api resources.APIResource, parent string) bool {
 }
 
 func apiChildParentValueMatches(apiRef, apiID, parent string) bool {
-	return parent == apiRef || apiID != "" && parent == apiID
+	return parent == apiRef || (apiID != "" && parent == apiID)
 }
 
 // planAPIChildResourceChanges plans changes for child resources of an existing API

--- a/internal/declarative/planner/portal_planner.go
+++ b/internal/declarative/planner/portal_planner.go
@@ -455,6 +455,26 @@ func (p *portalPlannerImpl) addAuthStrategyReference(change *PlannedChange, port
 	}
 }
 
+func planOptionalBoolChange(
+	desired *bool,
+	current *bool,
+	fieldName string,
+	updates map[string]any,
+	changedFields map[string]FieldChange,
+) {
+	if desired == nil {
+		return
+	}
+	if current == nil || *current != *desired {
+		updates[fieldName] = *desired
+		var oldValue any
+		if current != nil {
+			oldValue = *current
+		}
+		changedFields[fieldName] = FieldChange{Old: oldValue, New: *desired}
+	}
+}
+
 // shouldUpdatePortal checks if portal needs update based on configured fields only
 func (p *portalPlannerImpl) shouldUpdatePortal(
 	current state.Portal,
@@ -501,75 +521,29 @@ func (p *portalPlannerImpl) shouldUpdatePortal(
 		}
 	}
 
-	if desired.AuthenticationEnabled != nil {
-		if curr := current.GetAuthenticationEnabled(); curr == nil || *curr != *desired.AuthenticationEnabled {
-			updates[FieldAuthenticationEnabled] = *desired.AuthenticationEnabled
-			var oldValue any
-			if curr != nil {
-				oldValue = *curr
-			}
-			changedFields[FieldAuthenticationEnabled] = FieldChange{
-				Old: oldValue,
-				New: *desired.AuthenticationEnabled,
-			}
-		}
-	}
-
-	if desired.RbacEnabled != nil {
-		if curr := current.GetRbacEnabled(); curr == nil || *curr != *desired.RbacEnabled {
-			updates[FieldRBACEnabled] = *desired.RbacEnabled
-			var oldValue any
-			if curr != nil {
-				oldValue = *curr
-			}
-			changedFields[FieldRBACEnabled] = FieldChange{
-				Old: oldValue,
-				New: *desired.RbacEnabled,
-			}
-		}
-	}
-
-	if desired.SiprEnabled != nil {
-		if curr := current.GetSiprEnabled(); curr == nil || *curr != *desired.SiprEnabled {
-			updates[FieldSIPREnabled] = *desired.SiprEnabled
-			var oldValue any
-			if curr != nil {
-				oldValue = *curr
-			}
-			changedFields[FieldSIPREnabled] = FieldChange{
-				Old: oldValue,
-				New: *desired.SiprEnabled,
-			}
-		}
-	}
-
-	if desired.AutoApproveDevelopers != nil {
-		if curr := current.GetAutoApproveDevelopers(); curr == nil || *curr != *desired.AutoApproveDevelopers {
-			updates[FieldAutoApproveDevelopers] = *desired.AutoApproveDevelopers
-			var oldValue any
-			if curr != nil {
-				oldValue = *curr
-			}
-			changedFields[FieldAutoApproveDevelopers] = FieldChange{
-				Old: oldValue,
-				New: *desired.AutoApproveDevelopers,
-			}
-		}
-	}
-
-	if desired.AutoApproveApplications != nil {
-		if curr := current.GetAutoApproveApplications(); curr == nil || *curr != *desired.AutoApproveApplications {
-			updates[FieldAutoApproveApplications] = *desired.AutoApproveApplications
-			var oldValue any
-			if curr != nil {
-				oldValue = *curr
-			}
-			changedFields[FieldAutoApproveApplications] = FieldChange{
-				Old: oldValue,
-				New: *desired.AutoApproveApplications,
-			}
-		}
-	}
+	planOptionalBoolChange(
+		desired.AuthenticationEnabled,
+		current.GetAuthenticationEnabled(),
+		FieldAuthenticationEnabled,
+		updates,
+		changedFields,
+	)
+	planOptionalBoolChange(desired.RbacEnabled, current.GetRbacEnabled(), FieldRBACEnabled, updates, changedFields)
+	planOptionalBoolChange(desired.SiprEnabled, current.GetSiprEnabled(), FieldSIPREnabled, updates, changedFields)
+	planOptionalBoolChange(
+		desired.AutoApproveDevelopers,
+		current.GetAutoApproveDevelopers(),
+		FieldAutoApproveDevelopers,
+		updates,
+		changedFields,
+	)
+	planOptionalBoolChange(
+		desired.AutoApproveApplications,
+		current.GetAutoApproveApplications(),
+		FieldAutoApproveApplications,
+		updates,
+		changedFields,
+	)
 
 	if desired.DefaultAPIVisibility != nil {
 		currentVisibility := string(current.DefaultAPIVisibility)


### PR DESCRIPTION
## Description

- consolidate AI Gateway write-only field scrubbing and remove redundant helpers
- extract portal optional boolean change planning
- centralize API implementation display fallbacks and use sorted map keys
- clarify API child parent matching precedence

## Rationale

These behavior-preserving refactors reduce duplicated planner and rendering logic while aligning the implementation with Go 1.26 idioms and existing repository conventions.

Closes #2020
Closes #2024

## Validation

- go fix ./...
- make format
- make build
- make lint
- make test-all

All executed checks passed. The shell installer lint within make test-all was skipped because shellcheck is not installed.