### PR TITLE
test(e2e): separate baseline cohorts and correct rerun timing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,12 +252,14 @@ diagnose-e2e-ci:
 E2E_BASELINE_COUNT ?= 20
 E2E_BASELINE_SCAN ?= 100
 E2E_BASELINE_DIR ?= .e2e-artifacts/baseline
-E2E_BASELINE_OBSERVATIONS ?= test/e2e/baselines/stage0-2026-09-observations.json
-E2E_BASELINE_REPORT ?= test/e2e/baselines/stage0-2026-09.md
+E2E_BASELINE_COHORT ?= cache-enabled
+E2E_BASELINE_OBSERVATIONS ?= test/e2e/baselines/post-cache-2026-09-observations.json
+E2E_BASELINE_REPORT ?= test/e2e/baselines/post-cache-2026-09.md
 
 .PHONY: collect-e2e-baseline
 collect-e2e-baseline:
 	@python3 scripts/e2e-baseline.py \
+		--cohort "$(E2E_BASELINE_COHORT)" \
 		--count "$(E2E_BASELINE_COUNT)" \
 		--scan "$(E2E_BASELINE_SCAN)" \
 		--observations "$(E2E_BASELINE_OBSERVATIONS)" \
@@ -270,6 +272,7 @@ collect-e2e-baseline:
 baseline-e2e-ci:
 	@mkdir -p "$(E2E_BASELINE_DIR)"
 	@python3 scripts/e2e-baseline.py \
+		--cohort "$(E2E_BASELINE_COHORT)" \
 		--count "$(E2E_BASELINE_COUNT)" \
 		--scan "$(E2E_BASELINE_SCAN)" \
 		--output "$(E2E_BASELINE_DIR)/e2e-baseline.md" \

--- a/scripts/e2e-baseline.py
+++ b/scripts/e2e-baseline.py
@@ -20,8 +20,16 @@ HARNESS_JOB = "Test scenario harness"
 VERIFY_JOB = "Verify scenario results and coverage"
 REQUIRED_JOB = "Publish “E2E Required”"
 SCENARIO_JOB_PREFIX = "Run scenarios — "
