### PR TITLE
task(e2e): enable build caching

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -601,10 +601,22 @@ jobs:
           echo "GOPRIVATE=github.com/Kong/sdk-konnect-go-internal" >> "${GITHUB_ENV}"
 
       - name: Setup Go
+        id: setup-go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
-          cache: false
+          cache: true
+          cache-dependency-path: |
+            go.mod
+            go.sum
+
+      - name: Report Go cache status
+        shell: bash
+        env:
+          CACHE_HIT: ${{ steps.setup-go.outputs.cache-hit }}
+        run: |
+          echo "Go build cache primary-key hit: ${CACHE_HIT}"
+          printf 'Go build cache primary-key hit: `%s`\n' "${CACHE_HIT}" >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Use local private SDK module
         shell: bash


### PR DESCRIPTION
> [!IMPORTANT]
> This intentionally advances the low-risk build-cache stage using the six-run preliminary uncached cohort. It does not change workflow concurrency, scenario assignment, organization isolation, or reset behavior.

## Summary

- enable the built-in `actions/setup-go` module and build caches for `e2e-build` only
- key the cache from both `go.mod` and `go.sum`
- publish the primary-key hit status in the build log and job summary
- leave the parallel harness job explicitly uncached to avoid competing cache saves

## Rationale

Across the six currently retained uncached full `.com` runs:

- median build-job duration is 309 seconds
- median `Build kongctl` duration is 240 seconds
- median scenario-binary build duration is 38 seconds
- median queue-to-required-status duration is 974 seconds

The latest uncached build announced dependency downloads during approximately its first eight seconds but continued compiling for about four minutes. Restoring Go build outputs therefore has a clear opportunity beyond module-download savings. Even a 50% reduction in the two build steps would save approximately 139 seconds, or 14% of current median queue-to-result latency.

`setup-go` caches Go module and content-addressed build caches; it does not preserve the generated `kongctl` or `e2e.test` workspace binaries. Source and private-SDK changes remain subject to normal Go input validation and recompilation.

## Runtime validation results

The same PR merge commit was run once cold and twice warm. All three complete E2E runs passed, including every live scenario shard and the aggregate coverage check.

| Observation | Primary-key hit | Build job | Setup Go | Build kongctl | Scenario binary | Post-cache save |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| Cold | `false` | 232 s | 7 s | 175 s | 26 s | 8 s |
| Warm 1 | `true` | 51 s | 27 s | 4 s | 1 s | 0 s |
| Warm 2 | `true` | 49 s | 25 s | 4 s | 1 s | 0 s |

The saved cache is 597,114,481 bytes (reported by the action as approximately 569 MiB). The 50-second warm median is:

- 259 seconds (84%) faster than the 309-second preliminary uncached median
- 182 seconds (78%) faster than this PR's 232-second cold observation

Cache restoration adds 18-20 seconds relative to cold setup, but avoids roughly three minutes of compilation. Cache misses remain safe and non-blocking; the cold run demonstrated the fallback behavior and took eight seconds to save the populated cache.

Run: https://github.com/Kong/kongctl/actions/runs/33906754133

## Runtime validation plan

1. Treat the initial successful PR E2E run as the cold/miss observation. ✅
2. Re-run the same commit after the cache has been saved. ✅
3. Confirm a primary-key cache hit and compare both build-step durations. ✅
4. Run at least one additional warm observation before merge. ✅

The six-run preliminary uncached snapshot is being retained separately by #2068. Future baseline collection should treat this change as the boundary between uncached and cached cohorts.

## Local verification

- `actionlint .github/workflows/e2e.yaml`
- `go fix ./...`
- `make format`
- `make build`
- `make lint`
- `make test`
- `make test-all`
- `git diff --check`

Contributes to Stage 2 of #2053; closes no issue.
