### PR TITLE
fix(ci): silence expected Apple credential error annotations

### DIFF
--- a/scripts/tests/test-prepare-apple-signing.sh
+++ b/scripts/tests/test-prepare-apple-signing.sh
@@ -31,7 +31,8 @@ for name in APPLE_NOTARY_API_PRIVATE_KEY APPLE_NOTARY_API_ISSUER_ID \
     echo "Accepted missing $name" >&2
     exit 1
   fi
-  grep -Fx "::error::Missing $name" "$test_dir/output"
+  # Assert expected errors without replaying them as GitHub Actions annotations.
+  grep -Fqx "::error::Missing $name" "$test_dir/output"
 done
 if APPLE_NOTARY_API_PRIVATE_KEY=invalid \
   bash "$repo_root/scripts/prepare-apple-signing.sh" > "$test_dir/output" 2>&1; then


### PR DESCRIPTION
## Summary

Stop the Apple credential negative tests from emitting seven misleading
GitHub Actions error annotations during otherwise successful validation.

Use a quiet exact-match assertion for captured expected errors. The tests
still require missing credentials to fail with the correct diagnostic;
production credential validation and its real error annotations are unchanged.

Follow-up to #2078, observed in the successful main validation run:
https://github.com/Kong/kongctl/actions/runs/34005691853

This deliberately does not suppress unrelated Homebrew/Vagrant diagnostics
or dependency deprecation warnings from the hosted runner.

## Validation

- Credential preparation tests pass; captured output contains no Actions
  error/warning commands.
- A direct missing-credential invocation still fails and emits its expected
  production error annotation.
- ShellCheck, build, lint, unit tests and integration tests pass.
- Go modernization and gofumpt checks are clean. The read-only golines check
  reports existing main-branch formatting differences; no Go files changed.
- No signing credentials, Apple submissions, releases or tap changes needed.
