### PR TITLE
task(e2e): add scenario velocity instrumentation

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -907,6 +907,20 @@ jobs:
           sudo chown -R "${USER}:${USER}" "${CAP_DIR}" 2>/dev/null || true
           ls -lh "${CAP_DIR}" || true
 
+      - name: Generate shard metrics
+        if: always()
+        run: |
+          python3 scripts/e2e-metrics.py \
+            "${KONGCTL_E2E_ARTIFACTS_DIR}" \
+            "${KONGCTL_E2E_ARTIFACTS_DIR}/e2e-metrics.json"
+
+      - name: Upload shard metrics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-metrics-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.org_name }}
+          path: ${{ env.KONGCTL_E2E_ARTIFACTS_DIR }}/e2e-metrics.json
+
       - name: Upload scenario results and diagnostics
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -94,6 +94,8 @@ jobs:
       - name: test
         run: |
           go test -race -count=1 ./...
+      - name: test E2E metrics scripts
+        run: make test-e2e-metrics
       - name: test integration
         run: |
           go test -v -count=1 -tags=integration -race ${GOTESTFLAGS} ./test/integration/...

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: test-all
-test-all: lint test-installer test test-integration
+test-all: lint test-installer test test-e2e-metrics test-integration
 
 VERSION ?= $(shell (git describe --tags --exact-match 2>/dev/null || echo dev) | sed 's/^v//')
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
@@ -108,6 +108,10 @@ coverage:
 .PHONY: test
 test:
 	go test -race -count=1 ./...
+
+.PHONY: test-e2e-metrics
+test-e2e-metrics:
+	python3 -m unittest discover -s scripts -p 'e2e_*_test.py'
 
 .PHONY: test-integration
 test-integration:
@@ -244,6 +248,20 @@ diagnose-e2e-ci:
 		$(if $(ARTIFACTS_DIR),--artifacts-dir "$(ARTIFACTS_DIR)") \
 		$(if $(DOWNLOAD_DIR),--download-dir "$(DOWNLOAD_DIR)") \
 		$(E2E_CI_DIAGNOSE_FLAGS)
+
+E2E_BASELINE_COUNT ?= 20
+E2E_BASELINE_SCAN ?= 100
+E2E_BASELINE_DIR ?= .e2e-artifacts/baseline
+
+.PHONY: baseline-e2e-ci
+baseline-e2e-ci:
+	@mkdir -p "$(E2E_BASELINE_DIR)"
+	@python3 scripts/e2e-baseline.py \
+		--count "$(E2E_BASELINE_COUNT)" \
+		--scan "$(E2E_BASELINE_SCAN)" \
+		--output "$(E2E_BASELINE_DIR)/e2e-baseline.md" \
+		--json-output "$(E2E_BASELINE_DIR)/e2e-baseline.json"
+	@echo "Wrote $(E2E_BASELINE_DIR)/e2e-baseline.md"
 
 .PHONY: reset-org
 reset-org:

