### PR TITLE
fix(declarative): explain AI Gateway provider auth types

### DIFF
--- a/internal/declarative/loader/load_schema.go
+++ b/internal/declarative/loader/load_schema.go
@@ -171,7 +171,13 @@ func formatDeclarativeSchemaError(
 	if path == "" {
 		path = "<document>"
 	}
-	return fmt.Errorf("invalid declarative value at %s in %s: %s", path, sourcePath, declarativeErrorMessage(leaf))
+	message := declarativeErrorMessage(leaf)
+	if _, ok := leaf.ErrorKind.(*kind.Const); ok {
+		if values := declarativeConstValuesAt(schema, document, leaf.InstanceLocation); len(values) > 1 {
+			message = "expected union discriminator one of " + strings.Join(values, ", ")
+		}
+	}
+	return fmt.Errorf("invalid declarative value at %s in %s: %s", path, sourcePath, message)
 }
 
 func portalSingletonNullSchemaError(path string) string {
@@ -326,6 +332,60 @@ func declarativeSchemaPropertiesAt(
 	}
 	slices.Sort(result)
 	return result
+}
+
+func declarativeConstValuesAt(
+	root *resources.JSONSchema,
+	document any,
+	path []string,
+) []string {
+	if len(path) == 0 {
+		return nil
+	}
+
+	parent := declarativeSchemaAt(root, document, path[:len(path)-1])
+	parent = resolveDeclarativeSchemaRef(root, parent)
+	if parent == nil {
+		return nil
+	}
+
+	name := path[len(path)-1]
+	values := make([]string, 0)
+	seen := make(map[string]struct{})
+	appendValues := func(schema *resources.JSONSchema) {
+		for _, value := range declarativeSchemaConstValues(root, schema) {
+			if _, ok := seen[value]; ok {
+				continue
+			}
+			seen[value] = struct{}{}
+			values = append(values, value)
+		}
+	}
+
+	appendValues(parent.Properties[name])
+	for _, branch := range parent.OneOf {
+		branch = resolveDeclarativeSchemaRef(root, branch)
+		if branch != nil {
+			appendValues(branch.Properties[name])
+		}
+	}
+	return values
+}
+
+func declarativeSchemaConstValues(root *resources.JSONSchema, schema *resources.JSONSchema) []string {
+	schema = resolveDeclarativeSchemaRef(root, schema)
+	if schema == nil {
+		return nil
+	}
+	if schema.Const != nil {
+		return []string{fmt.Sprint(schema.Const)}
+	}
+
+	var values []string
+	for _, branch := range schema.OneOf {
+		values = append(values, declarativeSchemaConstValues(root, branch)...)
+	}
+	return values
 }
 
 func declarativeRejectedFieldMessageAt(

--- a/internal/declarative/loader/load_schema.go
+++ b/internal/declarative/loader/load_schema.go
@@ -362,7 +362,6 @@ func declarativeConstValuesAt(
 		}
 	}
 
