### PR TITLE
fix(konnect): correct AI Gateway identity and cursor pagination

### DIFF
--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -459,16 +459,21 @@ SNIs. Use
 
 The `ref` value is a local declarative identifier used by kongctl for
 references and planning. Use `name` as the stable Konnect API name for the AI
-Gateway. If `name` is omitted, kongctl defaults it from `ref`. Use
+Gateway. Managed AI Gateways match only by `name` within their namespace;
+neither `ref`, UUID refs, nor `display_name` provide a fallback match. Changing
+`name` declares a different gateway. In sync mode, the previous gateway is
+eligible for deletion if it is no longer declared in the selected scope.
+If `name` is omitted, kongctl defaults it from `ref`. Use
 `display_name` for the human-readable name shown in Konnect. AI Gateway Model
 Providers, Auth Strategies, Policies, Agents, Consumers, Consumer
 Credentials, Consumer Groups, Models, MCP Servers, Config Stores, and Vaults
-use their own required `name` field as the stable Konnect child name. Config
-Store names are immutable after creation. AI Gateway Data Plane Certificates
-use their required `title` field as the stable Konnect child name. Child entries
-inherit
-management scope from their parent resource and do not accept `kongctl`
-metadata.
+use their own required `name` field as the stable Konnect child name.
+AI Gateway Consumers match only by `name` within their parent gateway;
+UUID refs and cached IDs do not override a different declared consumer name.
+Config Store names are immutable after creation. AI Gateway Data Plane
+Certificates use their required `title` field as the stable Konnect child name.
+Child entries inherit management scope from their parent resource and do not
+accept `kongctl` metadata.
 
 For AI Gateway Policies, `display_name` must be explicitly provided in both
 nested and root-level declarations; kongctl does not infer it from `name` or

--- a/docs/declarative-resource-reference.md
+++ b/docs/declarative-resource-reference.md
@@ -463,8 +463,9 @@ Gateway. Managed AI Gateways match only by `name` within their namespace;
 neither `ref`, UUID refs, nor `display_name` provide a fallback match. Changing
 `name` declares a different gateway. In sync mode, the previous gateway is
 eligible for deletion if it is no longer declared in the selected scope.
-If `name` is omitted, kongctl defaults it from `ref`. Use
-`display_name` for the human-readable name shown in Konnect. AI Gateway Model
+Managed AI Gateways require an explicit `name`; kongctl does not derive it
+from `ref`. Use `display_name` for the human-readable name shown in Konnect.
+AI Gateway Model
 Providers, Auth Strategies, Policies, Agents, Consumers, Consumer
 Credentials, Consumer Groups, Models, MCP Servers, Config Stores, and Vaults
 use their own required `name` field as the stable Konnect child name.
@@ -474,6 +475,17 @@ Config Store names are immutable after creation. AI Gateway Data Plane
 Certificates use their required `title` field as the stable Konnect child name.
 Child entries inherit management scope from their parent resource and do not
 accept `kongctl` metadata.
+
+When upgrading configurations that relied on UUID refs or display-name
+matching, explicitly set each gateway and consumer `name` to its existing API
+name before applying or syncing. A local `ref` can remain unchanged. Review the
+plan for unexpected CREATE or DELETE actions before executing it.
+
+Changing a consumer `name` declares a new consumer, not a rename. In sync mode,
+deleting the old consumer also removes its credentials; existing API keys for
+that consumer stop authenticating. Credentials for the new consumer must be
+configured explicitly. To change only its visible label while retaining its
+identity and credentials, update `display_name` and keep `name` unchanged.
 
 For AI Gateway Policies, `display_name` must be explicitly provided in both
 nested and root-level declarations; kongctl does not infer it from `name` or

--- a/docs/declarative.md
+++ b/docs/declarative.md
@@ -615,6 +615,7 @@ Config Store ID:
 ```yaml
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     config_stores:
       - ref: support-config-store

--- a/internal/cmd/root/products/konnect/aigateway/consumer_groups.go
+++ b/internal/cmd/root/products/konnect/aigateway/consumer_groups.go
@@ -317,6 +317,7 @@ func fetchAIGatewayConsumerGroups(
 ) ([]kkComps.AIGatewayConsumerGroup, error) {
 	requestPageSize := common.ResolveRequestPageSize(cfg)
 	var pageAfter *string
+	var cursors pagination.CursorTracker
 	var allData []kkComps.AIGatewayConsumerGroup
 
 	for {
@@ -343,7 +344,10 @@ func fetchAIGatewayConsumerGroups(
 		}
 
 		allData = append(allData, res.ListAIGatewayConsumerGroupsResponse.Data...)
-		nextCursor := pagination.ExtractPageAfterCursor(res.ListAIGatewayConsumerGroupsResponse.Meta.Page.Next)
+		nextCursor, err := cursors.Next(res.ListAIGatewayConsumerGroupsResponse.Meta.Page.Next)
+		if err != nil {
+			return nil, fmt.Errorf("list pagination failed: %w", err)
+		}
 		if nextCursor == "" {
 			break
 		}

--- a/internal/cmd/root/products/konnect/aigateway/consumers.go
+++ b/internal/cmd/root/products/konnect/aigateway/consumers.go
@@ -331,6 +331,7 @@ func fetchAIGatewayConsumers(
 ) ([]kkComps.AIGatewayConsumer, error) {
 	requestPageSize := common.ResolveRequestPageSize(cfg)
 	var pageAfter *string
+	var cursors pagination.CursorTracker
 	var allData []kkComps.AIGatewayConsumer
 
 	for {
@@ -352,7 +353,10 @@ func fetchAIGatewayConsumers(
 		}
 
 		allData = append(allData, res.ListAIGatewayConsumersResponse.Data...)
-		nextCursor := pagination.ExtractPageAfterCursor(res.ListAIGatewayConsumersResponse.Meta.Page.Next)
+		nextCursor, err := cursors.Next(res.ListAIGatewayConsumersResponse.Meta.Page.Next)
+		if err != nil {
+			return nil, fmt.Errorf("list pagination failed: %w", err)
+		}
 		if nextCursor == "" {
 			break
 		}

--- a/internal/cmd/root/products/konnect/aigateway/credentials.go
+++ b/internal/cmd/root/products/konnect/aigateway/credentials.go
@@ -375,6 +375,7 @@ func fetchAIGatewayConsumerCredentials(
 ) ([]kkComps.AIGatewayConsumerCredential, error) {
 	requestPageSize := common.ResolveRequestPageSize(cfg)
 	var pageAfter *string
+	var cursors pagination.CursorTracker
 	var allData []kkComps.AIGatewayConsumerCredential
 
 	for {
@@ -402,7 +403,10 @@ func fetchAIGatewayConsumerCredentials(
 		}
 
 		allData = append(allData, res.ListAIGatewayConsumerCredentialsResponse.Data...)
-		nextCursor := pagination.ExtractPageAfterCursor(res.ListAIGatewayConsumerCredentialsResponse.Meta.Page.Next)
+		nextCursor, err := cursors.Next(res.ListAIGatewayConsumerCredentialsResponse.Meta.Page.Next)
+		if err != nil {
+			return nil, fmt.Errorf("list pagination failed: %w", err)
+		}
 		if nextCursor == "" {
 			break
 		}

--- a/internal/declarative/loader/ai_gateway_agent_test.go
+++ b/internal/declarative/loader/ai_gateway_agent_test.go
@@ -11,6 +11,7 @@ import (
 const aiGatewayAgentYAML = `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     policies:
       - ref: mask-sensitive-data
@@ -89,6 +90,7 @@ ai_gateway_agents:
 	duplicates := `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     agents:
       - ref: booking-agent

--- a/internal/declarative/loader/ai_gateway_config_store_test.go
+++ b/internal/declarative/loader/ai_gateway_config_store_test.go
@@ -12,6 +12,7 @@ func TestLoaderExtractsNestedAIGatewayConfigStores(t *testing.T) {
 	input := `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     config_stores:
       - ref: support-store
@@ -52,6 +53,7 @@ ai_gateway_config_stores:
 	duplicates := `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     config_stores:
       - ref: support-store
@@ -80,6 +82,7 @@ func TestLoaderRejectsInvalidAIGatewayConfigStoreDisplayName(t *testing.T) {
 	input := `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     config_stores:
       - ref: support-store