--- a/scripts/e2e-baseline.py
+++ b/scripts/e2e-baseline.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Report latency and reset metrics for recent successful full .com E2E runs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import subprocess
+import tempfile
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable
+
+
+BUILD_JOB = "Build scenario executables"
+HARNESS_JOB = "Test scenario harness"
+VERIFY_JOB = "Verify scenario results and coverage"
+REQUIRED_JOB = "Publish “E2E Required”"
+SCENARIO_JOB_PREFIX = "Run scenarios — "
+
+
+def gh_json(arguments: list[str]) -> Any:
+    process = subprocess.run(
+        ["gh", *arguments],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    return json.loads(process.stdout)
+
+
+def timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def elapsed_seconds(start: str, end: str) -> float:
+    return (timestamp(end) - timestamp(start)).total_seconds()
+
+
+def duration(record: dict[str, Any]) -> float:
+    return elapsed_seconds(record["startedAt"], record["completedAt"])
+
+
+def nearest_rank(values: Iterable[float], percentile: float) -> float:
+    ordered = sorted(values)
+    if not ordered:
+        return 0.0
+    index = max(0, math.ceil(percentile * len(ordered)) - 1)
+    return ordered[index]
+
+
+def percentiles(values: Iterable[float]) -> dict[str, float]:
+    materialized = list(values)
+    return {
+        "p50": nearest_rank(materialized, 0.50),
+        "p75": nearest_rank(materialized, 0.75),
+        "p90": nearest_rank(materialized, 0.90),
+    }
+
+
+def select_latest_complete_attempt(metrics: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    attempts: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    for metric in metrics:
+        attempts[int(metric["run_attempt"])].append(metric)
+    for attempt in sorted(attempts, reverse=True):
+        selected = attempts[attempt]
+        totals = {int(metric["shard_total"]) for metric in selected}
+        indices = {int(metric["shard_index"]) for metric in selected}
+        if len(totals) != 1:
+            continue
+        total = totals.pop()
+        if total > 0 and indices == set(range(total)):
+            return sorted(selected, key=lambda metric: int(metric["shard_index"]))
+    return []
+
+
+def download_metrics(repo: str, run_id: int) -> list[dict[str, Any]]:
+    with tempfile.TemporaryDirectory(prefix="kongctl-e2e-metrics-") as temp_dir:
+        process = subprocess.run(
+            [
+                "gh",
+                "run",
+                "download",
+                str(run_id),
+                "--repo",
+                repo,
+                "--pattern",
+                f"e2e-metrics-{run_id}-*",
+                "--dir",
+                temp_dir,
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if process.returncode != 0:
+            return []
+        records = [
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in Path(temp_dir).rglob("e2e-metrics.json")
+        ]
+        return select_latest_complete_attempt(records)
+
+
+def named_job(jobs: list[dict[str, Any]], name: str) -> dict[str, Any] | None:
+    return next((job for job in jobs if job["name"] == name), None)
+
+
+def named_step(job: dict[str, Any], name: str) -> dict[str, Any] | None:
+    return next((step for step in job.get("steps", []) if step["name"] == name), None)
+
+
+def eligible_run(
+    run: dict[str, Any],
+    jobs: list[dict[str, Any]],
+    metrics: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    if not metrics or any(metric.get("konnect_environment") != "com" for metric in metrics):
+        return None
+
+    build = named_job(jobs, BUILD_JOB)
+    harness = named_job(jobs, HARNESS_JOB)
+    verify = named_job(jobs, VERIFY_JOB)
+    required = named_job(jobs, REQUIRED_JOB)
+    scenario_jobs = [job for job in jobs if job["name"].startswith(SCENARIO_JOB_PREFIX)]
+    required_jobs = [build, harness, verify, required, *scenario_jobs]
+    if any(job is None or job["conclusion"] != "success" for job in required_jobs):
+        return None
+    if len(scenario_jobs) != len(metrics):
+        return None
+
+    assert build is not None and harness is not None and verify is not None and required is not None
+    build_kongctl = named_step(build, "Build kongctl")
+    build_scenarios = named_step(build, "Build scenario test binary")
+    if build_kongctl is None or build_scenarios is None:
+        return None
+
+    ready_at = max(timestamp(build["completedAt"]), timestamp(harness["completedAt"]))
+    workflow_created_at = timestamp(run["createdAt"])
+    first_job_started_at = min(timestamp(job["startedAt"]) for job in jobs if job["startedAt"])
+    shard_durations = [float(metric["execution_duration_seconds"]) for metric in metrics]
+
+    reset = defaultdict(int)
+    scenarios: list[dict[str, Any]] = []
+    for metric in metrics:
+        for key, value in metric["reset"].items():
+            reset[key] += int(value)
+        scenarios.extend(metric["scenario_durations"])
+
+    return {
+        "run_id": int(run["databaseId"]),
+        "url": run["url"],
+        "created_at": run["createdAt"],
+        "workflow_admission_delay_seconds": (first_job_started_at - workflow_created_at).total_seconds(),
+        "queue_to_required_status_seconds": (timestamp(required["completedAt"]) - workflow_created_at).total_seconds(),
+        "build_job_seconds": duration(build),
+        "build_kongctl_seconds": duration(build_kongctl),
+        "build_scenario_binary_seconds": duration(build_scenarios),
+        "longest_shard_seconds": max(shard_durations),
+        "shard_spread_seconds": max(shard_durations) - min(shard_durations),
+        "shard_admission_delay_seconds": {
+            job["name"].removeprefix(SCENARIO_JOB_PREFIX): max(
+                0.0,
+                (timestamp(job["startedAt"]) - ready_at).total_seconds(),
+            )
+            for job in scenario_jobs
+        },
+        "shards": [
+            {
+                "org_name": metric["org_name"],
+                "selected_scenario_count": metric["selected_scenario_count"],
+                "execution_duration_seconds": metric["execution_duration_seconds"],
+            }
+            for metric in metrics
+        ],
+        "scenario_durations": scenarios,
+        "reset": dict(reset),
+    }
+
+
+def collect_runs(repo: str, count: int, scan: int) -> list[dict[str, Any]]:
+    candidates = gh_json(
+        [
+            "run",
+            "list",
+            "--repo",
+            repo,
+            "--workflow",
+            "e2e.yaml",
+            "--status",
+            "success",
+            "--limit",
+            str(scan),
+            "--json",
+            "databaseId,createdAt,url",
+        ]
+    )
+    selected: list[dict[str, Any]] = []
+    for candidate in candidates:
+        metrics = download_metrics(repo, int(candidate["databaseId"]))
+        if not metrics:
+            continue
+        view = gh_json(
+            [
+                "run",
+                "view",
+                str(candidate["databaseId"]),
+                "--repo",
+                repo,
+                "--json",
+                "jobs",
+            ]
+        )
+        record = eligible_run(candidate, view["jobs"], metrics)
+        if record is not None:
+            selected.append(record)
+        if len(selected) == count:
+            break
+    return selected
+
+
+def summarize(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    metric_names = [
+        "workflow_admission_delay_seconds",
+        "queue_to_required_status_seconds",
+        "build_job_seconds",
+        "build_kongctl_seconds",
+        "build_scenario_binary_seconds",
+        "longest_shard_seconds",
+        "shard_spread_seconds",
+    ]
+    reset_names = [
+        "count",
+        "duration_ms",
+        "list_calls",
+        "list_duration_ms",
+        "resources_found",
+        "delete_calls",
+        "delete_duration_ms",
+        "resources_deleted",
+    ]
+    return {
+        "run_count": len(runs),
+        "metrics": {name: percentiles(run[name] for run in runs) for name in metric_names},
+        "reset_per_run": {
+            name: percentiles(float(run["reset"].get(name, 0)) for run in runs) for name in reset_names
+        },
+    }
+
+
+def markdown_report(repo: str, runs: list[dict[str, Any]], summary: dict[str, Any]) -> str:
+    lines = [
+        "# Konnect `.com` E2E baseline",
+        "",
+        f"Repository: `{repo}`  ",
+        f"Full successful runs: {len(runs)}",
+        "",
+        "The report scans successful `e2e.yaml` runs newest-first, retains only runs with a complete",
+        "latest-attempt metrics manifest for every `.com` shard, and requires successful build, harness,",
+        "scenario, coverage-verification, and required-status jobs. Short gate-only runs are excluded.",
+        "Percentiles use the nearest-rank method.",
+        "",
+        "## Latency",
+        "",
+        "| Metric | p50 | p75 | p90 |",
+        "| --- | ---: | ---: | ---: |",
+    ]
+    for name, values in summary["metrics"].items():
+        lines.append(f"| {name} | {values['p50']:.1f}s | {values['p75']:.1f}s | {values['p90']:.1f}s |")
+
+    lines.extend(
+        [
+            "",
+            "## Reset cost per workflow run",
+            "",
+            "| Metric | p50 | p75 | p90 |",
+            "| --- | ---: | ---: | ---: |",
+        ]
+    )
+    for name, values in summary["reset_per_run"].items():
+        suffix = "ms" if name.endswith("_ms") else ""
+        lines.append(
+            f"| {name} | {values['p50']:.1f}{suffix} | {values['p75']:.1f}{suffix} | "
+            f"{values['p90']:.1f}{suffix} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Included runs",
+            "",
+            "| Run | Created | Queue-to-status | Build | Longest shard | Spread | Resets |",
+            "| --- | --- | ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for run in runs:
+        lines.append(
+            f"| [{run['run_id']}]({run['url']}) | {run['created_at']} | "
+            f"{run['queue_to_required_status_seconds']:.0f}s | {run['build_job_seconds']:.0f}s | "
+            f"{run['longest_shard_seconds']:.0f}s | {run['shard_spread_seconds']:.0f}s | "
+            f"{run['reset'].get('count', 0)} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Organization shards",
+            "",
+            "| Run | Organization | Admission delay | Selected | Execution |",
+            "| --- | --- | ---: | ---: | ---: |",
+        ]
+    )
+    for run in runs:
+        for shard in run["shards"]:
+            org_name = shard["org_name"]
+            admission_delay = run["shard_admission_delay_seconds"].get(org_name, 0)
+            lines.append(
+                f"| {run['run_id']} | `{org_name}` | {admission_delay:.0f}s | "
+                f"{shard['selected_scenario_count']} | {shard['execution_duration_seconds']}s |"
+            )
+
+    scenario_samples: dict[str, list[float]] = defaultdict(list)
+    for run in runs:
+        for scenario in run["scenario_durations"]:
+            scenario_samples[scenario["scenario"]].append(float(scenario["duration_seconds"]))
+    lines.extend(
+        [
+            "",
+            "## Individual scenario durations",
+            "",
+            "| Scenario | Samples | Median | p90 |",
+            "| --- | ---: | ---: | ---: |",
+        ]
+    )
+    scenario_rows = sorted(
+        scenario_samples.items(),
+        key=lambda item: (-nearest_rank(item[1], 0.50), item[0]),
+    )
+    for scenario, samples in scenario_rows:
+        lines.append(
+            f"| `{scenario}` | {len(samples)} | {nearest_rank(samples, 0.50):.2f}s | "
+            f"{nearest_rank(samples, 0.90):.2f}s |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default="kong/kongctl")
+    parser.add_argument("--count", type=int, default=20)
+    parser.add_argument("--scan", type=int, default=100)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--json-output", type=Path)
+    args = parser.parse_args()
+    if args.count < 1 or args.scan < args.count:
+        parser.error("--count must be positive and --scan must be at least --count")
+
+    runs = collect_runs(args.repo, args.count, args.scan)
+    if len(runs) < args.count:
+        raise SystemExit(
+            f"found {len(runs)} eligible full .com runs, need {args.count}; "
+            "increase --scan or wait for more instrumented runs"
+        )
+    summary = summarize(runs)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(markdown_report(args.repo, runs, summary), encoding="utf-8")
+    if args.json_output is not None:
+        args.json_output.parent.mkdir(parents=True, exist_ok=True)
+        args.json_output.write_text(
+            json.dumps({"summary": summary, "runs": runs}, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e-baseline.py
+++ b/scripts/e2e-baseline.py
@@ -60,25 +60,39 @@ def percentiles(values: Iterable[float]) -> dict[str, float]:
     }
 
 
-def select_latest_complete_attempt(metrics: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    attempts: dict[int, list[dict[str, Any]]] = defaultdict(list)
-    for metric in metrics:
-        attempts[int(metric["run_attempt"])].append(metric)
-    for attempt in sorted(attempts, reverse=True):
-        selected = attempts[attempt]
-        totals = {int(metric["shard_total"]) for metric in selected}
-        indices = {int(metric["shard_index"]) for metric in selected}
-        if len(totals) != 1:
-            continue
-        total = totals.pop()
-        if total > 0 and indices == set(range(total)):
-            return sorted(selected, key=lambda metric: int(metric["shard_index"]))
-    return []
+def select_complete_attempt(metrics: list[dict[str, Any]], run_attempt: int) -> list[dict[str, Any]]:
+    selected = [metric for metric in metrics if int(metric["run_attempt"]) == run_attempt]
+    totals = {int(metric["shard_total"]) for metric in selected}
+    indices = {int(metric["shard_index"]) for metric in selected}
+    if len(totals) != 1:
+        return []
+    total = totals.pop()
+    if total <= 0 or indices != set(range(total)):
+        return []
+    return sorted(selected, key=lambda metric: int(metric["shard_index"]))
 
 
-def download_metrics(repo: str, run_id: int) -> list[dict[str, Any]]:
+def download_metrics(repo: str, run_id: int, run_attempt: int) -> list[dict[str, Any]]:
+    artifact_prefix = f"e2e-metrics-{run_id}-{run_attempt}-"
+    response = gh_json(
+        [
+            "api",
+            "--method",
+            "GET",
+            f"repos/{repo}/actions/runs/{run_id}/artifacts",
+            "-f",
+            "per_page=100",
+        ]
+    )
+    artifacts = response.get("artifacts", [])
+    if not any(
+        artifact["name"].startswith(artifact_prefix) and not artifact.get("expired", False)
+        for artifact in artifacts
+    ):
+        return []
+
     with tempfile.TemporaryDirectory(prefix="kongctl-e2e-metrics-") as temp_dir:
-        process = subprocess.run(
+        subprocess.run(
             [
                 "gh",
                 "run",
@@ -87,20 +101,18 @@ def download_metrics(repo: str, run_id: int) -> list[dict[str, Any]]:
                 "--repo",
                 repo,
                 "--pattern",
-                f"e2e-metrics-{run_id}-*",
+                f"{artifact_prefix}*",
                 "--dir",
                 temp_dir,
             ],
+            check=True,
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
         )
-        if process.returncode != 0:
-            return []
         records = [
             json.loads(path.read_text(encoding="utf-8"))
             for path in Path(temp_dir).rglob("e2e-metrics.json")
         ]
-        return select_latest_complete_attempt(records)
+        return select_complete_attempt(records, run_attempt)
 
 
 def named_job(jobs: list[dict[str, Any]], name: str) -> dict[str, Any] | None:
@@ -198,9 +210,6 @@ def collect_runs(repo: str, count: int, scan: int) -> list[dict[str, Any]]:
     )
     selected: list[dict[str, Any]] = []
     for candidate in candidates:
-        metrics = download_metrics(repo, int(candidate["databaseId"]))
-        if not metrics:
-            continue
         view = gh_json(
             [
                 "run",
@@ -209,9 +218,13 @@ def collect_runs(repo: str, count: int, scan: int) -> list[dict[str, Any]]:
                 "--repo",
                 repo,
                 "--json",
-                "jobs",
+                "attempt,jobs",
             ]
         )
+        run_attempt = int(view["attempt"])
+        metrics = download_metrics(repo, int(candidate["databaseId"]), run_attempt)
+        if not metrics:
+            continue
         record = eligible_run(candidate, view["jobs"], metrics)
         if record is not None:
             selected.append(record)

--- a/scripts/e2e-metrics.py
+++ b/scripts/e2e-metrics.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Build a small, secret-free metrics record from one E2E shard artifact tree."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+
+SCENARIO_RESULT_RE = re.compile(
+    r"^\s*--- (PASS|FAIL|SKIP): Test_Scenarios/(.+?/scenario\.yaml) \(([0-9.]+)s\)\s*$"
+)
+
+
+def parse_key_values(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line or line.startswith("[") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key] = value
+    return values
+
+
+def parse_manifest(path: Path) -> list[str]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    return [line for line in lines[3:] if line]
+
+
+def parse_scenario_durations(path: Path) -> list[dict[str, Any]]:
+    scenarios: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        match = SCENARIO_RESULT_RE.match(line)
+        if match is None:
+            continue
+        result, scenario, duration = match.groups()
+        scenarios.append(
+            {
+                "scenario": scenario.removeprefix("test/e2e/scenarios/"),
+                "result": result.lower(),
+                "duration_seconds": float(duration),
+            }
+        )
+    return scenarios
+
+
+def reset_details(observation: dict[str, Any]) -> tuple[int, list[dict[str, Any]]]:
+    if "regions" in observation:
+        regions = observation.get("regions") or []
+        duration_ms = sum(int(region.get("duration_ms") or 0) for region in regions)
+        details = [detail for region in regions for detail in (region.get("details") or [])]
+        return duration_ms, details
+    return int(observation.get("duration_ms") or 0), observation.get("details") or []
+
+
+def collect_reset_metrics(root: Path) -> dict[str, int]:
+    totals = {
+        "count": 0,
+        "duration_ms": 0,
+        "list_calls": 0,
+        "list_duration_ms": 0,
+        "resources_found": 0,
+        "delete_calls": 0,
+        "delete_duration_ms": 0,
+        "resources_deleted": 0,
+    }
+    for path in root.rglob("observation.json"):
+        try:
+            observation = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if observation.get("type") != "reset_summary" or not observation.get("executed"):
+            continue
+        totals["count"] += 1
+        duration_ms, details = reset_details(observation)
+        totals["duration_ms"] += duration_ms
+        for detail in details:
+            totals["list_calls"] += int(detail.get("list_calls") or 0)
+            totals["list_duration_ms"] += int(detail.get("list_duration_ms") or 0)
+            totals["resources_found"] += int(detail.get("total") or 0)
+            totals["delete_calls"] += int(detail.get("delete_calls") or 0)
+            totals["delete_duration_ms"] += int(detail.get("delete_duration_ms") or 0)
+            totals["resources_deleted"] += int(detail.get("deleted") or 0)
+    return totals
+
+
+def collect_metrics(root: Path, environ: dict[str, str]) -> dict[str, Any]:
+    manifests = list(root.rglob("assigned-scenarios.txt"))
+    results = list(root.rglob("scenario-results.txt"))
+    run_logs = list(root.rglob("run.log"))
+    if len(manifests) != 1 or len(results) != 1 or len(run_logs) != 1:
+        raise ValueError("artifact tree must contain one manifest, scenario results file, and run log")
+
+    result_values = parse_key_values(results[0])
+    manifest_values = parse_key_values(manifests[0])
+    scenarios = parse_scenario_durations(run_logs[0])
+    assigned = parse_manifest(manifests[0])
+
+    return {
+        "schema_version": 1,
+        "run_id": int(environ.get("GITHUB_RUN_ID", "0")),
+        "run_attempt": int(result_values.get("run_attempt", environ.get("GITHUB_RUN_ATTEMPT", "1"))),
+        "org_name": result_values.get("org_name", environ.get("KONGCTL_E2E_MATRIX_ORG", "")),
+        "konnect_environment": environ.get("KONGCTL_E2E_KONNECT_ENV", "com"),
+        "shard_index": int(manifest_values.get("shard_index", result_values.get("shard_index", "0"))),
+        "shard_total": int(manifest_values.get("shard_total", result_values.get("shard_total", "0"))),
+        "selected_scenario_count": len(assigned),
+        "execution_duration_seconds": int(result_values.get("duration_seconds", "0")),
+        "scenario_durations": scenarios,
+        "reset": collect_reset_metrics(root),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("artifact_root", type=Path)
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+
+    metrics = collect_metrics(args.artifact_root, dict(os.environ))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(metrics, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e-metrics.py
+++ b/scripts/e2e-metrics.py
@@ -69,10 +69,7 @@ def collect_reset_metrics(root: Path) -> dict[str, int]:
         "resources_deleted": 0,
     }
     for path in root.rglob("observation.json"):
-        try:
-            observation = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            continue
+        observation = json.loads(path.read_text(encoding="utf-8"))
         if observation.get("type") != "reset_summary" or not observation.get("executed"):
             continue
         totals["count"] += 1

--- a/scripts/e2e_baseline_test.py
+++ b/scripts/e2e_baseline_test.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("e2e-baseline.py")
+SPEC = importlib.util.spec_from_file_location("e2e_baseline", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class E2EBaselineTest(unittest.TestCase):
+    def test_nearest_rank(self) -> None:
+        values = list(range(1, 21))
+        self.assertEqual(10, MODULE.nearest_rank(values, 0.50))
+        self.assertEqual(15, MODULE.nearest_rank(values, 0.75))
+        self.assertEqual(18, MODULE.nearest_rank(values, 0.90))
+
+    def test_selects_latest_complete_attempt(self) -> None:
+        metrics = [
+            {"run_attempt": 1, "shard_index": 0, "shard_total": 2},
+            {"run_attempt": 1, "shard_index": 1, "shard_total": 2},
+            {"run_attempt": 2, "shard_index": 0, "shard_total": 2},
+        ]
+        selected = MODULE.select_latest_complete_attempt(metrics)
+        self.assertEqual([1, 1], [metric["run_attempt"] for metric in selected])
+
+    def test_rejects_incomplete_attempt(self) -> None:
+        metrics = [{"run_attempt": 1, "shard_index": 0, "shard_total": 2}]
+        self.assertEqual([], MODULE.select_latest_complete_attempt(metrics))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/e2e_baseline_test.py
+++ b/scripts/e2e_baseline_test.py
@@ -19,18 +19,22 @@ class E2EBaselineTest(unittest.TestCase):
         self.assertEqual(15, MODULE.nearest_rank(values, 0.75))
         self.assertEqual(18, MODULE.nearest_rank(values, 0.90))
 
-    def test_selects_latest_complete_attempt(self) -> None:
+    def test_selects_requested_complete_attempt(self) -> None:
         metrics = [
             {"run_attempt": 1, "shard_index": 0, "shard_total": 2},
             {"run_attempt": 1, "shard_index": 1, "shard_total": 2},
             {"run_attempt": 2, "shard_index": 0, "shard_total": 2},
         ]
-        selected = MODULE.select_latest_complete_attempt(metrics)
+        selected = MODULE.select_complete_attempt(metrics, 1)
         self.assertEqual([1, 1], [metric["run_attempt"] for metric in selected])
 
-    def test_rejects_incomplete_attempt(self) -> None:
-        metrics = [{"run_attempt": 1, "shard_index": 0, "shard_total": 2}]
-        self.assertEqual([], MODULE.select_latest_complete_attempt(metrics))
+    def test_rejects_incomplete_latest_attempt(self) -> None:
+        metrics = [
+            {"run_attempt": 1, "shard_index": 0, "shard_total": 2},
+            {"run_attempt": 1, "shard_index": 1, "shard_total": 2},
+            {"run_attempt": 2, "shard_index": 0, "shard_total": 2},
+        ]
+        self.assertEqual([], MODULE.select_complete_attempt(metrics, 2))
 
 
 if __name__ == "__main__":

--- a/scripts/e2e_metrics_test.py
+++ b/scripts/e2e_metrics_test.py
@@ -82,6 +82,16 @@ class E2EMetricsTest(unittest.TestCase):
             metrics["reset"],
         )
 
+    def test_rejects_malformed_observation(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            reset_dir = root / "commands" / "000-reset_org"
+            reset_dir.mkdir(parents=True)
+            (reset_dir / "observation.json").write_text("not json", encoding="utf-8")
+
+            with self.assertRaises(json.JSONDecodeError):
+                MODULE.collect_reset_metrics(root)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/e2e_metrics_test.py
+++ b/scripts/e2e_metrics_test.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("e2e-metrics.py")
+SPEC = importlib.util.spec_from_file_location("e2e_metrics", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class E2EMetricsTest(unittest.TestCase):
+    def test_collects_scenario_and_reset_metrics(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "assigned-scenarios.txt").write_text(
+                "shard_index=1\nshard_total=2\n\na/scenario.yaml\nb/scenario.yaml\n",
+                encoding="utf-8",
+            )
+            (root / "scenario-results.txt").write_text(
+                "org_name=acceptance-2\nrun_attempt=3\nduration_seconds=42\n",
+                encoding="utf-8",
+            )
+            (root / "run.log").write_text(
+                "    --- PASS: Test_Scenarios/test/e2e/scenarios/a/scenario.yaml (1.25s)\n"
+                "    --- FAIL: Test_Scenarios/test/e2e/scenarios/b/scenario.yaml (2.50s)\n",
+                encoding="utf-8",
+            )
+            reset_dir = root / "commands" / "000-reset_org"
+            reset_dir.mkdir(parents=True)
+            (reset_dir / "observation.json").write_text(
+                json.dumps(
+                    {
+                        "type": "reset_summary",
+                        "executed": True,
+                        "regions": [
+                            {
+                                "duration_ms": 500,
+                                "details": [
+                                    {
+                                        "total": 2,
+                                        "deleted": 1,
+                                        "list_calls": 2,
+                                        "list_duration_ms": 300,
+                                        "delete_calls": 1,
+                                        "delete_duration_ms": 100,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            metrics = MODULE.collect_metrics(
+                root,
+                {"GITHUB_RUN_ID": "123", "KONGCTL_E2E_KONNECT_ENV": "com"},
+            )
+
+        self.assertEqual(2, metrics["selected_scenario_count"])
+        self.assertEqual(42, metrics["execution_duration_seconds"])
+        self.assertEqual("acceptance-2", metrics["org_name"])
+        self.assertEqual(1.25, metrics["scenario_durations"][0]["duration_seconds"])
+        self.assertEqual("fail", metrics["scenario_durations"][1]["result"])
+        self.assertEqual(
+            {
+                "count": 1,
+                "duration_ms": 500,
+                "list_calls": 2,
+                "list_duration_ms": 300,
+                "resources_found": 2,
+                "delete_calls": 1,
+                "delete_duration_ms": 100,
+                "resources_deleted": 1,
+            },
+            metrics["reset"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -559,3 +559,38 @@ flags through `E2E_CI_DIAGNOSE_FLAGS`, for example:
 ```sh
 make diagnose-e2e-ci RUN=2254 E2E_CI_DIAGNOSE_FLAGS="--all-shards"
 ```
+
+### CI Performance Baseline
+
+Every `.com` scenario shard uploads a small `e2e-metrics-*` artifact. It
+contains no credentials or request payloads. The record includes selected and
+individual scenario durations plus reset counts, list calls, resources found,
+delete calls, resources deleted, and list/delete timing.
+
+After at least 20 instrumented successful full runs, generate a reproducible
+baseline with:
+
+```sh
+gh auth status
+make baseline-e2e-ci
+```
+
+The command writes Markdown and JSON reports under
+`.e2e-artifacts/baseline/`. It scans the 100 most recent successful workflow
+runs by default, then retains only complete `.com` runs whose latest attempt
+has every shard and whose build, harness, scenario, coverage-verification, and
+required-status jobs succeeded. This excludes short runs where the gate did
+not require scenarios.
+
+The report includes p50, p75, and p90 values for workflow admission delay,
+queue-to-required-status latency, build job and build-step duration,
+longest-shard duration, shard spread, and reset cost. It also reports each
+organization's admission delay, selected scenario count, execution duration,
+and every scenario's measured Go subtest duration in the JSON data. Percentile
+calculations use the nearest-rank method.
+
+Increase the search window when fewer than 20 eligible runs appear:
+
+```sh
+make baseline-e2e-ci E2E_BASELINE_SCAN=200
+```

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -567,6 +567,10 @@ contains no credentials or request payloads. The record includes selected and
 individual scenario durations plus reset counts, list calls, resources found,
 delete calls, resources deleted, and list/delete timing.
 
+`resources_found` counts the initial resources returned for each resource
+family in a reset. List and delete durations cover each complete operation,
+including response-body handling and retry attempts, but exclude retry sleep.
+
 After at least 20 instrumented successful full runs, generate a reproducible
 baseline with:
 

--- a/test/e2e/harness/reset.go
+++ b/test/e2e/harness/reset.go
@@ -203,8 +203,6 @@ func deleteAll(
 			if skipped > 0 {
 				Infof("Skipping %d filtered %s resources", skipped, endpoint)
 			}
-		} else if len(items)+deleted > total {
-			total = len(items) + deleted
 		}
 
 		if len(idsToDelete) == 0 {
@@ -319,7 +317,12 @@ type resetHTTPMetrics struct {
 	DeleteDuration time.Duration
 }
 
-func resetEndpointResult(apiVersion, endpoint string, total, deleted int, metrics resetHTTPMetrics, err error) resetEndpoint {
+func resetEndpointResult(
+	apiVersion, endpoint string,
+	total, deleted int,
+	metrics resetHTTPMetrics,
+	err error,
+) resetEndpoint {
 	return resetEndpoint{
 		APIVersion:       apiVersion,
 		Endpoint:         endpoint,
@@ -340,32 +343,6 @@ type resetHTTPSession struct {
 	metrics   resetHTTPMetrics
 }
 
-type resetMetricsRoundTripper struct {
-	base    http.RoundTripper
-	metrics *resetHTTPMetrics
-}
-
-func (t *resetMetricsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	startedAt := time.Now()
-	resp, err := t.base.RoundTrip(req)
-	duration := time.Since(startedAt)
-	switch req.Method {
-	case http.MethodGet:
-		t.metrics.ListCalls++
-		t.metrics.ListDuration += duration
-	case http.MethodDelete:
-		t.metrics.DeleteCalls++
-		t.metrics.DeleteDuration += duration
-	}
-	return resp, err
-}
-
-func (t *resetMetricsRoundTripper) CloseIdleConnections() {
-	if transport, ok := t.base.(interface{ CloseIdleConnections() }); ok {
-		transport.CloseIdleConnections()
-	}
-}
-
 func newResetHTTPSession(timeout time.Duration, options HTTPTransportOptions) *resetHTTPSession {
 	return &resetHTTPSession{
 		newClient: func() *http.Client {
@@ -380,11 +357,6 @@ func (s *resetHTTPSession) Client() *http.Client {
 	}
 	if s.client == nil {
 		s.client = s.newClient()
-		transport := s.client.Transport
-		if transport == nil {
-			transport = http.DefaultTransport
-		}
-		s.client.Transport = &resetMetricsRoundTripper{base: transport, metrics: &s.metrics}
 	}
 	return s.client
 }
@@ -394,6 +366,22 @@ func (s *resetHTTPSession) Metrics() resetHTTPMetrics {
 		return resetHTTPMetrics{}
 	}
 	return s.metrics
+}
+
+func (s *resetHTTPSession) RecordList(duration time.Duration) {
+	if s == nil {
+		return
+	}
+	s.metrics.ListCalls++
+	s.metrics.ListDuration += duration
+}
+
+func (s *resetHTTPSession) RecordDelete(duration time.Duration) {
+	if s == nil {
+		return
+	}
+	s.metrics.DeleteCalls++
+	s.metrics.DeleteDuration += duration
 }
 
 func (s *resetHTTPSession) Rebuild(err error) {
@@ -494,6 +482,10 @@ func tryDeletePortalCustomDomain(
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
+	startedAt := time.Now()
+	defer func() {
+		session.RecordDelete(time.Since(startedAt))
+	}()
 	resp, err := session.Client().Do(req)
 	if err != nil {
 		Warnf("pre-delete portal custom domain %s: %v", portalID, err)
@@ -950,6 +942,7 @@ func retryListItems(
 		client := session.Client()
 		items, err = listItemsWithContext(ctx, client, url, token)
 		duration := time.Since(start)
+		session.RecordList(duration)
 		if err == nil {
 			return items, nil
 		}
@@ -997,6 +990,7 @@ func retryDeleteOne(
 		client := session.Client()
 		err = deleteOneWithContext(ctx, client, baseURL, token, id)
 		duration := time.Since(start)
+		session.RecordDelete(duration)
 		if err == nil {
 			return nil
 		}

--- a/test/e2e/harness/reset.go
+++ b/test/e2e/harness/reset.go
@@ -49,7 +49,7 @@ func resetOrg(stage string, capture bool) error {
 		if !truthyEnv(v) { // values like 0,false,off,no
 			Infof("Reset disabled by KONGCTL_E2E_RESET=%s", v)
 			if capture {
-				captureResetEvent(stage, false, "skipped", "reset disabled", "", nil)
+				captureResetEvent(stage, false, "skipped", "reset disabled", "", resetResult{})
 			}
 			return nil
 		}
@@ -62,7 +62,7 @@ func resetOrg(stage string, capture bool) error {
 	if token == "" {
 		Warnf("reset requested, but KONGCTL_E2E_KONNECT_PAT is not set; skipping reset")
 		if capture {
-			captureResetEvent(stage, false, "skipped", "missing PAT", baseURL, nil)
+			captureResetEvent(stage, false, "skipped", "missing PAT", baseURL, resetResult{})
 		}
 		return nil
 	}
@@ -77,7 +77,7 @@ func resetOrg(stage string, capture bool) error {
 			status = "error"
 			reason = err.Error()
 		}
-		captureResetEvent(stage, true, status, reason, baseURL, result.Details)
+		captureResetEvent(stage, true, status, reason, baseURL, result)
 	}
 	if err != nil {
 		return err
@@ -127,7 +127,8 @@ func deleteAll(
 	preDeleteFn func(ctx context.Context, session *resetHTTPSession, endpointURL, token, id string),
 	policy HTTPRetryPolicy,
 	transportOptions HTTPTransportOptions,
-) (int, int, error) {
+) (total int, deleted int, metrics resetHTTPMetrics, err error) {
+	startedAt := time.Now()
 	url := fmt.Sprintf("%s/%s/%s", strings.TrimRight(baseURL, "/"), apiVersion, endpoint)
 	if deleteBaseURL == "" {
 		deleteBaseURL = baseURL
@@ -146,7 +147,11 @@ func deleteAll(
 	)
 	Infof("Fetching %s for deletion...", endpoint)
 	session := newResetHTTPSession(policy.RequestTimeout, transportOptions)
-	defer session.Close()
+	defer func() {
+		session.Close()
+		metrics = session.Metrics()
+		metrics.Duration = time.Since(startedAt)
+	}()
 
 	if filter == nil {
 		filter = shouldDeleteResource
@@ -159,25 +164,23 @@ func deleteAll(
 	const maxAttempts = 5
 	const retryDelay = 2 * time.Second
 
-	total := 0
-	deleted := 0
 	attempt := 0
 
 	for {
 		if err := ctx.Err(); err != nil {
-			return total, deleted, err
+			return total, deleted, metrics, err
 		}
 		items, err := retryListAllItems(ctx, session, url, token, endpoint, policy)
 		if err != nil {
-			return total, deleted, err
+			return total, deleted, metrics, err
 		}
 
 		if len(items) == 0 {
 			if total == 0 {
 				Infof("No %s found", endpoint)
-				return 0, 0, nil
+				return 0, 0, metrics, nil
 			}
-			return total, deleted, nil
+			return total, deleted, metrics, nil
 		}
 
 		// Filter items based on the filter function
@@ -206,7 +209,7 @@ func deleteAll(
 
 		if len(idsToDelete) == 0 {
 			Infof("No %s matched deletion filter; nothing to delete", endpoint)
-			return total, deleted, nil
+			return total, deleted, metrics, nil
 		}
 
 		Infof("Attempt %d deleting %d %s", attempt+1, len(idsToDelete), endpoint)
@@ -228,12 +231,12 @@ func deleteAll(
 		}
 
 		if conflicts == 0 {
-			return total, deleted, nil
+			return total, deleted, metrics, nil
 		}
 
 		attempt++
 		if attempt >= maxAttempts {
-			return total, deleted, fmt.Errorf(
+			return total, deleted, metrics, fmt.Errorf(
 				"failed to delete all %s after %d attempts (conflicts remain)",
 				endpoint,
 				maxAttempts,
@@ -242,7 +245,7 @@ func deleteAll(
 
 		Infof("Retrying deletion of %s (%d conflicts remaining)", endpoint, conflicts)
 		if err := sleepWithContext(ctx, retryDelay); err != nil {
-			return total, deleted, err
+			return total, deleted, metrics, err
 		}
 	}
 }
@@ -291,20 +294,76 @@ func (e *httpError) Error() string {
 }
 
 type resetEndpoint struct {
-	APIVersion string `json:"api_version"`
-	Endpoint   string `json:"endpoint"`
-	Total      int    `json:"total"`
-	Deleted    int    `json:"deleted"`
-	Error      string `json:"error,omitempty"`
+	APIVersion       string `json:"api_version"`
+	Endpoint         string `json:"endpoint"`
+	Total            int    `json:"total"`
+	Deleted          int    `json:"deleted"`
+	DurationMS       int64  `json:"duration_ms"`
+	ListCalls        int    `json:"list_calls"`
+	ListDurationMS   int64  `json:"list_duration_ms"`
+	DeleteCalls      int    `json:"delete_calls"`
+	DeleteDurationMS int64  `json:"delete_duration_ms"`
+	Error            string `json:"error,omitempty"`
 }
 
 type resetResult struct {
-	Details []resetEndpoint
+	DurationMS int64           `json:"duration_ms"`
+	Details    []resetEndpoint `json:"details"`
+}
+
+type resetHTTPMetrics struct {
+	Duration       time.Duration
+	ListCalls      int
+	ListDuration   time.Duration
+	DeleteCalls    int
+	DeleteDuration time.Duration
+}
+
+func resetEndpointResult(apiVersion, endpoint string, total, deleted int, metrics resetHTTPMetrics, err error) resetEndpoint {
+	return resetEndpoint{
+		APIVersion:       apiVersion,
+		Endpoint:         endpoint,
+		Total:            total,
+		Deleted:          deleted,
+		DurationMS:       metrics.Duration.Milliseconds(),
+		ListCalls:        metrics.ListCalls,
+		ListDurationMS:   metrics.ListDuration.Milliseconds(),
+		DeleteCalls:      metrics.DeleteCalls,
+		DeleteDurationMS: metrics.DeleteDuration.Milliseconds(),
+		Error:            errorString(err),
+	}
 }
 
 type resetHTTPSession struct {
 	newClient func() *http.Client
 	client    *http.Client
+	metrics   resetHTTPMetrics
+}
+
+type resetMetricsRoundTripper struct {
+	base    http.RoundTripper
+	metrics *resetHTTPMetrics
+}
+
+func (t *resetMetricsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	startedAt := time.Now()
+	resp, err := t.base.RoundTrip(req)
+	duration := time.Since(startedAt)
+	switch req.Method {
+	case http.MethodGet:
+		t.metrics.ListCalls++
+		t.metrics.ListDuration += duration
+	case http.MethodDelete:
+		t.metrics.DeleteCalls++
+		t.metrics.DeleteDuration += duration
+	}
+	return resp, err
+}
+
+func (t *resetMetricsRoundTripper) CloseIdleConnections() {
+	if transport, ok := t.base.(interface{ CloseIdleConnections() }); ok {
+		transport.CloseIdleConnections()
+	}
 }
 
 func newResetHTTPSession(timeout time.Duration, options HTTPTransportOptions) *resetHTTPSession {
@@ -321,8 +380,20 @@ func (s *resetHTTPSession) Client() *http.Client {
 	}
 	if s.client == nil {
 		s.client = s.newClient()
+		transport := s.client.Transport
+		if transport == nil {
+			transport = http.DefaultTransport
+		}
+		s.client.Transport = &resetMetricsRoundTripper{base: transport, metrics: &s.metrics}
 	}
 	return s.client
+}
+
+func (s *resetHTTPSession) Metrics() resetHTTPMetrics {
+	if s == nil {
+		return resetHTTPMetrics{}
+	}
+	return s.metrics
 }
 
 func (s *resetHTTPSession) Rebuild(err error) {
@@ -438,11 +509,15 @@ func tryDeletePortalCustomDomain(
 	}
 }
 
-func executeReset(baseURL, token string, policy HTTPRetryPolicy) (resetResult, error) {
+func executeReset(baseURL, token string, policy HTTPRetryPolicy) (result resetResult, firstErr error) {
+	startedAt := time.Now()
+	defer func() {
+		result.DurationMS = time.Since(startedAt).Milliseconds()
+	}()
 	transportOptions := HTTPTransportOptionsFromEnv()
 	globalBaseURL, envErr := KonnectBaseAuthURL()
 	if envErr != nil {
-		return resetResult{}, envErr
+		return result, envErr
 	}
 	ctx := context.Background()
 	cancel := func() {}
@@ -451,20 +526,20 @@ func executeReset(baseURL, token string, policy HTTPRetryPolicy) (resetResult, e
 	}
 	defer cancel()
 
-	var result resetResult
-	var firstErr error
-
-	tot, del, err := resetConfiguredE2EUserAssignments(ctx, globalBaseURL, token, policy, transportOptions)
+	tot, del, metrics, err := resetConfiguredE2EUserAssignments(
+		ctx,
+		globalBaseURL,
+		token,
+		policy,
+		transportOptions,
+	)
 	if err != nil && firstErr == nil {
 		firstErr = err
 	}
-	result.Details = append(result.Details, resetEndpoint{
-		APIVersion: "v3",
-		Endpoint:   "e2e-user-assignments",
-		Total:      tot,
-		Deleted:    del,
-		Error:      errorString(err),
-	})
+	result.Details = append(
+		result.Details,
+		resetEndpointResult("v3", "e2e-user-assignments", tot, del, metrics, err),
+	)
 
 	for _, step := range resetSequence {
 		if err := ctx.Err(); err != nil {
@@ -490,7 +565,7 @@ func executeReset(baseURL, token string, policy HTTPRetryPolicy) (resetResult, e
 		if step.DeleteUseRegional {
 			deleteTargetURL = baseURL
 		}
-		tot, del, err := deleteAll(
+		tot, del, metrics, err := deleteAll(
 			ctx,
 			targetURL,
 			deleteTargetURL,
@@ -508,13 +583,10 @@ func executeReset(baseURL, token string, policy HTTPRetryPolicy) (resetResult, e
 		if err != nil && firstErr == nil {
 			firstErr = err
 		}
-		result.Details = append(result.Details, resetEndpoint{
-			APIVersion: step.Version,
-			Endpoint:   step.Endpoint,
-			Total:      tot,
-			Deleted:    del,
-			Error:      errorString(err),
-		})
+		result.Details = append(
+			result.Details,
+			resetEndpointResult(step.Version, step.Endpoint, tot, del, metrics, err),
+		)
 	}
 
 	return result, firstErr
@@ -530,23 +602,26 @@ func resetConfiguredE2EUserAssignments(
 	token string,
 	policy HTTPRetryPolicy,
 	transportOptions HTTPTransportOptions,
-) (int, int, error) {
+) (total int, deleted int, metrics resetHTTPMetrics, err error) {
+	startedAt := time.Now()
 	emails := configuredE2EUserEmails()
 	if len(emails) == 0 {
 		Debugf("No KONGCTL_E2E_ORG_USER_EMAIL_* values configured; skipping user assignment reset")
-		return 0, 0, nil
+		return 0, 0, metrics, nil
 	}
 
 	session := newResetHTTPSession(policy.RequestTimeout, transportOptions)
-	defer session.Close()
+	defer func() {
+		session.Close()
+		metrics = session.Metrics()
+		metrics.Duration = time.Since(startedAt)
+	}()
 
 	usersByEmail, err := listUsersByEmail(ctx, session, globalBaseURL, token, policy)
 	if err != nil {
-		return len(emails), 0, err
+		return len(emails), 0, metrics, err
 	}
 
-	total := 0
-	deleted := 0
 	for _, email := range emails {
 		user, ok := usersByEmail[email]
 		if !ok {
@@ -556,10 +631,10 @@ func resetConfiguredE2EUserAssignments(
 		total += userTotal
 		deleted += userDeleted
 		if err != nil {
-			return total, deleted, err
+			return total, deleted, metrics, err
 		}
 	}
-	return total, deleted, nil
+	return total, deleted, metrics, nil
 }
 
 func configuredE2EUserEmails() []string {
@@ -723,7 +798,7 @@ func captureResetEvent(
 	status string,
 	reason string,
 	baseURL string,
-	details []resetEndpoint,
+	result resetResult,
 ) {
 	// Best-effort capture; never fail tests from here.
 	rd, err := ensureRunDir()
@@ -781,11 +856,12 @@ func captureResetEvent(
 	}
 	// observation.json
 	obs := map[string]any{
-		"type":     "reset_summary",
-		"executed": executed,
-		"status":   status,
-		"reason":   reason,
-		"details":  details,
+		"type":        "reset_summary",
+		"executed":    executed,
+		"status":      status,
+		"reason":      reason,
+		"duration_ms": result.DurationMS,
+		"details":     result.Details,
 	}
 	if b, err := json.MarshalIndent(obs, "", "  "); err == nil {
 		_ = os.WriteFile(dir+string(os.PathSeparator)+"observation.json", b, 0o644)

--- a/test/e2e/harness/reset_test.go
+++ b/test/e2e/harness/reset_test.go
@@ -178,7 +178,7 @@ func TestDeleteAllDeletesFilteredItemsAcrossPages(t *testing.T) {
 		RequestTimeout: time.Second,
 		Backoff:        BackoffConfig{Attempts: 1},
 	}
-	total, deleteCount, err := deleteAll(
+	total, deleteCount, metrics, err := deleteAll(
 		t.Context(),
 		server.URL,
 		server.URL,
@@ -201,6 +201,15 @@ func TestDeleteAllDeletesFilteredItemsAcrossPages(t *testing.T) {
 	}
 	if deleteCount != 2 {
 		t.Fatalf("deleteAll() deleteCount = %d, want 2", deleteCount)
+	}
+	if metrics.ListCalls != 2 {
+		t.Fatalf("deleteAll() list calls = %d, want 2", metrics.ListCalls)
+	}
+	if metrics.DeleteCalls != 2 {
+		t.Fatalf("deleteAll() delete calls = %d, want 2", metrics.DeleteCalls)
+	}
+	if metrics.Duration <= 0 || metrics.ListDuration <= 0 || metrics.DeleteDuration <= 0 {
+		t.Fatalf("deleteAll() durations = %#v, want positive durations", metrics)
 	}
 	if !deleted["e2e-team-alpha"] || !deleted["e2e-team-beta"] {
 		t.Fatalf("deleteAll() deleted = %#v, want both e2e teams deleted", deleted)

--- a/test/e2e/harness/step.go
+++ b/test/e2e/harness/step.go
@@ -1128,11 +1128,16 @@ func (s *Step) ResetOrgForRegions(stage string, regions []string) error {
 		details := make([]map[string]any, 0, len(result.Details))
 		for _, d := range result.Details {
 			details = append(details, map[string]any{
-				"api_version": d.APIVersion,
-				"endpoint":    d.Endpoint,
-				"total":       d.Total,
-				"deleted":     d.Deleted,
-				"error":       d.Error,
+				"api_version":        d.APIVersion,
+				"endpoint":           d.Endpoint,
+				"total":              d.Total,
+				"deleted":            d.Deleted,
+				"duration_ms":        d.DurationMS,
+				"list_calls":         d.ListCalls,
+				"list_duration_ms":   d.ListDurationMS,
+				"delete_calls":       d.DeleteCalls,
+				"delete_duration_ms": d.DeleteDurationMS,
+				"error":              d.Error,
 			})
 		}
 		status := "ok"
@@ -1145,10 +1150,11 @@ func (s *Step) ResetOrgForRegions(stage string, regions []string) error {
 			}
 		}
 		summaries = append(summaries, map[string]any{
-			"base_url": baseURL,
-			"status":   status,
-			"reason":   reason,
-			"details":  details,
+			"base_url":    baseURL,
+			"status":      status,
+			"reason":      reason,
+			"duration_ms": result.DurationMS,
+			"details":     details,
 		})
 	}
 

--- a/test/e2e/harness/step.go
+++ b/test/e2e/harness/step.go
@@ -1125,21 +1125,6 @@ func (s *Step) ResetOrgForRegions(stage string, regions []string) error {
 
 	for _, baseURL := range baseURLs {
 		result, runErr := executeReset(baseURL, token, policy)
-		details := make([]map[string]any, 0, len(result.Details))
-		for _, d := range result.Details {
-			details = append(details, map[string]any{
-				"api_version":        d.APIVersion,
-				"endpoint":           d.Endpoint,
-				"total":              d.Total,
-				"deleted":            d.Deleted,
-				"duration_ms":        d.DurationMS,
-				"list_calls":         d.ListCalls,
-				"list_duration_ms":   d.ListDurationMS,
-				"delete_calls":       d.DeleteCalls,
-				"delete_duration_ms": d.DeleteDurationMS,
-				"error":              d.Error,
-			})
-		}
 		status := "ok"
 		reason := ""
 		if runErr != nil {
@@ -1154,7 +1139,7 @@ func (s *Step) ResetOrgForRegions(stage string, regions []string) error {
 			"status":      status,
 			"reason":      reason,
 			"duration_ms": result.DurationMS,
-			"details":     details,
+			"details":     result.Details,
 		})
 	}
 


### PR DESCRIPTION
> [!IMPORTANT]
> This PR enables Stage 0 data collection but does not complete Stage 0. The required 20-run baseline must be collected and published before the Stage 1 concurrency change.

## Summary

- capture reset wall time, complete list/delete operation counts and timing, and resources found/deleted
- publish a small secret-free metrics artifact for every `.com` scenario shard
- add a reproducible, run-attempt-consistent `gh` report for complete successful full runs
- add telemetry parser tests to `make test-all` and the standard CI workflow

## Rationale

This is the standalone instrumentation precursor for Stage 0 of #2053. It establishes the measurement path without changing workflow concurrency, Go caching, scenario assignment, or reset frequency. Keeping those changes separate preserves a clean comparison and rollback boundary.

The report command intentionally requires 20 instrumented successful full `.com` runs. After this merges, those runs will be collected and the baseline will be published before the workflow-level lock is changed.

Closes no issue; contributes to #2053.

## Verification

- `go fix ./...`
- `make format`
- `make build`
- `make lint`
- `make test-all`
- `make test-e2e-metrics`
- `actionlint .github/workflows/e2e.yaml .github/workflows/test.yaml`
- `python3 -m py_compile scripts/e2e-baseline.py scripts/e2e-metrics.py scripts/e2e_baseline_test.py scripts/e2e_metrics_test.py`