-	appendValues(parent.Properties[name])
 	for _, branch := range parent.OneOf {
 		branch = resolveDeclarativeSchemaRef(root, branch)
 		if branch != nil {

--- a/internal/declarative/loader/load_schema_test.go
+++ b/internal/declarative/loader/load_schema_test.go
@@ -171,6 +171,27 @@ ai_gateway_model_providers:
 	require.NoError(t, err)
 }
 
+func TestDeclarativeLoadSchemaReportsProviderAuthDiscriminatorValues(t *testing.T) {
+	t.Parallel()
+
+	input := `
+ai_gateway_model_providers:
+  - ref: bedrock-prod
+    name: bedrock-prod
+    display_name: Amazon Bedrock Prod
+    ai_gateway: ai-quickstart
+    type: bedrock
+    config:
+      auth:
+        type: gcp
+`
+
+	_, err := New().parseYAML(strings.NewReader(input), "manifest.yaml", ".")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "ai_gateway_model_providers[0].config.auth.type")
+	assert.ErrorContains(t, err, "expected union discriminator one of basic, aws")
+}
+
 func TestDeclarativeLoadSchemaHandlesNestedAIGatewayModelNameHeaderByType(t *testing.T) {
 	input := `
 ai_gateways:

--- a/internal/declarative/resources/ai_gateway_provider.go
+++ b/internal/declarative/resources/ai_gateway_provider.go
@@ -354,6 +354,7 @@ func aiGatewayProviderSDKExplainBranch(
 		explainSetConstStringField(auth.OneOf[i], "type", authType)
 		configureAIGatewayProviderAuthExplain(auth.OneOf[i])
 	}
+	explainRefreshUnionAggregate(auth)
 	return branch, nil
 }
 

--- a/internal/declarative/resources/explain.go
+++ b/internal/declarative/resources/explain.go
@@ -2539,12 +2539,20 @@ func explainAllowedValues(node *ExplainNode) []string {
 	}
 	if len(node.OneOf) > 0 {
 		values := make([]string, 0, len(node.OneOf))
+		seen := make(map[string]struct{})
 		for _, branch := range node.OneOf {
-			if branch == nil || branch.Const == nil {
+			branchValues := explainAllowedValues(branch)
+			if len(branchValues) == 0 {
 				values = nil
 				break
 			}
-			values = append(values, fmt.Sprint(branch.Const))
+			for _, value := range branchValues {
+				if _, ok := seen[value]; ok {
+					continue
+				}
+				seen[value] = struct{}{}
+				values = append(values, value)
+			}
 		}
 		if len(values) > 0 {
 			return values

--- a/internal/declarative/resources/explain_test.go
+++ b/internal/declarative/resources/explain_test.go
@@ -420,6 +420,22 @@ func TestRenderExplainText_AnalyticsDashboardAllowedValues(t *testing.T) {
 	assert.Contains(t, text, "ALLOWED: api_usage|llm_usage|agentic_usage|platform_usage")
 }
 
+func TestRenderExplainText_AIGatewayProviderAuthAllowedValues(t *testing.T) {
+	t.Parallel()
+
+	resource, err := ResolveExplainSubject("ai_gateway.model_providers")
+	require.NoError(t, err)
+	assert.Contains(
+		t,
+		RenderExplainText(resource, true),
+		"- type: string required allowed: basic|azure|aws|gcp|sagemaker",
+	)
+
+	field, err := ResolveExplainSubject("ai_gateway.model_providers.config.auth.type")
+	require.NoError(t, err)
+	assert.Contains(t, RenderExplainText(field, false), "ALLOWED: basic|azure|aws|gcp|sagemaker")
+}
+
 func TestRenderExplainText_ResourceSubject(t *testing.T) {
 	subject, err := ResolveExplainSubject("portal")
 	require.NoError(t, err)

--- a/internal/declarative/resources/explain_union_schemas.go
+++ b/internal/declarative/resources/explain_union_schemas.go
@@ -159,6 +159,17 @@ func explainUnionNode(branches ...*ExplainNode) *ExplainNode {
 	return node
 }
 
+func explainRefreshUnionAggregate(node *ExplainNode) {
+	if node == nil || len(node.OneOf) == 0 {
+		return
+	}
+
+	branches := node.OneOf
+	refreshed := explainAggregateUnionNode(branches...)
+	refreshed.OneOf = branches
+	*node = *refreshed
+}
+
 func explainAggregateUnionNode(branches ...*ExplainNode) *ExplainNode {
 	if len(branches) == 0 {
 		return explainObject()


### PR DESCRIPTION
## Summary

- preserve customized nested union discriminators when building explain aggregates
- list every current AI Gateway model-provider auth type in text and field explanations
- report provider-specific discriminator alternatives during declarative validation

## Rationale

The machine-readable schema retained the complete model-provider auth union, but human-readable explain output used a stale aggregate that exposed only basic. Validation errors similarly reported only the first failed discriminator branch.

This refreshes union aggregates after branch customization, recursively renders finite allowed values, and derives validation alternatives from the provider branch selected by the manifest. Vertex-specific handling is intentionally omitted because Vertex has been removed from the current AI Gateway API specification.

## Testing

- go fix ./...
- make format
- make build
- make lint
- make test
- make test-integration

Closes #1745