### PR TITLE
fix(docs): recommend formula-only Homebrew installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,17 @@ Install the prebuilt cask on macOS or Linux:
 brew install --cask kong/kongctl/kongctl
 ```
 
-Alternatively, install the source-built formula. Homebrew installs Go as a
-build dependency when it builds the formula:
+Alternatively, install the formula. Homebrew uses a prebuilt bottle when one
+is available for your platform, or installs the upstream release binary from
+its ZIP archive. Neither path requires Go:
 
 ```shell
 brew install --formula kong/kongctl/kongctl
 ```
+
+If switching from the cask to the formula, first run
+`brew uninstall --cask kong/kongctl/kongctl`. Both install the same `kongctl`
+command and cannot be installed together.
 
 ### Manual download
 

--- a/README.md
+++ b/README.md
@@ -74,23 +74,11 @@ the [release page](https://github.com/kong/kongctl/releases).
 
 ### Homebrew
 
-Install the prebuilt cask on macOS or Linux:
-
-```shell
-brew install --cask kong/kongctl/kongctl
-```
-
-Alternatively, install the formula. Homebrew uses a prebuilt bottle when one
-is available for your platform, or installs the upstream release binary from
-its ZIP archive. Neither path requires Go:
+Install kongctl on macOS or Linux with Homebrew:
 
 ```shell
 brew install --formula kong/kongctl/kongctl
 ```
-
-If switching from the cask to the formula, first run
-`brew uninstall --cask kong/kongctl/kongctl`. Both install the same `kongctl`
-command and cannot be installed together.
 
 ### Manual download
 

--- a/site/src/content/lessons/installation/install-kongctl.md
+++ b/site/src/content/lessons/installation/install-kongctl.md
@@ -25,20 +25,8 @@ Choose the installation command for your operating system.
 ### macOS or Linux with Homebrew
 
 ```shell
-brew install --cask kong/kongctl/kongctl
-```
-
-Alternatively, install the formula. Homebrew uses a prebuilt bottle when one
-is available for your platform, or installs the upstream release binary from
-its ZIP archive. Neither path requires Go:
-
-```shell
 brew install --formula kong/kongctl/kongctl
 ```
-
-If switching from the cask to the formula, first run
-`brew uninstall --cask kong/kongctl/kongctl`. Both install the same `kongctl`
-command and cannot be installed together.
 
 ### Linux or macOS with the shell installer
 

--- a/site/src/content/lessons/installation/install-kongctl.md
+++ b/site/src/content/lessons/installation/install-kongctl.md
@@ -28,12 +28,17 @@ Choose the installation command for your operating system.
 brew install --cask kong/kongctl/kongctl
 ```
 
-Alternatively, install the source-built formula. Homebrew installs Go as a
-build dependency when it builds the formula:
+Alternatively, install the formula. Homebrew uses a prebuilt bottle when one
+is available for your platform, or installs the upstream release binary from
+its ZIP archive. Neither path requires Go:
 
 ```shell
 brew install --formula kong/kongctl/kongctl
 ```
+
+If switching from the cask to the formula, first run
+`brew uninstall --cask kong/kongctl/kongctl`. Both install the same `kongctl`
+command and cannot be installed together.
 
 ### Linux or macOS with the shell installer
 

--- a/site/tests/e2e/learning.spec.ts
+++ b/site/tests/e2e/learning.spec.ts
@@ -670,7 +670,7 @@ test("copies terminal commands without a prompt", async ({ context, page }) => {
 
   const terminal = page
     .locator(".code-shell")
-    .filter({ hasText: "brew install --cask kong/kongctl/kongctl" });
+    .filter({ hasText: "brew install --formula kong/kongctl/kongctl" });
   await expect(
     terminal.getByText("Run this...", { exact: true }),
   ).toBeVisible();
@@ -679,7 +679,7 @@ test("copies terminal commands without a prompt", async ({ context, page }) => {
   await expect(terminal.getByText("Copied", { exact: true })).toBeVisible();
   await expect
     .poll(() => page.evaluate(() => navigator.clipboard.readText()))
-    .toBe("brew install --cask kong/kongctl/kongctl");
+    .toBe("brew install --formula kong/kongctl/kongctl");
   await expect(page.getByText("Example output", { exact: true })).toBeVisible();
 });
 


### PR DESCRIPTION
## Summary

- Make `brew install --formula kong/kongctl/kongctl` the only documented
  Homebrew install command in the README and Learn installation lesson.
- Remove cask, migration and implementation details from these introductory
  instructions. This does not change cask support or installer behavior.
- Update the browser clipboard test to expect the formula command.

Follow-up to #2078. Documentation only; no release or installer behavior changes.

## Validation

- Site unit tests: 11 passed.
- Astro checks and Prettier: passed.
- Site production build: passed (Node 24.19.0).
- `make test`: passed.
- `git diff --check`: passed.
- Focused Playwright clipboard test: timed out in the existing `beforeEach`
  navigation hook, before reaching the changed assertion. Reproduced against
  an isolated preview port; browser validation remains pending in CI.
