### PR TITLE
fix(declarative): resolve external portal publication refs

### DIFF
--- a/internal/declarative/planner/api_planner.go
+++ b/internal/declarative/planner/api_planner.go
@@ -1328,9 +1328,14 @@ func (p *Planner) planAPIPublicationCreate(
 		Namespace:    parentNamespace,
 	}
 
-	// Look up portal name for reference resolution using global lookup
-	var portalName string
-	if portal := p.resources.GetPortalByRef(publication.PortalID); portal != nil {
+	// Look up the portal using the declarative ref so resolved external IDs stay in routing metadata.
+	portalRef := publication.PortalID
+	if parsedRef, _, ok := tags.ParseRefPlaceholder(portalRef); ok {
+		portalRef = parsedRef
+	}
+	var portalID, portalName string
+	if portal := p.resources.GetPortalByRef(portalRef); portal != nil {
+		portalID = portal.GetKonnectID()
 		portalName = portal.Name
 	}
 
@@ -1355,8 +1360,7 @@ func (p *Planner) planAPIPublicationCreate(
 
 	// Set portal reference
 	if publication.PortalID != "" {
-		portalID := ""
-		if util.IsValidUUID(publication.PortalID) {
+		if portalID == "" && util.IsValidUUID(publication.PortalID) {
 			portalID = publication.PortalID
 		}
 		change.References[FieldPortalID] = ReferenceInfo{

--- a/internal/declarative/planner/api_planner_test.go
+++ b/internal/declarative/planner/api_planner_test.go
@@ -581,6 +581,39 @@ func TestShouldUpdateAPIPublicationResolvesAuthStrategyRefs(t *testing.T) {
 	assert.Empty(t, changedFields)
 }
 
+func TestPlanAPIPublicationCreateCarriesExternalPortalRoutingID(t *testing.T) {
+	t.Parallel()
+
+	const portalID = "a86aec1e-f67f-4624-919f-b11292b11159"
+	portal := resources.PortalResource{
+		BaseResource: resources.BaseResource{Ref: "shared-portal"},
+		External: &resources.ExternalBlock{Selector: &resources.ExternalSelector{
+			MatchFields: map[string]string{FieldName: "Platform Shared Portal"},
+		}},
+	}
+	portal.SetKonnectID(portalID)
+	planner := &Planner{resources: &resources.ResourceSet{Portals: []resources.PortalResource{portal}}}
+	plan := NewPlan(CurrentPlanVersion, "test", PlanModeApply)
+	portalRef := tags.RefPlaceholderPrefix + "shared-portal#id"
+
+	planner.planAPIPublicationCreate(
+		DefaultNamespace,
+		"api",
+		"api-id",
+		resources.APIPublicationResource{Ref: "publication", PortalID: portalRef},
+		nil,
+		plan,
+	)
+
+	require.Len(t, plan.Changes, 1)
+	change := plan.Changes[0]
+	assert.NotContains(t, change.Fields, FieldPortalID)
+	require.Contains(t, change.References, FieldPortalID)
+	assert.Equal(t, portalRef, change.References[FieldPortalID].Ref)
+	assert.Equal(t, portalID, change.References[FieldPortalID].ID)
+	require.NoError(t, ValidatePlanCompatibility(plan))
+}
+
 func TestShouldUpdateAPIPublicationIgnoresAuthStrategyWhenUnset(t *testing.T) {
 	t.Parallel()
 

--- a/test/e2e/scenarios/external/portal-publication/scenario.yaml
+++ b/test/e2e/scenarios/external/portal-publication/scenario.yaml
@@ -5,6 +5,8 @@ vars:
   platformPortalName: "Platform Shared Portal"
   teamAPIRef: test-api
   teamAPIName: "Test API"
+  inlineExternalAPIRef: inline-external-api
+  inlineExternalAPIName: "Inline External API"
   teamPortalDisplayName: "Shared Portal"
 
 steps:
@@ -70,6 +72,20 @@ steps:
               fields:
                 action: CREATE
                 "fields.visibility": "public"
+          - select: >-
+              plan.changes[?resource_type=='api' &&
+                            resource_ref=='{{ .vars.inlineExternalAPIRef }}'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                "fields.name": "{{ .vars.inlineExternalAPIName }}"
+          - select: >-
+              plan.changes[?resource_type=='api_publication' &&
+                            resource_ref=='inline-external-publication'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                "fields.visibility": "public"
       - name: 001-record-api-id
         run:
           - get
@@ -86,6 +102,20 @@ steps:
                 name: "{{ .vars.teamAPIName }}"
                 labels.team: team-a
                 labels.environment: test
+      - name: 002-record-inline-external-api-id
+        run:
+          - get
+          - apis
+          - -o
+          - json
+        recordVar:
+          name: inlineExternalAPIID
+          responsePath: "[?name=='{{ .vars.inlineExternalAPIName }}'] | [0].id"
+        assertions:
+          - select: "[?name=='{{ .vars.inlineExternalAPIName }}'] | [0]"
+            expect:
+              fields:
+                name: "{{ .vars.inlineExternalAPIName }}"
 
   - name: 003-verify-publication
     skipInputs: true
@@ -117,6 +147,22 @@ steps:
             expect:
               fields:
                 "length(@)": 1
+      - name: 002-get-inline-external-publication
+        run:
+          - get
+          - api
+          - publications
+          - --api-id
+          - "{{ .vars.inlineExternalAPIID }}"
+          - "{{ .vars.platformPortalID }}"
+          - -o
+          - json
+        assertions:
+          - select: "[0]"
+            expect:
+              fields:
+                portal_id: "{{ .vars.platformPortalID }}"
+                visibility: public
 
   - name: 004-delete-cleanup
     commands:

--- a/test/e2e/scenarios/external/portal-publication/testdata/team-a/api.yaml
+++ b/test/e2e/scenarios/external/portal-publication/testdata/team-a/api.yaml
@@ -44,5 +44,5 @@ apis:
 
     publications:
       - ref: test-api-publication
-        portal_id: !external name:Platform Shared Portal
+        portal_id: !ref shared-portal
         visibility: "public"

--- a/test/e2e/scenarios/external/portal-publication/testdata/team-a/api.yaml
+++ b/test/e2e/scenarios/external/portal-publication/testdata/team-a/api.yaml
@@ -46,3 +46,12 @@ apis:
       - ref: test-api-publication
         portal_id: !ref shared-portal
         visibility: "public"
+
+  - ref: inline-external-api
+    name: "Inline External API"
+    description: "API published using an inline external portal lookup"
+    version: "1.0.0"
+    publications:
+      - ref: inline-external-publication
+        portal_id: !external name:Platform Shared Portal
+        visibility: "public"


### PR DESCRIPTION
## Summary

- resolve API publication `!ref` values through locally declared external portals
- retain portal routing IDs in plan references without adding them back to SDK payload fields
- cover both external portal reference forms in the API publication E2E lifecycle:
  `_external` declaration plus `!ref`, and direct inline `!external`

## Rationale

PR #1924 moved API publication routing identifiers out of payload fields and into plan references. That exposed a latent lookup issue: the create planner passed the encoded `__REF__` placeholder to `GetPortalByRef`, so the external portal resolved during identity planning was not carried into the publication reference.

Parse the declarative ref before looking up the portal and store its resolved Konnect ID in `References.portal_id.id`. The routing ID remains absent from `Fields`, preserving the standardized planner-to-executor payload contract.

Fixes #2045

## Validation

- `go fix ./...`
- `make format`
- `make build`
- `make lint`
- `make test`
- `make test-integration`
- `make test-e2e-scenarios SCENARIO=external/portal-publication`
  - `_external` portal declaration referenced with `!ref`
  - direct API publication `portal_id: !external name:...`

