### PR TITLE
task(release): add read-only Apple notarization diagnostics

### DIFF
--- a/.github/workflows/apple-notary-diagnostics.yml
+++ b/.github/workflows/apple-notary-diagnostics.yml
@@ -1,0 +1,111 @@
+name: Apple notarization diagnostics
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing release or draft tag to inspect
+        required: true
+        default: v1.15.1
+        type: string
+      release_run_id:
+        description: Original signing Release run ID (not the recovery run)
+        required: true
+        default: '34009395370'
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: apple-notary-diagnostics
+  cancel-in-progress: false
+
+jobs:
+  inspect:
+    if: >-
+      github.repository == 'Kong/kongctl' &&
+      github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-15, macos-15-intel]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    permissions:
+      # Required to read draft releases; no GitHub write operations are performed.
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Download and checksum existing assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_id=$(bash scripts/apple-release-id.sh)
+          mkdir -p assets diagnostics
+          gh api "repos/$GITHUB_REPOSITORY/releases/$release_id" |
+            jq -Se --arg tag "$RELEASE_TAG" -f scripts/apple-release-snapshot.jq > diagnostics/release.json
+          gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --dir assets
+          (cd assets && shasum -a 256 --check checksums.txt)
+          for arch in amd64 arm64; do
+            checksum=$(cd assets && shasum -a 256 "kongctl_darwin_$arch.zip")
+            grep -Fx "$checksum" assets/checksums.txt > /dev/null
+          done
+          gh api "repos/$GITHUB_REPOSITORY/releases/$release_id" |
+            jq -Se --arg tag "$RELEASE_TAG" -f scripts/apple-release-snapshot.jq > assets/after.json
+          cmp diagnostics/release.json assets/after.json
+      - name: Assess both architectures without executing either binary
+        env:
+          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
+          APPLE_SIGNING_IDENTITY: ${{ vars.APPLE_SIGNING_IDENTITY }}
+        run: bash scripts/diagnose-apple-binaries.sh assets diagnostics
+      - name: Preserve diagnostic evidence (not release approval)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: apple-diagnostics-${{ matrix.os }}
+          path: diagnostics/
+          if-no-files-found: warn
+          retention-days: 3
+
+  notary-records:
+    needs: inspect
+    if: >-
+      github.repository == 'Kong/kongctl' &&
+      github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
+    runs-on: macos-15
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: apple-diagnostics-*
+          path: evidence
+      - name: Fetch original submission records and compare ticket hashes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_RUN_ID: ${{ inputs.release_run_id }}
+          APPLE_NOTARY_API_PRIVATE_KEY: ${{ secrets.APPLE_NOTARY_API_PRIVATE_KEY }}
+          APPLE_NOTARY_API_KEY_ID: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
+          APPLE_NOTARY_API_ISSUER_ID: ${{ secrets.APPLE_NOTARY_API_ISSUER_ID }}
+        run: node scripts/diagnose-apple-notary.mjs evidence notary-report
+      - name: Preserve only filtered ticket evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: apple-notary-ticket-report
+          path: notary-report/
+          if-no-files-found: warn
+          retention-days: 3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,6 +99,7 @@ jobs:
           bash scripts/tests/test-verify-apple-binary.sh
           bash scripts/tests/test-apple-release-gates.sh
           node --test scripts/tests/test-release-recovery.mjs
+          node --test scripts/tests/test-apple-notary-diagnostics.mjs
       - name: test
         run: |
           go test -race -count=1 ./...

--- a/docs/contributor/apple-signing.md
+++ b/docs/contributor/apple-signing.md
@@ -155,6 +155,43 @@ arbitrary previews needs a separate trusted approval boundary.
 
 ## Remaining production integration
 
