### PR TITLE
refactor(declarative): register Event Gateway execution capabilities

### DIFF
--- a/docs/contributor/declarative-resource-implementation-guide.md
+++ b/docs/contributor/declarative-resource-implementation-guide.md
@@ -40,10 +40,10 @@ The [resource registry][registry] drives iteration, aggregation,
 explain/scaffold, load-schema discovery, and dump-default metadata. The
 [root planner inventory][roots] drives root construction and dispatch.
 [Runtime executor registration][runtime-executors] supplies action routing and
-payload validation for AI Gateway resources. Other executor families, loader
-scope/extraction, namespace participation, relationships, state-client wiring,
-and dump collection still have separate integration points. Registering a
-declaration does not complete those steps automatically.
+payload validation for AI Gateway and Event Gateway resources. Other executor
+families, loader scope/extraction, namespace participation, relationships,
+state-client wiring, and dump collection still have separate integration
+points. Registering a declaration does not complete those steps automatically.
 
 ## 1. Define and register the resource
 
@@ -240,18 +240,26 @@ through the current execution path, including parents created in the same
 plan. Use SDK label conversion helpers so user-label removal and managed
 labels survive updates.
 
-For AI Gateway resources, add one entry to
-[`registerAIGatewayExecutors`][ai-executors]. The typed base executor supplies
-its resource kind and payload contract. `crudResourceExecutor` exposes
-create/update/delete; `createDeleteResourceExecutor` leaves update unsupported.
+Add AI Gateway resources in [AI Gateway registration][ai-executors] and Event
+Gateway resources in [Event Gateway registration][egw-executors]. The typed
+base executor supplies its resource kind and payload contract.
+`crudResourceExecutor` exposes create/update/delete;
+`createDeleteResourceExecutor` leaves update unsupported.
 Registration rejects missing contracts, empty action sets, and duplicate kinds,
 including conflicts with the legacy payload inventory. No per-kind field,
 payload-list entry, or action-switch case is needed for these resources.
 
-AI Gateway children share reference preparation before supported operations.
-Consumer groups also synchronize membership after successful create/update.
-Keep exceptional ordering and failures in explicit wrappers; unsupported
-operations must not resolve references or perform API calls.
+AI Gateway children prepare references before every supported operation;
+consumer groups synchronize membership after successful create/update.
+Event Gateway children prepare writes only; deletes use routing IDs in the
+plan. Static keys omit update. Virtual-cluster create/update retain distinct
+gateway lookup rules. Preserve empty-ID versus unknown-ID predicates and
+parent/reference precedence during migration.
+
+Use `prepareResourceExecutor` for all actions, `prepareResourceWrites` for
+create/update, and `prepareResourceWrite` for action-specific preparation.
+Keep ordering and failures explicit; unsupported operations must not resolve
+references or perform API calls.
 
 Other families retain [legacy executor wiring][executor]: inspect
 `NewWithOptions`, the three resource action switches, and payload registration.
@@ -461,6 +469,7 @@ engine contract. Each refactoring migration should:
 [runtime-executors]:
   ../../internal/declarative/executor/resource_executors.go
 [ai-executors]: ../../internal/declarative/executor/ai_gateway_executors.go
+[egw-executors]: ../../internal/declarative/executor/event_gateway_executors.go
 [base-executor]: ../../internal/declarative/executor/base_executor.go
 [base-operations]: ../../internal/declarative/executor/base_operations.go
 [payloads]: ../../internal/declarative/executor/payload_contract.go

