### PR TITLE
refactor(simplify): reduce AI Gateway and sync scope duplication

### DIFF
--- a/internal/cmd/root/products/konnect/aigateway/interactive_children.go
+++ b/internal/cmd/root/products/konnect/aigateway/interactive_children.go
@@ -76,13 +76,7 @@ func loadAIGatewayTLSChildren(kind aiGatewayTLSResourceKind) tableview.ChildLoad
 		rows := make([]table.Row, 0, len(items))
 		for _, item := range items {
 			record := aiGatewayTLSResourceRecord(item)
-			if kind == aiGatewaySNIKind {
-				rows = append(rows, table.Row{
-					record.ID, record.Name, record.DisplayName, record.Hostname, record.Certificate, record.Updated,
-				})
-			} else {
-				rows = append(rows, table.Row{record.ID, record.Name, record.Updated})
-			}
+			rows = append(rows, aiGatewayTLSRow(kind, record))
 		}
 		return tableview.ChildView{
 			Headers: resourceConfig.headers, Rows: rows, Title: resourceConfig.resource + "s",
@@ -526,15 +520,7 @@ func aiGatewayConsumerCredentialParentIDs(parent any) (string, string, error) {
 
 	switch p := parent.(type) {
 	case *aiGatewayConsumerDetailContext:
-		gatewayID := strings.TrimSpace(p.GatewayID)
-		consumerID := strings.TrimSpace(p.Consumer.ID)
-		if gatewayID == "" {
-			return "", "", fmt.Errorf("AI Gateway identifier is missing")
-		}
-		if consumerID == "" {
-			return "", "", fmt.Errorf("AI Gateway Consumer identifier is missing")
-		}
-		return gatewayID, consumerID, nil
+		return aiGatewayConsumerCredentialParentIDs(*p)
 	case aiGatewayConsumerDetailContext:
 		gatewayID := strings.TrimSpace(p.GatewayID)
 		consumerID := strings.TrimSpace(p.Consumer.ID)
@@ -557,11 +543,7 @@ func aiGatewayIDFromParent(parent any) (string, error) {
 
 	switch p := parent.(type) {
 	case *kkComps.AIGateway:
-		id := strings.TrimSpace(p.ID)
-		if id == "" {
-			return "", fmt.Errorf("AI Gateway identifier is missing")
-		}
-		return id, nil
+		return aiGatewayIDFromParent(*p)
 	case kkComps.AIGateway:
 		id := strings.TrimSpace(p.ID)
 		if id == "" {

--- a/internal/cmd/root/products/konnect/aigateway/tls_resources.go
+++ b/internal/cmd/root/products/konnect/aigateway/tls_resources.go
@@ -258,13 +258,7 @@ func renderAIGatewayTLSResources(
 	for _, item := range items {
 		record := aiGatewayTLSResourceRecord(item)
 		records = append(records, record)
-		if resourceConfig.kind == aiGatewaySNIKind {
-			rows = append(rows, table.Row{
-				record.ID, record.Name, record.DisplayName, record.Hostname, record.Certificate, record.Updated,
-			})
-		} else {
-			rows = append(rows, table.Row{record.ID, record.Name, record.Updated})
-		}
+		rows = append(rows, aiGatewayTLSRow(resourceConfig.kind, record))
 	}
 	display, raw := aiGatewayTLSRenderValues(records, items, single)
 	return tableview.RenderForFormat(
@@ -279,6 +273,15 @@ func renderAIGatewayTLSResources(
 			return items[index]
 		}),
 	)
+}
+
+func aiGatewayTLSRow(kind aiGatewayTLSResourceKind, record aiGatewayTLSRecord) table.Row {
+	if kind == aiGatewaySNIKind {
+		return table.Row{
+			record.ID, record.Name, record.DisplayName, record.Hostname, record.Certificate, record.Updated,
+		}
+	}
+	return table.Row{record.ID, record.Name, record.Updated}
 }
 
 func aiGatewayTLSRenderValues(records []aiGatewayTLSRecord, items []any, single bool) (any, any) {

--- a/internal/cmd/root/products/konnect/api/publications.go
+++ b/internal/cmd/root/products/konnect/api/publications.go
@@ -283,12 +283,12 @@ func filterPublicationsByPortal(
 }
 
 func publicationToRecord(publication kkComps.APIPublicationListItem) apiPublicationRecord {
-	visibility := "n/a"
+	visibility := valueNA
 	if publication.GetVisibility() != "" {
 		visibility = string(publication.GetVisibility())
 	}
 
-	authStrategies := "n/a"
+	authStrategies := valueNA
 	if ids := publication.GetAuthStrategyIds(); len(ids) > 0 {
 		authStrategies = strings.Join(ids, ", ")
 	}

--- a/internal/declarative/loader/sync_scope.go
+++ b/internal/declarative/loader/sync_scope.go
@@ -351,6 +351,25 @@ var rootChildCollectionScopes = []childCollectionScope{
 	},
 }
 
+var rootChildParentDescriptions = map[resources.ResourceType]string{
+	resources.ResourceTypeAIGatewayProvider:             "each Model Provider must declare an ai_gateway parent",
+	resources.ResourceTypeAIGatewayAuthStrategy:         "each Auth Strategy must declare an ai_gateway parent",
+	resources.ResourceTypeAIGatewayPolicy:               "each policy must declare an ai_gateway parent",
+	resources.ResourceTypeAIGatewayAgent:                "each Agent must declare an ai_gateway parent",
+	resources.ResourceTypeAIGatewayConsumer:             "each Consumer must declare an ai_gateway parent",
+	resources.ResourceTypeAIGatewayConsumerGroup:        "each Consumer Group must declare an ai_gateway parent",
+	resources.ResourceTypeAIGatewayConsumerCredential:   "each Credential must declare an ai_gateway_consumer parent",
+	resources.ResourceTypeAIGatewayModel:                "each model must declare an ai_gateway parent",
+	resources.ResourceTypeAIGatewayMCPServer:            "each MCP Server must declare an ai_gateway parent",
+	resources.ResourceTypeAIGatewayConfigStore:          "each Config Store must declare an ai_gateway parent",
+	resources.ResourceTypeAIGatewayConfigStoreSecret:    "each secret must declare an ai_gateway_config_store parent",
+	resources.ResourceTypeAIGatewayVault:                "each Vault must declare an ai_gateway parent",
+	resources.ResourceTypeAIGatewayDataPlaneCertificate: "each data plane certificate must declare an ai_gateway parent",
+	resources.ResourceTypeAIGatewayCertificate:          "each resource must declare an ai_gateway parent",
+	resources.ResourceTypeAIGatewayCACertificate:        "each resource must declare an ai_gateway parent",
+	resources.ResourceTypeAIGatewaySNI:                  "each resource must declare an ai_gateway parent",
+}
+
 var apiChildCollectionScopes = []childCollectionScope{
 	{key: "versions", resourceType: resources.ResourceTypeAPIVersion, parentType: resources.ResourceTypeAPI},
 	{key: "publications", resourceType: resources.ResourceTypeAPIPublication, parentType: resources.ResourceTypeAPI},
@@ -610,58 +629,8 @@ func captureRootChildScope(scope *resources.SyncScope, raw map[string]any, entry
 	}
 	items, ok := asSlice(value)
 	if !ok || len(items) == 0 {
-		if entry.resourceType == resources.ResourceTypeAIGatewayProvider {
-			return fmt.Errorf("%s cannot be empty because each Model Provider must declare an ai_gateway parent", entry.key)
-		}
-		if entry.resourceType == resources.ResourceTypeAIGatewayAuthStrategy {
-			return fmt.Errorf(
-				"%s cannot be empty because each Auth Strategy must declare an ai_gateway parent",
-				entry.key,
-			)
-		}
-		if entry.resourceType == resources.ResourceTypeAIGatewayPolicy {
-			return fmt.Errorf("%s cannot be empty because each policy must declare an ai_gateway parent", entry.key)
-		}
-		if entry.resourceType == resources.ResourceTypeAIGatewayAgent {
-			return fmt.Errorf("%s cannot be empty because each Agent must declare an ai_gateway parent", entry.key)
-		}
-		if entry.resourceType == resources.ResourceTypeAIGatewayConsumer {
-			return fmt.Errorf("%s cannot be empty because each Consumer must declare an ai_gateway parent", entry.key)
-		}
-		if entry.resourceType == resources.ResourceTypeAIGatewayConsumerGroup {
-			return fmt.Errorf("%s cannot be empty because each Consumer Group must declare an ai_gateway parent", entry.key)
-		}
-		if entry.resourceType == resources.ResourceTypeAIGatewayConsumerCredential {
-			return fmt.Errorf("%s cannot be empty because each Credential must declare an ai_gateway_consumer parent", entry.key)
-		}
-		if entry.resourceType == resources.ResourceTypeAIGatewayModel {
-			return fmt.Errorf("%s cannot be empty because each model must declare an ai_gateway parent", entry.key)
-		}
-		if entry.resourceType == resources.ResourceTypeAIGatewayMCPServer {
-			return fmt.Errorf("%s cannot be empty because each MCP Server must declare an ai_gateway parent", entry.key)
-		}
-		if entry.resourceType == resources.ResourceTypeAIGatewayConfigStore {
-			return fmt.Errorf("%s cannot be empty because each Config Store must declare an ai_gateway parent", entry.key)
-		}
-		if entry.resourceType == resources.ResourceTypeAIGatewayConfigStoreSecret {
-			return fmt.Errorf(
-				"%s cannot be empty because each secret must declare an ai_gateway_config_store parent",
-				entry.key,
-			)
-		}
-		if entry.resourceType == resources.ResourceTypeAIGatewayVault {
-			return fmt.Errorf("%s cannot be empty because each Vault must declare an ai_gateway parent", entry.key)
-		}
-		if entry.resourceType == resources.ResourceTypeAIGatewayDataPlaneCertificate {
-			return fmt.Errorf(
-				"%s cannot be empty because each data plane certificate must declare an ai_gateway parent",
-				entry.key,
-			)
-		}
-		if entry.resourceType == resources.ResourceTypeAIGatewayCertificate ||
-			entry.resourceType == resources.ResourceTypeAIGatewayCACertificate ||
-			entry.resourceType == resources.ResourceTypeAIGatewaySNI {
-			return fmt.Errorf("%s cannot be empty because each resource must declare an ai_gateway parent", entry.key)
+		if description, found := rootChildParentDescriptions[entry.resourceType]; found {
+			return fmt.Errorf("%s cannot be empty because %s", entry.key, description)
 		}
 		scope.AddRootChildCollection(entry.resourceType)
 		return nil


### PR DESCRIPTION
## Summary

- share AI Gateway TLS row construction between command and interactive views
- consolidate pointer and value parent handling
- use the shared API display fallback constant
- replace repetitive sync-scope parent validation branches with a lookup

## Rationale

This removes recently introduced duplication while preserving output, validation messages, and runtime behavior.

Closes #2059

## Testing

- go fix ./...
- make format
- make build
- make lint
- make test-all