-OBSERVATION_SCHEMA_VERSION = 1
+OBSERVATION_SCHEMA_VERSION = 2
+COHORTS = ("uncached", "cache-enabled")
 RUN_REQUIRED_FIELDS = {
+    "cohort",
+    "original_created_at",
+    "head_sha",
+    "harness_job_seconds",
+    "harness_setup_seconds",
+    "harness_test_seconds",
+    "build_setup_seconds",
     "run_id",
     "run_attempt",
     "url",
@@ -142,6 +150,13 @@ def named_step(job: dict[str, Any], name: str) -> dict[str, Any] | None:
     return next((step for step in job.get("steps", []) if step["name"] == name), None)
 
 
+def run_cohort(jobs: list[dict[str, Any]]) -> str | None:
+    build = named_job(jobs, BUILD_JOB)
+    if build is None:
+        return None
+    return "cache-enabled" if named_step(build, "Report Go cache status") else "uncached"
+
+
 def eligible_run(
     run: dict[str, Any],
     jobs: list[dict[str, Any]],
@@ -166,9 +181,17 @@ def eligible_run(
     build_scenarios = named_step(build, "Build scenario test binary")
     if build_kongctl is None or build_scenarios is None:
         return None
+    harness_setup = named_step(harness, "Setup Go")
+    harness_test = named_step(harness, HARNESS_JOB)
+    build_setup = named_step(build, "Setup Go")
+    if harness_setup is None or harness_test is None or build_setup is None:
+        return None
 
     ready_at = max(timestamp(build["completedAt"]), timestamp(harness["completedAt"]))
     workflow_created_at = timestamp(run["createdAt"])
+    if any(timestamp(job["startedAt"]) < workflow_created_at for job in required_jobs):
+        # A partial rerun can reuse jobs from an earlier attempt.
+        return None
     first_job_started_at = min(timestamp(job["startedAt"]) for job in jobs if job["startedAt"])
     shard_durations = [float(metric["execution_duration_seconds"]) for metric in metrics]
 
@@ -180,6 +203,13 @@ def eligible_run(
         scenarios.extend(metric["scenario_durations"])
 
     return {
+        "cohort": run_cohort(jobs),
+        "original_created_at": run["original_created_at"],
+        "head_sha": run["head_sha"],
+        "harness_job_seconds": duration(harness),
+        "harness_setup_seconds": duration(harness_setup),
+        "harness_test_seconds": duration(harness_test),
+        "build_setup_seconds": duration(build_setup),
         "run_id": int(run["databaseId"]),
         "run_attempt": int(metrics[0]["run_attempt"]),
         "url": run["url"],
@@ -216,6 +246,7 @@ def collect_runs(
     count: int,
     scan: int,
     excluded_run_ids: set[int] | None = None,
+    cohort: str = "cache-enabled",
 ) -> list[dict[str, Any]]:
     if count <= 0:
         return []
@@ -252,9 +283,22 @@ def collect_runs(
             ]
         )
         run_attempt = int(view["attempt"])
+        if run_cohort(view["jobs"]) != cohort:
+            continue
         metrics = download_metrics(repo, int(candidate["databaseId"]), run_attempt)
         if not metrics:
             continue
+        attempt = gh_json(
+            ["api", f"repos/{repo}/actions/runs/{candidate['databaseId']}/attempts/{run_attempt}"]
+        )
+        if attempt["conclusion"] != "success":
+            continue
+        candidate = {
+            **candidate,
+            "original_created_at": candidate["createdAt"],
+            "createdAt": attempt["created_at"],
+            "head_sha": attempt["head_sha"],
+        }
         record = eligible_run(candidate, view["jobs"], metrics)
         if record is not None:
             selected.append(record)
@@ -276,10 +320,21 @@ def validate_run(run: Any, index: int) -> dict[str, Any]:
     if not isinstance(run["created_at"], str):
         raise ValueError(f"observation run {index} has an invalid created_at")
     timestamp(run["created_at"])
+    if not isinstance(run["original_created_at"], str):
+        raise ValueError(f"observation run {index} has an invalid original_created_at")
+    timestamp(run["original_created_at"])
+    if not isinstance(run["head_sha"], str) or not run["head_sha"]:
+        raise ValueError(f"observation run {index} has an invalid head_sha")
+    for field in ("build_setup_seconds", "harness_job_seconds", "harness_setup_seconds", "harness_test_seconds"):
+        value = run[field]
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value) or value < 0:
+            raise ValueError(f"observation run {index} has an invalid {field}")
+    if run["cohort"] not in COHORTS:
+        raise ValueError(f"observation run {index} has an invalid cohort")
     return run
 
 
-def load_observations(path: Path, repo: str) -> list[dict[str, Any]]:
+def load_observations(path: Path, repo: str, cohort: str = "cache-enabled") -> list[dict[str, Any]]:
     if not path.exists():
         return []
     try:
@@ -297,10 +352,15 @@ def load_observations(path: Path, repo: str) -> list[dict[str, Any]]:
         raise ValueError(
             f"observations {path} are for repository {document.get('repository')!r}, expected {repo!r}"
         )
+    if document.get("cohort") != cohort:
+        raise ValueError(f"observations {path} cohort does not match requested {cohort!r}")
     runs = document.get("runs")
     if not isinstance(runs, list):
         raise ValueError(f"observations {path} field runs must be an array")
-    return [validate_run(run, index) for index, run in enumerate(runs)]
+    validated = [validate_run(run, index) for index, run in enumerate(runs)]
+    if any(run["cohort"] != cohort for run in validated):
+        raise ValueError(f"observations {path} contain mixed cohorts")
+    return validated
 
 
 def merge_runs(
@@ -316,10 +376,13 @@ def merge_runs(
     )
 
 
-def observation_document(repo: str, runs: list[dict[str, Any]]) -> dict[str, Any]:
+def observation_document(
+    repo: str, runs: list[dict[str, Any]], cohort: str = "cache-enabled"
+) -> dict[str, Any]:
     return {
         "schema_version": OBSERVATION_SCHEMA_VERSION,
         "repository": repo,
+        "cohort": cohort,
         "runs": runs,
     }
 
@@ -346,6 +409,10 @@ def summarize(runs: list[dict[str, Any]]) -> dict[str, Any]:
         "build_job_seconds",
         "build_kongctl_seconds",
         "build_scenario_binary_seconds",
+        "build_setup_seconds",
+        "harness_job_seconds",
+        "harness_setup_seconds",
+        "harness_test_seconds",
         "longest_shard_seconds",
         "shard_spread_seconds",
     ]
@@ -373,20 +440,29 @@ def markdown_report(
     runs: list[dict[str, Any]],
     summary: dict[str, Any],
     target_count: int,
+    cohort: str = "cache-enabled",
+    frozen: bool = False,
 ) -> str:
-    status = "complete" if len(runs) >= target_count else "collecting"
+    status = "frozen preliminary" if frozen else ("complete" if len(runs) >= target_count else "collecting")
     lines = [
         "# Konnect `.com` E2E baseline",
         "",
         f"Repository: `{repo}`",
+        f"Cohort: `{cohort}`",
         "",
         f"Full successful runs: {len(runs)} of {target_count}",
         f"Status: **{status}**",
         "",
-        "The report scans successful `e2e.yaml` runs newest-first, retains only runs with a complete",
-        "latest-attempt metrics manifest for every `.com` shard, and requires successful build, harness,",
-        "scenario, coverage-verification, and required-status jobs. Short gate-only runs are excluded.",
+        "The report scans successful `e2e.yaml` runs newest-first and retains only",
+        "runs with a complete latest-attempt metrics manifest for every `.com` shard.",
+        "Build, harness, scenario, coverage-verification, and required-status jobs",
+        "must succeed. Short gate-only runs are excluded.",
         "Percentiles use the nearest-rank method.",
+        "Latency starts at the selected attempt's creation time. Jobs reused from an",
+        "earlier attempt are excluded. Cache-enabled identifies the cache-reporting",
+        "step introduced by #2069 and includes both hits and misses. Keep that step",
+        "when changing the cache policy. Each run ID contributes one saved successful",
+        "attempt; reruns are not independent samples.",
         "",
         "## Latency",
         "",
@@ -417,13 +493,14 @@ def markdown_report(
             "",
             "## Included runs",
             "",
-            "| Run | Created | Queue-to-status | Build | Longest shard | Spread | Resets |",
+            "| Run / Attempt | Attempt created | Queue-to-status | Build | Longest shard | Spread | Resets |",
             "| --- | --- | ---: | ---: | ---: | ---: | ---: |",
         ]
     )
     for run in runs:
         lines.append(
-            f"| [{run['run_id']}]({run['url']}) | {run['created_at']} | "
+            f"| [{run['run_id']} / {run['run_attempt']}]({run['url']}/attempts/{run['run_attempt']}) | "
+            f"{run['created_at']} | "
             f"{run['queue_to_required_status_seconds']:.0f}s | {run['build_job_seconds']:.0f}s | "
             f"{run['longest_shard_seconds']:.0f}s | {run['shard_spread_seconds']:.0f}s | "
             f"{run['reset'].get('count', 0)} |"
@@ -477,6 +554,8 @@ def main() -> int:
     parser.add_argument("--repo", default="kong/kongctl")
     parser.add_argument("--count", type=int, default=20)
     parser.add_argument("--scan", type=int, default=100)
+    parser.add_argument("--cohort", choices=COHORTS, default="cache-enabled")
+    parser.add_argument("--frozen", action="store_true", help="report saved observations without collecting")
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--json-output", type=Path)
     parser.add_argument(
@@ -492,22 +571,25 @@ def main() -> int:
     args = parser.parse_args()
     if args.count < 1 or args.scan < 1:
         parser.error("--count and --scan must be positive")
+    if args.frozen and (args.observations is None or not args.observations.exists()):
+        parser.error("--frozen requires an existing --observations file")
 
     try:
-        saved = load_observations(args.observations, args.repo) if args.observations else []
+        saved = load_observations(args.observations, args.repo, args.cohort) if args.observations else []
     except ValueError as error:
         parser.error(str(error))
     saved_run_ids = {int(run["run_id"]) for run in saved}
     collected = collect_runs(
         args.repo,
-        max(0, args.count - len(saved)),
+        0 if args.frozen else max(0, args.count - len(saved)),
         args.scan,
         excluded_run_ids=saved_run_ids,
+        cohort=args.cohort,
     )
     runs = merge_runs(saved, collected)
     if args.observations is not None:
-        write_json(args.observations, observation_document(args.repo, runs))
-    if len(runs) < args.count:
+        write_json(args.observations, observation_document(args.repo, runs, args.cohort))
+    if len(runs) < args.count and not args.frozen:
         message = (
             f"found {len(runs)} eligible full .com runs, need {args.count}; "
             "increase --scan or collect again before older artifacts expire"
@@ -517,12 +599,15 @@ def main() -> int:
         print(message, file=sys.stderr)
     summary = summarize(runs)
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(markdown_report(args.repo, runs, summary, args.count), encoding="utf-8")
+    args.output.write_text(
+        markdown_report(args.repo, runs, summary, args.count, args.cohort, args.frozen), encoding="utf-8"
+    )
     if args.json_output is not None:
         write_json(
             args.json_output,
             {
                 "schema_version": OBSERVATION_SCHEMA_VERSION,
+                "cohort": args.cohort,
                 "summary": summary,
                 "target_run_count": args.count,
                 "runs": runs,

--- a/scripts/e2e_baseline_test.py
+++ b/scripts/e2e_baseline_test.py
@@ -5,6 +5,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 SCRIPT = Path(__file__).with_name("e2e-baseline.py")
@@ -63,7 +64,7 @@ class E2EBaselineTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "observations.json"
             path.write_text(
-                json.dumps({"schema_version": 2, "repository": "kong/kongctl", "runs": []}),
+                json.dumps({"schema_version": 99, "repository": "kong/kongctl", "runs": []}),
                 encoding="utf-8",
             )
 
@@ -76,8 +77,9 @@ class E2EBaselineTest(unittest.TestCase):
             path.write_text(
                 json.dumps(
                     {
-                        "schema_version": 1,
+                        "schema_version": MODULE.OBSERVATION_SCHEMA_VERSION,
                         "repository": "kong/kongctl",
+                        "cohort": "cache-enabled",
                         "runs": [{"run_id": 1}],
                     }
                 ),
@@ -95,6 +97,70 @@ class E2EBaselineTest(unittest.TestCase):
         self.assertIn("Full successful runs: 1 of 20", report)
         self.assertIn("Status: **collecting**", report)
 
+    def test_rejects_wrong_cohort_and_mixed_saved_data(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "observations.json"
+            runs = [self.run_record(1, "2026-09-01T00:00:00Z")]
+            MODULE.write_json(path, MODULE.observation_document("kong/kongctl", runs))
+            with self.assertRaisesRegex(ValueError, "cohort does not match"):
+                MODULE.load_observations(path, "kong/kongctl", "uncached")
+            runs[0]["cohort"] = "uncached"
+            MODULE.write_json(path, MODULE.observation_document("kong/kongctl", runs))
+            with self.assertRaisesRegex(ValueError, "mixed cohorts"):
+                MODULE.load_observations(path, "kong/kongctl")
+
+    def test_frozen_report_remains_preliminary(self) -> None:
+        runs = [self.run_record(1, "2026-09-01T00:00:00Z")]
+        report = MODULE.markdown_report("kong/kongctl", runs, MODULE.summarize(runs), 20, frozen=True)
+        self.assertIn("Status: **frozen preliminary**", report)
+        with patch.object(MODULE, "gh_json") as api:
+            self.assertEqual([], MODULE.collect_runs("kong/kongctl", 0, 100))
+            api.assert_not_called()
+
+    def test_rerun_uses_attempt_creation_and_records_harness_cost(self) -> None:
+        start = "2026-09-04T19:08:00Z"
+        end = "2026-09-04T19:18:50Z"
+        jobs = [
+            {"name": name, "conclusion": "success", "startedAt": start, "completedAt": end, "steps": []}
+            for name in [MODULE.BUILD_JOB, MODULE.HARNESS_JOB, MODULE.VERIFY_JOB,
+                         MODULE.REQUIRED_JOB, MODULE.SCENARIO_JOB_PREFIX + "org"]
+        ]
+        for job, names in [(jobs[0], ["Setup Go", "Build kongctl", "Build scenario test binary",
+                                    "Report Go cache status"]),
+                           (jobs[1], ["Setup Go", MODULE.HARNESS_JOB])]:
+            job["steps"] = [{"name": name, "startedAt": start, "completedAt": end} for name in names]
+        candidate = {"databaseId": 1, "createdAt": "2026-09-04T18:35:56Z", "url": "https://example.test/1"}
+        attempt = {"created_at": "2026-09-04T19:07:59Z", "head_sha": "abc", "conclusion": "success"}
+        metrics = [{"konnect_environment": "com", "run_attempt": 3, "org_name": "org",
+                    "execution_duration_seconds": 100, "selected_scenario_count": 1,
+                    "scenario_durations": [], "reset": {}}]
+        with patch.object(MODULE, "gh_json", side_effect=[
+            [candidate], {"attempt": 3, "jobs": jobs}, attempt,
+        ]) as api, patch.object(MODULE, "download_metrics", return_value=metrics):
+            records = MODULE.collect_runs("kong/kongctl", 1, 100)
+        record = records[0]
+        self.assertEqual(651, record["queue_to_required_status_seconds"])
+        self.assertEqual(1, record["workflow_admission_delay_seconds"])
+        self.assertEqual(650, record["harness_job_seconds"])
+        self.assertEqual(650, record["harness_setup_seconds"])
+        self.assertEqual(650, record["harness_test_seconds"])
+        self.assertEqual(candidate["createdAt"], record["original_created_at"])
+        self.assertEqual("cache-enabled", record["cohort"])
+        self.assertIn("/attempts/3", api.call_args.args[0][1])
+        jobs[0]["startedAt"] = candidate["createdAt"]
+        self.assertIsNone(MODULE.eligible_run(
+            {**candidate, "createdAt": attempt["created_at"], "original_created_at": candidate["createdAt"],
+             "head_sha": "abc"}, jobs, metrics,
+        ))
+
+    def test_other_cohort_is_excluded_before_artifact_download(self) -> None:
+        jobs = [{"name": MODULE.BUILD_JOB, "steps": []}]
+        with patch.object(MODULE, "gh_json", side_effect=[
+            [{"databaseId": 1}], {"attempt": 1, "jobs": jobs},
+        ]), patch.object(MODULE, "download_metrics") as download:
+            self.assertEqual([], MODULE.collect_runs("kong/kongctl", 1, 100))
+            download.assert_not_called()
+
     @staticmethod
     def run_record(
         run_id: int,
@@ -104,6 +170,13 @@ class E2EBaselineTest(unittest.TestCase):
         marker: str = "",
     ) -> dict[str, object]:
         return {
+            "cohort": "cache-enabled",
+            "original_created_at": created_at,
+            "head_sha": "abc",
+            "harness_job_seconds": 3.0,
+            "harness_setup_seconds": 1.0,
+            "harness_test_seconds": 2.0,
+            "build_setup_seconds": 1.0,
             "run_id": run_id,
             "run_attempt": attempt,
             "url": f"https://example.test/runs/{run_id}",

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -600,21 +600,53 @@ make baseline-e2e-ci E2E_BASELINE_SCAN=200
 ```
 
 GitHub Actions metrics artifacts may expire before 20 eligible runs complete.
-Collect and retain partial observations in the versioned Stage 0 snapshot with:
+Collect and retain partial observations in the versioned post-cache snapshot:
 
 ```sh
 make collect-e2e-baseline
 ```
 
 The target reads and updates
-`test/e2e/baselines/stage0-2026-09-observations.json`, deduplicates saved and
+`test/e2e/baselines/post-cache-2026-09-observations.json`, deduplicates saved and
 new runs by workflow run ID, and writes the current report to
-`test/e2e/baselines/stage0-2026-09.md`. It succeeds while the report is still
+`test/e2e/baselines/post-cache-2026-09.md`. It succeeds while the report is still
 collecting so the updated files can be committed before source artifacts
 expire. Saved observations remain eligible after their source artifacts are
 deleted.
 
-Use `E2E_BASELINE_OBSERVATIONS` and `E2E_BASELINE_REPORT` to collect a different
-baseline without changing the Stage 0 files. The observation file is
-repository-specific and schema-versioned; incompatible or malformed input
-fails before collection.
+Commit the updated files regularly, for example twice a week, before the
+10-day artifact retention expires. Collection remains an administrator task.
+
+`E2E_BASELINE_COHORT` defaults to `cache-enabled`. This includes cache hits and
+misses in builds containing the `Report Go cache status` step added by #2069.
+Keep that step as the identification marker when changing the cache policy.
+The `uncached` cohort contains builds without that step. A dependency change
+may produce a cold build and still belongs to `cache-enabled`.
+
+The collector rejects a saved file belonging to a different cohort and rejects
+mixed records. Set `E2E_BASELINE_COHORT`, `E2E_BASELINE_OBSERVATIONS`, and
+`E2E_BASELINE_REPORT` together when collecting a different cohort. Schema 2
+adds cohort, source revision, attempt timestamps, and build/harness setup and
+harness test timing. Older private copies must be recollected or explicitly
+migrated from verified job metadata; their cohort is never guessed on load.
+
+The Stage 0 files preserve the preliminary uncached baseline. They are frozen
+below the original 20-run target, rather than filling that target with cached
+runs. Regenerate their report offline with:
+
+```sh
+python3 scripts/e2e-baseline.py --cohort uncached --frozen \
+  --observations test/e2e/baselines/stage0-2026-09-observations.json \
+  --output test/e2e/baselines/stage0-2026-09.md
+```
+
+Latency uses the selected attempt's creation timestamp from GitHub's attempt
+API. The original workflow creation timestamp is retained for provenance but
+does not charge time between reruns as queue delay. Each workflow run ID
+contributes one saved successful attempt; collection keeps saved observations
+even when a later rerun occurs. Controlled same-commit reruns are useful cache
+experiments, but should not be counted as independent baseline samples.
+
+Gather the post-cache baseline before changing concurrency, assignment, or
+reset policy. Those future changes require a new, explicitly identified
+measurement period; the cache cohort alone does not distinguish them.

--- a/test/e2e/baselines/post-cache-2026-09-observations.json
+++ b/test/e2e/baselines/post-cache-2026-09-observations.json
@@ -1,0 +1,1789 @@
+{
+  "cohort": "cache-enabled",
+  "repository": "kong/kongctl",
+  "runs": [
+    {
+      "build_job_seconds": 322.0,
+      "build_kongctl_seconds": 243.0,
+      "build_scenario_binary_seconds": 38.0,
+      "build_setup_seconds": 11.0,
+      "cohort": "cache-enabled",
+      "created_at": "2026-09-05T14:44:15Z",
+      "harness_job_seconds": 78.0,
+      "harness_setup_seconds": 11.0,
+      "harness_test_seconds": 53.0,
+      "head_sha": "4c3bd980c47c92f74dcf1010ca225982dfbc5b6c",
+      "longest_shard_seconds": 496.0,
+      "original_created_at": "2026-09-05T14:44:15Z",
+      "queue_to_required_status_seconds": 912.0,
+      "reset": {
+        "count": 164,
+        "delete_calls": 103,
+        "delete_duration_ms": 10080,
+        "duration_ms": 507850,
+        "list_calls": 2459,
+        "list_duration_ms": 496309,
+        "resources_deleted": 84,
+        "resources_found": 1614
+      },
+      "run_attempt": 1,
+      "run_id": 33972692322,
+      "scenario_durations": [
+        {
+          "duration_seconds": 8.31,
+          "result": "pass",
+          "scenario": "adopt/auth-strategy-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.03,
+          "result": "pass",
+          "scenario": "ai-gateway/agent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.04,
+          "result": "pass",
+          "scenario": "ai-gateway/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.7,
+          "result": "pass",
+          "scenario": "ai-gateway/model/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.77,
+          "result": "pass",
+          "scenario": "ai-gateway/vault/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.08,
+          "result": "pass",
+          "scenario": "apis/comprehensive-fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.24,
+          "result": "pass",
+          "scenario": "apis/root-level-publication-visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.19,
+          "result": "pass",
+          "scenario": "control-plane/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.59,
+          "result": "pass",
+          "scenario": "control-plane/serverless/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.71,
+          "result": "pass",
+          "scenario": "deck/env-vars/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.08,
+          "result": "pass",
+          "scenario": "declarative/rename-sync-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.63,
+          "result": "pass",
+          "scenario": "delete/plan-based/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.02,
+          "result": "pass",
+          "scenario": "dump/dcr-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.79,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.14,
+          "result": "pass",
+          "scenario": "event-gateway/dataplane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.64,
+          "result": "pass",
+          "scenario": "event-gateway/listener-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 26.84,
+          "result": "pass",
+          "scenario": "event-gateway/produce-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.56,
+          "result": "pass",
+          "scenario": "event-gateway/virtual-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.18,
+          "result": "pass",
+          "scenario": "external/portal-publication/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.37,
+          "result": "pass",
+          "scenario": "org/get-org/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.08,
+          "result": "pass",
+          "scenario": "org/teams/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.42,
+          "result": "pass",
+          "scenario": "plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.55,
+          "result": "pass",
+          "scenario": "portal/api_with_attributes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.9,
+          "result": "pass",
+          "scenario": "portal/auth-strategy-link/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.45,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.05,
+          "result": "pass",
+          "scenario": "portal/email/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.38,
+          "result": "pass",
+          "scenario": "portal/integrations/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.9,
+          "result": "pass",
+          "scenario": "portal/publication-auth-omitted-noop/scenario.yaml"
+        },
+        {
+          "duration_seconds": 26.05,
+          "result": "pass",
+          "scenario": "portal/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.73,
+          "result": "pass",
+          "scenario": "protected-resources/org/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.05,
+          "result": "pass",
+          "scenario": "smoke/version/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.66,
+          "result": "pass",
+          "scenario": "apis/eventual-consistency-polp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.03,
+          "result": "pass",
+          "scenario": "dump/organization-teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.35,
+          "result": "pass",
+          "scenario": "org/system-accounts/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.35,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.11,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.17,
+          "result": "pass",
+          "scenario": "org/system-accounts/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.38,
+          "result": "pass",
+          "scenario": "org/token/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.5,
+          "result": "pass",
+          "scenario": "org/users/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.56,
+          "result": "pass",
+          "scenario": "org/users/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.52,
+          "result": "pass",
+          "scenario": "org/users/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.89,
+          "result": "pass",
+          "scenario": "org/users/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.64,
+          "result": "pass",
+          "scenario": "org/users/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.51,
+          "result": "pass",
+          "scenario": "adopt/create-portal-adopt-dump-plan/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.45,
+          "result": "pass",
+          "scenario": "ai-gateway/auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.45,
+          "result": "pass",
+          "scenario": "ai-gateway/maturity/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.34,
+          "result": "pass",
+          "scenario": "ai-gateway/policy-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 33.86,
+          "result": "pass",
+          "scenario": "all/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.28,
+          "result": "pass",
+          "scenario": "apis/control-plane-implementation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.91,
+          "result": "pass",
+          "scenario": "apis/versions-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.65,
+          "result": "pass",
+          "scenario": "control-plane/delete-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.15,
+          "result": "pass",
+          "scenario": "control-plane/sync-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.82,
+          "result": "pass",
+          "scenario": "deck/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.61,
+          "result": "pass",
+          "scenario": "delete/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.07,
+          "result": "pass",
+          "scenario": "diff/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.29,
+          "result": "pass",
+          "scenario": "dump/filtered/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.7,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.98,
+          "result": "pass",
+          "scenario": "event-gateway/dependency-order/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.91,
+          "result": "pass",
+          "scenario": "event-gateway/listener/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.96,
+          "result": "pass",
+          "scenario": "event-gateway/schema-registry/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.43,
+          "result": "pass",
+          "scenario": "explain/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.09,
+          "result": "pass",
+          "scenario": "external/portal-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.3,
+          "result": "pass",
+          "scenario": "org/system-accounts/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.68,
+          "result": "pass",
+          "scenario": "org/teams/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.8,
+          "result": "pass",
+          "scenario": "plan/remote-url-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.73,
+          "result": "pass",
+          "scenario": "portal/app-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.92,
+          "result": "pass",
+          "scenario": "portal/auth_settings/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.42,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy_ref_selection/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.22,
+          "result": "pass",
+          "scenario": "portal/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.82,
+          "result": "pass",
+          "scenario": "portal/ip-allow-list/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.24,
+          "result": "pass",
+          "scenario": "portal/snippets-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 51.68,
+          "result": "pass",
+          "scenario": "portal/visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.68,
+          "result": "pass",
+          "scenario": "protected-resources/portals/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.82,
+          "result": "pass",
+          "scenario": "yaml-tags/env/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.8,
+          "result": "pass",
+          "scenario": "adopt/event-gateway-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.66,
+          "result": "pass",
+          "scenario": "ai-gateway/config-store/scenario.yaml"
+        },
+        {
+          "duration_seconds": 19.47,
+          "result": "pass",
+          "scenario": "ai-gateway/mcp-server/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.74,
+          "result": "pass",
+          "scenario": "ai-gateway/policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.9,
+          "result": "pass",
+          "scenario": "analytics/dashboard-repro/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.0,
+          "result": "pass",
+          "scenario": "apis/get-api-by-name-and-id/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "auth/get-me/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.67,
+          "result": "pass",
+          "scenario": "control-plane/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.55,
+          "result": "pass",
+          "scenario": "control-plane/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.89,
+          "result": "pass",
+          "scenario": "deck/multi-file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.06,
+          "result": "pass",
+          "scenario": "delete/dry-run/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.12,
+          "result": "pass",
+          "scenario": "dump/ai-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 41.92,
+          "result": "pass",
+          "scenario": "dump/portal-owned/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.76,
+          "result": "pass",
+          "scenario": "event-gateway/cluster-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.02,
+          "result": "pass",
+          "scenario": "event-gateway/diff/scenario.yaml"
+        },
+        {
+          "duration_seconds": 25.8,
+          "result": "pass",
+          "scenario": "event-gateway/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.81,
+          "result": "pass",
+          "scenario": "event-gateway/static-key/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.13,
+          "result": "pass",
+          "scenario": "external/ai-gateway-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.23,
+          "result": "pass",
+          "scenario": "lint/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.99,
+          "result": "pass",
+          "scenario": "org/teams/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.75,
+          "result": "pass",
+          "scenario": "org/teams/roles/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.05,
+          "result": "pass",
+          "scenario": "plan/sync-partial-scope/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "portal/applications/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.11,
+          "result": "pass",
+          "scenario": "portal/auth_settings_deprecated_fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.71,
+          "result": "pass",
+          "scenario": "portal/edit/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.81,
+          "result": "pass",
+          "scenario": "portal/identity_providers/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.34,
+          "result": "pass",
+          "scenario": "portal/oidc-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.82,
+          "result": "pass",
+          "scenario": "portal/snippets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.65,
+          "result": "pass",
+          "scenario": "protected-resources/apis/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.86,
+          "result": "pass",
+          "scenario": "require-namespace/external/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.29,
+          "result": "pass",
+          "scenario": "yaml-tags/file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.84,
+          "result": "pass",
+          "scenario": "adopt/full/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.99,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer-group/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.47,
+          "result": "pass",
+          "scenario": "ai-gateway/model-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.35,
+          "result": "pass",
+          "scenario": "ai-gateway/root/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.65,
+          "result": "pass",
+          "scenario": "analytics/dashboard/scenario.yaml"
+        },
+        {
+          "duration_seconds": 28.97,
+          "result": "pass",
+          "scenario": "apis/nested-child-lifecycle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.7,
+          "result": "pass",
+          "scenario": "catalog/service/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.94,
+          "result": "pass",
+          "scenario": "control-plane/groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 21.12,
+          "result": "pass",
+          "scenario": "dcr-providers/workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.89,
+          "result": "pass",
+          "scenario": "deck/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.46,
+          "result": "pass",
+          "scenario": "delete/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.93,
+          "result": "pass",
+          "scenario": "dump/analytics-dashboards/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.39,
+          "result": "pass",
+          "scenario": "errors/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 27.67,
+          "result": "pass",
+          "scenario": "event-gateway/consume-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.4,
+          "result": "pass",
+          "scenario": "event-gateway/dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 43.19,
+          "result": "pass",
+          "scenario": "event-gateway/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.01,
+          "result": "pass",
+          "scenario": "event-gateway/tls-trust-bundle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.91,
+          "result": "pass",
+          "scenario": "external/api-impl/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.51,
+          "result": "pass",
+          "scenario": "namespace/defaults-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.09,
+          "result": "pass",
+          "scenario": "org/teams/external-role/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.33,
+          "result": "pass",
+          "scenario": "org/teams/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.72,
+          "result": "pass",
+          "scenario": "plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.49,
+          "result": "pass",
+          "scenario": "portal/assets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 26.14,
+          "result": "pass",
+          "scenario": "portal/custom-domain/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.84,
+          "result": "pass",
+          "scenario": "portal/email-domains/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.21,
+          "result": "pass",
+          "scenario": "portal/identity_providers_duplicate_type/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.68,
+          "result": "pass",
+          "scenario": "portal/page-frontmatter-conflict/scenario.yaml"
+        },
+        {
+          "duration_seconds": 36.91,
+          "result": "pass",
+          "scenario": "portal/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.04,
+          "result": "pass",
+          "scenario": "protected-resources/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.74,
+          "result": "pass",
+          "scenario": "require-namespace/portal/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.5,
+          "result": "pass",
+          "scenario": "adopt/team-create-adopt-dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.1,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.15,
+          "result": "pass",
+          "scenario": "ai-gateway/model-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.04,
+          "result": "pass",
+          "scenario": "ai-gateway/runtime-tls/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.06,
+          "result": "pass",
+          "scenario": "apis/child-delete-namespace/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.32,
+          "result": "pass",
+          "scenario": "apis/region/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.26,
+          "result": "pass",
+          "scenario": "control-plane/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.33,
+          "result": "pass",
+          "scenario": "control-plane/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.23,
+          "result": "pass",
+          "scenario": "deck/basic/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.56,
+          "result": "pass",
+          "scenario": "declarative/plan-mode-validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.87,
+          "result": "pass",
+          "scenario": "delete/partial-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.4,
+          "result": "pass",
+          "scenario": "dump/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.58,
+          "result": "pass",
+          "scenario": "event-gateway/adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.8,
+          "result": "pass",
+          "scenario": "event-gateway/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.43,
+          "result": "pass",
+          "scenario": "event-gateway/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "event-gateway/principal-metadata/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.71,
+          "result": "pass",
+          "scenario": "event-gateway/topic-aliases/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.98,
+          "result": "pass",
+          "scenario": "external/api-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.86,
+          "result": "pass",
+          "scenario": "namespace/validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.55,
+          "result": "pass",
+          "scenario": "org/teams/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.45,
+          "result": "pass",
+          "scenario": "patch/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.84,
+          "result": "pass",
+          "scenario": "portal/api_docs_with_children/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.88,
+          "result": "pass",
+          "scenario": "portal/audit-log-webhook/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.81,
+          "result": "pass",
+          "scenario": "portal/customization/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.5,
+          "result": "pass",
+          "scenario": "portal/email-templates/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.02,
+          "result": "pass",
+          "scenario": "portal/idp_team_group_mappings_readback/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.06,
+          "result": "pass",
+          "scenario": "portal/pages/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.02,
+          "result": "pass",
+          "scenario": "portal/team_group_mappings_no_idp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.29,
+          "result": "pass",
+          "scenario": "protected-resources/event-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.99,
+          "result": "pass",
+          "scenario": "scaffold/command-coverage/scenario.yaml"
+        }
+      ],
+      "shard_admission_delay_seconds": {
+        "kongctl-acceptance": 4.0,
+        "kongctl-acceptance-2": 4.0,
+        "kongctl-acceptance-3": 3.0,
+        "kongctl-acceptance-4": 4.0,
+        "kongctl-acceptance-5": 3.0
+      },
+      "shard_spread_seconds": 332.0,
+      "shards": [
+        {
+          "execution_duration_seconds": 496,
+          "org_name": "kongctl-acceptance",
+          "selected_scenario_count": 43
+        },
+        {
+          "execution_duration_seconds": 402,
+          "org_name": "kongctl-acceptance-2",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 287,
+          "org_name": "kongctl-acceptance-3",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 413,
+          "org_name": "kongctl-acceptance-4",
+          "selected_scenario_count": 30
+        },
+        {
+          "execution_duration_seconds": 164,
+          "org_name": "kongctl-acceptance-5",
+          "selected_scenario_count": 30
+        }
+      ],
+      "url": "https://github.com/Kong/kongctl/actions/runs/33972692322",
+      "workflow_admission_delay_seconds": 4.0
+    },
+    {
+      "build_job_seconds": 49.0,
+      "build_kongctl_seconds": 4.0,
+      "build_scenario_binary_seconds": 1.0,
+      "build_setup_seconds": 25.0,
+      "cohort": "cache-enabled",
+      "created_at": "2026-09-04T19:07:59Z",
+      "harness_job_seconds": 60.0,
+      "harness_setup_seconds": 10.0,
+      "harness_test_seconds": 38.0,
+      "head_sha": "4f4b0b07aa937ba0b9adf970afcc1f5ab5c7742e",
+      "longest_shard_seconds": 485.0,
+      "original_created_at": "2026-09-04T18:35:56Z",
+      "queue_to_required_status_seconds": 651.0,
+      "reset": {
+        "count": 164,
+        "delete_calls": 103,
+        "delete_duration_ms": 10268,
+        "duration_ms": 475189,
+        "list_calls": 2459,
+        "list_duration_ms": 463423,
+        "resources_deleted": 84,
+        "resources_found": 1614
+      },
+      "run_attempt": 3,
+      "run_id": 33906754133,
+      "scenario_durations": [
+        {
+          "duration_seconds": 7.39,
+          "result": "pass",
+          "scenario": "adopt/auth-strategy-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.06,
+          "result": "pass",
+          "scenario": "ai-gateway/agent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.25,
+          "result": "pass",
+          "scenario": "ai-gateway/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.47,
+          "result": "pass",
+          "scenario": "ai-gateway/model/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.56,
+          "result": "pass",
+          "scenario": "ai-gateway/vault/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.8,
+          "result": "pass",
+          "scenario": "apis/comprehensive-fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.45,
+          "result": "pass",
+          "scenario": "apis/root-level-publication-visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.81,
+          "result": "pass",
+          "scenario": "control-plane/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.7,
+          "result": "pass",
+          "scenario": "control-plane/serverless/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.3,
+          "result": "pass",
+          "scenario": "deck/env-vars/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.83,
+          "result": "pass",
+          "scenario": "declarative/rename-sync-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.6,
+          "result": "pass",
+          "scenario": "delete/plan-based/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.91,
+          "result": "pass",
+          "scenario": "dump/dcr-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.2,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.78,
+          "result": "pass",
+          "scenario": "event-gateway/dataplane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.59,
+          "result": "pass",
+          "scenario": "event-gateway/listener-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 26.66,
+          "result": "pass",
+          "scenario": "event-gateway/produce-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.39,
+          "result": "pass",
+          "scenario": "event-gateway/virtual-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.92,
+          "result": "pass",
+          "scenario": "external/portal-publication/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.4,
+          "result": "pass",
+          "scenario": "org/get-org/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.97,
+          "result": "pass",
+          "scenario": "org/teams/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.26,
+          "result": "pass",
+          "scenario": "plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.4,
+          "result": "pass",
+          "scenario": "portal/api_with_attributes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.39,
+          "result": "pass",
+          "scenario": "portal/auth-strategy-link/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.97,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.79,
+          "result": "pass",
+          "scenario": "portal/email/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.27,
+          "result": "pass",
+          "scenario": "portal/integrations/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.69,
+          "result": "pass",
+          "scenario": "portal/publication-auth-omitted-noop/scenario.yaml"
+        },
+        {
+          "duration_seconds": 25.51,
+          "result": "pass",
+          "scenario": "portal/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.7,
+          "result": "pass",
+          "scenario": "protected-resources/org/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.06,
+          "result": "pass",
+          "scenario": "smoke/version/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.6,
+          "result": "pass",
+          "scenario": "apis/eventual-consistency-polp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.67,
+          "result": "pass",
+          "scenario": "dump/organization-teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.17,
+          "result": "pass",
+          "scenario": "org/system-accounts/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.92,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.5,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.98,
+          "result": "pass",
+          "scenario": "org/system-accounts/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.42,
+          "result": "pass",
+          "scenario": "org/token/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.02,
+          "result": "pass",
+          "scenario": "org/users/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.39,
+          "result": "pass",
+          "scenario": "org/users/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.04,
+          "result": "pass",
+          "scenario": "org/users/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.77,
+          "result": "pass",
+          "scenario": "org/users/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.39,
+          "result": "pass",
+          "scenario": "org/users/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.28,
+          "result": "pass",
+          "scenario": "adopt/create-portal-adopt-dump-plan/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.64,
+          "result": "pass",
+          "scenario": "ai-gateway/auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.34,
+          "result": "pass",
+          "scenario": "ai-gateway/maturity/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.32,
+          "result": "pass",
+          "scenario": "ai-gateway/policy-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 28.8,
+          "result": "pass",
+          "scenario": "all/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.54,
+          "result": "pass",
+          "scenario": "apis/control-plane-implementation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.97,
+          "result": "pass",
+          "scenario": "apis/versions-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.5,
+          "result": "pass",
+          "scenario": "control-plane/delete-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.52,
+          "result": "pass",
+          "scenario": "control-plane/sync-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.78,
+          "result": "pass",
+          "scenario": "deck/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.51,
+          "result": "pass",
+          "scenario": "delete/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.33,
+          "result": "pass",
+          "scenario": "diff/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.92,
+          "result": "pass",
+          "scenario": "dump/filtered/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.93,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.75,
+          "result": "pass",
+          "scenario": "event-gateway/dependency-order/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.83,
+          "result": "pass",
+          "scenario": "event-gateway/listener/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.43,
+          "result": "pass",
+          "scenario": "event-gateway/schema-registry/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.05,
+          "result": "pass",
+          "scenario": "explain/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.97,
+          "result": "pass",
+          "scenario": "external/portal-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.15,
+          "result": "pass",
+          "scenario": "org/system-accounts/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.95,
+          "result": "pass",
+          "scenario": "org/teams/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.62,
+          "result": "pass",
+          "scenario": "plan/remote-url-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.63,
+          "result": "pass",
+          "scenario": "portal/app-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.54,
+          "result": "pass",
+          "scenario": "portal/auth_settings/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.64,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy_ref_selection/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.27,
+          "result": "pass",
+          "scenario": "portal/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.33,
+          "result": "pass",
+          "scenario": "portal/ip-allow-list/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.32,
+          "result": "pass",
+          "scenario": "portal/snippets-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 44.05,
+          "result": "pass",
+          "scenario": "portal/visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.78,
+          "result": "pass",
+          "scenario": "protected-resources/portals/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.23,
+          "result": "pass",
+          "scenario": "yaml-tags/env/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.55,
+          "result": "pass",
+          "scenario": "adopt/event-gateway-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.62,
+          "result": "pass",
+          "scenario": "ai-gateway/config-store/scenario.yaml"
+        },
+        {
+          "duration_seconds": 24.26,
+          "result": "pass",
+          "scenario": "ai-gateway/mcp-server/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.8,
+          "result": "pass",
+          "scenario": "ai-gateway/policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.31,
+          "result": "pass",
+          "scenario": "analytics/dashboard-repro/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.13,
+          "result": "pass",
+          "scenario": "apis/get-api-by-name-and-id/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "auth/get-me/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.87,
+          "result": "pass",
+          "scenario": "control-plane/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.61,
+          "result": "pass",
+          "scenario": "control-plane/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.3,
+          "result": "pass",
+          "scenario": "deck/multi-file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.22,
+          "result": "pass",
+          "scenario": "delete/dry-run/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.95,
+          "result": "pass",
+          "scenario": "dump/ai-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 50.95,
+          "result": "pass",
+          "scenario": "dump/portal-owned/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.41,
+          "result": "pass",
+          "scenario": "event-gateway/cluster-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.84,
+          "result": "pass",
+          "scenario": "event-gateway/diff/scenario.yaml"
+        },
+        {
+          "duration_seconds": 32.53,
+          "result": "pass",
+          "scenario": "event-gateway/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.6,
+          "result": "pass",
+          "scenario": "event-gateway/static-key/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.0,
+          "result": "pass",
+          "scenario": "external/ai-gateway-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.34,
+          "result": "pass",
+          "scenario": "lint/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.18,
+          "result": "pass",
+          "scenario": "org/teams/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.89,
+          "result": "pass",
+          "scenario": "org/teams/roles/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.57,
+          "result": "pass",
+          "scenario": "plan/sync-partial-scope/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "portal/applications/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.19,
+          "result": "pass",
+          "scenario": "portal/auth_settings_deprecated_fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.34,
+          "result": "pass",
+          "scenario": "portal/edit/scenario.yaml"
+        },
+        {
+          "duration_seconds": 28.94,
+          "result": "pass",
+          "scenario": "portal/identity_providers/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.83,
+          "result": "pass",
+          "scenario": "portal/oidc-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.48,
+          "result": "pass",
+          "scenario": "portal/snippets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.52,
+          "result": "pass",
+          "scenario": "protected-resources/apis/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.18,
+          "result": "pass",
+          "scenario": "require-namespace/external/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.39,
+          "result": "pass",
+          "scenario": "yaml-tags/file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.93,
+          "result": "pass",
+          "scenario": "adopt/full/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.05,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer-group/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.19,
+          "result": "pass",
+          "scenario": "ai-gateway/model-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.63,
+          "result": "pass",
+          "scenario": "ai-gateway/root/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.24,
+          "result": "pass",
+          "scenario": "analytics/dashboard/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.34,
+          "result": "pass",
+          "scenario": "apis/nested-child-lifecycle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.45,
+          "result": "pass",
+          "scenario": "catalog/service/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.07,
+          "result": "pass",
+          "scenario": "control-plane/groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.8,
+          "result": "pass",
+          "scenario": "dcr-providers/workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.92,
+          "result": "pass",
+          "scenario": "deck/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.03,
+          "result": "pass",
+          "scenario": "delete/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.71,
+          "result": "pass",
+          "scenario": "dump/analytics-dashboards/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.19,
+          "result": "pass",
+          "scenario": "errors/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.32,
+          "result": "pass",
+          "scenario": "event-gateway/consume-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.05,
+          "result": "pass",
+          "scenario": "event-gateway/dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 22.76,
+          "result": "pass",
+          "scenario": "event-gateway/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.25,
+          "result": "pass",
+          "scenario": "event-gateway/tls-trust-bundle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.14,
+          "result": "pass",
+          "scenario": "external/api-impl/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.32,
+          "result": "pass",
+          "scenario": "namespace/defaults-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.09,
+          "result": "pass",
+          "scenario": "org/teams/external-role/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.01,
+          "result": "pass",
+          "scenario": "org/teams/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.53,
+          "result": "pass",
+          "scenario": "plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.49,
+          "result": "pass",
+          "scenario": "portal/assets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.55,
+          "result": "pass",
+          "scenario": "portal/custom-domain/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.58,
+          "result": "pass",
+          "scenario": "portal/email-domains/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.19,
+          "result": "pass",
+          "scenario": "portal/identity_providers_duplicate_type/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.82,
+          "result": "pass",
+          "scenario": "portal/page-frontmatter-conflict/scenario.yaml"
+        },
+        {
+          "duration_seconds": 19.31,
+          "result": "pass",
+          "scenario": "portal/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.85,
+          "result": "pass",
+          "scenario": "protected-resources/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.58,
+          "result": "pass",
+          "scenario": "require-namespace/portal/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.9,
+          "result": "pass",
+          "scenario": "adopt/team-create-adopt-dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.78,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.02,
+          "result": "pass",
+          "scenario": "ai-gateway/model-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.87,
+          "result": "pass",
+          "scenario": "ai-gateway/runtime-tls/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.22,
+          "result": "pass",
+          "scenario": "apis/child-delete-namespace/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.58,
+          "result": "pass",
+          "scenario": "apis/region/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.4,
+          "result": "pass",
+          "scenario": "control-plane/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.84,
+          "result": "pass",
+          "scenario": "control-plane/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.19,
+          "result": "pass",
+          "scenario": "deck/basic/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.56,
+          "result": "pass",
+          "scenario": "declarative/plan-mode-validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.48,
+          "result": "pass",
+          "scenario": "delete/partial-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.13,
+          "result": "pass",
+          "scenario": "dump/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.25,
+          "result": "pass",
+          "scenario": "event-gateway/adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.96,
+          "result": "pass",
+          "scenario": "event-gateway/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 19.46,
+          "result": "pass",
+          "scenario": "event-gateway/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "event-gateway/principal-metadata/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.72,
+          "result": "pass",
+          "scenario": "event-gateway/topic-aliases/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.23,
+          "result": "pass",
+          "scenario": "external/api-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.89,
+          "result": "pass",
+          "scenario": "namespace/validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.44,
+          "result": "pass",
+          "scenario": "org/teams/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.44,
+          "result": "pass",
+          "scenario": "patch/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 29.25,
+          "result": "pass",
+          "scenario": "portal/api_docs_with_children/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.77,
+          "result": "pass",
+          "scenario": "portal/audit-log-webhook/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.92,
+          "result": "pass",
+          "scenario": "portal/customization/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.16,
+          "result": "pass",
+          "scenario": "portal/email-templates/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.87,
+          "result": "pass",
+          "scenario": "portal/idp_team_group_mappings_readback/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.06,
+          "result": "pass",
+          "scenario": "portal/pages/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.46,
+          "result": "pass",
+          "scenario": "portal/team_group_mappings_no_idp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.24,
+          "result": "pass",
+          "scenario": "protected-resources/event-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.96,
+          "result": "pass",
+          "scenario": "scaffold/command-coverage/scenario.yaml"
+        }
+      ],
+      "shard_admission_delay_seconds": {
+        "kongctl-acceptance": 4.0,
+        "kongctl-acceptance-2": 4.0,
+        "kongctl-acceptance-3": 4.0,
+        "kongctl-acceptance-4": 4.0,
+        "kongctl-acceptance-5": 4.0
+      },
+      "shard_spread_seconds": 267.0,
+      "shards": [
+        {
+          "execution_duration_seconds": 485,
+          "org_name": "kongctl-acceptance",
+          "selected_scenario_count": 43
+        },
+        {
+          "execution_duration_seconds": 336,
+          "org_name": "kongctl-acceptance-2",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 349,
+          "org_name": "kongctl-acceptance-3",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 218,
+          "org_name": "kongctl-acceptance-4",
+          "selected_scenario_count": 30
+        },
+        {
+          "execution_duration_seconds": 285,
+          "org_name": "kongctl-acceptance-5",
+          "selected_scenario_count": 30
+        }
+      ],
+      "url": "https://github.com/Kong/kongctl/actions/runs/33906754133",
+      "workflow_admission_delay_seconds": 3.0
+    }
+  ],
+  "schema_version": 2
+}

--- a/test/e2e/baselines/post-cache-2026-09.md
+++ b/test/e2e/baselines/post-cache-2026-09.md
@@ -1,0 +1,239 @@
+# Konnect `.com` E2E baseline
+
+Repository: `kong/kongctl`
+Cohort: `cache-enabled`
+
+Full successful runs: 2 of 20
+Status: **collecting**
+
+The report scans successful `e2e.yaml` runs newest-first and retains only
+runs with a complete latest-attempt metrics manifest for every `.com` shard.
+Build, harness, scenario, coverage-verification, and required-status jobs
+must succeed. Short gate-only runs are excluded.
+Percentiles use the nearest-rank method.
+Latency starts at the selected attempt's creation time. Jobs reused from an
+earlier attempt are excluded. Cache-enabled identifies the cache-reporting
+step introduced by #2069 and includes both hits and misses. Keep that step
+when changing the cache policy. Each run ID contributes one saved successful
+attempt; reruns are not independent samples.
+
+## Latency
+
+| Metric | p50 | p75 | p90 |
+| --- | ---: | ---: | ---: |
+| workflow_admission_delay_seconds | 3.0s | 4.0s | 4.0s |
+| queue_to_required_status_seconds | 651.0s | 912.0s | 912.0s |
+| build_job_seconds | 49.0s | 322.0s | 322.0s |
+| build_kongctl_seconds | 4.0s | 243.0s | 243.0s |
+| build_scenario_binary_seconds | 1.0s | 38.0s | 38.0s |
+| build_setup_seconds | 11.0s | 25.0s | 25.0s |
+| harness_job_seconds | 60.0s | 78.0s | 78.0s |
+| harness_setup_seconds | 10.0s | 11.0s | 11.0s |
+| harness_test_seconds | 38.0s | 53.0s | 53.0s |
+| longest_shard_seconds | 485.0s | 496.0s | 496.0s |
+| shard_spread_seconds | 267.0s | 332.0s | 332.0s |
+
+## Reset cost per workflow run
+
+| Metric | p50 | p75 | p90 |
+| --- | ---: | ---: | ---: |
+| count | 164.0 | 164.0 | 164.0 |
+| duration_ms | 475189.0ms | 507850.0ms | 507850.0ms |
+| list_calls | 2459.0 | 2459.0 | 2459.0 |
+| list_duration_ms | 463423.0ms | 496309.0ms | 496309.0ms |
+| resources_found | 1614.0 | 1614.0 | 1614.0 |
+| delete_calls | 103.0 | 103.0 | 103.0 |
+| delete_duration_ms | 10080.0ms | 10268.0ms | 10268.0ms |
+| resources_deleted | 84.0 | 84.0 | 84.0 |
+
+## Included runs
+
+| Run / Attempt | Attempt created | Queue-to-status | Build | Longest shard | Spread | Resets |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| [33972692322 / 1](https://github.com/Kong/kongctl/actions/runs/33972692322/attempts/1) | 2026-09-05T14:44:15Z | 912s | 322s | 496s | 332s | 164 |
+| [33906754133 / 3](https://github.com/Kong/kongctl/actions/runs/33906754133/attempts/3) | 2026-09-04T19:07:59Z | 651s | 49s | 485s | 267s | 164 |
+
+## Organization shards
+
+| Run | Organization | Admission delay | Selected | Execution |
+| --- | --- | ---: | ---: | ---: |
+| 33972692322 | `kongctl-acceptance` | 4s | 43 | 496s |
+| 33972692322 | `kongctl-acceptance-2` | 4s | 31 | 402s |
+| 33972692322 | `kongctl-acceptance-3` | 3s | 31 | 287s |
+| 33972692322 | `kongctl-acceptance-4` | 4s | 30 | 413s |
+| 33972692322 | `kongctl-acceptance-5` | 3s | 30 | 164s |
+| 33906754133 | `kongctl-acceptance` | 4s | 43 | 485s |
+| 33906754133 | `kongctl-acceptance-2` | 4s | 31 | 336s |
+| 33906754133 | `kongctl-acceptance-3` | 4s | 31 | 349s |
+| 33906754133 | `kongctl-acceptance-4` | 4s | 30 | 218s |
+| 33906754133 | `kongctl-acceptance-5` | 4s | 30 | 285s |
+
+## Individual scenario durations
+
+| Scenario | Samples | Median | p90 |
+| --- | ---: | ---: | ---: |
+| `portal/visibility/scenario.yaml` | 2 | 44.05s | 51.68s |
+| `dump/portal-owned/scenario.yaml` | 2 | 41.92s | 50.95s |
+| `all/scenario.yaml` | 2 | 28.80s | 33.86s |
+| `event-gateway/produce-policy/scenario.yaml` | 2 | 26.66s | 26.84s |
+| `event-gateway/plan/apply-workflow/scenario.yaml` | 2 | 25.80s | 32.53s |
+| `portal/teams/scenario.yaml` | 2 | 25.51s | 26.05s |
+| `portal/identity_providers/scenario.yaml` | 2 | 23.81s | 28.94s |
+| `event-gateway/plan/sync-workflow/scenario.yaml` | 2 | 22.76s | 43.19s |
+| `portal/auth-strategy-link/scenario.yaml` | 2 | 20.39s | 20.90s |
+| `ai-gateway/mcp-server/scenario.yaml` | 2 | 19.47s | 24.26s |
+| `portal/sync/scenario.yaml` | 2 | 19.31s | 36.91s |
+| `portal/api_docs_with_children/scenario.yaml` | 2 | 17.84s | 29.25s |
+| `portal/ip-allow-list/scenario.yaml` | 2 | 17.33s | 20.82s |
+| `apis/root-level-publication-visibility/scenario.yaml` | 2 | 17.24s | 17.45s |
+| `dump/organization-teams/scenario.yaml` | 2 | 16.67s | 17.03s |
+| `org/users/assignments/scenario.yaml` | 2 | 16.02s | 16.50s |
+| `portal/custom-domain/scenario.yaml` | 2 | 15.55s | 26.14s |
+| `apis/control-plane-implementation/scenario.yaml` | 2 | 15.54s | 18.28s |
+| `event-gateway/virtual-cluster/scenario.yaml` | 2 | 15.39s | 15.56s |
+| `apis/nested-child-lifecycle/scenario.yaml` | 2 | 15.34s | 28.97s |
+| `diff/command-coverage/scenario.yaml` | 2 | 15.33s | 18.07s |
+| `ai-gateway/agent/scenario.yaml` | 2 | 15.03s | 15.06s |
+| `event-gateway/backend-cluster/scenario.yaml` | 2 | 14.93s | 17.70s |
+| `event-gateway/consume-policy/scenario.yaml` | 2 | 14.32s | 27.67s |
+| `portal/external-sync/scenario.yaml` | 2 | 14.27s | 17.22s |
+| `org/system-accounts/assignments/scenario.yaml` | 2 | 14.17s | 14.35s |
+| `dump/filtered/scenario.yaml` | 2 | 13.92s | 16.29s |
+| `portal/email/scenario.yaml` | 2 | 13.79s | 14.05s |
+| `protected-resources/apis/scenario.yaml` | 2 | 13.65s | 14.52s |
+| `plan/apply-workflow/scenario.yaml` | 2 | 13.26s | 13.42s |
+| `yaml-tags/env/scenario.yaml` | 2 | 13.23s | 15.82s |
+| `ai-gateway/data-plane-certificate/scenario.yaml` | 2 | 13.04s | 13.25s |
+| `portal/default_application_auth_strategy/scenario.yaml` | 2 | 12.97s | 13.45s |
+| `declarative/rename-sync-delete/scenario.yaml` | 2 | 12.83s | 13.08s |
+| `control-plane/data-plane-certificate/scenario.yaml` | 2 | 12.81s | 13.19s |
+| `dcr-providers/workflow/scenario.yaml` | 2 | 12.80s | 21.12s |
+| `org/teams/roles/scenario.yaml` | 2 | 12.75s | 15.89s |
+| `ai-gateway/config-store/scenario.yaml` | 2 | 12.66s | 16.62s |
+| `ai-gateway/auth-strategy/scenario.yaml` | 2 | 12.64s | 15.45s |
+| `control-plane/serverless/scenario.yaml` | 2 | 12.59s | 12.70s |
+| `event-gateway/listener-policy/scenario.yaml` | 2 | 12.59s | 12.64s |
+| `ai-gateway/vault/scenario.yaml` | 2 | 12.56s | 12.77s |
+| `event-gateway/diff/scenario.yaml` | 2 | 12.02s | 14.84s |
+| `event-gateway/static-key/scenario.yaml` | 2 | 11.81s | 14.60s |
+| `org/users/plan/sync-workflow/scenario.yaml` | 2 | 11.77s | 11.89s |
+| `portal/auth_settings/scenario.yaml` | 2 | 11.54s | 13.92s |
+| `event-gateway/external-sync/scenario.yaml` | 2 | 11.43s | 19.46s |
+| `event-gateway/schema-registry/scenario.yaml` | 2 | 11.43s | 13.96s |
+| `org/users/sync/scenario.yaml` | 2 | 11.39s | 11.64s |
+| `ai-gateway/policy-matrix/scenario.yaml` | 2 | 11.32s | 13.34s |
+| `apis/comprehensive-fields/scenario.yaml` | 2 | 10.80s | 11.08s |
+| `event-gateway/cluster-policy/scenario.yaml` | 2 | 10.76s | 13.41s |
+| `portal/publication-auth-omitted-noop/scenario.yaml` | 2 | 10.69s | 10.90s |
+| `delete/declarative/scenario.yaml` | 2 | 10.51s | 12.61s |
+| `org/system-accounts/plan/sync-workflow/scenario.yaml` | 2 | 10.50s | 11.11s |
+| `ai-gateway/model/scenario.yaml` | 2 | 10.47s | 10.70s |
+| `portal/integrations/scenario.yaml` | 2 | 10.27s | 10.38s |
+| `external/ai-gateway-parent/scenario.yaml` | 2 | 10.13s | 11.00s |
+| `ai-gateway/consumer/scenario.yaml` | 2 | 10.10s | 16.78s |
+| `ai-gateway/consumer-group/scenario.yaml` | 2 | 10.05s | 18.99s |
+| `org/system-accounts/sync/scenario.yaml` | 2 | 9.98s | 10.17s |
+| `portal/audit-log-webhook/scenario.yaml` | 2 | 9.88s | 17.77s |
+| `event-gateway/listener/scenario.yaml` | 2 | 9.83s | 11.91s |
+| `event-gateway/dataplane-certificate/scenario.yaml` | 2 | 9.78s | 10.14s |
+| `protected-resources/portals/scenario.yaml` | 2 | 9.78s | 11.68s |
+| `portal/api_with_attributes/scenario.yaml` | 2 | 9.40s | 9.55s |
+| `ai-gateway/model-provider/scenario.yaml` | 2 | 9.15s | 15.02s |
+| `external/portal-publication/scenario.yaml` | 2 | 8.92s | 9.18s |
+| `ai-gateway/root/scenario.yaml` | 2 | 8.63s | 15.35s |
+| `portal/app-auth-strategy/scenario.yaml` | 2 | 8.63s | 10.73s |
+| `org/token/scenario.yaml` | 2 | 8.38s | 8.42s |
+| `deck/env-vars/scenario.yaml` | 2 | 8.30s | 8.71s |
+| `deck/basic/scenario.yaml` | 2 | 8.23s | 14.19s |
+| `org/users/plan/apply-workflow/scenario.yaml` | 2 | 8.04s | 8.52s |
+| `adopt/full/scenario.yaml` | 2 | 7.93s | 14.84s |
+| `org/system-accounts/plan/apply-workflow/scenario.yaml` | 2 | 7.92s | 8.35s |
+| `portal/snippets/scenario.yaml` | 2 | 7.82s | 9.48s |
+| `portal/edit/scenario.yaml` | 2 | 7.71s | 9.34s |
+| `control-plane/sync-groups/scenario.yaml` | 2 | 7.52s | 9.15s |
+| `portal/email-templates/scenario.yaml` | 2 | 7.50s | 13.16s |
+| `adopt/auth-strategy-adopt/scenario.yaml` | 2 | 7.39s | 8.31s |
+| `apis/region/scenario.yaml` | 2 | 7.32s | 10.58s |
+| `dump/ai-gateways/scenario.yaml` | 2 | 7.12s | 8.95s |
+| `portal/pages/scenario.yaml` | 2 | 7.06s | 12.06s |
+| `plan/sync-partial-scope/scenario.yaml` | 2 | 7.05s | 8.57s |
+| `deck/multi-file/scenario.yaml` | 2 | 6.89s | 8.30s |
+| `portal/page-frontmatter-conflict/scenario.yaml` | 2 | 6.82s | 12.68s |
+| `portal/customization/scenario.yaml` | 2 | 6.81s | 11.92s |
+| `adopt/event-gateway-adopt/scenario.yaml` | 2 | 6.80s | 7.55s |
+| `deck/idempotent/scenario.yaml` | 2 | 6.78s | 7.82s |
+| `event-gateway/dependency-order/scenario.yaml` | 2 | 6.75s | 7.98s |
+| `protected-resources/org/teams/scenario.yaml` | 2 | 6.70s | 6.73s |
+| `plan/remote-url-workflow/scenario.yaml` | 2 | 6.62s | 7.80s |
+| `apis/eventual-consistency-polp/scenario.yaml` | 2 | 6.60s | 6.66s |
+| `delete/plan-based/scenario.yaml` | 2 | 6.60s | 6.63s |
+| `portal/assets/scenario.yaml` | 2 | 6.49s | 12.49s |
+| `catalog/service/scenario.yaml` | 2 | 6.45s | 11.70s |
+| `portal/oidc-auth-strategy/scenario.yaml` | 2 | 6.34s | 7.83s |
+| `adopt/create-portal-adopt-dump-plan/scenario.yaml` | 2 | 6.28s | 8.51s |
+| `ai-gateway/runtime-tls/scenario.yaml` | 2 | 6.04s | 9.87s |
+| `portal/idp_team_group_mappings_readback/scenario.yaml` | 2 | 6.02s | 10.87s |
+| `external/api-parent/scenario.yaml` | 2 | 5.98s | 11.23s |
+| `org/teams/plan/apply-workflow/scenario.yaml` | 2 | 5.97s | 6.08s |
+| `org/teams/plan/sync-workflow/scenario.yaml` | 2 | 5.95s | 7.68s |
+| `deck/sync/scenario.yaml` | 2 | 5.92s | 11.89s |
+| `dump/dcr-provider/scenario.yaml` | 2 | 5.91s | 6.02s |
+| `control-plane/get/scenario.yaml` | 2 | 5.67s | 6.87s |
+| `portal/default_application_auth_strategy_ref_selection/scenario.yaml` | 2 | 5.64s | 6.42s |
+| `require-namespace/portal/scenario.yaml` | 2 | 5.58s | 9.74s |
+| `control-plane/delete-groups/scenario.yaml` | 2 | 5.50s | 6.65s |
+| `dump/control-planes/scenario.yaml` | 2 | 5.40s | 9.13s |
+| `org/users/get/scenario.yaml` | 2 | 5.39s | 5.56s |
+| `protected-resources/event-gateways/scenario.yaml` | 2 | 5.29s | 9.24s |
+| `yaml-tags/file/scenario.yaml` | 2 | 5.29s | 6.39s |
+| `event-gateway/tls-trust-bundle/scenario.yaml` | 2 | 5.25s | 11.01s |
+| `analytics/dashboard/scenario.yaml` | 2 | 5.24s | 9.65s |
+| `event-gateway/backend-cluster-pagination/scenario.yaml` | 2 | 5.20s | 5.79s |
+| `ai-gateway/model-matrix/scenario.yaml` | 2 | 5.19s | 10.47s |
+| `org/system-accounts/scenario.yaml` | 2 | 5.15s | 7.30s |
+| `external/api-impl/scenario.yaml` | 2 | 5.14s | 9.91s |
+| `org/teams/external-role/scenario.yaml` | 2 | 5.09s | 11.09s |
+| `apis/child-delete-namespace/scenario.yaml` | 2 | 5.06s | 9.22s |
+| `delete/dry-run/scenario.yaml` | 2 | 5.06s | 6.22s |
+| `apis/get-api-by-name-and-id/scenario.yaml` | 2 | 5.00s | 6.13s |
+| `org/teams/apply/scenario.yaml` | 2 | 4.99s | 6.18s |
+| `apis/versions-pagination/scenario.yaml` | 2 | 4.97s | 5.91s |
+| `external/portal-sync/scenario.yaml` | 2 | 4.97s | 6.09s |
+| `delete/partial-delete/scenario.yaml` | 2 | 4.87s | 8.48s |
+| `require-namespace/external/scenario.yaml` | 2 | 4.86s | 6.18s |
+| `ai-gateway/policy/scenario.yaml` | 2 | 4.74s | 5.80s |
+| `dump/analytics-dashboards/scenario.yaml` | 2 | 4.71s | 9.93s |
+| `event-gateway/topic-aliases/scenario.yaml` | 2 | 4.71s | 8.72s |
+| `control-plane/sync/scenario.yaml` | 2 | 4.55s | 5.61s |
+| `plan/sync-workflow/scenario.yaml` | 2 | 4.53s | 8.72s |
+| `org/get-org/scenario.yaml` | 2 | 4.37s | 4.40s |
+| `portal/snippets-pagination/scenario.yaml` | 2 | 4.32s | 5.24s |
+| `control-plane/groups/scenario.yaml` | 2 | 4.07s | 7.94s |
+| `event-gateway/dump/scenario.yaml` | 2 | 4.05s | 8.40s |
+| `protected-resources/control-planes/scenario.yaml` | 2 | 3.85s | 7.04s |
+| `event-gateway/control-planes/scenario.yaml` | 2 | 3.80s | 6.96s |
+| `adopt/team-create-adopt-dump/scenario.yaml` | 2 | 3.50s | 9.90s |
+| `control-plane/plan/apply-workflow/scenario.yaml` | 2 | 3.33s | 5.84s |
+| `namespace/defaults-sync/scenario.yaml` | 2 | 3.32s | 6.51s |
+| `control-plane/apply/scenario.yaml` | 2 | 3.26s | 5.40s |
+| `errors/declarative/scenario.yaml` | 2 | 3.19s | 5.39s |
+| `portal/team_group_mappings_no_idp/scenario.yaml` | 2 | 3.02s | 6.46s |
+| `org/teams/sync/scenario.yaml` | 2 | 3.01s | 6.33s |
+| `event-gateway/adopt/scenario.yaml` | 2 | 2.58s | 5.25s |
+| `org/teams/get/scenario.yaml` | 2 | 2.55s | 5.44s |
+| `delete/idempotent/scenario.yaml` | 2 | 2.03s | 4.46s |
+| `portal/email-domains/scenario.yaml` | 2 | 1.58s | 3.84s |
+| `explain/command-coverage/scenario.yaml` | 2 | 1.05s | 1.43s |
+| `scaffold/command-coverage/scenario.yaml` | 2 | 0.96s | 0.99s |
+| `analytics/dashboard-repro/scenario.yaml` | 2 | 0.90s | 1.31s |
+| `namespace/validation/scenario.yaml` | 2 | 0.86s | 0.89s |
+| `declarative/plan-mode-validation/scenario.yaml` | 2 | 0.56s | 0.56s |
+| `patch/command-coverage/scenario.yaml` | 2 | 0.44s | 0.45s |
+| `ai-gateway/maturity/scenario.yaml` | 2 | 0.34s | 0.45s |
+| `lint/command-coverage/scenario.yaml` | 2 | 0.23s | 0.34s |
+| `portal/identity_providers_duplicate_type/scenario.yaml` | 2 | 0.19s | 0.21s |
+| `portal/auth_settings_deprecated_fields/scenario.yaml` | 2 | 0.11s | 0.19s |
+| `smoke/version/scenario.yaml` | 2 | 0.05s | 0.06s |
+| `auth/get-me/scenario.yaml` | 2 | 0.00s | 0.00s |
+| `event-gateway/principal-metadata/scenario.yaml` | 2 | 0.00s | 0.00s |
+| `portal/applications/scenario.yaml` | 2 | 0.00s | 0.00s |

--- a/test/e2e/baselines/stage0-2026-09-observations.json
+++ b/test/e2e/baselines/stage0-2026-09-observations.json
@@ -1,12 +1,911 @@
 {
+  "cohort": "uncached",
   "repository": "kong/kongctl",
   "runs": [
+    {
+      "build_job_seconds": 298.0,
+      "build_kongctl_seconds": 235.0,
+      "build_scenario_binary_seconds": 36.0,
+      "build_setup_seconds": 9.0,
+      "cohort": "uncached",
+      "created_at": "2026-09-05T11:07:16Z",
+      "harness_job_seconds": 72.0,
+      "harness_setup_seconds": 8.0,
+      "harness_test_seconds": 53.0,
+      "head_sha": "674416c52ed37e8fbcaa911e08049fbd9f50e726",
+      "longest_shard_seconds": 582.0,
+      "original_created_at": "2026-09-05T11:07:16Z",
+      "queue_to_required_status_seconds": 1010.0,
+      "reset": {
+        "count": 164,
+        "delete_calls": 103,
+        "delete_duration_ms": 10649,
+        "duration_ms": 507088,
+        "list_calls": 2459,
+        "list_duration_ms": 494968,
+        "resources_deleted": 84,
+        "resources_found": 1614
+      },
+      "run_attempt": 1,
+      "run_id": 33962468090,
+      "scenario_durations": [
+        {
+          "duration_seconds": 9.81,
+          "result": "pass",
+          "scenario": "adopt/auth-strategy-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.41,
+          "result": "pass",
+          "scenario": "ai-gateway/agent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.82,
+          "result": "pass",
+          "scenario": "ai-gateway/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.44,
+          "result": "pass",
+          "scenario": "ai-gateway/model/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.1,
+          "result": "pass",
+          "scenario": "ai-gateway/vault/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.9,
+          "result": "pass",
+          "scenario": "apis/comprehensive-fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.52,
+          "result": "pass",
+          "scenario": "apis/root-level-publication-visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.25,
+          "result": "pass",
+          "scenario": "control-plane/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.03,
+          "result": "pass",
+          "scenario": "control-plane/serverless/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.08,
+          "result": "pass",
+          "scenario": "deck/env-vars/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.4,
+          "result": "pass",
+          "scenario": "declarative/rename-sync-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.92,
+          "result": "pass",
+          "scenario": "delete/plan-based/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.25,
+          "result": "pass",
+          "scenario": "dump/dcr-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.37,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.85,
+          "result": "pass",
+          "scenario": "event-gateway/dataplane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.92,
+          "result": "pass",
+          "scenario": "event-gateway/listener-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 31.85,
+          "result": "pass",
+          "scenario": "event-gateway/produce-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.49,
+          "result": "pass",
+          "scenario": "event-gateway/virtual-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.74,
+          "result": "pass",
+          "scenario": "external/portal-publication/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.36,
+          "result": "pass",
+          "scenario": "org/get-org/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.4,
+          "result": "pass",
+          "scenario": "org/teams/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.07,
+          "result": "pass",
+          "scenario": "plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.33,
+          "result": "pass",
+          "scenario": "portal/api_with_attributes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.86,
+          "result": "pass",
+          "scenario": "portal/auth-strategy-link/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.72,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.31,
+          "result": "pass",
+          "scenario": "portal/email/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.15,
+          "result": "pass",
+          "scenario": "portal/integrations/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.63,
+          "result": "pass",
+          "scenario": "portal/publication-auth-omitted-noop/scenario.yaml"
+        },
+        {
+          "duration_seconds": 30.81,
+          "result": "pass",
+          "scenario": "portal/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.23,
+          "result": "pass",
+          "scenario": "protected-resources/org/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.06,
+          "result": "pass",
+          "scenario": "smoke/version/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.84,
+          "result": "pass",
+          "scenario": "apis/eventual-consistency-polp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.0,
+          "result": "pass",
+          "scenario": "dump/organization-teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.35,
+          "result": "pass",
+          "scenario": "org/system-accounts/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.98,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.18,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.18,
+          "result": "pass",
+          "scenario": "org/system-accounts/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.89,
+          "result": "pass",
+          "scenario": "org/token/scenario.yaml"
+        },
+        {
+          "duration_seconds": 19.4,
+          "result": "pass",
+          "scenario": "org/users/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.64,
+          "result": "pass",
+          "scenario": "org/users/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.85,
+          "result": "pass",
+          "scenario": "org/users/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.57,
+          "result": "pass",
+          "scenario": "org/users/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.76,
+          "result": "pass",
+          "scenario": "org/users/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.99,
+          "result": "pass",
+          "scenario": "adopt/create-portal-adopt-dump-plan/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.8,
+          "result": "pass",
+          "scenario": "ai-gateway/auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.46,
+          "result": "pass",
+          "scenario": "ai-gateway/maturity/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.23,
+          "result": "pass",
+          "scenario": "ai-gateway/policy-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 33.66,
+          "result": "pass",
+          "scenario": "all/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.16,
+          "result": "pass",
+          "scenario": "apis/control-plane-implementation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.79,
+          "result": "pass",
+          "scenario": "apis/versions-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.57,
+          "result": "pass",
+          "scenario": "control-plane/delete-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.01,
+          "result": "pass",
+          "scenario": "control-plane/sync-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.79,
+          "result": "pass",
+          "scenario": "deck/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.46,
+          "result": "pass",
+          "scenario": "delete/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.84,
+          "result": "pass",
+          "scenario": "diff/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.11,
+          "result": "pass",
+          "scenario": "dump/filtered/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.77,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.99,
+          "result": "pass",
+          "scenario": "event-gateway/dependency-order/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.82,
+          "result": "pass",
+          "scenario": "event-gateway/listener/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.01,
+          "result": "pass",
+          "scenario": "event-gateway/schema-registry/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.41,
+          "result": "pass",
+          "scenario": "explain/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.96,
+          "result": "pass",
+          "scenario": "external/portal-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.39,
+          "result": "pass",
+          "scenario": "org/system-accounts/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.69,
+          "result": "pass",
+          "scenario": "org/teams/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.87,
+          "result": "pass",
+          "scenario": "plan/remote-url-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.46,
+          "result": "pass",
+          "scenario": "portal/app-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.63,
+          "result": "pass",
+          "scenario": "portal/auth_settings/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.51,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy_ref_selection/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.25,
+          "result": "pass",
+          "scenario": "portal/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.31,
+          "result": "pass",
+          "scenario": "portal/ip-allow-list/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.15,
+          "result": "pass",
+          "scenario": "portal/snippets-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 50.95,
+          "result": "pass",
+          "scenario": "portal/visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.53,
+          "result": "pass",
+          "scenario": "protected-resources/portals/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.57,
+          "result": "pass",
+          "scenario": "yaml-tags/env/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.08,
+          "result": "pass",
+          "scenario": "adopt/event-gateway-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.8,
+          "result": "pass",
+          "scenario": "ai-gateway/config-store/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.31,
+          "result": "pass",
+          "scenario": "ai-gateway/mcp-server/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.69,
+          "result": "pass",
+          "scenario": "ai-gateway/policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.39,
+          "result": "pass",
+          "scenario": "analytics/dashboard-repro/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.92,
+          "result": "pass",
+          "scenario": "apis/get-api-by-name-and-id/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "auth/get-me/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.62,
+          "result": "pass",
+          "scenario": "control-plane/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.64,
+          "result": "pass",
+          "scenario": "control-plane/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.99,
+          "result": "pass",
+          "scenario": "deck/multi-file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.35,
+          "result": "pass",
+          "scenario": "delete/dry-run/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.71,
+          "result": "pass",
+          "scenario": "dump/ai-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 49.12,
+          "result": "pass",
+          "scenario": "dump/portal-owned/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.25,
+          "result": "pass",
+          "scenario": "event-gateway/cluster-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.53,
+          "result": "pass",
+          "scenario": "event-gateway/diff/scenario.yaml"
+        },
+        {
+          "duration_seconds": 32.27,
+          "result": "pass",
+          "scenario": "event-gateway/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.37,
+          "result": "pass",
+          "scenario": "event-gateway/static-key/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.84,
+          "result": "pass",
+          "scenario": "external/ai-gateway-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.37,
+          "result": "pass",
+          "scenario": "lint/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.11,
+          "result": "pass",
+          "scenario": "org/teams/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.55,
+          "result": "pass",
+          "scenario": "org/teams/roles/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.46,
+          "result": "pass",
+          "scenario": "plan/sync-partial-scope/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "portal/applications/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.2,
+          "result": "pass",
+          "scenario": "portal/auth_settings_deprecated_fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.36,
+          "result": "pass",
+          "scenario": "portal/edit/scenario.yaml"
+        },
+        {
+          "duration_seconds": 28.79,
+          "result": "pass",
+          "scenario": "portal/identity_providers/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.74,
+          "result": "pass",
+          "scenario": "portal/oidc-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.45,
+          "result": "pass",
+          "scenario": "portal/snippets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.04,
+          "result": "pass",
+          "scenario": "protected-resources/apis/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.71,
+          "result": "pass",
+          "scenario": "require-namespace/external/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.21,
+          "result": "pass",
+          "scenario": "yaml-tags/file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.38,
+          "result": "pass",
+          "scenario": "adopt/full/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.67,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer-group/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.3,
+          "result": "pass",
+          "scenario": "ai-gateway/model-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.63,
+          "result": "pass",
+          "scenario": "ai-gateway/root/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.25,
+          "result": "pass",
+          "scenario": "analytics/dashboard/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.16,
+          "result": "pass",
+          "scenario": "apis/nested-child-lifecycle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.57,
+          "result": "pass",
+          "scenario": "catalog/service/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.07,
+          "result": "pass",
+          "scenario": "control-plane/groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.81,
+          "result": "pass",
+          "scenario": "dcr-providers/workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.9,
+          "result": "pass",
+          "scenario": "deck/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.03,
+          "result": "pass",
+          "scenario": "delete/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.66,
+          "result": "pass",
+          "scenario": "dump/analytics-dashboards/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.26,
+          "result": "pass",
+          "scenario": "errors/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.02,
+          "result": "pass",
+          "scenario": "event-gateway/consume-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.93,
+          "result": "pass",
+          "scenario": "event-gateway/dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 22.14,
+          "result": "pass",
+          "scenario": "event-gateway/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.25,
+          "result": "pass",
+          "scenario": "event-gateway/tls-trust-bundle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.15,
+          "result": "pass",
+          "scenario": "external/api-impl/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.27,
+          "result": "pass",
+          "scenario": "namespace/defaults-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.24,
+          "result": "pass",
+          "scenario": "org/teams/external-role/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.07,
+          "result": "pass",
+          "scenario": "org/teams/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.65,
+          "result": "pass",
+          "scenario": "plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.69,
+          "result": "pass",
+          "scenario": "portal/assets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.4,
+          "result": "pass",
+          "scenario": "portal/custom-domain/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.63,
+          "result": "pass",
+          "scenario": "portal/email-domains/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.19,
+          "result": "pass",
+          "scenario": "portal/identity_providers_duplicate_type/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.79,
+          "result": "pass",
+          "scenario": "portal/page-frontmatter-conflict/scenario.yaml"
+        },
+        {
+          "duration_seconds": 19.38,
+          "result": "pass",
+          "scenario": "portal/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.68,
+          "result": "pass",
+          "scenario": "protected-resources/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.61,
+          "result": "pass",
+          "scenario": "require-namespace/portal/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.54,
+          "result": "pass",
+          "scenario": "adopt/team-create-adopt-dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.85,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.85,
+          "result": "pass",
+          "scenario": "ai-gateway/model-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.11,
+          "result": "pass",
+          "scenario": "ai-gateway/runtime-tls/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.21,
+          "result": "pass",
+          "scenario": "apis/child-delete-namespace/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.89,
+          "result": "pass",
+          "scenario": "apis/region/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.32,
+          "result": "pass",
+          "scenario": "control-plane/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.42,
+          "result": "pass",
+          "scenario": "control-plane/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.8,
+          "result": "pass",
+          "scenario": "deck/basic/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.46,
+          "result": "pass",
+          "scenario": "declarative/plan-mode-validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.03,
+          "result": "pass",
+          "scenario": "delete/partial-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.46,
+          "result": "pass",
+          "scenario": "dump/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.23,
+          "result": "pass",
+          "scenario": "event-gateway/adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.59,
+          "result": "pass",
+          "scenario": "event-gateway/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.17,
+          "result": "pass",
+          "scenario": "event-gateway/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "event-gateway/principal-metadata/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.77,
+          "result": "pass",
+          "scenario": "event-gateway/topic-aliases/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.6,
+          "result": "pass",
+          "scenario": "external/api-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.74,
+          "result": "pass",
+          "scenario": "namespace/validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.95,
+          "result": "pass",
+          "scenario": "org/teams/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.36,
+          "result": "pass",
+          "scenario": "patch/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.16,
+          "result": "pass",
+          "scenario": "portal/api_docs_with_children/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.54,
+          "result": "pass",
+          "scenario": "portal/audit-log-webhook/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.42,
+          "result": "pass",
+          "scenario": "portal/customization/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.9,
+          "result": "pass",
+          "scenario": "portal/email-templates/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.55,
+          "result": "pass",
+          "scenario": "portal/idp_team_group_mappings_readback/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.74,
+          "result": "pass",
+          "scenario": "portal/pages/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.9,
+          "result": "pass",
+          "scenario": "portal/team_group_mappings_no_idp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.96,
+          "result": "pass",
+          "scenario": "protected-resources/event-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.79,
+          "result": "pass",
+          "scenario": "scaffold/command-coverage/scenario.yaml"
+        }
+      ],
+      "shard_admission_delay_seconds": {
+        "kongctl-acceptance": 4.0,
+        "kongctl-acceptance-2": 3.0,
+        "kongctl-acceptance-3": 14.0,
+        "kongctl-acceptance-4": 3.0,
+        "kongctl-acceptance-5": 2.0
+      },
+      "shard_spread_seconds": 363.0,
+      "shards": [
+        {
+          "execution_duration_seconds": 582,
+          "org_name": "kongctl-acceptance",
+          "selected_scenario_count": 43
+        },
+        {
+          "execution_duration_seconds": 396,
+          "org_name": "kongctl-acceptance-2",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 342,
+          "org_name": "kongctl-acceptance-3",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 219,
+          "org_name": "kongctl-acceptance-4",
+          "selected_scenario_count": 30
+        },
+        {
+          "execution_duration_seconds": 227,
+          "org_name": "kongctl-acceptance-5",
+          "selected_scenario_count": 30
+        }
+      ],
+      "url": "https://github.com/Kong/kongctl/actions/runs/33962468090",
+      "workflow_admission_delay_seconds": 35.0
+    },
     {
       "build_job_seconds": 314.0,
       "build_kongctl_seconds": 244.0,
       "build_scenario_binary_seconds": 39.0,
+      "build_setup_seconds": 11.0,
+      "cohort": "uncached",
       "created_at": "2026-09-04T17:08:46Z",
+      "harness_job_seconds": 76.0,
+      "harness_setup_seconds": 10.0,
+      "harness_test_seconds": 53.0,
+      "head_sha": "2cfc9dba9752f1ea5d1cb15c8156448b8adeccf9",
       "longest_shard_seconds": 551.0,
+      "original_created_at": "2026-09-04T17:08:46Z",
       "queue_to_required_status_seconds": 974.0,
       "reset": {
         "count": 164,
@@ -889,8 +1788,15 @@
       "build_job_seconds": 319.0,
       "build_kongctl_seconds": 252.0,
       "build_scenario_binary_seconds": 39.0,
+      "build_setup_seconds": 10.0,
+      "cohort": "uncached",
       "created_at": "2026-09-04T13:47:12Z",
+      "harness_job_seconds": 68.0,
+      "harness_setup_seconds": 8.0,
+      "harness_test_seconds": 49.0,
+      "head_sha": "541defc44a2cee2733e5e24765d1ee6720195481",
       "longest_shard_seconds": 503.0,
+      "original_created_at": "2026-09-04T13:47:12Z",
       "queue_to_required_status_seconds": 924.0,
       "reset": {
         "count": 164,
@@ -1773,8 +2679,15 @@
       "build_job_seconds": 310.0,
       "build_kongctl_seconds": 244.0,
       "build_scenario_binary_seconds": 38.0,
+      "build_setup_seconds": 10.0,
+      "cohort": "uncached",
       "created_at": "2026-09-02T21:19:02Z",
+      "harness_job_seconds": 75.0,
+      "harness_setup_seconds": 9.0,
+      "harness_test_seconds": 55.0,
+      "head_sha": "05b2d2ad300275f7d487e369e9343b0286eddf08",
       "longest_shard_seconds": 591.0,
+      "original_created_at": "2026-09-02T21:19:02Z",
       "queue_to_required_status_seconds": 1001.0,
       "reset": {
         "count": 164,
@@ -2657,8 +3570,15 @@
       "build_job_seconds": 300.0,
       "build_kongctl_seconds": 236.0,
       "build_scenario_binary_seconds": 37.0,
+      "build_setup_seconds": 10.0,
+      "cohort": "uncached",
       "created_at": "2026-09-02T20:14:41Z",
+      "harness_job_seconds": 76.0,
+      "harness_setup_seconds": 10.0,
+      "harness_test_seconds": 53.0,
+      "head_sha": "8a3c4a6f8b61e1566a9e2189c6cc55b51c24d582",
       "longest_shard_seconds": 571.0,
+      "original_created_at": "2026-09-02T20:14:41Z",
       "queue_to_required_status_seconds": 1015.0,
       "reset": {
         "count": 164,
@@ -3541,8 +4461,15 @@
       "build_job_seconds": 309.0,
       "build_kongctl_seconds": 240.0,
       "build_scenario_binary_seconds": 38.0,
+      "build_setup_seconds": 9.0,
+      "cohort": "uncached",
       "created_at": "2026-09-02T18:11:16Z",
+      "harness_job_seconds": 75.0,
+      "harness_setup_seconds": 9.0,
+      "harness_test_seconds": 53.0,
+      "head_sha": "b911c8d076bec2303ba5ff1be1b6ca55329d7225",
       "longest_shard_seconds": 389.0,
+      "original_created_at": "2026-09-02T18:11:16Z",
       "queue_to_required_status_seconds": 1166.0,
       "reset": {
         "count": 164,
@@ -4425,8 +5352,15 @@
       "build_job_seconds": 250.0,
       "build_kongctl_seconds": 196.0,
       "build_scenario_binary_seconds": 31.0,
+      "build_setup_seconds": 7.0,
+      "cohort": "uncached",
       "created_at": "2026-09-02T18:01:25Z",
+      "harness_job_seconds": 68.0,
+      "harness_setup_seconds": 10.0,
+      "harness_test_seconds": 42.0,
+      "head_sha": "1919f2e1e7471edb16a099238df17a56184cd458",
       "longest_shard_seconds": 506.0,
+      "original_created_at": "2026-09-02T18:01:25Z",
       "queue_to_required_status_seconds": 855.0,
       "reset": {
         "count": 164,
@@ -5306,5 +6240,5 @@
       "workflow_admission_delay_seconds": 3.0
     }
   ],
-  "schema_version": 1
+  "schema_version": 2
 }

--- a/test/e2e/baselines/stage0-2026-09.md
+++ b/test/e2e/baselines/stage0-2026-09.md
@@ -1,55 +1,72 @@
 # Konnect `.com` E2E baseline
 
 Repository: `kong/kongctl`
+Cohort: `uncached`
 
-Full successful runs: 6 of 20
-Status: **collecting**
+Full successful runs: 7 of 20
+Status: **frozen preliminary**
 
-The report scans successful `e2e.yaml` runs newest-first, retains only runs with a complete
-latest-attempt metrics manifest for every `.com` shard, and requires successful build, harness,
-scenario, coverage-verification, and required-status jobs. Short gate-only runs are excluded.
+The report scans successful `e2e.yaml` runs newest-first and retains only
+runs with a complete latest-attempt metrics manifest for every `.com` shard.
+Build, harness, scenario, coverage-verification, and required-status jobs
+must succeed. Short gate-only runs are excluded.
 Percentiles use the nearest-rank method.
+Latency starts at the selected attempt's creation time. Jobs reused from an
+earlier attempt are excluded. Cache-enabled identifies the cache-reporting
+step introduced by #2069 and includes both hits and misses. Keep that step
+when changing the cache policy. Each run ID contributes one saved successful
+attempt; reruns are not independent samples.
 
 ## Latency
 
 | Metric | p50 | p75 | p90 |
 | --- | ---: | ---: | ---: |
-| workflow_admission_delay_seconds | 3.0s | 41.0s | 373.0s |
-| queue_to_required_status_seconds | 974.0s | 1015.0s | 1166.0s |
+| workflow_admission_delay_seconds | 5.0s | 41.0s | 373.0s |
+| queue_to_required_status_seconds | 1001.0s | 1015.0s | 1166.0s |
 | build_job_seconds | 309.0s | 314.0s | 319.0s |
 | build_kongctl_seconds | 240.0s | 244.0s | 252.0s |
 | build_scenario_binary_seconds | 38.0s | 39.0s | 39.0s |
-| longest_shard_seconds | 506.0s | 571.0s | 591.0s |
-| shard_spread_seconds | 310.0s | 365.0s | 439.0s |
+| build_setup_seconds | 10.0s | 10.0s | 11.0s |
+| harness_job_seconds | 75.0s | 76.0s | 76.0s |
+| harness_setup_seconds | 9.0s | 10.0s | 10.0s |
+| harness_test_seconds | 53.0s | 53.0s | 55.0s |
+| longest_shard_seconds | 551.0s | 582.0s | 591.0s |
+| shard_spread_seconds | 345.0s | 365.0s | 439.0s |
 
 ## Reset cost per workflow run
 
 | Metric | p50 | p75 | p90 |
 | --- | ---: | ---: | ---: |
 | count | 164.0 | 164.0 | 164.0 |
-| duration_ms | 436018.0ms | 481577.0ms | 553040.0ms |
+| duration_ms | 472509.0ms | 507088.0ms | 553040.0ms |
 | list_calls | 2459.0 | 2459.0 | 2459.0 |
-| list_duration_ms | 425445.0ms | 470090.0ms | 540576.0ms |
+| list_duration_ms | 461408.0ms | 494968.0ms | 540576.0ms |
 | resources_found | 1614.0 | 1614.0 | 1614.0 |
 | delete_calls | 103.0 | 103.0 | 103.0 |
-| delete_duration_ms | 9126.0ms | 9988.0ms | 10953.0ms |
+| delete_duration_ms | 9622.0ms | 10649.0ms | 10953.0ms |
 | resources_deleted | 84.0 | 84.0 | 84.0 |
 
 ## Included runs
 
-| Run | Created | Queue-to-status | Build | Longest shard | Spread | Resets |
+| Run / Attempt | Attempt created | Queue-to-status | Build | Longest shard | Spread | Resets |
 | --- | --- | ---: | ---: | ---: | ---: | ---: |
-| [33898988419](https://github.com/Kong/kongctl/actions/runs/33898988419) | 2026-09-04T17:08:46Z | 974s | 314s | 551s | 365s | 164 |
-| [33879997896](https://github.com/Kong/kongctl/actions/runs/33879997896) | 2026-09-04T13:47:12Z | 924s | 319s | 503s | 307s | 164 |
-| [33684454835](https://github.com/Kong/kongctl/actions/runs/33684454835) | 2026-09-02T21:19:02Z | 1001s | 310s | 591s | 439s | 164 |
-| [33678109830](https://github.com/Kong/kongctl/actions/runs/33678109830) | 2026-09-02T20:14:41Z | 1015s | 300s | 571s | 345s | 164 |
-| [33665671597](https://github.com/Kong/kongctl/actions/runs/33665671597) | 2026-09-02T18:11:16Z | 1166s | 309s | 389s | 227s | 164 |
-| [33664659741](https://github.com/Kong/kongctl/actions/runs/33664659741) | 2026-09-02T18:01:25Z | 855s | 250s | 506s | 310s | 164 |
+| [33962468090 / 1](https://github.com/Kong/kongctl/actions/runs/33962468090/attempts/1) | 2026-09-05T11:07:16Z | 1010s | 298s | 582s | 363s | 164 |
+| [33898988419 / 1](https://github.com/Kong/kongctl/actions/runs/33898988419/attempts/1) | 2026-09-04T17:08:46Z | 974s | 314s | 551s | 365s | 164 |
+| [33879997896 / 1](https://github.com/Kong/kongctl/actions/runs/33879997896/attempts/1) | 2026-09-04T13:47:12Z | 924s | 319s | 503s | 307s | 164 |
+| [33684454835 / 1](https://github.com/Kong/kongctl/actions/runs/33684454835/attempts/1) | 2026-09-02T21:19:02Z | 1001s | 310s | 591s | 439s | 164 |
+| [33678109830 / 1](https://github.com/Kong/kongctl/actions/runs/33678109830/attempts/1) | 2026-09-02T20:14:41Z | 1015s | 300s | 571s | 345s | 164 |
+| [33665671597 / 1](https://github.com/Kong/kongctl/actions/runs/33665671597/attempts/1) | 2026-09-02T18:11:16Z | 1166s | 309s | 389s | 227s | 164 |
+| [33664659741 / 1](https://github.com/Kong/kongctl/actions/runs/33664659741/attempts/1) | 2026-09-02T18:01:25Z | 855s | 250s | 506s | 310s | 164 |
 
 ## Organization shards
 
 | Run | Organization | Admission delay | Selected | Execution |
 | --- | --- | ---: | ---: | ---: |
+| 33962468090 | `kongctl-acceptance` | 4s | 43 | 582s |
+| 33962468090 | `kongctl-acceptance-2` | 3s | 31 | 396s |
+| 33962468090 | `kongctl-acceptance-3` | 14s | 31 | 342s |
+| 33962468090 | `kongctl-acceptance-4` | 3s | 30 | 219s |
+| 33962468090 | `kongctl-acceptance-5` | 2s | 30 | 227s |
 | 33898988419 | `kongctl-acceptance` | 3s | 43 | 551s |
 | 33898988419 | `kongctl-acceptance-2` | 3s | 31 | 195s |
 | 33898988419 | `kongctl-acceptance-3` | 3s | 31 | 186s |
@@ -85,168 +102,168 @@ Percentiles use the nearest-rank method.
 
 | Scenario | Samples | Median | p90 |
 | --- | ---: | ---: | ---: |
-| `event-gateway/plan/sync-workflow/scenario.yaml` | 6 | 37.27s | 43.52s |
-| `dump/portal-owned/scenario.yaml` | 6 | 32.46s | 49.53s |
-| `portal/sync/scenario.yaml` | 6 | 32.35s | 36.28s |
-| `event-gateway/produce-policy/scenario.yaml` | 6 | 27.71s | 32.45s |
-| `portal/teams/scenario.yaml` | 6 | 26.78s | 30.87s |
-| `portal/visibility/scenario.yaml` | 6 | 25.84s | 51.22s |
-| `apis/nested-child-lifecycle/scenario.yaml` | 6 | 25.48s | 28.91s |
-| `event-gateway/consume-policy/scenario.yaml` | 6 | 24.12s | 27.48s |
-| `portal/custom-domain/scenario.yaml` | 6 | 23.63s | 26.92s |
-| `portal/auth-strategy-link/scenario.yaml` | 6 | 21.07s | 24.41s |
-| `event-gateway/plan/apply-workflow/scenario.yaml` | 6 | 20.42s | 32.42s |
-| `portal/api_docs_with_children/scenario.yaml` | 6 | 20.34s | 36.07s |
-| `all/scenario.yaml` | 6 | 19.67s | 33.79s |
-| `dcr-providers/workflow/scenario.yaml` | 6 | 18.79s | 21.17s |
-| `portal/identity_providers/scenario.yaml` | 6 | 18.19s | 28.95s |
-| `apis/root-level-publication-visibility/scenario.yaml` | 6 | 17.49s | 19.89s |
-| `dump/organization-teams/scenario.yaml` | 6 | 17.24s | 19.97s |
-| `org/users/assignments/scenario.yaml` | 6 | 17.16s | 19.68s |
-| `ai-gateway/consumer-group/scenario.yaml` | 6 | 16.47s | 19.01s |
-| `event-gateway/virtual-cluster/scenario.yaml` | 6 | 15.85s | 18.78s |
-| `ai-gateway/mcp-server/scenario.yaml` | 6 | 15.08s | 24.03s |
-| `ai-gateway/agent/scenario.yaml` | 6 | 15.00s | 17.63s |
-| `org/system-accounts/assignments/scenario.yaml` | 6 | 14.84s | 17.80s |
-| `portal/email/scenario.yaml` | 6 | 14.31s | 16.88s |
-| `plan/apply-workflow/scenario.yaml` | 6 | 13.91s | 16.10s |
-| `ai-gateway/root/scenario.yaml` | 6 | 13.68s | 15.19s |
-| `portal/default_application_auth_strategy/scenario.yaml` | 6 | 13.67s | 16.36s |
-| `ai-gateway/vault/scenario.yaml` | 6 | 13.49s | 15.40s |
-| `declarative/rename-sync-delete/scenario.yaml` | 6 | 13.39s | 15.46s |
-| `event-gateway/external-sync/scenario.yaml` | 6 | 13.37s | 24.17s |
-| `control-plane/data-plane-certificate/scenario.yaml` | 6 | 13.33s | 15.81s |
-| `adopt/full/scenario.yaml` | 6 | 13.05s | 14.77s |
-| `control-plane/serverless/scenario.yaml` | 6 | 12.98s | 15.13s |
-| `ai-gateway/data-plane-certificate/scenario.yaml` | 6 | 12.97s | 15.12s |
-| `event-gateway/listener-policy/scenario.yaml` | 6 | 12.87s | 15.13s |
-| `org/users/sync/scenario.yaml` | 6 | 11.94s | 13.98s |
-| `org/users/plan/sync-workflow/scenario.yaml` | 6 | 11.80s | 14.13s |
-| `portal/audit-log-webhook/scenario.yaml` | 6 | 11.58s | 22.23s |
-| `org/system-accounts/plan/sync-workflow/scenario.yaml` | 6 | 11.51s | 13.46s |
-| `ai-gateway/consumer/scenario.yaml` | 6 | 11.32s | 20.57s |
-| `apis/comprehensive-fields/scenario.yaml` | 6 | 11.26s | 13.48s |
-| `portal/publication-auth-omitted-noop/scenario.yaml` | 6 | 11.18s | 12.64s |
-| `portal/page-frontmatter-conflict/scenario.yaml` | 6 | 11.17s | 12.73s |
-| `portal/assets/scenario.yaml` | 6 | 10.95s | 12.57s |
-| `portal/integrations/scenario.yaml` | 6 | 10.80s | 12.25s |
-| `ai-gateway/model/scenario.yaml` | 6 | 10.79s | 12.61s |
-| `org/system-accounts/sync/scenario.yaml` | 6 | 10.77s | 12.28s |
-| `ai-gateway/config-store/scenario.yaml` | 6 | 10.33s | 15.94s |
-| `event-gateway/dataplane-certificate/scenario.yaml` | 6 | 10.25s | 12.39s |
-| `catalog/service/scenario.yaml` | 6 | 10.20s | 11.67s |
-| `deck/sync/scenario.yaml` | 6 | 10.04s | 11.89s |
-| `diff/command-coverage/scenario.yaml` | 6 | 9.98s | 18.11s |
-| `external/portal-publication/scenario.yaml` | 6 | 9.95s | 10.84s |
-| `portal/api_with_attributes/scenario.yaml` | 6 | 9.84s | 11.50s |
-| `ai-gateway/model-provider/scenario.yaml` | 6 | 9.81s | 18.38s |
-| `org/teams/roles/scenario.yaml` | 6 | 9.78s | 15.90s |
-| `portal/ip-allow-list/scenario.yaml` | 6 | 9.60s | 20.63s |
-| `deck/basic/scenario.yaml` | 6 | 9.57s | 17.95s |
-| `org/teams/external-role/scenario.yaml` | 6 | 9.55s | 11.15s |
-| `protected-resources/apis/scenario.yaml` | 6 | 9.30s | 14.27s |
-| `event-gateway/static-key/scenario.yaml` | 6 | 9.26s | 14.49s |
-| `event-gateway/tls-trust-bundle/scenario.yaml` | 6 | 9.14s | 10.61s |
-| `ai-gateway/model-matrix/scenario.yaml` | 6 | 9.11s | 10.22s |
-| `event-gateway/diff/scenario.yaml` | 6 | 9.11s | 14.66s |
-| `portal/email-templates/scenario.yaml` | 6 | 8.95s | 16.89s |
-| `deck/env-vars/scenario.yaml` | 6 | 8.88s | 10.24s |
-| `apis/control-plane-implementation/scenario.yaml` | 6 | 8.71s | 18.25s |
-| `adopt/auth-strategy-adopt/scenario.yaml` | 6 | 8.68s | 10.71s |
-| `org/users/plan/apply-workflow/scenario.yaml` | 6 | 8.61s | 10.32s |
-| `external/api-impl/scenario.yaml` | 6 | 8.60s | 9.82s |
-| `org/system-accounts/plan/apply-workflow/scenario.yaml` | 6 | 8.56s | 10.03s |
-| `require-namespace/portal/scenario.yaml` | 6 | 8.55s | 9.52s |
-| `analytics/dashboard/scenario.yaml` | 6 | 8.49s | 9.70s |
-| `dump/analytics-dashboards/scenario.yaml` | 6 | 8.48s | 9.90s |
-| `org/token/scenario.yaml` | 6 | 8.46s | 10.19s |
-| `yaml-tags/env/scenario.yaml` | 6 | 8.44s | 15.65s |
-| `portal/external-sync/scenario.yaml` | 6 | 8.37s | 17.17s |
-| `event-gateway/backend-cluster/scenario.yaml` | 6 | 8.34s | 17.75s |
-| `dump/filtered/scenario.yaml` | 6 | 8.32s | 16.72s |
-| `portal/pages/scenario.yaml` | 6 | 8.22s | 15.08s |
-| `event-gateway/cluster-policy/scenario.yaml` | 6 | 8.13s | 13.17s |
-| `apis/region/scenario.yaml` | 6 | 8.00s | 12.99s |
-| `portal/customization/scenario.yaml` | 6 | 7.98s | 15.12s |
-| `ai-gateway/auth-strategy/scenario.yaml` | 6 | 7.61s | 14.70s |
-| `plan/sync-workflow/scenario.yaml` | 6 | 7.56s | 8.57s |
-| `event-gateway/dump/scenario.yaml` | 6 | 7.27s | 8.28s |
-| `protected-resources/org/teams/scenario.yaml` | 6 | 7.10s | 8.30s |
-| `external/api-parent/scenario.yaml` | 6 | 7.04s | 14.14s |
-| `portal/idp_team_group_mappings_readback/scenario.yaml` | 6 | 6.97s | 13.08s |
-| `control-plane/groups/scenario.yaml` | 6 | 6.87s | 7.87s |
-| `delete/plan-based/scenario.yaml` | 6 | 6.83s | 8.05s |
-| `apis/eventual-consistency-polp/scenario.yaml` | 6 | 6.80s | 8.09s |
-| `protected-resources/event-gateways/scenario.yaml` | 6 | 6.80s | 11.56s |
-| `ai-gateway/runtime-tls/scenario.yaml` | 6 | 6.73s | 12.27s |
-| `external/ai-gateway-parent/scenario.yaml` | 6 | 6.62s | 11.11s |
-| `event-gateway/schema-registry/scenario.yaml` | 6 | 6.50s | 14.12s |
-| `portal/auth_settings/scenario.yaml` | 6 | 6.48s | 13.91s |
-| `org/teams/plan/apply-workflow/scenario.yaml` | 6 | 6.44s | 7.52s |
-| `protected-resources/control-planes/scenario.yaml` | 6 | 6.23s | 7.20s |
-| `dump/dcr-provider/scenario.yaml` | 6 | 6.19s | 7.23s |
-| `ai-gateway/policy-matrix/scenario.yaml` | 6 | 6.18s | 12.96s |
-| `dump/control-planes/scenario.yaml` | 6 | 6.18s | 11.24s |
-| `delete/declarative/scenario.yaml` | 6 | 6.10s | 12.66s |
-| `portal/edit/scenario.yaml` | 6 | 6.05s | 9.66s |
-| `portal/snippets/scenario.yaml` | 6 | 6.01s | 9.65s |
-| `org/users/get/scenario.yaml` | 6 | 5.99s | 6.69s |
-| `apis/child-delete-namespace/scenario.yaml` | 6 | 5.85s | 11.92s |
-| `namespace/defaults-sync/scenario.yaml` | 6 | 5.79s | 6.46s |
-| `event-gateway/backend-cluster-pagination/scenario.yaml` | 6 | 5.69s | 6.58s |
-| `portal/app-auth-strategy/scenario.yaml` | 6 | 5.64s | 10.75s |
-| `delete/partial-delete/scenario.yaml` | 6 | 5.55s | 10.40s |
-| `event-gateway/topic-aliases/scenario.yaml` | 6 | 5.51s | 10.95s |
-| `dump/ai-gateways/scenario.yaml` | 6 | 5.47s | 8.78s |
-| `adopt/create-portal-adopt-dump-plan/scenario.yaml` | 6 | 5.42s | 8.06s |
-| `org/teams/sync/scenario.yaml` | 6 | 5.42s | 6.10s |
-| `plan/sync-partial-scope/scenario.yaml` | 6 | 5.38s | 9.09s |
-| `event-gateway/listener/scenario.yaml` | 6 | 5.37s | 11.74s |
-| `adopt/event-gateway-adopt/scenario.yaml` | 6 | 5.31s | 8.31s |
-| `portal/oidc-auth-strategy/scenario.yaml` | 6 | 5.29s | 7.84s |
-| `protected-resources/portals/scenario.yaml` | 6 | 5.18s | 11.54s |
-| `deck/multi-file/scenario.yaml` | 6 | 5.00s | 8.33s |
-| `errors/declarative/scenario.yaml` | 6 | 4.65s | 5.32s |
-| `event-gateway/control-planes/scenario.yaml` | 6 | 4.62s | 8.61s |
-| `org/get-org/scenario.yaml` | 6 | 4.57s | 5.36s |
-| `control-plane/sync-groups/scenario.yaml` | 6 | 4.45s | 8.90s |
-| `control-plane/get/scenario.yaml` | 6 | 4.31s | 6.81s |
-| `yaml-tags/file/scenario.yaml` | 6 | 4.03s | 6.29s |
-| `delete/idempotent/scenario.yaml` | 6 | 3.92s | 4.63s |
-| `control-plane/plan/apply-workflow/scenario.yaml` | 6 | 3.87s | 7.07s |
-| `org/teams/apply/scenario.yaml` | 6 | 3.87s | 6.22s |
-| `portal/team_group_mappings_no_idp/scenario.yaml` | 6 | 3.85s | 8.53s |
-| `adopt/team-create-adopt-dump/scenario.yaml` | 6 | 3.78s | 7.26s |
-| `apis/get-api-by-name-and-id/scenario.yaml` | 6 | 3.77s | 6.03s |
-| `delete/dry-run/scenario.yaml` | 6 | 3.76s | 6.21s |
-| `plan/remote-url-workflow/scenario.yaml` | 6 | 3.75s | 7.70s |
-| `control-plane/apply/scenario.yaml` | 6 | 3.66s | 6.67s |
-| `ai-gateway/policy/scenario.yaml` | 6 | 3.65s | 5.81s |
-| `control-plane/sync/scenario.yaml` | 6 | 3.63s | 5.73s |
-| `event-gateway/dependency-order/scenario.yaml` | 6 | 3.57s | 7.90s |
-| `require-namespace/external/scenario.yaml` | 6 | 3.52s | 5.78s |
-| `deck/idempotent/scenario.yaml` | 6 | 3.51s | 7.72s |
-| `org/teams/plan/sync-workflow/scenario.yaml` | 6 | 3.36s | 7.52s |
-| `portal/email-domains/scenario.yaml` | 6 | 3.35s | 3.89s |
-| `org/teams/get/scenario.yaml` | 6 | 3.18s | 6.80s |
-| `event-gateway/adopt/scenario.yaml` | 6 | 3.14s | 6.63s |
-| `portal/default_application_auth_strategy_ref_selection/scenario.yaml` | 6 | 3.11s | 6.61s |
-| `control-plane/delete-groups/scenario.yaml` | 6 | 3.02s | 6.46s |
-| `apis/versions-pagination/scenario.yaml` | 6 | 2.67s | 5.80s |
-| `external/portal-sync/scenario.yaml` | 6 | 2.67s | 6.14s |
-| `org/system-accounts/scenario.yaml` | 6 | 2.53s | 6.58s |
-| `portal/snippets-pagination/scenario.yaml` | 6 | 2.22s | 5.19s |
-| `explain/command-coverage/scenario.yaml` | 6 | 1.34s | 1.50s |
-| `analytics/dashboard-repro/scenario.yaml` | 6 | 1.02s | 1.38s |
-| `scaffold/command-coverage/scenario.yaml` | 6 | 0.95s | 1.03s |
-| `namespace/validation/scenario.yaml` | 6 | 0.82s | 1.03s |
-| `declarative/plan-mode-validation/scenario.yaml` | 6 | 0.55s | 0.59s |
-| `patch/command-coverage/scenario.yaml` | 6 | 0.43s | 0.49s |
-| `ai-gateway/maturity/scenario.yaml` | 6 | 0.42s | 0.45s |
-| `lint/command-coverage/scenario.yaml` | 6 | 0.35s | 0.36s |
-| `portal/auth_settings_deprecated_fields/scenario.yaml` | 6 | 0.20s | 0.21s |
-| `portal/identity_providers_duplicate_type/scenario.yaml` | 6 | 0.19s | 0.20s |
-| `smoke/version/scenario.yaml` | 6 | 0.05s | 0.07s |
-| `auth/get-me/scenario.yaml` | 6 | 0.00s | 0.00s |
-| `event-gateway/principal-metadata/scenario.yaml` | 6 | 0.00s | 0.00s |
-| `portal/applications/scenario.yaml` | 6 | 0.00s | 0.00s |
+| `event-gateway/plan/sync-workflow/scenario.yaml` | 7 | 37.27s | 43.52s |
+| `portal/visibility/scenario.yaml` | 7 | 34.75s | 51.22s |
+| `dump/portal-owned/scenario.yaml` | 7 | 33.46s | 49.53s |
+| `portal/sync/scenario.yaml` | 7 | 32.35s | 36.28s |
+| `event-gateway/produce-policy/scenario.yaml` | 7 | 29.73s | 32.45s |
+| `portal/teams/scenario.yaml` | 7 | 28.74s | 30.87s |
+| `apis/nested-child-lifecycle/scenario.yaml` | 7 | 25.48s | 28.91s |
+| `event-gateway/consume-policy/scenario.yaml` | 7 | 24.12s | 27.48s |
+| `portal/custom-domain/scenario.yaml` | 7 | 23.63s | 26.92s |
+| `all/scenario.yaml` | 7 | 23.55s | 33.79s |
+| `portal/api_docs_with_children/scenario.yaml` | 7 | 23.16s | 36.07s |
+| `portal/auth-strategy-link/scenario.yaml` | 7 | 22.83s | 24.41s |
+| `event-gateway/plan/apply-workflow/scenario.yaml` | 7 | 21.25s | 32.42s |
+| `portal/identity_providers/scenario.yaml` | 7 | 19.29s | 28.95s |
+| `dcr-providers/workflow/scenario.yaml` | 7 | 18.79s | 21.17s |
+| `dump/organization-teams/scenario.yaml` | 7 | 18.51s | 20.00s |
+| `apis/root-level-publication-visibility/scenario.yaml` | 7 | 18.48s | 20.52s |
+| `org/users/assignments/scenario.yaml` | 7 | 18.18s | 19.68s |
+| `event-gateway/virtual-cluster/scenario.yaml` | 7 | 17.45s | 18.78s |
+| `ai-gateway/agent/scenario.yaml` | 7 | 16.93s | 17.63s |
+| `ai-gateway/consumer-group/scenario.yaml` | 7 | 16.47s | 19.01s |
+| `org/system-accounts/assignments/scenario.yaml` | 7 | 16.10s | 17.80s |
+| `portal/email/scenario.yaml` | 7 | 16.10s | 16.88s |
+| `portal/default_application_auth_strategy/scenario.yaml` | 7 | 15.55s | 16.36s |
+| `ai-gateway/mcp-server/scenario.yaml` | 7 | 15.19s | 24.03s |
+| `event-gateway/external-sync/scenario.yaml` | 7 | 15.17s | 24.17s |
+| `plan/apply-workflow/scenario.yaml` | 7 | 15.03s | 16.10s |
+| `portal/audit-log-webhook/scenario.yaml` | 7 | 14.54s | 22.23s |
+| `declarative/rename-sync-delete/scenario.yaml` | 7 | 14.35s | 15.46s |
+| `ai-gateway/data-plane-certificate/scenario.yaml` | 7 | 14.34s | 15.12s |
+| `control-plane/data-plane-certificate/scenario.yaml` | 7 | 14.34s | 15.81s |
+| `ai-gateway/vault/scenario.yaml` | 7 | 14.31s | 15.40s |
+| `control-plane/serverless/scenario.yaml` | 7 | 14.19s | 15.13s |
+| `event-gateway/listener-policy/scenario.yaml` | 7 | 13.92s | 15.13s |
+| `ai-gateway/consumer/scenario.yaml` | 7 | 13.85s | 20.57s |
+| `ai-gateway/root/scenario.yaml` | 7 | 13.68s | 15.19s |
+| `portal/ip-allow-list/scenario.yaml` | 7 | 13.19s | 20.63s |
+| `org/users/plan/sync-workflow/scenario.yaml` | 7 | 13.15s | 14.13s |
+| `adopt/full/scenario.yaml` | 7 | 13.05s | 14.77s |
+| `org/users/sync/scenario.yaml` | 7 | 12.91s | 13.98s |
+| `apis/comprehensive-fields/scenario.yaml` | 7 | 12.49s | 13.48s |
+| `org/system-accounts/plan/sync-workflow/scenario.yaml` | 7 | 12.44s | 13.46s |
+| `portal/integrations/scenario.yaml` | 7 | 11.95s | 12.25s |
+| `apis/control-plane-implementation/scenario.yaml` | 7 | 11.93s | 18.25s |
+| `ai-gateway/model/scenario.yaml` | 7 | 11.91s | 12.61s |
+| `ai-gateway/model-provider/scenario.yaml` | 7 | 11.85s | 18.38s |
+| `deck/basic/scenario.yaml` | 7 | 11.80s | 17.95s |
+| `portal/publication-auth-omitted-noop/scenario.yaml` | 7 | 11.80s | 12.64s |
+| `diff/command-coverage/scenario.yaml` | 7 | 11.57s | 18.11s |
+| `org/system-accounts/sync/scenario.yaml` | 7 | 11.52s | 12.28s |
+| `portal/external-sync/scenario.yaml` | 7 | 11.23s | 17.25s |
+| `portal/page-frontmatter-conflict/scenario.yaml` | 7 | 11.17s | 12.73s |
+| `event-gateway/dataplane-certificate/scenario.yaml` | 7 | 11.00s | 12.39s |
+| `portal/assets/scenario.yaml` | 7 | 10.95s | 12.57s |
+| `portal/email-templates/scenario.yaml` | 7 | 10.90s | 16.89s |
+| `portal/api_with_attributes/scenario.yaml` | 7 | 10.73s | 11.50s |
+| `event-gateway/backend-cluster/scenario.yaml` | 7 | 10.68s | 17.77s |
+| `ai-gateway/config-store/scenario.yaml` | 7 | 10.62s | 15.94s |
+| `dump/filtered/scenario.yaml` | 7 | 10.55s | 16.72s |
+| `yaml-tags/env/scenario.yaml` | 7 | 10.50s | 15.65s |
+| `org/teams/roles/scenario.yaml` | 7 | 10.23s | 15.90s |
+| `catalog/service/scenario.yaml` | 7 | 10.20s | 11.67s |
+| `deck/sync/scenario.yaml` | 7 | 10.04s | 11.89s |
+| `external/portal-publication/scenario.yaml` | 7 | 10.01s | 10.84s |
+| `apis/region/scenario.yaml` | 7 | 9.89s | 12.99s |
+| `portal/pages/scenario.yaml` | 7 | 9.74s | 15.08s |
+| `ai-gateway/auth-strategy/scenario.yaml` | 7 | 9.57s | 14.80s |
+| `org/teams/external-role/scenario.yaml` | 7 | 9.55s | 11.15s |
+| `portal/customization/scenario.yaml` | 7 | 9.42s | 15.12s |
+| `deck/env-vars/scenario.yaml` | 7 | 9.40s | 10.24s |
+| `adopt/auth-strategy-adopt/scenario.yaml` | 7 | 9.38s | 10.71s |
+| `protected-resources/apis/scenario.yaml` | 7 | 9.36s | 14.27s |
+| `org/users/plan/apply-workflow/scenario.yaml` | 7 | 9.31s | 10.32s |
+| `event-gateway/static-key/scenario.yaml` | 7 | 9.30s | 14.49s |
+| `event-gateway/diff/scenario.yaml` | 7 | 9.19s | 14.66s |
+| `event-gateway/tls-trust-bundle/scenario.yaml` | 7 | 9.14s | 10.61s |
+| `org/system-accounts/plan/apply-workflow/scenario.yaml` | 7 | 9.13s | 10.03s |
+| `org/token/scenario.yaml` | 7 | 9.12s | 10.19s |
+| `ai-gateway/model-matrix/scenario.yaml` | 7 | 9.11s | 10.22s |
+| `portal/auth_settings/scenario.yaml` | 7 | 8.84s | 13.91s |
+| `event-gateway/schema-registry/scenario.yaml` | 7 | 8.61s | 14.12s |
+| `external/api-impl/scenario.yaml` | 7 | 8.60s | 9.82s |
+| `external/api-parent/scenario.yaml` | 7 | 8.60s | 14.14s |
+| `event-gateway/cluster-policy/scenario.yaml` | 7 | 8.56s | 13.25s |
+| `portal/idp_team_group_mappings_readback/scenario.yaml` | 7 | 8.55s | 13.08s |
+| `require-namespace/portal/scenario.yaml` | 7 | 8.55s | 9.52s |
+| `analytics/dashboard/scenario.yaml` | 7 | 8.49s | 9.70s |
+| `dump/analytics-dashboards/scenario.yaml` | 7 | 8.48s | 9.90s |
+| `ai-gateway/runtime-tls/scenario.yaml` | 7 | 8.11s | 12.27s |
+| `ai-gateway/policy-matrix/scenario.yaml` | 7 | 8.03s | 13.23s |
+| `delete/declarative/scenario.yaml` | 7 | 8.02s | 12.66s |
+| `protected-resources/org/teams/scenario.yaml` | 7 | 7.87s | 8.30s |
+| `plan/sync-workflow/scenario.yaml` | 7 | 7.56s | 8.57s |
+| `dump/control-planes/scenario.yaml` | 7 | 7.46s | 11.24s |
+| `apis/eventual-consistency-polp/scenario.yaml` | 7 | 7.40s | 8.09s |
+| `event-gateway/dump/scenario.yaml` | 7 | 7.27s | 8.28s |
+| `event-gateway/listener/scenario.yaml` | 7 | 7.27s | 11.82s |
+| `delete/plan-based/scenario.yaml` | 7 | 7.24s | 8.05s |
+| `apis/child-delete-namespace/scenario.yaml` | 7 | 7.21s | 11.92s |
+| `protected-resources/portals/scenario.yaml` | 7 | 7.16s | 11.54s |
+| `delete/partial-delete/scenario.yaml` | 7 | 7.03s | 10.40s |
+| `protected-resources/event-gateways/scenario.yaml` | 7 | 6.96s | 11.56s |
+| `control-plane/groups/scenario.yaml` | 7 | 6.87s | 7.87s |
+| `org/teams/plan/apply-workflow/scenario.yaml` | 7 | 6.82s | 7.52s |
+| `portal/app-auth-strategy/scenario.yaml` | 7 | 6.79s | 10.75s |
+| `event-gateway/topic-aliases/scenario.yaml` | 7 | 6.77s | 10.95s |
+| `external/ai-gateway-parent/scenario.yaml` | 7 | 6.63s | 11.11s |
+| `dump/dcr-provider/scenario.yaml` | 7 | 6.55s | 7.25s |
+| `org/users/get/scenario.yaml` | 7 | 6.51s | 6.69s |
+| `protected-resources/control-planes/scenario.yaml` | 7 | 6.23s | 7.20s |
+| `adopt/event-gateway-adopt/scenario.yaml` | 7 | 6.10s | 8.31s |
+| `portal/edit/scenario.yaml` | 7 | 6.08s | 9.66s |
+| `event-gateway/backend-cluster-pagination/scenario.yaml` | 7 | 6.07s | 6.58s |
+| `portal/snippets/scenario.yaml` | 7 | 6.05s | 9.65s |
+| `namespace/defaults-sync/scenario.yaml` | 7 | 5.79s | 6.46s |
+| `adopt/create-portal-adopt-dump-plan/scenario.yaml` | 7 | 5.67s | 8.06s |
+| `plan/sync-partial-scope/scenario.yaml` | 7 | 5.64s | 9.09s |
+| `control-plane/sync-groups/scenario.yaml` | 7 | 5.60s | 9.01s |
+| `event-gateway/control-planes/scenario.yaml` | 7 | 5.59s | 8.61s |
+| `dump/ai-gateways/scenario.yaml` | 7 | 5.54s | 8.78s |
+| `adopt/team-create-adopt-dump/scenario.yaml` | 7 | 5.44s | 7.26s |
+| `org/teams/sync/scenario.yaml` | 7 | 5.42s | 6.10s |
+| `portal/oidc-auth-strategy/scenario.yaml` | 7 | 5.39s | 7.84s |
+| `plan/remote-url-workflow/scenario.yaml` | 7 | 5.16s | 7.87s |
+| `deck/multi-file/scenario.yaml` | 7 | 5.00s | 8.33s |
+| `portal/team_group_mappings_no_idp/scenario.yaml` | 7 | 4.90s | 8.53s |
+| `org/get-org/scenario.yaml` | 7 | 4.87s | 5.36s |
+| `event-gateway/dependency-order/scenario.yaml` | 7 | 4.85s | 7.99s |
+| `deck/idempotent/scenario.yaml` | 7 | 4.84s | 7.79s |
+| `errors/declarative/scenario.yaml` | 7 | 4.65s | 5.32s |
+| `control-plane/plan/apply-workflow/scenario.yaml` | 7 | 4.42s | 7.07s |
+| `org/teams/plan/sync-workflow/scenario.yaml` | 7 | 4.42s | 7.69s |
+| `control-plane/get/scenario.yaml` | 7 | 4.39s | 6.81s |
+| `control-plane/apply/scenario.yaml` | 7 | 4.32s | 6.67s |
+| `control-plane/delete-groups/scenario.yaml` | 7 | 4.32s | 6.57s |
+| `portal/default_application_auth_strategy_ref_selection/scenario.yaml` | 7 | 4.25s | 6.61s |
+| `event-gateway/adopt/scenario.yaml` | 7 | 4.23s | 6.63s |
+| `apis/versions-pagination/scenario.yaml` | 7 | 4.11s | 5.80s |
+| `yaml-tags/file/scenario.yaml` | 7 | 4.06s | 6.29s |
+| `org/teams/get/scenario.yaml` | 7 | 3.95s | 6.80s |
+| `delete/idempotent/scenario.yaml` | 7 | 3.92s | 4.63s |
+| `org/system-accounts/scenario.yaml` | 7 | 3.92s | 6.58s |
+| `require-namespace/external/scenario.yaml` | 7 | 3.90s | 5.78s |
+| `org/teams/apply/scenario.yaml` | 7 | 3.88s | 6.22s |
+| `delete/dry-run/scenario.yaml` | 7 | 3.87s | 6.35s |
+| `apis/get-api-by-name-and-id/scenario.yaml` | 7 | 3.83s | 6.03s |
+| `external/portal-sync/scenario.yaml` | 7 | 3.72s | 6.14s |
+| `control-plane/sync/scenario.yaml` | 7 | 3.68s | 5.73s |
+| `ai-gateway/policy/scenario.yaml` | 7 | 3.65s | 5.81s |
+| `portal/snippets-pagination/scenario.yaml` | 7 | 3.37s | 5.19s |
+| `portal/email-domains/scenario.yaml` | 7 | 3.35s | 3.89s |
+| `explain/command-coverage/scenario.yaml` | 7 | 1.36s | 1.50s |
+| `analytics/dashboard-repro/scenario.yaml` | 7 | 1.12s | 1.39s |
+| `scaffold/command-coverage/scenario.yaml` | 7 | 0.95s | 1.03s |
+| `namespace/validation/scenario.yaml` | 7 | 0.82s | 1.03s |
+| `declarative/plan-mode-validation/scenario.yaml` | 7 | 0.55s | 0.59s |
+| `ai-gateway/maturity/scenario.yaml` | 7 | 0.43s | 0.46s |
+| `patch/command-coverage/scenario.yaml` | 7 | 0.43s | 0.49s |
+| `lint/command-coverage/scenario.yaml` | 7 | 0.35s | 0.37s |
+| `portal/auth_settings_deprecated_fields/scenario.yaml` | 7 | 0.20s | 0.21s |
+| `portal/identity_providers_duplicate_type/scenario.yaml` | 7 | 0.19s | 0.20s |
+| `smoke/version/scenario.yaml` | 7 | 0.06s | 0.07s |
+| `auth/get-me/scenario.yaml` | 7 | 0.00s | 0.00s |
+| `event-gateway/principal-metadata/scenario.yaml` | 7 | 0.00s | 0.00s |
+| `portal/applications/scenario.yaml` | 7 | 0.00s | 0.00s |


### PR DESCRIPTION
The baseline collector currently mixes cache-enabled builds into the uncached
Stage 0 snapshot and charges reruns for time since the original workflow was
created. For example, #2069 attempt 3 reported 2,574 seconds to required status;
using its own creation timestamp yields 651 seconds.

This change filters collection by an explicit cache cohort, rejects mixed or
mismatched saved data, and uses attempt-specific timestamps. Partial reruns
that reuse earlier jobs are excluded. Reports also include build setup and
harness job/setup/test durations to expose the next potential bottleneck.

- Preserve seven uncached observations as a frozen preliminary baseline, below
  the original 20-run target. The six existing records retain their scenario
  and reset data; new metadata was verified against their GitHub job records.
- Seed the post-cache snapshot with two complete successful run IDs, including
  #2069 attempt 3 and the first available post-merge observation.
- Make `make collect-e2e-baseline` update the post-cache snapshot by default.
- Document twice-weekly administrative collection, offline frozen reporting,
  and schema 2 compatibility. Cache-enabled includes both hits and misses and
  is identified by the cache-reporting step introduced in #2069.

Validation: regression tests cover rerun timing, reused jobs, cohort rejection,
and frozen reporting. Live collection and offline report generation succeeded.
`go fix`, formatting, build, and `make test-all` passed using CI's pinned
golangci-lint v2.13.1. Integration tests used the repository's mock SDK mode;
installer shell lint was skipped because shellcheck is not installed locally.

Contributes to #2053. Scenario execution, sharding, and concurrency are unchanged.
