### PR TITLE
test(e2e): report weighted shard assignments without changing live execution

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -839,11 +839,13 @@ jobs:
       #     echo "Skipping E2E (no 'run-e2e' label)." && exit 0
 
       - name: Run assigned Konnect scenarios
+        id: scenarios
         run: |
           set -euo pipefail
 
           ART_DIR="${KONGCTL_E2E_ARTIFACTS_DIR}/$(date +%Y%m%d-%H%M%S)"
           mkdir -p "${ART_DIR}"
+          echo "artifacts_dir=${ART_DIR}" >> "${GITHUB_OUTPUT}"
           export KONGCTL_E2E_ARTIFACTS_DIR="${ART_DIR}"
 
           source "${GITHUB_WORKSPACE}/test/e2e/harness/ci/results.sh"
@@ -927,8 +929,10 @@ jobs:
       - name: Report weighted sharding predictions
         if: always() && env.KONGCTL_E2E_KONNECT_ENV == 'com'
         continue-on-error: true
+        env:
+          WEIGHTED_REPORT_DIR: ${{ steps.scenarios.outputs.artifacts_dir }}
         run: |
-          report="${KONGCTL_E2E_ARTIFACTS_DIR}/weighted-sharding-summary.md"
+          report="${WEIGHTED_REPORT_DIR}/weighted-sharding-summary.md"
           if [ -f "${report}" ]; then
             cat "${report}" >> "${GITHUB_STEP_SUMMARY}"
           else

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -919,6 +919,18 @@ jobs:
           sudo chown -R "${USER}:${USER}" "${CAP_DIR}" 2>/dev/null || true
           ls -lh "${CAP_DIR}" || true
 
+      - name: Report weighted sharding predictions
+        if: always() && env.KONGCTL_E2E_KONNECT_ENV == 'com'
+        continue-on-error: true
+        run: |
+          report="${KONGCTL_E2E_ARTIFACTS_DIR}/weighted-sharding-summary.md"
+          if [ -f "${report}" ]; then
+            cat "${report}" >> "${GITHUB_STEP_SUMMARY}"
+          else
+            echo "::warning::Weighted sharding report unavailable; live assignments are unchanged"
+            echo "Weighted sharding predictions unavailable for this shard." >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
       - name: Generate shard metrics
         if: always()
         run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -645,6 +645,11 @@ jobs:
       - name: Build scenario test binary
         run: go test -c -tags=e2e -o e2e.test ./test/e2e
 
+      - name: Validate report-only scheduler offline
+        env:
+          KONGCTL_E2E_BIN: ${{ github.workspace }}/kongctl
+        run: ./e2e.test -test.v -test.run '^TestWeighted' -test.timeout 1m
+
       - name: Upload scenario executables
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,12 @@ coverage:
 test:
 	go test -race -count=1 ./...
 
+.PHONY: refresh-e2e-weights
+refresh-e2e-weights:
+	python3 scripts/e2e-weights.py \
+		test/e2e/baselines/stage0-2026-09-observations.json \
+		test/e2e/baselines/post-cache-2026-09-observations.json
+
 .PHONY: test-e2e-metrics
 test-e2e-metrics:
 	python3 -m unittest discover -s scripts -p 'e2e_*_test.py'

--- a/scripts/e2e-weights.py
+++ b/scripts/e2e-weights.py
@@ -12,6 +12,30 @@ from collections import defaultdict
 from pathlib import Path
 
 
+MAX_DURATION_MS = 2**63 - 1
+
+
+def validate_document(document: object, path: Path) -> dict:
+    if not isinstance(document, dict) or document.get("schema_version") != 2 or document.get("repository") != "kong/kongctl":
+        raise ValueError(f"unsupported observations: {path}")
+    if not isinstance(document.get("runs"), list):
+        raise ValueError(f"observations {path} must contain a runs array")
+    for run in document["runs"]:
+        if not isinstance(run, dict):
+            raise ValueError(f"invalid run in {path}")
+        for field in ("run_id", "run_attempt"):
+            if type(run.get(field)) is not int or run[field] <= 0:
+                raise ValueError(f"invalid {field} in {path}")
+        if not isinstance(run.get("scenario_durations"), list):
+            raise ValueError(f"run {run['run_id']} must contain a scenario_durations array")
+        for record in run["scenario_durations"]:
+            if not isinstance(record, dict) or not isinstance(record.get("scenario"), str) or not record["scenario"]:
+                raise ValueError(f"invalid scenario record in run {run['run_id']}")
+            if record.get("result") not in ("pass", "fail", "skip") or "duration_seconds" not in record:
+                raise ValueError(f"invalid result or missing duration in run {run['run_id']}")
+    return document
+
+
 def normalize(path: str) -> str:
     for prefix in ("test/e2e/scenarios/", "scenarios/"):
         if path.startswith(prefix):
@@ -27,9 +51,7 @@ def generate(paths: list[Path], scenario_root: Path) -> dict:
     sources = {}
     for path in sorted(set(paths)):
         raw = path.read_bytes()
-        document = json.loads(raw)
-        if document.get("schema_version") != 2 or document.get("repository") != "kong/kongctl":
-            raise ValueError(f"unsupported observations: {path}")
+        document = validate_document(json.loads(raw), path)
         sources[path.as_posix()] = hashlib.sha256(raw).hexdigest()
         for run in document["runs"]:
             run_id = run["run_id"]
@@ -55,13 +77,17 @@ def generate(paths: list[Path], scenario_root: Path) -> dict:
                 continue
             if isinstance(seconds, bool) or not isinstance(seconds, (int, float)):
                 raise ValueError(f"invalid duration for {path}")
-            if not math.isfinite(seconds) or seconds <= 0:
+            if seconds <= 0 or (isinstance(seconds, float) and not math.isfinite(seconds)):
                 continue
+            if seconds > MAX_DURATION_MS / 1000:
+                raise ValueError(f"duration for {path} exceeds the supported millisecond range")
             durations[path].append(seconds * 1000)
     weights = {
         path: {"duration_ms": max(1, round(statistics.median(values))), "samples": len(values)}
         for path, values in sorted(durations.items()) if len(values) >= 10
     }
