### PR TITLE
test(e2e): cover AI gateway declarative deletion

### DIFF
--- a/test/e2e/scenarios/delete/declarative/scenario.yaml
+++ b/test/e2e/scenarios/delete/declarative/scenario.yaml
@@ -10,6 +10,7 @@ vars:
   controlPlaneName: "delete-test-cp"
   teamName: "delete-test-team-alpha"
   authStrategyName: "delete-test-key-auth"
+  aiGatewayName: "delete-test-ai-gw"
 
 defaults:
   mask:
@@ -42,6 +43,8 @@ steps:
           - "{{ .workdir }}/teams.yaml"
           - -f
           - "{{ .workdir }}/auth-strategies.yaml"
+          - -f
+          - "{{ .workdir }}/ai-gateways.yaml"
           - --auto-approve
         assertions:
           - select: plan.metadata
@@ -147,6 +150,16 @@ steps:
                 name: "{{ .vars.authStrategyName }}"
                 display_name: "Delete Test Key Auth"
 
+      # Verify AI gateway exists
+      - name: 008-get-ai-gateways
+        run: ["get", "ai-gateways", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.aiGatewayName }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.aiGatewayName }}"
+                display_name: "Delete Test AI Gateway"
+
   # Step 2: Delete all resources using delete -f
   - name: 002-delete-resources
     commands:
@@ -163,6 +176,8 @@ steps:
           - "{{ .workdir }}/teams.yaml"
           - -f
           - "{{ .workdir }}/auth-strategies.yaml"
+          - -f
+          - "{{ .workdir }}/ai-gateways.yaml"
           - --auto-approve
         assertions:
           - select: plan.metadata
@@ -172,8 +187,8 @@ steps:
           - select: plan.summary
             expect:
               fields:
-                total_changes: 6
-                by_action.DELETE: 6
+                total_changes: 7
+                by_action.DELETE: 7
           - select: "plan.changes[?resource_type=='application_auth_strategy'] | [0]"
             expect:
               fields:
@@ -228,6 +243,14 @@ steps:
         run: ["get", "auth-strategies", "-o", "json"]
         assertions:
           - select: "[?name=='{{ .vars.authStrategyName }}']"
+            expect:
+              fields:
+                "length(@)": 0
+
+      - name: 005-get-ai-gateways
+        run: ["get", "ai-gateways", "-o", "json"]
+        assertions:
+          - select: "[?name=='{{ .vars.aiGatewayName }}']"
             expect:
               fields:
                 "length(@)": 0

--- a/test/e2e/scenarios/delete/declarative/testdata/ai-gateways.yaml
+++ b/test/e2e/scenarios/delete/declarative/testdata/ai-gateways.yaml
@@ -1,0 +1,19 @@
+ai_gateways:
+  - ref: delete-test-ai-gw
+    name: delete-test-ai-gw
+    display_name: "Delete Test AI Gateway"
+    description: "AI Gateway for declarative delete e2e"
+    proxy_urls:
+      - host: delete-test-ai-gw.example.com
+        port: 443
+        protocol: https
+    policies:
+      - ref: delete-test-ai-gw-policy
+        name: delete-test-ai-gw-policy
+        type: ai-prompt-guard
+        display_name: "Delete Test Policy"
+        enabled: true
+        global: false
+        config:
+          deny_patterns:
+            - ".*test.*"


### PR DESCRIPTION
## Summary

- add an AI Gateway fixture with a policy child to the declarative delete scenario
- verify the gateway is created before deletion and absent afterward
- update the expected delete plan change count

## Rationale

The declarative delete E2E coverage did not exercise AI Gateway resources or deletion of a gateway containing child resources.

Closes #2043

## Testing

- `make test-e2e-scenarios SCENARIO=delete/declarative`
- `go fix ./...`
- `make format`
- `make build`
- `golangci-lint run -v --allow-parallel-runners`
- `make test`

E2E artifacts: `/home/rspurgeon/go/e2e-artifacts/20260902-090108`