--- a/internal/declarative/executor/event_gateway_executors.go
+++ b/internal/declarative/executor/event_gateway_executors.go
@@ -1,0 +1,185 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kong/kongctl/internal/declarative/planner"
+)
+
+func (e *Executor) registerEventGatewayControlPlaneExecutor() {
+	e.registerResourceExecutor(crudResourceExecutor(
+		NewManagedLabelBaseExecutor(NewEventGatewayControlPlaneControlPlaneAdapter(e.client), e.client, e.dryRun),
+	))
+}
+
+// registerEventGatewayChildExecutors couples construction, payload contracts,
+// supported actions, and reference preparation. Deletes use the IDs in the plan.
+func (e *Executor) registerEventGatewayChildExecutors() {
+	client, dryRun := e.client, e.dryRun
+	registerChild := func(resource resourceExecutor, prepare func(context.Context, *planner.PlannedChange) error) {
+		e.registerResourceExecutor(prepareResourceWrites(resource, prepare))
+	}
+	registerChild(crudResourceExecutor(
+		NewBaseExecutor(NewEventGatewayBackendClusterAdapter(client), client, dryRun),
+	), e.prepareEventGatewayReference)
+
+	virtualCluster := crudResourceExecutor(
+		NewBaseExecutor(NewEventGatewayVirtualClusterAdapter(client), client, dryRun),
+	)
+	virtualCluster.create = prepareResourceWrite(virtualCluster.create, e.prepareEventGatewayVirtualClusterCreate)
+	virtualCluster.update = prepareResourceWrite(virtualCluster.update, e.prepareEventGatewayVirtualClusterUpdate)
+	e.registerResourceExecutor(virtualCluster)
+
+	registerChild(crudResourceExecutor(
+		NewBaseExecutor(NewEventGatewayListenerAdapter(client), client, dryRun),
+	), e.prepareEventGatewayReference)
+	registerChild(crudResourceExecutor(
+		NewBaseExecutor(NewEventGatewayListenerPolicyAdapter(client), client, dryRun),
+	), e.prepareEventGatewayListenerPolicy)
+	registerChild(crudResourceExecutor(
+		NewBaseExecutor(NewEventGatewayClusterPolicyAdapter(client), client, dryRun),
+	), e.prepareEventGatewayClusterPolicy)
+	registerChild(crudResourceExecutor(
+		NewBaseExecutor(NewEventGatewayProducePolicyAdapter(client), client, dryRun),
+	), e.prepareEventGatewayProducePolicy)
+	registerChild(crudResourceExecutor(
+		NewBaseExecutor(NewEventGatewayConsumePolicyAdapter(client), client, dryRun),
+	), e.prepareEventGatewayClusterPolicy)
+	registerChild(crudResourceExecutor(
+		NewBaseExecutor(NewEventGatewayDataPlaneCertificateAdapter(client), client, dryRun),
+	), e.prepareEventGatewayReference)
+	registerChild(crudResourceExecutor(
+		NewBaseExecutor(NewEventGatewaySchemaRegistryAdapter(client), client, dryRun),
+	), e.prepareEventGatewayReference)
+	registerChild(createDeleteResourceExecutor(
+		NewBaseExecutor(NewEventGatewayStaticKeyAdapter(client), client, dryRun),
+	), e.prepareEventGatewayReference)
+	registerChild(crudResourceExecutor(
+		NewBaseExecutor(NewEventGatewayTLSTrustBundleAdapter(client), client, dryRun),
+	), e.prepareEventGatewayReference)
+}
+
+func (e *Executor) prepareEventGatewayReference(ctx context.Context, change *planner.PlannedChange) error {
+	// Resolve event gateway reference if needed
+	if gatewayRef, ok := change.References[planner.FieldEventGatewayID]; ok && gatewayRef.ID == "" {
+		gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
+		if err != nil {
+			return fmt.Errorf("failed to resolve event gateway reference: %w", err)
+		}
+		// Update the reference with the resolved ID
+		gatewayRef.ID = gatewayID
+		change.References[planner.FieldEventGatewayID] = gatewayRef
+	}
+	return nil
+}
+
+func (e *Executor) prepareEventGatewayVirtualClusterCreate(ctx context.Context, change *planner.PlannedChange) error {
+	// Resolve event gateway reference if needed.
+	// When the gateway was already created at plan time, its ID is in change.Parent.ID.
+	// When the gateway was being created in the same plan run, change.Parent is nil and
+	// the ID is stored in change.References["event_gateway_id"] after resolution below.
+	if gatewayRef, ok := change.References[planner.FieldEventGatewayID]; ok &&
+		unresolvedReferenceID(gatewayRef.ID) {
+		gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
+		if err != nil {
+			return fmt.Errorf("failed to resolve event gateway reference: %w", err)
+		}
+		// Update the reference with the resolved ID
+		gatewayRef.ID = gatewayID
+		change.References[planner.FieldEventGatewayID] = gatewayRef
+	}
+
+	// Determine the effective gateway ID for backend cluster resolution.
+	// Prefer the resolved reference over change.Parent (which is nil when the gateway
+	// was not yet created at plan time).
+	effectiveGatewayID := ""
+	if change.Parent != nil {
+		effectiveGatewayID = change.Parent.ID
+	}
+	if ref, ok := change.References[planner.FieldEventGatewayID]; ok && ref.ID != "" {
+		effectiveGatewayID = ref.ID
+	}
+
+	// Resolve event gateway backend cluster reference if needed
+	if backendClusterRef, ok := change.References[planner.FieldEventGatewayBackendClusterID]; ok &&
+		unresolvedReferenceID(backendClusterRef.ID) {
+		backendClusterID, err := e.resolveEventGatewayBackendClusterRef(ctx, effectiveGatewayID, backendClusterRef)
+		if err != nil {
+			return fmt.Errorf("failed to resolve event gateway backend cluster reference: %w", err)
+		}
+		// Update the reference with the resolved ID
+		backendClusterRef.ID = backendClusterID
+		change.References[planner.FieldEventGatewayBackendClusterID] = backendClusterRef
+	}
+	return nil
+}
+
+func (e *Executor) prepareEventGatewayVirtualClusterUpdate(ctx context.Context, change *planner.PlannedChange) error {
+	if err := e.prepareEventGatewayReference(ctx, change); err != nil {
+		return err
+	}
+	// Resolve event gateway backend cluster reference if needed
+	if backendClusterRef, ok := change.References[planner.FieldEventGatewayBackendClusterID]; ok &&
+		unresolvedReferenceID(backendClusterRef.ID) {
+		backendClusterID, err := e.resolveEventGatewayBackendClusterRef(ctx, change.Parent.ID, backendClusterRef)
+		if err != nil {
+			return fmt.Errorf("failed to resolve event gateway backend cluster reference: %w", err)
+		}
+		backendClusterRef.ID = backendClusterID
+		change.References[planner.FieldEventGatewayBackendClusterID] = backendClusterRef
+	}
+	return nil
+}
+
+func (e *Executor) prepareEventGatewayListenerPolicy(ctx context.Context, change *planner.PlannedChange) error {
+	if err := e.prepareEventGatewayReference(ctx, change); err != nil {
+		return err
+	}
+	// Resolve event gateway listener reference if needed
+	if listenerRef, ok := change.References[planner.FieldEventGatewayListenerID]; ok && listenerRef.ID == "" {
+		listenerID, err := e.resolveEventGatewayListenerRef(ctx, change, listenerRef)
+		if err != nil {
+			return fmt.Errorf("failed to resolve event gateway listener reference: %w", err)
+		}
+		listenerRef.ID = listenerID
+		change.References[planner.FieldEventGatewayListenerID] = listenerRef
+	}
+	// Resolve event gateway virtual cluster reference if needed (for forward_to_virtual_cluster policies)
+	if virtualClusterRef, ok := change.References[planner.FieldEventGatewayVirtualClusterID]; ok &&
+		unresolvedReferenceID(virtualClusterRef.ID) {
+		gatewayID := change.References[planner.FieldEventGatewayID].ID
+		virtualClusterID, err := e.resolveEventGatewayVirtualClusterRef(ctx, gatewayID, virtualClusterRef)
+		if err != nil {
+			return fmt.Errorf("failed to resolve event gateway virtual cluster reference: %w", err)
+		}
+		virtualClusterRef.ID = virtualClusterID
+		change.References[planner.FieldEventGatewayVirtualClusterID] = virtualClusterRef
+	}
+	return nil
+}
+
+func (e *Executor) prepareEventGatewayClusterPolicy(ctx context.Context, change *planner.PlannedChange) error {
+	if err := e.prepareEventGatewayReference(ctx, change); err != nil {
+		return err
+	}
+	// Resolve event gateway virtual cluster reference if needed
+	if virtualClusterRef, ok := change.References[planner.FieldEventGatewayVirtualClusterID]; ok &&
+		virtualClusterRef.ID == "" {
+		gatewayID := change.References[planner.FieldEventGatewayID].ID
+		virtualClusterID, err := e.resolveEventGatewayVirtualClusterRef(ctx, gatewayID, virtualClusterRef)
+		if err != nil {
+			return fmt.Errorf("failed to resolve event gateway virtual cluster reference: %w", err)
+		}
+		virtualClusterRef.ID = virtualClusterID
+		change.References[planner.FieldEventGatewayVirtualClusterID] = virtualClusterRef
+	}
+	return nil
+}
+
+func (e *Executor) prepareEventGatewayProducePolicy(ctx context.Context, change *planner.PlannedChange) error {
+	if err := e.prepareEventGatewayClusterPolicy(ctx, change); err != nil {
+		return err
+	}
+	return e.syncResolvedEventGatewayProducePolicyConfigRefs(ctx, change)
+}

