### PR TITLE
refactor(simplify): consolidate API display helpers

### DIFF
--- a/internal/cmd/root/products/konnect/api/attributes.go
+++ b/internal/cmd/root/products/konnect/api/attributes.go
@@ -3,6 +3,8 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
+	"slices"
 	"sort"
 	"strings"
 
@@ -172,11 +174,7 @@ func (h apiAttributesHandler) run(args []string) error {
 		normalized = map[string][]string{key: values}
 	}
 
-	keys := make([]string, 0, len(normalized))
-	for key := range normalized {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
+	keys := slices.Sorted(maps.Keys(normalized))
 
 	records := make([]apiAttributeRecord, 0, len(keys))
 	rows := make([]table.Row, 0, len(keys))

--- a/internal/cmd/root/products/konnect/api/documents.go
+++ b/internal/cmd/root/products/konnect/api/documents.go
@@ -3,7 +3,8 @@ package api
 import (
 	"context"
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -447,14 +448,12 @@ func documentSummaryDetailView(doc *kkComps.APIDocumentSummaryWithChildren, deta
 		return ""
 	}
 
-	const missing = "n/a"
-
-	status := missing
+	status := valueNA
 	if doc.Status != nil && *doc.Status != "" {
 		status = string(*doc.Status)
 	}
 
-	parentID := missing
+	parentID := valueNA
 	if doc.ParentDocumentID != nil && *doc.ParentDocumentID != "" {
 		parentID = *doc.ParentDocumentID
 	}
@@ -468,11 +467,7 @@ func documentSummaryDetailView(doc *kkComps.APIDocumentSummaryWithChildren, deta
 		"updated_at":         doc.UpdatedAt.In(time.Local).Format("2006-01-02 15:04:05"),
 	}
 
-	var keys []string
-	for key := range fields {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
+	keys := slices.Sorted(maps.Keys(fields))
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "id: %s\n", doc.ID)
@@ -493,11 +488,9 @@ func documentSummaryDetailView(doc *kkComps.APIDocumentSummaryWithChildren, deta
 }
 
 func apiDocumentDetailView(record apiDocumentDetailRecord) string {
-	const missing = "n/a"
-
 	parentID := record.ParentDocumentID
 	if strings.TrimSpace(parentID) == "" {
-		parentID = missing
+		parentID = valueNA
 	}
 
 	otherFields := map[string]string{
@@ -508,11 +501,7 @@ func apiDocumentDetailView(record apiDocumentDetailRecord) string {
 		"updated_at":         record.LocalUpdatedTime,
 	}
 
-	keys := make([]string, 0, len(otherFields))
-	for key := range otherFields {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
+	keys := slices.Sorted(maps.Keys(otherFields))
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "id: %s\n", record.RawID)

--- a/internal/cmd/root/products/konnect/api/getAPI.go
+++ b/internal/cmd/root/products/konnect/api/getAPI.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -58,31 +60,29 @@ type textDisplayRecord struct {
 }
 
 func apiToDisplayRecord(a *kkComps.APIResponseSchema) textDisplayRecord {
-	missing := "n/a"
-
 	var id, name string
 	if a.ID != "" {
 		id = a.ID
 	} else {
-		id = missing
+		id = valueNA
 	}
 
 	if a.Name != "" {
 		name = a.Name
 	} else {
-		name = missing
+		name = valueNA
 	}
 
-	description := missing
+	description := valueNA
 	if a.Description != nil && *a.Description != "" {
 		description = *a.Description
 	}
 
-	versionCount := missing
+	versionCount := valueNA
 	// Version count is not directly available in APIResponseSchema
 	// It would require a separate API call to list versions
 
-	publicationCount := missing
+	publicationCount := valueNA
 	if a.Portals != nil {
 		publicationCount = fmt.Sprintf("%d", len(a.Portals))
 	}
@@ -106,14 +106,13 @@ func apiDetailView(api *kkComps.APIResponseSchema) string {
 		return ""
 	}
 
-	const missing = "n/a"
 	id := strings.TrimSpace(api.ID)
 	if id == "" {
-		id = missing
+		id = valueNA
 	}
 	name := strings.TrimSpace(api.Name)
 	if name == "" {
-		name = missing
+		name = valueNA
 	}
 
 	type detailField struct {
@@ -189,11 +188,7 @@ func apiDetailView(api *kkComps.APIResponseSchema) string {
 		switch v := attrs.(type) {
 		case map[string]any:
 			if len(v) > 0 {
-				keys := make([]string, 0, len(v))
-				for k := range v {
-					keys = append(keys, k)
-				}
-				sort.Strings(keys)
+				keys := slices.Sorted(maps.Keys(v))
 				var sb strings.Builder
 				for _, k := range keys {
 					fmt.Fprintf(&sb, "  %s: %v\n", k, v[k])
@@ -202,11 +197,7 @@ func apiDetailView(api *kkComps.APIResponseSchema) string {
 			}
 		case map[string]string:
 			if len(v) > 0 {
-				keys := make([]string, 0, len(v))
-				for k := range v {
-					keys = append(keys, k)
-				}
-				sort.Strings(keys)
+				keys := slices.Sorted(maps.Keys(v))
 				var sb strings.Builder
 				for _, k := range keys {
 					fmt.Fprintf(&sb, "  %s: %s\n", k, v[k])
@@ -230,7 +221,7 @@ func apiDetailView(api *kkComps.APIResponseSchema) string {
 			case portalName != "":
 				line = portalName
 			default:
-				line = missing
+				line = valueNA
 			}
 			fmt.Fprintf(&sb, "  %s - %s\n", line, portal.ID)
 		}
@@ -238,11 +229,7 @@ func apiDetailView(api *kkComps.APIResponseSchema) string {
 	}
 
 	if labels := api.GetLabels(); len(labels) > 0 {
-		keys := make([]string, 0, len(labels))
-		for k := range labels {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
+		keys := slices.Sorted(maps.Keys(labels))
 		var sb strings.Builder
 		for _, k := range keys {
 			fmt.Fprintf(&sb, "  %s: %s\n", k, labels[k])

--- a/internal/cmd/root/products/konnect/api/implementations.go
+++ b/internal/cmd/root/products/konnect/api/implementations.go
@@ -44,18 +44,11 @@ type apiImplementationFields struct {
 	updatedAt      time.Time
 }
 
-func (f apiImplementationFields) displayServiceID() string {
-	if f.serviceID == "" {
-		return "n/a"
+func displayOrNA(value string) string {
+	if value == "" {
+		return valueNA
 	}
-	return f.serviceID
-}
-
-func (f apiImplementationFields) displayControlPlaneID() string {
-	if f.controlPlaneID == "" {
-		return "n/a"
-	}
-	return f.controlPlaneID
+	return value
 }
 
 var (
@@ -310,8 +303,8 @@ func implementationToRecord(implementation kkComps.APIImplementationListItem) ap
 
 	return apiImplementationRecord{
 		ImplementationID: fields.id,
-		ServiceID:        fields.displayServiceID(),
-		ControlPlaneID:   fields.displayControlPlaneID(),
+		ServiceID:        displayOrNA(fields.serviceID),
+		ControlPlaneID:   displayOrNA(fields.controlPlaneID),
 		LocalCreatedTime: fields.createdAt.In(time.Local).Format("2006-01-02 15:04:05"),
 		LocalUpdatedTime: fields.updatedAt.In(time.Local).Format("2006-01-02 15:04:05"),
 	}
@@ -329,9 +322,9 @@ func implementationDetailView(implementation *kkComps.APIImplementationListItem)
 
 	fields := map[string]string{
 		"api_id":           implementationFields.apiID,
-		"control_plane_id": implementationFields.displayControlPlaneID(),
+		"control_plane_id": displayOrNA(implementationFields.controlPlaneID),
 		"created_at":       implementationFields.createdAt.In(time.Local).Format("2006-01-02 15:04:05"),
-		"service_id":       implementationFields.displayServiceID(),
+		"service_id":       displayOrNA(implementationFields.serviceID),
 		"updated_at":       implementationFields.updatedAt.In(time.Local).Format("2006-01-02 15:04:05"),
 	}
 

--- a/internal/cmd/root/products/konnect/api/publications.go
+++ b/internal/cmd/root/products/konnect/api/publications.go
@@ -2,7 +2,8 @@ package api
 
 import (
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"strings"
 	"time"
 
@@ -323,11 +324,7 @@ func publicationDetailView(publication *kkComps.APIPublicationListItem) string {
 		"updated_at":        publication.GetUpdatedAt().In(time.Local).Format("2006-01-02 15:04:05"),
 	}
 
-	keys := make([]string, 0, len(fields))
-	for key := range fields {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
+	keys := slices.Sorted(maps.Keys(fields))
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "api_id: %s\n", publication.GetAPIID())

--- a/internal/cmd/root/products/konnect/api/versions.go
+++ b/internal/cmd/root/products/konnect/api/versions.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -476,11 +477,7 @@ func versionSummaryDetailView(
 		"updated_at": summary.GetUpdatedAt().In(time.Local).Format("2006-01-02 15:04:05"),
 	}
 
-	keys := make([]string, 0, len(fields))
-	for key := range fields {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
+	keys := slices.Sorted(maps.Keys(fields))
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "id: %s\n", summary.GetID())
@@ -507,11 +504,7 @@ func apiVersionDetailView(record apiVersionDetailRecord) string {
 		"updated_at": record.LocalUpdatedTime,
 	}
 
-	keys := make([]string, 0, len(fields))
-	for key := range fields {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
+	keys := slices.Sorted(maps.Keys(fields))
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "id: %s\n", record.RawID)


### PR DESCRIPTION
## Summary

- consolidate duplicate API implementation display methods into `displayOrNA`
- use the shared `valueNA` constant instead of local `n/a` values
- modernize map-key sorting with `slices.Sorted(maps.Keys(...))`

## Rationale

This removes repeated display and sorting boilerplate while preserving existing output and ordering behavior.

Closes #2037

## Testing

- `go fix ./...`
- `make format`
- `make build`
- `make lint`
- `make test-all`

All checks passed. The optional installer shell lint was skipped because `shellcheck` is not installed.