### PR TITLE
task(docs): update AI Gateway runtime image to 2.0.3

### DIFF
--- a/site/src/content/lessons/federated-api-platform-management/run-a-data-plane.md
+++ b/site/src/content/lessons/federated-api-platform-management/run-a-data-plane.md
@@ -115,7 +115,7 @@ docker run --detach --rm --name federated-aigw-dp \
   --volume "$PWD/platform/certs:/etc/kong/certs:ro" \
   --publish 8000:8000 \
   --publish 8443:8443 \
-  kong/kong-ai-gateway:2.0.2
+  kong/kong-ai-gateway:2.0.3
 ```
 
 The image runs as the non-root `kong` user. `--group-add` gives that user

--- a/site/src/content/lessons/quickstarts/consumer-credentials.md
+++ b/site/src/content/lessons/quickstarts/consumer-credentials.md
@@ -254,7 +254,7 @@ docker run --detach --rm --name consumer-credential-data-plane \
   --volume "$PWD/certs:/etc/kong/certs:ro" \
   --publish 8000:8000 \
   --publish 8443:8443 \
-  kong/kong-ai-gateway:2.0.2
+  kong/kong-ai-gateway:2.0.3
 ```
 
 The container exposes the local HTTP proxy on port `8000` and the HTTPS proxy

--- a/site/src/content/lessons/quickstarts/route-openai-requests.md
+++ b/site/src/content/lessons/quickstarts/route-openai-requests.md
@@ -212,7 +212,7 @@ docker run --detach --rm --name openai-llm-data-plane \
   --volume "$PWD/certs:/etc/kong/certs:ro" \
   --publish 8000:8000 \
   --publish 8443:8443 \
-  kong/kong-ai-gateway:2.0.2
+  kong/kong-ai-gateway:2.0.3
 ```
 
 The container exposes the local HTTP proxy on port `8000` and the HTTPS proxy

--- a/site/src/content/lessons/quickstarts/vault-backed-openai.md
+++ b/site/src/content/lessons/quickstarts/vault-backed-openai.md
@@ -278,7 +278,7 @@ docker run --detach --rm --name vault-backed-openai-data-plane \
   --volume "$PWD/certs:/etc/kong/certs:ro" \
   --publish 8000:8000 \
   --publish 8443:8443 \
-  kong/kong-ai-gateway:2.0.2
+  kong/kong-ai-gateway:2.0.3
 ```
 
 The container exposes the local HTTP proxy on port `8000` and the HTTPS proxy

--- a/site/tests/e2e/learning.spec.ts
+++ b/site/tests/e2e/learning.spec.ts
@@ -66,7 +66,7 @@ test("routes OpenAI requests through a local AI Gateway", async ({ page }) => {
   ).toBeVisible();
   await expect(lesson).toContainText("!env OPENAI_API_KEY");
   await expect(lesson).toContainText("openssl req -new -x509");
-  await expect(lesson).toContainText("kong/kong-ai-gateway:2.0.2");
+  await expect(lesson).toContainText("kong/kong-ai-gateway:2.0.3");
   await expect(lesson).toContainText(
     "http://localhost:8000/v1/chat/completions",
   );
@@ -113,7 +113,7 @@ test("protects an AI Gateway model with Consumer credentials", async ({
   await expect(lesson).toContainText("apikey: ${CONSUMER_API_KEY}");
   await expect(lesson).toContainText("HTTP/1.1 401 Unauthorized");
   await expect(lesson).toContainText("HTTP/1.1 200 OK");
-  await expect(lesson).toContainText("kong/kong-ai-gateway:2.0.2");
+  await expect(lesson).toContainText("kong/kong-ai-gateway:2.0.3");
   await expect(lesson).toContainText(
     "docker stop consumer-credential-data-plane",
   );


### PR DESCRIPTION
## Summary
- update AI Gateway data-plane Docker commands to use image tag 2.0.3
- update matching Learn site browser-test assertions

## Validation
- go fix ./...
- make format
- make build
- make test
- npm run check (site)
- npm test (site)
- npm run build (site)
- npm run test:e2e (site): 29 passed

## Known check issue
- make lint reports pre-existing findings in generated portal client code and unrelated mock helpers when run with local golangci-lint 2.12.2; no reported file is changed by this PR