+### Diagnose an existing signed release without publishing it
+
+Use **Apple notarization diagnostics**, dispatched from `main`, when a native
+notarization check repeatedly fails despite GoReleaser reporting success:
+
+- `release_tag`: the existing draft or published tag, such as `v1.15.1`.
+- `release_run_id`: the original signing Release run, not a recovery run.
+  For the first v1.15.1 draft this is `34009395370`.
+
+Both Intel and ARM runners download the existing assets, check their manifest,
+and assess **both** Darwin binaries without executing or modifying them. Each
+records code hashes, verification exit codes, and macOS security-service logs
+on failure. This distinguishes a binary-specific failure from a runner-specific
+failure without rebuilding or re-signing.
+
+A separate job uses only the three existing Apple notary API secrets to fetch
+submission history and logs for the original publisher's time window. It
+compares ticket code hashes against the exact downloaded binaries. No signing
+certificate is needed. Raw history, private keys, unrelated submission details,
+and raw Apple logs are not uploaded. Filtered ticket evidence and native
+diagnostics are retained for three days. Missing matches are inconclusive if
+history is incomplete or Apple requests fail.
+
+**A green diagnostic run means evidence was collected, not that notarization
+passed.** Read the job summaries and `apple-diagnostics-*` and
+`apple-notary-ticket-report` artifacts. The workflow never builds, signs,
+submits for notarization, changes release state, or updates Homebrew. Only the
+normal release verification and publication gates can approve a release.
+
+Apple explains how to [fetch the notary log][notary-log] and interpret its
+[ticket contents][notary-tickets].
+
+[notary-log]: https://developer.apple.com/forums/thread/705839
+[notary-tickets]: https://developer.apple.com/forums/thread/720093
+
+### Remaining rollout checks
+
 Do not merge this as a completed all-installation-method signing rollout.
 
 - Exercise the staged production build/draft/download/publish integration