@@ -98,6 +101,7 @@ func TestLoaderAcceptsVaultConfigStoreReference(t *testing.T) {
 	input := `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     config_stores:
       - ref: support-store
@@ -125,6 +129,7 @@ func TestLoaderExtractsNestedAIGatewayConfigStoreSecrets(t *testing.T) {
 	input := `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     config_stores:
       - ref: support-store
@@ -152,6 +157,7 @@ func TestLoaderAcceptsRootAIGatewayConfigStoreSecret(t *testing.T) {
 	rs, err := New().LoadFile(writeLoaderTestFile(t, `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
 ai_gateway_config_stores:
   - ref: support-store
@@ -175,6 +181,7 @@ func TestLoaderRejectsDuplicateAIGatewayConfigStoreSecretRefsAcrossStores(t *tes
 	_, err := New().LoadFile(writeLoaderTestFile(t, `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     config_stores:
       - ref: primary-store
@@ -220,6 +227,7 @@ func TestLoaderAIGatewayConfigStoreSecretSyncScope(t *testing.T) {
 		rs, err := New().LoadFile(writeLoaderTestFile(t, `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     config_stores:
       - ref: support-store
@@ -237,6 +245,7 @@ ai_gateways:
 		rs, err := New().LoadFile(writeLoaderTestFile(t, `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     config_stores:
       - ref: support-store
@@ -262,6 +271,7 @@ func TestLoaderRejectsLiteralAIGatewayConfigStoreSecretWithoutEchoingValue(t *te
 	_, err := New().LoadFile(writeLoaderTestFile(t, `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     config_stores:
       - ref: support-store
@@ -279,6 +289,7 @@ func TestLoaderAcceptsDumpedAIGatewayConfigStoreSecretWithoutValue(t *testing.T)
 	rs, err := New().LoadFile(writeLoaderTestFile(t, `
 ai_gateways:
   - ref: support-gateway-id
+    name: support-gateway-id
     display_name: Support Gateway
     config_stores:
       - ref: support-store-id

--- a/internal/declarative/loader/ai_gateway_consumer_group_test.go
+++ b/internal/declarative/loader/ai_gateway_consumer_group_test.go
@@ -11,6 +11,7 @@ import (
 const aiGatewayConsumerGroupYAML = `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     policies:
       - ref: mask-sensitive-data
@@ -77,6 +78,7 @@ ai_gateway_consumer_groups:
 	duplicates := `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     consumer_groups:
       - ref: premium-support-users

--- a/internal/declarative/loader/ai_gateway_consumer_test.go
+++ b/internal/declarative/loader/ai_gateway_consumer_test.go
@@ -11,6 +11,7 @@ import (
 const aiGatewayConsumerYAML = `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     policies:
       - ref: mask-sensitive-data
@@ -56,6 +57,7 @@ func TestLoaderExtractsNestedAIGatewayConsumerCredentials(t *testing.T) {
 	input := `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     consumers:
       - ref: support-user
@@ -103,6 +105,7 @@ ai_gateway_consumers:
 	duplicates := `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     consumers:
       - ref: support-user
@@ -135,6 +138,7 @@ ai_gateway_consumer_credentials:
 	duplicates := `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     consumers:
       - ref: support-user

--- a/internal/declarative/loader/ai_gateway_data_plane_certificate_test.go
+++ b/internal/declarative/loader/ai_gateway_data_plane_certificate_test.go
@@ -11,6 +11,7 @@ import (
 const aiGatewayDataPlaneCertificateYAML = `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     data_plane_certificates:
       - ref: support-data-plane-cert
@@ -54,6 +55,7 @@ ai_gateway_data_plane_certificates:
 	duplicates := `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     data_plane_certificates:
       - ref: support-data-plane-cert

--- a/internal/declarative/loader/ai_gateway_mcp_server_test.go
+++ b/internal/declarative/loader/ai_gateway_mcp_server_test.go
@@ -12,6 +12,7 @@ import (
 const aiGatewayMCPServerYAML = `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     mcp_servers:
       - ref: support-tools
@@ -50,6 +51,7 @@ func TestLoaderExtractsIssue1499NestedAIGatewayMCPServers(t *testing.T) {
 	input := `
 ai_gateways:
   - ref: poc-default-ai-gateway
+    name: poc-default-ai-gateway
     display_name: POC Default AI Gateway
     auth_strategies:
       - ref: poc-key-auth
@@ -173,6 +175,7 @@ func TestLoaderRejectsUpstreamMCPServerLevelAccess(t *testing.T) {
 	input := `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     mcp_servers:
       - ref: support-upstream
@@ -196,6 +199,7 @@ func TestLoaderRejectsPassthroughToolWithoutAccess(t *testing.T) {
 	input := `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     mcp_servers:
       - ref: support-passthrough
@@ -219,6 +223,7 @@ func TestLoaderRejectsMCPRouteWithoutMatcher(t *testing.T) {
 	input := `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     mcp_servers:
       - ref: support-passthrough
@@ -263,6 +268,7 @@ func TestLoaderRejectsAIGatewayMCPListenerWithoutSources(t *testing.T) {
 	input := `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     mcp_servers:
       - ref: support-listener
@@ -301,6 +307,7 @@ ai_gateway_mcp_servers:
 	duplicates := `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     mcp_servers:
       - ref: support-tools

--- a/internal/declarative/loader/ai_gateway_model_test.go
+++ b/internal/declarative/loader/ai_gateway_model_test.go
@@ -13,6 +13,7 @@ import (
 const aiGatewayModelYAML = `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     models:
       - ref: support-gpt
@@ -56,6 +57,7 @@ func TestLoaderAcceptsDottedAIGatewayModelRef(t *testing.T) {
 	input := `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     models:
       - ref: gpt-5.4
@@ -100,6 +102,7 @@ ai_gateway_models:
 	duplicates := `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     models:
       - ref: support-gpt

--- a/internal/declarative/loader/ai_gateway_policy_test.go
+++ b/internal/declarative/loader/ai_gateway_policy_test.go
@@ -11,6 +11,7 @@ import (
 const aiGatewayPolicyYAML = `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     policies:
       - ref: mask-sensitive-data
@@ -52,6 +53,7 @@ func TestLoaderRejectsAIGatewayPolicyWithoutDisplayName(t *testing.T) {
 			input := `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     policies:
       - ref: post-function
@@ -86,6 +88,7 @@ ai_gateway_policies:
 	duplicates := `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     policies:
       - ref: mask-sensitive-data

--- a/internal/declarative/loader/ai_gateway_test.go
+++ b/internal/declarative/loader/ai_gateway_test.go
@@ -1,10 +1,37 @@
 package loader
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestLoaderAIGatewayUniquenessUsesName(t *testing.T) {
+	for _, tc := range []struct{ name, displayName, wantError string }{
+		{name: "second-gateway", displayName: "Shared Display"},
+		{name: "first-gateway", displayName: "Different Display", wantError: "duplicate ai_gateway name"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			input := fmt.Sprintf(`
+ai_gateways:
+  - ref: first-local-ref
+    name: first-gateway
+    display_name: Shared Display
+  - ref: second-local-ref
+    name: %s
+    display_name: %s
+`, tc.name, tc.displayName)
+			rs, err := New().LoadFromSources([]Source{{Path: writeLoaderTestFile(t, input), Type: SourceTypeFile}}, false)
+			if tc.wantError != "" {
+				require.ErrorContains(t, err, tc.wantError)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, rs.AIGateways, 2)
+		})
+	}
+}
 
 func TestLoaderPreservesAIGatewayDeploymentType(t *testing.T) {
 	input := `

--- a/internal/declarative/loader/ai_gateway_test.go
+++ b/internal/declarative/loader/ai_gateway_test.go
@@ -7,6 +7,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestLoaderRequiresExplicitAIGatewayName(t *testing.T) {
+	for _, nameField := range []string{"", "    name: \"\"\n"} {
+		t.Run(nameField, func(t *testing.T) {
+			input := "ai_gateways:\n  - ref: local-ref\n" + nameField + "    display_name: Gateway Label\n"
+			_, err := New().LoadFromSources([]Source{{Path: writeLoaderTestFile(t, input), Type: SourceTypeFile}}, false)
+			require.ErrorContains(t, err, "name is required for AI Gateway local-ref")
+		})
+	}
+}
+
 func TestLoaderAIGatewayUniquenessUsesName(t *testing.T) {
 	for _, tc := range []struct{ name, displayName, wantError string }{
 		{name: "second-gateway", displayName: "Shared Display"},

--- a/internal/declarative/loader/ai_gateway_vault_test.go
+++ b/internal/declarative/loader/ai_gateway_vault_test.go
@@ -11,6 +11,7 @@ import (
 const aiGatewayVaultYAML = `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     vaults:
       - ref: support-env
@@ -55,6 +56,7 @@ ai_gateway_vaults:
 	duplicates := `
 ai_gateways:
   - ref: support-gateway
+    name: support-gateway
     display_name: Support Gateway
     vaults:
       - ref: support-env

--- a/internal/declarative/loader/config_templates_test.go
+++ b/internal/declarative/loader/config_templates_test.go
@@ -200,6 +200,7 @@ _templates:
 
 ai_gateways:
   - ref: shared-gateway
+    name: shared-gateway
     display_name: Shared Gateway
     policies:
       - _extends: standard-oidc-policy

--- a/internal/declarative/loader/load_schema_test.go
+++ b/internal/declarative/loader/load_schema_test.go
@@ -22,6 +22,7 @@ func TestDeclarativeLoadSchemaRejectsUnknownFieldsAtFullPaths(t *testing.T) {
 			yaml: `
 ai_gateways:
   - ref: example-gateway
+    name: example-gateway
     display_name: Example Gateway
     consumers:
       - ref: eason

--- a/internal/declarative/loader/loader_test.go
+++ b/internal/declarative/loader/loader_test.go
@@ -93,6 +93,7 @@ func TestLoaderFlattensAIGatewayProviders(t *testing.T) {
 	err := os.WriteFile(path, []byte(`
 ai_gateways:
   - ref: customer-support-gateway
+    name: customer-support-gateway
     display_name: Customer Support Gateway
     model_providers:
       - ref: openai-provider
@@ -124,6 +125,7 @@ func TestLoaderRejectsLegacyAIGatewayModelProviderAuthFields(t *testing.T) {
 	input := `
 ai_gateways:
   - ref: customer-support-gateway
+    name: customer-support-gateway
     display_name: Customer Support Gateway
     model_providers:
       - ref: openai-provider
@@ -157,6 +159,7 @@ func TestLoaderRejectsLegacyNestedAIGatewayProviders(t *testing.T) {
 	err := os.WriteFile(path, []byte(`
 ai_gateways:
   - ref: customer-support-gateway
+    name: customer-support-gateway
     display_name: Customer Support Gateway
     providers:
       - ref: openai-provider
@@ -181,6 +184,7 @@ func TestLoaderRejectsLegacyRootAIGatewayProviders(t *testing.T) {
 	err := os.WriteFile(path, []byte(`
 ai_gateways:
   - ref: customer-support-gateway
+    name: customer-support-gateway
     display_name: Customer Support Gateway
 ai_gateway_providers:
   - ref: openai-provider
@@ -205,6 +209,7 @@ func TestLoaderFlattensAIGatewayAuthStrategies(t *testing.T) {
 	err := os.WriteFile(path, []byte(`
 ai_gateways:
   - ref: customer-support-gateway
+    name: customer-support-gateway
     display_name: Customer Support Gateway
     auth_strategies:
       - ref: support-key-auth

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -817,7 +817,7 @@ func (l *Loader) validateAIGateways(
 	gateways []resources.AIGatewayResource,
 	rs *resources.ResourceSet,
 ) error {
-	displayNamesByNamespace := make(map[string]string)
+	namesByNamespace := make(map[string]string)
 
 	for i := range gateways {
 		gateway := &gateways[i]
@@ -837,17 +837,17 @@ func (l *Loader) validateAIGateways(
 			continue
 		}
 		namespace := resources.GetNamespace(gateway.Kongctl)
-		nameKey := namespace + "\x00" + gateway.DisplayName
-		if existingRef, exists := displayNamesByNamespace[nameKey]; exists {
+		nameKey := namespace + "\x00" + gateway.Name
+		if existingRef, exists := namesByNamespace[nameKey]; exists {
 			return fmt.Errorf(
-				"duplicate ai_gateway display_name '%s' in namespace '%s' (ref: %s conflicts with ref: %s)",
-				gateway.DisplayName,
+				"duplicate ai_gateway name '%s' in namespace '%s' (ref: %s conflicts with ref: %s)",
+				gateway.Name,
 				namespace,
 				gateway.GetRef(),
 				existingRef,
 			)
 		}
-		displayNamesByNamespace[nameKey] = gateway.GetRef()
+		namesByNamespace[nameKey] = gateway.GetRef()
 	}
 
 	return nil

--- a/internal/declarative/planner/ai_gateway_consumer_planner.go
+++ b/internal/declarative/planner/ai_gateway_consumer_planner.go
@@ -9,7 +9,6 @@ import (
 	"github.com/kong/kongctl/internal/declarative/labels"
 	"github.com/kong/kongctl/internal/declarative/resources"
 	"github.com/kong/kongctl/internal/declarative/state"
-	"github.com/kong/kongctl/internal/util"
 )
 
 func (p *Planner) planAIGatewayConsumerChanges(
@@ -49,15 +48,12 @@ func (p *Planner) planAIGatewayConsumerChanges(
 		return fmt.Errorf("failed to list AI Gateway Consumers for gateway %s: %w", gatewayID, err)
 	}
 
-	currentByID, currentByName := indexAIGatewayConsumers(currentConsumers)
+	currentByName := indexAIGatewayConsumers(currentConsumers)
 	desiredKeys := make(map[string]bool)
 
 	for _, desiredConsumer := range desired {
-		current, exists := matchCurrentAIGatewayConsumer(desiredConsumer, currentByID, currentByName)
+		current, exists := currentByName[desiredConsumer.Name]
 		desiredKeys[desiredConsumer.Name] = true
-		if id := aiGatewayConsumerDesiredID(desiredConsumer); id != "" {
-			desiredKeys[id] = true
-		}
 
 		if !exists {
 			dependsOn := aiGatewayConsumerPolicyCreateDependencies(
@@ -168,7 +164,7 @@ func (p *Planner) planAIGatewayConsumerChanges(
 		for _, current := range currentConsumers {
 			consumerID := resources.AIGatewayConsumerID(current.AIGatewayConsumer)
 			consumerName := resources.AIGatewayConsumerName(current.AIGatewayConsumer)
-			if desiredKeys[consumerID] || desiredKeys[consumerName] {
+			if desiredKeys[consumerName] {
 				continue
 			}
 			isProtected := labels.IsProtectedResource(current.NormalizedLabels)
@@ -345,43 +341,14 @@ func (p *Planner) shouldUpdateAIGatewayConsumer(
 	return true, updateFields, changedFields, nil
 }
 
-func indexAIGatewayConsumers(
-	consumers []state.AIGatewayConsumer,
-) (map[string]state.AIGatewayConsumer, map[string]state.AIGatewayConsumer) {
-	byID := make(map[string]state.AIGatewayConsumer)
-	byName := make(map[string]state.AIGatewayConsumer)
+func indexAIGatewayConsumers(consumers []state.AIGatewayConsumer) map[string]state.AIGatewayConsumer {
+	byName := make(map[string]state.AIGatewayConsumer, len(consumers))
 	for _, consumer := range consumers {
-		if id := resources.AIGatewayConsumerID(consumer.AIGatewayConsumer); id != "" {
-			byID[id] = consumer
-		}
 		if name := resources.AIGatewayConsumerName(consumer.AIGatewayConsumer); name != "" {
 			byName[name] = consumer
 		}
 	}
-	return byID, byName
-}
-
-func matchCurrentAIGatewayConsumer(
-	desired resources.AIGatewayConsumerResource,
-	currentByID map[string]state.AIGatewayConsumer,
-	currentByName map[string]state.AIGatewayConsumer,
-) (state.AIGatewayConsumer, bool) {
-	if id := aiGatewayConsumerDesiredID(desired); id != "" {
-		current, exists := currentByID[id]
-		return current, exists
-	}
-	current, exists := currentByName[desired.Name]
-	return current, exists
-}
-
-func aiGatewayConsumerDesiredID(desired resources.AIGatewayConsumerResource) string {
-	if id := desired.GetKonnectID(); id != "" {
-		return id
-	}
-	if util.IsValidUUID(desired.Ref) {
-		return desired.Ref
-	}
-	return ""
+	return byName
 }
 
 func aiGatewayConsumerPolicyCreateDependencies(

--- a/internal/declarative/planner/ai_gateway_consumer_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_consumer_planner_test.go
@@ -38,6 +38,48 @@ func TestAIGatewayConsumerPlannerCreatesChildForExistingGateway(t *testing.T) {
 	require.Equal(t, "api-key", change.Fields[FieldType])
 }
 
+func TestAIGatewayConsumerPlannerNameIsAuthoritative(t *testing.T) {
+	const existingID = "c3296957-12fb-4bdf-ae35-15b19a749592"
+	for _, tc := range []struct{ ref, id string }{
+		{ref: "support-user"},
+		{ref: existingID},
+		{ref: "cached-id", id: existingID},
+	} {
+		t.Run(tc.ref, func(t *testing.T) {
+			consumer := testAIGatewayConsumerResource(t, nil)
+			consumer.Name = "second-consumer"
+			consumer.Ref = tc.ref
+			consumer.SetKonnectID(tc.id)
+			current := testAIGatewayConsumer(nil)
+			current.ID = existingID
+			client := state.NewClient(state.ClientConfig{
+				AIGatewayAPI:          &testAIGatewayAPI{gateways: []kkComps.AIGateway{testAIGateway()}},
+				AIGatewayConsumersAPI: &testAIGatewayConsumerAPI{consumers: []kkComps.AIGatewayConsumer{current}},
+			})
+			plan, err := NewPlanner(client, slog.Default()).GeneratePlan(
+				t.Context(), testAIGatewayConsumerResourceSet(consumer), Options{Mode: PlanModeApply},
+			)
+			require.NoError(t, err)
+			require.Len(t, plan.Changes, 1)
+			require.Equal(t, ActionCreate, plan.Changes[0].Action)
+			require.Equal(t, "second-consumer", plan.Changes[0].Fields[FieldName])
+			require.Equal(t, "gateway-id", plan.Changes[0].Parent.ID)
+
+			rs := testAIGatewayConsumerResourceSet(consumer)
+			rs.EnsureSyncScope().AddRoot(resources.ResourceTypeAIGateway)
+			rs.SyncScope.AddChild(resources.ResourceTypeAIGateway, "support-gateway", resources.ResourceTypeAIGatewayConsumer)
+			plan, err = NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeSync})
+			require.NoError(t, err)
+			require.Len(t, plan.Changes, 2)
+			actions := map[ActionType]string{}
+			for _, change := range plan.Changes {
+				actions[change.Action] = change.Fields[FieldName].(string)
+			}
+			require.Equal(t, map[ActionType]string{ActionCreate: "second-consumer", ActionDelete: "support-user"}, actions)
+		})
+	}
+}
+
 func TestAIGatewayConsumerPlannerUpdatesExistingConsumer(t *testing.T) {
 	consumer := testAIGatewayConsumerResource(t, nil)
 	consumer.DisplayName = "Support User Updated"

--- a/internal/declarative/planner/ai_gateway_mcp_server_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_mcp_server_planner_test.go
@@ -57,6 +57,7 @@ func TestAIGatewayMCPServerPlannerCreatesIssue1499NestedServers(t *testing.T) {
 	input := `
 ai_gateways:
   - ref: poc-default-ai-gateway
+    name: poc-default-ai-gateway
     display_name: POC Default AI Gateway
     mcp_servers:
       - ref: poc-mcp-conversion

--- a/internal/declarative/planner/ai_gateway_planner.go
+++ b/internal/declarative/planner/ai_gateway_planner.go
@@ -11,7 +11,6 @@ import (
 	"github.com/kong/kongctl/internal/declarative/labels"
 	"github.com/kong/kongctl/internal/declarative/resources"
 	"github.com/kong/kongctl/internal/declarative/state"
-	"github.com/kong/kongctl/internal/util"
 )
 
 type aiGatewayPlannerImpl struct {
@@ -62,7 +61,7 @@ func (p *Planner) planAIGatewayChanges(
 		}
 	}
 
-	currentByID, currentByName, currentByDisplayName := indexAIGateways(currentGateways)
+	currentByName := indexAIGateways(currentGateways)
 
 	if plan.Metadata.Mode == PlanModeDelete {
 		var protectionErrors []error
@@ -70,15 +69,7 @@ func (p *Planner) planAIGatewayChanges(
 			if desiredGateway.IsExternal() {
 				continue
 			}
-			current, exists, err := matchCurrentAIGateway(
-				desiredGateway,
-				currentByID,
-				currentByName,
-				currentByDisplayName,
-			)
-			if err != nil {
-				return err
-			}
+			current, exists := currentByName[desiredGateway.Name]
 			if !exists {
 				plan.AddWarning("", fmt.Sprintf(
 					"ai_gateway %q not found in Konnect, skipping delete", desiredGateway.DisplayName,
@@ -113,10 +104,7 @@ func (p *Planner) planAIGatewayChanges(
 			continue
 		}
 
-		current, exists, err := matchCurrentAIGateway(desiredGateway, currentByID, currentByName, currentByDisplayName)
-		if err != nil {
-			return err
-		}
+		current, exists := currentByName[desiredGateway.Name]
 		gatewayID := ""
 		gatewayChangeID := ""
 		if !exists {
@@ -699,71 +687,14 @@ func (p *Planner) shouldUpdateAIGateway(
 	return len(updates) > 0, updates, changedFields
 }
 
-func indexAIGateways(
-	gateways []state.AIGateway,
-) (map[string]state.AIGateway, map[string]state.AIGateway, map[string][]state.AIGateway) {
-	byID := make(map[string]state.AIGateway)
-	byName := make(map[string]state.AIGateway)
-	byDisplayName := make(map[string][]state.AIGateway)
+func indexAIGateways(gateways []state.AIGateway) map[string]state.AIGateway {
+	byName := make(map[string]state.AIGateway, len(gateways))
 	for _, gateway := range gateways {
-		if gateway.ID != "" {
-			byID[gateway.ID] = gateway
-		}
 		if gateway.Name != "" {
 			byName[gateway.Name] = gateway
 		}
-		byDisplayName[gateway.DisplayName] = append(byDisplayName[gateway.DisplayName], gateway)
 	}
-	return byID, byName, byDisplayName
-}
-
-func matchCurrentAIGateway(
-	desired resources.AIGatewayResource,
-	currentByID map[string]state.AIGateway,
-	currentByName map[string]state.AIGateway,
-	currentByDisplayName map[string][]state.AIGateway,
-) (state.AIGateway, bool, error) {
-	if id := aiGatewayDesiredID(desired); id != "" {
-		current, exists := currentByID[id]
-		return current, exists, nil
-	}
-
-	if desired.Name != "" {
-		current, exists := currentByName[desired.Name]
-		if exists {
-			return current, true, nil
-		}
-	}
-
-	if desired.Ref != "" && desired.Ref != desired.Name {
-		current, exists := currentByName[desired.Ref]
-		if exists {
-			return current, true, nil
-		}
-	}
-
-	matches := currentByDisplayName[desired.DisplayName]
-	switch len(matches) {
-	case 0:
-		return state.AIGateway{}, false, nil
-	case 1:
-		return matches[0], true, nil
-	default:
-		return state.AIGateway{}, false, fmt.Errorf(
-			"multiple managed AI Gateways with display_name %q found in namespace; use a UUID ref or remove duplicates",
-			desired.DisplayName,
-		)
-	}
-}
-
-func aiGatewayDesiredID(desired resources.AIGatewayResource) string {
-	if id := desired.GetKonnectID(); id != "" {
-		return id
-	}
-	if util.IsValidUUID(desired.Ref) {
-		return desired.Ref
-	}
-	return ""
+	return byName
 }
 
 func aiGatewayIdentity(gateway state.AIGateway) string {

--- a/internal/declarative/planner/ai_gateway_planner.go
+++ b/internal/declarative/planner/ai_gateway_planner.go
@@ -72,14 +72,14 @@ func (p *Planner) planAIGatewayChanges(
 			current, exists := currentByName[desiredGateway.Name]
 			if !exists {
 				plan.AddWarning("", fmt.Sprintf(
-					"ai_gateway %q not found in Konnect, skipping delete", desiredGateway.DisplayName,
+					"ai_gateway %q not found in Konnect, skipping delete", desiredGateway.Name,
 				))
 				continue
 			}
 
 			isProtected := labels.IsProtectedResource(current.NormalizedLabels)
 			if err := p.validateProtection(
-				ResourceTypeAIGateway, desiredGateway.DisplayName, isProtected, ActionDelete,
+				ResourceTypeAIGateway, desiredGateway.Name, isProtected, ActionDelete,
 			); err != nil {
 				protectionErrors = append(protectionErrors, err)
 			} else {
@@ -123,7 +123,7 @@ func (p *Planner) planAIGatewayChanges(
 				protectionChange := &ProtectionChange{Old: isProtected, New: shouldProtect}
 				if err := p.validateProtectionWithChange(
 					ResourceTypeAIGateway,
-					desiredGateway.DisplayName,
+					desiredGateway.Name,
 					isProtected,
 					ActionUpdate,
 					protectionChange,
@@ -136,7 +136,7 @@ func (p *Planner) planAIGatewayChanges(
 			} else if needsUpdate {
 				if err := p.validateProtection(
 					ResourceTypeAIGateway,
-					desiredGateway.DisplayName,
+					desiredGateway.Name,
 					isProtected,
 					ActionUpdate,
 				); err != nil {
@@ -388,7 +388,7 @@ func (p *Planner) planAIGatewayChanges(
 			}
 
 			isProtected := labels.IsProtectedResource(current.NormalizedLabels)
-			if err := p.validateProtection(ResourceTypeAIGateway, current.DisplayName, isProtected, ActionDelete); err != nil {
+			if err := p.validateProtection(ResourceTypeAIGateway, current.Name, isProtected, ActionDelete); err != nil {
 				protectionErrors = append(protectionErrors, err)
 			} else {
 				p.planAIGatewayDelete(current, plan)

--- a/internal/declarative/planner/ai_gateway_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_planner_test.go
@@ -40,7 +40,7 @@ func TestAIGatewayPlannerCreateUsesExplicitNameNotRef(t *testing.T) {
 	require.Equal(t, kkComps.CreateAIGatewayRequestDeploymentTypeManaged, change.Fields[FieldDeploymentType])
 }
 
-func TestAIGatewayPlannerMatchesByNameBeforeDisplayName(t *testing.T) {
+func TestAIGatewayPlannerMatchesByNameWhenDisplayNameChanges(t *testing.T) {
 	client := state.NewClient(state.ClientConfig{
 		AIGatewayAPI: &testAIGatewayAPI{
 			gateways: []kkComps.AIGateway{{
@@ -75,7 +75,7 @@ func TestAIGatewayPlannerMatchesByNameBeforeDisplayName(t *testing.T) {
 	require.Contains(t, change.ChangedFields, FieldDisplayName)
 }
 
-func TestAIGatewayPlannerIgnoresImmutableNameDrift(t *testing.T) {
+func TestAIGatewayPlannerCreatesForDifferentNameWithSameRefAndDisplayName(t *testing.T) {
 	client := state.NewClient(state.ClientConfig{
 		AIGatewayAPI: &testAIGatewayAPI{
 			gateways: []kkComps.AIGateway{{
@@ -98,10 +98,12 @@ func TestAIGatewayPlannerIgnoresImmutableNameDrift(t *testing.T) {
 
 	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
 	require.NoError(t, err)
-	require.Empty(t, plan.Changes)
+	require.Len(t, plan.Changes, 1)
+	require.Equal(t, ActionCreate, plan.Changes[0].Action)
+	require.Equal(t, "support-gateway", plan.Changes[0].Fields[FieldName])
 }
 
-func TestAIGatewayPlannerPreservesCurrentNameInPutWhenDesiredNameDrifts(t *testing.T) {
+func TestAIGatewayPlannerCreatesForDifferentNameWithSameRef(t *testing.T) {
 	client := state.NewClient(state.ClientConfig{
 		AIGatewayAPI: &testAIGatewayAPI{
 			gateways: []kkComps.AIGateway{{
@@ -125,9 +127,77 @@ func TestAIGatewayPlannerPreservesCurrentNameInPutWhenDesiredNameDrifts(t *testi
 	plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeApply})
 	require.NoError(t, err)
 	require.Len(t, plan.Changes, 1)
-	require.Equal(t, "current-gateway-name", plan.Changes[0].Fields[FieldName])
+	require.Equal(t, ActionCreate, plan.Changes[0].Action)
+	require.Equal(t, "desired-but-immutable-name", plan.Changes[0].Fields[FieldName])
 	require.Equal(t, "Updated Support Gateway", plan.Changes[0].Fields[FieldDisplayName])
 	require.NotContains(t, plan.Changes[0].ChangedFields, FieldName)
+}
+
+func TestAIGatewayPlannerNameIsAuthoritative(t *testing.T) {
+	const existingID = "c3296957-12fb-4bdf-ae35-15b19a749592"
+	for _, mode := range []PlanMode{PlanModeApply, PlanModeSync, PlanModeDelete} {
+		for _, tc := range []struct{ ref, resolvedID string }{
+			{ref: "local-ref"},
+			{ref: "existing-name"},
+			{ref: existingID},
+			{ref: "cached-id", resolvedID: existingID},
+		} {
+			t.Run(string(mode)+"/"+tc.ref, func(t *testing.T) {
+				client := state.NewClient(state.ClientConfig{
+					AIGatewayAPI: &testAIGatewayAPI{
+						gateways: []kkComps.AIGateway{{
+							ID: existingID, Name: "existing-name", DisplayName: "Shared Display",
+							Labels: map[string]string{labels.NamespaceKey: "default"},
+						}},
+					},
+				})
+				desired := resources.AIGatewayResource{
+					BaseResource: resources.BaseResource{Ref: tc.ref},
+					CreateAIGatewayRequest: kkComps.CreateAIGatewayRequest{
+						Name: "new-name", DisplayName: "Shared Display",
+					},
+				}
+				// A cached ID must not override the declared name either.
+				desired.SetKonnectID(tc.resolvedID)
+				rs := &resources.ResourceSet{AIGateways: []resources.AIGatewayResource{desired}}
+				rs.EnsureSyncScope().AddRoot(resources.ResourceTypeAIGateway)
+				plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: mode})
+				require.NoError(t, err)
+				switch mode {
+				case PlanModeApply:
+					require.Len(t, plan.Changes, 1)
+					require.Equal(t, ActionCreate, plan.Changes[0].Action)
+				case PlanModeSync:
+					require.Len(t, plan.Changes, 2)
+					actions := map[ActionType]string{}
+					for _, change := range plan.Changes {
+						actions[change.Action] = change.Fields[FieldName].(string)
+					}
+					require.Equal(t, map[ActionType]string{ActionCreate: "new-name", ActionDelete: "existing-name"}, actions)
+				case PlanModeDelete:
+					require.Empty(t, plan.Changes)
+				}
+			})
+		}
+	}
+}
+
+func TestResolveAIGatewayIdentitiesUsesNameWhenDisplayNameChanges(t *testing.T) {
+	client := state.NewClient(state.ClientConfig{
+		AIGatewayAPI: &testAIGatewayAPI{gateways: []kkComps.AIGateway{{
+			ID: "gateway-id", Name: "support-gateway", DisplayName: "Old Display",
+			Labels: map[string]string{labels.NamespaceKey: "default"},
+		}}},
+	})
+	gateways := []resources.AIGatewayResource{{
+		BaseResource: resources.BaseResource{Ref: "local-ref"},
+		CreateAIGatewayRequest: kkComps.CreateAIGatewayRequest{
+			Name: "support-gateway", DisplayName: "New Display",
+		},
+	}}
+	err := NewPlanner(client, slog.Default()).resolveAIGatewayIdentities(t.Context(), gateways)
+	require.NoError(t, err)
+	require.Equal(t, "gateway-id", gateways[0].GetKonnectID())
 }
 
 func TestAIGatewayPlannerDeleteUsesNameBeforeDisplayName(t *testing.T) {

--- a/internal/declarative/planner/ai_gateway_planner_test.go
+++ b/internal/declarative/planner/ai_gateway_planner_test.go
@@ -176,9 +176,44 @@ func TestAIGatewayPlannerNameIsAuthoritative(t *testing.T) {
 					require.Equal(t, map[ActionType]string{ActionCreate: "new-name", ActionDelete: "existing-name"}, actions)
 				case PlanModeDelete:
 					require.Empty(t, plan.Changes)
+					require.Len(t, plan.Warnings, 1)
+					require.Contains(t, plan.Warnings[0].Message, "new-name")
+					require.NotContains(t, plan.Warnings[0].Message, "Shared Display")
 				}
 			})
 		}
+	}
+}
+
+func TestAIGatewayPlannerDeleteMatchesName(t *testing.T) {
+	for _, protected := range []bool{false, true} {
+		t.Run(map[bool]string{false: "delete", true: "protected"}[protected], func(t *testing.T) {
+			gatewayLabels := map[string]string{labels.NamespaceKey: "default"}
+			if protected {
+				gatewayLabels[labels.ProtectedKey] = labels.TrueValue
+			}
+			client := state.NewClient(state.ClientConfig{AIGatewayAPI: &testAIGatewayAPI{
+				gateways: []kkComps.AIGateway{{
+					ID: "gateway-id", Name: "existing-name", DisplayName: "Live Label", Labels: gatewayLabels,
+				}},
+			}})
+			rs := &resources.ResourceSet{AIGateways: []resources.AIGatewayResource{{
+				BaseResource: resources.BaseResource{Ref: "different-local-ref"},
+				CreateAIGatewayRequest: kkComps.CreateAIGatewayRequest{
+					Name: "existing-name", DisplayName: "Desired Label",
+				},
+			}}}
+			plan, err := NewPlanner(client, slog.Default()).GeneratePlan(t.Context(), rs, Options{Mode: PlanModeDelete})
+			if protected {
+				require.ErrorContains(t, err, "existing-name")
+				require.NotContains(t, err.Error(), "Desired Label")
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, plan.Changes, 1)
+			require.Equal(t, ActionDelete, plan.Changes[0].Action)
+			require.Equal(t, "gateway-id", plan.Changes[0].ResourceID)
+		})
 	}
 }
 

--- a/internal/declarative/planner/planner.go
+++ b/internal/declarative/planner/planner.go
@@ -986,7 +986,7 @@ func (p *Planner) resolveCatalogServiceIdentities(
 // resolveAIGatewayIdentities resolves Konnect IDs for AI Gateway resources.
 func (p *Planner) resolveAIGatewayIdentities(ctx context.Context, gateways []resources.AIGatewayResource) error {
 	var (
-		managedByDisplayName map[string]*state.AIGateway
+		managedByName        map[string]*state.AIGateway
 		managedLoaded        bool
 		gatewayByID          map[string]*state.AIGateway
 		gatewayByDisplayName map[string][]*state.AIGateway
@@ -1004,14 +1004,14 @@ func (p *Planner) resolveAIGatewayIdentities(ctx context.Context, gateways []res
 			return err
 		}
 
-		managedByDisplayName = make(map[string]*state.AIGateway, len(currentGateways))
+		managedByName = make(map[string]*state.AIGateway, len(currentGateways))
 		for i := range currentGateways {
 			current := &currentGateways[i]
-			if current.DisplayName == "" {
+			if current.Name == "" {
 				continue
 			}
-			if _, exists := managedByDisplayName[current.DisplayName]; !exists {
-				managedByDisplayName[current.DisplayName] = current
+			if _, exists := managedByName[current.Name]; !exists {
+				managedByName[current.Name] = current
 			}
 		}
 
@@ -1078,7 +1078,7 @@ func (p *Planner) resolveAIGatewayIdentities(ctx context.Context, gateways []res
 			continue
 		}
 
-		if gateway.DisplayName == "" {
+		if gateway.Name == "" {
 			continue
 		}
 
@@ -1089,7 +1089,7 @@ func (p *Planner) resolveAIGatewayIdentities(ctx context.Context, gateways []res
 			return fmt.Errorf("failed to list managed AI Gateways: %w", err)
 		}
 
-		if current, ok := managedByDisplayName[gateway.DisplayName]; ok {
+		if current, ok := managedByName[gateway.Name]; ok {
 			gateway.TryMatchKonnectResource(current)
 		}
 	}

--- a/internal/declarative/resources/ai_gateway.go
+++ b/internal/declarative/resources/ai_gateway.go
@@ -355,9 +355,6 @@ func (a AIGatewayResource) Validate() error {
 
 // SetDefaults applies default values to AI Gateway resource.
 func (a *AIGatewayResource) SetDefaults() {
-	if a.Name == "" {
-		a.Name = a.Ref
-	}
 	if a.DisplayName == "" {
 		a.DisplayName = a.Name
 	}
@@ -430,7 +427,7 @@ func aiGatewayExplainNode(_ ExplainBuildContext) (*ExplainNode, error) {
 		explainResourceRefField(),
 		explainKongctlField(),
 		explainExternalField(),
-		explainField("name", explainStringNode("my-ai-gateway"), false, true),
+		explainField("name", explainStringNode("my-ai-gateway"), true, true),
 		explainField("display_name", explainStringNode("My AI Gateway"), true, true),
 		explainField("description", &ExplainNode{Kind: explainKindString, Nullable: true}, false, false),
 		explainField("deployment_type", explainStringNode("hybrid"), false, false),

--- a/internal/declarative/resources/ai_gateway_consumer.go
+++ b/internal/declarative/resources/ai_gateway_consumer.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	kkComps "github.com/Kong/sdk-konnect-go/models/components"
-	"github.com/kong/kongctl/internal/util"
 )
 
 const (
@@ -135,12 +134,6 @@ func (a *AIGatewayConsumerResource) TryMatchKonnectResource(konnectResource any)
 	name := a.Name
 	if name == "" {
 		return false
-	}
-	if id := AIGatewayConsumerID(konnectResource); id != "" && (util.IsValidUUID(a.Ref) || a.GetKonnectID() != "") {
-		if a.Ref == id || a.GetKonnectID() == id {
-			a.SetKonnectID(id)
-			return true
-		}
 	}
 	if id := AIGatewayConsumerID(konnectResource); id != "" && AIGatewayConsumerName(konnectResource) == name {
 		a.SetKonnectID(id)

--- a/internal/declarative/resources/ai_gateway_consumer_test.go
+++ b/internal/declarative/resources/ai_gateway_consumer_test.go
@@ -1,0 +1,35 @@
+package resources
+
+import (
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAIGatewayConsumerMatchesOnlyByName(t *testing.T) {
+	const id = "c3296957-12fb-4bdf-ae35-15b19a749592"
+	for _, tc := range []struct{ name, ref, resolvedID string }{
+		{name: "same-name", ref: "local-alias"},
+		{name: "different-name", ref: id},
+		{name: "different-name", ref: "local-alias", resolvedID: id},
+		{name: "different-name", ref: "same-name"},
+	} {
+		t.Run(tc.name+"/"+tc.ref, func(t *testing.T) {
+			desired := AIGatewayConsumerResource{
+				BaseResource: BaseResource{Ref: tc.ref},
+				CreateAIGatewayConsumerRequest: kkComps.CreateAIGatewayConsumerRequest{
+					Name: tc.name, DisplayName: "Shared Display",
+				},
+			}
+			desired.SetKonnectID(tc.resolvedID)
+			matched := desired.TryMatchKonnectResource(kkComps.AIGatewayConsumer{
+				ID: id, Name: "same-name", DisplayName: "Shared Display",
+			})
+			require.Equal(t, tc.name == "same-name", matched)
+			if matched {
+				require.Equal(t, id, desired.GetKonnectID())
+			}
+		})
+	}
+}

--- a/internal/declarative/resources/ai_gateway_test.go
+++ b/internal/declarative/resources/ai_gateway_test.go
@@ -81,7 +81,7 @@ func requireAIGatewaySerializedPayload(t *testing.T, payload map[string]any) {
 	require.Equal(t, "https", proxyURL["protocol"])
 }
 
-func TestAIGatewayResourceSetDefaultsUsesRefOnlyWhenNameOmitted(t *testing.T) {
+func TestAIGatewayResourceRequiresExplicitName(t *testing.T) {
 	t.Parallel()
 
 	resource := AIGatewayResource{
@@ -99,8 +99,8 @@ func TestAIGatewayResourceSetDefaultsUsesRefOnlyWhenNameOmitted(t *testing.T) {
 	resource = AIGatewayResource{BaseResource: BaseResource{Ref: "local-ref"}}
 	resource.SetDefaults()
 
-	require.Equal(t, "local-ref", resource.Name)
-	require.Equal(t, "local-ref", resource.DisplayName)
+	require.Empty(t, resource.Name)
+	require.ErrorContains(t, resource.Validate(), "name is required")
 }
 
 func TestAIGatewayResourceAllowsExternalWithoutDisplayName(t *testing.T) {

--- a/internal/declarative/state/ai_gateway_consumer_credentials.go
+++ b/internal/declarative/state/ai_gateway_consumer_credentials.go
@@ -22,6 +22,7 @@ func (c *Client) ListAIGatewayConsumerCredentials(
 
 	var allData []kkComps.AIGatewayConsumerCredential
 	var pageAfter *string
+	var cursors pagination.CursorTracker
 	pageSize := int64(100)
 
 	for {
@@ -43,7 +44,10 @@ func (c *Client) ListAIGatewayConsumerCredentials(
 
 		allData = append(allData, resp.ListAIGatewayConsumerCredentialsResponse.Data...)
 
-		nextCursor := pagination.ExtractPageAfterCursor(resp.ListAIGatewayConsumerCredentialsResponse.Meta.Page.Next)
+		nextCursor, err := cursors.Next(resp.ListAIGatewayConsumerCredentialsResponse.Meta.Page.Next)
+		if err != nil {
+			return nil, fmt.Errorf("list pagination failed: %w", err)
+		}
 		if nextCursor == "" {
 			break
 		}

--- a/internal/declarative/state/ai_gateway_consumer_groups.go
+++ b/internal/declarative/state/ai_gateway_consumer_groups.go
@@ -19,6 +19,7 @@ func (c *Client) ListAIGatewayConsumerGroups(ctx context.Context, gatewayID stri
 
 	var allData []kkComps.AIGatewayConsumerGroup
 	var pageAfter *string
+	var cursors pagination.CursorTracker
 	pageSize := int64(100)
 
 	for {
@@ -39,7 +40,10 @@ func (c *Client) ListAIGatewayConsumerGroups(ctx context.Context, gatewayID stri
 
 		allData = append(allData, resp.ListAIGatewayConsumerGroupsResponse.Data...)
 
-		nextCursor := pagination.ExtractPageAfterCursor(resp.ListAIGatewayConsumerGroupsResponse.Meta.Page.Next)
+		nextCursor, err := cursors.Next(resp.ListAIGatewayConsumerGroupsResponse.Meta.Page.Next)
+		if err != nil {
+			return nil, fmt.Errorf("list pagination failed: %w", err)
+		}
 		if nextCursor == "" {
 			break
 		}
@@ -194,6 +198,7 @@ func (c *Client) ListAIGatewayConsumersInConsumerGroup(
 
 	var allData []kkComps.AIGatewayConsumer
 	var pageAfter *string
+	var cursors pagination.CursorTracker
 	pageSize := int64(100)
 
 	for {
@@ -214,7 +219,10 @@ func (c *Client) ListAIGatewayConsumersInConsumerGroup(
 
 		allData = append(allData, resp.ListAIGatewayConsumersResponse.Data...)
 
-		nextCursor := pagination.ExtractPageAfterCursor(resp.ListAIGatewayConsumersResponse.Meta.Page.Next)
+		nextCursor, err := cursors.Next(resp.ListAIGatewayConsumersResponse.Meta.Page.Next)
+		if err != nil {
+			return nil, fmt.Errorf("list pagination failed: %w", err)
+		}
 		if nextCursor == "" {
 			break
 		}

--- a/internal/declarative/state/ai_gateway_consumers.go
+++ b/internal/declarative/state/ai_gateway_consumers.go
@@ -18,6 +18,7 @@ func (c *Client) ListAIGatewayConsumers(ctx context.Context, gatewayID string) (
 
 	var allData []kkComps.AIGatewayConsumer
 	var pageAfter *string
+	var cursors pagination.CursorTracker
 	pageSize := int64(100)
 
 	for {
@@ -38,7 +39,10 @@ func (c *Client) ListAIGatewayConsumers(ctx context.Context, gatewayID string) (
 
 		allData = append(allData, resp.ListAIGatewayConsumersResponse.Data...)
 
-		nextCursor := pagination.ExtractPageAfterCursor(resp.ListAIGatewayConsumersResponse.Meta.Page.Next)
+		nextCursor, err := cursors.Next(resp.ListAIGatewayConsumersResponse.Meta.Page.Next)
+		if err != nil {
+			return nil, fmt.Errorf("list pagination failed: %w", err)
+		}
 		if nextCursor == "" {
 			break
 		}

--- a/internal/declarative/state/ai_gateway_consumers_test.go
+++ b/internal/declarative/state/ai_gateway_consumers_test.go
@@ -1,0 +1,118 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	kkComps "github.com/Kong/sdk-konnect-go/models/components"
+	kkOps "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/kong/kongctl/internal/konnect/helpers"
+	"github.com/stretchr/testify/require"
+)
+
+type paginatedAIGatewayConsumersAPI struct {
+	helpers.AIGatewayConsumersAPI
+	list            func(kkOps.ListAiGatewayConsumersRequest) (*kkOps.ListAiGatewayConsumersResponse, error)
+	listCredentials func(
+		kkOps.ListAiGatewayConsumerCredentialsRequest,
+	) (*kkOps.ListAiGatewayConsumerCredentialsResponse, error)
+}
+
+func (a paginatedAIGatewayConsumersAPI) ListAiGatewayConsumerCredentials(
+	_ context.Context, req kkOps.ListAiGatewayConsumerCredentialsRequest, _ ...kkOps.Option,
+) (*kkOps.ListAiGatewayConsumerCredentialsResponse, error) {
+	return a.listCredentials(req)
+}
+
+func (a paginatedAIGatewayConsumersAPI) ListAiGatewayConsumers(
+	_ context.Context, req kkOps.ListAiGatewayConsumersRequest, _ ...kkOps.Option,
+) (*kkOps.ListAiGatewayConsumersResponse, error) {
+	return a.list(req)
+}
+
+func TestListAIGatewayConsumersFollowsBareCursor(t *testing.T) {
+	for _, failSecondPage := range []bool{false, true} {
+		t.Run(fmt.Sprintf("second-page-error=%t", failSecondPage), func(t *testing.T) {
+			const cursor = "abc+def/ghi=="
+			pageError := errors.New("second page unavailable")
+			calls := 0
+			client := NewClient(ClientConfig{AIGatewayConsumersAPI: &paginatedAIGatewayConsumersAPI{
+				list: func(req kkOps.ListAiGatewayConsumersRequest) (*kkOps.ListAiGatewayConsumersResponse, error) {
+					calls++
+					require.LessOrEqual(t, calls, 2, "pagination must terminate")
+					require.Equal(t, "gateway-id", req.GatewayID)
+					require.EqualValues(t, 100, *req.PageSize)
+					start, count := 0, 100
+					var next *string
+					if calls == 1 {
+						require.Nil(t, req.PageAfter)
+						next = new(cursor)
+					} else {
+						require.Equal(t, cursor, *req.PageAfter)
+						if failSecondPage {
+							return nil, pageError
+						}
+						start, count = 100, 4
+					}
+					data := make([]kkComps.AIGatewayConsumer, count)
+					for i := range count {
+						data[i] = kkComps.AIGatewayConsumer{
+							ID: fmt.Sprintf("id-%d", start+i), Name: fmt.Sprintf("consumer-%d", start+i),
+							DisplayName: "Shared display name",
+						}
+					}
+					return &kkOps.ListAiGatewayConsumersResponse{
+						ListAIGatewayConsumersResponse: &kkComps.ListAIGatewayConsumersResponse{
+							Data: data, Meta: kkComps.CursorMeta{Page: kkComps.CursorMetaPage{Next: next}},
+						},
+					}, nil
+				},
+			}})
+			consumers, err := client.ListAIGatewayConsumers(t.Context(), "gateway-id")
+			require.Equal(t, 2, calls)
+			if failSecondPage {
+				require.ErrorIs(t, err, pageError)
+				require.Nil(t, consumers, "a failed page must not return incomplete live state")
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, consumers, 104)
+			for i, consumer := range consumers {
+				require.Equal(t, fmt.Sprintf("consumer-%d", i), consumer.Name)
+			}
+		})
+	}
+}
+
+func TestListAIGatewayConsumerCredentialsFollowsBareCursor(t *testing.T) {
+	calls := 0
+	client := NewClient(ClientConfig{AIGatewayConsumersAPI: &paginatedAIGatewayConsumersAPI{
+		listCredentials: func(
+			req kkOps.ListAiGatewayConsumerCredentialsRequest,
+		) (*kkOps.ListAiGatewayConsumerCredentialsResponse, error) {
+			calls++
+			require.LessOrEqual(t, calls, 2)
+			require.Equal(t, "gateway-id", req.GatewayID)
+			require.Equal(t, "consumer-id", req.ConsumerID)
+			var next *string
+			if calls == 1 {
+				require.Nil(t, req.PageAfter)
+				next = new("next-credential")
+			} else {
+				require.Equal(t, "next-credential", *req.PageAfter)
+			}
+			return &kkOps.ListAiGatewayConsumerCredentialsResponse{
+				ListAIGatewayConsumerCredentialsResponse: &kkComps.ListAIGatewayConsumerCredentialsResponse{
+					Data: []kkComps.AIGatewayConsumerCredential{{ID: fmt.Sprintf("credential-%d", calls)}},
+					Meta: kkComps.CursorMeta{Page: kkComps.CursorMetaPage{Next: next}},
+				},
+			}, nil
+		},
+	}})
+	credentials, err := client.ListAIGatewayConsumerCredentials(t.Context(), "gateway-id", "consumer-id")
+	require.NoError(t, err)
+	require.Equal(t, 2, calls)
+	require.Len(t, credentials, 2)
+}

--- a/internal/declarative/state/ai_gateway_consumers_test.go
+++ b/internal/declarative/state/ai_gateway_consumers_test.go
@@ -116,3 +116,31 @@ func TestListAIGatewayConsumerCredentialsFollowsBareCursor(t *testing.T) {
 	require.Equal(t, 2, calls)
 	require.Len(t, credentials, 2)
 }
+
+func TestListAIGatewayConsumersRejectsCursorCycles(t *testing.T) {
+	for _, sequence := range [][]string{{"first", "first"}, {"first", "second", "first"}} {
+		t.Run(sequence[1], func(t *testing.T) {
+			calls := 0
+			client := NewClient(ClientConfig{AIGatewayConsumersAPI: &paginatedAIGatewayConsumersAPI{
+				list: func(req kkOps.ListAiGatewayConsumersRequest) (*kkOps.ListAiGatewayConsumersResponse, error) {
+					require.Less(t, calls, len(sequence), "pagination must terminate")
+					if calls > 0 {
+						require.Equal(t, sequence[calls-1], *req.PageAfter)
+					}
+					next := sequence[calls]
+					calls++
+					return &kkOps.ListAiGatewayConsumersResponse{
+						ListAIGatewayConsumersResponse: &kkComps.ListAIGatewayConsumersResponse{
+							Data: []kkComps.AIGatewayConsumer{{ID: "consumer-id"}},
+							Meta: kkComps.CursorMeta{Page: kkComps.CursorMetaPage{Next: &next}},
+						},
+					}, nil
+				},
+			}})
+			consumers, err := client.ListAIGatewayConsumers(t.Context(), "gateway-id")
+			require.ErrorContains(t, err, "previously seen cursor")
+			require.Nil(t, consumers, "never return incomplete live state")
+			require.Equal(t, len(sequence), calls)
+		})
+	}
+}

--- a/internal/util/pagination/pagination.go
+++ b/internal/util/pagination/pagination.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 )
 
-// ExtractPageAfterCursor returns the cursor value from a paginated "next" link.
-// It tolerates raw URLs as well as plain query parameter snippets.
+// ExtractPageAfterCursor returns the cursor from a pagination token, next-page
+// URL, or query parameter snippet. Bare tokens are opaque and are not decoded.
 func ExtractPageAfterCursor(next *string) string {
 	if next == nil {
 		return ""
@@ -33,7 +33,10 @@ func ExtractPageAfterCursor(next *string) string {
 		}
 	}
 
-	return ""
+	if strings.Contains(value, "://") || strings.Contains(value, "?") {
+		return ""
+	}
+	return value
 }
 
 func extractPageAfterCursorSnippet(value string) (string, bool) {

--- a/internal/util/pagination/pagination.go
+++ b/internal/util/pagination/pagination.go
@@ -1,9 +1,32 @@
 package pagination
 
 import (
+	"errors"
 	"net/url"
 	"strings"
 )
+
+// CursorTracker detects repeated cursors within one list operation, including
+// cycles involving multiple pages. Its zero value is ready to use.
+type CursorTracker struct {
+	seen map[string]struct{}
+}
+
+// Next extracts a next-page cursor and rejects previously seen cursors.
+func (t *CursorTracker) Next(next *string) (string, error) {
+	cursor := ExtractPageAfterCursor(next)
+	if cursor == "" {
+		return "", nil
+	}
+	if _, exists := t.seen[cursor]; exists {
+		return "", errors.New("pagination returned a previously seen cursor")
+	}
+	if t.seen == nil {
+		t.seen = make(map[string]struct{})
+	}
+	t.seen[cursor] = struct{}{}
+	return cursor, nil
+}
 
 // ExtractPageAfterCursor returns the cursor from a pagination token, next-page
 // URL, or query parameter snippet. Bare tokens are opaque and are not decoded.

--- a/internal/util/pagination/pagination_test.go
+++ b/internal/util/pagination/pagination_test.go
@@ -40,3 +40,30 @@ func TestExtractPageAfterCursor(t *testing.T) {
 	}
 	require.Empty(t, ExtractPageAfterCursor(nil))
 }
+
+func TestCursorTrackerRejectsRepeatedAndCyclicCursors(t *testing.T) {
+	for _, sequence := range [][]string{
+		{"first", "first"},
+		{"first", "second", "first"},
+		{"abc/def", "?page[after]=abc%2Fdef"},
+	} {
+		t.Run(sequence[1], func(t *testing.T) {
+			var tracker CursorTracker
+			for i, next := range sequence {
+				cursor, err := tracker.Next(&next)
+				if i == len(sequence)-1 {
+					require.ErrorContains(t, err, "previously seen cursor")
+					require.Empty(t, cursor)
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, next, cursor)
+				}
+			}
+		})
+	}
+	var tracker CursorTracker
+	for _, next := range []*string{new("first"), new("second"), nil} {
+		_, err := tracker.Next(next)
+		require.NoError(t, err)
+	}
+}

--- a/internal/util/pagination/pagination_test.go
+++ b/internal/util/pagination/pagination_test.go
@@ -17,3 +17,26 @@ func TestExtractPageAfterCursor_DecodesFallbackQuerySnippet(t *testing.T) {
 		require.Equal(t, "cursor/value", ExtractPageAfterCursor(&next))
 	})
 }
+
+func TestExtractPageAfterCursor(t *testing.T) {
+	const issueCursor = "KVpEDAMKQ0FFXRZTFA19EFoXMWYNDVpODUBQABEQTUFcShZUFQ"
+	for _, tc := range []struct{ name, next, want string }{
+		{"empty", "", ""},
+		{"whitespace", " \n ", ""},
+		{"bare cursor", issueCursor, issueCursor},
+		{"opaque cursor", "abc+def/ghi==", "abc+def/ghi=="},
+		{"leading slash in opaque cursor", "/abc+def==", "/abc+def=="},
+		{"opaque percent", "abc%2Fdef", "abc%2Fdef"},
+		{"absolute URL", "https://example.test/items?page%5Bafter%5D=abc%2Bdef%2Fghi%3D%3D", "abc+def/ghi=="},
+		{"relative URL", "/items?page[after]=next", "next"},
+		{"query", "?page[after]=next&page[size]=100", "next"},
+		{"URL without cursor", "https://example.test/items?page[size]=100", ""},
+		{"relative URL without cursor", "/items?page[size]=100", ""},
+		{"empty cursor", "?page[after]=", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, ExtractPageAfterCursor(&tc.next))
+		})
+	}
+	require.Empty(t, ExtractPageAfterCursor(nil))
+}

--- a/test/e2e/scenarios/ai-gateway/agent/overlays/001-update/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/agent/overlays/001-update/config.yaml
@@ -4,6 +4,7 @@ _defaults:
 
 ai_gateways:
   - ref: ai-gateway-agent-e2e
+    name: ai-gateway-agent-e2e
     display_name: "AI Gateway Agent E2E"
     description: "AI Gateway Agent e2e"
     proxy_urls:

--- a/test/e2e/scenarios/ai-gateway/agent/overlays/002-sync-delete-agent/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/agent/overlays/002-sync-delete-agent/config.yaml
@@ -4,6 +4,7 @@ _defaults:
 
 ai_gateways:
   - ref: ai-gateway-agent-e2e
+    name: ai-gateway-agent-e2e
     display_name: "AI Gateway Agent E2E"
     description: "AI Gateway Agent e2e"
     proxy_urls:

--- a/test/e2e/scenarios/ai-gateway/agent/overlays/003-sync-delete-auth-strategy/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/agent/overlays/003-sync-delete-auth-strategy/config.yaml
@@ -4,6 +4,7 @@ _defaults:
 
 ai_gateways:
   - ref: ai-gateway-agent-e2e
+    name: ai-gateway-agent-e2e
     display_name: "AI Gateway Agent E2E"
     description: "AI Gateway Agent e2e"
     proxy_urls:

--- a/test/e2e/scenarios/ai-gateway/agent/testdata/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/agent/testdata/config.yaml
@@ -4,6 +4,7 @@ _defaults:
 
 ai_gateways:
   - ref: ai-gateway-agent-e2e
+    name: ai-gateway-agent-e2e
     display_name: "AI Gateway Agent E2E"
     description: "AI Gateway Agent e2e"
     proxy_urls:

--- a/test/e2e/scenarios/ai-gateway/config-store/overlays/001-update/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/config-store/overlays/001-update/config.yaml
@@ -4,6 +4,7 @@ _defaults:
 
 ai_gateways:
   - ref: ai-gateway-config-store-e2e
+    name: ai-gateway-config-store-e2e
     display_name: AI Gateway Config Store E2E
     config_stores:
       - ref: support-store

--- a/test/e2e/scenarios/ai-gateway/config-store/overlays/002-sync-delete-vault/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/config-store/overlays/002-sync-delete-vault/config.yaml
@@ -4,6 +4,7 @@ _defaults:
 
 ai_gateways:
   - ref: ai-gateway-config-store-e2e
+    name: ai-gateway-config-store-e2e
     display_name: AI Gateway Config Store E2E
     config_stores:
       - ref: support-store

--- a/test/e2e/scenarios/ai-gateway/config-store/overlays/003-sync-delete-store/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/config-store/overlays/003-sync-delete-store/config.yaml
@@ -4,5 +4,6 @@ _defaults:
 
 ai_gateways:
   - ref: ai-gateway-config-store-e2e
+    name: ai-gateway-config-store-e2e
     display_name: AI Gateway Config Store E2E
     config_stores: []

--- a/test/e2e/scenarios/ai-gateway/config-store/testdata/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/config-store/testdata/config.yaml
@@ -4,6 +4,7 @@ _defaults:
 
 ai_gateways:
   - ref: ai-gateway-config-store-e2e
+    name: ai-gateway-config-store-e2e
     display_name: AI Gateway Config Store E2E
     config_stores:
       - ref: support-store

--- a/test/e2e/scenarios/ai-gateway/consumer-pagination/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/consumer-pagination/scenario.yaml
@@ -1,0 +1,118 @@
+baseInputsPath: testdata
+
+env:
+  KONGCTL_LOG_LEVEL: info
+
+steps:
+  - name: 000-reset-org
+    skipInputs: true
+    commands:
+      - resetOrg: true
+
+  - name: 001-consumers-across-pages-and-gateways
+    commands:
+      - name: 000-generate-consumers
+        exec:
+          - python3
+          - "{{ .workdir }}/generate_consumers.py"
+          - "{{ .workdir }}/config.yaml"
+        assertions:
+          - expect:
+              fields:
+                gateways: 2
+                consumers: 105
+      - name: 001-apply-consumers
+        run:
+          - apply
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                applied: 107
+                failed: 0
+                status: success
+      - name: 002-list-all-primary-consumers
+        env:
+          KONNECT_SDK_HTTP_DUMP_REQUEST: "true"
+          KONNECT_SDK_HTTP_DUMP_RESPONSE: "true"
+        run:
+          - get
+          - ai-gateway
+          - consumers
+          - --gateway-name
+          - consumer-pagination-primary
+          - --page-size
+          - "100"
+        assertions:
+          - expect:
+              fields:
+                "length(@)": 104
+                "length([?name=='consumer-000'])": 1
+                "length([?name=='consumer-103'])": 1
+                "length([?labels.parent=='primary'])": 104
+      - name: 003-same-consumer-name-in-second-gateway
+        run:
+          - get
+          - ai-gateway
+          - consumers
+          - --gateway-name
+          - consumer-pagination-secondary
+        assertions:
+          - expect:
+              fields:
+                "length(@)": 1
+                "[0].name": consumer-000
+                "[0].labels.parent": secondary
+      - name: 004-plan-apply-no-phantom-creates
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+      - name: 005-plan-sync-no-phantom-creates
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - sync
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+      - name: 006-sync-no-conflicts
+        run:
+          - sync
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+                failed: 0
+      - name: 007-cleanup-gateways
+        run:
+          - delete
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --auto-approve
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                failed: 0
+                status: success

--- a/test/e2e/scenarios/ai-gateway/consumer-pagination/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/consumer-pagination/scenario.yaml
@@ -114,5 +114,6 @@ steps:
           - select: summary
             expect:
               fields:
+                applied: 2
                 failed: 0
                 status: success

--- a/test/e2e/scenarios/ai-gateway/consumer-pagination/testdata/generate_consumers.py
+++ b/test/e2e/scenarios/ai-gateway/consumer-pagination/testdata/generate_consumers.py
@@ -1,0 +1,33 @@
+"""Generate consumers across two gateways to exercise pagination and identity."""
+
+import json
+import pathlib
+import sys
+
+
+gateways = []
+for suffix, count in (("primary", 104), ("secondary", 1)):
+    gateways.append(
+        {
+            "ref": f"local-{suffix}",
+            "name": f"consumer-pagination-{suffix}",
+            "display_name": "Consumer Pagination",
+            "consumers": [
+                {
+                    "ref": f"local-{suffix}-{i:03d}",
+                    "name": f"consumer-{i:03d}",
+                    "display_name": "Shared Consumer Display",
+                    "type": "api-key",
+                    "labels": {"parent": suffix},
+                }
+                for i in range(count)
+            ],
+        }
+    )
+
+config = {
+    "_defaults": {"kongctl": {"namespace": "consumer-pagination-e2e"}},
+    "ai_gateways": gateways,
+}
+pathlib.Path(sys.argv[1]).write_text(json.dumps(config, indent=2) + "\n")
+print(json.dumps({"gateways": 2, "consumers": 105}))

--- a/test/e2e/scenarios/ai-gateway/consumer/overlays/001-update/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/consumer/overlays/001-update/config.yaml
@@ -4,6 +4,7 @@ _defaults:
 
 ai_gateways:
   - ref: ai-gateway-consumer-e2e
+    name: ai-gateway-consumer-e2e
     display_name: "AI Gateway Consumer E2E"
     description: "AI Gateway Consumer e2e"
     proxy_urls:

--- a/test/e2e/scenarios/ai-gateway/consumer/overlays/002-sync-delete-consumer/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/consumer/overlays/002-sync-delete-consumer/config.yaml
@@ -4,6 +4,7 @@ _defaults:
 
 ai_gateways:
   - ref: ai-gateway-consumer-e2e
+    name: ai-gateway-consumer-e2e
     display_name: "AI Gateway Consumer E2E"
     description: "AI Gateway Consumer e2e"
     proxy_urls:

--- a/test/e2e/scenarios/ai-gateway/consumer/overlays/002-sync-delete-credential/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/consumer/overlays/002-sync-delete-credential/config.yaml
@@ -4,6 +4,7 @@ _defaults:
 
 ai_gateways:
   - ref: ai-gateway-consumer-e2e
+    name: ai-gateway-consumer-e2e
     display_name: "AI Gateway Consumer E2E"
     description: "AI Gateway Consumer e2e"
     proxy_urls:

--- a/test/e2e/scenarios/ai-gateway/consumer/overlays/003-sync-delete-policy/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/consumer/overlays/003-sync-delete-policy/config.yaml
@@ -4,6 +4,7 @@ _defaults:
 
 ai_gateways:
   - ref: ai-gateway-consumer-e2e
+    name: ai-gateway-consumer-e2e
     display_name: "AI Gateway Consumer E2E"
     description: "AI Gateway Consumer e2e"
     proxy_urls:

--- a/test/e2e/scenarios/ai-gateway/consumer/overlays/consumer-uuid-ref.yaml
+++ b/test/e2e/scenarios/ai-gateway/consumer/overlays/consumer-uuid-ref.yaml
@@ -1,0 +1,6 @@
+ops:
+  - file: config.yaml
+    match: "ai_gateways[?ref=='ai-gateway-consumer-e2e'].consumers[?ref=='support-agent'] | [0]"
+    set:
+      ref: "{{ .vars.consumer_id }}"
+      name: support-agent-second

--- a/test/e2e/scenarios/ai-gateway/consumer/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/consumer/scenario.yaml
@@ -317,6 +317,135 @@ steps:
               fields:
                 "@": "{{ .vars.credential_name }}"
 
+  - name: 002a-consumer-name-survives-ref-change
+    inputOverlayOps:
+      - file: config.yaml
+        match: "ai_gateways[?ref=='ai-gateway-consumer-e2e'].consumers[?ref=='support-agent'] | [0]"
+        set:
+          ref: support-agent-local-alias
+    commands:
+      - name: 000-plan-existing-consumer-by-name
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 0
+
+  - name: 002b-consumer-name-does-not-fall-back
+    inputOverlayOps:
+      - file: config.yaml
+        match: "ai_gateways[?ref=='ai-gateway-consumer-e2e'].consumers[?ref=='support-agent'] | [0]"
+        set:
+          name: support-agent-second
+    commands:
+      # Keep the original ref and display_name: a new name is a new consumer.
+      - name: 000-plan-new-consumer-with-existing-ref-and-display-name
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+          - --write-secrets
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 2
+                by_action.CREATE: 2
+          - select: >-
+              changes[?resource_type=='ai_gateway_consumer'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: "{{ .vars.consumer_ref }}"
+                fields.name: support-agent-second
+                fields.display_name: "{{ .vars.consumer_display_name }}"
+          - select: >-
+              changes[?resource_type=='ai_gateway_consumer_credential'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                parent.ref: "{{ .vars.consumer_ref }}"
+
+  - name: 002b2-consumer-name-does-not-fall-back-to-uuid-ref
+    inputOverlayOpsFiles:
+      - overlays/consumer-uuid-ref.yaml
+    commands:
+      - name: 000-plan-new-consumer-with-existing-uuid-ref
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+          - --write-secrets
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 2
+                by_action.CREATE: 2
+          - select: "changes[?resource_type=='ai_gateway_consumer'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+                fields.name: support-agent-second
+
+  - name: 002c-gateway-name-isolates-consumer-identity
+    inputOverlayOps:
+      - file: config.yaml
+        match: "ai_gateways[?ref=='ai-gateway-consumer-e2e'] | [0]"
+        set:
+          ref: ai-gateway-consumer-second-local-ref
+          name: ai-gateway-consumer-second
+    commands:
+      # Keep the display_name and namespace, and all child names unchanged.
+      # Issue #2093: the old gateway must not supply this gateway's consumers.
+      - name: 000-plan-new-gateway-and-consumers-with-shared-display-name
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+          - --write-secrets
+        assertions:
+          - select: summary
+            expect:
+              fields:
+                total_changes: 4
+                by_action.CREATE: 4
+          - select: "changes[?resource_type=='ai_gateway'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+                fields.name: ai-gateway-consumer-second
+                fields.display_name: "{{ .vars.gateway_name }}"
+          - select: >-
+              changes[?resource_type=='ai_gateway_consumer'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                fields.name: "{{ .vars.consumer_name }}"
+                references.ai_gateway_id.ref: ai-gateway-consumer-second-local-ref
+          - select: >-
+              changes[?resource_type=='ai_gateway_consumer_credential'] | [0]
+            expect:
+              fields:
+                action: CREATE
+                parent.ref: "{{ .vars.consumer_ref }}"
+
   - name: 003-plan-apply-update
     inputOverlayDirs:
       - overlays/001-update

--- a/test/e2e/scenarios/ai-gateway/consumer/testdata/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/consumer/testdata/config.yaml
@@ -4,6 +4,7 @@ _defaults:
 
 ai_gateways:
   - ref: ai-gateway-consumer-e2e
+    name: ai-gateway-consumer-e2e
     display_name: "AI Gateway Consumer E2E"
     description: "AI Gateway Consumer e2e"
     proxy_urls:

--- a/test/e2e/scenarios/ai-gateway/data-plane-certificate/overlays/001-rotate-cert/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/data-plane-certificate/overlays/001-rotate-cert/config.yaml
@@ -4,6 +4,7 @@ _defaults:
 
 ai_gateways:
   - ref: ai-gateway-data-plane-certificate-e2e
+    name: ai-gateway-data-plane-certificate-e2e
     display_name: "AI Gateway Data Plane Certificate E2E"
     description: "AI Gateway data plane certificate e2e"
     proxy_urls:

--- a/test/e2e/scenarios/ai-gateway/data-plane-certificate/overlays/002-sync-delete-cert/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/data-plane-certificate/overlays/002-sync-delete-cert/config.yaml
@@ -4,6 +4,7 @@ _defaults:
 
 ai_gateways:
   - ref: ai-gateway-data-plane-certificate-e2e
+    name: ai-gateway-data-plane-certificate-e2e
     display_name: "AI Gateway Data Plane Certificate E2E"
     description: "AI Gateway data plane certificate e2e"
     proxy_urls:

--- a/test/e2e/scenarios/ai-gateway/data-plane-certificate/testdata/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/data-plane-certificate/testdata/config.yaml
@@ -4,6 +4,7 @@ _defaults:
 
 ai_gateways:
   - ref: ai-gateway-data-plane-certificate-e2e
+    name: ai-gateway-data-plane-certificate-e2e
     display_name: "AI Gateway Data Plane Certificate E2E"
     description: "AI Gateway data plane certificate e2e"
     proxy_urls:

--- a/test/e2e/scenarios/ai-gateway/root/scenario.yaml
+++ b/test/e2e/scenarios/ai-gateway/root/scenario.yaml
@@ -60,6 +60,10 @@ steps:
             expect:
               fields:
                 "@": true
+          - select: "contains(required, 'name')"
+            expect:
+              fields:
+                "@": true
       - name: 001-scaffold-ai-gateway
         run:
           - scaffold

--- a/test/e2e/scenarios/ai-gateway/vault/overlays/001-update/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/vault/overlays/001-update/config.yaml
@@ -4,6 +4,7 @@ _defaults:
 
 ai_gateways:
   - ref: ai-gateway-vault-e2e
+    name: ai-gateway-vault-e2e
     display_name: "AI Gateway Vault E2E"
     description: "AI Gateway Vault e2e"
     proxy_urls:

--- a/test/e2e/scenarios/ai-gateway/vault/overlays/002-sync-delete-vault/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/vault/overlays/002-sync-delete-vault/config.yaml
@@ -4,6 +4,7 @@ _defaults:
 
 ai_gateways:
   - ref: ai-gateway-vault-e2e
+    name: ai-gateway-vault-e2e
     display_name: "AI Gateway Vault E2E"
     description: "AI Gateway Vault e2e"
     proxy_urls:

--- a/test/e2e/scenarios/ai-gateway/vault/testdata/config.yaml
+++ b/test/e2e/scenarios/ai-gateway/vault/testdata/config.yaml
@@ -4,6 +4,7 @@ _defaults:
 
 ai_gateways:
   - ref: ai-gateway-vault-e2e
+    name: ai-gateway-vault-e2e
     display_name: "AI Gateway Vault E2E"
     description: "AI Gateway Vault e2e"
     proxy_urls:


### PR DESCRIPTION
AI Gateway lists stopped after the first page when `meta.page.next` contained a
bare cursor, causing plan/sync to recreate existing consumers beyond item 100.
Accept opaque cursors alongside next-page URLs and query snippets in the shared
pagination helper, preserving cursor characters without decoding bare tokens.
Consumer, credential, and consumer-group listing rejects repeated or cyclic
cursors with an error instead of returning incomplete results.

Managed AI Gateways now match only by name within their namespace, and managed
consumers match only by name within their parent gateway. Remove gateway
display-name/ref/ID fallbacks and consumer UUID-ref/cached-ID overrides. Validate
gateway name uniqueness instead of display-name uniqueness, so two distinct
gateways can share a display name in one manifest. Managed gateways require an
explicit `name`; remove the legacy `name = ref` default and mark `name` required
in the explain schema. Existing manifests that omitted it must set the actual
Konnect API name before applying or syncing.

Changing an explicit name declares a different resource; sync can delete the old
resource when it is no longer declared in scope. Deleting an old consumer removes
its credentials and invalidates its API keys; the migration guidance now explains
that consequence. Explicit external lookup
selectors and imperative get-by-ID commands retain their existing behavior.

Closes #2093.

Validation:
- `go fix ./...`, clean `make format`, `make build`, `make lint` (zero issues).
- `make test` and `make test-integration`, both with the race detector.
- Installer and E2E metrics tests passed.
- Consumer, consumer-pagination, and gateway-root E2E scenarios passed against
  Konnect US. The pagination scenario creates 104 consumers in one gateway plus
  a same-named consumer in another gateway, shares display names, verifies all
  consumers are listed, and confirms repeated apply/sync plans have zero changes.
- Regression tests cover gateway/consumer identity, duplicate-name validation,
  required gateway names, positive gateway deletion, raw/URL cursor formats,
  cursor cycles, nested credential pagination, and second-page errors
  returning no incomplete live state.

Local E2E artifacts:
`/home/rspurgeon/.cache/kongctl-2096-findings-e2e-xo2j602o/`

The live HTTP artifacts confirm `page[size]=100` followed by a second consumer
request with `page[after]`. All scenario-created gateways were cleaned up.