--- a/internal/declarative/executor/executor.go
+++ b/internal/declarative/executor/executor.go
@@ -58,7 +58,6 @@ type Executor struct {
 	]
 	catalogServiceExecutor                 *BaseExecutor[kkComps.CreateCatalogService, kkComps.UpdateCatalogService]
 	dashboardExecutor                      *BaseExecutor[kkComps.DashboardUpdateRequest, kkComps.DashboardUpdateRequest]
-	eventGatewayControlPlaneExecutor       *BaseExecutor[kkComps.CreateGatewayRequest, kkComps.UpdateGatewayRequest]
 	organizationTeamExecutor               *BaseExecutor[kkComps.CreateTeam, kkComps.UpdateTeam]
 	organizationTeamRoleExecutor           *BaseExecutor[kkComps.AssignRole, kkComps.AssignRole]
 	organizationUserTeamMembershipExecutor *BaseExecutor[
@@ -72,31 +71,6 @@ type Executor struct {
 	]
 	organizationSystemAccountRoleExecutor    *BaseExecutor[kkComps.AssignRole, kkComps.AssignRole]
 	controlPlaneDataPlaneCertificateExecutor *BaseCreateDeleteExecutor[kkComps.DataPlaneClientCertificateRequest]
-
-	// Event Gateway child resource executors
-	eventGatewayBackendClusterExecutor *BaseExecutor[
-		kkComps.CreateBackendClusterRequest, kkComps.UpdateBackendClusterRequest]
-	eventGatewayVirtualClusterExecutor *BaseExecutor[
-		kkComps.CreateVirtualClusterRequest, kkComps.UpdateVirtualClusterRequest]
-	eventGatewayListenerExecutor *BaseExecutor[
-		kkComps.CreateEventGatewayListenerRequest, kkComps.UpdateEventGatewayListenerRequest]
-	eventGatewayListenerPolicyExecutor *BaseExecutor[
-		kkComps.EventGatewayListenerPolicyCreate, kkComps.EventGatewayListenerPolicyUpdate]
-	eventGatewayClusterPolicyExecutor *BaseExecutor[
-		kkComps.EventGatewayClusterPolicyModify, kkComps.EventGatewayClusterPolicyModify]
-	eventGatewayProducePolicyExecutor *BaseExecutor[
-		kkComps.EventGatewayProducePolicyCreate, kkComps.EventGatewayProducePolicyUpdate]
-	eventGatewayConsumePolicyExecutor *BaseExecutor[
-		kkComps.EventGatewayConsumePolicyCreate, kkComps.EventGatewayConsumePolicyUpdate]
-	eventGatewayDataPlaneCertificateExecutor *BaseExecutor[
-		kkComps.CreateEventGatewayDataPlaneCertificateRequest,
-		kkComps.UpdateEventGatewayDataPlaneCertificateRequest]
-	eventGatewaySchemaRegistryExecutor *BaseExecutor[
-		kkComps.SchemaRegistryCreate, kkComps.SchemaRegistryUpdate]
-	eventGatewayStaticKeyExecutor *BaseExecutor[
-		kkComps.EventGatewayStaticKeyCreate, kkComps.EventGatewayStaticKeyCreate]
-	eventGatewayTLSTrustBundleExecutor *BaseExecutor[
-		kkComps.CreateTLSTrustBundleRequest, kkComps.UpdateTLSTrustBundleRequest]
 
 	// Portal child resource executors
 	portalCustomizationExecutor    *BaseSingletonExecutor[kkComps.PortalCustomization]
@@ -248,13 +222,7 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 		client,
 		dryRun,
 	)
-	e.eventGatewayControlPlaneExecutor = NewManagedLabelBaseExecutor[
-		kkComps.CreateGatewayRequest, kkComps.UpdateGatewayRequest,
-	](
-		NewEventGatewayControlPlaneControlPlaneAdapter(client),
-		client,
-		dryRun,
-	)
+	e.registerEventGatewayControlPlaneExecutor()
 	e.organizationTeamExecutor = NewManagedLabelBaseExecutor[kkComps.CreateTeam, kkComps.UpdateTeam](
 		NewOrganizationTeamAdapter(client),
 		client,
@@ -292,83 +260,7 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 		dryRun,
 	)
 