--- a/scripts/diagnose-apple-binaries.sh
+++ b/scripts/diagnose-apple-binaries.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Diagnostic only: never execute, sign, or modify the downloaded binaries.
+set -euo pipefail
+[[ $# -eq 2 ]]
+script_dir=$(cd "$(dirname "$0")" && pwd)
+assets=$(cd "$1" && pwd)
+mkdir -p "$2"
+output=$(cd "$2" && pwd)
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+sw_vers > "$output/runner.txt"
+uname -m >> "$output/runner.txt"
+printf '[]\n' > "$output/hashes.json"
+failed=false
+for arch in amd64 arm64; do
+  mkdir "$work/$arch"
+  # Extract only the executable, never arbitrary archive paths or scripts.
+  unzip -p "$assets/kongctl_darwin_$arch.zip" kongctl > "$work/$arch/kongctl"
+  status=0
+  bash "$script_dir/verify-apple-binary.sh" "$work/$arch/kongctl" \
+    > "$output/$arch-verification.txt" 2>&1 || status=$?
+  codesign --display --verbose=4 "$work/$arch/kongctl" > "$output/$arch-signature.txt" 2>&1
+  cdhash=$(sed -n 's/^CDHash=//p' "$output/$arch-signature.txt")
+  [[ "$cdhash" =~ ^[0-9a-f]{40}$ ]]
+  jq --arg arch "$arch" --arg cdhash "$cdhash" --argjson status "$status" \
+    '. + [{arch: $arch, cdhash: $cdhash, verification_exit_code: $status}]' \
+    "$output/hashes.json" > "$work/hashes.json"
+  cp "$work/hashes.json" "$output/hashes.json"
+  printf '%s: verification exit %s; CDHash %s\n' "$arch" "$status" "$cdhash"
+  if [[ "$status" -ne 0 ]]; then failed=true; fi
+done
+if [[ "$failed" == true ]]; then
+  # No Apple private credentials are present on this runner. Keep evidence local
+  # to its short-lived artifact; don't dump daemon logs into console output.
+  /usr/bin/log show --last 5m --style compact --info --debug \
+    --predicate 'process == "syspolicyd" OR process == "trustd" OR process == "amfid"' \
+    > "$output/security-services.txt" 2>&1 || true
+  echo '::warning::A notarization/signature assessment failed; see diagnostic artifacts'
+fi
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    echo '### Apple binary diagnostics'
+    echo
+    echo 'Evidence collection only; this workflow never approves a release.'
+    echo
+    jq -r '.[] | "- \(.arch): verification exit \(.verification_exit_code); CDHash `\(.cdhash)`"' \
+      "$output/hashes.json"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/scripts/diagnose-apple-notary.mjs
+++ b/scripts/diagnose-apple-notary.mjs
@@ -1,0 +1,330 @@
+// Diagnostic only. The only Apple operations are history, info, and log.
+import { execFileSync } from "node:child_process";
+import { createPrivateKey } from "node:crypto";
+import {
+  appendFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const arches = ["amd64", "arm64"];
+const statuses = ["Accepted", "Invalid", "In Progress", "Rejected"];
+
+export function validateEvidence(reports, tag) {
+  if (reports.length !== 2) throw new Error("Expected both runner reports");
+  const expected = {};
+  for (const { release, hashes } of reports) {
+    if (
+      release.tag_name !== tag ||
+      !Number.isSafeInteger(release.id) ||
+      JSON.stringify(release) !== JSON.stringify(reports[0].release)
+    ) {
+      throw new Error("Runner release snapshots differ");
+    }
+    if (!Array.isArray(hashes) || hashes.length !== 2)
+      throw new Error("Missing binary hashes");
+    for (const arch of arches) {
+      const entries = hashes.filter((entry) => entry.arch === arch);
+      if (entries.length !== 1 || !/^[0-9a-f]{40}$/.test(entries[0].cdhash)) {
+        throw new Error("Invalid or ambiguous binary hash");
+      }
+      if (expected[arch] && expected[arch] !== entries[0].cdhash) {
+        throw new Error("Binary hashes differ across runners");
+      }
+      expected[arch] = entries[0].cdhash;
+    }
+  }
+  return expected;
+}
+
+export function selectSubmissions(history, start, end) {
+  const from = Date.parse(start);
+  const to = Date.parse(end);
+  if (
+    !Number.isFinite(from) ||
+    !Number.isFinite(to) ||
+    from > to ||
+    !Array.isArray(history.history)
+  ) {
+    throw new Error("Invalid submission history or signing time window");
+  }
+  const selected = history.history.filter((entry) => {
+    const time = Date.parse(entry.createdDate);
+    return time >= from && time <= to;
+  });
+  // Avoid fetching an unbounded account-wide history in a diagnostic workflow.
+  if (selected.length > 20 || selected.some((entry) => !uuid.test(entry.id))) {
+    throw new Error("Unexpected submission count or ID in signing window");
+  }
+  return selected;
+}
+
+export function summarizeSubmission(entry, info, log, expected) {
+  const tickets = Array.isArray(log?.ticketContents) ? log.ticketContents : [];
+  const hashes = new Set(Object.values(expected));
+  const matches = tickets.filter((ticket) => hashes.has(ticket.cdhash));
+  const relevant =
+    matches.length > 0 ||
+    tickets.some((ticket) => /(?:^|\/)kongctl$/.test(ticket.path ?? "")) ||
+    /kongctl/i.test(entry.name ?? "");
+  if (!relevant) return null;
+  // Never persist raw logs, unrelated paths/names, account history, or download URLs.
+  return {
+    submission_id: entry.id,
+    created_date: entry.createdDate,
+    status: statuses.includes(info?.status) ? info.status : "Unavailable",
+    log_available: log !== null,
+    ticket_entry_count: tickets.length,
+    matching_architectures: arches.filter((arch) =>
+      matches.some((ticket) => ticket.cdhash === expected[arch]),
+    ),
+    matching_ticket_hashes: [
+      ...new Set(matches.map((ticket) => ticket.cdhash)),
+    ],
+    kongctl_ticket_hashes: tickets
+      .filter(
+        (ticket) =>
+          /(?:^|\/)kongctl$/.test(ticket.path ?? "") &&
+          /^[0-9a-f]{40}$/.test(ticket.cdhash ?? ""),
+      )
+      .map((ticket) => ({
+        cdhash: ticket.cdhash,
+        arch: ["arm64", "x86_64"].includes(ticket.arch)
+          ? ticket.arch
+          : "unknown",
+      })),
+    issue_count: Array.isArray(log?.issues) ? log.issues.length : 0,
+  };
+}
+
+function readJSON(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+async function main() {
+  const [evidence, output] = process.argv.slice(2);
+  const tag = process.env.RELEASE_TAG;
+  const runID = process.env.RELEASE_RUN_ID;
+  if (
+    !evidence ||
+    !output ||
+    !/^v\d+\.\d+\.\d+$/.test(tag ?? "") ||
+    !/^[1-9][0-9]*$/.test(runID ?? "") ||
+    !Number.isSafeInteger(Number(runID))
+  ) {
+    throw new Error(
+      "Expected evidence/output directories and valid release tag/run ID",
+    );
+  }
+  if (
+    process.env.GITHUB_REPOSITORY !== "Kong/kongctl" ||
+    process.env.GITHUB_REF !== "refs/heads/main" ||
+    process.env.GITHUB_EVENT_NAME !== "workflow_dispatch"
+  ) {
+    throw new Error(
+      "Apple records may only be fetched by a manual Kong/kongctl main workflow",
+    );
+  }
+  const env = { ...process.env };
+  for (const name of Object.keys(env))
+    if (name.startsWith("APPLE_")) delete env[name];
+  const run = (command, args) => {
+    try {
+      return execFileSync(command, args, {
+        encoding: "utf8",
+        timeout: 60000,
+        maxBuffer: 16 * 1024 * 1024,
+        env:
+          command === "xcrun"
+            ? { ...env, GH_TOKEN: "", GITHUB_TOKEN: "" }
+            : env,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch {
+      // Child error objects can contain command arguments and private API output.
+      throw new Error(
+        `Read-only ${command} request failed or timed out; private output withheld`,
+      );
+    }
+  };
+  const api = (path) => JSON.parse(run("gh", ["api", path]));
+  const reports = ["macos-15", "macos-15-intel"].map((host) => ({
+    host,
+    release: readJSON(
+      join(evidence, `apple-diagnostics-${host}`, "release.json"),
+    ),
+    hashes: readJSON(
+      join(evidence, `apple-diagnostics-${host}`, "hashes.json"),
+    ),
+  }));
+  const expected = validateEvidence(reports, tag);
+  const source = api(`repos/Kong/kongctl/actions/runs/${runID}`);
+  const tagCommit = run("git", [
+    "rev-list",
+    "-n",
+    "1",
+    `refs/tags/${tag}`,
+  ]).trim();
+  run("git", ["merge-base", "--is-ancestor", tagCommit, "HEAD"]);
+  if (
+    source.path !== ".github/workflows/release.lock.yml" ||
+    source.event !== "workflow_dispatch" ||
+    source.head_branch !== "main" ||
+    source.status !== "completed" ||
+    source.head_sha !== tagCommit
+  ) {
+    throw new Error(
+      "Source must be the original completed main Release run at the tag commit",
+    );
+  }
+  const pages = JSON.parse(
+    run("gh", [
+      "api",
+      "--paginate",
+      "--slurp",
+      `repos/Kong/kongctl/actions/runs/${runID}/jobs?per_page=100`,
+    ]),
+  );
+  const publishers = pages
+    .flatMap((page) => page.jobs)
+    .filter(
+      (job) => job.name === "publish_release" && job.conclusion === "success",
+    );
+  if (publishers.length !== 1)
+    throw new Error("Expected one successful original publisher");
+  const { started_at: start, completed_at: end } = publishers[0];
+  for (const name of [
+    "APPLE_NOTARY_API_PRIVATE_KEY",
+    "APPLE_NOTARY_API_KEY_ID",
+    "APPLE_NOTARY_API_ISSUER_ID",
+    "RUNNER_TEMP",
+  ]) {
+    if (!process.env[name]) throw new Error(`Missing ${name}`);
+  }
+  // Validate without importing a certificate/key into any persistent keychain.
+  try {
+    createPrivateKey(process.env.APPLE_NOTARY_API_PRIVATE_KEY);
+  } catch {
+    throw new Error("Invalid Apple API private key");
+  }
+  const privateDir = mkdtempSync(
+    join(process.env.RUNNER_TEMP, "kongctl-notary-diagnostics-"),
+  );
+  let report;
+  try {
+    const key = join(privateDir, "AuthKey.p8");
+    writeFileSync(key, process.env.APPLE_NOTARY_API_PRIVATE_KEY, {
+      mode: 0o600,
+      flag: "wx",
+    });
+    const auth = [
+      "--key",
+      key,
+      "--key-id",
+      process.env.APPLE_NOTARY_API_KEY_ID,
+      "--issuer",
+      process.env.APPLE_NOTARY_API_ISSUER_ID,
+    ];
+    let history;
+    try {
+      history = JSON.parse(
+        run("xcrun", [
+          "notarytool",
+          "history",
+          ...auth,
+          "--output-format",
+          "json",
+        ]),
+      );
+    } catch {
+      throw new Error(
+        "Unable to retrieve or parse Apple history; private output withheld",
+      );
+    }
+    const candidates = selectSubmissions(history, start, end);
+    const submissions = [];
+    let unavailable = 0;
+    for (const entry of candidates) {
+      let info = null;
+      let log = null;
+      try {
+        info = JSON.parse(
+          run("xcrun", [
+            "notarytool",
+            "info",
+            entry.id,
+            ...auth,
+            "--output-format",
+            "json",
+          ]),
+        );
+      } catch {
+        unavailable++;
+      }
+      try {
+        log = JSON.parse(
+          run("xcrun", ["notarytool", "log", entry.id, ...auth]),
+        );
+      } catch {
+        unavailable++;
+      }
+      const summary = summarizeSubmission(entry, info, log, expected);
+      if (summary) submissions.push(summary);
+    }
+    report = {
+      diagnostic_only: true,
+      release_tag: tag,
+      release_id: reports[0].release.id,
+      original_run_id: runID,
+      signing_window: { start, end },
+      expected_cdhashes: expected,
+      runner_results: reports.map(({ host, hashes }) => ({ host, hashes })),
+      candidate_count: candidates.length,
+      unavailable_requests: unavailable,
+      submissions,
+      note: "Missing matches are inconclusive if history is incomplete or requests failed. This is not release approval.",
+    };
+  } finally {
+    rmSync(privateDir, { recursive: true, force: true });
+  }
+  mkdirSync(output, { recursive: true });
+  writeFileSync(
+    join(output, "ticket-report.json"),
+    `${JSON.stringify(report, null, 2)}\n`,
+  );
+  console.log(JSON.stringify(report, null, 2));
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    const lines = [
+      "### Apple ticket diagnostics",
+      "",
+      "Evidence collection only; no release is approved or published.",
+      "",
+    ];
+    for (const arch of arches) {
+      const matched = report.submissions.some(
+        (s) =>
+          s.status === "Accepted" && s.matching_architectures.includes(arch),
+      );
+      lines.push(
+        `- ${arch}: ${matched ? "Accepted ticket contains the exact code hash" : "No accepted matching ticket found in retrieved logs (inconclusive)"}`,
+      );
+    }
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join("\n")}\n`);
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/tests/test-apple-notary-diagnostics.mjs
+++ b/scripts/tests/test-apple-notary-diagnostics.mjs
@@ -1,0 +1,408 @@
+import assert from "node:assert/strict";
+import {
+  readFileSync,
+  writeFileSync,
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  existsSync,
+  readdirSync,
+} from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { generateKeyPairSync } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import {
+  selectSubmissions,
+  summarizeSubmission,
+  validateEvidence,
+} from "../diagnose-apple-notary.mjs";
+
+const expected = { amd64: "a".repeat(40), arm64: "b".repeat(40) };
+const release = { id: 100, tag_name: "v1.15.1", draft: true, assets: [] };
+const hashes = Object.entries(expected).map(([arch, cdhash]) => ({
+  arch,
+  cdhash,
+  verification_exit_code: 0,
+}));
+const entry = {
+  id: "11111111-1111-1111-1111-111111111111",
+  createdDate: "2026-09-06T04:02:21Z",
+  name: "kongctl.zip",
+};
+const start = "2026-09-06T03:38:23Z";
+const end = "2026-09-06T04:04:43Z";
+
+test("collector cleans its key and withholds private output on API failure", () => {
+  const directory = mkdtempSync(
+    join(tmpdir(), "kongctl-notary-collector-test-"),
+  );
+  try {
+    const tools = join(directory, "tools");
+    const evidence = join(directory, "evidence");
+    const output = join(directory, "output");
+    mkdirSync(tools);
+    for (const host of ["macos-15", "macos-15-intel"]) {
+      const path = join(evidence, `apple-diagnostics-${host}`);
+      mkdirSync(path, { recursive: true });
+      writeFileSync(join(path, "release.json"), JSON.stringify(release));
+      writeFileSync(join(path, "hashes.json"), JSON.stringify(hashes));
+    }
+    const mock = `#!/usr/bin/env node
+const fs = require('node:fs');
+const tool = require('node:path').basename(process.argv[1]);
+const args = process.argv.slice(2);
+const send = value => process.stdout.write(JSON.stringify(value));
+if (process.env.APPLE_NOTARY_API_PRIVATE_KEY) throw Error('Private key leaked into child environment');
+if (tool === 'git') {
+  if (args[0] === 'rev-list') process.stdout.write('tag-commit\\n');
+} else if (tool === 'gh') {
+  if (args.at(-1).includes('/jobs')) send([{jobs:[{name:'publish_release',conclusion:'success',started_at:'${start}',completed_at:'${end}'}]}]);
+  else send({path:'.github/workflows/release.lock.yml',event:'workflow_dispatch',head_branch:'main',status:'completed',head_sha:'tag-commit'});
+} else if (tool === 'xcrun') {
+  if (process.env.GH_TOKEN) throw Error('GitHub token leaked into Apple request');
+  const key = args[args.indexOf('--key') + 1];
+  if ((fs.statSync(key).mode & 0o777) !== 0o600) throw Error('Unsafe key permissions');
+  if (args[1] === 'history') {
+    if (process.env.FAIL_HISTORY) process.stdout.write('PRIVATE-ACCOUNT-DATA not JSON');
+    else send({history:[${JSON.stringify(entry)}]});
+  } else if (args[1] === 'info') send({status:'Accepted'});
+  else if (args[1] === 'log') send({ticketContents:[{path:'kongctl.zip/kongctl',cdhash:'${expected.amd64}',arch:'x86_64'}],issues:null});
+  else throw Error('Unexpected mutating Apple command');
+} else throw Error('Unexpected tool');
+`;
+    for (const name of ["gh", "git", "xcrun"])
+      writeFileSync(join(tools, name), mock, { mode: 0o700 });
+    const { privateKey } = generateKeyPairSync("ec", {
+      namedCurve: "prime256v1",
+    });
+    const env = {
+      ...process.env,
+      PATH: `${tools}:${process.env.PATH}`,
+      RUNNER_TEMP: directory,
+      GITHUB_REPOSITORY: "Kong/kongctl",
+      GITHUB_REF: "refs/heads/main",
+      GITHUB_EVENT_NAME: "workflow_dispatch",
+      RELEASE_TAG: "v1.15.1",
+      RELEASE_RUN_ID: "123",
+      GH_TOKEN: "fixture-token",
+      APPLE_NOTARY_API_PRIVATE_KEY: privateKey.export({
+        type: "pkcs8",
+        format: "pem",
+      }),
+      APPLE_NOTARY_API_KEY_ID: "fixture-key-id",
+      APPLE_NOTARY_API_ISSUER_ID: "fixture-issuer",
+      GITHUB_STEP_SUMMARY: join(directory, "summary"),
+    };
+    const script = fileURLToPath(
+      new URL("../diagnose-apple-notary.mjs", import.meta.url),
+    );
+    const success = spawnSync(process.execPath, [script, evidence, output], {
+      env,
+      encoding: "utf8",
+    });
+    assert.equal(success.status, 0, success.stderr);
+    const report = JSON.parse(
+      readFileSync(join(output, "ticket-report.json"), "utf8"),
+    );
+    assert.deepEqual(report.submissions[0].matching_architectures, ["amd64"]);
+    assert.equal(
+      readdirSync(directory).some((name) =>
+        name.startsWith("kongctl-notary-diagnostics-"),
+      ),
+      false,
+    );
+    const failure = spawnSync(
+      process.execPath,
+      [script, evidence, join(directory, "failed-output")],
+      {
+        env: { ...env, FAIL_HISTORY: "true" },
+        encoding: "utf8",
+      },
+    );
+    assert.equal(failure.status, 1);
+    assert.doesNotMatch(
+      failure.stderr + failure.stdout,
+      /PRIVATE-ACCOUNT-DATA|fixture-token|BEGIN PRIVATE KEY/,
+    );
+    assert.equal(
+      readdirSync(directory).some((name) =>
+        name.startsWith("kongctl-notary-diagnostics-"),
+      ),
+      false,
+    );
+    assert.equal(existsSync(join(directory, "failed-output")), false);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("collect both architectures after Intel failure without executing binaries", () => {
+  const directory = mkdtempSync(
+    join(tmpdir(), "kongctl-native-diagnostics-test-"),
+  );
+  try {
+    const tools = join(directory, "tools");
+    const assets = join(directory, "assets");
+    const output = join(directory, "output");
+    mkdirSync(tools);
+    mkdirSync(assets);
+    const marker = join(directory, "executed");
+    writeFileSync(
+      join(assets, "kongctl"),
+      `#!/bin/sh\ntouch '${marker}'\nexit 99\n`,
+      { mode: 0o700 },
+    );
+    for (const arch of ["amd64", "arm64"]) {
+      execFileSync("zip", ["-q", `kongctl_darwin_${arch}.zip`, "kongctl"], {
+        cwd: assets,
+      });
+    }
+    writeFileSync(join(tools, "sw_vers"), "#!/bin/sh\necho macOS-fixture\n", {
+      mode: 0o700,
+    });
+    writeFileSync(
+      join(tools, "codesign"),
+      `#!/bin/sh
+case "$*" in
+  *--display*)
+    echo 'Authority=Developer ID Application: Example Inc. (ABCDE12345)'
+    echo 'TeamIdentifier=not set'
+    echo 'CodeDirectory v=20500 flags=0x10000(runtime)'
+    echo 'Timestamp=fixture'
+    case "$*" in
+      */amd64/*) echo 'CDHash=${expected.amd64}' ;;
+      *) echo 'CDHash=${expected.arm64}' ;;
+    esac
+    ;;
+  *--check-notarization*amd64*) exit 3 ;;
+esac
+`,
+      { mode: 0o700 },
+    );
+    execFileSync(
+      "bash",
+      [
+        fileURLToPath(
+          new URL("../diagnose-apple-binaries.sh", import.meta.url),
+        ),
+        assets,
+        output,
+      ],
+      {
+        env: {
+          ...process.env,
+          PATH: `${tools}:${process.env.PATH}`,
+          APPLE_TEAM_ID: "ABCDE12345",
+          APPLE_SIGNING_IDENTITY:
+            "Developer ID Application: Example Inc. (ABCDE12345)",
+          GITHUB_STEP_SUMMARY: join(directory, "summary"),
+        },
+      },
+    );
+    const result = JSON.parse(
+      readFileSync(join(output, "hashes.json"), "utf8"),
+    );
+    assert.deepEqual(
+      result.map((value) => value.verification_exit_code),
+      [3, 0],
+    );
+    assert.deepEqual(
+      result.map((value) => value.cdhash),
+      [expected.amd64, expected.arm64],
+    );
+    assert.equal(existsSync(marker), false);
+    assert.ok(existsSync(join(output, "amd64-verification.txt")));
+    assert.ok(existsSync(join(output, "arm64-verification.txt")));
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("require the exact same release and binary hashes on both runners", () => {
+  assert.deepEqual(
+    validateEvidence(
+      [
+        { release, hashes },
+        { release, hashes },
+      ],
+      release.tag_name,
+    ),
+    expected,
+  );
+  assert.throws(() =>
+    validateEvidence([{ release, hashes }], release.tag_name),
+  );
+  assert.throws(() =>
+    validateEvidence(
+      [
+        { release, hashes },
+        { release: { ...release, id: 101 }, hashes },
+      ],
+      release.tag_name,
+    ),
+  );
+  assert.throws(() =>
+    validateEvidence(
+      [
+        { release, hashes },
+        {
+          release,
+          hashes: [{ ...hashes[0], cdhash: "c".repeat(40) }, hashes[1]],
+        },
+      ],
+      release.tag_name,
+    ),
+  );
+  assert.throws(() =>
+    validateEvidence(
+      [
+        { release, hashes },
+        { release, hashes: [hashes[0], hashes[0]] },
+      ],
+      release.tag_name,
+    ),
+  );
+});
+
+test("only select submissions inside the original publisher window", () => {
+  const history = {
+    history: [
+      entry,
+      { ...entry, createdDate: "2026-09-06T02:00:00Z" },
+      { ...entry, createdDate: "2026-09-06T05:00:00Z" },
+    ],
+  };
+  assert.deepEqual(selectSubmissions(history, start, end), [entry]);
+  assert.throws(() => selectSubmissions({}, start, end));
+  assert.throws(() => selectSubmissions(history, end, start));
+  assert.throws(() =>
+    selectSubmissions(
+      { history: [{ ...entry, id: "--malicious-option" }] },
+      start,
+      end,
+    ),
+  );
+  assert.throws(() =>
+    selectSubmissions({ history: Array(21).fill(entry) }, start, end),
+  );
+});
+
+test("correlate ticket contents by exact hash, not submission success alone", () => {
+  const log = {
+    ticketContents: [
+      { path: "archive/kongctl", cdhash: expected.arm64, arch: "arm64" },
+    ],
+    issues: null,
+  };
+  const result = summarizeSubmission(
+    entry,
+    { status: "Accepted" },
+    log,
+    expected,
+  );
+  assert.deepEqual(result.matching_architectures, ["arm64"]);
+  assert.deepEqual(result.matching_ticket_hashes, [expected.arm64]);
+  assert.equal(result.status, "Accepted");
+  const mismatch = summarizeSubmission(
+    entry,
+    { status: "Accepted" },
+    {
+      ticketContents: [
+        { path: "archive/kongctl", cdhash: "c".repeat(40), arch: "x86_64" },
+      ],
+    },
+    expected,
+  );
+  assert.deepEqual(mismatch.matching_architectures, []);
+  assert.deepEqual(mismatch.kongctl_ticket_hashes, [
+    { cdhash: "c".repeat(40), arch: "x86_64" },
+  ]);
+});
+
+test("missing logs and in-progress submissions are not interpreted as accepted", () => {
+  const result = summarizeSubmission(
+    entry,
+    { status: "In Progress" },
+    null,
+    expected,
+  );
+  assert.equal(result.log_available, false);
+  assert.equal(result.status, "In Progress");
+  assert.deepEqual(result.matching_architectures, []);
+  assert.equal(
+    summarizeSubmission(entry, null, null, expected).status,
+    "Unavailable",
+  );
+});
+
+test("do not expose unrelated account metadata, ticket paths, URLs, or issue text", () => {
+  const other = { ...entry, name: "private-project.zip" };
+  assert.equal(
+    summarizeSubmission(
+      other,
+      { status: "Accepted" },
+      { ticketContents: [] },
+      expected,
+    ),
+    null,
+  );
+  const result = summarizeSubmission(
+    entry,
+    { status: "Accepted", private: "secret" },
+    {
+      private: "secret",
+      ticketContents: [
+        {
+          path: "private-project/kongctl",
+          cdhash: expected.amd64,
+          arch: "x86_64",
+        },
+      ],
+      issues: [{ message: "secret", path: "private-project" }],
+      logFileUrl: "secret",
+    },
+    expected,
+  );
+  assert.doesNotMatch(
+    JSON.stringify(result),
+    /secret|private-project|logFileUrl/,
+  );
+  assert.equal(result.issue_count, 1);
+});
+
+test("workflow is main-only, uses isolated credentials, and has no publisher", () => {
+  const workflow = readFileSync(
+    new URL(
+      "../../.github/workflows/apple-notary-diagnostics.yml",
+      import.meta.url,
+    ),
+    "utf8",
+  );
+  const inspect = workflow
+    .split("  inspect:\n")[1]
+    .split("  notary-records:\n")[0];
+  assert.match(inspect, /refs\/heads\/main/);
+  assert.doesNotMatch(inspect, /secrets\.APPLE_/);
+  assert.doesNotMatch(
+    workflow,
+    /SIGNING_CERTIFICATE|goreleaser-action|release edit|publish-tap|workflow_run:/,
+  );
+  const collector = readFileSync(
+    new URL("../diagnose-apple-notary.mjs", import.meta.url),
+    "utf8",
+  );
+  assert.doesNotMatch(
+    collector,
+    /"notarytool", "(?:submit|store-credentials)"/,
+  );
+  assert.match(collector, /finally \{\s*rmSync\(privateDir/);
+  assert.match(collector, /timeout: 60000/);
+  const native = readFileSync(
+    new URL("../diagnose-apple-binaries.sh", import.meta.url),
+    "utf8",
+  );
+  assert.doesNotMatch(native, /chmod|--sign|--force|kongctl" version|xattr -w/);
+});


### PR DESCRIPTION
## Summary

Add a manually dispatched, main-only Apple notarization diagnostic workflow for existing release assets. This investigates the repeated Intel failure in [Release recovery run 34011914250](https://github.com/Kong/kongctl/actions/runs/34011914250/job/101429878457), where signature verification succeeds but the notarized code requirement fails.

- Assess both Darwin binaries on both ARM and Intel macOS runners without executing them. Preserve hashes, verification results, and security-service logs on assessment failure.
- Retrieve Apple submission history/info/log records within the original signing job's time window and compare ticket contents with the exact downloaded code hashes.
- Keep Apple API credentials exclusively in kongctl. No signing certificate is needed. Store the API key temporarily with mode 0600 and remove it afterward; never upload raw account history, raw Apple logs, or private credentials.
- Retain filtered evidence for three days and document how to interpret it. Missing ticket matches remain inconclusive when history or requests are incomplete.

This does not change release gates, release state, assets, signing, notarization submissions, or Homebrew. A green diagnostic run means evidence collection completed, not that the release is approved.

## Validation

- Eight new diagnostic tests pass, including simulated subprocess execution, key cleanup on success/failure, output filtering, exact ticket hash matching, and collection continuing after an Intel assessment failure without executing either binary.
- All 24 existing recovery tests pass.
- `make test` and `make build` pass.
- ShellCheck and actionlint pass for the new script/workflow; JavaScript formatting and `git diff --check` pass.
- Full local lint is not clean: installed golangci-lint 2.12.2 reports 60 existing issues in unchanged Go code, plus a stale cached-worktree access warning. CI uses 2.13.1. Checking the existing test workflow also reports its pre-existing unquoted GOTESTFLAGS ShellCheck finding. No Go code or dependencies are changed.
- Actual macOS/Apple API diagnostics must run after merge; these local tests do not establish why Apple's Intel assessment fails.

## After merge

Open Actions → **Apple notarization diagnostics** → **Run workflow**:

- Branch: `main`
- `release_tag`: `v1.15.1`
- `release_run_id`: `34009395370` — the original signing run, **not** recovery run `34011914250`.

Review the job summaries and `apple-diagnostics-*` / `apple-notary-ticket-report` artifacts before deciding the next recovery step. Leave the existing draft unpublished while investigating.