+    if any(weight["duration_ms"] > MAX_DURATION_MS for weight in weights.values()):
+        raise ValueError("median duration exceeds the supported millisecond range")
     fallback = max(1, round(statistics.median(w["duration_ms"] for w in weights.values()))) if weights else 1000
     return {
         "schema_version": 1,
@@ -80,9 +106,9 @@ def main() -> None:
     args = parser.parse_args()
     try:
         weights = generate(args.observations, args.scenario_root)
+        args.output.write_text(json.dumps(weights, indent=2, sort_keys=True) + "\n")
     except (ValueError, KeyError, OSError) as error:
         parser.error(str(error))
-    args.output.write_text(json.dumps(weights, indent=2, sort_keys=True) + "\n")
 
 
 if __name__ == "__main__":

--- a/scripts/e2e-weights.py
+++ b/scripts/e2e-weights.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Generate deterministic scenario weights from saved, successful baselines."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import statistics
+from collections import defaultdict
+from pathlib import Path
+
+
+def normalize(path: str) -> str:
+    for prefix in ("test/e2e/scenarios/", "scenarios/"):
+        if path.startswith(prefix):
+            path = path[len(prefix):]
+    return path.rstrip("/")
+
+
+def generate(paths: list[Path], scenario_root: Path) -> dict:
+    active = {p.relative_to(scenario_root).as_posix() for p in scenario_root.rglob("scenario.yaml")}
+    if not active:
+        raise ValueError(f"no scenarios found in {scenario_root}")
+    runs = {}
+    sources = {}
+    for path in sorted(set(paths)):
+        raw = path.read_bytes()
+        document = json.loads(raw)
+        if document.get("schema_version") != 2 or document.get("repository") != "kong/kongctl":
+            raise ValueError(f"unsupported observations: {path}")
+        sources[path.as_posix()] = hashlib.sha256(raw).hexdigest()
+        for run in document["runs"]:
+            run_id = run["run_id"]
+            previous = runs.get(run_id)
+            if previous is not None:
+                if previous["run_attempt"] == run["run_attempt"]:
+                    if previous["scenario_durations"] != run["scenario_durations"]:
+                        raise ValueError(f"conflicting observations for run {run_id}")
+                    continue
+                if previous["run_attempt"] > run["run_attempt"]:
+                    continue
+            runs[run_id] = run
+    durations = defaultdict(list)
+    for run in runs.values():
+        seen = set()
+        for record in run["scenario_durations"]:
+            path = normalize(record["scenario"])
+            if path in seen:
+                raise ValueError(f"duplicate scenario {path} in run {run['run_id']}")
+            seen.add(path)
+            seconds = record["duration_seconds"]
+            if record["result"] != "pass" or path not in active:
+                continue
+            if isinstance(seconds, bool) or not isinstance(seconds, (int, float)):
+                raise ValueError(f"invalid duration for {path}")
+            if not math.isfinite(seconds) or seconds <= 0:
+                continue
+            durations[path].append(seconds * 1000)
+    weights = {
+        path: {"duration_ms": max(1, round(statistics.median(values))), "samples": len(values)}
+        for path, values in sorted(durations.items()) if len(values) >= 10
+    }
+    fallback = max(1, round(statistics.median(w["duration_ms"] for w in weights.values()))) if weights else 1000
+    return {
+        "schema_version": 1,
+        "default_duration_ms": fallback,
+        "sources": list(sources),
+        "source_sha256": sources,
+        "scenarios": weights,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("observations", nargs="+", type=Path)
+    parser.add_argument("--scenario-root", type=Path, default=Path("test/e2e/scenarios"))
+    parser.add_argument("--output", type=Path, default=Path("test/e2e/baselines/scenario-weights.json"))
+    args = parser.parse_args()
+    try:
+        weights = generate(args.observations, args.scenario_root)
+    except (ValueError, KeyError, OSError) as error:
+        parser.error(str(error))
+    args.output.write_text(json.dumps(weights, indent=2, sort_keys=True) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/e2e_weights_test.py
+++ b/scripts/e2e_weights_test.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SPEC = importlib.util.spec_from_file_location("e2e_weights", Path(__file__).with_name("e2e-weights.py"))
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class E2EWeightsTest(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        self.scenarios = self.root / "scenarios"
+        for name in ("a", "b", "new"):
+            path = self.scenarios / name / "scenario.yaml"
+            path.parent.mkdir(parents=True)
+            path.write_text("# fixture\n")
+
+    def observations(self, name, runs):
+        path = self.root / name
+        path.write_text(json.dumps({"schema_version": 2, "repository": "kong/kongctl", "runs": runs}))
+        return path
+
+    @staticmethod
+    def runs(count=10):
+        return [{
+            "run_id": i + 1, "run_attempt": 1,
+            "scenario_durations": [
+                {"scenario": "scenarios/a/scenario.yaml", "result": "pass", "duration_seconds": i + 1},
+                {"scenario": "b/scenario.yaml", "result": "pass", "duration_seconds": 20},
+                {"scenario": "removed/scenario.yaml", "result": "pass", "duration_seconds": 99},
+            ],
+        } for i in range(count)]
+
+    def test_medians_fallback_and_deduplication(self):
+        first = self.observations("first.json", self.runs())
+        second = self.observations("second.json", self.runs())
+        result = MODULE.generate([second, first, first], self.scenarios)
+        self.assertEqual({"duration_ms": 5500, "samples": 10}, result["scenarios"]["a/scenario.yaml"])
+        self.assertEqual(12750, result["default_duration_ms"])
+        self.assertNotIn("removed/scenario.yaml", result["scenarios"])
+        self.assertNotIn("new/scenario.yaml", result["scenarios"])
+        self.assertEqual(result, MODULE.generate([first, second], self.scenarios))
+        self.assertEqual(2, len(result["source_sha256"]))
+
+    def test_latest_attempt_only(self):
+        first = self.observations("first.json", self.runs())
+        runs = self.runs()
+        for run in runs:
+            run["run_attempt"] = 2
+            run["scenario_durations"][0]["duration_seconds"] = 30
+        second = self.observations("second.json", runs)
+        result = MODULE.generate([first, second], self.scenarios)
+        self.assertEqual({"duration_ms": 30000, "samples": 10}, result["scenarios"]["a/scenario.yaml"])
+
+    def test_insufficient_and_unusable_samples_use_uniform_fallback(self):
+        runs = self.runs(9)
+        extra = self.runs(6)
+        for i, (run, value) in enumerate(zip(extra, [0, -1, float("nan"), float("inf"), 3, 3])):
+            run["run_id"] = i + 20
+            for record in run["scenario_durations"]:
+                record["duration_seconds"] = value
+                if i == 4:
+                    record["result"] = "fail"
+                if i == 5:
+                    record["result"] = "skip"
+        path = self.observations("observations.json", runs + extra)
+        result = MODULE.generate([path], self.scenarios)
+        self.assertEqual({}, result["scenarios"])
+        self.assertEqual(1000, result["default_duration_ms"])
+
+    def test_conflicting_duplicate_rejected(self):
+        first = self.observations("first.json", self.runs())
+        runs = self.runs()
+        runs[0]["scenario_durations"][0]["duration_seconds"] = 100
+        second = self.observations("second.json", runs)
+        with self.assertRaisesRegex(ValueError, "conflicting"):
+            MODULE.generate([first, second], self.scenarios)
+
+    def test_duplicate_scenario_rejected(self):
+        runs = self.runs()
+        runs[0]["scenario_durations"].append(runs[0]["scenario_durations"][0])
+        path = self.observations("observations.json", runs)
+        with self.assertRaisesRegex(ValueError, "duplicate scenario"):
+            MODULE.generate([path], self.scenarios)
+
+    def test_invalid_input(self):
+        path = self.observations("observations.json", [])
+        path.write_text("{}")
+        with self.assertRaisesRegex(ValueError, "unsupported"):
+            MODULE.generate([path], self.scenarios)
+        with self.assertRaisesRegex(ValueError, "no scenarios"):
+            MODULE.generate([path], self.root / "missing")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/e2e_weights_test.py
+++ b/scripts/e2e_weights_test.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -99,6 +101,38 @@ class E2EWeightsTest(unittest.TestCase):
             MODULE.generate([path], self.scenarios)
         with self.assertRaisesRegex(ValueError, "no scenarios"):
             MODULE.generate([path], self.root / "missing")
+
+    def test_malformed_records_rejected(self):
+        for field, value in (("run_id", True), ("run_id", 0), ("run_attempt", "1"),
+                             ("scenario_durations", None), ("scenario_durations", [{}])):
+            with self.subTest(field=field, value=value):
+                runs = self.runs()
+                runs[0][field] = value
+                path = self.observations("observations.json", runs)
+                with self.assertRaises(ValueError):
+                    MODULE.generate([path], self.scenarios)
+
+    def test_out_of_range_duration_rejected(self):
+        runs = self.runs()
+        runs[0]["scenario_durations"][0]["duration_seconds"] = 10**400
+        path = self.observations("observations.json", runs)
+        with self.assertRaisesRegex(ValueError, "millisecond range"):
+            MODULE.generate([path], self.scenarios)
+
+    def test_cli_preserves_snapshot_when_input_is_invalid(self):
+        path = self.observations("observations.json", [])
+        path.write_text("null")
+        output = self.root / "weights.json"
+        output.write_text("preserved snapshot\n")
+        result = subprocess.run(
+            [sys.executable, str(Path(MODULE.__file__)), str(path),
+             "--scenario-root", str(self.scenarios), "--output", str(output)],
+            capture_output=True, text=True, check=False,
+        )
+        self.assertEqual(2, result.returncode)
+        self.assertIn("unsupported observations", result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
+        self.assertEqual("preserved snapshot\n", output.read_text())
 
 
 if __name__ == "__main__":

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -650,3 +650,56 @@ experiments, but should not be counted as independent baseline samples.
 Gather the post-cache baseline before changing concurrency, assignment, or
 reset policy. Those future changes require a new, explicitly identified
 measurement period; the cache cohort alone does not distinguish them.
+
+### Weighted sharding predictions
+
+Full, sharded `.com` runs also compute a **report-only** weighted assignment.
+Live execution still uses the existing selector, including its ordering and
+organization pins. Filtered, unsharded, and `.tech` runs do not generate these
+predictions. This does not introduce replay, skip scenarios, or change reset
+policy or concurrency.
+
+The proposed scheduler reserves pinned load first, then assigns unpinned
+scenarios in descending estimated-duration order to the least-loaded org.
+Equal weights use scenario path order; equal loads use configured organization
+order. Proposed scenario lists are sorted by path. Counts need not be equal:
+the goal is balanced estimated time, not balanced scenario counts.
+
+Refresh the checked-in snapshot manually from saved observations:
+
+```sh
+make refresh-e2e-weights
+```
+
+This writes `test/e2e/baselines/scenario-weights.json`. The initial inputs are
+the frozen Stage 0 and post-cache observations; these are pooled only for
+scenario duration estimates, not for workflow/build-cache comparisons. The
+generator uses one attempt per workflow run (the highest supplied attempt),
+rejects conflicting duplicate observations, and requires at least 10 finite,
+positive, passing durations per scenario. Weights are conventional medians
+rounded to milliseconds. Failed, skipped, and nonpositive durations do not
+contribute. Removed scenarios are omitted on refresh.
+
+New or insufficiently sampled scenarios use the median of established scenario
+weights. If no scenario qualifies, all scenarios receive a uniform 1000ms
+weight. Such a report is a balancing illustration, not a calibrated time
+prediction. The snapshot records sample counts and source paths/SHA-256 hashes
+and is embedded in the scenario test binary; selection never queries GitHub.
+Refresh is explicit, not part of builds or baseline collection.
+
+Each shard's workflow summary compares current and proposed estimated totals,
+longest-shard time, and spread. Its `e2e-artifacts-*` artifact contains:
+
+- `proposed-scenario-assignments.json`: versioned, full-pool comparison with
+  per-scenario weights, fallback indicators, and organization assignments.
+- `weighted-sharding-summary.md`: the human-readable comparison.
+
+These are separate from `assigned-scenarios.txt` and `e2e-metrics.json`, which
+continue to describe actual execution. Reporting errors produce warnings and
+do not fail scenario tests. Missing reports also appear as workflow warnings.
+
+Predictions exclude job overhead and assume that scenario durations transfer
+across organizations and execution ordering. They are not measured savings.
+Repeated runs from the same PR are correlated samples. Review these reports
+alongside the completed post-cache baseline before a separate activation PR;
+activation must start a separately identified measurement period.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -687,6 +687,21 @@ prediction. The snapshot records sample counts and source paths/SHA-256 hashes
 and is embedded in the scenario test binary; selection never queries GitHub.
 Refresh is explicit, not part of builds or baseline collection.
 
+Predictions do not learn from each run: unchanged manifests, organizations,
+and weights produce the same proposed assignments. Collect observations first,
+then refresh and review the snapshot when newer timing data warrants it.
+Malformed observation records are rejected before replacing the snapshot.
+
+The build job runs the weighted scheduler tests using its already compiled
+test binary and kongctl executable. This offline check covers the full
+repository corpus, pin preservation, coverage, and identical full-pool reports
+across matrix organizations; it never executes scenarios or contacts Konnect.
+Run it locally with:
+
+```sh
+CGO_ENABLED=0 go test -tags=e2e ./test/e2e -run '^TestWeighted' -v
+```
+
 Each shard's workflow summary compares current and proposed estimated totals,
 longest-shard time, and spread. Its `e2e-artifacts-*` artifact contains:
 

--- a/test/e2e/baselines/post-cache-2026-09-analysis.md
+++ b/test/e2e/baselines/post-cache-2026-09-analysis.md
@@ -1,0 +1,163 @@
+# E2E cache and optimization assessment — September 6, 2026
+
+Build caching is delivering the expected benefit on normal PRs and main runs.
+The next largest measured opportunity is pin-aware weighted sharding.
+
+## Evidence and collection
+
+The cumulative post-cache observation file now contains 14 successful full
+`.com` runs, including 11 observations added to the three already present in
+the local worktree. The frozen uncached baseline contains seven runs. The
+20-run post-cache target remains incomplete. No workflow or scenario behavior
+was changed during this assessment.
+
+Collection used `scripts/e2e-baseline.py` with `--count 20 --scan 150`, the
+`cache-enabled` cohort, cumulative observations, and `--allow-partial`.
+Percentiles below use the collector's nearest-rank method. Latency is measured
+from the selected attempt's creation time through required-status completion.
+Gate-only runs, incomplete runs, and failed workflows are excluded from the
+baseline. One latest/saved attempt is represented per workflow run ID.
+
+An additional build-log audit examined 16 completed workflows with successful
+cache-enabled build jobs since the #2069 experiment. It includes the two
+failed workflows omitted from the successful-run baseline. Both failures
+occurred in scenario execution; their build and harness jobs succeeded.
+The audit does not count #2069's earlier attempts again.
+
+## Build-cache value
+
+| Metric | Uncached p50 (7 runs) | Cache-enabled p50 (14 runs) |
+| --- | ---: | ---: |
+| Build job | 309 s | 49 s |
+| Build kongctl | 240 s | 4 s |
+| Build scenario binary | 38 s | 1 s |
+| Setup Go in build job | 10 s | 22 s |
+| Harness job | 75 s | 72 s |
+| Queue to required status | 1,001 s | 657 s |
+| Longest scenario shard | 551 s | 480 s |
+| Shard spread | 345 s | 267 s |
+
+The build-job median improved by 260 seconds, or 84%. Observed overall latency
+improved by 344 seconds, or 34%. The latter is not wholly attributable to
+caching: scenario and reset times also improved, and queueing varies.
+
+All 15 cache hits in the supplemental audit completed the build job in
+42–64 seconds; their median was 49 seconds. The sole miss was the first
+available main run after the cache/dependency change, at 322 seconds. Its
+cache-save step took 11 seconds. Subsequent main and PR builds restored that
+dependency key. The extra setup cost is already included in build-job time.
+
+Cache evidence retained from the `Report Go cache status` build step:
+
+| Workflow run | Outcome | Cache hit | Build job |
+| --- | --- | --- | ---: |
+| 34026314755 | success | true | 55 s |
+| 34009619734 | failure in scenarios | true | 56 s |
+| 34007840146 | success | true | 64 s |
+| 34006266279 | success | true | 60 s |
+| 34006212666 | success | true | 42 s |
+| 34004626083 | success | true | 44 s |
+| 34004275715 | success | true | 46 s |
+| 34003980091 | success | true | 50 s |
+| 34003060095 | success | true | 50 s |
+| 34002577998 | success | true | 43 s |
+| 34002088234 | failure in scenarios | true | 48 s |
+| 34000248405 | success | true | 43 s |
+| 33995527990 | success | true | 51 s |
+| 33975197426 | success | true | 42 s |
+| 33972692322 | success | false | 322 s |
+| 33906754133 (attempt 3) | success | true | 49 s |
+
+This is broader evidence than identical-commit reruns: the two astra-refactor
+runs built kongctl in 8–11 seconds and the declarative-capabilities PR built it
+in 10 seconds, with cache hits in all three. Those full workflows passed.
+
+The sample is still clustered: six of the 14 successful observations came
+from the Apple notarization PR, and dependencies changed little. Do not treat
+the observed hit rate as a long-term guarantee. Dependency and toolchain
+changes can still cause misses. There is no present evidence justifying more
+complex build cache keys, periodic refresh, or a dedicated warming workflow.
+
+## Next optimization: weighted sharding
+
+The pinned `kongctl-acceptance` shard was slowest in 10 of 14 successful runs.
+It receives 43 scenarios; other shards receive 30–31. Median execution was
+480 seconds on that shard versus 200 seconds on `kongctl-acceptance-4`.
+
+Across both cohorts, 162 passing scenarios each have 21 duration samples.
+The three other scenarios are recorded as skipped, so their times should not
+be used as meaningful weights. Caching occurs before scenario execution,
+making both cohorts useful for an exploratory duration model. Code changes,
+organization differences, and temporal correlation still limit inference.
+
+An offline simulation compared the current modulo assignment, pin-aware
+uniform balancing, and pin-aware descending-median-weight balancing:
+
+- Preassign all 12 pins and include their weight in the organization's load.
+- Assign remaining scenarios to the lowest predicted load with stable ties.
+- Train weights on other runs, excluding the evaluated run's entire PR branch
+  among the cache-enabled observations. Retained uncached observations are
+  also training data. Missing successful history uses the training median.
+- Sum the evaluated run's actual individual scenario durations under each
+  proposed assignment. The current modulo sums reproduce actual longest
+  shards within approximately two seconds, which checks the reconstruction.
+
+| Assignment | Runs improved | Median estimated saving |
+| --- | ---: | ---: |
+| Pin-aware uniform weights | 12 / 14 | 91 s |
+| Pin-aware historical weights | 13 / 14 | 136 s |
+
+Weighted assignment was approximately 21 seconds slower on the remaining
+run. These are simulated savings, not measured CI improvements. The model
+assumes a scenario retains its observed duration when moved to another
+organization or position. Training can include later runs, so this is a
+retrospective branch-held-out comparison, not a prospective forecast.
+
+There is enough history to develop and test the scheduler and weight
+generation now. Require completeness, no overlap, deterministic output, pin
+preservation, and conservative defaults. Publish predicted shard loads and
+validate actual savings in a standalone rollout. Keep scenario coverage and
+organization isolation intact. Do not claim this simulation completes the
+live validation required by #2053.
+
+## Other opportunities
+
+1. Workflow pipelining still matters for busy periods. Median admission delay
+   is only four seconds, but p90 is 546 seconds and the maximum is 571 seconds.
+   Removing the full-workflow lock could address that tail. First finish the
+   cached baseline and perform the two controlled overlapping runs specified
+   in #2053, retaining per-organization serialization. Do not combine this
+   rollout with a shard-assignment change.
+2. Harness caching is a smaller opportunity. On warm successful runs, the
+   harness finished a median 23 seconds after the build. That is the median
+   maximum possible saving from accelerating the harness alone with these
+   job timings. A restore-only cache experiment could avoid competing saves,
+   but restore cost reduces the attainable saving. Prioritize sharding.
+3. Reset listing accounts for 97.5% of total measured reset wall time across
+   the post-cache runs. Median cumulative reset time is 415 seconds across
+   all five shards, including 404 seconds listing and nine seconds deleting.
+   These totals are not directly subtractable from workflow wall time. More
+   deletion cleanup alone cannot remove the dominant list cost. Reduced
+   resets still require a verified cleanup contract and failure-safe policy;
+   do not skip resets solely on the strength of these timing numbers.
+
+Collect six more successful full cache-enabled runs for the planned 20-run
+baseline. Additional observations should include normal feature changes and
+main runs, rather than deliberately repeating the same commit to fill the
+target. Continue preserving observations before artifact expiry.
+
+## Sources and retained outputs
+
+- [Cumulative observations](post-cache-2026-09-observations.json)
+- [Generated percentile and scenario report](post-cache-2026-09.md)
+- [Frozen uncached report](stage0-2026-09.md)
+- [Optimization specification](https://github.com/Kong/kongctl/issues/2053)
+- [Cache implementation and experiment](https://github.com/Kong/kongctl/pull/2069)
+- [Refactoring PR build](https://github.com/Kong/kongctl/actions/runs/34026314755)
+- [Main cache miss](https://github.com/Kong/kongctl/actions/runs/33972692322)
+- [Subsequent main cache hit](https://github.com/Kong/kongctl/actions/runs/33995527990)
+- [setup-go cache restore source](https://github.com/actions/setup-go/blob/v7.0.0/src/cache-restore.ts)
+- [GitHub cache scope reference](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching)
+
+Local audit scripts, cache-log excerpts, and per-run simulation results are
+also retained under `/home/rspurgeon/.cache/e2e-analysis.dLljuBEN/`.

--- a/test/e2e/baselines/post-cache-2026-09-observations.json
+++ b/test/e2e/baselines/post-cache-2026-09-observations.json
@@ -3,6 +3,10698 @@
   "repository": "kong/kongctl",
   "runs": [
     {
+      "build_job_seconds": 55.0,
+      "build_kongctl_seconds": 10.0,
+      "build_scenario_binary_seconds": 6.0,
+      "build_setup_seconds": 21.0,
+      "cohort": "cache-enabled",
+      "created_at": "2026-09-06T10:02:36Z",
+      "harness_job_seconds": 67.0,
+      "harness_setup_seconds": 7.0,
+      "harness_test_seconds": 49.0,
+      "head_sha": "c151459d16954c40e1d79878571378322f3e2c04",
+      "longest_shard_seconds": 359.0,
+      "original_created_at": "2026-09-06T10:02:36Z",
+      "queue_to_required_status_seconds": 535.0,
+      "reset": {
+        "count": 164,
+        "delete_calls": 103,
+        "delete_duration_ms": 8560,
+        "duration_ms": 396245,
+        "list_calls": 2459,
+        "list_duration_ms": 386205,
+        "resources_deleted": 84,
+        "resources_found": 1614
+      },
+      "run_attempt": 1,
+      "run_id": 34026314755,
+      "scenario_durations": [
+        {
+          "duration_seconds": 5.92,
+          "result": "pass",
+          "scenario": "adopt/auth-strategy-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.27,
+          "result": "pass",
+          "scenario": "ai-gateway/agent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.48,
+          "result": "pass",
+          "scenario": "ai-gateway/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.23,
+          "result": "pass",
+          "scenario": "ai-gateway/model/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.57,
+          "result": "pass",
+          "scenario": "ai-gateway/vault/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.55,
+          "result": "pass",
+          "scenario": "apis/comprehensive-fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.62,
+          "result": "pass",
+          "scenario": "apis/root-level-publication-visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.96,
+          "result": "pass",
+          "scenario": "control-plane/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.96,
+          "result": "pass",
+          "scenario": "control-plane/serverless/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.42,
+          "result": "pass",
+          "scenario": "deck/env-vars/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.0,
+          "result": "pass",
+          "scenario": "declarative/rename-sync-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.23,
+          "result": "pass",
+          "scenario": "delete/plan-based/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.83,
+          "result": "pass",
+          "scenario": "dump/dcr-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.29,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.38,
+          "result": "pass",
+          "scenario": "event-gateway/dataplane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.96,
+          "result": "pass",
+          "scenario": "event-gateway/listener-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.63,
+          "result": "pass",
+          "scenario": "event-gateway/produce-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.09,
+          "result": "pass",
+          "scenario": "event-gateway/virtual-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.06,
+          "result": "pass",
+          "scenario": "external/portal-publication/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.41,
+          "result": "pass",
+          "scenario": "org/get-org/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.84,
+          "result": "pass",
+          "scenario": "org/teams/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.13,
+          "result": "pass",
+          "scenario": "plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.47,
+          "result": "pass",
+          "scenario": "portal/api_with_attributes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.13,
+          "result": "pass",
+          "scenario": "portal/auth-strategy-link/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.18,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.43,
+          "result": "pass",
+          "scenario": "portal/email/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.56,
+          "result": "pass",
+          "scenario": "portal/integrations/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.28,
+          "result": "pass",
+          "scenario": "portal/publication-auth-omitted-noop/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.79,
+          "result": "pass",
+          "scenario": "portal/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.57,
+          "result": "pass",
+          "scenario": "protected-resources/org/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.06,
+          "result": "pass",
+          "scenario": "smoke/version/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.19,
+          "result": "pass",
+          "scenario": "apis/eventual-consistency-polp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.43,
+          "result": "pass",
+          "scenario": "dump/organization-teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.0,
+          "result": "pass",
+          "scenario": "org/system-accounts/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.96,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.81,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.12,
+          "result": "pass",
+          "scenario": "org/system-accounts/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.69,
+          "result": "pass",
+          "scenario": "org/token/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.31,
+          "result": "pass",
+          "scenario": "org/users/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.17,
+          "result": "pass",
+          "scenario": "org/users/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.14,
+          "result": "pass",
+          "scenario": "org/users/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.14,
+          "result": "pass",
+          "scenario": "org/users/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.21,
+          "result": "pass",
+          "scenario": "org/users/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.03,
+          "result": "pass",
+          "scenario": "adopt/create-portal-adopt-dump-plan/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.24,
+          "result": "pass",
+          "scenario": "ai-gateway/auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.33,
+          "result": "pass",
+          "scenario": "ai-gateway/maturity/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.99,
+          "result": "pass",
+          "scenario": "ai-gateway/policy-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 31.51,
+          "result": "pass",
+          "scenario": "all/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.47,
+          "result": "pass",
+          "scenario": "apis/control-plane-implementation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.35,
+          "result": "pass",
+          "scenario": "apis/versions-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.83,
+          "result": "pass",
+          "scenario": "control-plane/delete-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.91,
+          "result": "pass",
+          "scenario": "control-plane/sync-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.0,
+          "result": "pass",
+          "scenario": "deck/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.15,
+          "result": "pass",
+          "scenario": "delete/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.19,
+          "result": "pass",
+          "scenario": "diff/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.03,
+          "result": "pass",
+          "scenario": "dump/filtered/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.31,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.98,
+          "result": "pass",
+          "scenario": "event-gateway/dependency-order/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.28,
+          "result": "pass",
+          "scenario": "event-gateway/listener/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.37,
+          "result": "pass",
+          "scenario": "event-gateway/schema-registry/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.08,
+          "result": "pass",
+          "scenario": "explain/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.47,
+          "result": "pass",
+          "scenario": "external/portal-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.59,
+          "result": "pass",
+          "scenario": "org/system-accounts/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.37,
+          "result": "pass",
+          "scenario": "org/teams/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.53,
+          "result": "pass",
+          "scenario": "plan/remote-url-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.08,
+          "result": "pass",
+          "scenario": "portal/app-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.26,
+          "result": "pass",
+          "scenario": "portal/auth_settings/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.86,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy_ref_selection/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.29,
+          "result": "pass",
+          "scenario": "portal/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.82,
+          "result": "pass",
+          "scenario": "portal/ip-allow-list/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.58,
+          "result": "pass",
+          "scenario": "portal/snippets-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 47.38,
+          "result": "pass",
+          "scenario": "portal/visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.81,
+          "result": "pass",
+          "scenario": "protected-resources/portals/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.05,
+          "result": "pass",
+          "scenario": "yaml-tags/env/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.68,
+          "result": "pass",
+          "scenario": "adopt/event-gateway-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.58,
+          "result": "pass",
+          "scenario": "ai-gateway/config-store/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.59,
+          "result": "pass",
+          "scenario": "ai-gateway/mcp-server/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.77,
+          "result": "pass",
+          "scenario": "ai-gateway/policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.99,
+          "result": "pass",
+          "scenario": "analytics/dashboard-repro/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.01,
+          "result": "pass",
+          "scenario": "apis/get-api-by-name-and-id/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "auth/get-me/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.53,
+          "result": "pass",
+          "scenario": "control-plane/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.81,
+          "result": "pass",
+          "scenario": "control-plane/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.0,
+          "result": "pass",
+          "scenario": "deck/multi-file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.94,
+          "result": "pass",
+          "scenario": "delete/dry-run/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.26,
+          "result": "pass",
+          "scenario": "dump/ai-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 26.13,
+          "result": "pass",
+          "scenario": "dump/portal-owned/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.01,
+          "result": "pass",
+          "scenario": "event-gateway/cluster-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.14,
+          "result": "pass",
+          "scenario": "event-gateway/diff/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.88,
+          "result": "pass",
+          "scenario": "event-gateway/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.38,
+          "result": "pass",
+          "scenario": "event-gateway/static-key/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.11,
+          "result": "pass",
+          "scenario": "external/ai-gateway-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.34,
+          "result": "pass",
+          "scenario": "lint/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.97,
+          "result": "pass",
+          "scenario": "org/teams/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.13,
+          "result": "pass",
+          "scenario": "org/teams/roles/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.44,
+          "result": "pass",
+          "scenario": "plan/sync-partial-scope/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "portal/applications/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.19,
+          "result": "pass",
+          "scenario": "portal/auth_settings_deprecated_fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.7,
+          "result": "pass",
+          "scenario": "portal/edit/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.51,
+          "result": "pass",
+          "scenario": "portal/identity_providers/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.15,
+          "result": "pass",
+          "scenario": "portal/oidc-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.85,
+          "result": "pass",
+          "scenario": "portal/snippets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.64,
+          "result": "pass",
+          "scenario": "protected-resources/apis/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.97,
+          "result": "pass",
+          "scenario": "require-namespace/external/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.12,
+          "result": "pass",
+          "scenario": "yaml-tags/file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.45,
+          "result": "pass",
+          "scenario": "adopt/full/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.36,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer-group/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.7,
+          "result": "pass",
+          "scenario": "ai-gateway/model-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.54,
+          "result": "pass",
+          "scenario": "ai-gateway/root/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.94,
+          "result": "pass",
+          "scenario": "analytics/dashboard/scenario.yaml"
+        },
+        {
+          "duration_seconds": 24.53,
+          "result": "pass",
+          "scenario": "apis/nested-child-lifecycle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.57,
+          "result": "pass",
+          "scenario": "catalog/service/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.67,
+          "result": "pass",
+          "scenario": "control-plane/groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.67,
+          "result": "pass",
+          "scenario": "dcr-providers/workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.9,
+          "result": "pass",
+          "scenario": "deck/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.74,
+          "result": "pass",
+          "scenario": "delete/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.26,
+          "result": "pass",
+          "scenario": "dump/analytics-dashboards/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.28,
+          "result": "pass",
+          "scenario": "errors/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 22.45,
+          "result": "pass",
+          "scenario": "event-gateway/consume-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.8,
+          "result": "pass",
+          "scenario": "event-gateway/dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 35.19,
+          "result": "pass",
+          "scenario": "event-gateway/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.67,
+          "result": "pass",
+          "scenario": "event-gateway/tls-trust-bundle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.27,
+          "result": "pass",
+          "scenario": "external/api-impl/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.28,
+          "result": "pass",
+          "scenario": "namespace/defaults-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.02,
+          "result": "pass",
+          "scenario": "org/teams/external-role/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.95,
+          "result": "pass",
+          "scenario": "org/teams/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.03,
+          "result": "pass",
+          "scenario": "plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.3,
+          "result": "pass",
+          "scenario": "portal/assets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 22.19,
+          "result": "pass",
+          "scenario": "portal/custom-domain/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.13,
+          "result": "pass",
+          "scenario": "portal/email-domains/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.14,
+          "result": "pass",
+          "scenario": "portal/identity_providers_duplicate_type/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.55,
+          "result": "pass",
+          "scenario": "portal/page-frontmatter-conflict/scenario.yaml"
+        },
+        {
+          "duration_seconds": 31.71,
+          "result": "pass",
+          "scenario": "portal/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.14,
+          "result": "pass",
+          "scenario": "protected-resources/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.89,
+          "result": "pass",
+          "scenario": "require-namespace/portal/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.89,
+          "result": "pass",
+          "scenario": "adopt/team-create-adopt-dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.12,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.76,
+          "result": "pass",
+          "scenario": "ai-gateway/model-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.18,
+          "result": "pass",
+          "scenario": "ai-gateway/runtime-tls/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.34,
+          "result": "pass",
+          "scenario": "apis/child-delete-namespace/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.69,
+          "result": "pass",
+          "scenario": "apis/region/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.59,
+          "result": "pass",
+          "scenario": "control-plane/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.15,
+          "result": "pass",
+          "scenario": "control-plane/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.66,
+          "result": "pass",
+          "scenario": "deck/basic/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.55,
+          "result": "pass",
+          "scenario": "declarative/plan-mode-validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.29,
+          "result": "pass",
+          "scenario": "delete/partial-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.44,
+          "result": "pass",
+          "scenario": "dump/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.33,
+          "result": "pass",
+          "scenario": "event-gateway/adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.17,
+          "result": "pass",
+          "scenario": "event-gateway/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 19.42,
+          "result": "pass",
+          "scenario": "event-gateway/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "event-gateway/principal-metadata/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.77,
+          "result": "pass",
+          "scenario": "event-gateway/topic-aliases/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.49,
+          "result": "pass",
+          "scenario": "external/api-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.91,
+          "result": "pass",
+          "scenario": "namespace/validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.13,
+          "result": "pass",
+          "scenario": "org/teams/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.44,
+          "result": "pass",
+          "scenario": "patch/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 29.26,
+          "result": "pass",
+          "scenario": "portal/api_docs_with_children/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.77,
+          "result": "pass",
+          "scenario": "portal/audit-log-webhook/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.7,
+          "result": "pass",
+          "scenario": "portal/customization/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.29,
+          "result": "pass",
+          "scenario": "portal/email-templates/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.41,
+          "result": "pass",
+          "scenario": "portal/idp_team_group_mappings_readback/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.07,
+          "result": "pass",
+          "scenario": "portal/pages/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.59,
+          "result": "pass",
+          "scenario": "portal/team_group_mappings_no_idp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.34,
+          "result": "pass",
+          "scenario": "protected-resources/event-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.93,
+          "result": "pass",
+          "scenario": "scaffold/command-coverage/scenario.yaml"
+        }
+      ],
+      "shard_admission_delay_seconds": {
+        "kongctl-acceptance": 3.0,
+        "kongctl-acceptance-2": 4.0,
+        "kongctl-acceptance-3": 3.0,
+        "kongctl-acceptance-4": 4.0,
+        "kongctl-acceptance-5": 3.0
+      },
+      "shard_spread_seconds": 180.0,
+      "shards": [
+        {
+          "execution_duration_seconds": 320,
+          "org_name": "kongctl-acceptance",
+          "selected_scenario_count": 43
+        },
+        {
+          "execution_duration_seconds": 359,
+          "org_name": "kongctl-acceptance-2",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 179,
+          "org_name": "kongctl-acceptance-3",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 343,
+          "org_name": "kongctl-acceptance-4",
+          "selected_scenario_count": 30
+        },
+        {
+          "execution_duration_seconds": 284,
+          "org_name": "kongctl-acceptance-5",
+          "selected_scenario_count": 30
+        }
+      ],
+      "url": "https://github.com/Kong/kongctl/actions/runs/34026314755",
+      "workflow_admission_delay_seconds": 8.0
+    },
+    {
+      "build_job_seconds": 64.0,
+      "build_kongctl_seconds": 8.0,
+      "build_scenario_binary_seconds": 5.0,
+      "build_setup_seconds": 32.0,
+      "cohort": "cache-enabled",
+      "created_at": "2026-09-06T02:59:07Z",
+      "harness_job_seconds": 80.0,
+      "harness_setup_seconds": 12.0,
+      "harness_test_seconds": 55.0,
+      "head_sha": "f5a6c8d66f60dfaa4ae4dd2338eb417dde04a844",
+      "longest_shard_seconds": 357.0,
+      "original_created_at": "2026-09-06T02:59:07Z",
+      "queue_to_required_status_seconds": 539.0,
+      "reset": {
+        "count": 164,
+        "delete_calls": 103,
+        "delete_duration_ms": 9552,
+        "duration_ms": 448513,
+        "list_calls": 2459,
+        "list_duration_ms": 437512,
+        "resources_deleted": 84,
+        "resources_found": 1614
+      },
+      "run_attempt": 1,
+      "run_id": 34007840146,
+      "scenario_durations": [
+        {
+          "duration_seconds": 6.14,
+          "result": "pass",
+          "scenario": "adopt/auth-strategy-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.42,
+          "result": "pass",
+          "scenario": "ai-gateway/agent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.86,
+          "result": "pass",
+          "scenario": "ai-gateway/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.62,
+          "result": "pass",
+          "scenario": "ai-gateway/model/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.73,
+          "result": "pass",
+          "scenario": "ai-gateway/vault/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.01,
+          "result": "pass",
+          "scenario": "apis/comprehensive-fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.71,
+          "result": "pass",
+          "scenario": "apis/root-level-publication-visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.46,
+          "result": "pass",
+          "scenario": "control-plane/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.36,
+          "result": "pass",
+          "scenario": "control-plane/serverless/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.0,
+          "result": "pass",
+          "scenario": "deck/env-vars/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.5,
+          "result": "pass",
+          "scenario": "declarative/rename-sync-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.9,
+          "result": "pass",
+          "scenario": "delete/plan-based/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.61,
+          "result": "pass",
+          "scenario": "dump/dcr-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.96,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.93,
+          "result": "pass",
+          "scenario": "event-gateway/dataplane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.47,
+          "result": "pass",
+          "scenario": "event-gateway/listener-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.27,
+          "result": "pass",
+          "scenario": "event-gateway/produce-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.82,
+          "result": "pass",
+          "scenario": "event-gateway/virtual-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.56,
+          "result": "pass",
+          "scenario": "external/portal-publication/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.23,
+          "result": "pass",
+          "scenario": "org/get-org/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.45,
+          "result": "pass",
+          "scenario": "org/teams/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.89,
+          "result": "pass",
+          "scenario": "plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.85,
+          "result": "pass",
+          "scenario": "portal/api_with_attributes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.76,
+          "result": "pass",
+          "scenario": "portal/auth-strategy-link/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.82,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.23,
+          "result": "pass",
+          "scenario": "portal/email/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.07,
+          "result": "pass",
+          "scenario": "portal/integrations/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.81,
+          "result": "pass",
+          "scenario": "portal/publication-auth-omitted-noop/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.88,
+          "result": "pass",
+          "scenario": "portal/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.99,
+          "result": "pass",
+          "scenario": "protected-resources/org/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.07,
+          "result": "pass",
+          "scenario": "smoke/version/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.69,
+          "result": "pass",
+          "scenario": "apis/eventual-consistency-polp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.93,
+          "result": "pass",
+          "scenario": "dump/organization-teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.48,
+          "result": "pass",
+          "scenario": "org/system-accounts/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.5,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.21,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.7,
+          "result": "pass",
+          "scenario": "org/system-accounts/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.26,
+          "result": "pass",
+          "scenario": "org/token/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.57,
+          "result": "pass",
+          "scenario": "org/users/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.96,
+          "result": "pass",
+          "scenario": "org/users/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.74,
+          "result": "pass",
+          "scenario": "org/users/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.61,
+          "result": "pass",
+          "scenario": "org/users/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.66,
+          "result": "pass",
+          "scenario": "org/users/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.14,
+          "result": "pass",
+          "scenario": "adopt/create-portal-adopt-dump-plan/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.11,
+          "result": "pass",
+          "scenario": "ai-gateway/auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.43,
+          "result": "pass",
+          "scenario": "ai-gateway/maturity/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.35,
+          "result": "pass",
+          "scenario": "ai-gateway/policy-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 29.74,
+          "result": "pass",
+          "scenario": "all/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.14,
+          "result": "pass",
+          "scenario": "apis/control-plane-implementation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.05,
+          "result": "pass",
+          "scenario": "apis/versions-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.66,
+          "result": "pass",
+          "scenario": "control-plane/delete-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.95,
+          "result": "pass",
+          "scenario": "control-plane/sync-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.86,
+          "result": "pass",
+          "scenario": "deck/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.91,
+          "result": "pass",
+          "scenario": "delete/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.03,
+          "result": "pass",
+          "scenario": "diff/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.41,
+          "result": "pass",
+          "scenario": "dump/filtered/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.37,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.88,
+          "result": "pass",
+          "scenario": "event-gateway/dependency-order/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.35,
+          "result": "pass",
+          "scenario": "event-gateway/listener/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.17,
+          "result": "pass",
+          "scenario": "event-gateway/schema-registry/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.32,
+          "result": "pass",
+          "scenario": "explain/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.31,
+          "result": "pass",
+          "scenario": "external/portal-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.68,
+          "result": "pass",
+          "scenario": "org/system-accounts/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.56,
+          "result": "pass",
+          "scenario": "org/teams/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.98,
+          "result": "pass",
+          "scenario": "plan/remote-url-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.32,
+          "result": "pass",
+          "scenario": "portal/app-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.94,
+          "result": "pass",
+          "scenario": "portal/auth_settings/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.63,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy_ref_selection/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.11,
+          "result": "pass",
+          "scenario": "portal/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.78,
+          "result": "pass",
+          "scenario": "portal/ip-allow-list/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.4,
+          "result": "pass",
+          "scenario": "portal/snippets-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 45.57,
+          "result": "pass",
+          "scenario": "portal/visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.21,
+          "result": "pass",
+          "scenario": "protected-resources/portals/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.01,
+          "result": "pass",
+          "scenario": "yaml-tags/env/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.5,
+          "result": "pass",
+          "scenario": "adopt/event-gateway-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.92,
+          "result": "pass",
+          "scenario": "ai-gateway/config-store/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.45,
+          "result": "pass",
+          "scenario": "ai-gateway/mcp-server/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.72,
+          "result": "pass",
+          "scenario": "ai-gateway/policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.3,
+          "result": "pass",
+          "scenario": "analytics/dashboard-repro/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.09,
+          "result": "pass",
+          "scenario": "apis/get-api-by-name-and-id/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "auth/get-me/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.86,
+          "result": "pass",
+          "scenario": "control-plane/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.04,
+          "result": "pass",
+          "scenario": "control-plane/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.55,
+          "result": "pass",
+          "scenario": "deck/multi-file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.15,
+          "result": "pass",
+          "scenario": "delete/dry-run/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.56,
+          "result": "pass",
+          "scenario": "dump/ai-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 49.91,
+          "result": "pass",
+          "scenario": "dump/portal-owned/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.0,
+          "result": "pass",
+          "scenario": "event-gateway/cluster-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.52,
+          "result": "pass",
+          "scenario": "event-gateway/diff/scenario.yaml"
+        },
+        {
+          "duration_seconds": 31.9,
+          "result": "pass",
+          "scenario": "event-gateway/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.32,
+          "result": "pass",
+          "scenario": "event-gateway/static-key/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.97,
+          "result": "pass",
+          "scenario": "external/ai-gateway-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.35,
+          "result": "pass",
+          "scenario": "lint/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.16,
+          "result": "pass",
+          "scenario": "org/teams/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.53,
+          "result": "pass",
+          "scenario": "org/teams/roles/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.35,
+          "result": "pass",
+          "scenario": "plan/sync-partial-scope/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "portal/applications/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.19,
+          "result": "pass",
+          "scenario": "portal/auth_settings_deprecated_fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.12,
+          "result": "pass",
+          "scenario": "portal/edit/scenario.yaml"
+        },
+        {
+          "duration_seconds": 28.55,
+          "result": "pass",
+          "scenario": "portal/identity_providers/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.89,
+          "result": "pass",
+          "scenario": "portal/oidc-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.95,
+          "result": "pass",
+          "scenario": "portal/snippets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.2,
+          "result": "pass",
+          "scenario": "protected-resources/apis/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.77,
+          "result": "pass",
+          "scenario": "require-namespace/external/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.41,
+          "result": "pass",
+          "scenario": "yaml-tags/file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.66,
+          "result": "pass",
+          "scenario": "adopt/full/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.15,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer-group/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.79,
+          "result": "pass",
+          "scenario": "ai-gateway/model-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.69,
+          "result": "pass",
+          "scenario": "ai-gateway/root/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.65,
+          "result": "pass",
+          "scenario": "analytics/dashboard/scenario.yaml"
+        },
+        {
+          "duration_seconds": 24.92,
+          "result": "pass",
+          "scenario": "apis/nested-child-lifecycle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.21,
+          "result": "pass",
+          "scenario": "catalog/service/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.87,
+          "result": "pass",
+          "scenario": "control-plane/groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.55,
+          "result": "pass",
+          "scenario": "dcr-providers/workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.12,
+          "result": "pass",
+          "scenario": "deck/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.12,
+          "result": "pass",
+          "scenario": "delete/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.59,
+          "result": "pass",
+          "scenario": "dump/analytics-dashboards/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.78,
+          "result": "pass",
+          "scenario": "errors/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.79,
+          "result": "pass",
+          "scenario": "event-gateway/consume-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.06,
+          "result": "pass",
+          "scenario": "event-gateway/dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 37.01,
+          "result": "pass",
+          "scenario": "event-gateway/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.94,
+          "result": "pass",
+          "scenario": "event-gateway/tls-trust-bundle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.77,
+          "result": "pass",
+          "scenario": "external/api-impl/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.89,
+          "result": "pass",
+          "scenario": "namespace/defaults-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.44,
+          "result": "pass",
+          "scenario": "org/teams/external-role/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.37,
+          "result": "pass",
+          "scenario": "org/teams/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.44,
+          "result": "pass",
+          "scenario": "plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.74,
+          "result": "pass",
+          "scenario": "portal/assets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.25,
+          "result": "pass",
+          "scenario": "portal/custom-domain/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.17,
+          "result": "pass",
+          "scenario": "portal/email-domains/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.19,
+          "result": "pass",
+          "scenario": "portal/identity_providers_duplicate_type/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.05,
+          "result": "pass",
+          "scenario": "portal/page-frontmatter-conflict/scenario.yaml"
+        },
+        {
+          "duration_seconds": 31.82,
+          "result": "pass",
+          "scenario": "portal/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.31,
+          "result": "pass",
+          "scenario": "protected-resources/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.48,
+          "result": "pass",
+          "scenario": "require-namespace/portal/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.49,
+          "result": "pass",
+          "scenario": "adopt/team-create-adopt-dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.81,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.36,
+          "result": "pass",
+          "scenario": "ai-gateway/model-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.25,
+          "result": "pass",
+          "scenario": "ai-gateway/runtime-tls/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.78,
+          "result": "pass",
+          "scenario": "apis/child-delete-namespace/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.29,
+          "result": "pass",
+          "scenario": "apis/region/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.69,
+          "result": "pass",
+          "scenario": "control-plane/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.95,
+          "result": "pass",
+          "scenario": "control-plane/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.08,
+          "result": "pass",
+          "scenario": "deck/basic/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.45,
+          "result": "pass",
+          "scenario": "declarative/plan-mode-validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.68,
+          "result": "pass",
+          "scenario": "delete/partial-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.43,
+          "result": "pass",
+          "scenario": "dump/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.57,
+          "result": "pass",
+          "scenario": "event-gateway/adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.2,
+          "result": "pass",
+          "scenario": "event-gateway/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 19.82,
+          "result": "pass",
+          "scenario": "event-gateway/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "event-gateway/principal-metadata/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.97,
+          "result": "pass",
+          "scenario": "event-gateway/topic-aliases/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.95,
+          "result": "pass",
+          "scenario": "external/api-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.79,
+          "result": "pass",
+          "scenario": "namespace/validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.52,
+          "result": "pass",
+          "scenario": "org/teams/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.37,
+          "result": "pass",
+          "scenario": "patch/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 30.14,
+          "result": "pass",
+          "scenario": "portal/api_docs_with_children/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.57,
+          "result": "pass",
+          "scenario": "portal/audit-log-webhook/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.25,
+          "result": "pass",
+          "scenario": "portal/customization/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.9,
+          "result": "pass",
+          "scenario": "portal/email-templates/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.91,
+          "result": "pass",
+          "scenario": "portal/idp_team_group_mappings_readback/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.61,
+          "result": "pass",
+          "scenario": "portal/pages/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.9,
+          "result": "pass",
+          "scenario": "portal/team_group_mappings_no_idp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.44,
+          "result": "pass",
+          "scenario": "protected-resources/event-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.78,
+          "result": "pass",
+          "scenario": "scaffold/command-coverage/scenario.yaml"
+        }
+      ],
+      "shard_admission_delay_seconds": {
+        "kongctl-acceptance": 4.0,
+        "kongctl-acceptance-2": 4.0,
+        "kongctl-acceptance-3": 4.0,
+        "kongctl-acceptance-4": 4.0,
+        "kongctl-acceptance-5": 3.0
+      },
+      "shard_spread_seconds": 65.0,
+      "shards": [
+        {
+          "execution_duration_seconds": 299,
+          "org_name": "kongctl-acceptance",
+          "selected_scenario_count": 43
+        },
+        {
+          "execution_duration_seconds": 350,
+          "org_name": "kongctl-acceptance-2",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 344,
+          "org_name": "kongctl-acceptance-3",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 357,
+          "org_name": "kongctl-acceptance-4",
+          "selected_scenario_count": 30
+        },
+        {
+          "execution_duration_seconds": 292,
+          "org_name": "kongctl-acceptance-5",
+          "selected_scenario_count": 30
+        }
+      ],
+      "url": "https://github.com/Kong/kongctl/actions/runs/34007840146",
+      "workflow_admission_delay_seconds": 3.0
+    },
+    {
+      "build_job_seconds": 60.0,
+      "build_kongctl_seconds": 11.0,
+      "build_scenario_binary_seconds": 6.0,
+      "build_setup_seconds": 24.0,
+      "cohort": "cache-enabled",
+      "created_at": "2026-09-06T02:21:19Z",
+      "harness_job_seconds": 72.0,
+      "harness_setup_seconds": 8.0,
+      "harness_test_seconds": 51.0,
+      "head_sha": "dd77efc914c597b02120e6b073978d45a267258a",
+      "longest_shard_seconds": 396.0,
+      "original_created_at": "2026-09-06T02:21:19Z",
+      "queue_to_required_status_seconds": 1139.0,
+      "reset": {
+        "count": 164,
+        "delete_calls": 103,
+        "delete_duration_ms": 8313,
+        "duration_ms": 363366,
+        "list_calls": 2459,
+        "list_duration_ms": 353559,
+        "resources_deleted": 84,
+        "resources_found": 1614
+      },
+      "run_attempt": 1,
+      "run_id": 34006266279,
+      "scenario_durations": [
+        {
+          "duration_seconds": 5.57,
+          "result": "pass",
+          "scenario": "adopt/auth-strategy-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.63,
+          "result": "pass",
+          "scenario": "ai-gateway/agent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.04,
+          "result": "pass",
+          "scenario": "ai-gateway/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.9,
+          "result": "pass",
+          "scenario": "ai-gateway/model/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.24,
+          "result": "pass",
+          "scenario": "ai-gateway/vault/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.03,
+          "result": "pass",
+          "scenario": "apis/comprehensive-fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.08,
+          "result": "pass",
+          "scenario": "apis/root-level-publication-visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.58,
+          "result": "pass",
+          "scenario": "control-plane/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.63,
+          "result": "pass",
+          "scenario": "control-plane/serverless/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.12,
+          "result": "pass",
+          "scenario": "deck/env-vars/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.61,
+          "result": "pass",
+          "scenario": "declarative/rename-sync-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.01,
+          "result": "pass",
+          "scenario": "delete/plan-based/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.16,
+          "result": "pass",
+          "scenario": "dump/dcr-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.98,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.02,
+          "result": "pass",
+          "scenario": "event-gateway/dataplane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.51,
+          "result": "pass",
+          "scenario": "event-gateway/listener-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.55,
+          "result": "pass",
+          "scenario": "event-gateway/produce-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.6,
+          "result": "pass",
+          "scenario": "event-gateway/virtual-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.67,
+          "result": "pass",
+          "scenario": "external/portal-publication/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.27,
+          "result": "pass",
+          "scenario": "org/get-org/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.58,
+          "result": "pass",
+          "scenario": "org/teams/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.7,
+          "result": "pass",
+          "scenario": "plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.31,
+          "result": "pass",
+          "scenario": "portal/api_with_attributes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.29,
+          "result": "pass",
+          "scenario": "portal/auth-strategy-link/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.93,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.08,
+          "result": "pass",
+          "scenario": "portal/email/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.51,
+          "result": "pass",
+          "scenario": "portal/integrations/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.01,
+          "result": "pass",
+          "scenario": "portal/publication-auth-omitted-noop/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.71,
+          "result": "pass",
+          "scenario": "portal/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.01,
+          "result": "pass",
+          "scenario": "protected-resources/org/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.07,
+          "result": "pass",
+          "scenario": "smoke/version/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.7,
+          "result": "pass",
+          "scenario": "apis/eventual-consistency-polp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.06,
+          "result": "pass",
+          "scenario": "dump/organization-teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.43,
+          "result": "pass",
+          "scenario": "org/system-accounts/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.74,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.41,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.8,
+          "result": "pass",
+          "scenario": "org/system-accounts/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.59,
+          "result": "pass",
+          "scenario": "org/token/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.89,
+          "result": "pass",
+          "scenario": "org/users/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.96,
+          "result": "pass",
+          "scenario": "org/users/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.74,
+          "result": "pass",
+          "scenario": "org/users/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.78,
+          "result": "pass",
+          "scenario": "org/users/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.64,
+          "result": "pass",
+          "scenario": "org/users/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.79,
+          "result": "pass",
+          "scenario": "adopt/create-portal-adopt-dump-plan/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.96,
+          "result": "pass",
+          "scenario": "ai-gateway/auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.44,
+          "result": "pass",
+          "scenario": "ai-gateway/maturity/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.91,
+          "result": "pass",
+          "scenario": "ai-gateway/policy-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 33.0,
+          "result": "pass",
+          "scenario": "all/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.94,
+          "result": "pass",
+          "scenario": "apis/control-plane-implementation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.85,
+          "result": "pass",
+          "scenario": "apis/versions-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.45,
+          "result": "pass",
+          "scenario": "control-plane/delete-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.29,
+          "result": "pass",
+          "scenario": "control-plane/sync-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.42,
+          "result": "pass",
+          "scenario": "deck/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.61,
+          "result": "pass",
+          "scenario": "delete/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.68,
+          "result": "pass",
+          "scenario": "diff/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.91,
+          "result": "pass",
+          "scenario": "dump/filtered/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.43,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.87,
+          "result": "pass",
+          "scenario": "event-gateway/dependency-order/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.55,
+          "result": "pass",
+          "scenario": "event-gateway/listener/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.91,
+          "result": "pass",
+          "scenario": "event-gateway/schema-registry/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.4,
+          "result": "pass",
+          "scenario": "explain/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.94,
+          "result": "pass",
+          "scenario": "external/portal-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.23,
+          "result": "pass",
+          "scenario": "org/system-accounts/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.15,
+          "result": "pass",
+          "scenario": "org/teams/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.65,
+          "result": "pass",
+          "scenario": "plan/remote-url-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.57,
+          "result": "pass",
+          "scenario": "portal/app-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.59,
+          "result": "pass",
+          "scenario": "portal/auth_settings/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.27,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy_ref_selection/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.78,
+          "result": "pass",
+          "scenario": "portal/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.34,
+          "result": "pass",
+          "scenario": "portal/ip-allow-list/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.3,
+          "result": "pass",
+          "scenario": "portal/snippets-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 51.15,
+          "result": "pass",
+          "scenario": "portal/visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.11,
+          "result": "pass",
+          "scenario": "protected-resources/portals/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.69,
+          "result": "pass",
+          "scenario": "yaml-tags/env/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.13,
+          "result": "pass",
+          "scenario": "adopt/event-gateway-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.79,
+          "result": "pass",
+          "scenario": "ai-gateway/config-store/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.43,
+          "result": "pass",
+          "scenario": "ai-gateway/mcp-server/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.43,
+          "result": "pass",
+          "scenario": "ai-gateway/policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.98,
+          "result": "pass",
+          "scenario": "analytics/dashboard-repro/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.62,
+          "result": "pass",
+          "scenario": "apis/get-api-by-name-and-id/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "auth/get-me/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.03,
+          "result": "pass",
+          "scenario": "control-plane/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.46,
+          "result": "pass",
+          "scenario": "control-plane/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.52,
+          "result": "pass",
+          "scenario": "deck/multi-file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.6,
+          "result": "pass",
+          "scenario": "delete/dry-run/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.8,
+          "result": "pass",
+          "scenario": "dump/ai-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 22.46,
+          "result": "pass",
+          "scenario": "dump/portal-owned/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.91,
+          "result": "pass",
+          "scenario": "event-gateway/cluster-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.4,
+          "result": "pass",
+          "scenario": "event-gateway/diff/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.66,
+          "result": "pass",
+          "scenario": "event-gateway/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.81,
+          "result": "pass",
+          "scenario": "event-gateway/static-key/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.37,
+          "result": "pass",
+          "scenario": "external/ai-gateway-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.35,
+          "result": "pass",
+          "scenario": "lint/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.51,
+          "result": "pass",
+          "scenario": "org/teams/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.17,
+          "result": "pass",
+          "scenario": "org/teams/roles/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.05,
+          "result": "pass",
+          "scenario": "plan/sync-partial-scope/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "portal/applications/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.2,
+          "result": "pass",
+          "scenario": "portal/auth_settings_deprecated_fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.26,
+          "result": "pass",
+          "scenario": "portal/edit/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.88,
+          "result": "pass",
+          "scenario": "portal/identity_providers/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.87,
+          "result": "pass",
+          "scenario": "portal/oidc-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.28,
+          "result": "pass",
+          "scenario": "portal/snippets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.89,
+          "result": "pass",
+          "scenario": "protected-resources/apis/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.68,
+          "result": "pass",
+          "scenario": "require-namespace/external/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.77,
+          "result": "pass",
+          "scenario": "yaml-tags/file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.37,
+          "result": "pass",
+          "scenario": "adopt/full/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.53,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer-group/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.77,
+          "result": "pass",
+          "scenario": "ai-gateway/model-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.97,
+          "result": "pass",
+          "scenario": "ai-gateway/root/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.18,
+          "result": "pass",
+          "scenario": "analytics/dashboard/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.94,
+          "result": "pass",
+          "scenario": "apis/nested-child-lifecycle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.95,
+          "result": "pass",
+          "scenario": "catalog/service/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.77,
+          "result": "pass",
+          "scenario": "control-plane/groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.79,
+          "result": "pass",
+          "scenario": "dcr-providers/workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.29,
+          "result": "pass",
+          "scenario": "deck/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.85,
+          "result": "pass",
+          "scenario": "delete/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.1,
+          "result": "pass",
+          "scenario": "dump/analytics-dashboards/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.08,
+          "result": "pass",
+          "scenario": "errors/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.72,
+          "result": "pass",
+          "scenario": "event-gateway/consume-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.66,
+          "result": "pass",
+          "scenario": "event-gateway/dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.65,
+          "result": "pass",
+          "scenario": "event-gateway/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.7,
+          "result": "pass",
+          "scenario": "event-gateway/tls-trust-bundle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.58,
+          "result": "pass",
+          "scenario": "external/api-impl/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.95,
+          "result": "pass",
+          "scenario": "namespace/defaults-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.68,
+          "result": "pass",
+          "scenario": "org/teams/external-role/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.88,
+          "result": "pass",
+          "scenario": "org/teams/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.15,
+          "result": "pass",
+          "scenario": "plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.89,
+          "result": "pass",
+          "scenario": "portal/assets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.32,
+          "result": "pass",
+          "scenario": "portal/custom-domain/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.5,
+          "result": "pass",
+          "scenario": "portal/email-domains/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.19,
+          "result": "pass",
+          "scenario": "portal/identity_providers_duplicate_type/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.08,
+          "result": "pass",
+          "scenario": "portal/page-frontmatter-conflict/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.48,
+          "result": "pass",
+          "scenario": "portal/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.34,
+          "result": "pass",
+          "scenario": "protected-resources/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.14,
+          "result": "pass",
+          "scenario": "require-namespace/portal/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.82,
+          "result": "pass",
+          "scenario": "adopt/team-create-adopt-dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.37,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.27,
+          "result": "pass",
+          "scenario": "ai-gateway/model-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.1,
+          "result": "pass",
+          "scenario": "ai-gateway/runtime-tls/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.22,
+          "result": "pass",
+          "scenario": "apis/child-delete-namespace/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.78,
+          "result": "pass",
+          "scenario": "apis/region/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.65,
+          "result": "pass",
+          "scenario": "control-plane/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.02,
+          "result": "pass",
+          "scenario": "control-plane/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.68,
+          "result": "pass",
+          "scenario": "deck/basic/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.59,
+          "result": "pass",
+          "scenario": "declarative/plan-mode-validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.16,
+          "result": "pass",
+          "scenario": "delete/partial-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.26,
+          "result": "pass",
+          "scenario": "dump/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.57,
+          "result": "pass",
+          "scenario": "event-gateway/adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.52,
+          "result": "pass",
+          "scenario": "event-gateway/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.82,
+          "result": "pass",
+          "scenario": "event-gateway/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "event-gateway/principal-metadata/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.74,
+          "result": "pass",
+          "scenario": "event-gateway/topic-aliases/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.93,
+          "result": "pass",
+          "scenario": "external/api-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.03,
+          "result": "pass",
+          "scenario": "namespace/validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.77,
+          "result": "pass",
+          "scenario": "org/teams/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.47,
+          "result": "pass",
+          "scenario": "patch/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 35.36,
+          "result": "pass",
+          "scenario": "portal/api_docs_with_children/scenario.yaml"
+        },
+        {
+          "duration_seconds": 21.78,
+          "result": "pass",
+          "scenario": "portal/audit-log-webhook/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.86,
+          "result": "pass",
+          "scenario": "portal/customization/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.5,
+          "result": "pass",
+          "scenario": "portal/email-templates/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.84,
+          "result": "pass",
+          "scenario": "portal/idp_team_group_mappings_readback/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.84,
+          "result": "pass",
+          "scenario": "portal/pages/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.3,
+          "result": "pass",
+          "scenario": "portal/team_group_mappings_no_idp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.49,
+          "result": "pass",
+          "scenario": "protected-resources/event-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.0,
+          "result": "pass",
+          "scenario": "scaffold/command-coverage/scenario.yaml"
+        }
+      ],
+      "shard_admission_delay_seconds": {
+        "kongctl-acceptance": 2.0,
+        "kongctl-acceptance-2": 3.0,
+        "kongctl-acceptance-3": 2.0,
+        "kongctl-acceptance-4": 2.0,
+        "kongctl-acceptance-5": 3.0
+      },
+      "shard_spread_seconds": 236.0,
+      "shards": [
+        {
+          "execution_duration_seconds": 306,
+          "org_name": "kongctl-acceptance",
+          "selected_scenario_count": 43
+        },
+        {
+          "execution_duration_seconds": 396,
+          "org_name": "kongctl-acceptance-2",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 160,
+          "org_name": "kongctl-acceptance-3",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 200,
+          "org_name": "kongctl-acceptance-4",
+          "selected_scenario_count": 30
+        },
+        {
+          "execution_duration_seconds": 344,
+          "org_name": "kongctl-acceptance-5",
+          "selected_scenario_count": 30
+        }
+      ],
+      "url": "https://github.com/Kong/kongctl/actions/runs/34006266279",
+      "workflow_admission_delay_seconds": 571.0
+    },
+    {
+      "build_job_seconds": 42.0,
+      "build_kongctl_seconds": 5.0,
+      "build_scenario_binary_seconds": 1.0,
+      "build_setup_seconds": 20.0,
+      "cohort": "cache-enabled",
+      "created_at": "2026-09-06T02:20:06Z",
+      "harness_job_seconds": 65.0,
+      "harness_setup_seconds": 10.0,
+      "harness_test_seconds": 41.0,
+      "head_sha": "89bac8c1e57fa741d5386b05078fe600f1beaf26",
+      "longest_shard_seconds": 480.0,
+      "original_created_at": "2026-09-06T02:20:06Z",
+      "queue_to_required_status_seconds": 641.0,
+      "reset": {
+        "count": 164,
+        "delete_calls": 103,
+        "delete_duration_ms": 9440,
+        "duration_ms": 415210,
+        "list_calls": 2459,
+        "list_duration_ms": 404252,
+        "resources_deleted": 84,
+        "resources_found": 1614
+      },
+      "run_attempt": 1,
+      "run_id": 34006212666,
+      "scenario_durations": [
+        {
+          "duration_seconds": 8.08,
+          "result": "pass",
+          "scenario": "adopt/auth-strategy-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.19,
+          "result": "pass",
+          "scenario": "ai-gateway/agent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.72,
+          "result": "pass",
+          "scenario": "ai-gateway/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.47,
+          "result": "pass",
+          "scenario": "ai-gateway/model/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.49,
+          "result": "pass",
+          "scenario": "ai-gateway/vault/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.75,
+          "result": "pass",
+          "scenario": "apis/comprehensive-fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.61,
+          "result": "pass",
+          "scenario": "apis/root-level-publication-visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.74,
+          "result": "pass",
+          "scenario": "control-plane/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.83,
+          "result": "pass",
+          "scenario": "control-plane/serverless/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.24,
+          "result": "pass",
+          "scenario": "deck/env-vars/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.54,
+          "result": "pass",
+          "scenario": "declarative/rename-sync-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.45,
+          "result": "pass",
+          "scenario": "delete/plan-based/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.74,
+          "result": "pass",
+          "scenario": "dump/dcr-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.15,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.51,
+          "result": "pass",
+          "scenario": "event-gateway/dataplane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.34,
+          "result": "pass",
+          "scenario": "event-gateway/listener-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 26.12,
+          "result": "pass",
+          "scenario": "event-gateway/produce-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.43,
+          "result": "pass",
+          "scenario": "event-gateway/virtual-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.73,
+          "result": "pass",
+          "scenario": "external/portal-publication/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.1,
+          "result": "pass",
+          "scenario": "org/get-org/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.95,
+          "result": "pass",
+          "scenario": "org/teams/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.96,
+          "result": "pass",
+          "scenario": "plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.35,
+          "result": "pass",
+          "scenario": "portal/api_with_attributes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.07,
+          "result": "pass",
+          "scenario": "portal/auth-strategy-link/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.34,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.64,
+          "result": "pass",
+          "scenario": "portal/email/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.17,
+          "result": "pass",
+          "scenario": "portal/integrations/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.29,
+          "result": "pass",
+          "scenario": "portal/publication-auth-omitted-noop/scenario.yaml"
+        },
+        {
+          "duration_seconds": 25.84,
+          "result": "pass",
+          "scenario": "portal/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.28,
+          "result": "pass",
+          "scenario": "protected-resources/org/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.06,
+          "result": "pass",
+          "scenario": "smoke/version/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.4,
+          "result": "pass",
+          "scenario": "apis/eventual-consistency-polp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.41,
+          "result": "pass",
+          "scenario": "dump/organization-teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.04,
+          "result": "pass",
+          "scenario": "org/system-accounts/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.95,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.73,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.92,
+          "result": "pass",
+          "scenario": "org/system-accounts/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.35,
+          "result": "pass",
+          "scenario": "org/token/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.73,
+          "result": "pass",
+          "scenario": "org/users/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.27,
+          "result": "pass",
+          "scenario": "org/users/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.97,
+          "result": "pass",
+          "scenario": "org/users/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.22,
+          "result": "pass",
+          "scenario": "org/users/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.32,
+          "result": "pass",
+          "scenario": "org/users/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.26,
+          "result": "pass",
+          "scenario": "adopt/create-portal-adopt-dump-plan/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.33,
+          "result": "pass",
+          "scenario": "ai-gateway/auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.43,
+          "result": "pass",
+          "scenario": "ai-gateway/maturity/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.82,
+          "result": "pass",
+          "scenario": "ai-gateway/policy-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.13,
+          "result": "pass",
+          "scenario": "all/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.52,
+          "result": "pass",
+          "scenario": "apis/control-plane-implementation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.63,
+          "result": "pass",
+          "scenario": "apis/versions-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.09,
+          "result": "pass",
+          "scenario": "control-plane/delete-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.42,
+          "result": "pass",
+          "scenario": "control-plane/sync-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.35,
+          "result": "pass",
+          "scenario": "deck/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.06,
+          "result": "pass",
+          "scenario": "delete/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.33,
+          "result": "pass",
+          "scenario": "diff/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.61,
+          "result": "pass",
+          "scenario": "dump/filtered/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.5,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.46,
+          "result": "pass",
+          "scenario": "event-gateway/dependency-order/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.39,
+          "result": "pass",
+          "scenario": "event-gateway/listener/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.56,
+          "result": "pass",
+          "scenario": "event-gateway/schema-registry/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.38,
+          "result": "pass",
+          "scenario": "explain/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.61,
+          "result": "pass",
+          "scenario": "external/portal-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.46,
+          "result": "pass",
+          "scenario": "org/system-accounts/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.29,
+          "result": "pass",
+          "scenario": "org/teams/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.68,
+          "result": "pass",
+          "scenario": "plan/remote-url-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.58,
+          "result": "pass",
+          "scenario": "portal/app-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.33,
+          "result": "pass",
+          "scenario": "portal/auth_settings/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.04,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy_ref_selection/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.45,
+          "result": "pass",
+          "scenario": "portal/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.17,
+          "result": "pass",
+          "scenario": "portal/ip-allow-list/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.19,
+          "result": "pass",
+          "scenario": "portal/snippets-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 25.93,
+          "result": "pass",
+          "scenario": "portal/visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.07,
+          "result": "pass",
+          "scenario": "protected-resources/portals/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.4,
+          "result": "pass",
+          "scenario": "yaml-tags/env/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.93,
+          "result": "pass",
+          "scenario": "adopt/event-gateway-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.64,
+          "result": "pass",
+          "scenario": "ai-gateway/config-store/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.39,
+          "result": "pass",
+          "scenario": "ai-gateway/mcp-server/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.97,
+          "result": "pass",
+          "scenario": "ai-gateway/policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.17,
+          "result": "pass",
+          "scenario": "analytics/dashboard-repro/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.27,
+          "result": "pass",
+          "scenario": "apis/get-api-by-name-and-id/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "auth/get-me/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.93,
+          "result": "pass",
+          "scenario": "control-plane/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.98,
+          "result": "pass",
+          "scenario": "control-plane/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.05,
+          "result": "pass",
+          "scenario": "deck/multi-file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.3,
+          "result": "pass",
+          "scenario": "delete/dry-run/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.41,
+          "result": "pass",
+          "scenario": "dump/ai-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 42.43,
+          "result": "pass",
+          "scenario": "dump/portal-owned/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.47,
+          "result": "pass",
+          "scenario": "event-gateway/cluster-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.67,
+          "result": "pass",
+          "scenario": "event-gateway/diff/scenario.yaml"
+        },
+        {
+          "duration_seconds": 27.75,
+          "result": "pass",
+          "scenario": "event-gateway/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.82,
+          "result": "pass",
+          "scenario": "event-gateway/static-key/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.51,
+          "result": "pass",
+          "scenario": "external/ai-gateway-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.32,
+          "result": "pass",
+          "scenario": "lint/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.4,
+          "result": "pass",
+          "scenario": "org/teams/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.33,
+          "result": "pass",
+          "scenario": "org/teams/roles/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.46,
+          "result": "pass",
+          "scenario": "plan/sync-partial-scope/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "portal/applications/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.18,
+          "result": "pass",
+          "scenario": "portal/auth_settings_deprecated_fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.13,
+          "result": "pass",
+          "scenario": "portal/edit/scenario.yaml"
+        },
+        {
+          "duration_seconds": 25.12,
+          "result": "pass",
+          "scenario": "portal/identity_providers/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.85,
+          "result": "pass",
+          "scenario": "portal/oidc-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.2,
+          "result": "pass",
+          "scenario": "portal/snippets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.34,
+          "result": "pass",
+          "scenario": "protected-resources/apis/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.99,
+          "result": "pass",
+          "scenario": "require-namespace/external/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.51,
+          "result": "pass",
+          "scenario": "yaml-tags/file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.95,
+          "result": "pass",
+          "scenario": "adopt/full/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.65,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer-group/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.63,
+          "result": "pass",
+          "scenario": "ai-gateway/model-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.66,
+          "result": "pass",
+          "scenario": "ai-gateway/root/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.51,
+          "result": "pass",
+          "scenario": "analytics/dashboard/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.53,
+          "result": "pass",
+          "scenario": "apis/nested-child-lifecycle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.87,
+          "result": "pass",
+          "scenario": "catalog/service/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.58,
+          "result": "pass",
+          "scenario": "control-plane/groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.53,
+          "result": "pass",
+          "scenario": "dcr-providers/workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.22,
+          "result": "pass",
+          "scenario": "deck/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.69,
+          "result": "pass",
+          "scenario": "delete/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.03,
+          "result": "pass",
+          "scenario": "dump/analytics-dashboards/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.95,
+          "result": "pass",
+          "scenario": "errors/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.38,
+          "result": "pass",
+          "scenario": "event-gateway/consume-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.41,
+          "result": "pass",
+          "scenario": "event-gateway/dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 19.44,
+          "result": "pass",
+          "scenario": "event-gateway/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.61,
+          "result": "pass",
+          "scenario": "event-gateway/tls-trust-bundle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.59,
+          "result": "pass",
+          "scenario": "external/api-impl/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.93,
+          "result": "pass",
+          "scenario": "namespace/defaults-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.42,
+          "result": "pass",
+          "scenario": "org/teams/external-role/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.79,
+          "result": "pass",
+          "scenario": "org/teams/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.2,
+          "result": "pass",
+          "scenario": "plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.5,
+          "result": "pass",
+          "scenario": "portal/assets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.72,
+          "result": "pass",
+          "scenario": "portal/custom-domain/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.34,
+          "result": "pass",
+          "scenario": "portal/email-domains/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.19,
+          "result": "pass",
+          "scenario": "portal/identity_providers_duplicate_type/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.93,
+          "result": "pass",
+          "scenario": "portal/page-frontmatter-conflict/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.54,
+          "result": "pass",
+          "scenario": "portal/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.16,
+          "result": "pass",
+          "scenario": "protected-resources/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.0,
+          "result": "pass",
+          "scenario": "require-namespace/portal/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.43,
+          "result": "pass",
+          "scenario": "adopt/team-create-adopt-dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.31,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.69,
+          "result": "pass",
+          "scenario": "ai-gateway/model-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.32,
+          "result": "pass",
+          "scenario": "ai-gateway/runtime-tls/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.43,
+          "result": "pass",
+          "scenario": "apis/child-delete-namespace/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.62,
+          "result": "pass",
+          "scenario": "apis/region/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.84,
+          "result": "pass",
+          "scenario": "control-plane/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.04,
+          "result": "pass",
+          "scenario": "control-plane/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.8,
+          "result": "pass",
+          "scenario": "deck/basic/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.59,
+          "result": "pass",
+          "scenario": "declarative/plan-mode-validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.21,
+          "result": "pass",
+          "scenario": "delete/partial-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.4,
+          "result": "pass",
+          "scenario": "dump/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.55,
+          "result": "pass",
+          "scenario": "event-gateway/adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.57,
+          "result": "pass",
+          "scenario": "event-gateway/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 24.23,
+          "result": "pass",
+          "scenario": "event-gateway/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "event-gateway/principal-metadata/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.93,
+          "result": "pass",
+          "scenario": "event-gateway/topic-aliases/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.47,
+          "result": "pass",
+          "scenario": "external/api-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.06,
+          "result": "pass",
+          "scenario": "namespace/validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.85,
+          "result": "pass",
+          "scenario": "org/teams/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.48,
+          "result": "pass",
+          "scenario": "patch/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 35.26,
+          "result": "pass",
+          "scenario": "portal/api_docs_with_children/scenario.yaml"
+        },
+        {
+          "duration_seconds": 21.82,
+          "result": "pass",
+          "scenario": "portal/audit-log-webhook/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.81,
+          "result": "pass",
+          "scenario": "portal/customization/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.43,
+          "result": "pass",
+          "scenario": "portal/email-templates/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.79,
+          "result": "pass",
+          "scenario": "portal/idp_team_group_mappings_readback/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.86,
+          "result": "pass",
+          "scenario": "portal/pages/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.39,
+          "result": "pass",
+          "scenario": "portal/team_group_mappings_no_idp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.52,
+          "result": "pass",
+          "scenario": "protected-resources/event-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.0,
+          "result": "pass",
+          "scenario": "scaffold/command-coverage/scenario.yaml"
+        }
+      ],
+      "shard_admission_delay_seconds": {
+        "kongctl-acceptance": 3.0,
+        "kongctl-acceptance-2": 39.0,
+        "kongctl-acceptance-3": 3.0,
+        "kongctl-acceptance-4": 3.0,
+        "kongctl-acceptance-5": 3.0
+      },
+      "shard_spread_seconds": 286.0,
+      "shards": [
+        {
+          "execution_duration_seconds": 480,
+          "org_name": "kongctl-acceptance",
+          "selected_scenario_count": 43
+        },
+        {
+          "execution_duration_seconds": 194,
+          "org_name": "kongctl-acceptance-2",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 299,
+          "org_name": "kongctl-acceptance-3",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 194,
+          "org_name": "kongctl-acceptance-4",
+          "selected_scenario_count": 30
+        },
+        {
+          "execution_duration_seconds": 346,
+          "org_name": "kongctl-acceptance-5",
+          "selected_scenario_count": 30
+        }
+      ],
+      "url": "https://github.com/Kong/kongctl/actions/runs/34006212666",
+      "workflow_admission_delay_seconds": 7.0
+    },
+    {
+      "build_job_seconds": 44.0,
+      "build_kongctl_seconds": 4.0,
+      "build_scenario_binary_seconds": 1.0,
+      "build_setup_seconds": 22.0,
+      "cohort": "cache-enabled",
+      "created_at": "2026-09-06T01:43:24Z",
+      "harness_job_seconds": 73.0,
+      "harness_setup_seconds": 10.0,
+      "harness_test_seconds": 52.0,
+      "head_sha": "dd50be43fb9af970af02ad3fb347267f1ef3649e",
+      "longest_shard_seconds": 392.0,
+      "original_created_at": "2026-09-06T01:43:24Z",
+      "queue_to_required_status_seconds": 1102.0,
+      "reset": {
+        "count": 164,
+        "delete_calls": 103,
+        "delete_duration_ms": 8984,
+        "duration_ms": 399816,
+        "list_calls": 2459,
+        "list_duration_ms": 389354,
+        "resources_deleted": 84,
+        "resources_found": 1614
+      },
+      "run_attempt": 1,
+      "run_id": 34004626083,
+      "scenario_durations": [
+        {
+          "duration_seconds": 7.03,
+          "result": "pass",
+          "scenario": "adopt/auth-strategy-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.93,
+          "result": "pass",
+          "scenario": "ai-gateway/agent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.32,
+          "result": "pass",
+          "scenario": "ai-gateway/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.31,
+          "result": "pass",
+          "scenario": "ai-gateway/model/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.21,
+          "result": "pass",
+          "scenario": "ai-gateway/vault/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.88,
+          "result": "pass",
+          "scenario": "apis/comprehensive-fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.66,
+          "result": "pass",
+          "scenario": "apis/root-level-publication-visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.4,
+          "result": "pass",
+          "scenario": "control-plane/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.36,
+          "result": "pass",
+          "scenario": "control-plane/serverless/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.63,
+          "result": "pass",
+          "scenario": "deck/env-vars/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.55,
+          "result": "pass",
+          "scenario": "declarative/rename-sync-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.02,
+          "result": "pass",
+          "scenario": "delete/plan-based/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.73,
+          "result": "pass",
+          "scenario": "dump/dcr-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.14,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.94,
+          "result": "pass",
+          "scenario": "event-gateway/dataplane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.68,
+          "result": "pass",
+          "scenario": "event-gateway/listener-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 22.56,
+          "result": "pass",
+          "scenario": "event-gateway/produce-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.65,
+          "result": "pass",
+          "scenario": "event-gateway/virtual-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.33,
+          "result": "pass",
+          "scenario": "external/portal-publication/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.15,
+          "result": "pass",
+          "scenario": "org/get-org/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.78,
+          "result": "pass",
+          "scenario": "org/teams/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.57,
+          "result": "pass",
+          "scenario": "plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.68,
+          "result": "pass",
+          "scenario": "portal/api_with_attributes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.93,
+          "result": "pass",
+          "scenario": "portal/auth-strategy-link/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.94,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.38,
+          "result": "pass",
+          "scenario": "portal/email/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.02,
+          "result": "pass",
+          "scenario": "portal/integrations/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.66,
+          "result": "pass",
+          "scenario": "portal/publication-auth-omitted-noop/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.37,
+          "result": "pass",
+          "scenario": "portal/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.44,
+          "result": "pass",
+          "scenario": "protected-resources/org/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.05,
+          "result": "pass",
+          "scenario": "smoke/version/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.95,
+          "result": "pass",
+          "scenario": "apis/eventual-consistency-polp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.91,
+          "result": "pass",
+          "scenario": "dump/organization-teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.01,
+          "result": "pass",
+          "scenario": "org/system-accounts/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.97,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.38,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.77,
+          "result": "pass",
+          "scenario": "org/system-accounts/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.28,
+          "result": "pass",
+          "scenario": "org/token/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.88,
+          "result": "pass",
+          "scenario": "org/users/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.08,
+          "result": "pass",
+          "scenario": "org/users/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.52,
+          "result": "pass",
+          "scenario": "org/users/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.95,
+          "result": "pass",
+          "scenario": "org/users/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.26,
+          "result": "pass",
+          "scenario": "org/users/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.28,
+          "result": "pass",
+          "scenario": "adopt/create-portal-adopt-dump-plan/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.12,
+          "result": "pass",
+          "scenario": "ai-gateway/auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.43,
+          "result": "pass",
+          "scenario": "ai-gateway/maturity/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.68,
+          "result": "pass",
+          "scenario": "ai-gateway/policy-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 28.97,
+          "result": "pass",
+          "scenario": "all/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.96,
+          "result": "pass",
+          "scenario": "apis/control-plane-implementation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.99,
+          "result": "pass",
+          "scenario": "apis/versions-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.31,
+          "result": "pass",
+          "scenario": "control-plane/delete-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.78,
+          "result": "pass",
+          "scenario": "control-plane/sync-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.43,
+          "result": "pass",
+          "scenario": "deck/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.04,
+          "result": "pass",
+          "scenario": "delete/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.7,
+          "result": "pass",
+          "scenario": "diff/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.3,
+          "result": "pass",
+          "scenario": "dump/filtered/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.39,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.35,
+          "result": "pass",
+          "scenario": "event-gateway/dependency-order/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.22,
+          "result": "pass",
+          "scenario": "event-gateway/listener/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.08,
+          "result": "pass",
+          "scenario": "event-gateway/schema-registry/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.39,
+          "result": "pass",
+          "scenario": "explain/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.78,
+          "result": "pass",
+          "scenario": "external/portal-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.92,
+          "result": "pass",
+          "scenario": "org/system-accounts/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.13,
+          "result": "pass",
+          "scenario": "org/teams/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.43,
+          "result": "pass",
+          "scenario": "plan/remote-url-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.6,
+          "result": "pass",
+          "scenario": "portal/app-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.98,
+          "result": "pass",
+          "scenario": "portal/auth_settings/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.1,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy_ref_selection/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.41,
+          "result": "pass",
+          "scenario": "portal/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.18,
+          "result": "pass",
+          "scenario": "portal/ip-allow-list/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.01,
+          "result": "pass",
+          "scenario": "portal/snippets-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 44.0,
+          "result": "pass",
+          "scenario": "portal/visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.03,
+          "result": "pass",
+          "scenario": "protected-resources/portals/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.94,
+          "result": "pass",
+          "scenario": "yaml-tags/env/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.82,
+          "result": "pass",
+          "scenario": "adopt/event-gateway-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.71,
+          "result": "pass",
+          "scenario": "ai-gateway/config-store/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.22,
+          "result": "pass",
+          "scenario": "ai-gateway/mcp-server/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.33,
+          "result": "pass",
+          "scenario": "ai-gateway/policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.04,
+          "result": "pass",
+          "scenario": "analytics/dashboard-repro/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.05,
+          "result": "pass",
+          "scenario": "apis/get-api-by-name-and-id/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "auth/get-me/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.34,
+          "result": "pass",
+          "scenario": "control-plane/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.61,
+          "result": "pass",
+          "scenario": "control-plane/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.25,
+          "result": "pass",
+          "scenario": "deck/multi-file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.81,
+          "result": "pass",
+          "scenario": "delete/dry-run/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.48,
+          "result": "pass",
+          "scenario": "dump/ai-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 32.45,
+          "result": "pass",
+          "scenario": "dump/portal-owned/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.41,
+          "result": "pass",
+          "scenario": "event-gateway/cluster-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.33,
+          "result": "pass",
+          "scenario": "event-gateway/diff/scenario.yaml"
+        },
+        {
+          "duration_seconds": 21.15,
+          "result": "pass",
+          "scenario": "event-gateway/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.41,
+          "result": "pass",
+          "scenario": "event-gateway/static-key/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.66,
+          "result": "pass",
+          "scenario": "external/ai-gateway-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.34,
+          "result": "pass",
+          "scenario": "lint/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.72,
+          "result": "pass",
+          "scenario": "org/teams/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.98,
+          "result": "pass",
+          "scenario": "org/teams/roles/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.37,
+          "result": "pass",
+          "scenario": "plan/sync-partial-scope/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "portal/applications/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.18,
+          "result": "pass",
+          "scenario": "portal/auth_settings_deprecated_fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.96,
+          "result": "pass",
+          "scenario": "portal/edit/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.0,
+          "result": "pass",
+          "scenario": "portal/identity_providers/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.18,
+          "result": "pass",
+          "scenario": "portal/oidc-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.17,
+          "result": "pass",
+          "scenario": "portal/snippets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.56,
+          "result": "pass",
+          "scenario": "protected-resources/apis/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.71,
+          "result": "pass",
+          "scenario": "require-namespace/external/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.12,
+          "result": "pass",
+          "scenario": "yaml-tags/file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.42,
+          "result": "pass",
+          "scenario": "adopt/full/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.14,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer-group/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.4,
+          "result": "pass",
+          "scenario": "ai-gateway/model-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.26,
+          "result": "pass",
+          "scenario": "ai-gateway/root/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.37,
+          "result": "pass",
+          "scenario": "analytics/dashboard/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.21,
+          "result": "pass",
+          "scenario": "apis/nested-child-lifecycle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.44,
+          "result": "pass",
+          "scenario": "catalog/service/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.44,
+          "result": "pass",
+          "scenario": "control-plane/groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.2,
+          "result": "pass",
+          "scenario": "dcr-providers/workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.23,
+          "result": "pass",
+          "scenario": "deck/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.67,
+          "result": "pass",
+          "scenario": "delete/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.91,
+          "result": "pass",
+          "scenario": "dump/analytics-dashboards/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.7,
+          "result": "pass",
+          "scenario": "errors/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.93,
+          "result": "pass",
+          "scenario": "event-gateway/consume-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.3,
+          "result": "pass",
+          "scenario": "event-gateway/dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.72,
+          "result": "pass",
+          "scenario": "event-gateway/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.37,
+          "result": "pass",
+          "scenario": "event-gateway/tls-trust-bundle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.45,
+          "result": "pass",
+          "scenario": "external/api-impl/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.88,
+          "result": "pass",
+          "scenario": "namespace/defaults-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.2,
+          "result": "pass",
+          "scenario": "org/teams/external-role/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.46,
+          "result": "pass",
+          "scenario": "org/teams/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.86,
+          "result": "pass",
+          "scenario": "plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.3,
+          "result": "pass",
+          "scenario": "portal/assets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.42,
+          "result": "pass",
+          "scenario": "portal/custom-domain/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.32,
+          "result": "pass",
+          "scenario": "portal/email-domains/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.17,
+          "result": "pass",
+          "scenario": "portal/identity_providers_duplicate_type/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.73,
+          "result": "pass",
+          "scenario": "portal/page-frontmatter-conflict/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.97,
+          "result": "pass",
+          "scenario": "portal/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.03,
+          "result": "pass",
+          "scenario": "protected-resources/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.78,
+          "result": "pass",
+          "scenario": "require-namespace/portal/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.34,
+          "result": "pass",
+          "scenario": "adopt/team-create-adopt-dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 19.98,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.11,
+          "result": "pass",
+          "scenario": "ai-gateway/model-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.06,
+          "result": "pass",
+          "scenario": "ai-gateway/runtime-tls/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.18,
+          "result": "pass",
+          "scenario": "apis/child-delete-namespace/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.22,
+          "result": "pass",
+          "scenario": "apis/region/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.74,
+          "result": "pass",
+          "scenario": "control-plane/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.89,
+          "result": "pass",
+          "scenario": "control-plane/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.52,
+          "result": "pass",
+          "scenario": "deck/basic/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.57,
+          "result": "pass",
+          "scenario": "declarative/plan-mode-validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.03,
+          "result": "pass",
+          "scenario": "delete/partial-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.04,
+          "result": "pass",
+          "scenario": "dump/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.57,
+          "result": "pass",
+          "scenario": "event-gateway/adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.45,
+          "result": "pass",
+          "scenario": "event-gateway/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.58,
+          "result": "pass",
+          "scenario": "event-gateway/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "event-gateway/principal-metadata/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.71,
+          "result": "pass",
+          "scenario": "event-gateway/topic-aliases/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.85,
+          "result": "pass",
+          "scenario": "external/api-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.04,
+          "result": "pass",
+          "scenario": "namespace/validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.63,
+          "result": "pass",
+          "scenario": "org/teams/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.46,
+          "result": "pass",
+          "scenario": "patch/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 35.11,
+          "result": "pass",
+          "scenario": "portal/api_docs_with_children/scenario.yaml"
+        },
+        {
+          "duration_seconds": 21.59,
+          "result": "pass",
+          "scenario": "portal/audit-log-webhook/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.02,
+          "result": "pass",
+          "scenario": "portal/customization/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.25,
+          "result": "pass",
+          "scenario": "portal/email-templates/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.77,
+          "result": "pass",
+          "scenario": "portal/idp_team_group_mappings_readback/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.46,
+          "result": "pass",
+          "scenario": "portal/pages/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.07,
+          "result": "pass",
+          "scenario": "portal/team_group_mappings_no_idp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.23,
+          "result": "pass",
+          "scenario": "protected-resources/event-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.99,
+          "result": "pass",
+          "scenario": "scaffold/command-coverage/scenario.yaml"
+        }
+      ],
+      "shard_admission_delay_seconds": {
+        "kongctl-acceptance": 3.0,
+        "kongctl-acceptance-2": 3.0,
+        "kongctl-acceptance-3": 3.0,
+        "kongctl-acceptance-4": 3.0,
+        "kongctl-acceptance-5": 4.0
+      },
+      "shard_spread_seconds": 205.0,
+      "shards": [
+        {
+          "execution_duration_seconds": 392,
+          "org_name": "kongctl-acceptance",
+          "selected_scenario_count": 43
+        },
+        {
+          "execution_duration_seconds": 326,
+          "org_name": "kongctl-acceptance-2",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 226,
+          "org_name": "kongctl-acceptance-3",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 187,
+          "org_name": "kongctl-acceptance-4",
+          "selected_scenario_count": 30
+        },
+        {
+          "execution_duration_seconds": 341,
+          "org_name": "kongctl-acceptance-5",
+          "selected_scenario_count": 30
+        }
+      ],
+      "url": "https://github.com/Kong/kongctl/actions/runs/34004626083",
+      "workflow_admission_delay_seconds": 546.0
+    },
+    {
+      "build_job_seconds": 46.0,
+      "build_kongctl_seconds": 4.0,
+      "build_scenario_binary_seconds": 0.0,
+      "build_setup_seconds": 25.0,
+      "cohort": "cache-enabled",
+      "created_at": "2026-09-06T01:35:05Z",
+      "harness_job_seconds": 72.0,
+      "harness_setup_seconds": 10.0,
+      "harness_test_seconds": 49.0,
+      "head_sha": "fb21bfe7142c48969f7705219a5b04954f2faf8c",
+      "longest_shard_seconds": 583.0,
+      "original_created_at": "2026-09-06T01:35:05Z",
+      "queue_to_required_status_seconds": 1009.0,
+      "reset": {
+        "count": 164,
+        "delete_calls": 103,
+        "delete_duration_ms": 10082,
+        "duration_ms": 462432,
+        "list_calls": 2459,
+        "list_duration_ms": 450914,
+        "resources_deleted": 84,
+        "resources_found": 1614
+      },
+      "run_attempt": 1,
+      "run_id": 34004275715,
+      "scenario_durations": [
+        {
+          "duration_seconds": 9.45,
+          "result": "pass",
+          "scenario": "adopt/auth-strategy-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.25,
+          "result": "pass",
+          "scenario": "ai-gateway/agent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.02,
+          "result": "pass",
+          "scenario": "ai-gateway/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.45,
+          "result": "pass",
+          "scenario": "ai-gateway/model/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.88,
+          "result": "pass",
+          "scenario": "ai-gateway/vault/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.74,
+          "result": "pass",
+          "scenario": "apis/comprehensive-fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 19.72,
+          "result": "pass",
+          "scenario": "apis/root-level-publication-visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.45,
+          "result": "pass",
+          "scenario": "control-plane/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.46,
+          "result": "pass",
+          "scenario": "control-plane/serverless/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.34,
+          "result": "pass",
+          "scenario": "deck/env-vars/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.21,
+          "result": "pass",
+          "scenario": "declarative/rename-sync-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.06,
+          "result": "pass",
+          "scenario": "delete/plan-based/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.12,
+          "result": "pass",
+          "scenario": "dump/dcr-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.44,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.95,
+          "result": "pass",
+          "scenario": "event-gateway/dataplane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.9,
+          "result": "pass",
+          "scenario": "event-gateway/listener-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 32.14,
+          "result": "pass",
+          "scenario": "event-gateway/produce-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.53,
+          "result": "pass",
+          "scenario": "event-gateway/virtual-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.83,
+          "result": "pass",
+          "scenario": "external/portal-publication/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.17,
+          "result": "pass",
+          "scenario": "org/get-org/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.49,
+          "result": "pass",
+          "scenario": "org/teams/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.18,
+          "result": "pass",
+          "scenario": "plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.18,
+          "result": "pass",
+          "scenario": "portal/api_with_attributes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 24.09,
+          "result": "pass",
+          "scenario": "portal/auth-strategy-link/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.71,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.36,
+          "result": "pass",
+          "scenario": "portal/email/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.42,
+          "result": "pass",
+          "scenario": "portal/integrations/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.52,
+          "result": "pass",
+          "scenario": "portal/publication-auth-omitted-noop/scenario.yaml"
+        },
+        {
+          "duration_seconds": 30.63,
+          "result": "pass",
+          "scenario": "portal/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.29,
+          "result": "pass",
+          "scenario": "protected-resources/org/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.06,
+          "result": "pass",
+          "scenario": "smoke/version/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.03,
+          "result": "pass",
+          "scenario": "apis/eventual-consistency-polp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.0,
+          "result": "pass",
+          "scenario": "dump/organization-teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.99,
+          "result": "pass",
+          "scenario": "org/system-accounts/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.71,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.15,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.21,
+          "result": "pass",
+          "scenario": "org/system-accounts/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.85,
+          "result": "pass",
+          "scenario": "org/token/scenario.yaml"
+        },
+        {
+          "duration_seconds": 19.63,
+          "result": "pass",
+          "scenario": "org/users/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.73,
+          "result": "pass",
+          "scenario": "org/users/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.85,
+          "result": "pass",
+          "scenario": "org/users/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.68,
+          "result": "pass",
+          "scenario": "org/users/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.59,
+          "result": "pass",
+          "scenario": "org/users/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.55,
+          "result": "pass",
+          "scenario": "adopt/create-portal-adopt-dump-plan/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.93,
+          "result": "pass",
+          "scenario": "ai-gateway/auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.42,
+          "result": "pass",
+          "scenario": "ai-gateway/maturity/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.54,
+          "result": "pass",
+          "scenario": "ai-gateway/policy-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 19.72,
+          "result": "pass",
+          "scenario": "all/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.34,
+          "result": "pass",
+          "scenario": "apis/control-plane-implementation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.93,
+          "result": "pass",
+          "scenario": "apis/versions-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.43,
+          "result": "pass",
+          "scenario": "control-plane/delete-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.89,
+          "result": "pass",
+          "scenario": "control-plane/sync-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.1,
+          "result": "pass",
+          "scenario": "deck/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.64,
+          "result": "pass",
+          "scenario": "delete/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.79,
+          "result": "pass",
+          "scenario": "diff/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.12,
+          "result": "pass",
+          "scenario": "dump/filtered/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.48,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.93,
+          "result": "pass",
+          "scenario": "event-gateway/dependency-order/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.01,
+          "result": "pass",
+          "scenario": "event-gateway/listener/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.35,
+          "result": "pass",
+          "scenario": "event-gateway/schema-registry/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.38,
+          "result": "pass",
+          "scenario": "explain/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.95,
+          "result": "pass",
+          "scenario": "external/portal-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.86,
+          "result": "pass",
+          "scenario": "org/system-accounts/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.72,
+          "result": "pass",
+          "scenario": "org/teams/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.1,
+          "result": "pass",
+          "scenario": "plan/remote-url-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.97,
+          "result": "pass",
+          "scenario": "portal/app-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.08,
+          "result": "pass",
+          "scenario": "portal/auth_settings/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.39,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy_ref_selection/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.07,
+          "result": "pass",
+          "scenario": "portal/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.96,
+          "result": "pass",
+          "scenario": "portal/ip-allow-list/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.5,
+          "result": "pass",
+          "scenario": "portal/snippets-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 28.28,
+          "result": "pass",
+          "scenario": "portal/visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.89,
+          "result": "pass",
+          "scenario": "protected-resources/portals/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.16,
+          "result": "pass",
+          "scenario": "yaml-tags/env/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.13,
+          "result": "pass",
+          "scenario": "adopt/event-gateway-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.62,
+          "result": "pass",
+          "scenario": "ai-gateway/config-store/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.56,
+          "result": "pass",
+          "scenario": "ai-gateway/mcp-server/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.67,
+          "result": "pass",
+          "scenario": "ai-gateway/policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.29,
+          "result": "pass",
+          "scenario": "analytics/dashboard-repro/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.09,
+          "result": "pass",
+          "scenario": "apis/get-api-by-name-and-id/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "auth/get-me/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.69,
+          "result": "pass",
+          "scenario": "control-plane/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.57,
+          "result": "pass",
+          "scenario": "control-plane/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.96,
+          "result": "pass",
+          "scenario": "deck/multi-file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.97,
+          "result": "pass",
+          "scenario": "delete/dry-run/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.76,
+          "result": "pass",
+          "scenario": "dump/ai-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 49.77,
+          "result": "pass",
+          "scenario": "dump/portal-owned/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.15,
+          "result": "pass",
+          "scenario": "event-gateway/cluster-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.6,
+          "result": "pass",
+          "scenario": "event-gateway/diff/scenario.yaml"
+        },
+        {
+          "duration_seconds": 32.02,
+          "result": "pass",
+          "scenario": "event-gateway/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.53,
+          "result": "pass",
+          "scenario": "event-gateway/static-key/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.06,
+          "result": "pass",
+          "scenario": "external/ai-gateway-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.35,
+          "result": "pass",
+          "scenario": "lint/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.19,
+          "result": "pass",
+          "scenario": "org/teams/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.63,
+          "result": "pass",
+          "scenario": "org/teams/roles/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.59,
+          "result": "pass",
+          "scenario": "plan/sync-partial-scope/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "portal/applications/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.19,
+          "result": "pass",
+          "scenario": "portal/auth_settings_deprecated_fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.28,
+          "result": "pass",
+          "scenario": "portal/edit/scenario.yaml"
+        },
+        {
+          "duration_seconds": 29.18,
+          "result": "pass",
+          "scenario": "portal/identity_providers/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.97,
+          "result": "pass",
+          "scenario": "portal/oidc-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.57,
+          "result": "pass",
+          "scenario": "portal/snippets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.24,
+          "result": "pass",
+          "scenario": "protected-resources/apis/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.88,
+          "result": "pass",
+          "scenario": "require-namespace/external/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.48,
+          "result": "pass",
+          "scenario": "yaml-tags/file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.55,
+          "result": "pass",
+          "scenario": "adopt/full/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.61,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer-group/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.67,
+          "result": "pass",
+          "scenario": "ai-gateway/model-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.68,
+          "result": "pass",
+          "scenario": "ai-gateway/root/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.5,
+          "result": "pass",
+          "scenario": "analytics/dashboard/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.26,
+          "result": "pass",
+          "scenario": "apis/nested-child-lifecycle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.73,
+          "result": "pass",
+          "scenario": "catalog/service/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.53,
+          "result": "pass",
+          "scenario": "control-plane/groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.37,
+          "result": "pass",
+          "scenario": "dcr-providers/workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.04,
+          "result": "pass",
+          "scenario": "deck/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.71,
+          "result": "pass",
+          "scenario": "delete/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.92,
+          "result": "pass",
+          "scenario": "dump/analytics-dashboards/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.89,
+          "result": "pass",
+          "scenario": "errors/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.24,
+          "result": "pass",
+          "scenario": "event-gateway/consume-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.3,
+          "result": "pass",
+          "scenario": "event-gateway/dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 19.48,
+          "result": "pass",
+          "scenario": "event-gateway/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.54,
+          "result": "pass",
+          "scenario": "event-gateway/tls-trust-bundle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.58,
+          "result": "pass",
+          "scenario": "external/api-impl/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.89,
+          "result": "pass",
+          "scenario": "namespace/defaults-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.42,
+          "result": "pass",
+          "scenario": "org/teams/external-role/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.59,
+          "result": "pass",
+          "scenario": "org/teams/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.02,
+          "result": "pass",
+          "scenario": "plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.53,
+          "result": "pass",
+          "scenario": "portal/assets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.76,
+          "result": "pass",
+          "scenario": "portal/custom-domain/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.35,
+          "result": "pass",
+          "scenario": "portal/email-domains/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.18,
+          "result": "pass",
+          "scenario": "portal/identity_providers_duplicate_type/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.78,
+          "result": "pass",
+          "scenario": "portal/page-frontmatter-conflict/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.55,
+          "result": "pass",
+          "scenario": "portal/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.21,
+          "result": "pass",
+          "scenario": "protected-resources/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.89,
+          "result": "pass",
+          "scenario": "require-namespace/portal/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.39,
+          "result": "pass",
+          "scenario": "adopt/team-create-adopt-dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.84,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.38,
+          "result": "pass",
+          "scenario": "ai-gateway/model-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.49,
+          "result": "pass",
+          "scenario": "ai-gateway/runtime-tls/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.8,
+          "result": "pass",
+          "scenario": "apis/child-delete-namespace/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.5,
+          "result": "pass",
+          "scenario": "apis/region/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.01,
+          "result": "pass",
+          "scenario": "control-plane/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.05,
+          "result": "pass",
+          "scenario": "control-plane/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.0,
+          "result": "pass",
+          "scenario": "deck/basic/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.47,
+          "result": "pass",
+          "scenario": "declarative/plan-mode-validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.58,
+          "result": "pass",
+          "scenario": "delete/partial-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.74,
+          "result": "pass",
+          "scenario": "dump/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.52,
+          "result": "pass",
+          "scenario": "event-gateway/adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.22,
+          "result": "pass",
+          "scenario": "event-gateway/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.01,
+          "result": "pass",
+          "scenario": "event-gateway/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "event-gateway/principal-metadata/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.09,
+          "result": "pass",
+          "scenario": "event-gateway/topic-aliases/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.83,
+          "result": "pass",
+          "scenario": "external/api-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.82,
+          "result": "pass",
+          "scenario": "namespace/validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.61,
+          "result": "pass",
+          "scenario": "org/teams/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.37,
+          "result": "pass",
+          "scenario": "patch/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 30.21,
+          "result": "pass",
+          "scenario": "portal/api_docs_with_children/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.61,
+          "result": "pass",
+          "scenario": "portal/audit-log-webhook/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.36,
+          "result": "pass",
+          "scenario": "portal/customization/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.1,
+          "result": "pass",
+          "scenario": "portal/email-templates/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.1,
+          "result": "pass",
+          "scenario": "portal/idp_team_group_mappings_readback/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.62,
+          "result": "pass",
+          "scenario": "portal/pages/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.05,
+          "result": "pass",
+          "scenario": "portal/team_group_mappings_no_idp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.8,
+          "result": "pass",
+          "scenario": "protected-resources/event-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.81,
+          "result": "pass",
+          "scenario": "scaffold/command-coverage/scenario.yaml"
+        }
+      ],
+      "shard_admission_delay_seconds": {
+        "kongctl-acceptance": 4.0,
+        "kongctl-acceptance-2": 2.0,
+        "kongctl-acceptance-3": 4.0,
+        "kongctl-acceptance-4": 2.0,
+        "kongctl-acceptance-5": 3.0
+      },
+      "shard_spread_seconds": 392.0,
+      "shards": [
+        {
+          "execution_duration_seconds": 583,
+          "org_name": "kongctl-acceptance",
+          "selected_scenario_count": 43
+        },
+        {
+          "execution_duration_seconds": 213,
+          "org_name": "kongctl-acceptance-2",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 344,
+          "org_name": "kongctl-acceptance-3",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 191,
+          "org_name": "kongctl-acceptance-4",
+          "selected_scenario_count": 30
+        },
+        {
+          "execution_duration_seconds": 294,
+          "org_name": "kongctl-acceptance-5",
+          "selected_scenario_count": 30
+        }
+      ],
+      "url": "https://github.com/Kong/kongctl/actions/runs/34004275715",
+      "workflow_admission_delay_seconds": 259.0
+    },
+    {
+      "build_job_seconds": 50.0,
+      "build_kongctl_seconds": 4.0,
+      "build_scenario_binary_seconds": 1.0,
+      "build_setup_seconds": 26.0,
+      "cohort": "cache-enabled",
+      "created_at": "2026-09-06T01:28:27Z",
+      "harness_job_seconds": 76.0,
+      "harness_setup_seconds": 11.0,
+      "harness_test_seconds": 53.0,
+      "head_sha": "ec465ce1470d236245efa091841cf3148b62854d",
+      "longest_shard_seconds": 344.0,
+      "original_created_at": "2026-09-06T01:28:27Z",
+      "queue_to_required_status_seconds": 532.0,
+      "reset": {
+        "count": 164,
+        "delete_calls": 103,
+        "delete_duration_ms": 8565,
+        "duration_ms": 353542,
+        "list_calls": 2459,
+        "list_duration_ms": 343483,
+        "resources_deleted": 84,
+        "resources_found": 1614
+      },
+      "run_attempt": 1,
+      "run_id": 34003980091,
+      "scenario_durations": [
+        {
+          "duration_seconds": 5.84,
+          "result": "pass",
+          "scenario": "adopt/auth-strategy-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.23,
+          "result": "pass",
+          "scenario": "ai-gateway/agent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.9,
+          "result": "pass",
+          "scenario": "ai-gateway/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.8,
+          "result": "pass",
+          "scenario": "ai-gateway/model/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.96,
+          "result": "pass",
+          "scenario": "ai-gateway/vault/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.66,
+          "result": "pass",
+          "scenario": "apis/comprehensive-fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.9,
+          "result": "pass",
+          "scenario": "apis/root-level-publication-visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.22,
+          "result": "pass",
+          "scenario": "control-plane/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.45,
+          "result": "pass",
+          "scenario": "control-plane/serverless/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.88,
+          "result": "pass",
+          "scenario": "deck/env-vars/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.26,
+          "result": "pass",
+          "scenario": "declarative/rename-sync-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.71,
+          "result": "pass",
+          "scenario": "delete/plan-based/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.45,
+          "result": "pass",
+          "scenario": "dump/dcr-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.78,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.7,
+          "result": "pass",
+          "scenario": "event-gateway/dataplane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.12,
+          "result": "pass",
+          "scenario": "event-gateway/listener-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.89,
+          "result": "pass",
+          "scenario": "event-gateway/produce-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.99,
+          "result": "pass",
+          "scenario": "event-gateway/virtual-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.48,
+          "result": "pass",
+          "scenario": "external/portal-publication/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.05,
+          "result": "pass",
+          "scenario": "org/get-org/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.28,
+          "result": "pass",
+          "scenario": "org/teams/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.34,
+          "result": "pass",
+          "scenario": "plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.85,
+          "result": "pass",
+          "scenario": "portal/api_with_attributes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.97,
+          "result": "pass",
+          "scenario": "portal/auth-strategy-link/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.5,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.44,
+          "result": "pass",
+          "scenario": "portal/email/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.98,
+          "result": "pass",
+          "scenario": "portal/integrations/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.72,
+          "result": "pass",
+          "scenario": "portal/publication-auth-omitted-noop/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.72,
+          "result": "pass",
+          "scenario": "portal/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.73,
+          "result": "pass",
+          "scenario": "protected-resources/org/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.06,
+          "result": "pass",
+          "scenario": "smoke/version/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.51,
+          "result": "pass",
+          "scenario": "apis/eventual-consistency-polp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.3,
+          "result": "pass",
+          "scenario": "dump/organization-teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.1,
+          "result": "pass",
+          "scenario": "org/system-accounts/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.39,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.05,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.44,
+          "result": "pass",
+          "scenario": "org/system-accounts/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.41,
+          "result": "pass",
+          "scenario": "org/token/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.18,
+          "result": "pass",
+          "scenario": "org/users/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.79,
+          "result": "pass",
+          "scenario": "org/users/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.85,
+          "result": "pass",
+          "scenario": "org/users/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.91,
+          "result": "pass",
+          "scenario": "org/users/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.53,
+          "result": "pass",
+          "scenario": "org/users/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.57,
+          "result": "pass",
+          "scenario": "adopt/create-portal-adopt-dump-plan/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.23,
+          "result": "pass",
+          "scenario": "ai-gateway/auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.45,
+          "result": "pass",
+          "scenario": "ai-gateway/maturity/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.92,
+          "result": "pass",
+          "scenario": "ai-gateway/policy-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.27,
+          "result": "pass",
+          "scenario": "all/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.65,
+          "result": "pass",
+          "scenario": "apis/control-plane-implementation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.91,
+          "result": "pass",
+          "scenario": "apis/versions-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.38,
+          "result": "pass",
+          "scenario": "control-plane/delete-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.02,
+          "result": "pass",
+          "scenario": "control-plane/sync-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.0,
+          "result": "pass",
+          "scenario": "deck/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.71,
+          "result": "pass",
+          "scenario": "delete/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.64,
+          "result": "pass",
+          "scenario": "diff/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.33,
+          "result": "pass",
+          "scenario": "dump/filtered/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.43,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.97,
+          "result": "pass",
+          "scenario": "event-gateway/dependency-order/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.12,
+          "result": "pass",
+          "scenario": "event-gateway/listener/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.39,
+          "result": "pass",
+          "scenario": "event-gateway/schema-registry/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.43,
+          "result": "pass",
+          "scenario": "explain/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.99,
+          "result": "pass",
+          "scenario": "external/portal-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.98,
+          "result": "pass",
+          "scenario": "org/system-accounts/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.74,
+          "result": "pass",
+          "scenario": "org/teams/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.1,
+          "result": "pass",
+          "scenario": "plan/remote-url-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.07,
+          "result": "pass",
+          "scenario": "portal/app-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.09,
+          "result": "pass",
+          "scenario": "portal/auth_settings/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.42,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy_ref_selection/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.46,
+          "result": "pass",
+          "scenario": "portal/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.68,
+          "result": "pass",
+          "scenario": "portal/ip-allow-list/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.46,
+          "result": "pass",
+          "scenario": "portal/snippets-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 31.59,
+          "result": "pass",
+          "scenario": "portal/visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.95,
+          "result": "pass",
+          "scenario": "protected-resources/portals/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.26,
+          "result": "pass",
+          "scenario": "yaml-tags/env/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.81,
+          "result": "pass",
+          "scenario": "adopt/event-gateway-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.53,
+          "result": "pass",
+          "scenario": "ai-gateway/config-store/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.76,
+          "result": "pass",
+          "scenario": "ai-gateway/mcp-server/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.76,
+          "result": "pass",
+          "scenario": "ai-gateway/policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.31,
+          "result": "pass",
+          "scenario": "analytics/dashboard-repro/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.03,
+          "result": "pass",
+          "scenario": "apis/get-api-by-name-and-id/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "auth/get-me/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.73,
+          "result": "pass",
+          "scenario": "control-plane/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.8,
+          "result": "pass",
+          "scenario": "control-plane/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.1,
+          "result": "pass",
+          "scenario": "deck/multi-file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.09,
+          "result": "pass",
+          "scenario": "delete/dry-run/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.71,
+          "result": "pass",
+          "scenario": "dump/ai-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 49.25,
+          "result": "pass",
+          "scenario": "dump/portal-owned/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.2,
+          "result": "pass",
+          "scenario": "event-gateway/cluster-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.58,
+          "result": "pass",
+          "scenario": "event-gateway/diff/scenario.yaml"
+        },
+        {
+          "duration_seconds": 32.09,
+          "result": "pass",
+          "scenario": "event-gateway/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.75,
+          "result": "pass",
+          "scenario": "event-gateway/static-key/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.12,
+          "result": "pass",
+          "scenario": "external/ai-gateway-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.35,
+          "result": "pass",
+          "scenario": "lint/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.1,
+          "result": "pass",
+          "scenario": "org/teams/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.61,
+          "result": "pass",
+          "scenario": "org/teams/roles/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.5,
+          "result": "pass",
+          "scenario": "plan/sync-partial-scope/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "portal/applications/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.19,
+          "result": "pass",
+          "scenario": "portal/auth_settings_deprecated_fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.3,
+          "result": "pass",
+          "scenario": "portal/edit/scenario.yaml"
+        },
+        {
+          "duration_seconds": 29.03,
+          "result": "pass",
+          "scenario": "portal/identity_providers/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.96,
+          "result": "pass",
+          "scenario": "portal/oidc-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.56,
+          "result": "pass",
+          "scenario": "portal/snippets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.19,
+          "result": "pass",
+          "scenario": "protected-resources/apis/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.85,
+          "result": "pass",
+          "scenario": "require-namespace/external/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.37,
+          "result": "pass",
+          "scenario": "yaml-tags/file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.51,
+          "result": "pass",
+          "scenario": "adopt/full/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.82,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer-group/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.45,
+          "result": "pass",
+          "scenario": "ai-gateway/model-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.0,
+          "result": "pass",
+          "scenario": "ai-gateway/root/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.63,
+          "result": "pass",
+          "scenario": "analytics/dashboard/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.38,
+          "result": "pass",
+          "scenario": "apis/nested-child-lifecycle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.9,
+          "result": "pass",
+          "scenario": "catalog/service/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.52,
+          "result": "pass",
+          "scenario": "control-plane/groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.53,
+          "result": "pass",
+          "scenario": "dcr-providers/workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.29,
+          "result": "pass",
+          "scenario": "deck/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.72,
+          "result": "pass",
+          "scenario": "delete/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.01,
+          "result": "pass",
+          "scenario": "dump/analytics-dashboards/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.04,
+          "result": "pass",
+          "scenario": "errors/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.63,
+          "result": "pass",
+          "scenario": "event-gateway/consume-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.5,
+          "result": "pass",
+          "scenario": "event-gateway/dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 19.73,
+          "result": "pass",
+          "scenario": "event-gateway/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.64,
+          "result": "pass",
+          "scenario": "event-gateway/tls-trust-bundle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.49,
+          "result": "pass",
+          "scenario": "external/api-impl/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.15,
+          "result": "pass",
+          "scenario": "namespace/defaults-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.28,
+          "result": "pass",
+          "scenario": "org/teams/external-role/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.72,
+          "result": "pass",
+          "scenario": "org/teams/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.07,
+          "result": "pass",
+          "scenario": "plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.57,
+          "result": "pass",
+          "scenario": "portal/assets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.67,
+          "result": "pass",
+          "scenario": "portal/custom-domain/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.3,
+          "result": "pass",
+          "scenario": "portal/email-domains/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.2,
+          "result": "pass",
+          "scenario": "portal/identity_providers_duplicate_type/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.99,
+          "result": "pass",
+          "scenario": "portal/page-frontmatter-conflict/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.63,
+          "result": "pass",
+          "scenario": "portal/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.24,
+          "result": "pass",
+          "scenario": "protected-resources/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.21,
+          "result": "pass",
+          "scenario": "require-namespace/portal/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.6,
+          "result": "pass",
+          "scenario": "adopt/team-create-adopt-dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.02,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.46,
+          "result": "pass",
+          "scenario": "ai-gateway/model-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.03,
+          "result": "pass",
+          "scenario": "ai-gateway/runtime-tls/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.44,
+          "result": "pass",
+          "scenario": "apis/child-delete-namespace/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.44,
+          "result": "pass",
+          "scenario": "apis/region/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.82,
+          "result": "pass",
+          "scenario": "control-plane/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.95,
+          "result": "pass",
+          "scenario": "control-plane/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.66,
+          "result": "pass",
+          "scenario": "deck/basic/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.57,
+          "result": "pass",
+          "scenario": "declarative/plan-mode-validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.11,
+          "result": "pass",
+          "scenario": "delete/partial-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.3,
+          "result": "pass",
+          "scenario": "dump/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.6,
+          "result": "pass",
+          "scenario": "event-gateway/adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.51,
+          "result": "pass",
+          "scenario": "event-gateway/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.74,
+          "result": "pass",
+          "scenario": "event-gateway/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "event-gateway/principal-metadata/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.84,
+          "result": "pass",
+          "scenario": "event-gateway/topic-aliases/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.37,
+          "result": "pass",
+          "scenario": "external/api-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.01,
+          "result": "pass",
+          "scenario": "namespace/validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.95,
+          "result": "pass",
+          "scenario": "org/teams/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.46,
+          "result": "pass",
+          "scenario": "patch/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 35.15,
+          "result": "pass",
+          "scenario": "portal/api_docs_with_children/scenario.yaml"
+        },
+        {
+          "duration_seconds": 21.51,
+          "result": "pass",
+          "scenario": "portal/audit-log-webhook/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.62,
+          "result": "pass",
+          "scenario": "portal/customization/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.34,
+          "result": "pass",
+          "scenario": "portal/email-templates/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.8,
+          "result": "pass",
+          "scenario": "portal/idp_team_group_mappings_readback/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.04,
+          "result": "pass",
+          "scenario": "portal/pages/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.24,
+          "result": "pass",
+          "scenario": "portal/team_group_mappings_no_idp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.28,
+          "result": "pass",
+          "scenario": "protected-resources/event-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.98,
+          "result": "pass",
+          "scenario": "scaffold/command-coverage/scenario.yaml"
+        }
+      ],
+      "shard_admission_delay_seconds": {
+        "kongctl-acceptance": 3.0,
+        "kongctl-acceptance-2": 3.0,
+        "kongctl-acceptance-3": 5.0,
+        "kongctl-acceptance-4": 3.0,
+        "kongctl-acceptance-5": 3.0
+      },
+      "shard_spread_seconds": 147.0,
+      "shards": [
+        {
+          "execution_duration_seconds": 295,
+          "org_name": "kongctl-acceptance",
+          "selected_scenario_count": 43
+        },
+        {
+          "execution_duration_seconds": 219,
+          "org_name": "kongctl-acceptance-2",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 344,
+          "org_name": "kongctl-acceptance-3",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 197,
+          "org_name": "kongctl-acceptance-4",
+          "selected_scenario_count": 30
+        },
+        {
+          "execution_duration_seconds": 344,
+          "org_name": "kongctl-acceptance-5",
+          "selected_scenario_count": 30
+        }
+      ],
+      "url": "https://github.com/Kong/kongctl/actions/runs/34003980091",
+      "workflow_admission_delay_seconds": 3.0
+    },
+    {
+      "build_job_seconds": 50.0,
+      "build_kongctl_seconds": 3.0,
+      "build_scenario_binary_seconds": 1.0,
+      "build_setup_seconds": 29.0,
+      "cohort": "cache-enabled",
+      "created_at": "2026-09-06T01:07:11Z",
+      "harness_job_seconds": 72.0,
+      "harness_setup_seconds": 7.0,
+      "harness_test_seconds": 52.0,
+      "head_sha": "e8401610d5bae874ff6a0a04d654386675558123",
+      "longest_shard_seconds": 508.0,
+      "original_created_at": "2026-09-06T01:07:11Z",
+      "queue_to_required_status_seconds": 707.0,
+      "reset": {
+        "count": 164,
+        "delete_calls": 103,
+        "delete_duration_ms": 9985,
+        "duration_ms": 486068,
+        "list_calls": 2459,
+        "list_duration_ms": 474589,
+        "resources_deleted": 84,
+        "resources_found": 1614
+      },
+      "run_attempt": 1,
+      "run_id": 34003060095,
+      "scenario_durations": [
+        {
+          "duration_seconds": 8.13,
+          "result": "pass",
+          "scenario": "adopt/auth-strategy-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.49,
+          "result": "pass",
+          "scenario": "ai-gateway/agent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.17,
+          "result": "pass",
+          "scenario": "ai-gateway/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.14,
+          "result": "pass",
+          "scenario": "ai-gateway/model/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.1,
+          "result": "pass",
+          "scenario": "ai-gateway/vault/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.3,
+          "result": "pass",
+          "scenario": "apis/comprehensive-fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.6,
+          "result": "pass",
+          "scenario": "apis/root-level-publication-visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.52,
+          "result": "pass",
+          "scenario": "control-plane/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.31,
+          "result": "pass",
+          "scenario": "control-plane/serverless/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.78,
+          "result": "pass",
+          "scenario": "deck/env-vars/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.42,
+          "result": "pass",
+          "scenario": "declarative/rename-sync-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.82,
+          "result": "pass",
+          "scenario": "delete/plan-based/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.26,
+          "result": "pass",
+          "scenario": "dump/dcr-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.45,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.28,
+          "result": "pass",
+          "scenario": "event-gateway/dataplane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.88,
+          "result": "pass",
+          "scenario": "event-gateway/listener-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 28.05,
+          "result": "pass",
+          "scenario": "event-gateway/produce-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.09,
+          "result": "pass",
+          "scenario": "event-gateway/virtual-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.46,
+          "result": "pass",
+          "scenario": "external/portal-publication/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.41,
+          "result": "pass",
+          "scenario": "org/get-org/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.65,
+          "result": "pass",
+          "scenario": "org/teams/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.86,
+          "result": "pass",
+          "scenario": "plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.99,
+          "result": "pass",
+          "scenario": "portal/api_with_attributes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.95,
+          "result": "pass",
+          "scenario": "portal/auth-strategy-link/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.79,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.22,
+          "result": "pass",
+          "scenario": "portal/email/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.65,
+          "result": "pass",
+          "scenario": "portal/integrations/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.85,
+          "result": "pass",
+          "scenario": "portal/publication-auth-omitted-noop/scenario.yaml"
+        },
+        {
+          "duration_seconds": 26.7,
+          "result": "pass",
+          "scenario": "portal/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.37,
+          "result": "pass",
+          "scenario": "protected-resources/org/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.06,
+          "result": "pass",
+          "scenario": "smoke/version/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.71,
+          "result": "pass",
+          "scenario": "apis/eventual-consistency-polp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.88,
+          "result": "pass",
+          "scenario": "dump/organization-teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.93,
+          "result": "pass",
+          "scenario": "org/system-accounts/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.51,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.38,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.55,
+          "result": "pass",
+          "scenario": "org/system-accounts/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.42,
+          "result": "pass",
+          "scenario": "org/token/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.86,
+          "result": "pass",
+          "scenario": "org/users/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.75,
+          "result": "pass",
+          "scenario": "org/users/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.57,
+          "result": "pass",
+          "scenario": "org/users/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.05,
+          "result": "pass",
+          "scenario": "org/users/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.88,
+          "result": "pass",
+          "scenario": "org/users/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.49,
+          "result": "pass",
+          "scenario": "adopt/create-portal-adopt-dump-plan/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.95,
+          "result": "pass",
+          "scenario": "ai-gateway/auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.42,
+          "result": "pass",
+          "scenario": "ai-gateway/maturity/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.34,
+          "result": "pass",
+          "scenario": "ai-gateway/policy-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 28.77,
+          "result": "pass",
+          "scenario": "all/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.78,
+          "result": "pass",
+          "scenario": "apis/control-plane-implementation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.0,
+          "result": "pass",
+          "scenario": "apis/versions-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.19,
+          "result": "pass",
+          "scenario": "control-plane/delete-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.52,
+          "result": "pass",
+          "scenario": "control-plane/sync-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.3,
+          "result": "pass",
+          "scenario": "deck/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.11,
+          "result": "pass",
+          "scenario": "delete/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.84,
+          "result": "pass",
+          "scenario": "diff/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.65,
+          "result": "pass",
+          "scenario": "dump/filtered/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.38,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.37,
+          "result": "pass",
+          "scenario": "event-gateway/dependency-order/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.3,
+          "result": "pass",
+          "scenario": "event-gateway/listener/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.28,
+          "result": "pass",
+          "scenario": "event-gateway/schema-registry/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.34,
+          "result": "pass",
+          "scenario": "explain/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.71,
+          "result": "pass",
+          "scenario": "external/portal-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.13,
+          "result": "pass",
+          "scenario": "org/system-accounts/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.93,
+          "result": "pass",
+          "scenario": "org/teams/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.45,
+          "result": "pass",
+          "scenario": "plan/remote-url-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.65,
+          "result": "pass",
+          "scenario": "portal/app-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.04,
+          "result": "pass",
+          "scenario": "portal/auth_settings/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.17,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy_ref_selection/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.96,
+          "result": "pass",
+          "scenario": "portal/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.51,
+          "result": "pass",
+          "scenario": "portal/ip-allow-list/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.17,
+          "result": "pass",
+          "scenario": "portal/snippets-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 42.11,
+          "result": "pass",
+          "scenario": "portal/visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.38,
+          "result": "pass",
+          "scenario": "protected-resources/portals/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.84,
+          "result": "pass",
+          "scenario": "yaml-tags/env/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.24,
+          "result": "pass",
+          "scenario": "adopt/event-gateway-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.74,
+          "result": "pass",
+          "scenario": "ai-gateway/config-store/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.64,
+          "result": "pass",
+          "scenario": "ai-gateway/mcp-server/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.65,
+          "result": "pass",
+          "scenario": "ai-gateway/policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.4,
+          "result": "pass",
+          "scenario": "analytics/dashboard-repro/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.97,
+          "result": "pass",
+          "scenario": "apis/get-api-by-name-and-id/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "auth/get-me/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.85,
+          "result": "pass",
+          "scenario": "control-plane/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.64,
+          "result": "pass",
+          "scenario": "control-plane/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.18,
+          "result": "pass",
+          "scenario": "deck/multi-file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.08,
+          "result": "pass",
+          "scenario": "delete/dry-run/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.91,
+          "result": "pass",
+          "scenario": "dump/ai-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 50.87,
+          "result": "pass",
+          "scenario": "dump/portal-owned/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.4,
+          "result": "pass",
+          "scenario": "event-gateway/cluster-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.69,
+          "result": "pass",
+          "scenario": "event-gateway/diff/scenario.yaml"
+        },
+        {
+          "duration_seconds": 32.47,
+          "result": "pass",
+          "scenario": "event-gateway/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.55,
+          "result": "pass",
+          "scenario": "event-gateway/static-key/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.04,
+          "result": "pass",
+          "scenario": "external/ai-gateway-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.38,
+          "result": "pass",
+          "scenario": "lint/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.29,
+          "result": "pass",
+          "scenario": "org/teams/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.66,
+          "result": "pass",
+          "scenario": "org/teams/roles/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.5,
+          "result": "pass",
+          "scenario": "plan/sync-partial-scope/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "portal/applications/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.19,
+          "result": "pass",
+          "scenario": "portal/auth_settings_deprecated_fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.36,
+          "result": "pass",
+          "scenario": "portal/edit/scenario.yaml"
+        },
+        {
+          "duration_seconds": 29.42,
+          "result": "pass",
+          "scenario": "portal/identity_providers/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.86,
+          "result": "pass",
+          "scenario": "portal/oidc-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.5,
+          "result": "pass",
+          "scenario": "portal/snippets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.45,
+          "result": "pass",
+          "scenario": "protected-resources/apis/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.04,
+          "result": "pass",
+          "scenario": "require-namespace/external/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.85,
+          "result": "pass",
+          "scenario": "yaml-tags/file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.45,
+          "result": "pass",
+          "scenario": "adopt/full/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.29,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer-group/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.88,
+          "result": "pass",
+          "scenario": "ai-gateway/model-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.51,
+          "result": "pass",
+          "scenario": "ai-gateway/root/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.43,
+          "result": "pass",
+          "scenario": "analytics/dashboard/scenario.yaml"
+        },
+        {
+          "duration_seconds": 25.23,
+          "result": "pass",
+          "scenario": "apis/nested-child-lifecycle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.64,
+          "result": "pass",
+          "scenario": "catalog/service/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.9,
+          "result": "pass",
+          "scenario": "control-plane/groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.9,
+          "result": "pass",
+          "scenario": "dcr-providers/workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.13,
+          "result": "pass",
+          "scenario": "deck/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.92,
+          "result": "pass",
+          "scenario": "delete/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.68,
+          "result": "pass",
+          "scenario": "dump/analytics-dashboards/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.67,
+          "result": "pass",
+          "scenario": "errors/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.82,
+          "result": "pass",
+          "scenario": "event-gateway/consume-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.09,
+          "result": "pass",
+          "scenario": "event-gateway/dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 37.16,
+          "result": "pass",
+          "scenario": "event-gateway/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.27,
+          "result": "pass",
+          "scenario": "event-gateway/tls-trust-bundle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.63,
+          "result": "pass",
+          "scenario": "external/api-impl/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.67,
+          "result": "pass",
+          "scenario": "namespace/defaults-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.57,
+          "result": "pass",
+          "scenario": "org/teams/external-role/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.31,
+          "result": "pass",
+          "scenario": "org/teams/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.48,
+          "result": "pass",
+          "scenario": "plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.73,
+          "result": "pass",
+          "scenario": "portal/assets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 22.91,
+          "result": "pass",
+          "scenario": "portal/custom-domain/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.34,
+          "result": "pass",
+          "scenario": "portal/email-domains/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.18,
+          "result": "pass",
+          "scenario": "portal/identity_providers_duplicate_type/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.14,
+          "result": "pass",
+          "scenario": "portal/page-frontmatter-conflict/scenario.yaml"
+        },
+        {
+          "duration_seconds": 32.14,
+          "result": "pass",
+          "scenario": "portal/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.41,
+          "result": "pass",
+          "scenario": "protected-resources/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.51,
+          "result": "pass",
+          "scenario": "require-namespace/portal/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.2,
+          "result": "pass",
+          "scenario": "adopt/team-create-adopt-dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.99,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.57,
+          "result": "pass",
+          "scenario": "ai-gateway/model-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.71,
+          "result": "pass",
+          "scenario": "ai-gateway/runtime-tls/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.79,
+          "result": "pass",
+          "scenario": "apis/child-delete-namespace/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.5,
+          "result": "pass",
+          "scenario": "apis/region/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.53,
+          "result": "pass",
+          "scenario": "control-plane/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.88,
+          "result": "pass",
+          "scenario": "control-plane/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.49,
+          "result": "pass",
+          "scenario": "deck/basic/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.58,
+          "result": "pass",
+          "scenario": "declarative/plan-mode-validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.71,
+          "result": "pass",
+          "scenario": "delete/partial-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.06,
+          "result": "pass",
+          "scenario": "dump/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.11,
+          "result": "pass",
+          "scenario": "event-gateway/adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.51,
+          "result": "pass",
+          "scenario": "event-gateway/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.03,
+          "result": "pass",
+          "scenario": "event-gateway/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "event-gateway/principal-metadata/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.39,
+          "result": "pass",
+          "scenario": "event-gateway/topic-aliases/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.11,
+          "result": "pass",
+          "scenario": "external/api-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.87,
+          "result": "pass",
+          "scenario": "namespace/validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.27,
+          "result": "pass",
+          "scenario": "org/teams/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.46,
+          "result": "pass",
+          "scenario": "patch/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.28,
+          "result": "pass",
+          "scenario": "portal/api_docs_with_children/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.29,
+          "result": "pass",
+          "scenario": "portal/audit-log-webhook/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.81,
+          "result": "pass",
+          "scenario": "portal/customization/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.86,
+          "result": "pass",
+          "scenario": "portal/email-templates/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.06,
+          "result": "pass",
+          "scenario": "portal/idp_team_group_mappings_readback/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.83,
+          "result": "pass",
+          "scenario": "portal/pages/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.96,
+          "result": "pass",
+          "scenario": "portal/team_group_mappings_no_idp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.0,
+          "result": "pass",
+          "scenario": "protected-resources/event-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.97,
+          "result": "pass",
+          "scenario": "scaffold/command-coverage/scenario.yaml"
+        }
+      ],
+      "shard_admission_delay_seconds": {
+        "kongctl-acceptance": 4.0,
+        "kongctl-acceptance-2": 3.0,
+        "kongctl-acceptance-3": 3.0,
+        "kongctl-acceptance-4": 3.0,
+        "kongctl-acceptance-5": 3.0
+      },
+      "shard_spread_seconds": 319.0,
+      "shards": [
+        {
+          "execution_duration_seconds": 508,
+          "org_name": "kongctl-acceptance",
+          "selected_scenario_count": 43
+        },
+        {
+          "execution_duration_seconds": 325,
+          "org_name": "kongctl-acceptance-2",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 348,
+          "org_name": "kongctl-acceptance-3",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 359,
+          "org_name": "kongctl-acceptance-4",
+          "selected_scenario_count": 30
+        },
+        {
+          "execution_duration_seconds": 189,
+          "org_name": "kongctl-acceptance-5",
+          "selected_scenario_count": 30
+        }
+      ],
+      "url": "https://github.com/Kong/kongctl/actions/runs/34003060095",
+      "workflow_admission_delay_seconds": 30.0
+    },
+    {
+      "build_job_seconds": 43.0,
+      "build_kongctl_seconds": 4.0,
+      "build_scenario_binary_seconds": 1.0,
+      "build_setup_seconds": 22.0,
+      "cohort": "cache-enabled",
+      "created_at": "2026-09-06T00:56:12Z",
+      "harness_job_seconds": 64.0,
+      "harness_setup_seconds": 10.0,
+      "harness_test_seconds": 43.0,
+      "head_sha": "8456f6acc2a16ea07f3d9a0e70e9bf4c81259788",
+      "longest_shard_seconds": 489.0,
+      "original_created_at": "2026-09-06T00:56:12Z",
+      "queue_to_required_status_seconds": 657.0,
+      "reset": {
+        "count": 164,
+        "delete_calls": 103,
+        "delete_duration_ms": 8414,
+        "duration_ms": 385755,
+        "list_calls": 2459,
+        "list_duration_ms": 375836,
+        "resources_deleted": 84,
+        "resources_found": 1614
+      },
+      "run_attempt": 1,
+      "run_id": 34002577998,
+      "scenario_durations": [
+        {
+          "duration_seconds": 8.42,
+          "result": "pass",
+          "scenario": "adopt/auth-strategy-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.9,
+          "result": "pass",
+          "scenario": "ai-gateway/agent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.72,
+          "result": "pass",
+          "scenario": "ai-gateway/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.55,
+          "result": "pass",
+          "scenario": "ai-gateway/model/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.14,
+          "result": "pass",
+          "scenario": "ai-gateway/vault/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.41,
+          "result": "pass",
+          "scenario": "apis/comprehensive-fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.91,
+          "result": "pass",
+          "scenario": "apis/root-level-publication-visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.89,
+          "result": "pass",
+          "scenario": "control-plane/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.93,
+          "result": "pass",
+          "scenario": "control-plane/serverless/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.54,
+          "result": "pass",
+          "scenario": "deck/env-vars/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.74,
+          "result": "pass",
+          "scenario": "declarative/rename-sync-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.58,
+          "result": "pass",
+          "scenario": "delete/plan-based/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.88,
+          "result": "pass",
+          "scenario": "dump/dcr-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.29,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.04,
+          "result": "pass",
+          "scenario": "event-gateway/dataplane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.22,
+          "result": "pass",
+          "scenario": "event-gateway/listener-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 26.86,
+          "result": "pass",
+          "scenario": "event-gateway/produce-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.45,
+          "result": "pass",
+          "scenario": "event-gateway/virtual-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.12,
+          "result": "pass",
+          "scenario": "external/portal-publication/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.81,
+          "result": "pass",
+          "scenario": "org/get-org/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.11,
+          "result": "pass",
+          "scenario": "org/teams/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.25,
+          "result": "pass",
+          "scenario": "plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.42,
+          "result": "pass",
+          "scenario": "portal/api_with_attributes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.42,
+          "result": "pass",
+          "scenario": "portal/auth-strategy-link/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.11,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.9,
+          "result": "pass",
+          "scenario": "portal/email/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.38,
+          "result": "pass",
+          "scenario": "portal/integrations/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.38,
+          "result": "pass",
+          "scenario": "portal/publication-auth-omitted-noop/scenario.yaml"
+        },
+        {
+          "duration_seconds": 25.48,
+          "result": "pass",
+          "scenario": "portal/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.66,
+          "result": "pass",
+          "scenario": "protected-resources/org/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.06,
+          "result": "pass",
+          "scenario": "smoke/version/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.62,
+          "result": "pass",
+          "scenario": "apis/eventual-consistency-polp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.37,
+          "result": "pass",
+          "scenario": "dump/organization-teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.93,
+          "result": "pass",
+          "scenario": "org/system-accounts/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.92,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.72,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.82,
+          "result": "pass",
+          "scenario": "org/system-accounts/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.33,
+          "result": "pass",
+          "scenario": "org/token/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.14,
+          "result": "pass",
+          "scenario": "org/users/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.38,
+          "result": "pass",
+          "scenario": "org/users/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.31,
+          "result": "pass",
+          "scenario": "org/users/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.46,
+          "result": "pass",
+          "scenario": "org/users/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.44,
+          "result": "pass",
+          "scenario": "org/users/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.87,
+          "result": "pass",
+          "scenario": "adopt/create-portal-adopt-dump-plan/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.27,
+          "result": "pass",
+          "scenario": "ai-gateway/auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.36,
+          "result": "pass",
+          "scenario": "ai-gateway/maturity/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.39,
+          "result": "pass",
+          "scenario": "ai-gateway/policy-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.42,
+          "result": "pass",
+          "scenario": "all/scenario.yaml"
+        },
+        {
+          "duration_seconds": 31.08,
+          "result": "pass",
+          "scenario": "apis/control-plane-implementation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.95,
+          "result": "pass",
+          "scenario": "apis/versions-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.29,
+          "result": "pass",
+          "scenario": "control-plane/delete-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.1,
+          "result": "pass",
+          "scenario": "control-plane/sync-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.09,
+          "result": "pass",
+          "scenario": "deck/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.35,
+          "result": "pass",
+          "scenario": "delete/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.27,
+          "result": "pass",
+          "scenario": "diff/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.26,
+          "result": "pass",
+          "scenario": "dump/filtered/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.59,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.99,
+          "result": "pass",
+          "scenario": "event-gateway/dependency-order/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.58,
+          "result": "pass",
+          "scenario": "event-gateway/listener/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.04,
+          "result": "pass",
+          "scenario": "event-gateway/schema-registry/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.11,
+          "result": "pass",
+          "scenario": "explain/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.74,
+          "result": "pass",
+          "scenario": "external/portal-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.81,
+          "result": "pass",
+          "scenario": "org/system-accounts/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.75,
+          "result": "pass",
+          "scenario": "org/teams/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.23,
+          "result": "pass",
+          "scenario": "plan/remote-url-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.28,
+          "result": "pass",
+          "scenario": "portal/app-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.74,
+          "result": "pass",
+          "scenario": "portal/auth_settings/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.93,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy_ref_selection/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.92,
+          "result": "pass",
+          "scenario": "portal/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.03,
+          "result": "pass",
+          "scenario": "portal/ip-allow-list/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.49,
+          "result": "pass",
+          "scenario": "portal/snippets-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 36.85,
+          "result": "pass",
+          "scenario": "portal/visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.49,
+          "result": "pass",
+          "scenario": "protected-resources/portals/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.75,
+          "result": "pass",
+          "scenario": "yaml-tags/env/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.91,
+          "result": "pass",
+          "scenario": "adopt/event-gateway-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.53,
+          "result": "pass",
+          "scenario": "ai-gateway/config-store/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.19,
+          "result": "pass",
+          "scenario": "ai-gateway/mcp-server/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.41,
+          "result": "pass",
+          "scenario": "ai-gateway/policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.92,
+          "result": "pass",
+          "scenario": "analytics/dashboard-repro/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.56,
+          "result": "pass",
+          "scenario": "apis/get-api-by-name-and-id/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "auth/get-me/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.92,
+          "result": "pass",
+          "scenario": "control-plane/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.47,
+          "result": "pass",
+          "scenario": "control-plane/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.37,
+          "result": "pass",
+          "scenario": "deck/multi-file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.61,
+          "result": "pass",
+          "scenario": "delete/dry-run/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.66,
+          "result": "pass",
+          "scenario": "dump/ai-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 22.57,
+          "result": "pass",
+          "scenario": "dump/portal-owned/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.28,
+          "result": "pass",
+          "scenario": "event-gateway/cluster-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.66,
+          "result": "pass",
+          "scenario": "event-gateway/diff/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.98,
+          "result": "pass",
+          "scenario": "event-gateway/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.48,
+          "result": "pass",
+          "scenario": "event-gateway/static-key/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.4,
+          "result": "pass",
+          "scenario": "external/ai-gateway-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.33,
+          "result": "pass",
+          "scenario": "lint/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.49,
+          "result": "pass",
+          "scenario": "org/teams/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.03,
+          "result": "pass",
+          "scenario": "org/teams/roles/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.9,
+          "result": "pass",
+          "scenario": "plan/sync-partial-scope/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "portal/applications/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.18,
+          "result": "pass",
+          "scenario": "portal/auth_settings_deprecated_fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.19,
+          "result": "pass",
+          "scenario": "portal/edit/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.51,
+          "result": "pass",
+          "scenario": "portal/identity_providers/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.69,
+          "result": "pass",
+          "scenario": "portal/oidc-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.42,
+          "result": "pass",
+          "scenario": "portal/snippets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.79,
+          "result": "pass",
+          "scenario": "protected-resources/apis/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.63,
+          "result": "pass",
+          "scenario": "require-namespace/external/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.8,
+          "result": "pass",
+          "scenario": "yaml-tags/file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.4,
+          "result": "pass",
+          "scenario": "adopt/full/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.44,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer-group/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.57,
+          "result": "pass",
+          "scenario": "ai-gateway/model-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.87,
+          "result": "pass",
+          "scenario": "ai-gateway/root/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.63,
+          "result": "pass",
+          "scenario": "analytics/dashboard/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.57,
+          "result": "pass",
+          "scenario": "apis/nested-child-lifecycle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.85,
+          "result": "pass",
+          "scenario": "catalog/service/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.56,
+          "result": "pass",
+          "scenario": "control-plane/groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.59,
+          "result": "pass",
+          "scenario": "dcr-providers/workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.29,
+          "result": "pass",
+          "scenario": "deck/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.72,
+          "result": "pass",
+          "scenario": "delete/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.01,
+          "result": "pass",
+          "scenario": "dump/analytics-dashboards/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.05,
+          "result": "pass",
+          "scenario": "errors/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.56,
+          "result": "pass",
+          "scenario": "event-gateway/consume-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.41,
+          "result": "pass",
+          "scenario": "event-gateway/dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.34,
+          "result": "pass",
+          "scenario": "event-gateway/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.65,
+          "result": "pass",
+          "scenario": "event-gateway/tls-trust-bundle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.68,
+          "result": "pass",
+          "scenario": "external/api-impl/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.06,
+          "result": "pass",
+          "scenario": "namespace/defaults-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.56,
+          "result": "pass",
+          "scenario": "org/teams/external-role/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.62,
+          "result": "pass",
+          "scenario": "org/teams/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.15,
+          "result": "pass",
+          "scenario": "plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.7,
+          "result": "pass",
+          "scenario": "portal/assets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.18,
+          "result": "pass",
+          "scenario": "portal/custom-domain/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.43,
+          "result": "pass",
+          "scenario": "portal/email-domains/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.2,
+          "result": "pass",
+          "scenario": "portal/identity_providers_duplicate_type/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.29,
+          "result": "pass",
+          "scenario": "portal/page-frontmatter-conflict/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.54,
+          "result": "pass",
+          "scenario": "portal/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.3,
+          "result": "pass",
+          "scenario": "protected-resources/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.13,
+          "result": "pass",
+          "scenario": "require-namespace/portal/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.57,
+          "result": "pass",
+          "scenario": "adopt/team-create-adopt-dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.33,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.72,
+          "result": "pass",
+          "scenario": "ai-gateway/model-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.74,
+          "result": "pass",
+          "scenario": "ai-gateway/runtime-tls/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.7,
+          "result": "pass",
+          "scenario": "apis/child-delete-namespace/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.37,
+          "result": "pass",
+          "scenario": "apis/region/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.88,
+          "result": "pass",
+          "scenario": "control-plane/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.25,
+          "result": "pass",
+          "scenario": "control-plane/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.34,
+          "result": "pass",
+          "scenario": "deck/basic/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.57,
+          "result": "pass",
+          "scenario": "declarative/plan-mode-validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.01,
+          "result": "pass",
+          "scenario": "delete/partial-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.68,
+          "result": "pass",
+          "scenario": "dump/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.63,
+          "result": "pass",
+          "scenario": "event-gateway/adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.39,
+          "result": "pass",
+          "scenario": "event-gateway/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.59,
+          "result": "pass",
+          "scenario": "event-gateway/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "event-gateway/principal-metadata/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.23,
+          "result": "pass",
+          "scenario": "event-gateway/topic-aliases/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.94,
+          "result": "pass",
+          "scenario": "external/api-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.97,
+          "result": "pass",
+          "scenario": "namespace/validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.73,
+          "result": "pass",
+          "scenario": "org/teams/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.46,
+          "result": "pass",
+          "scenario": "patch/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 30.78,
+          "result": "pass",
+          "scenario": "portal/api_docs_with_children/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.82,
+          "result": "pass",
+          "scenario": "portal/audit-log-webhook/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.19,
+          "result": "pass",
+          "scenario": "portal/customization/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.14,
+          "result": "pass",
+          "scenario": "portal/email-templates/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.29,
+          "result": "pass",
+          "scenario": "portal/idp_team_group_mappings_readback/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.88,
+          "result": "pass",
+          "scenario": "portal/pages/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.02,
+          "result": "pass",
+          "scenario": "portal/team_group_mappings_no_idp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.78,
+          "result": "pass",
+          "scenario": "protected-resources/event-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.98,
+          "result": "pass",
+          "scenario": "scaffold/command-coverage/scenario.yaml"
+        }
+      ],
+      "shard_admission_delay_seconds": {
+        "kongctl-acceptance": 3.0,
+        "kongctl-acceptance-2": 3.0,
+        "kongctl-acceptance-3": 3.0,
+        "kongctl-acceptance-4": 2.0,
+        "kongctl-acceptance-5": 3.0
+      },
+      "shard_spread_seconds": 329.0,
+      "shards": [
+        {
+          "execution_duration_seconds": 489,
+          "org_name": "kongctl-acceptance",
+          "selected_scenario_count": 43
+        },
+        {
+          "execution_duration_seconds": 290,
+          "org_name": "kongctl-acceptance-2",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 160,
+          "org_name": "kongctl-acceptance-3",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 197,
+          "org_name": "kongctl-acceptance-4",
+          "selected_scenario_count": 30
+        },
+        {
+          "execution_duration_seconds": 300,
+          "org_name": "kongctl-acceptance-5",
+          "selected_scenario_count": 30
+        }
+      ],
+      "url": "https://github.com/Kong/kongctl/actions/runs/34002577998",
+      "workflow_admission_delay_seconds": 2.0
+    },
+    {
+      "build_job_seconds": 43.0,
+      "build_kongctl_seconds": 4.0,
+      "build_scenario_binary_seconds": 1.0,
+      "build_setup_seconds": 22.0,
+      "cohort": "cache-enabled",
+      "created_at": "2026-09-06T00:02:43Z",
+      "harness_job_seconds": 75.0,
+      "harness_setup_seconds": 9.0,
+      "harness_test_seconds": 53.0,
+      "head_sha": "f2d7e9445f96b039d8eef9c42d18bfd302e59c6a",
+      "longest_shard_seconds": 505.0,
+      "original_created_at": "2026-09-06T00:02:43Z",
+      "queue_to_required_status_seconds": 709.0,
+      "reset": {
+        "count": 164,
+        "delete_calls": 103,
+        "delete_duration_ms": 8775,
+        "duration_ms": 418556,
+        "list_calls": 2459,
+        "list_duration_ms": 408352,
+        "resources_deleted": 84,
+        "resources_found": 1614
+      },
+      "run_attempt": 1,
+      "run_id": 34000248405,
+      "scenario_durations": [
+        {
+          "duration_seconds": 8.5,
+          "result": "pass",
+          "scenario": "adopt/auth-strategy-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.13,
+          "result": "pass",
+          "scenario": "ai-gateway/agent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.03,
+          "result": "pass",
+          "scenario": "ai-gateway/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.87,
+          "result": "pass",
+          "scenario": "ai-gateway/model/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.07,
+          "result": "pass",
+          "scenario": "ai-gateway/vault/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.34,
+          "result": "pass",
+          "scenario": "apis/comprehensive-fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.42,
+          "result": "pass",
+          "scenario": "apis/root-level-publication-visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.2,
+          "result": "pass",
+          "scenario": "control-plane/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.78,
+          "result": "pass",
+          "scenario": "control-plane/serverless/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.85,
+          "result": "pass",
+          "scenario": "deck/env-vars/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.56,
+          "result": "pass",
+          "scenario": "declarative/rename-sync-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.85,
+          "result": "pass",
+          "scenario": "delete/plan-based/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.23,
+          "result": "pass",
+          "scenario": "dump/dcr-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.63,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.1,
+          "result": "pass",
+          "scenario": "event-gateway/dataplane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.7,
+          "result": "pass",
+          "scenario": "event-gateway/listener-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 27.5,
+          "result": "pass",
+          "scenario": "event-gateway/produce-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.95,
+          "result": "pass",
+          "scenario": "event-gateway/virtual-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.46,
+          "result": "pass",
+          "scenario": "external/portal-publication/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.54,
+          "result": "pass",
+          "scenario": "org/get-org/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.36,
+          "result": "pass",
+          "scenario": "org/teams/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.67,
+          "result": "pass",
+          "scenario": "plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.8,
+          "result": "pass",
+          "scenario": "portal/api_with_attributes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 21.19,
+          "result": "pass",
+          "scenario": "portal/auth-strategy-link/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.73,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.25,
+          "result": "pass",
+          "scenario": "portal/email/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.47,
+          "result": "pass",
+          "scenario": "portal/integrations/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.99,
+          "result": "pass",
+          "scenario": "portal/publication-auth-omitted-noop/scenario.yaml"
+        },
+        {
+          "duration_seconds": 26.46,
+          "result": "pass",
+          "scenario": "portal/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.02,
+          "result": "pass",
+          "scenario": "protected-resources/org/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.05,
+          "result": "pass",
+          "scenario": "smoke/version/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.83,
+          "result": "pass",
+          "scenario": "apis/eventual-consistency-polp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.34,
+          "result": "pass",
+          "scenario": "dump/organization-teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.81,
+          "result": "pass",
+          "scenario": "org/system-accounts/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.54,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.3,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.49,
+          "result": "pass",
+          "scenario": "org/system-accounts/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.58,
+          "result": "pass",
+          "scenario": "org/token/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.8,
+          "result": "pass",
+          "scenario": "org/users/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.04,
+          "result": "pass",
+          "scenario": "org/users/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.56,
+          "result": "pass",
+          "scenario": "org/users/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.98,
+          "result": "pass",
+          "scenario": "org/users/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.84,
+          "result": "pass",
+          "scenario": "org/users/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.35,
+          "result": "pass",
+          "scenario": "adopt/create-portal-adopt-dump-plan/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.19,
+          "result": "pass",
+          "scenario": "ai-gateway/auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.44,
+          "result": "pass",
+          "scenario": "ai-gateway/maturity/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.21,
+          "result": "pass",
+          "scenario": "ai-gateway/policy-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 35.14,
+          "result": "pass",
+          "scenario": "all/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.38,
+          "result": "pass",
+          "scenario": "apis/control-plane-implementation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.93,
+          "result": "pass",
+          "scenario": "apis/versions-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.7,
+          "result": "pass",
+          "scenario": "control-plane/delete-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.08,
+          "result": "pass",
+          "scenario": "control-plane/sync-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.9,
+          "result": "pass",
+          "scenario": "deck/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.69,
+          "result": "pass",
+          "scenario": "delete/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.95,
+          "result": "pass",
+          "scenario": "diff/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.52,
+          "result": "pass",
+          "scenario": "dump/filtered/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.88,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.2,
+          "result": "pass",
+          "scenario": "event-gateway/dependency-order/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.84,
+          "result": "pass",
+          "scenario": "event-gateway/listener/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.26,
+          "result": "pass",
+          "scenario": "event-gateway/schema-registry/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.41,
+          "result": "pass",
+          "scenario": "explain/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.08,
+          "result": "pass",
+          "scenario": "external/portal-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.42,
+          "result": "pass",
+          "scenario": "org/system-accounts/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.46,
+          "result": "pass",
+          "scenario": "org/teams/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.73,
+          "result": "pass",
+          "scenario": "plan/remote-url-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.73,
+          "result": "pass",
+          "scenario": "portal/app-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.09,
+          "result": "pass",
+          "scenario": "portal/auth_settings/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.46,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy_ref_selection/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.36,
+          "result": "pass",
+          "scenario": "portal/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.61,
+          "result": "pass",
+          "scenario": "portal/ip-allow-list/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.3,
+          "result": "pass",
+          "scenario": "portal/snippets-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 51.73,
+          "result": "pass",
+          "scenario": "portal/visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.4,
+          "result": "pass",
+          "scenario": "protected-resources/portals/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.01,
+          "result": "pass",
+          "scenario": "yaml-tags/env/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.14,
+          "result": "pass",
+          "scenario": "adopt/event-gateway-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.61,
+          "result": "pass",
+          "scenario": "ai-gateway/config-store/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.04,
+          "result": "pass",
+          "scenario": "ai-gateway/mcp-server/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.4,
+          "result": "pass",
+          "scenario": "ai-gateway/policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.95,
+          "result": "pass",
+          "scenario": "analytics/dashboard-repro/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.74,
+          "result": "pass",
+          "scenario": "apis/get-api-by-name-and-id/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "auth/get-me/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.08,
+          "result": "pass",
+          "scenario": "control-plane/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.43,
+          "result": "pass",
+          "scenario": "control-plane/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.47,
+          "result": "pass",
+          "scenario": "deck/multi-file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.61,
+          "result": "pass",
+          "scenario": "delete/dry-run/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.65,
+          "result": "pass",
+          "scenario": "dump/ai-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.36,
+          "result": "pass",
+          "scenario": "dump/portal-owned/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.98,
+          "result": "pass",
+          "scenario": "event-gateway/cluster-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.36,
+          "result": "pass",
+          "scenario": "event-gateway/diff/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.3,
+          "result": "pass",
+          "scenario": "event-gateway/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.75,
+          "result": "pass",
+          "scenario": "event-gateway/static-key/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.19,
+          "result": "pass",
+          "scenario": "external/ai-gateway-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.34,
+          "result": "pass",
+          "scenario": "lint/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.5,
+          "result": "pass",
+          "scenario": "org/teams/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.93,
+          "result": "pass",
+          "scenario": "org/teams/roles/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.93,
+          "result": "pass",
+          "scenario": "plan/sync-partial-scope/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "portal/applications/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.19,
+          "result": "pass",
+          "scenario": "portal/auth_settings_deprecated_fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.27,
+          "result": "pass",
+          "scenario": "portal/edit/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.79,
+          "result": "pass",
+          "scenario": "portal/identity_providers/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.36,
+          "result": "pass",
+          "scenario": "portal/oidc-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.32,
+          "result": "pass",
+          "scenario": "portal/snippets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.0,
+          "result": "pass",
+          "scenario": "protected-resources/apis/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.65,
+          "result": "pass",
+          "scenario": "require-namespace/external/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.76,
+          "result": "pass",
+          "scenario": "yaml-tags/file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.15,
+          "result": "pass",
+          "scenario": "adopt/full/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.24,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer-group/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.87,
+          "result": "pass",
+          "scenario": "ai-gateway/model-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.32,
+          "result": "pass",
+          "scenario": "ai-gateway/root/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.45,
+          "result": "pass",
+          "scenario": "analytics/dashboard/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.86,
+          "result": "pass",
+          "scenario": "apis/nested-child-lifecycle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.85,
+          "result": "pass",
+          "scenario": "catalog/service/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.27,
+          "result": "pass",
+          "scenario": "control-plane/groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.02,
+          "result": "pass",
+          "scenario": "dcr-providers/workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.67,
+          "result": "pass",
+          "scenario": "deck/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.69,
+          "result": "pass",
+          "scenario": "delete/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.27,
+          "result": "pass",
+          "scenario": "dump/analytics-dashboards/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.93,
+          "result": "pass",
+          "scenario": "errors/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.06,
+          "result": "pass",
+          "scenario": "event-gateway/consume-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.33,
+          "result": "pass",
+          "scenario": "event-gateway/dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 28.68,
+          "result": "pass",
+          "scenario": "event-gateway/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.73,
+          "result": "pass",
+          "scenario": "event-gateway/tls-trust-bundle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.39,
+          "result": "pass",
+          "scenario": "external/api-impl/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.23,
+          "result": "pass",
+          "scenario": "namespace/defaults-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.74,
+          "result": "pass",
+          "scenario": "org/teams/external-role/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.02,
+          "result": "pass",
+          "scenario": "org/teams/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.7,
+          "result": "pass",
+          "scenario": "plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.46,
+          "result": "pass",
+          "scenario": "portal/assets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.39,
+          "result": "pass",
+          "scenario": "portal/custom-domain/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.09,
+          "result": "pass",
+          "scenario": "portal/email-domains/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.19,
+          "result": "pass",
+          "scenario": "portal/identity_providers_duplicate_type/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.04,
+          "result": "pass",
+          "scenario": "portal/page-frontmatter-conflict/scenario.yaml"
+        },
+        {
+          "duration_seconds": 24.46,
+          "result": "pass",
+          "scenario": "portal/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.76,
+          "result": "pass",
+          "scenario": "protected-resources/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.08,
+          "result": "pass",
+          "scenario": "require-namespace/portal/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.69,
+          "result": "pass",
+          "scenario": "adopt/team-create-adopt-dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.48,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.28,
+          "result": "pass",
+          "scenario": "ai-gateway/model-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.75,
+          "result": "pass",
+          "scenario": "ai-gateway/runtime-tls/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.86,
+          "result": "pass",
+          "scenario": "apis/child-delete-namespace/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.82,
+          "result": "pass",
+          "scenario": "apis/region/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.25,
+          "result": "pass",
+          "scenario": "control-plane/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.4,
+          "result": "pass",
+          "scenario": "control-plane/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.16,
+          "result": "pass",
+          "scenario": "deck/basic/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.58,
+          "result": "pass",
+          "scenario": "declarative/plan-mode-validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.92,
+          "result": "pass",
+          "scenario": "delete/partial-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.45,
+          "result": "pass",
+          "scenario": "dump/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.7,
+          "result": "pass",
+          "scenario": "event-gateway/adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.79,
+          "result": "pass",
+          "scenario": "event-gateway/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.33,
+          "result": "pass",
+          "scenario": "event-gateway/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "event-gateway/principal-metadata/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.74,
+          "result": "pass",
+          "scenario": "event-gateway/topic-aliases/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.02,
+          "result": "pass",
+          "scenario": "external/api-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.8,
+          "result": "pass",
+          "scenario": "namespace/validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.65,
+          "result": "pass",
+          "scenario": "org/teams/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.45,
+          "result": "pass",
+          "scenario": "patch/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.57,
+          "result": "pass",
+          "scenario": "portal/api_docs_with_children/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.76,
+          "result": "pass",
+          "scenario": "portal/audit-log-webhook/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.83,
+          "result": "pass",
+          "scenario": "portal/customization/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.55,
+          "result": "pass",
+          "scenario": "portal/email-templates/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.67,
+          "result": "pass",
+          "scenario": "portal/idp_team_group_mappings_readback/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.95,
+          "result": "pass",
+          "scenario": "portal/pages/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.55,
+          "result": "pass",
+          "scenario": "portal/team_group_mappings_no_idp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.81,
+          "result": "pass",
+          "scenario": "protected-resources/event-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.97,
+          "result": "pass",
+          "scenario": "scaffold/command-coverage/scenario.yaml"
+        }
+      ],
+      "shard_admission_delay_seconds": {
+        "kongctl-acceptance": 3.0,
+        "kongctl-acceptance-2": 4.0,
+        "kongctl-acceptance-3": 3.0,
+        "kongctl-acceptance-4": 39.0,
+        "kongctl-acceptance-5": 3.0
+      },
+      "shard_spread_seconds": 346.0,
+      "shards": [
+        {
+          "execution_duration_seconds": 505,
+          "org_name": "kongctl-acceptance",
+          "selected_scenario_count": 43
+        },
+        {
+          "execution_duration_seconds": 405,
+          "org_name": "kongctl-acceptance-2",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 159,
+          "org_name": "kongctl-acceptance-3",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 277,
+          "org_name": "kongctl-acceptance-4",
+          "selected_scenario_count": 30
+        },
+        {
+          "execution_duration_seconds": 164,
+          "org_name": "kongctl-acceptance-5",
+          "selected_scenario_count": 30
+        }
+      ],
+      "url": "https://github.com/Kong/kongctl/actions/runs/34000248405",
+      "workflow_admission_delay_seconds": 2.0
+    },
+    {
+      "build_job_seconds": 51.0,
+      "build_kongctl_seconds": 5.0,
+      "build_scenario_binary_seconds": 1.0,
+      "build_setup_seconds": 25.0,
+      "cohort": "cache-enabled",
+      "created_at": "2026-09-05T22:18:22Z",
+      "harness_job_seconds": 74.0,
+      "harness_setup_seconds": 10.0,
+      "harness_test_seconds": 53.0,
+      "head_sha": "27f27fcc85e1ac32b9ee014f3c543be57b474ae6",
+      "longest_shard_seconds": 513.0,
+      "original_created_at": "2026-09-05T22:18:22Z",
+      "queue_to_required_status_seconds": 686.0,
+      "reset": {
+        "count": 164,
+        "delete_calls": 103,
+        "delete_duration_ms": 9495,
+        "duration_ms": 439352,
+        "list_calls": 2459,
+        "list_duration_ms": 428409,
+        "resources_deleted": 84,
+        "resources_found": 1614
+      },
+      "run_attempt": 1,
+      "run_id": 33995527990,
+      "scenario_durations": [
+        {
+          "duration_seconds": 8.35,
+          "result": "pass",
+          "scenario": "adopt/auth-strategy-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.5,
+          "result": "pass",
+          "scenario": "ai-gateway/agent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.57,
+          "result": "pass",
+          "scenario": "ai-gateway/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.37,
+          "result": "pass",
+          "scenario": "ai-gateway/model/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.35,
+          "result": "pass",
+          "scenario": "ai-gateway/vault/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.62,
+          "result": "pass",
+          "scenario": "apis/comprehensive-fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.63,
+          "result": "pass",
+          "scenario": "apis/root-level-publication-visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.83,
+          "result": "pass",
+          "scenario": "control-plane/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.47,
+          "result": "pass",
+          "scenario": "control-plane/serverless/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.98,
+          "result": "pass",
+          "scenario": "deck/env-vars/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.31,
+          "result": "pass",
+          "scenario": "declarative/rename-sync-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.89,
+          "result": "pass",
+          "scenario": "delete/plan-based/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.42,
+          "result": "pass",
+          "scenario": "dump/dcr-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.45,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.67,
+          "result": "pass",
+          "scenario": "event-gateway/dataplane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.14,
+          "result": "pass",
+          "scenario": "event-gateway/listener-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 28.33,
+          "result": "pass",
+          "scenario": "event-gateway/produce-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.56,
+          "result": "pass",
+          "scenario": "event-gateway/virtual-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.73,
+          "result": "pass",
+          "scenario": "external/portal-publication/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.41,
+          "result": "pass",
+          "scenario": "org/get-org/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.42,
+          "result": "pass",
+          "scenario": "org/teams/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.77,
+          "result": "pass",
+          "scenario": "plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.05,
+          "result": "pass",
+          "scenario": "portal/api_with_attributes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 21.23,
+          "result": "pass",
+          "scenario": "portal/auth-strategy-link/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.71,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.52,
+          "result": "pass",
+          "scenario": "portal/email/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.01,
+          "result": "pass",
+          "scenario": "portal/integrations/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.19,
+          "result": "pass",
+          "scenario": "portal/publication-auth-omitted-noop/scenario.yaml"
+        },
+        {
+          "duration_seconds": 26.86,
+          "result": "pass",
+          "scenario": "portal/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.31,
+          "result": "pass",
+          "scenario": "protected-resources/org/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.06,
+          "result": "pass",
+          "scenario": "smoke/version/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.84,
+          "result": "pass",
+          "scenario": "apis/eventual-consistency-polp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.07,
+          "result": "pass",
+          "scenario": "dump/organization-teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.96,
+          "result": "pass",
+          "scenario": "org/system-accounts/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.5,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.67,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.46,
+          "result": "pass",
+          "scenario": "org/system-accounts/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.68,
+          "result": "pass",
+          "scenario": "org/token/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.12,
+          "result": "pass",
+          "scenario": "org/users/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.93,
+          "result": "pass",
+          "scenario": "org/users/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.08,
+          "result": "pass",
+          "scenario": "org/users/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.77,
+          "result": "pass",
+          "scenario": "org/users/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.94,
+          "result": "pass",
+          "scenario": "org/users/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.07,
+          "result": "pass",
+          "scenario": "adopt/create-portal-adopt-dump-plan/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.92,
+          "result": "pass",
+          "scenario": "ai-gateway/auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.31,
+          "result": "pass",
+          "scenario": "ai-gateway/maturity/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.29,
+          "result": "pass",
+          "scenario": "ai-gateway/policy-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.32,
+          "result": "pass",
+          "scenario": "all/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.42,
+          "result": "pass",
+          "scenario": "apis/control-plane-implementation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.8,
+          "result": "pass",
+          "scenario": "apis/versions-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.09,
+          "result": "pass",
+          "scenario": "control-plane/delete-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.1,
+          "result": "pass",
+          "scenario": "control-plane/sync-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.91,
+          "result": "pass",
+          "scenario": "deck/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.04,
+          "result": "pass",
+          "scenario": "delete/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.45,
+          "result": "pass",
+          "scenario": "diff/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.76,
+          "result": "pass",
+          "scenario": "dump/filtered/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.17,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.92,
+          "result": "pass",
+          "scenario": "event-gateway/dependency-order/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.17,
+          "result": "pass",
+          "scenario": "event-gateway/listener/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.68,
+          "result": "pass",
+          "scenario": "event-gateway/schema-registry/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.0,
+          "result": "pass",
+          "scenario": "explain/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.86,
+          "result": "pass",
+          "scenario": "external/portal-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.81,
+          "result": "pass",
+          "scenario": "org/system-accounts/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.41,
+          "result": "pass",
+          "scenario": "org/teams/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.33,
+          "result": "pass",
+          "scenario": "plan/remote-url-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.96,
+          "result": "pass",
+          "scenario": "portal/app-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.13,
+          "result": "pass",
+          "scenario": "portal/auth_settings/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.18,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy_ref_selection/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.96,
+          "result": "pass",
+          "scenario": "portal/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.08,
+          "result": "pass",
+          "scenario": "portal/ip-allow-list/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.69,
+          "result": "pass",
+          "scenario": "portal/snippets-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 33.77,
+          "result": "pass",
+          "scenario": "portal/visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.25,
+          "result": "pass",
+          "scenario": "protected-resources/portals/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.69,
+          "result": "pass",
+          "scenario": "yaml-tags/env/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.89,
+          "result": "pass",
+          "scenario": "adopt/event-gateway-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.41,
+          "result": "pass",
+          "scenario": "ai-gateway/config-store/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.15,
+          "result": "pass",
+          "scenario": "ai-gateway/mcp-server/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.86,
+          "result": "pass",
+          "scenario": "ai-gateway/policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.94,
+          "result": "pass",
+          "scenario": "analytics/dashboard-repro/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.03,
+          "result": "pass",
+          "scenario": "apis/get-api-by-name-and-id/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "auth/get-me/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.37,
+          "result": "pass",
+          "scenario": "control-plane/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.82,
+          "result": "pass",
+          "scenario": "control-plane/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.9,
+          "result": "pass",
+          "scenario": "deck/multi-file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.0,
+          "result": "pass",
+          "scenario": "delete/dry-run/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.29,
+          "result": "pass",
+          "scenario": "dump/ai-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 25.09,
+          "result": "pass",
+          "scenario": "dump/portal-owned/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.44,
+          "result": "pass",
+          "scenario": "event-gateway/cluster-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.13,
+          "result": "pass",
+          "scenario": "event-gateway/diff/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.55,
+          "result": "pass",
+          "scenario": "event-gateway/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.33,
+          "result": "pass",
+          "scenario": "event-gateway/static-key/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.96,
+          "result": "pass",
+          "scenario": "external/ai-gateway-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.33,
+          "result": "pass",
+          "scenario": "lint/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.85,
+          "result": "pass",
+          "scenario": "org/teams/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.96,
+          "result": "pass",
+          "scenario": "org/teams/roles/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.4,
+          "result": "pass",
+          "scenario": "plan/sync-partial-scope/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "portal/applications/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.17,
+          "result": "pass",
+          "scenario": "portal/auth_settings_deprecated_fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.85,
+          "result": "pass",
+          "scenario": "portal/edit/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.26,
+          "result": "pass",
+          "scenario": "portal/identity_providers/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.2,
+          "result": "pass",
+          "scenario": "portal/oidc-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.83,
+          "result": "pass",
+          "scenario": "portal/snippets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.56,
+          "result": "pass",
+          "scenario": "protected-resources/apis/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.91,
+          "result": "pass",
+          "scenario": "require-namespace/external/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.14,
+          "result": "pass",
+          "scenario": "yaml-tags/file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.49,
+          "result": "pass",
+          "scenario": "adopt/full/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.95,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer-group/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.21,
+          "result": "pass",
+          "scenario": "ai-gateway/model-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.99,
+          "result": "pass",
+          "scenario": "ai-gateway/root/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.12,
+          "result": "pass",
+          "scenario": "analytics/dashboard/scenario.yaml"
+        },
+        {
+          "duration_seconds": 19.01,
+          "result": "pass",
+          "scenario": "apis/nested-child-lifecycle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.72,
+          "result": "pass",
+          "scenario": "catalog/service/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.87,
+          "result": "pass",
+          "scenario": "control-plane/groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.2,
+          "result": "pass",
+          "scenario": "dcr-providers/workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.33,
+          "result": "pass",
+          "scenario": "deck/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.79,
+          "result": "pass",
+          "scenario": "delete/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.05,
+          "result": "pass",
+          "scenario": "dump/analytics-dashboards/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.45,
+          "result": "pass",
+          "scenario": "errors/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.23,
+          "result": "pass",
+          "scenario": "event-gateway/consume-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.14,
+          "result": "pass",
+          "scenario": "event-gateway/dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 28.62,
+          "result": "pass",
+          "scenario": "event-gateway/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.54,
+          "result": "pass",
+          "scenario": "event-gateway/tls-trust-bundle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.39,
+          "result": "pass",
+          "scenario": "external/api-impl/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.16,
+          "result": "pass",
+          "scenario": "namespace/defaults-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.61,
+          "result": "pass",
+          "scenario": "org/teams/external-role/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.96,
+          "result": "pass",
+          "scenario": "org/teams/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.45,
+          "result": "pass",
+          "scenario": "plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.63,
+          "result": "pass",
+          "scenario": "portal/assets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.93,
+          "result": "pass",
+          "scenario": "portal/custom-domain/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.33,
+          "result": "pass",
+          "scenario": "portal/email-domains/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.16,
+          "result": "pass",
+          "scenario": "portal/identity_providers_duplicate_type/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.37,
+          "result": "pass",
+          "scenario": "portal/page-frontmatter-conflict/scenario.yaml"
+        },
+        {
+          "duration_seconds": 24.08,
+          "result": "pass",
+          "scenario": "portal/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.43,
+          "result": "pass",
+          "scenario": "protected-resources/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.53,
+          "result": "pass",
+          "scenario": "require-namespace/portal/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.71,
+          "result": "pass",
+          "scenario": "adopt/team-create-adopt-dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 19.74,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.01,
+          "result": "pass",
+          "scenario": "ai-gateway/model-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.1,
+          "result": "pass",
+          "scenario": "ai-gateway/runtime-tls/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.27,
+          "result": "pass",
+          "scenario": "apis/child-delete-namespace/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.26,
+          "result": "pass",
+          "scenario": "apis/region/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.79,
+          "result": "pass",
+          "scenario": "control-plane/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.08,
+          "result": "pass",
+          "scenario": "control-plane/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.74,
+          "result": "pass",
+          "scenario": "deck/basic/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.57,
+          "result": "pass",
+          "scenario": "declarative/plan-mode-validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.22,
+          "result": "pass",
+          "scenario": "delete/partial-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.16,
+          "result": "pass",
+          "scenario": "dump/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.58,
+          "result": "pass",
+          "scenario": "event-gateway/adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.5,
+          "result": "pass",
+          "scenario": "event-gateway/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.51,
+          "result": "pass",
+          "scenario": "event-gateway/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "event-gateway/principal-metadata/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.8,
+          "result": "pass",
+          "scenario": "event-gateway/topic-aliases/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.02,
+          "result": "pass",
+          "scenario": "external/api-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.0,
+          "result": "pass",
+          "scenario": "namespace/validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.67,
+          "result": "pass",
+          "scenario": "org/teams/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.47,
+          "result": "pass",
+          "scenario": "patch/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 35.43,
+          "result": "pass",
+          "scenario": "portal/api_docs_with_children/scenario.yaml"
+        },
+        {
+          "duration_seconds": 21.66,
+          "result": "pass",
+          "scenario": "portal/audit-log-webhook/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.74,
+          "result": "pass",
+          "scenario": "portal/customization/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.68,
+          "result": "pass",
+          "scenario": "portal/email-templates/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.85,
+          "result": "pass",
+          "scenario": "portal/idp_team_group_mappings_readback/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.97,
+          "result": "pass",
+          "scenario": "portal/pages/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.23,
+          "result": "pass",
+          "scenario": "portal/team_group_mappings_no_idp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.37,
+          "result": "pass",
+          "scenario": "protected-resources/event-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.0,
+          "result": "pass",
+          "scenario": "scaffold/command-coverage/scenario.yaml"
+        }
+      ],
+      "shard_admission_delay_seconds": {
+        "kongctl-acceptance": 4.0,
+        "kongctl-acceptance-2": 3.0,
+        "kongctl-acceptance-3": 3.0,
+        "kongctl-acceptance-4": 3.0,
+        "kongctl-acceptance-5": 3.0
+      },
+      "shard_spread_seconds": 337.0,
+      "shards": [
+        {
+          "execution_duration_seconds": 513,
+          "org_name": "kongctl-acceptance",
+          "selected_scenario_count": 43
+        },
+        {
+          "execution_duration_seconds": 261,
+          "org_name": "kongctl-acceptance-2",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 176,
+          "org_name": "kongctl-acceptance-3",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 267,
+          "org_name": "kongctl-acceptance-4",
+          "selected_scenario_count": 30
+        },
+        {
+          "execution_duration_seconds": 342,
+          "org_name": "kongctl-acceptance-5",
+          "selected_scenario_count": 30
+        }
+      ],
+      "url": "https://github.com/Kong/kongctl/actions/runs/33995527990",
+      "workflow_admission_delay_seconds": 4.0
+    },
+    {
+      "build_job_seconds": 42.0,
+      "build_kongctl_seconds": 4.0,
+      "build_scenario_binary_seconds": 1.0,
+      "build_setup_seconds": 21.0,
+      "cohort": "cache-enabled",
+      "created_at": "2026-09-05T15:34:06Z",
+      "harness_job_seconds": 73.0,
+      "harness_setup_seconds": 8.0,
+      "harness_test_seconds": 51.0,
+      "head_sha": "9cb8f7203f1353148f41b2ace0523ea0ac887f79",
+      "longest_shard_seconds": 405.0,
+      "original_created_at": "2026-09-05T15:34:06Z",
+      "queue_to_required_status_seconds": 571.0,
+      "reset": {
+        "count": 164,
+        "delete_calls": 103,
+        "delete_duration_ms": 8055,
+        "duration_ms": 335852,
+        "list_calls": 2459,
+        "list_duration_ms": 326313,
+        "resources_deleted": 84,
+        "resources_found": 1614
+      },
+      "run_attempt": 1,
+      "run_id": 33975197426,
+      "scenario_durations": [
+        {
+          "duration_seconds": 7.55,
+          "result": "pass",
+          "scenario": "adopt/auth-strategy-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.37,
+          "result": "pass",
+          "scenario": "ai-gateway/agent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.54,
+          "result": "pass",
+          "scenario": "ai-gateway/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.74,
+          "result": "pass",
+          "scenario": "ai-gateway/model/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.77,
+          "result": "pass",
+          "scenario": "ai-gateway/vault/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.18,
+          "result": "pass",
+          "scenario": "apis/comprehensive-fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.38,
+          "result": "pass",
+          "scenario": "apis/root-level-publication-visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.8,
+          "result": "pass",
+          "scenario": "control-plane/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.67,
+          "result": "pass",
+          "scenario": "control-plane/serverless/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.74,
+          "result": "pass",
+          "scenario": "deck/env-vars/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.44,
+          "result": "pass",
+          "scenario": "declarative/rename-sync-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.34,
+          "result": "pass",
+          "scenario": "delete/plan-based/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.96,
+          "result": "pass",
+          "scenario": "dump/dcr-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.32,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.63,
+          "result": "pass",
+          "scenario": "event-gateway/dataplane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.64,
+          "result": "pass",
+          "scenario": "event-gateway/listener-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 22.54,
+          "result": "pass",
+          "scenario": "event-gateway/produce-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.51,
+          "result": "pass",
+          "scenario": "event-gateway/virtual-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.67,
+          "result": "pass",
+          "scenario": "external/portal-publication/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.35,
+          "result": "pass",
+          "scenario": "org/get-org/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.94,
+          "result": "pass",
+          "scenario": "org/teams/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.02,
+          "result": "pass",
+          "scenario": "plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.92,
+          "result": "pass",
+          "scenario": "portal/api_with_attributes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.09,
+          "result": "pass",
+          "scenario": "portal/auth-strategy-link/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.21,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.57,
+          "result": "pass",
+          "scenario": "portal/email/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.56,
+          "result": "pass",
+          "scenario": "portal/integrations/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.01,
+          "result": "pass",
+          "scenario": "portal/publication-auth-omitted-noop/scenario.yaml"
+        },
+        {
+          "duration_seconds": 21.51,
+          "result": "pass",
+          "scenario": "portal/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.41,
+          "result": "pass",
+          "scenario": "protected-resources/org/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.06,
+          "result": "pass",
+          "scenario": "smoke/version/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.25,
+          "result": "pass",
+          "scenario": "apis/eventual-consistency-polp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.21,
+          "result": "pass",
+          "scenario": "dump/organization-teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.48,
+          "result": "pass",
+          "scenario": "org/system-accounts/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.38,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.75,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.02,
+          "result": "pass",
+          "scenario": "org/system-accounts/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.34,
+          "result": "pass",
+          "scenario": "org/token/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.49,
+          "result": "pass",
+          "scenario": "org/users/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.78,
+          "result": "pass",
+          "scenario": "org/users/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.07,
+          "result": "pass",
+          "scenario": "org/users/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.07,
+          "result": "pass",
+          "scenario": "org/users/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.23,
+          "result": "pass",
+          "scenario": "org/users/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.41,
+          "result": "pass",
+          "scenario": "adopt/create-portal-adopt-dump-plan/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.12,
+          "result": "pass",
+          "scenario": "ai-gateway/auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.41,
+          "result": "pass",
+          "scenario": "ai-gateway/maturity/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.94,
+          "result": "pass",
+          "scenario": "ai-gateway/policy-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.16,
+          "result": "pass",
+          "scenario": "all/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.31,
+          "result": "pass",
+          "scenario": "apis/control-plane-implementation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.64,
+          "result": "pass",
+          "scenario": "apis/versions-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.98,
+          "result": "pass",
+          "scenario": "control-plane/delete-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.3,
+          "result": "pass",
+          "scenario": "control-plane/sync-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.37,
+          "result": "pass",
+          "scenario": "deck/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.43,
+          "result": "pass",
+          "scenario": "delete/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.08,
+          "result": "pass",
+          "scenario": "diff/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.17,
+          "result": "pass",
+          "scenario": "dump/filtered/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.28,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.39,
+          "result": "pass",
+          "scenario": "event-gateway/dependency-order/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.29,
+          "result": "pass",
+          "scenario": "event-gateway/listener/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.37,
+          "result": "pass",
+          "scenario": "event-gateway/schema-registry/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.33,
+          "result": "pass",
+          "scenario": "explain/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.62,
+          "result": "pass",
+          "scenario": "external/portal-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.44,
+          "result": "pass",
+          "scenario": "org/system-accounts/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.26,
+          "result": "pass",
+          "scenario": "org/teams/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.63,
+          "result": "pass",
+          "scenario": "plan/remote-url-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.4,
+          "result": "pass",
+          "scenario": "portal/app-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.33,
+          "result": "pass",
+          "scenario": "portal/auth_settings/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.96,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy_ref_selection/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.3,
+          "result": "pass",
+          "scenario": "portal/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.39,
+          "result": "pass",
+          "scenario": "portal/ip-allow-list/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.21,
+          "result": "pass",
+          "scenario": "portal/snippets-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 25.67,
+          "result": "pass",
+          "scenario": "portal/visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.11,
+          "result": "pass",
+          "scenario": "protected-resources/portals/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.32,
+          "result": "pass",
+          "scenario": "yaml-tags/env/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.27,
+          "result": "pass",
+          "scenario": "adopt/event-gateway-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.83,
+          "result": "pass",
+          "scenario": "ai-gateway/config-store/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.28,
+          "result": "pass",
+          "scenario": "ai-gateway/mcp-server/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.4,
+          "result": "pass",
+          "scenario": "ai-gateway/policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.03,
+          "result": "pass",
+          "scenario": "analytics/dashboard-repro/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.64,
+          "result": "pass",
+          "scenario": "apis/get-api-by-name-and-id/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "auth/get-me/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.98,
+          "result": "pass",
+          "scenario": "control-plane/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.58,
+          "result": "pass",
+          "scenario": "control-plane/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.52,
+          "result": "pass",
+          "scenario": "deck/multi-file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.61,
+          "result": "pass",
+          "scenario": "delete/dry-run/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.11,
+          "result": "pass",
+          "scenario": "dump/ai-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 22.99,
+          "result": "pass",
+          "scenario": "dump/portal-owned/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.85,
+          "result": "pass",
+          "scenario": "event-gateway/cluster-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.42,
+          "result": "pass",
+          "scenario": "event-gateway/diff/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.19,
+          "result": "pass",
+          "scenario": "event-gateway/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.59,
+          "result": "pass",
+          "scenario": "event-gateway/static-key/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.29,
+          "result": "pass",
+          "scenario": "external/ai-gateway-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.34,
+          "result": "pass",
+          "scenario": "lint/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.56,
+          "result": "pass",
+          "scenario": "org/teams/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.05,
+          "result": "pass",
+          "scenario": "org/teams/roles/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.97,
+          "result": "pass",
+          "scenario": "plan/sync-partial-scope/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "portal/applications/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.19,
+          "result": "pass",
+          "scenario": "portal/auth_settings_deprecated_fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.27,
+          "result": "pass",
+          "scenario": "portal/edit/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.78,
+          "result": "pass",
+          "scenario": "portal/identity_providers/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.85,
+          "result": "pass",
+          "scenario": "portal/oidc-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.36,
+          "result": "pass",
+          "scenario": "portal/snippets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.02,
+          "result": "pass",
+          "scenario": "protected-resources/apis/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.72,
+          "result": "pass",
+          "scenario": "require-namespace/external/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.81,
+          "result": "pass",
+          "scenario": "yaml-tags/file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.5,
+          "result": "pass",
+          "scenario": "adopt/full/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.79,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer-group/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.41,
+          "result": "pass",
+          "scenario": "ai-gateway/model-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.81,
+          "result": "pass",
+          "scenario": "ai-gateway/root/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.82,
+          "result": "pass",
+          "scenario": "analytics/dashboard/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.57,
+          "result": "pass",
+          "scenario": "apis/nested-child-lifecycle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.99,
+          "result": "pass",
+          "scenario": "catalog/service/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.54,
+          "result": "pass",
+          "scenario": "control-plane/groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.59,
+          "result": "pass",
+          "scenario": "dcr-providers/workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.23,
+          "result": "pass",
+          "scenario": "deck/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.69,
+          "result": "pass",
+          "scenario": "delete/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.99,
+          "result": "pass",
+          "scenario": "dump/analytics-dashboards/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.98,
+          "result": "pass",
+          "scenario": "errors/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.51,
+          "result": "pass",
+          "scenario": "event-gateway/consume-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.4,
+          "result": "pass",
+          "scenario": "event-gateway/dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 19.84,
+          "result": "pass",
+          "scenario": "event-gateway/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.53,
+          "result": "pass",
+          "scenario": "event-gateway/tls-trust-bundle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.51,
+          "result": "pass",
+          "scenario": "external/api-impl/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.89,
+          "result": "pass",
+          "scenario": "namespace/defaults-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.46,
+          "result": "pass",
+          "scenario": "org/teams/external-role/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.61,
+          "result": "pass",
+          "scenario": "org/teams/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.04,
+          "result": "pass",
+          "scenario": "plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.55,
+          "result": "pass",
+          "scenario": "portal/assets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.95,
+          "result": "pass",
+          "scenario": "portal/custom-domain/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.3,
+          "result": "pass",
+          "scenario": "portal/email-domains/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.19,
+          "result": "pass",
+          "scenario": "portal/identity_providers_duplicate_type/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.96,
+          "result": "pass",
+          "scenario": "portal/page-frontmatter-conflict/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.82,
+          "result": "pass",
+          "scenario": "portal/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.22,
+          "result": "pass",
+          "scenario": "protected-resources/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.13,
+          "result": "pass",
+          "scenario": "require-namespace/portal/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.94,
+          "result": "pass",
+          "scenario": "adopt/team-create-adopt-dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.04,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.45,
+          "result": "pass",
+          "scenario": "ai-gateway/model-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.05,
+          "result": "pass",
+          "scenario": "ai-gateway/runtime-tls/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.21,
+          "result": "pass",
+          "scenario": "apis/child-delete-namespace/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.67,
+          "result": "pass",
+          "scenario": "apis/region/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.81,
+          "result": "pass",
+          "scenario": "control-plane/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.21,
+          "result": "pass",
+          "scenario": "control-plane/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.83,
+          "result": "pass",
+          "scenario": "deck/basic/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.58,
+          "result": "pass",
+          "scenario": "declarative/plan-mode-validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.28,
+          "result": "pass",
+          "scenario": "delete/partial-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.28,
+          "result": "pass",
+          "scenario": "dump/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.56,
+          "result": "pass",
+          "scenario": "event-gateway/adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.52,
+          "result": "pass",
+          "scenario": "event-gateway/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 24.07,
+          "result": "pass",
+          "scenario": "event-gateway/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "event-gateway/principal-metadata/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.81,
+          "result": "pass",
+          "scenario": "event-gateway/topic-aliases/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.95,
+          "result": "pass",
+          "scenario": "external/api-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.07,
+          "result": "pass",
+          "scenario": "namespace/validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.63,
+          "result": "pass",
+          "scenario": "org/teams/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.47,
+          "result": "pass",
+          "scenario": "patch/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 35.97,
+          "result": "pass",
+          "scenario": "portal/api_docs_with_children/scenario.yaml"
+        },
+        {
+          "duration_seconds": 22.27,
+          "result": "pass",
+          "scenario": "portal/audit-log-webhook/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.55,
+          "result": "pass",
+          "scenario": "portal/customization/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.65,
+          "result": "pass",
+          "scenario": "portal/email-templates/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.05,
+          "result": "pass",
+          "scenario": "portal/idp_team_group_mappings_readback/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.93,
+          "result": "pass",
+          "scenario": "portal/pages/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.24,
+          "result": "pass",
+          "scenario": "portal/team_group_mappings_no_idp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.57,
+          "result": "pass",
+          "scenario": "protected-resources/event-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.0,
+          "result": "pass",
+          "scenario": "scaffold/command-coverage/scenario.yaml"
+        }
+      ],
+      "shard_admission_delay_seconds": {
+        "kongctl-acceptance": 3.0,
+        "kongctl-acceptance-2": 2.0,
+        "kongctl-acceptance-3": 2.0,
+        "kongctl-acceptance-4": 2.0,
+        "kongctl-acceptance-5": 3.0
+      },
+      "shard_spread_seconds": 245.0,
+      "shards": [
+        {
+          "execution_duration_seconds": 405,
+          "org_name": "kongctl-acceptance",
+          "selected_scenario_count": 43
+        },
+        {
+          "execution_duration_seconds": 191,
+          "org_name": "kongctl-acceptance-2",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 160,
+          "org_name": "kongctl-acceptance-3",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 194,
+          "org_name": "kongctl-acceptance-4",
+          "selected_scenario_count": 30
+        },
+        {
+          "execution_duration_seconds": 346,
+          "org_name": "kongctl-acceptance-5",
+          "selected_scenario_count": 30
+        }
+      ],
+      "url": "https://github.com/Kong/kongctl/actions/runs/33975197426",
+      "workflow_admission_delay_seconds": 3.0
+    },
+    {
       "build_job_seconds": 322.0,
       "build_kongctl_seconds": 243.0,
       "build_scenario_binary_seconds": 38.0,

--- a/test/e2e/baselines/post-cache-2026-09.md
+++ b/test/e2e/baselines/post-cache-2026-09.md
@@ -3,7 +3,7 @@
 Repository: `kong/kongctl`
 Cohort: `cache-enabled`
 
-Full successful runs: 2 of 20
+Full successful runs: 14 of 20
 Status: **collecting**
 
 The report scans successful `e2e.yaml` runs newest-first and retains only
@@ -21,35 +21,47 @@ attempt; reruns are not independent samples.
 
 | Metric | p50 | p75 | p90 |
 | --- | ---: | ---: | ---: |
-| workflow_admission_delay_seconds | 3.0s | 4.0s | 4.0s |
-| queue_to_required_status_seconds | 651.0s | 912.0s | 912.0s |
-| build_job_seconds | 49.0s | 322.0s | 322.0s |
-| build_kongctl_seconds | 4.0s | 243.0s | 243.0s |
-| build_scenario_binary_seconds | 1.0s | 38.0s | 38.0s |
-| build_setup_seconds | 11.0s | 25.0s | 25.0s |
-| harness_job_seconds | 60.0s | 78.0s | 78.0s |
-| harness_setup_seconds | 10.0s | 11.0s | 11.0s |
-| harness_test_seconds | 38.0s | 53.0s | 53.0s |
-| longest_shard_seconds | 485.0s | 496.0s | 496.0s |
-| shard_spread_seconds | 267.0s | 332.0s | 332.0s |
+| workflow_admission_delay_seconds | 4.0s | 30.0s | 546.0s |
+| queue_to_required_status_seconds | 657.0s | 912.0s | 1102.0s |
+| build_job_seconds | 49.0s | 55.0s | 64.0s |
+| build_kongctl_seconds | 4.0s | 8.0s | 11.0s |
+| build_scenario_binary_seconds | 1.0s | 5.0s | 6.0s |
+| build_setup_seconds | 22.0s | 25.0s | 29.0s |
+| harness_job_seconds | 72.0s | 75.0s | 78.0s |
+| harness_setup_seconds | 10.0s | 10.0s | 11.0s |
+| harness_test_seconds | 51.0s | 53.0s | 53.0s |
+| longest_shard_seconds | 480.0s | 505.0s | 513.0s |
+| shard_spread_seconds | 267.0s | 332.0s | 346.0s |
 
 ## Reset cost per workflow run
 
 | Metric | p50 | p75 | p90 |
 | --- | ---: | ---: | ---: |
 | count | 164.0 | 164.0 | 164.0 |
-| duration_ms | 475189.0ms | 507850.0ms | 507850.0ms |
+| duration_ms | 415210.0ms | 462432.0ms | 486068.0ms |
 | list_calls | 2459.0 | 2459.0 | 2459.0 |
-| list_duration_ms | 463423.0ms | 496309.0ms | 496309.0ms |
+| list_duration_ms | 404252.0ms | 450914.0ms | 474589.0ms |
 | resources_found | 1614.0 | 1614.0 | 1614.0 |
 | delete_calls | 103.0 | 103.0 | 103.0 |
-| delete_duration_ms | 10080.0ms | 10268.0ms | 10268.0ms |
+| delete_duration_ms | 8984.0ms | 9985.0ms | 10082.0ms |
 | resources_deleted | 84.0 | 84.0 | 84.0 |
 
 ## Included runs
 
 | Run / Attempt | Attempt created | Queue-to-status | Build | Longest shard | Spread | Resets |
 | --- | --- | ---: | ---: | ---: | ---: | ---: |
+| [34026314755 / 1](https://github.com/Kong/kongctl/actions/runs/34026314755/attempts/1) | 2026-09-06T10:02:36Z | 535s | 55s | 359s | 180s | 164 |
+| [34007840146 / 1](https://github.com/Kong/kongctl/actions/runs/34007840146/attempts/1) | 2026-09-06T02:59:07Z | 539s | 64s | 357s | 65s | 164 |
+| [34006266279 / 1](https://github.com/Kong/kongctl/actions/runs/34006266279/attempts/1) | 2026-09-06T02:21:19Z | 1139s | 60s | 396s | 236s | 164 |
+| [34006212666 / 1](https://github.com/Kong/kongctl/actions/runs/34006212666/attempts/1) | 2026-09-06T02:20:06Z | 641s | 42s | 480s | 286s | 164 |
+| [34004626083 / 1](https://github.com/Kong/kongctl/actions/runs/34004626083/attempts/1) | 2026-09-06T01:43:24Z | 1102s | 44s | 392s | 205s | 164 |
+| [34004275715 / 1](https://github.com/Kong/kongctl/actions/runs/34004275715/attempts/1) | 2026-09-06T01:35:05Z | 1009s | 46s | 583s | 392s | 164 |
+| [34003980091 / 1](https://github.com/Kong/kongctl/actions/runs/34003980091/attempts/1) | 2026-09-06T01:28:27Z | 532s | 50s | 344s | 147s | 164 |
+| [34003060095 / 1](https://github.com/Kong/kongctl/actions/runs/34003060095/attempts/1) | 2026-09-06T01:07:11Z | 707s | 50s | 508s | 319s | 164 |
+| [34002577998 / 1](https://github.com/Kong/kongctl/actions/runs/34002577998/attempts/1) | 2026-09-06T00:56:12Z | 657s | 43s | 489s | 329s | 164 |
+| [34000248405 / 1](https://github.com/Kong/kongctl/actions/runs/34000248405/attempts/1) | 2026-09-06T00:02:43Z | 709s | 43s | 505s | 346s | 164 |
+| [33995527990 / 1](https://github.com/Kong/kongctl/actions/runs/33995527990/attempts/1) | 2026-09-05T22:18:22Z | 686s | 51s | 513s | 337s | 164 |
+| [33975197426 / 1](https://github.com/Kong/kongctl/actions/runs/33975197426/attempts/1) | 2026-09-05T15:34:06Z | 571s | 42s | 405s | 245s | 164 |
 | [33972692322 / 1](https://github.com/Kong/kongctl/actions/runs/33972692322/attempts/1) | 2026-09-05T14:44:15Z | 912s | 322s | 496s | 332s | 164 |
 | [33906754133 / 3](https://github.com/Kong/kongctl/actions/runs/33906754133/attempts/3) | 2026-09-04T19:07:59Z | 651s | 49s | 485s | 267s | 164 |
 
@@ -57,6 +69,66 @@ attempt; reruns are not independent samples.
 
 | Run | Organization | Admission delay | Selected | Execution |
 | --- | --- | ---: | ---: | ---: |
+| 34026314755 | `kongctl-acceptance` | 3s | 43 | 320s |
+| 34026314755 | `kongctl-acceptance-2` | 4s | 31 | 359s |
+| 34026314755 | `kongctl-acceptance-3` | 3s | 31 | 179s |
+| 34026314755 | `kongctl-acceptance-4` | 4s | 30 | 343s |
+| 34026314755 | `kongctl-acceptance-5` | 3s | 30 | 284s |
+| 34007840146 | `kongctl-acceptance` | 4s | 43 | 299s |
+| 34007840146 | `kongctl-acceptance-2` | 4s | 31 | 350s |
+| 34007840146 | `kongctl-acceptance-3` | 4s | 31 | 344s |
+| 34007840146 | `kongctl-acceptance-4` | 4s | 30 | 357s |
+| 34007840146 | `kongctl-acceptance-5` | 3s | 30 | 292s |
+| 34006266279 | `kongctl-acceptance` | 2s | 43 | 306s |
+| 34006266279 | `kongctl-acceptance-2` | 3s | 31 | 396s |
+| 34006266279 | `kongctl-acceptance-3` | 2s | 31 | 160s |
+| 34006266279 | `kongctl-acceptance-4` | 2s | 30 | 200s |
+| 34006266279 | `kongctl-acceptance-5` | 3s | 30 | 344s |
+| 34006212666 | `kongctl-acceptance` | 3s | 43 | 480s |
+| 34006212666 | `kongctl-acceptance-2` | 39s | 31 | 194s |
+| 34006212666 | `kongctl-acceptance-3` | 3s | 31 | 299s |
+| 34006212666 | `kongctl-acceptance-4` | 3s | 30 | 194s |
+| 34006212666 | `kongctl-acceptance-5` | 3s | 30 | 346s |
+| 34004626083 | `kongctl-acceptance` | 3s | 43 | 392s |
+| 34004626083 | `kongctl-acceptance-2` | 3s | 31 | 326s |
+| 34004626083 | `kongctl-acceptance-3` | 3s | 31 | 226s |
+| 34004626083 | `kongctl-acceptance-4` | 3s | 30 | 187s |
+| 34004626083 | `kongctl-acceptance-5` | 4s | 30 | 341s |
+| 34004275715 | `kongctl-acceptance` | 4s | 43 | 583s |
+| 34004275715 | `kongctl-acceptance-2` | 2s | 31 | 213s |
+| 34004275715 | `kongctl-acceptance-3` | 4s | 31 | 344s |
+| 34004275715 | `kongctl-acceptance-4` | 2s | 30 | 191s |
+| 34004275715 | `kongctl-acceptance-5` | 3s | 30 | 294s |
+| 34003980091 | `kongctl-acceptance` | 3s | 43 | 295s |
+| 34003980091 | `kongctl-acceptance-2` | 3s | 31 | 219s |
+| 34003980091 | `kongctl-acceptance-3` | 5s | 31 | 344s |
+| 34003980091 | `kongctl-acceptance-4` | 3s | 30 | 197s |
+| 34003980091 | `kongctl-acceptance-5` | 3s | 30 | 344s |
+| 34003060095 | `kongctl-acceptance` | 4s | 43 | 508s |
+| 34003060095 | `kongctl-acceptance-2` | 3s | 31 | 325s |
+| 34003060095 | `kongctl-acceptance-3` | 3s | 31 | 348s |
+| 34003060095 | `kongctl-acceptance-4` | 3s | 30 | 359s |
+| 34003060095 | `kongctl-acceptance-5` | 3s | 30 | 189s |
+| 34002577998 | `kongctl-acceptance` | 3s | 43 | 489s |
+| 34002577998 | `kongctl-acceptance-2` | 3s | 31 | 290s |
+| 34002577998 | `kongctl-acceptance-3` | 3s | 31 | 160s |
+| 34002577998 | `kongctl-acceptance-4` | 2s | 30 | 197s |
+| 34002577998 | `kongctl-acceptance-5` | 3s | 30 | 300s |
+| 34000248405 | `kongctl-acceptance` | 3s | 43 | 505s |
+| 34000248405 | `kongctl-acceptance-2` | 4s | 31 | 405s |
+| 34000248405 | `kongctl-acceptance-3` | 3s | 31 | 159s |
+| 34000248405 | `kongctl-acceptance-4` | 39s | 30 | 277s |
+| 34000248405 | `kongctl-acceptance-5` | 3s | 30 | 164s |
+| 33995527990 | `kongctl-acceptance` | 4s | 43 | 513s |
+| 33995527990 | `kongctl-acceptance-2` | 3s | 31 | 261s |
+| 33995527990 | `kongctl-acceptance-3` | 3s | 31 | 176s |
+| 33995527990 | `kongctl-acceptance-4` | 3s | 30 | 267s |
+| 33995527990 | `kongctl-acceptance-5` | 3s | 30 | 342s |
+| 33975197426 | `kongctl-acceptance` | 3s | 43 | 405s |
+| 33975197426 | `kongctl-acceptance-2` | 2s | 31 | 191s |
+| 33975197426 | `kongctl-acceptance-3` | 2s | 31 | 160s |
+| 33975197426 | `kongctl-acceptance-4` | 2s | 30 | 194s |
+| 33975197426 | `kongctl-acceptance-5` | 3s | 30 | 346s |
 | 33972692322 | `kongctl-acceptance` | 4s | 43 | 496s |
 | 33972692322 | `kongctl-acceptance-2` | 4s | 31 | 402s |
 | 33972692322 | `kongctl-acceptance-3` | 3s | 31 | 287s |
@@ -72,168 +144,168 @@ attempt; reruns are not independent samples.
 
 | Scenario | Samples | Median | p90 |
 | --- | ---: | ---: | ---: |
-| `portal/visibility/scenario.yaml` | 2 | 44.05s | 51.68s |
-| `dump/portal-owned/scenario.yaml` | 2 | 41.92s | 50.95s |
-| `all/scenario.yaml` | 2 | 28.80s | 33.86s |
-| `event-gateway/produce-policy/scenario.yaml` | 2 | 26.66s | 26.84s |
-| `event-gateway/plan/apply-workflow/scenario.yaml` | 2 | 25.80s | 32.53s |
-| `portal/teams/scenario.yaml` | 2 | 25.51s | 26.05s |
-| `portal/identity_providers/scenario.yaml` | 2 | 23.81s | 28.94s |
-| `event-gateway/plan/sync-workflow/scenario.yaml` | 2 | 22.76s | 43.19s |
-| `portal/auth-strategy-link/scenario.yaml` | 2 | 20.39s | 20.90s |
-| `ai-gateway/mcp-server/scenario.yaml` | 2 | 19.47s | 24.26s |
-| `portal/sync/scenario.yaml` | 2 | 19.31s | 36.91s |
-| `portal/api_docs_with_children/scenario.yaml` | 2 | 17.84s | 29.25s |
-| `portal/ip-allow-list/scenario.yaml` | 2 | 17.33s | 20.82s |
-| `apis/root-level-publication-visibility/scenario.yaml` | 2 | 17.24s | 17.45s |
-| `dump/organization-teams/scenario.yaml` | 2 | 16.67s | 17.03s |
-| `org/users/assignments/scenario.yaml` | 2 | 16.02s | 16.50s |
-| `portal/custom-domain/scenario.yaml` | 2 | 15.55s | 26.14s |
-| `apis/control-plane-implementation/scenario.yaml` | 2 | 15.54s | 18.28s |
-| `event-gateway/virtual-cluster/scenario.yaml` | 2 | 15.39s | 15.56s |
-| `apis/nested-child-lifecycle/scenario.yaml` | 2 | 15.34s | 28.97s |
-| `diff/command-coverage/scenario.yaml` | 2 | 15.33s | 18.07s |
-| `ai-gateway/agent/scenario.yaml` | 2 | 15.03s | 15.06s |
-| `event-gateway/backend-cluster/scenario.yaml` | 2 | 14.93s | 17.70s |
-| `event-gateway/consume-policy/scenario.yaml` | 2 | 14.32s | 27.67s |
-| `portal/external-sync/scenario.yaml` | 2 | 14.27s | 17.22s |
-| `org/system-accounts/assignments/scenario.yaml` | 2 | 14.17s | 14.35s |
-| `dump/filtered/scenario.yaml` | 2 | 13.92s | 16.29s |
-| `portal/email/scenario.yaml` | 2 | 13.79s | 14.05s |
-| `protected-resources/apis/scenario.yaml` | 2 | 13.65s | 14.52s |
-| `plan/apply-workflow/scenario.yaml` | 2 | 13.26s | 13.42s |
-| `yaml-tags/env/scenario.yaml` | 2 | 13.23s | 15.82s |
-| `ai-gateway/data-plane-certificate/scenario.yaml` | 2 | 13.04s | 13.25s |
-| `portal/default_application_auth_strategy/scenario.yaml` | 2 | 12.97s | 13.45s |
-| `declarative/rename-sync-delete/scenario.yaml` | 2 | 12.83s | 13.08s |
-| `control-plane/data-plane-certificate/scenario.yaml` | 2 | 12.81s | 13.19s |
-| `dcr-providers/workflow/scenario.yaml` | 2 | 12.80s | 21.12s |
-| `org/teams/roles/scenario.yaml` | 2 | 12.75s | 15.89s |
-| `ai-gateway/config-store/scenario.yaml` | 2 | 12.66s | 16.62s |
-| `ai-gateway/auth-strategy/scenario.yaml` | 2 | 12.64s | 15.45s |
-| `control-plane/serverless/scenario.yaml` | 2 | 12.59s | 12.70s |
-| `event-gateway/listener-policy/scenario.yaml` | 2 | 12.59s | 12.64s |
-| `ai-gateway/vault/scenario.yaml` | 2 | 12.56s | 12.77s |
-| `event-gateway/diff/scenario.yaml` | 2 | 12.02s | 14.84s |
-| `event-gateway/static-key/scenario.yaml` | 2 | 11.81s | 14.60s |
-| `org/users/plan/sync-workflow/scenario.yaml` | 2 | 11.77s | 11.89s |
-| `portal/auth_settings/scenario.yaml` | 2 | 11.54s | 13.92s |
-| `event-gateway/external-sync/scenario.yaml` | 2 | 11.43s | 19.46s |
-| `event-gateway/schema-registry/scenario.yaml` | 2 | 11.43s | 13.96s |
-| `org/users/sync/scenario.yaml` | 2 | 11.39s | 11.64s |
-| `ai-gateway/policy-matrix/scenario.yaml` | 2 | 11.32s | 13.34s |
-| `apis/comprehensive-fields/scenario.yaml` | 2 | 10.80s | 11.08s |
-| `event-gateway/cluster-policy/scenario.yaml` | 2 | 10.76s | 13.41s |
-| `portal/publication-auth-omitted-noop/scenario.yaml` | 2 | 10.69s | 10.90s |
-| `delete/declarative/scenario.yaml` | 2 | 10.51s | 12.61s |
-| `org/system-accounts/plan/sync-workflow/scenario.yaml` | 2 | 10.50s | 11.11s |
-| `ai-gateway/model/scenario.yaml` | 2 | 10.47s | 10.70s |
-| `portal/integrations/scenario.yaml` | 2 | 10.27s | 10.38s |
-| `external/ai-gateway-parent/scenario.yaml` | 2 | 10.13s | 11.00s |
-| `ai-gateway/consumer/scenario.yaml` | 2 | 10.10s | 16.78s |
-| `ai-gateway/consumer-group/scenario.yaml` | 2 | 10.05s | 18.99s |
-| `org/system-accounts/sync/scenario.yaml` | 2 | 9.98s | 10.17s |
-| `portal/audit-log-webhook/scenario.yaml` | 2 | 9.88s | 17.77s |
-| `event-gateway/listener/scenario.yaml` | 2 | 9.83s | 11.91s |
-| `event-gateway/dataplane-certificate/scenario.yaml` | 2 | 9.78s | 10.14s |
-| `protected-resources/portals/scenario.yaml` | 2 | 9.78s | 11.68s |
-| `portal/api_with_attributes/scenario.yaml` | 2 | 9.40s | 9.55s |
-| `ai-gateway/model-provider/scenario.yaml` | 2 | 9.15s | 15.02s |
-| `external/portal-publication/scenario.yaml` | 2 | 8.92s | 9.18s |
-| `ai-gateway/root/scenario.yaml` | 2 | 8.63s | 15.35s |
-| `portal/app-auth-strategy/scenario.yaml` | 2 | 8.63s | 10.73s |
-| `org/token/scenario.yaml` | 2 | 8.38s | 8.42s |
-| `deck/env-vars/scenario.yaml` | 2 | 8.30s | 8.71s |
-| `deck/basic/scenario.yaml` | 2 | 8.23s | 14.19s |
-| `org/users/plan/apply-workflow/scenario.yaml` | 2 | 8.04s | 8.52s |
-| `adopt/full/scenario.yaml` | 2 | 7.93s | 14.84s |
-| `org/system-accounts/plan/apply-workflow/scenario.yaml` | 2 | 7.92s | 8.35s |
-| `portal/snippets/scenario.yaml` | 2 | 7.82s | 9.48s |
-| `portal/edit/scenario.yaml` | 2 | 7.71s | 9.34s |
-| `control-plane/sync-groups/scenario.yaml` | 2 | 7.52s | 9.15s |
-| `portal/email-templates/scenario.yaml` | 2 | 7.50s | 13.16s |
-| `adopt/auth-strategy-adopt/scenario.yaml` | 2 | 7.39s | 8.31s |
-| `apis/region/scenario.yaml` | 2 | 7.32s | 10.58s |
-| `dump/ai-gateways/scenario.yaml` | 2 | 7.12s | 8.95s |
-| `portal/pages/scenario.yaml` | 2 | 7.06s | 12.06s |
-| `plan/sync-partial-scope/scenario.yaml` | 2 | 7.05s | 8.57s |
-| `deck/multi-file/scenario.yaml` | 2 | 6.89s | 8.30s |
-| `portal/page-frontmatter-conflict/scenario.yaml` | 2 | 6.82s | 12.68s |
-| `portal/customization/scenario.yaml` | 2 | 6.81s | 11.92s |
-| `adopt/event-gateway-adopt/scenario.yaml` | 2 | 6.80s | 7.55s |
-| `deck/idempotent/scenario.yaml` | 2 | 6.78s | 7.82s |
-| `event-gateway/dependency-order/scenario.yaml` | 2 | 6.75s | 7.98s |
-| `protected-resources/org/teams/scenario.yaml` | 2 | 6.70s | 6.73s |
-| `plan/remote-url-workflow/scenario.yaml` | 2 | 6.62s | 7.80s |
-| `apis/eventual-consistency-polp/scenario.yaml` | 2 | 6.60s | 6.66s |
-| `delete/plan-based/scenario.yaml` | 2 | 6.60s | 6.63s |
-| `portal/assets/scenario.yaml` | 2 | 6.49s | 12.49s |
-| `catalog/service/scenario.yaml` | 2 | 6.45s | 11.70s |
-| `portal/oidc-auth-strategy/scenario.yaml` | 2 | 6.34s | 7.83s |
-| `adopt/create-portal-adopt-dump-plan/scenario.yaml` | 2 | 6.28s | 8.51s |
-| `ai-gateway/runtime-tls/scenario.yaml` | 2 | 6.04s | 9.87s |
-| `portal/idp_team_group_mappings_readback/scenario.yaml` | 2 | 6.02s | 10.87s |
-| `external/api-parent/scenario.yaml` | 2 | 5.98s | 11.23s |
-| `org/teams/plan/apply-workflow/scenario.yaml` | 2 | 5.97s | 6.08s |
-| `org/teams/plan/sync-workflow/scenario.yaml` | 2 | 5.95s | 7.68s |
-| `deck/sync/scenario.yaml` | 2 | 5.92s | 11.89s |
-| `dump/dcr-provider/scenario.yaml` | 2 | 5.91s | 6.02s |
-| `control-plane/get/scenario.yaml` | 2 | 5.67s | 6.87s |
-| `portal/default_application_auth_strategy_ref_selection/scenario.yaml` | 2 | 5.64s | 6.42s |
-| `require-namespace/portal/scenario.yaml` | 2 | 5.58s | 9.74s |
-| `control-plane/delete-groups/scenario.yaml` | 2 | 5.50s | 6.65s |
-| `dump/control-planes/scenario.yaml` | 2 | 5.40s | 9.13s |
-| `org/users/get/scenario.yaml` | 2 | 5.39s | 5.56s |
-| `protected-resources/event-gateways/scenario.yaml` | 2 | 5.29s | 9.24s |
-| `yaml-tags/file/scenario.yaml` | 2 | 5.29s | 6.39s |
-| `event-gateway/tls-trust-bundle/scenario.yaml` | 2 | 5.25s | 11.01s |
-| `analytics/dashboard/scenario.yaml` | 2 | 5.24s | 9.65s |
-| `event-gateway/backend-cluster-pagination/scenario.yaml` | 2 | 5.20s | 5.79s |
-| `ai-gateway/model-matrix/scenario.yaml` | 2 | 5.19s | 10.47s |
-| `org/system-accounts/scenario.yaml` | 2 | 5.15s | 7.30s |
-| `external/api-impl/scenario.yaml` | 2 | 5.14s | 9.91s |
-| `org/teams/external-role/scenario.yaml` | 2 | 5.09s | 11.09s |
-| `apis/child-delete-namespace/scenario.yaml` | 2 | 5.06s | 9.22s |
-| `delete/dry-run/scenario.yaml` | 2 | 5.06s | 6.22s |
-| `apis/get-api-by-name-and-id/scenario.yaml` | 2 | 5.00s | 6.13s |
-| `org/teams/apply/scenario.yaml` | 2 | 4.99s | 6.18s |
-| `apis/versions-pagination/scenario.yaml` | 2 | 4.97s | 5.91s |
-| `external/portal-sync/scenario.yaml` | 2 | 4.97s | 6.09s |
-| `delete/partial-delete/scenario.yaml` | 2 | 4.87s | 8.48s |
-| `require-namespace/external/scenario.yaml` | 2 | 4.86s | 6.18s |
-| `ai-gateway/policy/scenario.yaml` | 2 | 4.74s | 5.80s |
-| `dump/analytics-dashboards/scenario.yaml` | 2 | 4.71s | 9.93s |
-| `event-gateway/topic-aliases/scenario.yaml` | 2 | 4.71s | 8.72s |
-| `control-plane/sync/scenario.yaml` | 2 | 4.55s | 5.61s |
-| `plan/sync-workflow/scenario.yaml` | 2 | 4.53s | 8.72s |
-| `org/get-org/scenario.yaml` | 2 | 4.37s | 4.40s |
-| `portal/snippets-pagination/scenario.yaml` | 2 | 4.32s | 5.24s |
-| `control-plane/groups/scenario.yaml` | 2 | 4.07s | 7.94s |
-| `event-gateway/dump/scenario.yaml` | 2 | 4.05s | 8.40s |
-| `protected-resources/control-planes/scenario.yaml` | 2 | 3.85s | 7.04s |
-| `event-gateway/control-planes/scenario.yaml` | 2 | 3.80s | 6.96s |
-| `adopt/team-create-adopt-dump/scenario.yaml` | 2 | 3.50s | 9.90s |
-| `control-plane/plan/apply-workflow/scenario.yaml` | 2 | 3.33s | 5.84s |
-| `namespace/defaults-sync/scenario.yaml` | 2 | 3.32s | 6.51s |
-| `control-plane/apply/scenario.yaml` | 2 | 3.26s | 5.40s |
-| `errors/declarative/scenario.yaml` | 2 | 3.19s | 5.39s |
-| `portal/team_group_mappings_no_idp/scenario.yaml` | 2 | 3.02s | 6.46s |
-| `org/teams/sync/scenario.yaml` | 2 | 3.01s | 6.33s |
-| `event-gateway/adopt/scenario.yaml` | 2 | 2.58s | 5.25s |
-| `org/teams/get/scenario.yaml` | 2 | 2.55s | 5.44s |
-| `delete/idempotent/scenario.yaml` | 2 | 2.03s | 4.46s |
-| `portal/email-domains/scenario.yaml` | 2 | 1.58s | 3.84s |
-| `explain/command-coverage/scenario.yaml` | 2 | 1.05s | 1.43s |
-| `scaffold/command-coverage/scenario.yaml` | 2 | 0.96s | 0.99s |
-| `analytics/dashboard-repro/scenario.yaml` | 2 | 0.90s | 1.31s |
-| `namespace/validation/scenario.yaml` | 2 | 0.86s | 0.89s |
-| `declarative/plan-mode-validation/scenario.yaml` | 2 | 0.56s | 0.56s |
-| `patch/command-coverage/scenario.yaml` | 2 | 0.44s | 0.45s |
-| `ai-gateway/maturity/scenario.yaml` | 2 | 0.34s | 0.45s |
-| `lint/command-coverage/scenario.yaml` | 2 | 0.23s | 0.34s |
-| `portal/identity_providers_duplicate_type/scenario.yaml` | 2 | 0.19s | 0.21s |
-| `portal/auth_settings_deprecated_fields/scenario.yaml` | 2 | 0.11s | 0.19s |
-| `smoke/version/scenario.yaml` | 2 | 0.05s | 0.06s |
-| `auth/get-me/scenario.yaml` | 2 | 0.00s | 0.00s |
-| `event-gateway/principal-metadata/scenario.yaml` | 2 | 0.00s | 0.00s |
-| `portal/applications/scenario.yaml` | 2 | 0.00s | 0.00s |
+| `portal/visibility/scenario.yaml` | 14 | 42.11s | 51.68s |
+| `dump/portal-owned/scenario.yaml` | 14 | 32.45s | 50.87s |
+| `portal/api_docs_with_children/scenario.yaml` | 14 | 30.21s | 35.43s |
+| `all/scenario.yaml` | 14 | 28.77s | 33.86s |
+| `event-gateway/produce-policy/scenario.yaml` | 14 | 26.12s | 28.33s |
+| `portal/teams/scenario.yaml` | 14 | 25.48s | 26.86s |
+| `event-gateway/plan/apply-workflow/scenario.yaml` | 14 | 21.15s | 32.47s |
+| `event-gateway/plan/sync-workflow/scenario.yaml` | 14 | 20.65s | 37.16s |
+| `portal/auth-strategy-link/scenario.yaml` | 14 | 20.07s | 21.23s |
+| `event-gateway/external-sync/scenario.yaml` | 14 | 20.01s | 24.07s |
+| `portal/identity_providers/scenario.yaml` | 14 | 20.00s | 29.18s |
+| `portal/audit-log-webhook/scenario.yaml` | 14 | 18.61s | 21.82s |
+| `portal/sync/scenario.yaml` | 14 | 17.82s | 32.14s |
+| `ai-gateway/consumer/scenario.yaml` | 14 | 16.84s | 20.31s |
+| `apis/root-level-publication-visibility/scenario.yaml` | 14 | 16.61s | 17.63s |
+| `dump/organization-teams/scenario.yaml` | 14 | 16.37s | 17.34s |
+| `portal/ip-allow-list/scenario.yaml` | 14 | 16.18s | 20.61s |
+| `org/users/assignments/scenario.yaml` | 14 | 15.73s | 17.12s |
+| `portal/custom-domain/scenario.yaml` | 14 | 15.55s | 23.25s |
+| `event-gateway/virtual-cluster/scenario.yaml` | 14 | 15.39s | 16.56s |
+| `ai-gateway/model-provider/scenario.yaml` | 14 | 15.38s | 18.46s |
+| `ai-gateway/mcp-server/scenario.yaml` | 14 | 15.22s | 23.76s |
+| `deck/basic/scenario.yaml` | 14 | 15.08s | 17.80s |
+| `apis/control-plane-implementation/scenario.yaml` | 14 | 14.96s | 18.38s |
+| `diff/command-coverage/scenario.yaml` | 14 | 14.70s | 17.95s |
+| `apis/nested-child-lifecycle/scenario.yaml` | 14 | 14.38s | 25.23s |
+| `event-gateway/backend-cluster/scenario.yaml` | 14 | 14.38s | 17.70s |
+| `ai-gateway/agent/scenario.yaml` | 14 | 14.19s | 15.50s |
+| `portal/email-templates/scenario.yaml` | 14 | 14.10s | 16.65s |
+| `org/system-accounts/assignments/scenario.yaml` | 14 | 13.93s | 14.96s |
+| `portal/email/scenario.yaml` | 14 | 13.64s | 14.52s |
+| `portal/external-sync/scenario.yaml` | 14 | 13.41s | 17.22s |
+| `dump/filtered/scenario.yaml` | 14 | 13.30s | 16.29s |
+| `portal/default_application_auth_strategy/scenario.yaml` | 14 | 12.97s | 13.79s |
+| `plan/apply-workflow/scenario.yaml` | 14 | 12.96s | 13.86s |
+| `yaml-tags/env/scenario.yaml` | 14 | 12.84s | 15.82s |
+| `control-plane/data-plane-certificate/scenario.yaml` | 14 | 12.74s | 13.83s |
+| `ai-gateway/data-plane-certificate/scenario.yaml` | 14 | 12.72s | 13.57s |
+| `event-gateway/consume-policy/scenario.yaml` | 14 | 12.72s | 23.82s |
+| `portal/pages/scenario.yaml` | 14 | 12.62s | 14.97s |
+| `control-plane/serverless/scenario.yaml` | 14 | 12.59s | 13.47s |
+| `declarative/rename-sync-delete/scenario.yaml` | 14 | 12.54s | 14.74s |
+| `ai-gateway/vault/scenario.yaml` | 14 | 12.49s | 13.35s |
+| `portal/customization/scenario.yaml` | 14 | 12.36s | 14.86s |
+| `event-gateway/listener-policy/scenario.yaml` | 14 | 12.22s | 13.14s |
+| `ai-gateway/auth-strategy/scenario.yaml` | 14 | 11.95s | 15.19s |
+| `external/api-parent/scenario.yaml` | 14 | 11.94s | 14.37s |
+| `dcr-providers/workflow/scenario.yaml` | 14 | 11.79s | 18.90s |
+| `apis/region/scenario.yaml` | 14 | 11.50s | 12.67s |
+| `org/users/sync/scenario.yaml` | 14 | 11.32s | 11.94s |
+| `org/users/plan/sync-workflow/scenario.yaml` | 14 | 11.22s | 12.05s |
+| `portal/idp_team_group_mappings_readback/scenario.yaml` | 14 | 11.10s | 12.85s |
+| `event-gateway/schema-registry/scenario.yaml` | 14 | 11.08s | 13.96s |
+| `portal/auth_settings/scenario.yaml` | 14 | 10.98s | 13.92s |
+| `apis/comprehensive-fields/scenario.yaml` | 14 | 10.75s | 11.62s |
+| `ai-gateway/config-store/scenario.yaml` | 14 | 10.71s | 15.92s |
+| `org/system-accounts/plan/sync-workflow/scenario.yaml` | 14 | 10.50s | 11.67s |
+| `ai-gateway/runtime-tls/scenario.yaml` | 14 | 10.49s | 12.10s |
+| `ai-gateway/model/scenario.yaml` | 14 | 10.47s | 11.37s |
+| `ai-gateway/policy-matrix/scenario.yaml` | 14 | 10.34s | 13.21s |
+| `portal/publication-auth-omitted-noop/scenario.yaml` | 14 | 10.29s | 11.85s |
+| `portal/integrations/scenario.yaml` | 14 | 10.17s | 11.01s |
+| `delete/declarative/scenario.yaml` | 14 | 10.04s | 12.61s |
+| `org/teams/roles/scenario.yaml` | 14 | 9.98s | 15.66s |
+| `org/system-accounts/sync/scenario.yaml` | 14 | 9.82s | 10.55s |
+| `apis/child-delete-namespace/scenario.yaml` | 14 | 9.78s | 11.43s |
+| `protected-resources/event-gateways/scenario.yaml` | 14 | 9.78s | 11.52s |
+| `dump/control-planes/scenario.yaml` | 14 | 9.68s | 11.30s |
+| `protected-resources/apis/scenario.yaml` | 14 | 9.56s | 14.45s |
+| `event-gateway/dataplane-certificate/scenario.yaml` | 14 | 9.51s | 10.67s |
+| `event-gateway/static-key/scenario.yaml` | 14 | 9.41s | 14.60s |
+| `portal/api_with_attributes/scenario.yaml` | 14 | 9.35s | 10.05s |
+| `event-gateway/diff/scenario.yaml` | 14 | 9.33s | 14.69s |
+| `event-gateway/listener/scenario.yaml` | 14 | 9.22s | 11.84s |
+| `event-gateway/topic-aliases/scenario.yaml` | 14 | 9.09s | 10.84s |
+| `protected-resources/portals/scenario.yaml` | 14 | 9.03s | 12.11s |
+| `ai-gateway/consumer-group/scenario.yaml` | 14 | 8.82s | 16.29s |
+| `external/portal-publication/scenario.yaml` | 14 | 8.73s | 9.73s |
+| `delete/partial-delete/scenario.yaml` | 14 | 8.68s | 10.22s |
+| `ai-gateway/root/scenario.yaml` | 14 | 8.63s | 13.69s |
+| `portal/app-auth-strategy/scenario.yaml` | 14 | 8.60s | 10.73s |
+| `event-gateway/cluster-policy/scenario.yaml` | 14 | 8.41s | 13.40s |
+| `org/token/scenario.yaml` | 14 | 8.33s | 8.68s |
+| `deck/env-vars/scenario.yaml` | 14 | 8.24s | 8.98s |
+| `event-gateway/control-planes/scenario.yaml` | 14 | 8.20s | 8.52s |
+| `org/users/plan/apply-workflow/scenario.yaml` | 14 | 7.97s | 9.08s |
+| `adopt/full/scenario.yaml` | 14 | 7.93s | 12.66s |
+| `org/system-accounts/plan/apply-workflow/scenario.yaml` | 14 | 7.92s | 8.54s |
+| `adopt/auth-strategy-adopt/scenario.yaml` | 14 | 7.55s | 8.50s |
+| `control-plane/sync-groups/scenario.yaml` | 14 | 7.52s | 9.15s |
+| `portal/team_group_mappings_no_idp/scenario.yaml` | 14 | 7.02s | 8.30s |
+| `external/ai-gateway-parent/scenario.yaml` | 14 | 6.66s | 11.06s |
+| `protected-resources/org/teams/scenario.yaml` | 14 | 6.66s | 7.37s |
+| `delete/plan-based/scenario.yaml` | 14 | 6.45s | 6.89s |
+| `plan/remote-url-workflow/scenario.yaml` | 14 | 6.43s | 7.73s |
+| `apis/eventual-consistency-polp/scenario.yaml` | 14 | 6.40s | 6.84s |
+| `event-gateway/dependency-order/scenario.yaml` | 14 | 6.35s | 7.98s |
+| `deck/idempotent/scenario.yaml` | 14 | 6.30s | 8.42s |
+| `portal/page-frontmatter-conflict/scenario.yaml` | 14 | 6.29s | 11.14s |
+| `adopt/create-portal-adopt-dump-plan/scenario.yaml` | 14 | 6.28s | 8.51s |
+| `portal/snippets/scenario.yaml` | 14 | 6.17s | 9.57s |
+| `control-plane/plan/apply-workflow/scenario.yaml` | 14 | 6.15s | 7.08s |
+| `catalog/service/scenario.yaml` | 14 | 5.99s | 10.64s |
+| `portal/edit/scenario.yaml` | 14 | 5.96s | 9.34s |
+| `org/teams/plan/apply-workflow/scenario.yaml` | 14 | 5.95s | 6.65s |
+| `org/teams/plan/sync-workflow/scenario.yaml` | 14 | 5.93s | 7.46s |
+| `adopt/team-create-adopt-dump/scenario.yaml` | 14 | 5.89s | 7.34s |
+| `portal/assets/scenario.yaml` | 14 | 5.89s | 10.74s |
+| `control-plane/apply/scenario.yaml` | 14 | 5.88s | 6.82s |
+| `adopt/event-gateway-adopt/scenario.yaml` | 14 | 5.82s | 8.24s |
+| `dump/dcr-provider/scenario.yaml` | 14 | 5.74s | 6.42s |
+| `org/teams/get/scenario.yaml` | 14 | 5.61s | 6.85s |
+| `event-gateway/adopt/scenario.yaml` | 14 | 5.57s | 6.58s |
+| `dump/ai-gateways/scenario.yaml` | 14 | 5.48s | 8.91s |
+| `plan/sync-partial-scope/scenario.yaml` | 14 | 5.37s | 8.57s |
+| `deck/sync/scenario.yaml` | 14 | 5.29s | 10.13s |
+| `org/teams/external-role/scenario.yaml` | 14 | 5.28s | 9.57s |
+| `org/users/get/scenario.yaml` | 14 | 5.27s | 6.04s |
+| `deck/multi-file/scenario.yaml` | 14 | 5.25s | 8.30s |
+| `analytics/dashboard/scenario.yaml` | 14 | 5.24s | 8.65s |
+| `require-namespace/portal/scenario.yaml` | 14 | 5.21s | 8.51s |
+| `control-plane/delete-groups/scenario.yaml` | 14 | 5.19s | 6.65s |
+| `portal/oidc-auth-strategy/scenario.yaml` | 14 | 5.18s | 7.96s |
+| `event-gateway/backend-cluster-pagination/scenario.yaml` | 14 | 5.15s | 5.79s |
+| `portal/default_application_auth_strategy_ref_selection/scenario.yaml` | 14 | 5.10s | 6.42s |
+| `apis/versions-pagination/scenario.yaml` | 14 | 4.97s | 5.91s |
+| `org/system-accounts/scenario.yaml` | 14 | 4.92s | 6.42s |
+| `ai-gateway/model-matrix/scenario.yaml` | 14 | 4.77s | 8.88s |
+| `external/portal-sync/scenario.yaml` | 14 | 4.71s | 6.08s |
+| `event-gateway/tls-trust-bundle/scenario.yaml` | 14 | 4.70s | 9.27s |
+| `external/api-impl/scenario.yaml` | 14 | 4.68s | 8.77s |
+| `control-plane/get/scenario.yaml` | 14 | 4.34s | 6.86s |
+| `ai-gateway/policy/scenario.yaml` | 14 | 4.33s | 5.76s |
+| `plan/sync-workflow/scenario.yaml` | 14 | 4.20s | 7.48s |
+| `org/get-org/scenario.yaml` | 14 | 4.15s | 4.81s |
+| `yaml-tags/file/scenario.yaml` | 14 | 4.12s | 6.48s |
+| `dump/analytics-dashboards/scenario.yaml` | 14 | 4.10s | 8.68s |
+| `apis/get-api-by-name-and-id/scenario.yaml` | 14 | 4.05s | 6.09s |
+| `portal/snippets-pagination/scenario.yaml` | 14 | 4.01s | 5.30s |
+| `delete/dry-run/scenario.yaml` | 14 | 3.81s | 6.15s |
+| `control-plane/groups/scenario.yaml` | 14 | 3.77s | 6.90s |
+| `org/teams/apply/scenario.yaml` | 14 | 3.72s | 6.19s |
+| `require-namespace/external/scenario.yaml` | 14 | 3.71s | 6.04s |
+| `event-gateway/dump/scenario.yaml` | 14 | 3.66s | 7.09s |
+| `control-plane/sync/scenario.yaml` | 14 | 3.61s | 5.80s |
+| `protected-resources/control-planes/scenario.yaml` | 14 | 3.34s | 6.41s |
+| `namespace/defaults-sync/scenario.yaml` | 14 | 3.15s | 5.89s |
+| `errors/declarative/scenario.yaml` | 14 | 3.08s | 4.78s |
+| `org/teams/sync/scenario.yaml` | 14 | 2.88s | 5.37s |
+| `delete/idempotent/scenario.yaml` | 14 | 1.85s | 4.12s |
+| `portal/email-domains/scenario.yaml` | 14 | 1.50s | 3.34s |
+| `explain/command-coverage/scenario.yaml` | 14 | 1.34s | 1.43s |
+| `analytics/dashboard-repro/scenario.yaml` | 14 | 1.03s | 1.31s |
+| `scaffold/command-coverage/scenario.yaml` | 14 | 0.98s | 1.00s |
+| `namespace/validation/scenario.yaml` | 14 | 0.91s | 1.06s |
+| `declarative/plan-mode-validation/scenario.yaml` | 14 | 0.57s | 0.59s |
+| `patch/command-coverage/scenario.yaml` | 14 | 0.46s | 0.47s |
+| `ai-gateway/maturity/scenario.yaml` | 14 | 0.42s | 0.45s |
+| `lint/command-coverage/scenario.yaml` | 14 | 0.34s | 0.35s |
+| `portal/auth_settings_deprecated_fields/scenario.yaml` | 14 | 0.19s | 0.19s |
+| `portal/identity_providers_duplicate_type/scenario.yaml` | 14 | 0.19s | 0.20s |
+| `smoke/version/scenario.yaml` | 14 | 0.06s | 0.07s |
+| `auth/get-me/scenario.yaml` | 14 | 0.00s | 0.00s |
+| `event-gateway/principal-metadata/scenario.yaml` | 14 | 0.00s | 0.00s |
+| `portal/applications/scenario.yaml` | 14 | 0.00s | 0.00s |

--- a/test/e2e/baselines/scenario-weights.json
+++ b/test/e2e/baselines/scenario-weights.json
@@ -1,0 +1,662 @@
+{
+  "default_duration_ms": 8840,
+  "scenarios": {
+    "adopt/auth-strategy-adopt/scenario.yaml": {
+      "duration_ms": 8310,
+      "samples": 21
+    },
+    "adopt/create-portal-adopt-dump-plan/scenario.yaml": {
+      "duration_ms": 6280,
+      "samples": 21
+    },
+    "adopt/event-gateway-adopt/scenario.yaml": {
+      "duration_ms": 6100,
+      "samples": 21
+    },
+    "adopt/full/scenario.yaml": {
+      "duration_ms": 10490,
+      "samples": 21
+    },
+    "adopt/team-create-adopt-dump/scenario.yaml": {
+      "duration_ms": 5570,
+      "samples": 21
+    },
+    "ai-gateway/agent/scenario.yaml": {
+      "duration_ms": 15000,
+      "samples": 21
+    },
+    "ai-gateway/auth-strategy/scenario.yaml": {
+      "duration_ms": 11950,
+      "samples": 21
+    },
+    "ai-gateway/config-store/scenario.yaml": {
+      "duration_ms": 10710,
+      "samples": 21
+    },
+    "ai-gateway/consumer-group/scenario.yaml": {
+      "duration_ms": 12240,
+      "samples": 21
+    },
+    "ai-gateway/consumer/scenario.yaml": {
+      "duration_ms": 16840,
+      "samples": 21
+    },
+    "ai-gateway/data-plane-certificate/scenario.yaml": {
+      "duration_ms": 12970,
+      "samples": 21
+    },
+    "ai-gateway/maturity/scenario.yaml": {
+      "duration_ms": 430,
+      "samples": 21
+    },
+    "ai-gateway/mcp-server/scenario.yaml": {
+      "duration_ms": 15220,
+      "samples": 21
+    },
+    "ai-gateway/model-matrix/scenario.yaml": {
+      "duration_ms": 6870,
+      "samples": 21
+    },
+    "ai-gateway/model-provider/scenario.yaml": {
+      "duration_ms": 15360,
+      "samples": 21
+    },
+    "ai-gateway/model/scenario.yaml": {
+      "duration_ms": 10700,
+      "samples": 21
+    },
+    "ai-gateway/policy-matrix/scenario.yaml": {
+      "duration_ms": 10340,
+      "samples": 21
+    },
+    "ai-gateway/policy/scenario.yaml": {
+      "duration_ms": 3760,
+      "samples": 21
+    },
+    "ai-gateway/root/scenario.yaml": {
+      "duration_ms": 10320,
+      "samples": 21
+    },
+    "ai-gateway/runtime-tls/scenario.yaml": {
+      "duration_ms": 10250,
+      "samples": 21
+    },
+    "ai-gateway/vault/scenario.yaml": {
+      "duration_ms": 13040,
+      "samples": 21
+    },
+    "all/scenario.yaml": {
+      "duration_ms": 28770,
+      "samples": 21
+    },
+    "analytics/dashboard-repro/scenario.yaml": {
+      "duration_ms": 1040,
+      "samples": 21
+    },
+    "analytics/dashboard/scenario.yaml": {
+      "duration_ms": 6450,
+      "samples": 21
+    },
+    "apis/child-delete-namespace/scenario.yaml": {
+      "duration_ms": 9700,
+      "samples": 21
+    },
+    "apis/comprehensive-fields/scenario.yaml": {
+      "duration_ms": 11110,
+      "samples": 21
+    },
+    "apis/control-plane-implementation/scenario.yaml": {
+      "duration_ms": 14960,
+      "samples": 21
+    },
+    "apis/eventual-consistency-polp/scenario.yaml": {
+      "duration_ms": 6660,
+      "samples": 21
+    },
+    "apis/get-api-by-name-and-id/scenario.yaml": {
+      "duration_ms": 3960,
+      "samples": 21
+    },
+    "apis/nested-child-lifecycle/scenario.yaml": {
+      "duration_ms": 19010,
+      "samples": 21
+    },
+    "apis/region/scenario.yaml": {
+      "duration_ms": 11370,
+      "samples": 21
+    },
+    "apis/root-level-publication-visibility/scenario.yaml": {
+      "duration_ms": 17420,
+      "samples": 21
+    },
+    "apis/versions-pagination/scenario.yaml": {
+      "duration_ms": 4970,
+      "samples": 21
+    },
+    "catalog/service/scenario.yaml": {
+      "duration_ms": 7850,
+      "samples": 21
+    },
+    "control-plane/apply/scenario.yaml": {
+      "duration_ms": 5840,
+      "samples": 21
+    },
+    "control-plane/data-plane-certificate/scenario.yaml": {
+      "duration_ms": 13160,
+      "samples": 21
+    },
+    "control-plane/delete-groups/scenario.yaml": {
+      "duration_ms": 5190,
+      "samples": 21
+    },
+    "control-plane/get/scenario.yaml": {
+      "duration_ms": 4390,
+      "samples": 21
+    },
+    "control-plane/groups/scenario.yaml": {
+      "duration_ms": 5270,
+      "samples": 21
+    },
+    "control-plane/plan/apply-workflow/scenario.yaml": {
+      "duration_ms": 6050,
+      "samples": 21
+    },
+    "control-plane/serverless/scenario.yaml": {
+      "duration_ms": 12830,
+      "samples": 21
+    },
+    "control-plane/sync-groups/scenario.yaml": {
+      "duration_ms": 7520,
+      "samples": 21
+    },
+    "control-plane/sync/scenario.yaml": {
+      "duration_ms": 3680,
+      "samples": 21
+    },
+    "dcr-providers/workflow/scenario.yaml": {
+      "duration_ms": 16020,
+      "samples": 21
+    },
+    "deck/basic/scenario.yaml": {
+      "duration_ms": 15000,
+      "samples": 21
+    },
+    "deck/env-vars/scenario.yaml": {
+      "duration_ms": 8710,
+      "samples": 21
+    },
+    "deck/idempotent/scenario.yaml": {
+      "duration_ms": 6300,
+      "samples": 21
+    },
+    "deck/multi-file/scenario.yaml": {
+      "duration_ms": 5070,
+      "samples": 21
+    },
+    "deck/sync/scenario.yaml": {
+      "duration_ms": 7670,
+      "samples": 21
+    },
+    "declarative/plan-mode-validation/scenario.yaml": {
+      "duration_ms": 570,
+      "samples": 21
+    },
+    "declarative/rename-sync-delete/scenario.yaml": {
+      "duration_ms": 13310,
+      "samples": 21
+    },
+    "delete/declarative/scenario.yaml": {
+      "duration_ms": 10040,
+      "samples": 21
+    },
+    "delete/dry-run/scenario.yaml": {
+      "duration_ms": 3870,
+      "samples": 21
+    },
+    "delete/idempotent/scenario.yaml": {
+      "duration_ms": 2790,
+      "samples": 21
+    },
+    "delete/partial-delete/scenario.yaml": {
+      "duration_ms": 8580,
+      "samples": 21
+    },
+    "delete/plan-based/scenario.yaml": {
+      "duration_ms": 6630,
+      "samples": 21
+    },
+    "diff/command-coverage/scenario.yaml": {
+      "duration_ms": 14700,
+      "samples": 21
+    },
+    "dump/ai-gateways/scenario.yaml": {
+      "duration_ms": 5540,
+      "samples": 21
+    },
+    "dump/analytics-dashboards/scenario.yaml": {
+      "duration_ms": 6270,
+      "samples": 21
+    },
+    "dump/control-planes/scenario.yaml": {
+      "duration_ms": 9560,
+      "samples": 21
+    },
+    "dump/dcr-provider/scenario.yaml": {
+      "duration_ms": 6020,
+      "samples": 21
+    },
+    "dump/filtered/scenario.yaml": {
+      "duration_ms": 13300,
+      "samples": 21
+    },
+    "dump/organization-teams/scenario.yaml": {
+      "duration_ms": 16880,
+      "samples": 21
+    },
+    "dump/portal-owned/scenario.yaml": {
+      "duration_ms": 33460,
+      "samples": 21
+    },
+    "errors/declarative/scenario.yaml": {
+      "duration_ms": 3930,
+      "samples": 21
+    },
+    "event-gateway/adopt/scenario.yaml": {
+      "duration_ms": 5520,
+      "samples": 21
+    },
+    "event-gateway/backend-cluster-pagination/scenario.yaml": {
+      "duration_ms": 5430,
+      "samples": 21
+    },
+    "event-gateway/backend-cluster/scenario.yaml": {
+      "duration_ms": 14380,
+      "samples": 21
+    },
+    "event-gateway/cluster-policy/scenario.yaml": {
+      "duration_ms": 8560,
+      "samples": 21
+    },
+    "event-gateway/consume-policy/scenario.yaml": {
+      "duration_ms": 18060,
+      "samples": 21
+    },
+    "event-gateway/control-planes/scenario.yaml": {
+      "duration_ms": 7220,
+      "samples": 21
+    },
+    "event-gateway/dataplane-certificate/scenario.yaml": {
+      "duration_ms": 10100,
+      "samples": 21
+    },
+    "event-gateway/dependency-order/scenario.yaml": {
+      "duration_ms": 6350,
+      "samples": 21
+    },
+    "event-gateway/diff/scenario.yaml": {
+      "duration_ms": 9330,
+      "samples": 21
+    },
+    "event-gateway/dump/scenario.yaml": {
+      "duration_ms": 5330,
+      "samples": 21
+    },
+    "event-gateway/external-sync/scenario.yaml": {
+      "duration_ms": 19820,
+      "samples": 21
+    },
+    "event-gateway/listener-policy/scenario.yaml": {
+      "duration_ms": 12640,
+      "samples": 21
+    },
+    "event-gateway/listener/scenario.yaml": {
+      "duration_ms": 9220,
+      "samples": 21
+    },
+    "event-gateway/plan/apply-workflow/scenario.yaml": {
+      "duration_ms": 21250,
+      "samples": 21
+    },
+    "event-gateway/plan/sync-workflow/scenario.yaml": {
+      "duration_ms": 28680,
+      "samples": 21
+    },
+    "event-gateway/produce-policy/scenario.yaml": {
+      "duration_ms": 26860,
+      "samples": 21
+    },
+    "event-gateway/schema-registry/scenario.yaml": {
+      "duration_ms": 11080,
+      "samples": 21
+    },
+    "event-gateway/static-key/scenario.yaml": {
+      "duration_ms": 9410,
+      "samples": 21
+    },
+    "event-gateway/tls-trust-bundle/scenario.yaml": {
+      "duration_ms": 6730,
+      "samples": 21
+    },
+    "event-gateway/topic-aliases/scenario.yaml": {
+      "duration_ms": 8970,
+      "samples": 21
+    },
+    "event-gateway/virtual-cluster/scenario.yaml": {
+      "duration_ms": 15560,
+      "samples": 21
+    },
+    "explain/command-coverage/scenario.yaml": {
+      "duration_ms": 1360,
+      "samples": 21
+    },
+    "external/ai-gateway-parent/scenario.yaml": {
+      "duration_ms": 6640,
+      "samples": 21
+    },
+    "external/api-impl/scenario.yaml": {
+      "duration_ms": 6390,
+      "samples": 21
+    },
+    "external/api-parent/scenario.yaml": {
+      "duration_ms": 11830,
+      "samples": 21
+    },
+    "external/portal-publication/scenario.yaml": {
+      "duration_ms": 9180,
+      "samples": 21
+    },
+    "external/portal-sync/scenario.yaml": {
+      "duration_ms": 4710,
+      "samples": 21
+    },
+    "lint/command-coverage/scenario.yaml": {
+      "duration_ms": 350,
+      "samples": 21
+    },
+    "namespace/defaults-sync/scenario.yaml": {
+      "duration_ms": 4230,
+      "samples": 21
+    },
+    "namespace/validation/scenario.yaml": {
+      "duration_ms": 890,
+      "samples": 21
+    },
+    "org/get-org/scenario.yaml": {
+      "duration_ms": 4410,
+      "samples": 21
+    },
+    "org/system-accounts/assignments/scenario.yaml": {
+      "duration_ms": 14350,
+      "samples": 21
+    },
+    "org/system-accounts/plan/apply-workflow/scenario.yaml": {
+      "duration_ms": 8350,
+      "samples": 21
+    },
+    "org/system-accounts/plan/sync-workflow/scenario.yaml": {
+      "duration_ms": 11110,
+      "samples": 21
+    },
+    "org/system-accounts/scenario.yaml": {
+      "duration_ms": 4920,
+      "samples": 21
+    },
+    "org/system-accounts/sync/scenario.yaml": {
+      "duration_ms": 10170,
+      "samples": 21
+    },
+    "org/teams/apply/scenario.yaml": {
+      "duration_ms": 3880,
+      "samples": 21
+    },
+    "org/teams/external-role/scenario.yaml": {
+      "duration_ms": 6740,
+      "samples": 21
+    },
+    "org/teams/get/scenario.yaml": {
+      "duration_ms": 5520,
+      "samples": 21
+    },
+    "org/teams/plan/apply-workflow/scenario.yaml": {
+      "duration_ms": 6110,
+      "samples": 21
+    },
+    "org/teams/plan/sync-workflow/scenario.yaml": {
+      "duration_ms": 5930,
+      "samples": 21
+    },
+    "org/teams/roles/scenario.yaml": {
+      "duration_ms": 10230,
+      "samples": 21
+    },
+    "org/teams/sync/scenario.yaml": {
+      "duration_ms": 4020,
+      "samples": 21
+    },
+    "org/token/scenario.yaml": {
+      "duration_ms": 8380,
+      "samples": 21
+    },
+    "org/users/assignments/scenario.yaml": {
+      "duration_ms": 16500,
+      "samples": 21
+    },
+    "org/users/get/scenario.yaml": {
+      "duration_ms": 5560,
+      "samples": 21
+    },
+    "org/users/plan/apply-workflow/scenario.yaml": {
+      "duration_ms": 8470,
+      "samples": 21
+    },
+    "org/users/plan/sync-workflow/scenario.yaml": {
+      "duration_ms": 11770,
+      "samples": 21
+    },
+    "org/users/sync/scenario.yaml": {
+      "duration_ms": 11640,
+      "samples": 21
+    },
+    "patch/command-coverage/scenario.yaml": {
+      "duration_ms": 460,
+      "samples": 21
+    },
+    "plan/apply-workflow/scenario.yaml": {
+      "duration_ms": 13420,
+      "samples": 21
+    },
+    "plan/remote-url-workflow/scenario.yaml": {
+      "duration_ms": 6430,
+      "samples": 21
+    },
+    "plan/sync-partial-scope/scenario.yaml": {
+      "duration_ms": 5640,
+      "samples": 21
+    },
+    "plan/sync-workflow/scenario.yaml": {
+      "duration_ms": 5700,
+      "samples": 21
+    },
+    "portal/api_docs_with_children/scenario.yaml": {
+      "duration_ms": 30140,
+      "samples": 21
+    },
+    "portal/api_with_attributes/scenario.yaml": {
+      "duration_ms": 9550,
+      "samples": 21
+    },
+    "portal/app-auth-strategy/scenario.yaml": {
+      "duration_ms": 8600,
+      "samples": 21
+    },
+    "portal/assets/scenario.yaml": {
+      "duration_ms": 8460,
+      "samples": 21
+    },
+    "portal/audit-log-webhook/scenario.yaml": {
+      "duration_ms": 18570,
+      "samples": 21
+    },
+    "portal/auth-strategy-link/scenario.yaml": {
+      "duration_ms": 20900,
+      "samples": 21
+    },
+    "portal/auth_settings/scenario.yaml": {
+      "duration_ms": 10980,
+      "samples": 21
+    },
+    "portal/auth_settings_deprecated_fields/scenario.yaml": {
+      "duration_ms": 190,
+      "samples": 21
+    },
+    "portal/custom-domain/scenario.yaml": {
+      "duration_ms": 18390,
+      "samples": 21
+    },
+    "portal/customization/scenario.yaml": {
+      "duration_ms": 12250,
+      "samples": 21
+    },
+    "portal/default_application_auth_strategy/scenario.yaml": {
+      "duration_ms": 13450,
+      "samples": 21
+    },
+    "portal/default_application_auth_strategy_ref_selection/scenario.yaml": {
+      "duration_ms": 5100,
+      "samples": 21
+    },
+    "portal/edit/scenario.yaml": {
+      "duration_ms": 6080,
+      "samples": 21
+    },
+    "portal/email-domains/scenario.yaml": {
+      "duration_ms": 3080,
+      "samples": 21
+    },
+    "portal/email-templates/scenario.yaml": {
+      "duration_ms": 13900,
+      "samples": 21
+    },
+    "portal/email/scenario.yaml": {
+      "duration_ms": 14050,
+      "samples": 21
+    },
+    "portal/external-sync/scenario.yaml": {
+      "duration_ms": 13410,
+      "samples": 21
+    },
+    "portal/identity_providers/scenario.yaml": {
+      "duration_ms": 20000,
+      "samples": 21
+    },
+    "portal/identity_providers_duplicate_type/scenario.yaml": {
+      "duration_ms": 190,
+      "samples": 21
+    },
+    "portal/idp_team_group_mappings_readback/scenario.yaml": {
+      "duration_ms": 10910,
+      "samples": 21
+    },
+    "portal/integrations/scenario.yaml": {
+      "duration_ms": 10380,
+      "samples": 21
+    },
+    "portal/ip-allow-list/scenario.yaml": {
+      "duration_ms": 16180,
+      "samples": 21
+    },
+    "portal/oidc-auth-strategy/scenario.yaml": {
+      "duration_ms": 5390,
+      "samples": 21
+    },
+    "portal/page-frontmatter-conflict/scenario.yaml": {
+      "duration_ms": 9040,
+      "samples": 21
+    },
+    "portal/pages/scenario.yaml": {
+      "duration_ms": 12610,
+      "samples": 21
+    },
+    "portal/publication-auth-omitted-noop/scenario.yaml": {
+      "duration_ms": 10900,
+      "samples": 21
+    },
+    "portal/snippets-pagination/scenario.yaml": {
+      "duration_ms": 4010,
+      "samples": 21
+    },
+    "portal/snippets/scenario.yaml": {
+      "duration_ms": 6170,
+      "samples": 21
+    },
+    "portal/sync/scenario.yaml": {
+      "duration_ms": 24460,
+      "samples": 21
+    },
+    "portal/team_group_mappings_no_idp/scenario.yaml": {
+      "duration_ms": 6900,
+      "samples": 21
+    },
+    "portal/teams/scenario.yaml": {
+      "duration_ms": 26050,
+      "samples": 21
+    },
+    "portal/visibility/scenario.yaml": {
+      "duration_ms": 42110,
+      "samples": 21
+    },
+    "protected-resources/apis/scenario.yaml": {
+      "duration_ms": 9560,
+      "samples": 21
+    },
+    "protected-resources/control-planes/scenario.yaml": {
+      "duration_ms": 4760,
+      "samples": 21
+    },
+    "protected-resources/event-gateways/scenario.yaml": {
+      "duration_ms": 9440,
+      "samples": 21
+    },
+    "protected-resources/org/teams/scenario.yaml": {
+      "duration_ms": 7010,
+      "samples": 21
+    },
+    "protected-resources/portals/scenario.yaml": {
+      "duration_ms": 9030,
+      "samples": 21
+    },
+    "require-namespace/external/scenario.yaml": {
+      "duration_ms": 3900,
+      "samples": 21
+    },
+    "require-namespace/portal/scenario.yaml": {
+      "duration_ms": 7080,
+      "samples": 21
+    },
+    "scaffold/command-coverage/scenario.yaml": {
+      "duration_ms": 980,
+      "samples": 21
+    },
+    "smoke/version/scenario.yaml": {
+      "duration_ms": 60,
+      "samples": 21
+    },
+    "yaml-tags/env/scenario.yaml": {
+      "duration_ms": 12840,
+      "samples": 21
+    },
+    "yaml-tags/file/scenario.yaml": {
+      "duration_ms": 4120,
+      "samples": 21
+    }
+  },
+  "schema_version": 1,
+  "source_sha256": {
+    "test/e2e/baselines/post-cache-2026-09-observations.json": "522713d68c11ee949a4b3418b0703c4831b2449a446a413247b57bac1ae7e6f7",
+    "test/e2e/baselines/stage0-2026-09-observations.json": "d8fbb43c85bc02479536fb30b51e7af2b2e1f72f85b6b54517991c49e685bdf5"
+  },
+  "sources": [
+    "test/e2e/baselines/post-cache-2026-09-observations.json",
+    "test/e2e/baselines/stage0-2026-09-observations.json"
+  ]
+}

--- a/test/e2e/scenarios_test.go
+++ b/test/e2e/scenarios_test.go
@@ -68,7 +68,7 @@ func Test_Scenarios(t *testing.T) {
 		allowedEnvs,
 	)
 
-	selected, err := selectScenariosWithConfig(scenarios, scenarioSelectionConfig{
+	selectionConfig := scenarioSelectionConfig{
 		Filter:       filt,
 		Shard:        shard,
 		CurrentEnv:   os.Getenv("KONGCTL_E2E_MATRIX_ORG"),
@@ -76,13 +76,17 @@ func Test_Scenarios(t *testing.T) {
 		Assignments:  assignments,
 		ValidateEnvs: validateEnvs,
 		EnforceEnv:   shard.Enabled,
-	})
+	}
+	selected, err := selectScenariosWithConfig(scenarios, selectionConfig)
 	if err != nil {
 		t.Fatalf("select scenarios: %v", err)
 	}
 	excluded := missingAssignedEnvironmentScenarios(scenarios, assignments, allowedEnvs, validateEnvs)
 	if err := writeScenarioShardManifest(os.Getenv("KONGCTL_E2E_ARTIFACTS_DIR"), shard, selected, excluded); err != nil {
 		t.Fatalf("write shard manifest: %v", err)
+	}
+	if err := writeWeightedScenarioReport(os.Getenv("KONGCTL_E2E_ARTIFACTS_DIR"), scenarios, selectionConfig); err != nil {
+		t.Logf("WARNING: weighted sharding report unavailable (live assignments unchanged): %v", err)
 	}
 
 	if len(selected) == 0 {

--- a/test/e2e/scenarios_weighted.go
+++ b/test/e2e/scenarios_weighted.go
@@ -1,0 +1,210 @@
+package e2e
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// Embed the snapshot so the precompiled scenario binary uses the same weights
+// regardless of its working directory. No network access is needed.
+//
+//go:embed baselines/scenario-weights.json
+var scenarioWeightsJSON []byte
+
+type scenarioWeight struct {
+	DurationMS int64 `json:"duration_ms"`
+	Samples    int   `json:"samples"`
+}
+
+type scenarioWeights struct {
+	SchemaVersion int                       `json:"schema_version"`
+	DefaultMS     int64                     `json:"default_duration_ms"`
+	Sources       []string                  `json:"sources"`
+	SourceSHA256  map[string]string         `json:"source_sha256"`
+	Scenarios     map[string]scenarioWeight `json:"scenarios"`
+}
+
+type weightedScenario struct {
+	Scenario   string `json:"scenario"`
+	DurationMS int64  `json:"duration_ms"`
+	Samples    int    `json:"samples"`
+	Fallback   bool   `json:"fallback"`
+}
+
+type weightedOrganization struct {
+	Environment string             `json:"environment"`
+	Current     []weightedScenario `json:"current"`
+	Proposed    []weightedScenario `json:"proposed"`
+	CurrentMS   int64              `json:"current_estimated_ms"`
+	ProposedMS  int64              `json:"proposed_estimated_ms"`
+}
+
+type weightedScenarioReport struct {
+	SchemaVersion int                    `json:"schema_version"`
+	Mode          string                 `json:"mode"`
+	Uniform       bool                   `json:"uniform_weights"`
+	Sources       []string               `json:"weight_sources"`
+	SourceSHA256  map[string]string      `json:"weight_source_sha256"`
+	Organizations []weightedOrganization `json:"organizations"`
+}
+
+func (w scenarioWeights) validate() error {
+	if w.SchemaVersion != 1 || w.DefaultMS <= 0 {
+		return fmt.Errorf("invalid scenario weight version or default duration")
+	}
+	for path, weight := range w.Scenarios {
+		if path == "" || path != normalizeScenarioPath(path) || weight.DurationMS <= 0 || weight.Samples < 10 {
+			return fmt.Errorf("invalid scenario weight for %q", path)
+		}
+	}
+	return nil
+}
+
+// planWeightedScenarios never selects scenarios for execution. Current retains
+// the existing selector's ordering; Proposed is a deterministic shadow plan.
+func planWeightedScenarios(
+	scenarios []string,
+	environments []string,
+	assignments map[string]scenarioAssignment,
+	weights scenarioWeights,
+) (weightedScenarioReport, error) {
+	report := weightedScenarioReport{SchemaVersion: 1, Mode: "report-only"}
+	if err := weights.validate(); err != nil {
+		return report, err
+	}
+	if len(environments) == 0 {
+		return report, fmt.Errorf("weighted plan requires environments")
+	}
+	report.Sources = weights.Sources
+	report.SourceSHA256 = weights.SourceSHA256
+	report.Uniform = len(weights.Scenarios) == 0
+	indices := make(map[string]int, len(environments))
+	for i, env := range environments {
+		if _, exists := indices[env]; exists || strings.TrimSpace(env) == "" {
+			return report, fmt.Errorf("invalid or duplicate environment %q", env)
+		}
+		indices[env] = i
+		report.Organizations = append(report.Organizations, weightedOrganization{
+			Environment: env, Current: []weightedScenario{}, Proposed: []weightedScenario{},
+		})
+	}
+	items := make(map[string]weightedScenario, len(scenarios))
+	unpinned := make([]weightedScenario, 0, len(scenarios))
+	var total int64
+	for _, path := range scenarios {
+		path = normalizeScenarioPath(path)
+		if _, exists := items[path]; exists || path == "" {
+			return report, fmt.Errorf("invalid or duplicate scenario %q", path)
+		}
+		weight, known := weights.Scenarios[path]
+		if !known {
+			weight.DurationMS = weights.DefaultMS
+		}
+		if weight.DurationMS > math.MaxInt64-total {
+			return report, fmt.Errorf("scenario weight total overflows milliseconds")
+		}
+		total += weight.DurationMS
+		item := weightedScenario{path, weight.DurationMS, weight.Samples, !known}
+		items[path] = item
+		if env := assignments[path].Environment; env != "" {
+			index, exists := indices[env]
+			if !exists {
+				return report, fmt.Errorf("scenario %s pinned to unavailable environment %q", path, env)
+			}
+			org := &report.Organizations[index]
+			org.Proposed = append(org.Proposed, item)
+			org.ProposedMS += item.DurationMS
+		} else {
+			unpinned = append(unpinned, item)
+		}
+	}
+	slices.SortFunc(unpinned, func(a, b weightedScenario) int {
+		if a.DurationMS > b.DurationMS {
+			return -1
+		}
+		if a.DurationMS < b.DurationMS {
+			return 1
+		}
+		return strings.Compare(a.Scenario, b.Scenario)
+	})
+	for _, item := range unpinned {
+		index := 0
+		for i := range report.Organizations {
+			if report.Organizations[i].ProposedMS < report.Organizations[index].ProposedMS {
+				index = i
+			}
+		}
+		org := &report.Organizations[index]
+		org.Proposed = append(org.Proposed, item)
+		org.ProposedMS += item.DurationMS
+	}
+	for i := range report.Organizations {
+		org := &report.Organizations[i]
+		slices.SortFunc(org.Proposed, func(a, b weightedScenario) int { return strings.Compare(a.Scenario, b.Scenario) })
+		current, err := selectScenariosWithConfig(scenarios, scenarioSelectionConfig{
+			Shard:      scenarioShard{Enabled: true, Index: i, Total: len(environments)},
+			CurrentEnv: org.Environment, AllowedEnvs: environments, Assignments: assignments,
+			ValidateEnvs: true, EnforceEnv: true,
+		})
+		if err != nil {
+			return report, err
+		}
+		for _, path := range current {
+			item := items[normalizeScenarioPath(path)]
+			org.Current = append(org.Current, item)
+			org.CurrentMS += item.DurationMS
+		}
+	}
+	return report, nil
+}
+
+func writeWeightedScenarioReport(artifactsDir string, scenarios []string, cfg scenarioSelectionConfig) error {
+	if cfg.Filter != "" || !cfg.Shard.Enabled || !cfg.ValidateEnvs || artifactsDir == "" {
+		return nil
+	}
+	if cfg.Shard.Total != len(cfg.AllowedEnvs) || cfg.Shard.Index < 0 || cfg.Shard.Index >= cfg.Shard.Total ||
+		cfg.AllowedEnvs[cfg.Shard.Index] != cfg.CurrentEnv {
+		return fmt.Errorf("weighted report requires shard indices matching configured organization order")
+	}
+	var weights scenarioWeights
+	if err := json.Unmarshal(scenarioWeightsJSON, &weights); err != nil {
+		return fmt.Errorf("parse scenario weights: %w", err)
+	}
+	report, err := planWeightedScenarios(scenarios, cfg.AllowedEnvs, cfg.Assignments, weights)
+	if err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(artifactsDir, 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(artifactsDir, "proposed-scenario-assignments.json"), data, 0o600); err != nil {
+		return err
+	}
+	var summary strings.Builder
+	summary.WriteString("### Weighted sharding predictions (report only)\n\n")
+	summary.WriteString("Live assignments are unchanged. Estimates exclude job overhead and are not measured savings.\n\n")
+	fmt.Fprintf(&summary, "Uniform fallback weights: %t.\n\n", report.Uniform)
+	summary.WriteString("| Organization | Current estimate (s) | Proposed estimate (s) |\n| --- | ---: | ---: |\n")
+	currentMin, proposedMin := int64(math.MaxInt64), int64(math.MaxInt64)
+	var currentMax, proposedMax int64
+	for _, org := range report.Organizations {
+		fmt.Fprintf(&summary, "| %s | %.2f | %.2f |\n", org.Environment,
+			float64(org.CurrentMS)/1000, float64(org.ProposedMS)/1000)
+		currentMin, proposedMin = min(currentMin, org.CurrentMS), min(proposedMin, org.ProposedMS)
+		currentMax, proposedMax = max(currentMax, org.CurrentMS), max(proposedMax, org.ProposedMS)
+	}
+	fmt.Fprintf(&summary, "\nEstimated longest shard: %.2fs → %.2fs; spread: %.2fs → %.2fs.\n",
+		float64(currentMax)/1000, float64(proposedMax)/1000,
+		float64(currentMax-currentMin)/1000, float64(proposedMax-proposedMin)/1000)
+	return os.WriteFile(filepath.Join(artifactsDir, "weighted-sharding-summary.md"), []byte(summary.String()), 0o600)
+}

--- a/test/e2e/scenarios_weighted_repository_test.go
+++ b/test/e2e/scenarios_weighted_repository_test.go
@@ -1,0 +1,112 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+// TestWeightedRepositoryPlan validates the real corpus without executing any
+// scenario or contacting Konnect. The build job runs this in the compiled binary.
+func TestWeightedRepositoryPlan(t *testing.T) {
+	root := "scenarios"
+	if _, err := os.Stat(root); os.IsNotExist(err) {
+		root = "test/e2e/scenarios"
+	}
+	var paths []string
+	if err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.IsDir() && entry.Name() == "scenario.yaml" {
+			paths = append(paths, path)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("no repository scenarios found")
+	}
+	slices.Sort(paths)
+	pins, err := loadScenarioAssignments(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Derive pin destinations from manifests, not a maintained scenario mapping.
+	// Add unpinned destinations to exercise balancing across five organizations.
+	orgSet := map[string]bool{}
+	for _, pin := range pins {
+		orgSet[pin.Environment] = true
+	}
+	envs := slices.Sorted(maps.Keys(orgSet))
+	for i := 0; len(envs) < 5; i++ {
+		name := fmt.Sprintf("weighted-test-org-%d", i)
+		if !orgSet[name] {
+			envs = append(envs, name)
+		}
+	}
+	var reference []byte
+	for i, env := range envs {
+		dir := t.TempDir()
+		cfg := scenarioSelectionConfig{
+			Shard:      scenarioShard{Enabled: true, Index: i, Total: len(envs)},
+			CurrentEnv: env, AllowedEnvs: envs, Assignments: pins, ValidateEnvs: true, EnforceEnv: true,
+		}
+		if err := writeWeightedScenarioReport(dir, paths, cfg); err != nil {
+			t.Fatal(err)
+		}
+		data, err := os.ReadFile(filepath.Join(dir, "proposed-scenario-assignments.json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if i > 0 && string(data) != string(reference) {
+			t.Fatal("matrix organizations generated different full-pool plans")
+		}
+		reference = data
+		var report weightedScenarioReport
+		if err := json.Unmarshal(data, &report); err != nil {
+			t.Fatal(err)
+		}
+		selected, err := selectScenariosWithConfig(paths, cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var current []string
+		for _, item := range report.Organizations[i].Current {
+			current = append(current, item.Scenario)
+		}
+		for j := range selected {
+			selected[j] = normalizeScenarioPath(selected[j])
+		}
+		if !slices.Equal(current, selected) {
+			t.Fatalf("report for %s does not match actual selector", env)
+		}
+		seen := map[string]bool{}
+		var currentTotal, proposedTotal int64
+		for _, org := range report.Organizations {
+			currentTotal += org.CurrentMS
+			proposedTotal += org.ProposedMS
+			for _, item := range org.Proposed {
+				if seen[item.Scenario] {
+					t.Fatalf("duplicate proposed scenario %s", item.Scenario)
+				}
+				seen[item.Scenario] = true
+				if pin := pins[item.Scenario].Environment; pin != "" && pin != org.Environment {
+					t.Fatalf("scenario %s moved away from pin %s", item.Scenario, pin)
+				}
+			}
+		}
+		if len(seen) != len(paths) || currentTotal != proposedTotal {
+			t.Fatal("proposed assignment changed coverage or total weight")
+		}
+	}
+	t.Logf("validated %d scenarios and %d pins across %d organizations", len(paths), len(pins), len(envs))
+}

--- a/test/e2e/scenarios_weighted_test.go
+++ b/test/e2e/scenarios_weighted_test.go
@@ -1,0 +1,195 @@
+package e2e
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func TestWeightedScenarioPlan(t *testing.T) {
+	paths := []string{"scenarios/a/scenario.yaml", "scenarios/b/scenario.yaml", "scenarios/c/scenario.yaml"}
+	original := slices.Clone(paths)
+	weights := scenarioWeights{SchemaVersion: 1, DefaultMS: 10, Scenarios: map[string]scenarioWeight{
+		"a/scenario.yaml":       {DurationMS: 100, Samples: 10},
+		"b/scenario.yaml":       {DurationMS: 60, Samples: 11},
+		"removed/scenario.yaml": {DurationMS: 999, Samples: 10},
+	}}
+	pins := map[string]scenarioAssignment{"a/scenario.yaml": {Environment: "one"}}
+	plan, err := planWeightedScenarios(paths, []string{"one", "two"}, pins, weights)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Organizations[0].ProposedMS != 100 || plan.Organizations[1].ProposedMS != 70 {
+		t.Fatalf("pinned load not reserved first: %+v", plan)
+	}
+	seen := map[string]bool{}
+	for _, org := range plan.Organizations {
+		for _, item := range org.Proposed {
+			if seen[item.Scenario] {
+				t.Fatalf("duplicate assignment: %s", item.Scenario)
+			}
+			seen[item.Scenario] = true
+		}
+	}
+	if len(seen) != len(paths) || !plan.Organizations[1].Proposed[1].Fallback {
+		t.Fatalf("coverage or new-scenario fallback incorrect: %+v", plan)
+	}
+	if plan.Organizations[0].CurrentMS != 160 || plan.Organizations[1].CurrentMS != 10 {
+		t.Fatalf("current selector comparison incorrect: %+v", plan)
+	}
+	reversed := slices.Clone(paths)
+	slices.Reverse(reversed)
+	other, err := planWeightedScenarios(reversed, []string{"one", "two"}, pins, weights)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, org := range plan.Organizations {
+		if !reflect.DeepEqual(org.Proposed, other.Organizations[i].Proposed) {
+			t.Fatal("proposed assignment depends on input order")
+		}
+	}
+	if !reflect.DeepEqual(paths, original) {
+		t.Fatal("scheduler mutated input")
+	}
+}
+
+func TestWeightedUniformTiesAndEmptyShards(t *testing.T) {
+	weights := scenarioWeights{SchemaVersion: 1, DefaultMS: 1000}
+	for _, paths := range [][]string{nil, {"b", "a"}, {"b", "a", "c"}} {
+		plan, err := planWeightedScenarios(paths, []string{"one", "two", "three"}, nil, weights)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !plan.Uniform || len(plan.Organizations) != 3 {
+			t.Fatal("uniform fallback or empty shard missing")
+		}
+		if len(paths) > 0 && plan.Organizations[0].Proposed[0].Scenario != "a" {
+			t.Fatal("ties must use path and configured org order")
+		}
+	}
+}
+
+func TestWeightedInvalidInputs(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		paths   []string
+		envs    []string
+		pins    map[string]scenarioAssignment
+		weights scenarioWeights
+	}{
+		{"version", nil, []string{"one"}, nil, scenarioWeights{DefaultMS: 1}},
+		{"zero default", nil, []string{"one"}, nil, scenarioWeights{SchemaVersion: 1}},
+		{"no orgs", nil, nil, nil, scenarioWeights{SchemaVersion: 1, DefaultMS: 1}},
+		{"duplicate org", nil, []string{"one", "one"}, nil, scenarioWeights{SchemaVersion: 1, DefaultMS: 1}},
+		{
+			"duplicate scenario",
+			[]string{"a", "scenarios/a"},
+			[]string{"one"},
+			nil,
+			scenarioWeights{SchemaVersion: 1, DefaultMS: 1},
+		},
+		{
+			"missing pin",
+			[]string{"a"},
+			[]string{"one"},
+			map[string]scenarioAssignment{"a": {Environment: "two"}},
+			scenarioWeights{SchemaVersion: 1, DefaultMS: 1},
+		},
+		{"overflow", []string{"a", "b"}, []string{"one"}, nil, scenarioWeights{SchemaVersion: 1, DefaultMS: math.MaxInt64}},
+		{
+			"bad weight",
+			[]string{"a"},
+			[]string{"one"},
+			nil,
+			scenarioWeights{
+				SchemaVersion: 1, DefaultMS: 1,
+				Scenarios: map[string]scenarioWeight{"a": {DurationMS: -1, Samples: 10}},
+			},
+		},
+		{
+			"few samples",
+			[]string{"a"},
+			[]string{"one"},
+			nil,
+			scenarioWeights{
+				SchemaVersion: 1, DefaultMS: 1,
+				Scenarios: map[string]scenarioWeight{"a": {DurationMS: 1, Samples: 9}},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := planWeightedScenarios(tc.paths, tc.envs, tc.pins, tc.weights); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestWeightedReportIsolation(t *testing.T) {
+	var weights scenarioWeights
+	if err := json.Unmarshal(scenarioWeightsJSON, &weights); err != nil {
+		t.Fatal(err)
+	}
+	if err := weights.validate(); err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	paths := []string{"new/scenario.yaml"}
+	cfg := scenarioSelectionConfig{
+		Shard: scenarioShard{Enabled: true, Total: 1}, CurrentEnv: "one",
+		AllowedEnvs: []string{"one"}, ValidateEnvs: true,
+	}
+	if err := writeScenarioShardManifest(dir, cfg.Shard, paths, nil); err != nil {
+		t.Fatal(err)
+	}
+	manifest := filepath.Join(dir, "assigned-scenarios.txt")
+	before, err := os.ReadFile(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeWeightedScenarioReport(dir, paths, cfg); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(manifest)
+	if err != nil || string(before) != string(after) {
+		t.Fatal("actual manifest changed")
+	}
+	for _, name := range []string{"proposed-scenario-assignments.json", "weighted-sharding-summary.md"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, mode := range []string{"filtered", "tech", "unsharded"} {
+		t.Run(mode, func(t *testing.T) {
+			dir := t.TempDir()
+			copyCfg := cfg
+			switch mode {
+			case "filtered":
+				copyCfg.Filter = "new"
+			case "tech":
+				copyCfg.ValidateEnvs = false
+			case "unsharded":
+				copyCfg.Shard.Enabled = false
+			}
+			if err := writeWeightedScenarioReport(dir, paths, copyCfg); err != nil {
+				t.Fatal(err)
+			}
+			entries, err := os.ReadDir(dir)
+			if err != nil || len(entries) != 0 {
+				t.Fatal("ineligible run generated report")
+			}
+		})
+	}
+	invalid := cfg
+	invalid.Shard.Total = 2
+	if err := writeWeightedScenarioReport(dir, paths, invalid); err == nil {
+		t.Fatal("expected mismatched matrix error")
+	}
+	if err := writeWeightedScenarioReport(manifest, paths, cfg); err == nil {
+		t.Fatal("expected report I/O error")
+	}
+}


### PR DESCRIPTION
## Summary

Related to #2053; this does not complete or close the optimization issue.

- Preserve the 14-run post-cache observations, generated baseline report, and cache/optimization assessment.
- Add deterministic pin-aware weighted scheduling in report-only mode: reserve pinned load, then assign longest scenarios to the least-loaded organization with stable ties.
- Embed a manually generated snapshot covering 162 scenarios with 21 passing samples each, with source hashes and fallback weights.
- Publish current versus proposed predicted loads in full .com shard summaries and separate JSON/Markdown artifacts.
- Add scheduler/generator tests and document practical operation and rollout.

## Safety and rollout

Actual scenario selection, ordering, organization pins, coverage manifests, metrics, reset policy, and concurrency are unchanged. Filtered, unsharded, and .tech runs do not generate weighted reports. Reporting errors are warnings, not scenario failures. No kongctl production behavior changes.

Predictions are not measured savings. Keep collecting the post-cache baseline; activate weighted assignments in a separate PR and begin a separately identified measurement period. Weight refresh remains manual with `make refresh-e2e-weights`; baseline collection does not automatically update weights.

## Review structure

1. `6b9ab37f`: saved observations, baseline report, and analysis.
2. `fa8c3e19`: report-only implementation, snapshot, tests, and usage documentation.

The large observation JSON is retained to preserve data beyond artifact expiry and reproduce the weight snapshot.

## Validation

Passed on current main:

- `CGO_ENABLED=0 go fix ./...`
- `make format` (no changes)
- `make build`
- `make test-all` (golangci-lint v2.13.1; installer, race-enabled unit, Python, and integration tests)
- `CGO_ENABLED=0 go test -tags=e2e ./test/e2e -run "TestWeighted|TestScenario"`
- `actionlint -shellcheck= .github/workflows/e2e.yaml`
- `git diff --check`

No live Konnect scenarios were run locally; integration tests used the default mock SDK. Full shell checking has existing warnings unrelated to this diff. The pre-commit executable is not installed locally, so those hooks were unavailable.