-	// Initialize event gateway child resource executors
-	e.eventGatewayBackendClusterExecutor = NewBaseExecutor[
-		kkComps.CreateBackendClusterRequest, kkComps.UpdateBackendClusterRequest](
-		NewEventGatewayBackendClusterAdapter(client),
-		client,
-		dryRun,
-	)
-
-	e.eventGatewayVirtualClusterExecutor = NewBaseExecutor[
-		kkComps.CreateVirtualClusterRequest, kkComps.UpdateVirtualClusterRequest](
-		NewEventGatewayVirtualClusterAdapter(client),
-		client,
-		dryRun,
-	)
-
-	e.eventGatewayListenerExecutor = NewBaseExecutor[
-		kkComps.CreateEventGatewayListenerRequest, kkComps.UpdateEventGatewayListenerRequest](
-		NewEventGatewayListenerAdapter(client),
-		client,
-		dryRun,
-	)
-
-	e.eventGatewayListenerPolicyExecutor = NewBaseExecutor[
-		kkComps.EventGatewayListenerPolicyCreate, kkComps.EventGatewayListenerPolicyUpdate](
-		NewEventGatewayListenerPolicyAdapter(client),
-		client,
-		dryRun,
-	)
-
-	e.eventGatewayClusterPolicyExecutor = NewBaseExecutor[
-		kkComps.EventGatewayClusterPolicyModify, kkComps.EventGatewayClusterPolicyModify](
-		NewEventGatewayClusterPolicyAdapter(client),
-		client,
-		dryRun,
-	)
-
-	e.eventGatewayProducePolicyExecutor = NewBaseExecutor[
-		kkComps.EventGatewayProducePolicyCreate, kkComps.EventGatewayProducePolicyUpdate](
-		NewEventGatewayProducePolicyAdapter(client),
-		client,
-		dryRun,
-	)
-	e.eventGatewayConsumePolicyExecutor = NewBaseExecutor[
-		kkComps.EventGatewayConsumePolicyCreate, kkComps.EventGatewayConsumePolicyUpdate](
-		NewEventGatewayConsumePolicyAdapter(client),
-		client,
-		dryRun,
-	)
-
-	e.eventGatewayDataPlaneCertificateExecutor = NewBaseExecutor[
-		kkComps.CreateEventGatewayDataPlaneCertificateRequest,
-		kkComps.UpdateEventGatewayDataPlaneCertificateRequest](
-		NewEventGatewayDataPlaneCertificateAdapter(client),
-		client,
-		dryRun,
-	)
-
-	e.eventGatewaySchemaRegistryExecutor = NewBaseExecutor[
-		kkComps.SchemaRegistryCreate, kkComps.SchemaRegistryUpdate](
-		NewEventGatewaySchemaRegistryAdapter(client),
-		client,
-		dryRun,
-	)
-
-	e.eventGatewayStaticKeyExecutor = NewBaseExecutor[
-		kkComps.EventGatewayStaticKeyCreate, kkComps.EventGatewayStaticKeyCreate](
-		NewEventGatewayStaticKeyAdapter(client),
-		client,
-		dryRun,
-	)
-
-	e.eventGatewayTLSTrustBundleExecutor = NewBaseExecutor[
-		kkComps.CreateTLSTrustBundleRequest, kkComps.UpdateTLSTrustBundleRequest](
-		NewEventGatewayTLSTrustBundleAdapter(client),
-		client,
-		dryRun,
-	)
+	e.registerEventGatewayChildExecutors()
 
 	// Initialize portal child resource executors
 	e.portalCustomizationExecutor = NewBaseSingletonExecutor[kkComps.PortalCustomization](
@@ -480,7 +372,6 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 		e.dcrProviderExecutor,
 		e.catalogServiceExecutor,
 		e.dashboardExecutor,
-		e.eventGatewayControlPlaneExecutor,
 		e.organizationTeamExecutor,
 		e.organizationTeamRoleExecutor,
 		e.organizationUserTeamMembershipExecutor,
@@ -488,17 +379,6 @@ func NewWithOptions(client *state.Client, reporter ProgressReporter, dryRun bool
 		e.organizationSystemAccountTeamMembershipExecutor,
 		e.organizationSystemAccountRoleExecutor,
 		e.controlPlaneDataPlaneCertificateExecutor,
-		e.eventGatewayBackendClusterExecutor,
-		e.eventGatewayVirtualClusterExecutor,
-		e.eventGatewayListenerExecutor,
-		e.eventGatewayListenerPolicyExecutor,
-		e.eventGatewayClusterPolicyExecutor,
-		e.eventGatewayProducePolicyExecutor,
-		e.eventGatewayConsumePolicyExecutor,
-		e.eventGatewayDataPlaneCertificateExecutor,
-		e.eventGatewaySchemaRegistryExecutor,
-		e.eventGatewayStaticKeyExecutor,
-		e.eventGatewayTLSTrustBundleExecutor,
 		e.portalCustomizationExecutor,
 		e.portalAuthSettingsExecutor,
 		e.portalIntegrationExecutor,
@@ -2895,59 +2775,6 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 			change.References[planner.FieldPortalID] = portalRef
 		}
 		return e.portalEmailTemplateExecutor.Create(ctx, *change)
-	case planner.ResourceTypeEventGatewayControlPlane:
-		return e.eventGatewayControlPlaneExecutor.Create(ctx, *change)
-	case planner.ResourceTypeEventGatewayBackendCluster:
-		// Resolve event gateway reference if needed
-		if gatewayRef, ok := change.References[planner.FieldEventGatewayID]; ok && gatewayRef.ID == "" {
-			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
-			}
-			// Update the reference with the resolved ID
-			gatewayRef.ID = gatewayID
-			change.References[planner.FieldEventGatewayID] = gatewayRef
-		}
-		return e.eventGatewayBackendClusterExecutor.Create(ctx, *change)
-	case planner.ResourceTypeEventGatewayVirtualCluster:
-		// Resolve event gateway reference if needed.
-		// When the gateway was already created at plan time, its ID is in change.Parent.ID.
-		// When the gateway was being created in the same plan run, change.Parent is nil and
-		// the ID is stored in change.References["event_gateway_id"] after resolution below.
-		if gatewayRef, ok := change.References[planner.FieldEventGatewayID]; ok &&
-			unresolvedReferenceID(gatewayRef.ID) {
-			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
-			}
-			// Update the reference with the resolved ID
-			gatewayRef.ID = gatewayID
-			change.References[planner.FieldEventGatewayID] = gatewayRef
-		}
-
-		// Determine the effective gateway ID for backend cluster resolution.
-		// Prefer the resolved reference over change.Parent (which is nil when the gateway
-		// was not yet created at plan time).
-		effectiveGatewayID := ""
-		if change.Parent != nil {
-			effectiveGatewayID = change.Parent.ID
-		}
-		if ref, ok := change.References[planner.FieldEventGatewayID]; ok && ref.ID != "" {
-			effectiveGatewayID = ref.ID
-		}
-
-		// Resolve event gateway backend cluster reference if needed
-		if backendClusterRef, ok := change.References[planner.FieldEventGatewayBackendClusterID]; ok &&
-			unresolvedReferenceID(backendClusterRef.ID) {
-			backendClusterID, err := e.resolveEventGatewayBackendClusterRef(ctx, effectiveGatewayID, backendClusterRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway backend cluster reference: %w", err)
-			}
-			// Update the reference with the resolved ID
-			backendClusterRef.ID = backendClusterID
-			change.References[planner.FieldEventGatewayBackendClusterID] = backendClusterRef
-		}
-		return e.eventGatewayVirtualClusterExecutor.Create(ctx, *change)
 	case planner.ResourceTypeOrganizationTeam:
 		return e.organizationTeamExecutor.Create(ctx, *change)
 	case planner.ResourceTypeOrganizationTeamRole:
@@ -2994,162 +2821,6 @@ func (e *Executor) createResource(ctx context.Context, change *planner.PlannedCh
 		}
 		return e.organizationSystemAccountRoleExecutor.Create(ctx, *change)
 
-	case planner.ResourceTypeEventGatewayListener:
-		// Resolve event gateway reference if needed
-		if gatewayRef, ok := change.References[planner.FieldEventGatewayID]; ok && gatewayRef.ID == "" {
-			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
-			}
-			// Update the reference with the resolved ID
-			gatewayRef.ID = gatewayID
-			change.References[planner.FieldEventGatewayID] = gatewayRef
-		}
-		return e.eventGatewayListenerExecutor.Create(ctx, *change)
-	case planner.ResourceTypeEventGatewayListenerPolicy:
-		// Resolve event gateway reference if needed
-		if gatewayRef, ok := change.References[planner.FieldEventGatewayID]; ok && gatewayRef.ID == "" {
-			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
-			}
-			gatewayRef.ID = gatewayID
-			change.References[planner.FieldEventGatewayID] = gatewayRef
-		}
-		// Resolve event gateway listener reference if needed
-		if listenerRef, ok := change.References[planner.FieldEventGatewayListenerID]; ok && listenerRef.ID == "" {
-			listenerID, err := e.resolveEventGatewayListenerRef(ctx, change, listenerRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway listener reference: %w", err)
-			}
-			listenerRef.ID = listenerID
-			change.References[planner.FieldEventGatewayListenerID] = listenerRef
-		}
-		// Resolve event gateway virtual cluster reference if needed (for forward_to_virtual_cluster policies)
-		if virtualClusterRef, ok := change.References[planner.FieldEventGatewayVirtualClusterID]; ok &&
-			unresolvedReferenceID(virtualClusterRef.ID) {
-			gatewayID := change.References[planner.FieldEventGatewayID].ID
-			virtualClusterID, err := e.resolveEventGatewayVirtualClusterRef(ctx, gatewayID, virtualClusterRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway virtual cluster reference: %w", err)
-			}
-			virtualClusterRef.ID = virtualClusterID
-			change.References[planner.FieldEventGatewayVirtualClusterID] = virtualClusterRef
-		}
-		return e.eventGatewayListenerPolicyExecutor.Create(ctx, *change)
-	case planner.ResourceTypeEventGatewayDataPlaneCertificate:
-		// Resolve event gateway reference if needed
-		if gatewayRef, ok := change.References[planner.FieldEventGatewayID]; ok && gatewayRef.ID == "" {
-			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
-			}
-			gatewayRef.ID = gatewayID
-			change.References[planner.FieldEventGatewayID] = gatewayRef
-		}
-		return e.eventGatewayDataPlaneCertificateExecutor.Create(ctx, *change)
-	case planner.ResourceTypeEventGatewaySchemaRegistry:
-		// Resolve event gateway reference if needed
-		if gatewayRef, ok := change.References[planner.FieldEventGatewayID]; ok && gatewayRef.ID == "" {
-			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
-			}
-			gatewayRef.ID = gatewayID
-			change.References[planner.FieldEventGatewayID] = gatewayRef
-		}
-		return e.eventGatewaySchemaRegistryExecutor.Create(ctx, *change)
-	case planner.ResourceTypeEventGatewayStaticKey:
-		// Resolve event gateway reference if needed
-		if gatewayRef, ok := change.References[planner.FieldEventGatewayID]; ok && gatewayRef.ID == "" {
-			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
-			}
-			gatewayRef.ID = gatewayID
-			change.References[planner.FieldEventGatewayID] = gatewayRef
-		}
-		return e.eventGatewayStaticKeyExecutor.Create(ctx, *change)
-	case planner.ResourceTypeEventGatewayTLSTrustBundle:
-		// Resolve event gateway reference if needed
-		if gatewayRef, ok := change.References[planner.FieldEventGatewayID]; ok && gatewayRef.ID == "" {
-			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
-			}
-			gatewayRef.ID = gatewayID
-			change.References[planner.FieldEventGatewayID] = gatewayRef
-		}
-		return e.eventGatewayTLSTrustBundleExecutor.Create(ctx, *change)
-	case planner.ResourceTypeEventGatewayClusterPolicy:
-		// Resolve event gateway reference if needed
-		if gatewayRef, ok := change.References[planner.FieldEventGatewayID]; ok && gatewayRef.ID == "" {
-			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
-			}
-			gatewayRef.ID = gatewayID
-			change.References[planner.FieldEventGatewayID] = gatewayRef
-		}
-		// Resolve event gateway virtual cluster reference if needed
-		if virtualClusterRef, ok := change.References[planner.FieldEventGatewayVirtualClusterID]; ok &&
-			virtualClusterRef.ID == "" {
-			gatewayID := change.References[planner.FieldEventGatewayID].ID
-			virtualClusterID, err := e.resolveEventGatewayVirtualClusterRef(ctx, gatewayID, virtualClusterRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway virtual cluster reference: %w", err)
-			}
-			virtualClusterRef.ID = virtualClusterID
-			change.References[planner.FieldEventGatewayVirtualClusterID] = virtualClusterRef
-		}
-		return e.eventGatewayClusterPolicyExecutor.Create(ctx, *change)
-	case planner.ResourceTypeEventGatewayProducePolicy:
-		// Resolve event gateway reference if needed
-		if gatewayRef, ok := change.References[planner.FieldEventGatewayID]; ok && gatewayRef.ID == "" {
-			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
-			}
-			gatewayRef.ID = gatewayID
-			change.References[planner.FieldEventGatewayID] = gatewayRef
-		}
-		// Resolve event gateway virtual cluster reference if needed
-		if virtualClusterRef, ok := change.References[planner.FieldEventGatewayVirtualClusterID]; ok &&
-			virtualClusterRef.ID == "" {
-			gatewayID := change.References[planner.FieldEventGatewayID].ID
-			virtualClusterID, err := e.resolveEventGatewayVirtualClusterRef(ctx, gatewayID, virtualClusterRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway virtual cluster reference: %w", err)
-			}
-			virtualClusterRef.ID = virtualClusterID
-			change.References[planner.FieldEventGatewayVirtualClusterID] = virtualClusterRef
-		}
-		if err := e.syncResolvedEventGatewayProducePolicyConfigRefs(ctx, change); err != nil {
-			return "", err
-		}
-		return e.eventGatewayProducePolicyExecutor.Create(ctx, *change)
-	case planner.ResourceTypeEventGatewayConsumePolicy:
-		// Resolve event gateway reference if needed
-		if gatewayRef, ok := change.References[planner.FieldEventGatewayID]; ok && gatewayRef.ID == "" {
-			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
-			}
-			gatewayRef.ID = gatewayID
-			change.References[planner.FieldEventGatewayID] = gatewayRef
-		}
-		// Resolve event gateway virtual cluster reference if needed
-		if virtualClusterRef, ok := change.References[planner.FieldEventGatewayVirtualClusterID]; ok &&
-			virtualClusterRef.ID == "" {
-			gatewayID := change.References[planner.FieldEventGatewayID].ID
-			virtualClusterID, err := e.resolveEventGatewayVirtualClusterRef(ctx, gatewayID, virtualClusterRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway virtual cluster reference: %w", err)
-			}
-			virtualClusterRef.ID = virtualClusterID
-			change.References[planner.FieldEventGatewayVirtualClusterID] = virtualClusterRef
-		}
-		return e.eventGatewayConsumePolicyExecutor.Create(ctx, *change)
 	default:
 		return "", fmt.Errorf("create operation not yet implemented for %s", change.ResourceType)
 	}
