### PR TITLE
refactor(declarative): inline const value collection

### DIFF
--- a/internal/declarative/loader/load_schema.go
+++ b/internal/declarative/loader/load_schema.go
@@ -350,22 +350,19 @@ func declarativeConstValuesAt(
 	}
 
 	name := path[len(path)-1]
-	values := make([]string, 0)
+	var values []string
 	seen := make(map[string]struct{})
-	appendValues := func(schema *resources.JSONSchema) {
-		for _, value := range declarativeSchemaConstValues(root, schema) {
+	for _, branch := range parent.OneOf {
+		branch = resolveDeclarativeSchemaRef(root, branch)
+		if branch == nil {
+			continue
+		}
+		for _, value := range declarativeSchemaConstValues(root, branch.Properties[name]) {
 			if _, ok := seen[value]; ok {
 				continue
 			}
 			seen[value] = struct{}{}
 			values = append(values, value)
-		}
-	}
-
-	for _, branch := range parent.OneOf {
-		branch = resolveDeclarativeSchemaRef(root, branch)
-		if branch != nil {
-			appendValues(branch.Properties[name])
 		}
 	}
 	return values


### PR DESCRIPTION
## Summary

- inline the single-use const-value collection closure
- flatten nil branch handling with an early continue
- use an idiomatic nil slice when no values are collected

## Rationale

This removes unnecessary indirection from declarative schema traversal while
preserving value ordering and deduplication behavior.

Closes #2042

## Testing

- go fix ./...
- make format
- make build
- make lint
- make test-all