@@ -3412,186 +3083,8 @@ func (e *Executor) updateResource(ctx context.Context, change *planner.PlannedCh
 		}
 		return e.apiVersionExecutor.Update(ctx, *change)
 	// Note: api_publication and api_implementation don't support update
-	case planner.ResourceTypeEventGatewayControlPlane:
-		return e.eventGatewayControlPlaneExecutor.Update(ctx, *change)
-	case planner.ResourceTypeEventGatewayBackendCluster:
-		// Resolve event gateway reference if needed (typically should already be in Parent)
-		if gatewayRef, ok := change.References[planner.FieldEventGatewayID]; ok && gatewayRef.ID == "" {
-			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
-			}
-			gatewayRef.ID = gatewayID
-			change.References[planner.FieldEventGatewayID] = gatewayRef
-		}
-		return e.eventGatewayBackendClusterExecutor.Update(ctx, *change)
-	case planner.ResourceTypeEventGatewayVirtualCluster:
-		// Resolve event gateway reference if needed (typically should already be in Parent)
-		if gatewayRef, ok := change.References[planner.FieldEventGatewayID]; ok && gatewayRef.ID == "" {
-			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
-			}
-			gatewayRef.ID = gatewayID
-			change.References[planner.FieldEventGatewayID] = gatewayRef
-		}
-		// Resolve event gateway backend cluster reference if needed
-		if backendClusterRef, ok := change.References[planner.FieldEventGatewayBackendClusterID]; ok &&
-			unresolvedReferenceID(backendClusterRef.ID) {
-			backendClusterID, err := e.resolveEventGatewayBackendClusterRef(ctx, change.Parent.ID, backendClusterRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway backend cluster reference: %w", err)
-			}
-			backendClusterRef.ID = backendClusterID
-			change.References[planner.FieldEventGatewayBackendClusterID] = backendClusterRef
-		}
-		return e.eventGatewayVirtualClusterExecutor.Update(ctx, *change)
 	case planner.ResourceTypeOrganizationTeam:
 		return e.organizationTeamExecutor.Update(ctx, *change)
-	case planner.ResourceTypeEventGatewayListener:
-		// Resolve event gateway reference if needed (typically should already be in Parent)
-		if gatewayRef, ok := change.References[planner.FieldEventGatewayID]; ok && gatewayRef.ID == "" {
-			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
-			}
-			gatewayRef.ID = gatewayID
-			change.References[planner.FieldEventGatewayID] = gatewayRef
-		}
-		return e.eventGatewayListenerExecutor.Update(ctx, *change)
-	case planner.ResourceTypeEventGatewayListenerPolicy:
-		// Resolve event gateway reference if needed
-		if gatewayRef, ok := change.References[planner.FieldEventGatewayID]; ok && gatewayRef.ID == "" {
-			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
-			}
-			gatewayRef.ID = gatewayID
-			change.References[planner.FieldEventGatewayID] = gatewayRef
-		}
-		// Resolve event gateway listener reference if needed
-		if listenerRef, ok := change.References[planner.FieldEventGatewayListenerID]; ok && listenerRef.ID == "" {
-			listenerID, err := e.resolveEventGatewayListenerRef(ctx, change, listenerRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway listener reference: %w", err)
-			}
-			listenerRef.ID = listenerID
-			change.References[planner.FieldEventGatewayListenerID] = listenerRef
-		}
-		// Resolve event gateway virtual cluster reference if needed (for forward_to_virtual_cluster policies)
-		if virtualClusterRef, ok := change.References[planner.FieldEventGatewayVirtualClusterID]; ok &&
-			unresolvedReferenceID(virtualClusterRef.ID) {
-			gatewayID := change.References[planner.FieldEventGatewayID].ID
-			virtualClusterID, err := e.resolveEventGatewayVirtualClusterRef(ctx, gatewayID, virtualClusterRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway virtual cluster reference: %w", err)
-			}
-			virtualClusterRef.ID = virtualClusterID
-			change.References[planner.FieldEventGatewayVirtualClusterID] = virtualClusterRef
-		}
-		return e.eventGatewayListenerPolicyExecutor.Update(ctx, *change)
-	case planner.ResourceTypeEventGatewayDataPlaneCertificate:
-		// Resolve event gateway reference if needed (typically should already be in Parent)
-		if gatewayRef, ok := change.References[planner.FieldEventGatewayID]; ok && gatewayRef.ID == "" {
-			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
-			}
-			gatewayRef.ID = gatewayID
-			change.References[planner.FieldEventGatewayID] = gatewayRef
-		}
-		return e.eventGatewayDataPlaneCertificateExecutor.Update(ctx, *change)
-	case planner.ResourceTypeEventGatewaySchemaRegistry:
-		// Resolve event gateway reference if needed (typically should already be in Parent)
-		if gatewayRef, ok := change.References[planner.FieldEventGatewayID]; ok && gatewayRef.ID == "" {
-			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
-			}
-			gatewayRef.ID = gatewayID
-			change.References[planner.FieldEventGatewayID] = gatewayRef
-		}
-		return e.eventGatewaySchemaRegistryExecutor.Update(ctx, *change)
-	case planner.ResourceTypeEventGatewayTLSTrustBundle:
-		// Resolve event gateway reference if needed (typically should already be in Parent)
-		if gatewayRef, ok := change.References[planner.FieldEventGatewayID]; ok && gatewayRef.ID == "" {
-			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
-			}
-			gatewayRef.ID = gatewayID
-			change.References[planner.FieldEventGatewayID] = gatewayRef
-		}
-		return e.eventGatewayTLSTrustBundleExecutor.Update(ctx, *change)
-	case planner.ResourceTypeEventGatewayClusterPolicy:
-		// Resolve event gateway reference if needed
-		if gatewayRef, ok := change.References[planner.FieldEventGatewayID]; ok && gatewayRef.ID == "" {
-			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
-			}
-			gatewayRef.ID = gatewayID
-			change.References[planner.FieldEventGatewayID] = gatewayRef
-		}
-		// Resolve event gateway virtual cluster reference if needed
-		if virtualClusterRef, ok := change.References[planner.FieldEventGatewayVirtualClusterID]; ok &&
-			virtualClusterRef.ID == "" {
-			gatewayID := change.References[planner.FieldEventGatewayID].ID
-			virtualClusterID, err := e.resolveEventGatewayVirtualClusterRef(ctx, gatewayID, virtualClusterRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway virtual cluster reference: %w", err)
-			}
-			virtualClusterRef.ID = virtualClusterID
-			change.References[planner.FieldEventGatewayVirtualClusterID] = virtualClusterRef
-		}
-		return e.eventGatewayClusterPolicyExecutor.Update(ctx, *change)
-	case planner.ResourceTypeEventGatewayProducePolicy:
-		// Resolve event gateway reference if needed
-		if gatewayRef, ok := change.References[planner.FieldEventGatewayID]; ok && gatewayRef.ID == "" {
-			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
-			}
-			gatewayRef.ID = gatewayID
-			change.References[planner.FieldEventGatewayID] = gatewayRef
-		}
-		// Resolve event gateway virtual cluster reference if needed
-		if virtualClusterRef, ok := change.References[planner.FieldEventGatewayVirtualClusterID]; ok &&
-			virtualClusterRef.ID == "" {
-			gatewayID := change.References[planner.FieldEventGatewayID].ID
-			virtualClusterID, err := e.resolveEventGatewayVirtualClusterRef(ctx, gatewayID, virtualClusterRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway virtual cluster reference: %w", err)
-			}
-			virtualClusterRef.ID = virtualClusterID
-			change.References[planner.FieldEventGatewayVirtualClusterID] = virtualClusterRef
-		}
-		if err := e.syncResolvedEventGatewayProducePolicyConfigRefs(ctx, change); err != nil {
-			return "", err
-		}
-		return e.eventGatewayProducePolicyExecutor.Update(ctx, *change)
-	case planner.ResourceTypeEventGatewayConsumePolicy:
-		// Resolve event gateway reference if needed
-		if gatewayRef, ok := change.References[planner.FieldEventGatewayID]; ok && gatewayRef.ID == "" {
-			gatewayID, err := e.resolveEventGatewayRef(ctx, gatewayRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway reference: %w", err)
-			}
-			gatewayRef.ID = gatewayID
-			change.References[planner.FieldEventGatewayID] = gatewayRef
-		}
-		// Resolve event gateway virtual cluster reference if needed
-		if virtualClusterRef, ok := change.References[planner.FieldEventGatewayVirtualClusterID]; ok &&
-			virtualClusterRef.ID == "" {
-			gatewayID := change.References[planner.FieldEventGatewayID].ID
-			virtualClusterID, err := e.resolveEventGatewayVirtualClusterRef(ctx, gatewayID, virtualClusterRef)
-			if err != nil {
-				return "", fmt.Errorf("failed to resolve event gateway virtual cluster reference: %w", err)
-			}
-			virtualClusterRef.ID = virtualClusterID
-			change.References[planner.FieldEventGatewayVirtualClusterID] = virtualClusterRef
-		}
-		return e.eventGatewayConsumePolicyExecutor.Update(ctx, *change)
 	default:
 		return "", fmt.Errorf("update operation not yet implemented for %s", change.ResourceType)
 	}
@@ -3760,41 +3253,6 @@ func (e *Executor) deleteResource(ctx context.Context, change *planner.PlannedCh
 		}
 		return e.portalEmailTemplateExecutor.Delete(ctx, *change)
 	// Note: portal_customization is a singleton resource and cannot be deleted
-	case planner.ResourceTypeEventGatewayControlPlane:
-		return e.eventGatewayControlPlaneExecutor.Delete(ctx, *change)
-	case planner.ResourceTypeEventGatewayBackendCluster:
-		// No need to resolve event gateway reference for delete - parent ID should be in Parent field
-		return e.eventGatewayBackendClusterExecutor.Delete(ctx, *change)
-	case planner.ResourceTypeEventGatewayVirtualCluster:
-		// No need to resolve event gateway reference for delete - parent ID should be in Parent field
-		return e.eventGatewayVirtualClusterExecutor.Delete(ctx, *change)
-	case planner.ResourceTypeEventGatewayListener:
-		// No need to resolve event gateway reference for delete - parent ID should be in Parent field
-		return e.eventGatewayListenerExecutor.Delete(ctx, *change)
-	case planner.ResourceTypeEventGatewayListenerPolicy:
-		// Both gateway ID and listener ID should be in References for delete
-		return e.eventGatewayListenerPolicyExecutor.Delete(ctx, *change)
-	case planner.ResourceTypeEventGatewayDataPlaneCertificate:
-		// No need to resolve event gateway reference for delete - parent ID should be in Parent field
-		return e.eventGatewayDataPlaneCertificateExecutor.Delete(ctx, *change)
-	case planner.ResourceTypeEventGatewaySchemaRegistry:
-		// No need to resolve event gateway reference for delete - parent ID should be in Parent field
-		return e.eventGatewaySchemaRegistryExecutor.Delete(ctx, *change)
-	case planner.ResourceTypeEventGatewayStaticKey:
-		// No need to resolve event gateway reference for delete - parent ID should be in Parent field
-		return e.eventGatewayStaticKeyExecutor.Delete(ctx, *change)
-	case planner.ResourceTypeEventGatewayTLSTrustBundle:
-		// No need to resolve event gateway reference for delete - parent ID should be in Parent field
-		return e.eventGatewayTLSTrustBundleExecutor.Delete(ctx, *change)
-	case planner.ResourceTypeEventGatewayClusterPolicy:
-		// Both gateway ID and virtual cluster ID should be in References for delete
-		return e.eventGatewayClusterPolicyExecutor.Delete(ctx, *change)
-	case planner.ResourceTypeEventGatewayProducePolicy:
-		// Both gateway ID and virtual cluster ID should be in References for delete
-		return e.eventGatewayProducePolicyExecutor.Delete(ctx, *change)
-	case planner.ResourceTypeEventGatewayConsumePolicy:
-		// Both gateway ID and virtual cluster ID should be in References for delete
-		return e.eventGatewayConsumePolicyExecutor.Delete(ctx, *change)
 	case planner.ResourceTypeOrganizationTeam:
 		return e.organizationTeamExecutor.Delete(ctx, *change)
 	case planner.ResourceTypeOrganizationTeamRole:

--- a/internal/declarative/executor/resource_executors.go
+++ b/internal/declarative/executor/resource_executors.go
@@ -54,19 +54,7 @@ func prepareResourceExecutor(
 	resource resourceExecutor,
 	prepare func(context.Context, *planner.PlannedChange) error,
 ) resourceExecutor {
-	prepareWrite := func(write resourceWrite) resourceWrite {
-		if write == nil {
-			return nil
-		}
-		return func(ctx context.Context, change *planner.PlannedChange) (string, error) {
-			if err := prepare(ctx, change); err != nil {
-				return "", err
-			}
-			return write(ctx, change)
-		}
-	}
-	resource.create = prepareWrite(resource.create)
-	resource.update = prepareWrite(resource.update)
+	resource = prepareResourceWrites(resource, prepare)
 	if remove := resource.remove; remove != nil {
 		resource.remove = func(ctx context.Context, change *planner.PlannedChange) error {
 			if err := prepare(ctx, change); err != nil {
@@ -76,6 +64,32 @@ func prepareResourceExecutor(
 		}
 	}
 	return resource
+}
+
+// prepareResourceWrites leaves deletion unchanged for resources whose delete
+// plans already carry all required routing information.
+func prepareResourceWrites(
+	resource resourceExecutor,
+	prepare func(context.Context, *planner.PlannedChange) error,
+) resourceExecutor {
+	resource.create = prepareResourceWrite(resource.create, prepare)
+	resource.update = prepareResourceWrite(resource.update, prepare)
+	return resource
+}
+
+func prepareResourceWrite(
+	write resourceWrite,
+	prepare func(context.Context, *planner.PlannedChange) error,
+) resourceWrite {
+	if write == nil {
+		return nil
+	}
+	return func(ctx context.Context, change *planner.PlannedChange) (string, error) {
+		if err := prepare(ctx, change); err != nil {
+			return "", err
+		}
+		return write(ctx, change)
+	}
 }
 
 func (e *Executor) registerResourceExecutor(resource resourceExecutor) {


### PR DESCRIPTION
Event Gateway resources currently repeat constructor fields, payload registration, and action routing in the executor. This change registers all 12 kinds through the runtime capability boundary introduced in #2092, removing 35 switch cases and 12 concrete executor fields.

- Couple each typed adapter with its payload contract and supported actions. Static keys remain create/delete-only; the other 11 kinds retain CRUD dispatch.
- Share write preparation while keeping deletes on their existing plan IDs. Preserve empty-ID versus unknown-ID checks, listener/virtual-cluster/config reference ordering, and the distinct gateway lookup rules for virtual-cluster create and update.
- Extract reusable preparation wrappers for all actions, writes, or an individual write. Existing AI Gateway behavior remains covered by its unchanged regression tests.
- Update the authoritative implementation guide with both registration paths and the remaining legacy integration points.

**Stacked on #2092.** The base is `refactor/declarative-capabilities`; review this diff after #2092. Continues #2079, which remains In Progress. No merge is requested or performed.

## Validation

- Full unit and integration suites passed with race detection, including the unchanged executor tests.
- CGO-disabled build, read-only modernization, formatting, and diff checks passed.
- Installer/ShellCheck and E2E-metrics checks passed.
- Audited all 2,719 baseline files: no tests, fixtures, mocks, or goldens changed or added.
- Static comparison verified the order of all 45 directly constructed adapters, 90 remaining dispatch cases, and the extracted logic of all 21 child write preparations.
- Checked contributor-guide links and 80-column wrapping.

Lint passes with zero findings using the repository/CI-pinned golangci-lint 2.13.1 and unlimited reporting. The earlier baseline report came from a local 2.12.2 binary. This PR's head `6e710754` passed CI, including the [full E2E suite](https://github.com/Kong/kongctl/actions/runs/34046799058). Existing unit coverage does not exhaustively execute every Event Gateway dispatch path.

