### PR TITLE
test(e2e): activate weighted scenario sharding with rollback

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -112,6 +112,7 @@ jobs:
       konnect_base_auth_url: ${{ steps.target.outputs.konnect_base_auth_url }}
       konnect_machine_client_id: ${{ steps.target.outputs.konnect_machine_client_id }}
       orgs_json: ${{ steps.target.outputs.orgs_json }}
+      shard_strategy: ${{ steps.target.outputs.shard_strategy }}
       status_sha: ${{ steps.detect.outputs.status_sha }}
       checkout_repository: ${{ steps.detect.outputs.checkout_repository }}
       checkout_ref: ${{ steps.detect.outputs.checkout_ref }}
@@ -133,6 +134,7 @@ jobs:
         env:
           DISPATCH_KONNECT_ENVIRONMENT: ${{ github.event_name == 'workflow_dispatch' && inputs.konnect_environment || '' }}
           CONFIGURED_KONNECT_ENVIRONMENT: ${{ vars.KONGCTL_E2E_KONNECT_ENV || '' }}
+          CONFIGURED_SHARD_STRATEGY: ${{ vars.KONGCTL_E2E_SHARD_STRATEGY || 'weighted' }}
           PR_HAS_TECH_LABEL: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'konnect-env:tech') && 'true' || 'false' }}
           DEFAULT_ORGS_JSON: ${{ vars.KONGCTL_E2E_ORGS_JSON || '' }}
           COM_ORGS_JSON: ${{ vars.KONGCTL_E2E_COM_ORGS_JSON || '' }}
@@ -252,6 +254,14 @@ jobs:
           echo "konnect_base_auth_url=${konnect_base_auth_url}" >> "${GITHUB_OUTPUT}"
           echo "konnect_machine_client_id=${konnect_machine_client_id}" >> "${GITHUB_OUTPUT}"
           echo "orgs_json=${orgs_json}" >> "${GITHUB_OUTPUT}"
+          shard_strategy=modulo
+          if [ "${konnect_environment}" = "com" ]; then
+            case "${CONFIGURED_SHARD_STRATEGY}" in
+              weighted|modulo) shard_strategy="${CONFIGURED_SHARD_STRATEGY}" ;;
+              *) echo "::error::KONGCTL_E2E_SHARD_STRATEGY must be weighted or modulo"; exit 1 ;;
+            esac
+          fi
+          echo "shard_strategy=${shard_strategy}" >> "${GITHUB_OUTPUT}"
 
       - name: Decide whether scenario suite is required
         id: detect
@@ -645,7 +655,7 @@ jobs:
       - name: Build scenario test binary
         run: go test -c -tags=e2e -o e2e.test ./test/e2e
 
-      - name: Validate report-only scheduler offline
+      - name: Validate scenario allocation offline
         env:
           KONGCTL_E2E_BIN: ${{ github.workspace }}/kongctl
         run: ./e2e.test -test.v -test.run '^TestWeighted' -test.timeout 1m
@@ -680,6 +690,8 @@ jobs:
         include: ${{ fromJSON(needs.e2e-needed.outputs.orgs_json) }}
     env:
       KONGCTL_E2E_MATRIX_ORG: ${{ matrix.org_name }}
+      # Roll back full .com allocation by setting the repository variable to modulo.
+      KONGCTL_E2E_SHARD_STRATEGY: ${{ needs.e2e-needed.outputs.shard_strategy }}
       KONGCTL_E2E_BIN: ${{ github.workspace }}/kongctl
       KONGCTL_E2E_TEST_BIN: ${{ github.workspace }}/e2e.test
       KONGCTL_E2E_TEST_TIMEOUT: ${{ vars.KONGCTL_E2E_TEST_TIMEOUT || '55m' }}
@@ -936,7 +948,7 @@ jobs:
           if [ -f "${report}" ]; then
             cat "${report}" >> "${GITHUB_STEP_SUMMARY}"
           else
-            echo "::warning::Weighted sharding report unavailable; live assignments are unchanged"
+            echo "::warning::Sharding comparison unavailable; inspect scenario-allocation.json for actual allocation"
             echo "Weighted sharding predictions unavailable for this shard." >> "${GITHUB_STEP_SUMMARY}"
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,6 @@ test:
 .PHONY: refresh-e2e-weights
 refresh-e2e-weights:
 	python3 scripts/e2e-weights.py \
-		test/e2e/baselines/stage0-2026-09-observations.json \
 		test/e2e/baselines/post-cache-2026-09-observations.json
 
 .PHONY: test-e2e-metrics
@@ -259,12 +258,14 @@ E2E_BASELINE_COUNT ?= 20
 E2E_BASELINE_SCAN ?= 100
 E2E_BASELINE_DIR ?= .e2e-artifacts/baseline
 E2E_BASELINE_COHORT ?= cache-enabled
-E2E_BASELINE_OBSERVATIONS ?= test/e2e/baselines/post-cache-2026-09-observations.json
-E2E_BASELINE_REPORT ?= test/e2e/baselines/post-cache-2026-09.md
+E2E_BASELINE_ALLOCATION ?= $(shell python3 scripts/e2e-weights.py --print-allocation-id)
+E2E_BASELINE_OBSERVATIONS ?= test/e2e/baselines/weighted-v1-2026-09-observations.json
+E2E_BASELINE_REPORT ?= test/e2e/baselines/weighted-v1-2026-09.md
 
 .PHONY: collect-e2e-baseline
 collect-e2e-baseline:
 	@python3 scripts/e2e-baseline.py \
+		--allocation-id "$(E2E_BASELINE_ALLOCATION)" \
 		--cohort "$(E2E_BASELINE_COHORT)" \
 		--count "$(E2E_BASELINE_COUNT)" \
 		--scan "$(E2E_BASELINE_SCAN)" \
@@ -278,6 +279,7 @@ collect-e2e-baseline:
 baseline-e2e-ci:
 	@mkdir -p "$(E2E_BASELINE_DIR)"
 	@python3 scripts/e2e-baseline.py \
+		--allocation-id "$(E2E_BASELINE_ALLOCATION)" \
 		--cohort "$(E2E_BASELINE_COHORT)" \
 		--count "$(E2E_BASELINE_COUNT)" \
 		--scan "$(E2E_BASELINE_SCAN)" \

--- a/scripts/e2e-baseline.py
+++ b/scripts/e2e-baseline.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import re
 import subprocess
 import sys
 import tempfile
@@ -22,6 +23,23 @@ REQUIRED_JOB = "Publish “E2E Required”"
 SCENARIO_JOB_PREFIX = "Run scenarios — "
 OBSERVATION_SCHEMA_VERSION = 2
 COHORTS = ("uncached", "cache-enabled")
+LEGACY_ALLOCATION = "modulo-v1"
+
+
+def valid_allocation(value: Any) -> bool:
+    return isinstance(value, str) and re.fullmatch(r"modulo-v1|weighted-v1:[0-9a-f]{64}", value) is not None
+
+
+def metric_allocation(metric: dict[str, Any]) -> str | None:
+    if metric.get("schema_version", 1) not in (1, 2):
+        return None
+    # Only pre-activation metrics may omit allocation identity.
+    if metric.get("schema_version", 1) == 1 and "allocation_id" not in metric:
+        return LEGACY_ALLOCATION
+    value = metric.get("allocation_id")
+    return value if valid_allocation(value) else None
+
+
 RUN_REQUIRED_FIELDS = {
     "cohort",
     "original_created_at",
@@ -94,7 +112,7 @@ def select_complete_attempt(metrics: list[dict[str, Any]], run_attempt: int) -> 
     if len(totals) != 1:
         return []
     total = totals.pop()
-    if total <= 0 or indices != set(range(total)):
+    if total <= 0 or len(selected) != total or indices != set(range(total)):
         return []
     return sorted(selected, key=lambda metric: int(metric["shard_index"]))
 
@@ -164,6 +182,9 @@ def eligible_run(
 ) -> dict[str, Any] | None:
     if not metrics or any(metric.get("konnect_environment") != "com" for metric in metrics):
         return None
+    allocations = {metric_allocation(metric) for metric in metrics}
+    if len(allocations) != 1 or None in allocations:
+        return None
 
     build = named_job(jobs, BUILD_JOB)
     harness = named_job(jobs, HARNESS_JOB)
@@ -204,6 +225,7 @@ def eligible_run(
 
     return {
         "cohort": run_cohort(jobs),
+        "allocation_id": allocations.pop(),
         "original_created_at": run["original_created_at"],
         "head_sha": run["head_sha"],
         "harness_job_seconds": duration(harness),
@@ -247,6 +269,7 @@ def collect_runs(
     scan: int,
     excluded_run_ids: set[int] | None = None,
     cohort: str = "cache-enabled",
+    allocation_id: str = LEGACY_ALLOCATION,
 ) -> list[dict[str, Any]]:
     if count <= 0:
         return []
@@ -286,7 +309,7 @@ def collect_runs(
         if run_cohort(view["jobs"]) != cohort:
             continue
         metrics = download_metrics(repo, int(candidate["databaseId"]), run_attempt)
-        if not metrics:
+        if not metrics or any(metric_allocation(metric) != allocation_id for metric in metrics):
             continue
         attempt = gh_json(
             ["api", f"repos/{repo}/actions/runs/{candidate['databaseId']}/attempts/{run_attempt}"]
@@ -300,7 +323,7 @@ def collect_runs(
             "head_sha": attempt["head_sha"],
         }
         record = eligible_run(candidate, view["jobs"], metrics)
-        if record is not None:
+        if record is not None and record["allocation_id"] == allocation_id:
             selected.append(record)
         if len(selected) == count:
             break
@@ -334,7 +357,9 @@ def validate_run(run: Any, index: int) -> dict[str, Any]:
     return run
 
 
-def load_observations(path: Path, repo: str, cohort: str = "cache-enabled") -> list[dict[str, Any]]:
+def load_observations(
+    path: Path, repo: str, cohort: str = "cache-enabled", allocation_id: str = LEGACY_ALLOCATION,
+) -> list[dict[str, Any]]:
     if not path.exists():
         return []
     try:
@@ -354,12 +379,16 @@ def load_observations(path: Path, repo: str, cohort: str = "cache-enabled") -> l
         )
     if document.get("cohort") != cohort:
         raise ValueError(f"observations {path} cohort does not match requested {cohort!r}")
+    if document.get("allocation_id", LEGACY_ALLOCATION) != allocation_id:
+        raise ValueError(f"observations {path} allocation does not match requested {allocation_id!r}")
     runs = document.get("runs")
     if not isinstance(runs, list):
         raise ValueError(f"observations {path} field runs must be an array")
     validated = [validate_run(run, index) for index, run in enumerate(runs)]
     if any(run["cohort"] != cohort for run in validated):
         raise ValueError(f"observations {path} contain mixed cohorts")
+    if any(run.get("allocation_id", LEGACY_ALLOCATION) != allocation_id for run in validated):
+        raise ValueError(f"observations {path} contain mixed allocations")
     return validated
 
 
@@ -377,12 +406,13 @@ def merge_runs(
 
 
 def observation_document(
-    repo: str, runs: list[dict[str, Any]], cohort: str = "cache-enabled"
+    repo: str, runs: list[dict[str, Any]], cohort: str = "cache-enabled", allocation_id: str = LEGACY_ALLOCATION,
 ) -> dict[str, Any]:
     return {
         "schema_version": OBSERVATION_SCHEMA_VERSION,
         "repository": repo,
         "cohort": cohort,
+        "allocation_id": allocation_id,
         "runs": runs,
     }
 
@@ -442,6 +472,7 @@ def markdown_report(
     target_count: int,
     cohort: str = "cache-enabled",
     frozen: bool = False,
+    allocation_id: str = LEGACY_ALLOCATION,
 ) -> str:
     status = "frozen preliminary" if frozen else ("complete" if len(runs) >= target_count else "collecting")
     lines = [
@@ -449,6 +480,7 @@ def markdown_report(
         "",
         f"Repository: `{repo}`",
         f"Cohort: `{cohort}`",
+        f"Allocation: `{allocation_id}`",
         "",
         f"Full successful runs: {len(runs)} of {target_count}",
         f"Status: **{status}**",
@@ -555,6 +587,8 @@ def main() -> int:
     parser.add_argument("--count", type=int, default=20)
     parser.add_argument("--scan", type=int, default=100)
     parser.add_argument("--cohort", choices=COHORTS, default="cache-enabled")
+    parser.add_argument("--allocation-id", default=LEGACY_ALLOCATION,
+                        help="modulo-v1 or weighted-v1:<snapshot SHA-256>; never pool allocations")
     parser.add_argument("--frozen", action="store_true", help="report saved observations without collecting")
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--json-output", type=Path)
@@ -571,11 +605,13 @@ def main() -> int:
     args = parser.parse_args()
     if args.count < 1 or args.scan < 1:
         parser.error("--count and --scan must be positive")
+    if not valid_allocation(args.allocation_id):
+        parser.error("invalid --allocation-id; use modulo-v1 or weighted-v1:<64 lowercase hex characters>")
     if args.frozen and (args.observations is None or not args.observations.exists()):
         parser.error("--frozen requires an existing --observations file")
 
     try:
-        saved = load_observations(args.observations, args.repo, args.cohort) if args.observations else []
+        saved = load_observations(args.observations, args.repo, args.cohort, args.allocation_id) if args.observations else []
     except ValueError as error:
         parser.error(str(error))
     saved_run_ids = {int(run["run_id"]) for run in saved}
@@ -585,10 +621,11 @@ def main() -> int:
         args.scan,
         excluded_run_ids=saved_run_ids,
         cohort=args.cohort,
+        allocation_id=args.allocation_id,
     )
     runs = merge_runs(saved, collected)
     if args.observations is not None:
-        write_json(args.observations, observation_document(args.repo, runs, args.cohort))
+        write_json(args.observations, observation_document(args.repo, runs, args.cohort, args.allocation_id))
     if len(runs) < args.count and not args.frozen:
         message = (
             f"found {len(runs)} eligible full .com runs, need {args.count}; "
@@ -600,7 +637,7 @@ def main() -> int:
     summary = summarize(runs)
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(
-        markdown_report(args.repo, runs, summary, args.count, args.cohort, args.frozen), encoding="utf-8"
+        markdown_report(args.repo, runs, summary, args.count, args.cohort, args.frozen, args.allocation_id), encoding="utf-8"
     )
     if args.json_output is not None:
         write_json(
@@ -608,6 +645,7 @@ def main() -> int:
             {
                 "schema_version": OBSERVATION_SCHEMA_VERSION,
                 "cohort": args.cohort,
+                "allocation_id": args.allocation_id,
                 "summary": summary,
                 "target_run_count": args.count,
                 "runs": runs,

--- a/scripts/e2e-metrics.py
+++ b/scripts/e2e-metrics.py
@@ -96,9 +96,18 @@ def collect_metrics(root: Path, environ: dict[str, str]) -> dict[str, Any]:
     manifest_values = parse_key_values(manifests[0])
     scenarios = parse_scenario_durations(run_logs[0])
     assigned = parse_manifest(manifests[0])
+    allocation = json.loads((manifests[0].parent / "scenario-allocation.json").read_text(encoding="utf-8"))
+    if not isinstance(allocation, dict):
+        raise ValueError("invalid scenario-allocation.json")
+    allocation_id = allocation.get("allocation_id", "")
+    expected = r"modulo-v1" if allocation.get("strategy") == "modulo" else r"weighted-v1:[0-9a-f]{64}"
+    if (allocation.get("schema_version") != 1 or allocation.get("strategy") not in ("modulo", "weighted")
+            or not isinstance(allocation_id, str) or not re.fullmatch(expected, allocation_id)):
+        raise ValueError("invalid scenario-allocation.json")
 
     return {
-        "schema_version": 1,
+        "schema_version": 2,
+        "allocation_id": allocation_id,
         "run_id": int(environ.get("GITHUB_RUN_ID", "0")),
         "run_attempt": int(result_values.get("run_attempt", environ.get("GITHUB_RUN_ATTEMPT", "1"))),
         "org_name": result_values.get("org_name", environ.get("KONGCTL_E2E_MATRIX_ORG", "")),

--- a/scripts/e2e-weights.py
+++ b/scripts/e2e-weights.py
@@ -100,11 +100,18 @@ def generate(paths: list[Path], scenario_root: Path) -> dict:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("observations", nargs="+", type=Path)
+    parser.add_argument("observations", nargs="*", type=Path)
+    parser.add_argument("--print-allocation-id", action="store_true",
+                        help="print the weighted allocation ID of --output without changing it")
     parser.add_argument("--scenario-root", type=Path, default=Path("test/e2e/scenarios"))
     parser.add_argument("--output", type=Path, default=Path("test/e2e/baselines/scenario-weights.json"))
     args = parser.parse_args()
     try:
+        if args.print_allocation_id:
+            print("weighted-v1:" + hashlib.sha256(args.output.read_bytes()).hexdigest())
+            return
+        if not args.observations:
+            parser.error("provide observation files or --print-allocation-id")
         weights = generate(args.observations, args.scenario_root)
         args.output.write_text(json.dumps(weights, indent=2, sort_keys=True) + "\n")
     except (ValueError, KeyError, OSError) as error:

--- a/scripts/e2e_baseline_test.py
+++ b/scripts/e2e_baseline_test.py
@@ -161,6 +161,51 @@ class E2EBaselineTest(unittest.TestCase):
             self.assertEqual([], MODULE.collect_runs("kong/kongctl", 1, 100))
             download.assert_not_called()
 
+    def test_allocation_compatibility_and_invalid_metadata(self) -> None:
+        self.assertEqual("modulo-v1", MODULE.metric_allocation({"schema_version": 1}))
+        for metric in ({"schema_version": 2}, {"schema_version": 99, "allocation_id": "modulo-v1"},
+                       {"schema_version": 2, "allocation_id": "weighted-v1:bad"}):
+            self.assertIsNone(MODULE.metric_allocation(metric))
+        weighted = "weighted-v1:" + "a" * 64
+        self.assertEqual(weighted, MODULE.metric_allocation({"schema_version": 2, "allocation_id": weighted}))
+
+    def test_wrong_allocation_is_excluded_before_attempt_lookup(self) -> None:
+        jobs = [{"name": MODULE.BUILD_JOB, "steps": [{"name": "Report Go cache status"}]}]
+        with patch.object(MODULE, "gh_json", side_effect=[
+            [{"databaseId": 1}], {"attempt": 1, "jobs": jobs},
+        ]) as api, patch.object(MODULE, "download_metrics", return_value=[{"schema_version": 1}]):
+            self.assertEqual([], MODULE.collect_runs("kong/kongctl", 1, 100, allocation_id="weighted-v1:" + "a" * 64))
+            self.assertEqual(2, api.call_count)
+
+    def test_saved_allocations_cannot_be_mixed(self) -> None:
+        weighted = "weighted-v1:" + "a" * 64
+        runs = [self.run_record(1, "2026-09-01T00:00:00Z")]
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "observations.json"
+            MODULE.write_json(path, MODULE.observation_document("kong/kongctl", runs))
+            with self.assertRaisesRegex(ValueError, "allocation does not match"):
+                MODULE.load_observations(path, "kong/kongctl", allocation_id=weighted)
+            runs[0]["allocation_id"] = weighted
+            MODULE.write_json(path, MODULE.observation_document("kong/kongctl", runs, allocation_id=weighted))
+            self.assertEqual(runs, MODULE.load_observations(path, "kong/kongctl", allocation_id=weighted))
+            with self.assertRaisesRegex(ValueError, "allocation does not match"):
+                MODULE.load_observations(path, "kong/kongctl", allocation_id="weighted-v1:" + "b" * 64)
+            runs[0]["allocation_id"] = "modulo-v1"
+            MODULE.write_json(path, MODULE.observation_document("kong/kongctl", runs, allocation_id=weighted))
+            with self.assertRaisesRegex(ValueError, "mixed allocations"):
+                MODULE.load_observations(path, "kong/kongctl", allocation_id=weighted)
+
+    def test_mixed_shard_allocations_are_ineligible(self) -> None:
+        metrics = [
+            {"schema_version": 1, "konnect_environment": "com"},
+            {"schema_version": 2, "konnect_environment": "com", "allocation_id": "weighted-v1:" + "a" * 64},
+        ]
+        self.assertIsNone(MODULE.eligible_run({}, [], metrics))
+
+    def test_duplicate_shard_index_is_not_a_complete_attempt(self) -> None:
+        metric = {"run_attempt": 1, "shard_index": 0, "shard_total": 1}
+        self.assertEqual([], MODULE.select_complete_attempt([metric, metric], 1))
+
     @staticmethod
     def run_record(
         run_id: int,

--- a/scripts/e2e_metrics_test.py
+++ b/scripts/e2e_metrics_test.py
@@ -31,6 +31,9 @@ class E2EMetricsTest(unittest.TestCase):
                 "    --- FAIL: Test_Scenarios/test/e2e/scenarios/b/scenario.yaml (2.50s)\n",
                 encoding="utf-8",
             )
+            (root / "scenario-allocation.json").write_text(json.dumps({
+                "schema_version": 1, "strategy": "weighted", "allocation_id": "weighted-v1:" + "a" * 64,
+            }))
             reset_dir = root / "commands" / "000-reset_org"
             reset_dir.mkdir(parents=True)
             (reset_dir / "observation.json").write_text(
@@ -64,6 +67,8 @@ class E2EMetricsTest(unittest.TestCase):
             )
 
         self.assertEqual(2, metrics["selected_scenario_count"])
+        self.assertEqual(2, metrics["schema_version"])
+        self.assertEqual("weighted-v1:" + "a" * 64, metrics["allocation_id"])
         self.assertEqual(42, metrics["execution_duration_seconds"])
         self.assertEqual("acceptance-2", metrics["org_name"])
         self.assertEqual(1.25, metrics["scenario_durations"][0]["duration_seconds"])
@@ -91,6 +96,23 @@ class E2EMetricsTest(unittest.TestCase):
 
             with self.assertRaises(json.JSONDecodeError):
                 MODULE.collect_reset_metrics(root)
+
+    def test_allocation_is_required_and_authoritative(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "assigned-scenarios.txt").write_text("shard_index=0\nshard_total=1\n\na/scenario.yaml\n")
+            (root / "scenario-results.txt").write_text("duration_seconds=1\n")
+            (root / "run.log").write_text("")
+            with self.assertRaises(FileNotFoundError):
+                MODULE.collect_metrics(root, {})
+            path = root / "scenario-allocation.json"
+            for allocation in (None, {}, {"schema_version": 1, "strategy": "weighted", "allocation_id": "modulo-v1"}):
+                path.write_text(json.dumps(allocation))
+                with self.assertRaises(ValueError):
+                    MODULE.collect_metrics(root, {})
+            path.write_text(json.dumps({"schema_version": 1, "strategy": "modulo", "allocation_id": "modulo-v1"}))
+            metrics = MODULE.collect_metrics(root, {"KONGCTL_E2E_SHARD_STRATEGY": "weighted"})
+            self.assertEqual("modulo-v1", metrics["allocation_id"])
 
 
 if __name__ == "__main__":

--- a/scripts/e2e_weights_test.py
+++ b/scripts/e2e_weights_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import hashlib
 import json
 import subprocess
 import sys
@@ -133,6 +134,17 @@ class E2EWeightsTest(unittest.TestCase):
         self.assertIn("unsupported observations", result.stderr)
         self.assertNotIn("Traceback", result.stderr)
         self.assertEqual("preserved snapshot\n", output.read_text())
+
+    def test_print_allocation_id_does_not_modify_snapshot(self):
+        output = self.root / "weights.json"
+        content = b'{"schema_version": 1}\n'
+        output.write_bytes(content)
+        result = subprocess.run(
+            [sys.executable, str(Path(MODULE.__file__)), "--print-allocation-id", "--output", str(output)],
+            capture_output=True, text=True, check=True,
+        )
+        self.assertEqual("weighted-v1:" + hashlib.sha256(content).hexdigest(), result.stdout.strip())
+        self.assertEqual(content, output.read_bytes())
 
 
 if __name__ == "__main__":

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -600,22 +600,36 @@ make baseline-e2e-ci E2E_BASELINE_SCAN=200
 ```
 
 GitHub Actions metrics artifacts may expire before 20 eligible runs complete.
-Collect and retain partial observations in the versioned post-cache snapshot:
+Collect and retain partial observations in the versioned weighted snapshot:
 
 ```sh
 make collect-e2e-baseline
 ```
 
 The target reads and updates
-`test/e2e/baselines/post-cache-2026-09-observations.json`, deduplicates saved and
+`test/e2e/baselines/weighted-v1-2026-09-observations.json`, deduplicates saved and
 new runs by workflow run ID, and writes the current report to
-`test/e2e/baselines/post-cache-2026-09.md`. It succeeds while the report is still
+`test/e2e/baselines/weighted-v1-2026-09.md`. It succeeds while the report is still
 collecting so the updated files can be committed before source artifacts
 expire. Saved observations remain eligible after their source artifacts are
 deleted.
 
 Commit the updated files regularly, for example twice a week, before the
 10-day artifact retention expires. Collection remains an administrator task.
+
+Collection defaults to the exact weighted allocation embedded in the current
+checkout. `E2E_BASELINE_ALLOCATION` combines the algorithm version and the
+weight snapshot SHA-256. A different strategy or weight hash is excluded from
+collection; a mismatched saved file is rejected before it is overwritten.
+Keep the 20-run `post-cache-2026-09-*` files as the pre-activation baseline.
+Do not overwrite them with weighted or rollback observations.
+
+Metrics schema 2 records `allocation_id` from the harness allocation sidecar,
+not from requested environment settings. Missing or inconsistent metadata fails
+metrics generation. Historical schema 1 metrics and saved observations without
+allocation identity are explicitly treated as `modulo-v1`; mixed-shard runs
+are rejected. Observation schema 2 is retained with an additive allocation ID
+on newly saved documents and runs.
 
 `E2E_BASELINE_COHORT` defaults to `cache-enabled`. This includes cache hits and
 misses in builds containing the `Report Go cache status` step added by #2069.
@@ -651,30 +665,31 @@ Gather the post-cache baseline before changing concurrency, assignment, or
 reset policy. Those future changes require a new, explicitly identified
 measurement period; the cache cohort alone does not distinguish them.
 
-### Weighted sharding predictions
+### Weighted sharding allocation and rollback
 
-Full, sharded `.com` runs also compute a **report-only** weighted assignment.
-Live execution still uses the existing selector, including its ordering and
-organization pins. Filtered, unsharded, and `.tech` runs do not generate these
-predictions. This does not introduce replay, skip scenarios, or change reset
-policy or concurrency.
+Full, sharded `.com` runs use weighted allocation by default. This is the
+activation following #2094, which only reported proposals. Filtered, unsharded,
+and `.tech` execution retains the original selector. No scenarios are removed,
+no replay is introduced, and reset policy and concurrency are unchanged.
 
-The proposed scheduler reserves pinned load first, then assigns unpinned
+The scheduler reserves pinned load first, then assigns unpinned
 scenarios in descending estimated-duration order to the least-loaded org.
 Equal weights use scenario path order; equal loads use configured organization
-order. Proposed scenario lists are sorted by path. Counts need not be equal:
+order. Weighted execution lists are sorted by path. Counts need not be equal:
 the goal is balanced estimated time, not balanced scenario counts.
 
-Refresh the checked-in snapshot manually from saved observations:
+The activation snapshot uses only the completed 20-run cache-enabled baseline.
+Keep it fixed during the first 20 successful weighted runs. An intentional
+refresh starts a new allocation identity and requires a separate observation
+file; it is not routine maintenance during that experiment. To regenerate the
+activation snapshot from its frozen source:
 
 ```sh
 make refresh-e2e-weights
 ```
 
-This writes `test/e2e/baselines/scenario-weights.json`. The initial inputs are
-the frozen Stage 0 and post-cache observations; these are pooled only for
-scenario duration estimates, not for workflow/build-cache comparisons. The
-generator uses one attempt per workflow run (the highest supplied attempt),
+This writes `test/e2e/baselines/scenario-weights.json`. The generator uses one
+attempt per workflow run (the highest supplied attempt),
 rejects conflicting duplicate observations, and requires at least 10 finite,
 positive, passing durations per scenario. Weights are conventional medians
 rounded to milliseconds. Failed, skipped, and nonpositive durations do not
@@ -687,10 +702,32 @@ prediction. The snapshot records sample counts and source paths/SHA-256 hashes
 and is embedded in the scenario test binary; selection never queries GitHub.
 Refresh is explicit, not part of builds or baseline collection.
 
-Predictions do not learn from each run: unchanged manifests, organizations,
-and weights produce the same proposed assignments. Collect observations first,
-then refresh and review the snapshot when newer timing data warrants it.
-Malformed observation records are rejected before replacing the snapshot.
+Weights do not learn from each run: unchanged manifests, organizations, and
+weights produce the same assignments. Malformed activation weights fail before
+execution instead of silently reverting to a different allocation. Malformed
+observation records are rejected before replacing the snapshot.
+
+For rollback, set the GitHub repository variable `KONGCTL_E2E_SHARD_STRATEGY`
+to `modulo`. The target-selection job captures it once for the entire matrix;
+already selected runs keep their allocation, and later runs use the original
+selector, including its original ordering. Rollback works even if weights are
+invalid. Set it to `weighted` (or remove the variable) to resume activation.
+An invalid value fails the `.com` target-selection job. Locally the equivalent
+override is `KONGCTL_E2E_SHARD_STRATEGY=modulo`.
+
+Record rollback measurements separately, for example:
+
+```sh
+make collect-e2e-baseline E2E_BASELINE_ALLOCATION=modulo-v1 \
+  E2E_BASELINE_OBSERVATIONS=.e2e-artifacts/rollback-observations.json \
+  E2E_BASELINE_REPORT=.e2e-artifacts/rollback.md
+```
+
+For an exact snapshot identity without changing weights:
+
+```sh
+python3 scripts/e2e-weights.py --print-allocation-id
+```
 
 The build job runs the weighted scheduler tests using its already compiled
 test binary and kongctl executable. This offline check covers the full
@@ -702,19 +739,26 @@ Run it locally with:
 CGO_ENABLED=0 go test -tags=e2e ./test/e2e -run '^TestWeighted' -v
 ```
 
-Each shard's workflow summary compares current and proposed estimated totals,
+Each shard's workflow summary identifies the actual allocation and compares
+modulo and weighted estimated totals,
 longest-shard time, and spread. Its `e2e-artifacts-*` artifact contains:
 
-- `proposed-scenario-assignments.json`: versioned, full-pool comparison with
-  per-scenario weights, fallback indicators, and organization assignments.
+- `scenario-allocation.json`: the actual strategy and allocation identity.
+- `proposed-scenario-assignments.json`: schema 2 full-pool comparison with
+  `legacy` and `weighted` assignments plus the actual allocation identity.
+  Schema 1 `current`/`proposed` fields from report-only runs are historical.
 - `weighted-sharding-summary.md`: the human-readable comparison.
 
 These are separate from `assigned-scenarios.txt` and `e2e-metrics.json`, which
-continue to describe actual execution. Reporting errors produce warnings and
-do not fail scenario tests. Missing reports also appear as workflow warnings.
+describe actual weighted or modulo execution. Comparison-report errors produce
+warnings; allocation metadata errors fail before execution so measurements
+cannot silently be assigned to the wrong experiment.
 
 Predictions exclude job overhead and assume that scenario durations transfer
 across organizations and execution ordering. They are not measured savings.
-Repeated runs from the same PR are correlated samples. Review these reports
-alongside the completed post-cache baseline before a separate activation PR;
-activation must start a separately identified measurement period.
+Repeated runs from the same PR are correlated samples. Compare measured
+longest-shard duration, spread, and overall latency with the completed
+pre-activation baseline. Also inspect failed/cancelled workflows and beta
+scenario failures: this successful-run collector alone cannot establish
+reliability. Roll back promptly for coverage/pinning problems or reproducible
+ordering-dependent failures; do not weaken assertions to retain speedups.

--- a/test/e2e/baselines/post-cache-2026-09-observations.json
+++ b/test/e2e/baselines/post-cache-2026-09-observations.json
@@ -3,6 +3,5357 @@
   "repository": "kong/kongctl",
   "runs": [
     {
+      "build_job_seconds": 53.0,
+      "build_kongctl_seconds": 10.0,
+      "build_scenario_binary_seconds": 7.0,
+      "build_setup_seconds": 21.0,
+      "cohort": "cache-enabled",
+      "created_at": "2026-09-06T17:11:44Z",
+      "harness_job_seconds": 76.0,
+      "harness_setup_seconds": 9.0,
+      "harness_test_seconds": 53.0,
+      "head_sha": "0cdd6dd9375f120891588bf8f4f70515dbfb6132",
+      "longest_shard_seconds": 492.0,
+      "original_created_at": "2026-09-06T17:11:44Z",
+      "queue_to_required_status_seconds": 2102.0,
+      "reset": {
+        "count": 164,
+        "delete_calls": 103,
+        "delete_duration_ms": 9186,
+        "duration_ms": 450436,
+        "list_calls": 2459,
+        "list_duration_ms": 439797,
+        "resources_deleted": 84,
+        "resources_found": 1614
+      },
+      "run_attempt": 1,
+      "run_id": 34047830584,
+      "scenario_durations": [
+        {
+          "duration_seconds": 7.9,
+          "result": "pass",
+          "scenario": "adopt/auth-strategy-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.65,
+          "result": "pass",
+          "scenario": "ai-gateway/agent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.59,
+          "result": "pass",
+          "scenario": "ai-gateway/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.03,
+          "result": "pass",
+          "scenario": "ai-gateway/model/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.53,
+          "result": "pass",
+          "scenario": "ai-gateway/vault/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.99,
+          "result": "pass",
+          "scenario": "apis/comprehensive-fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 22.12,
+          "result": "pass",
+          "scenario": "apis/root-level-publication-visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.13,
+          "result": "pass",
+          "scenario": "control-plane/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.51,
+          "result": "pass",
+          "scenario": "control-plane/serverless/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.36,
+          "result": "pass",
+          "scenario": "deck/env-vars/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.63,
+          "result": "pass",
+          "scenario": "declarative/rename-sync-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.57,
+          "result": "pass",
+          "scenario": "delete/plan-based/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.9,
+          "result": "pass",
+          "scenario": "dump/dcr-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.08,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.8,
+          "result": "pass",
+          "scenario": "event-gateway/dataplane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.26,
+          "result": "pass",
+          "scenario": "event-gateway/listener-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 26.32,
+          "result": "pass",
+          "scenario": "event-gateway/produce-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.08,
+          "result": "pass",
+          "scenario": "event-gateway/virtual-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.93,
+          "result": "pass",
+          "scenario": "external/portal-publication/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.24,
+          "result": "pass",
+          "scenario": "org/get-org/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.05,
+          "result": "pass",
+          "scenario": "org/teams/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.21,
+          "result": "pass",
+          "scenario": "plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.29,
+          "result": "pass",
+          "scenario": "portal/api_with_attributes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.32,
+          "result": "pass",
+          "scenario": "portal/auth-strategy-link/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.0,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.52,
+          "result": "pass",
+          "scenario": "portal/email/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.95,
+          "result": "pass",
+          "scenario": "portal/integrations/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.59,
+          "result": "pass",
+          "scenario": "portal/publication-auth-omitted-noop/scenario.yaml"
+        },
+        {
+          "duration_seconds": 25.42,
+          "result": "pass",
+          "scenario": "portal/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.81,
+          "result": "pass",
+          "scenario": "protected-resources/org/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.06,
+          "result": "pass",
+          "scenario": "smoke/version/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.38,
+          "result": "pass",
+          "scenario": "apis/eventual-consistency-polp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.18,
+          "result": "pass",
+          "scenario": "dump/organization-teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.21,
+          "result": "pass",
+          "scenario": "org/system-accounts/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.16,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.03,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.93,
+          "result": "pass",
+          "scenario": "org/system-accounts/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.1,
+          "result": "pass",
+          "scenario": "org/token/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.02,
+          "result": "pass",
+          "scenario": "org/users/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.43,
+          "result": "pass",
+          "scenario": "org/users/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.33,
+          "result": "pass",
+          "scenario": "org/users/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.27,
+          "result": "pass",
+          "scenario": "org/users/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.55,
+          "result": "pass",
+          "scenario": "org/users/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.37,
+          "result": "pass",
+          "scenario": "adopt/create-portal-adopt-dump-plan/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.26,
+          "result": "pass",
+          "scenario": "ai-gateway/auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.33,
+          "result": "pass",
+          "scenario": "ai-gateway/maturity/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.06,
+          "result": "pass",
+          "scenario": "ai-gateway/policy-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 25.56,
+          "result": "pass",
+          "scenario": "all/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.69,
+          "result": "pass",
+          "scenario": "apis/control-plane-implementation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.82,
+          "result": "pass",
+          "scenario": "apis/versions-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.33,
+          "result": "pass",
+          "scenario": "control-plane/delete-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.29,
+          "result": "pass",
+          "scenario": "control-plane/sync-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.05,
+          "result": "pass",
+          "scenario": "deck/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.09,
+          "result": "pass",
+          "scenario": "delete/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.94,
+          "result": "pass",
+          "scenario": "diff/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.81,
+          "result": "pass",
+          "scenario": "dump/filtered/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.33,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.36,
+          "result": "pass",
+          "scenario": "event-gateway/dependency-order/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.45,
+          "result": "pass",
+          "scenario": "event-gateway/listener/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.09,
+          "result": "pass",
+          "scenario": "event-gateway/schema-registry/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.07,
+          "result": "pass",
+          "scenario": "explain/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.84,
+          "result": "pass",
+          "scenario": "external/portal-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.99,
+          "result": "pass",
+          "scenario": "org/system-accounts/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.69,
+          "result": "pass",
+          "scenario": "org/teams/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.23,
+          "result": "pass",
+          "scenario": "plan/remote-url-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.19,
+          "result": "pass",
+          "scenario": "portal/app-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.98,
+          "result": "pass",
+          "scenario": "portal/auth_settings/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.35,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy_ref_selection/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.65,
+          "result": "pass",
+          "scenario": "portal/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.9,
+          "result": "pass",
+          "scenario": "portal/ip-allow-list/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.5,
+          "result": "pass",
+          "scenario": "portal/snippets-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 34.71,
+          "result": "pass",
+          "scenario": "portal/visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.88,
+          "result": "pass",
+          "scenario": "protected-resources/portals/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.53,
+          "result": "pass",
+          "scenario": "yaml-tags/env/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.04,
+          "result": "pass",
+          "scenario": "adopt/event-gateway-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.58,
+          "result": "pass",
+          "scenario": "ai-gateway/config-store/scenario.yaml"
+        },
+        {
+          "duration_seconds": 22.77,
+          "result": "pass",
+          "scenario": "ai-gateway/mcp-server/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.77,
+          "result": "pass",
+          "scenario": "ai-gateway/policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.32,
+          "result": "pass",
+          "scenario": "analytics/dashboard-repro/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.74,
+          "result": "pass",
+          "scenario": "apis/get-api-by-name-and-id/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "auth/get-me/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.57,
+          "result": "pass",
+          "scenario": "control-plane/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.64,
+          "result": "pass",
+          "scenario": "control-plane/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.54,
+          "result": "pass",
+          "scenario": "deck/multi-file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.29,
+          "result": "pass",
+          "scenario": "delete/dry-run/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.93,
+          "result": "pass",
+          "scenario": "dump/ai-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 39.28,
+          "result": "pass",
+          "scenario": "dump/portal-owned/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.49,
+          "result": "pass",
+          "scenario": "event-gateway/cluster-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.72,
+          "result": "pass",
+          "scenario": "event-gateway/diff/scenario.yaml"
+        },
+        {
+          "duration_seconds": 25.54,
+          "result": "pass",
+          "scenario": "event-gateway/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.69,
+          "result": "pass",
+          "scenario": "event-gateway/static-key/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.63,
+          "result": "pass",
+          "scenario": "external/ai-gateway-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.36,
+          "result": "pass",
+          "scenario": "lint/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.92,
+          "result": "pass",
+          "scenario": "org/teams/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.4,
+          "result": "pass",
+          "scenario": "org/teams/roles/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.84,
+          "result": "pass",
+          "scenario": "plan/sync-partial-scope/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "portal/applications/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.19,
+          "result": "pass",
+          "scenario": "portal/auth_settings_deprecated_fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.51,
+          "result": "pass",
+          "scenario": "portal/edit/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.39,
+          "result": "pass",
+          "scenario": "portal/identity_providers/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.46,
+          "result": "pass",
+          "scenario": "portal/oidc-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.9,
+          "result": "pass",
+          "scenario": "portal/snippets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.38,
+          "result": "pass",
+          "scenario": "protected-resources/apis/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.68,
+          "result": "pass",
+          "scenario": "require-namespace/external/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.01,
+          "result": "pass",
+          "scenario": "yaml-tags/file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.26,
+          "result": "pass",
+          "scenario": "adopt/full/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.71,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer-group/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.87,
+          "result": "pass",
+          "scenario": "ai-gateway/model-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.72,
+          "result": "pass",
+          "scenario": "ai-gateway/root/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.42,
+          "result": "pass",
+          "scenario": "analytics/dashboard/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.97,
+          "result": "pass",
+          "scenario": "apis/nested-child-lifecycle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.74,
+          "result": "pass",
+          "scenario": "catalog/service/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.61,
+          "result": "pass",
+          "scenario": "control-plane/groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.55,
+          "result": "pass",
+          "scenario": "dcr-providers/workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.76,
+          "result": "pass",
+          "scenario": "deck/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.85,
+          "result": "pass",
+          "scenario": "delete/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.1,
+          "result": "pass",
+          "scenario": "dump/analytics-dashboards/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.66,
+          "result": "pass",
+          "scenario": "errors/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.62,
+          "result": "pass",
+          "scenario": "event-gateway/consume-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.13,
+          "result": "pass",
+          "scenario": "event-gateway/dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 27.42,
+          "result": "pass",
+          "scenario": "event-gateway/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.42,
+          "result": "pass",
+          "scenario": "event-gateway/tls-trust-bundle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.49,
+          "result": "pass",
+          "scenario": "external/api-impl/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.1,
+          "result": "pass",
+          "scenario": "namespace/defaults-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.85,
+          "result": "pass",
+          "scenario": "org/teams/external-role/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.82,
+          "result": "pass",
+          "scenario": "org/teams/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.6,
+          "result": "pass",
+          "scenario": "plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.9,
+          "result": "pass",
+          "scenario": "portal/assets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.19,
+          "result": "pass",
+          "scenario": "portal/custom-domain/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.32,
+          "result": "pass",
+          "scenario": "portal/email-domains/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.16,
+          "result": "pass",
+          "scenario": "portal/identity_providers_duplicate_type/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.1,
+          "result": "pass",
+          "scenario": "portal/page-frontmatter-conflict/scenario.yaml"
+        },
+        {
+          "duration_seconds": 24.94,
+          "result": "pass",
+          "scenario": "portal/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.03,
+          "result": "pass",
+          "scenario": "protected-resources/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.5,
+          "result": "pass",
+          "scenario": "require-namespace/portal/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.73,
+          "result": "pass",
+          "scenario": "adopt/team-create-adopt-dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.93,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.09,
+          "result": "pass",
+          "scenario": "ai-gateway/model-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.29,
+          "result": "pass",
+          "scenario": "ai-gateway/runtime-tls/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.37,
+          "result": "pass",
+          "scenario": "apis/child-delete-namespace/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.94,
+          "result": "pass",
+          "scenario": "apis/region/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.45,
+          "result": "pass",
+          "scenario": "control-plane/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.86,
+          "result": "pass",
+          "scenario": "control-plane/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.6,
+          "result": "pass",
+          "scenario": "deck/basic/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.5,
+          "result": "pass",
+          "scenario": "declarative/plan-mode-validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.62,
+          "result": "pass",
+          "scenario": "delete/partial-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.63,
+          "result": "pass",
+          "scenario": "dump/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.13,
+          "result": "pass",
+          "scenario": "event-gateway/adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.35,
+          "result": "pass",
+          "scenario": "event-gateway/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.68,
+          "result": "pass",
+          "scenario": "event-gateway/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "event-gateway/principal-metadata/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.05,
+          "result": "pass",
+          "scenario": "event-gateway/topic-aliases/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.06,
+          "result": "pass",
+          "scenario": "external/api-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.78,
+          "result": "pass",
+          "scenario": "namespace/validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.22,
+          "result": "pass",
+          "scenario": "org/teams/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.41,
+          "result": "pass",
+          "scenario": "patch/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.46,
+          "result": "pass",
+          "scenario": "portal/api_docs_with_children/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.12,
+          "result": "pass",
+          "scenario": "portal/audit-log-webhook/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.42,
+          "result": "pass",
+          "scenario": "portal/customization/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.65,
+          "result": "pass",
+          "scenario": "portal/email-templates/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.37,
+          "result": "pass",
+          "scenario": "portal/idp_team_group_mappings_readback/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.68,
+          "result": "pass",
+          "scenario": "portal/pages/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.87,
+          "result": "pass",
+          "scenario": "portal/team_group_mappings_no_idp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.32,
+          "result": "pass",
+          "scenario": "protected-resources/event-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.86,
+          "result": "pass",
+          "scenario": "scaffold/command-coverage/scenario.yaml"
+        }
+      ],
+      "shard_admission_delay_seconds": {
+        "kongctl-acceptance": 3.0,
+        "kongctl-acceptance-2": 3.0,
+        "kongctl-acceptance-3": 4.0,
+        "kongctl-acceptance-4": 3.0,
+        "kongctl-acceptance-5": 3.0
+      },
+      "shard_spread_seconds": 256.0,
+      "shards": [
+        {
+          "execution_duration_seconds": 492,
+          "org_name": "kongctl-acceptance",
+          "selected_scenario_count": 43
+        },
+        {
+          "execution_duration_seconds": 274,
+          "org_name": "kongctl-acceptance-2",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 291,
+          "org_name": "kongctl-acceptance-3",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 278,
+          "org_name": "kongctl-acceptance-4",
+          "selected_scenario_count": 30
+        },
+        {
+          "execution_duration_seconds": 236,
+          "org_name": "kongctl-acceptance-5",
+          "selected_scenario_count": 30
+        }
+      ],
+      "url": "https://github.com/Kong/kongctl/actions/runs/34047830584",
+      "workflow_admission_delay_seconds": 1441.0
+    },
+    {
+      "build_job_seconds": 52.0,
+      "build_kongctl_seconds": 10.0,
+      "build_scenario_binary_seconds": 6.0,
+      "build_setup_seconds": 20.0,
+      "cohort": "cache-enabled",
+      "created_at": "2026-09-06T17:01:21Z",
+      "harness_job_seconds": 71.0,
+      "harness_setup_seconds": 9.0,
+      "harness_test_seconds": 49.0,
+      "head_sha": "fc1621dfb7096ca3074b2123e620c20ccd03fc31",
+      "longest_shard_seconds": 414.0,
+      "original_created_at": "2026-09-06T17:01:21Z",
+      "queue_to_required_status_seconds": 2058.0,
+      "reset": {
+        "count": 164,
+        "delete_calls": 103,
+        "delete_duration_ms": 9019,
+        "duration_ms": 424782,
+        "list_calls": 2459,
+        "list_duration_ms": 414290,
+        "resources_deleted": 84,
+        "resources_found": 1614
+      },
+      "run_attempt": 1,
+      "run_id": 34047278188,
+      "scenario_durations": [
+        {
+          "duration_seconds": 5.28,
+          "result": "pass",
+          "scenario": "adopt/auth-strategy-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.98,
+          "result": "pass",
+          "scenario": "ai-gateway/agent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.1,
+          "result": "pass",
+          "scenario": "ai-gateway/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.85,
+          "result": "pass",
+          "scenario": "ai-gateway/model/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.27,
+          "result": "pass",
+          "scenario": "ai-gateway/vault/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.33,
+          "result": "pass",
+          "scenario": "apis/comprehensive-fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.13,
+          "result": "pass",
+          "scenario": "apis/root-level-publication-visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.37,
+          "result": "pass",
+          "scenario": "control-plane/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.43,
+          "result": "pass",
+          "scenario": "control-plane/serverless/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.46,
+          "result": "pass",
+          "scenario": "deck/env-vars/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.59,
+          "result": "pass",
+          "scenario": "declarative/rename-sync-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.94,
+          "result": "pass",
+          "scenario": "delete/plan-based/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.44,
+          "result": "pass",
+          "scenario": "dump/dcr-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.76,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.14,
+          "result": "pass",
+          "scenario": "event-gateway/dataplane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.47,
+          "result": "pass",
+          "scenario": "event-gateway/listener-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.62,
+          "result": "pass",
+          "scenario": "event-gateway/produce-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.32,
+          "result": "pass",
+          "scenario": "event-gateway/virtual-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.26,
+          "result": "pass",
+          "scenario": "external/portal-publication/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.04,
+          "result": "pass",
+          "scenario": "org/get-org/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.12,
+          "result": "pass",
+          "scenario": "org/teams/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.85,
+          "result": "pass",
+          "scenario": "plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.55,
+          "result": "pass",
+          "scenario": "portal/api_with_attributes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.73,
+          "result": "pass",
+          "scenario": "portal/auth-strategy-link/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.92,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.07,
+          "result": "pass",
+          "scenario": "portal/email/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.87,
+          "result": "pass",
+          "scenario": "portal/integrations/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.42,
+          "result": "pass",
+          "scenario": "portal/publication-auth-omitted-noop/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.96,
+          "result": "pass",
+          "scenario": "portal/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.58,
+          "result": "pass",
+          "scenario": "protected-resources/org/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.06,
+          "result": "pass",
+          "scenario": "smoke/version/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.36,
+          "result": "pass",
+          "scenario": "apis/eventual-consistency-polp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.22,
+          "result": "pass",
+          "scenario": "dump/organization-teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.36,
+          "result": "pass",
+          "scenario": "org/system-accounts/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.17,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.53,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.07,
+          "result": "pass",
+          "scenario": "org/system-accounts/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.84,
+          "result": "pass",
+          "scenario": "org/token/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.88,
+          "result": "pass",
+          "scenario": "org/users/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.6,
+          "result": "pass",
+          "scenario": "org/users/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.18,
+          "result": "pass",
+          "scenario": "org/users/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.85,
+          "result": "pass",
+          "scenario": "org/users/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.03,
+          "result": "pass",
+          "scenario": "org/users/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.9,
+          "result": "pass",
+          "scenario": "adopt/create-portal-adopt-dump-plan/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.96,
+          "result": "pass",
+          "scenario": "ai-gateway/auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.44,
+          "result": "pass",
+          "scenario": "ai-gateway/maturity/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.87,
+          "result": "pass",
+          "scenario": "ai-gateway/policy-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 33.69,
+          "result": "pass",
+          "scenario": "all/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.11,
+          "result": "pass",
+          "scenario": "apis/control-plane-implementation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.84,
+          "result": "pass",
+          "scenario": "apis/versions-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.46,
+          "result": "pass",
+          "scenario": "control-plane/delete-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.0,
+          "result": "pass",
+          "scenario": "control-plane/sync-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.7,
+          "result": "pass",
+          "scenario": "deck/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.34,
+          "result": "pass",
+          "scenario": "delete/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.78,
+          "result": "pass",
+          "scenario": "diff/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.43,
+          "result": "pass",
+          "scenario": "dump/filtered/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.6,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.0,
+          "result": "pass",
+          "scenario": "event-gateway/dependency-order/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.68,
+          "result": "pass",
+          "scenario": "event-gateway/listener/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.87,
+          "result": "pass",
+          "scenario": "event-gateway/schema-registry/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.4,
+          "result": "pass",
+          "scenario": "explain/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.95,
+          "result": "pass",
+          "scenario": "external/portal-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.61,
+          "result": "pass",
+          "scenario": "org/system-accounts/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.32,
+          "result": "pass",
+          "scenario": "org/teams/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.88,
+          "result": "pass",
+          "scenario": "plan/remote-url-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.38,
+          "result": "pass",
+          "scenario": "portal/app-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.64,
+          "result": "pass",
+          "scenario": "portal/auth_settings/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.31,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy_ref_selection/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.96,
+          "result": "pass",
+          "scenario": "portal/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.44,
+          "result": "pass",
+          "scenario": "portal/ip-allow-list/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.14,
+          "result": "pass",
+          "scenario": "portal/snippets-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 51.57,
+          "result": "pass",
+          "scenario": "portal/visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.39,
+          "result": "pass",
+          "scenario": "protected-resources/portals/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.55,
+          "result": "pass",
+          "scenario": "yaml-tags/env/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.87,
+          "result": "pass",
+          "scenario": "adopt/event-gateway-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.12,
+          "result": "pass",
+          "scenario": "ai-gateway/config-store/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.49,
+          "result": "pass",
+          "scenario": "ai-gateway/mcp-server/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.14,
+          "result": "pass",
+          "scenario": "ai-gateway/policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.02,
+          "result": "pass",
+          "scenario": "analytics/dashboard-repro/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.82,
+          "result": "pass",
+          "scenario": "apis/get-api-by-name-and-id/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "auth/get-me/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.08,
+          "result": "pass",
+          "scenario": "control-plane/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.49,
+          "result": "pass",
+          "scenario": "control-plane/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.4,
+          "result": "pass",
+          "scenario": "deck/multi-file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.55,
+          "result": "pass",
+          "scenario": "delete/dry-run/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.74,
+          "result": "pass",
+          "scenario": "dump/ai-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.19,
+          "result": "pass",
+          "scenario": "dump/portal-owned/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.73,
+          "result": "pass",
+          "scenario": "event-gateway/cluster-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.34,
+          "result": "pass",
+          "scenario": "event-gateway/diff/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.28,
+          "result": "pass",
+          "scenario": "event-gateway/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.62,
+          "result": "pass",
+          "scenario": "event-gateway/static-key/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.27,
+          "result": "pass",
+          "scenario": "external/ai-gateway-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.34,
+          "result": "pass",
+          "scenario": "lint/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.58,
+          "result": "pass",
+          "scenario": "org/teams/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.16,
+          "result": "pass",
+          "scenario": "org/teams/roles/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.94,
+          "result": "pass",
+          "scenario": "plan/sync-partial-scope/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "portal/applications/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.19,
+          "result": "pass",
+          "scenario": "portal/auth_settings_deprecated_fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.21,
+          "result": "pass",
+          "scenario": "portal/edit/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.74,
+          "result": "pass",
+          "scenario": "portal/identity_providers/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.75,
+          "result": "pass",
+          "scenario": "portal/oidc-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.28,
+          "result": "pass",
+          "scenario": "portal/snippets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.9,
+          "result": "pass",
+          "scenario": "protected-resources/apis/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.71,
+          "result": "pass",
+          "scenario": "require-namespace/external/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.82,
+          "result": "pass",
+          "scenario": "yaml-tags/file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.58,
+          "result": "pass",
+          "scenario": "adopt/full/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.65,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer-group/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.45,
+          "result": "pass",
+          "scenario": "ai-gateway/model-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.4,
+          "result": "pass",
+          "scenario": "ai-gateway/root/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.72,
+          "result": "pass",
+          "scenario": "analytics/dashboard/scenario.yaml"
+        },
+        {
+          "duration_seconds": 29.84,
+          "result": "pass",
+          "scenario": "apis/nested-child-lifecycle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.97,
+          "result": "pass",
+          "scenario": "catalog/service/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.98,
+          "result": "pass",
+          "scenario": "control-plane/groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 21.28,
+          "result": "pass",
+          "scenario": "dcr-providers/workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.76,
+          "result": "pass",
+          "scenario": "deck/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.53,
+          "result": "pass",
+          "scenario": "delete/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.03,
+          "result": "pass",
+          "scenario": "dump/analytics-dashboards/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.3,
+          "result": "pass",
+          "scenario": "errors/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 27.74,
+          "result": "pass",
+          "scenario": "event-gateway/consume-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.39,
+          "result": "pass",
+          "scenario": "event-gateway/dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 43.07,
+          "result": "pass",
+          "scenario": "event-gateway/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.43,
+          "result": "pass",
+          "scenario": "event-gateway/tls-trust-bundle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.88,
+          "result": "pass",
+          "scenario": "external/api-impl/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.36,
+          "result": "pass",
+          "scenario": "namespace/defaults-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.09,
+          "result": "pass",
+          "scenario": "org/teams/external-role/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.11,
+          "result": "pass",
+          "scenario": "org/teams/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.6,
+          "result": "pass",
+          "scenario": "plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.4,
+          "result": "pass",
+          "scenario": "portal/assets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 26.61,
+          "result": "pass",
+          "scenario": "portal/custom-domain/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.09,
+          "result": "pass",
+          "scenario": "portal/email-domains/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.19,
+          "result": "pass",
+          "scenario": "portal/identity_providers_duplicate_type/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.83,
+          "result": "pass",
+          "scenario": "portal/page-frontmatter-conflict/scenario.yaml"
+        },
+        {
+          "duration_seconds": 37.25,
+          "result": "pass",
+          "scenario": "portal/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.22,
+          "result": "pass",
+          "scenario": "protected-resources/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.63,
+          "result": "pass",
+          "scenario": "require-namespace/portal/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.61,
+          "result": "pass",
+          "scenario": "adopt/team-create-adopt-dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.26,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.38,
+          "result": "pass",
+          "scenario": "ai-gateway/model-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.44,
+          "result": "pass",
+          "scenario": "ai-gateway/runtime-tls/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.48,
+          "result": "pass",
+          "scenario": "apis/child-delete-namespace/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.55,
+          "result": "pass",
+          "scenario": "apis/region/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.75,
+          "result": "pass",
+          "scenario": "control-plane/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.97,
+          "result": "pass",
+          "scenario": "control-plane/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.86,
+          "result": "pass",
+          "scenario": "deck/basic/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.58,
+          "result": "pass",
+          "scenario": "declarative/plan-mode-validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.26,
+          "result": "pass",
+          "scenario": "delete/partial-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.56,
+          "result": "pass",
+          "scenario": "dump/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.61,
+          "result": "pass",
+          "scenario": "event-gateway/adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.47,
+          "result": "pass",
+          "scenario": "event-gateway/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.69,
+          "result": "pass",
+          "scenario": "event-gateway/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "event-gateway/principal-metadata/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.81,
+          "result": "pass",
+          "scenario": "event-gateway/topic-aliases/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.08,
+          "result": "pass",
+          "scenario": "external/api-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.04,
+          "result": "pass",
+          "scenario": "namespace/validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.72,
+          "result": "pass",
+          "scenario": "org/teams/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.47,
+          "result": "pass",
+          "scenario": "patch/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 35.17,
+          "result": "pass",
+          "scenario": "portal/api_docs_with_children/scenario.yaml"
+        },
+        {
+          "duration_seconds": 21.68,
+          "result": "pass",
+          "scenario": "portal/audit-log-webhook/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.45,
+          "result": "pass",
+          "scenario": "portal/customization/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.31,
+          "result": "pass",
+          "scenario": "portal/email-templates/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.4,
+          "result": "pass",
+          "scenario": "portal/idp_team_group_mappings_readback/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.73,
+          "result": "pass",
+          "scenario": "portal/pages/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.24,
+          "result": "pass",
+          "scenario": "portal/team_group_mappings_no_idp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.28,
+          "result": "pass",
+          "scenario": "protected-resources/event-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.99,
+          "result": "pass",
+          "scenario": "scaffold/command-coverage/scenario.yaml"
+        }
+      ],
+      "shard_admission_delay_seconds": {
+        "kongctl-acceptance": 3.0,
+        "kongctl-acceptance-2": 3.0,
+        "kongctl-acceptance-3": 3.0,
+        "kongctl-acceptance-4": 4.0,
+        "kongctl-acceptance-5": 4.0
+      },
+      "shard_spread_seconds": 254.0,
+      "shards": [
+        {
+          "execution_duration_seconds": 272,
+          "org_name": "kongctl-acceptance",
+          "selected_scenario_count": 43
+        },
+        {
+          "execution_duration_seconds": 395,
+          "org_name": "kongctl-acceptance-2",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 160,
+          "org_name": "kongctl-acceptance-3",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 414,
+          "org_name": "kongctl-acceptance-4",
+          "selected_scenario_count": 30
+        },
+        {
+          "execution_duration_seconds": 344,
+          "org_name": "kongctl-acceptance-5",
+          "selected_scenario_count": 30
+        }
+      ],
+      "url": "https://github.com/Kong/kongctl/actions/runs/34047278188",
+      "workflow_admission_delay_seconds": 1476.0
+    },
+    {
+      "build_job_seconds": 62.0,
+      "build_kongctl_seconds": 17.0,
+      "build_scenario_binary_seconds": 10.0,
+      "build_setup_seconds": 19.0,
+      "cohort": "cache-enabled",
+      "created_at": "2026-09-06T16:52:03Z",
+      "harness_job_seconds": 58.0,
+      "harness_setup_seconds": 7.0,
+      "harness_test_seconds": 40.0,
+      "head_sha": "e817a3944272c890e102c2eefbbc37be6b00d5ea",
+      "longest_shard_seconds": 578.0,
+      "original_created_at": "2026-09-06T16:52:03Z",
+      "queue_to_required_status_seconds": 2031.0,
+      "reset": {
+        "count": 165,
+        "delete_calls": 103,
+        "delete_duration_ms": 10482,
+        "duration_ms": 419087,
+        "list_calls": 2465,
+        "list_duration_ms": 407132,
+        "resources_deleted": 84,
+        "resources_found": 1620
+      },
+      "run_attempt": 1,
+      "run_id": 34046810193,
+      "scenario_durations": [
+        {
+          "duration_seconds": 8.71,
+          "result": "pass",
+          "scenario": "adopt/auth-strategy-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.06,
+          "result": "pass",
+          "scenario": "ai-gateway/agent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 26.51,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer/scenario.yaml"
+        },
+        {
+          "duration_seconds": 21.47,
+          "result": "pass",
+          "scenario": "ai-gateway/model-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.11,
+          "result": "pass",
+          "scenario": "ai-gateway/runtime-tls/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.21,
+          "result": "pass",
+          "scenario": "apis/child-delete-namespace/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.86,
+          "result": "pass",
+          "scenario": "apis/region/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.08,
+          "result": "pass",
+          "scenario": "control-plane/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.56,
+          "result": "pass",
+          "scenario": "control-plane/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.78,
+          "result": "pass",
+          "scenario": "deck/basic/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.57,
+          "result": "pass",
+          "scenario": "declarative/plan-mode-validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.0,
+          "result": "pass",
+          "scenario": "delete/partial-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.23,
+          "result": "pass",
+          "scenario": "dump/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.96,
+          "result": "pass",
+          "scenario": "event-gateway/adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.83,
+          "result": "pass",
+          "scenario": "event-gateway/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 26.05,
+          "result": "pass",
+          "scenario": "event-gateway/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "event-gateway/principal-metadata/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.65,
+          "result": "pass",
+          "scenario": "event-gateway/topic-aliases/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.12,
+          "result": "pass",
+          "scenario": "external/api-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.02,
+          "result": "pass",
+          "scenario": "namespace/validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.61,
+          "result": "pass",
+          "scenario": "org/teams/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.46,
+          "result": "pass",
+          "scenario": "patch/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 40.86,
+          "result": "pass",
+          "scenario": "portal/api_docs_with_children/scenario.yaml"
+        },
+        {
+          "duration_seconds": 25.35,
+          "result": "pass",
+          "scenario": "portal/audit-log-webhook/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.08,
+          "result": "pass",
+          "scenario": "portal/customization/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.94,
+          "result": "pass",
+          "scenario": "portal/email-templates/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.0,
+          "result": "pass",
+          "scenario": "portal/idp_team_group_mappings_readback/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.24,
+          "result": "pass",
+          "scenario": "portal/pages/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.8,
+          "result": "pass",
+          "scenario": "portal/team_group_mappings_no_idp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.0,
+          "result": "pass",
+          "scenario": "protected-resources/event-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.98,
+          "result": "pass",
+          "scenario": "scaffold/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.95,
+          "result": "pass",
+          "scenario": "apis/eventual-consistency-polp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.13,
+          "result": "pass",
+          "scenario": "dump/organization-teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.11,
+          "result": "pass",
+          "scenario": "org/system-accounts/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.86,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.08,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.22,
+          "result": "pass",
+          "scenario": "org/system-accounts/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.97,
+          "result": "pass",
+          "scenario": "org/token/scenario.yaml"
+        },
+        {
+          "duration_seconds": 19.7,
+          "result": "pass",
+          "scenario": "org/users/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.81,
+          "result": "pass",
+          "scenario": "org/users/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.5,
+          "result": "pass",
+          "scenario": "org/users/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.7,
+          "result": "pass",
+          "scenario": "org/users/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.67,
+          "result": "pass",
+          "scenario": "org/users/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.93,
+          "result": "pass",
+          "scenario": "adopt/create-portal-adopt-dump-plan/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.11,
+          "result": "pass",
+          "scenario": "ai-gateway/auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.26,
+          "result": "pass",
+          "scenario": "ai-gateway/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.64,
+          "result": "pass",
+          "scenario": "ai-gateway/model/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.94,
+          "result": "pass",
+          "scenario": "ai-gateway/vault/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.8,
+          "result": "pass",
+          "scenario": "apis/comprehensive-fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.9,
+          "result": "pass",
+          "scenario": "apis/root-level-publication-visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.23,
+          "result": "pass",
+          "scenario": "control-plane/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.15,
+          "result": "pass",
+          "scenario": "control-plane/serverless/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.64,
+          "result": "pass",
+          "scenario": "deck/env-vars/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.57,
+          "result": "pass",
+          "scenario": "declarative/rename-sync-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.54,
+          "result": "pass",
+          "scenario": "delete/plan-based/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.09,
+          "result": "pass",
+          "scenario": "dump/dcr-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.39,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.12,
+          "result": "pass",
+          "scenario": "event-gateway/dataplane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.01,
+          "result": "pass",
+          "scenario": "event-gateway/listener-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 19.51,
+          "result": "pass",
+          "scenario": "event-gateway/produce-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.93,
+          "result": "pass",
+          "scenario": "event-gateway/virtual-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.17,
+          "result": "pass",
+          "scenario": "external/portal-publication/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.65,
+          "result": "pass",
+          "scenario": "org/get-org/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.0,
+          "result": "pass",
+          "scenario": "org/teams/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.37,
+          "result": "pass",
+          "scenario": "plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.68,
+          "result": "pass",
+          "scenario": "portal/api_with_attributes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.19,
+          "result": "pass",
+          "scenario": "portal/auth-strategy-link/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.26,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.55,
+          "result": "pass",
+          "scenario": "portal/email/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.96,
+          "result": "pass",
+          "scenario": "portal/integrations/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.62,
+          "result": "pass",
+          "scenario": "portal/publication-auth-omitted-noop/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.73,
+          "result": "pass",
+          "scenario": "portal/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.88,
+          "result": "pass",
+          "scenario": "protected-resources/org/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.04,
+          "result": "pass",
+          "scenario": "smoke/version/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.24,
+          "result": "pass",
+          "scenario": "adopt/event-gateway-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.24,
+          "result": "pass",
+          "scenario": "ai-gateway/config-store/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.43,
+          "result": "pass",
+          "scenario": "ai-gateway/maturity/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.09,
+          "result": "pass",
+          "scenario": "ai-gateway/policy-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.86,
+          "result": "pass",
+          "scenario": "all/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.72,
+          "result": "pass",
+          "scenario": "apis/control-plane-implementation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.77,
+          "result": "pass",
+          "scenario": "apis/versions-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.21,
+          "result": "pass",
+          "scenario": "control-plane/delete-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.55,
+          "result": "pass",
+          "scenario": "control-plane/sync-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.75,
+          "result": "pass",
+          "scenario": "deck/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.48,
+          "result": "pass",
+          "scenario": "delete/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.0,
+          "result": "pass",
+          "scenario": "diff/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.49,
+          "result": "pass",
+          "scenario": "dump/filtered/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.14,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.8,
+          "result": "pass",
+          "scenario": "event-gateway/dependency-order/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.83,
+          "result": "pass",
+          "scenario": "event-gateway/listener/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.03,
+          "result": "pass",
+          "scenario": "event-gateway/schema-registry/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.35,
+          "result": "pass",
+          "scenario": "explain/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.79,
+          "result": "pass",
+          "scenario": "external/portal-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.84,
+          "result": "pass",
+          "scenario": "org/system-accounts/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.58,
+          "result": "pass",
+          "scenario": "org/teams/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.01,
+          "result": "pass",
+          "scenario": "plan/remote-url-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.87,
+          "result": "pass",
+          "scenario": "portal/app-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.64,
+          "result": "pass",
+          "scenario": "portal/auth_settings/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.3,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy_ref_selection/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.88,
+          "result": "pass",
+          "scenario": "portal/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.83,
+          "result": "pass",
+          "scenario": "portal/ip-allow-list/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.38,
+          "result": "pass",
+          "scenario": "portal/snippets-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 27.11,
+          "result": "pass",
+          "scenario": "portal/visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.63,
+          "result": "pass",
+          "scenario": "protected-resources/portals/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.77,
+          "result": "pass",
+          "scenario": "yaml-tags/env/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.17,
+          "result": "pass",
+          "scenario": "adopt/full/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.25,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer-group/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.77,
+          "result": "pass",
+          "scenario": "ai-gateway/mcp-server/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.46,
+          "result": "pass",
+          "scenario": "ai-gateway/policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.97,
+          "result": "pass",
+          "scenario": "analytics/dashboard-repro/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.64,
+          "result": "pass",
+          "scenario": "apis/get-api-by-name-and-id/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "auth/get-me/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.08,
+          "result": "pass",
+          "scenario": "control-plane/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.32,
+          "result": "pass",
+          "scenario": "control-plane/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.99,
+          "result": "pass",
+          "scenario": "deck/multi-file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.67,
+          "result": "pass",
+          "scenario": "delete/dry-run/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.62,
+          "result": "pass",
+          "scenario": "dump/ai-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 38.19,
+          "result": "pass",
+          "scenario": "dump/portal-owned/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.89,
+          "result": "pass",
+          "scenario": "event-gateway/cluster-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.26,
+          "result": "pass",
+          "scenario": "event-gateway/diff/scenario.yaml"
+        },
+        {
+          "duration_seconds": 24.17,
+          "result": "pass",
+          "scenario": "event-gateway/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.94,
+          "result": "pass",
+          "scenario": "event-gateway/static-key/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.18,
+          "result": "pass",
+          "scenario": "external/ai-gateway-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.26,
+          "result": "pass",
+          "scenario": "lint/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.75,
+          "result": "pass",
+          "scenario": "org/teams/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.97,
+          "result": "pass",
+          "scenario": "org/teams/roles/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.46,
+          "result": "pass",
+          "scenario": "plan/sync-partial-scope/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "portal/applications/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.14,
+          "result": "pass",
+          "scenario": "portal/auth_settings_deprecated_fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.17,
+          "result": "pass",
+          "scenario": "portal/edit/scenario.yaml"
+        },
+        {
+          "duration_seconds": 22.29,
+          "result": "pass",
+          "scenario": "portal/identity_providers/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.07,
+          "result": "pass",
+          "scenario": "portal/oidc-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.15,
+          "result": "pass",
+          "scenario": "portal/snippets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.72,
+          "result": "pass",
+          "scenario": "protected-resources/apis/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.33,
+          "result": "pass",
+          "scenario": "require-namespace/external/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.77,
+          "result": "pass",
+          "scenario": "yaml-tags/file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.09,
+          "result": "pass",
+          "scenario": "adopt/team-create-adopt-dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.62,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.04,
+          "result": "pass",
+          "scenario": "ai-gateway/model-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.88,
+          "result": "pass",
+          "scenario": "ai-gateway/root/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.74,
+          "result": "pass",
+          "scenario": "analytics/dashboard/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.82,
+          "result": "pass",
+          "scenario": "apis/nested-child-lifecycle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.05,
+          "result": "pass",
+          "scenario": "catalog/service/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.79,
+          "result": "pass",
+          "scenario": "control-plane/groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.98,
+          "result": "pass",
+          "scenario": "dcr-providers/workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.35,
+          "result": "pass",
+          "scenario": "deck/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.77,
+          "result": "pass",
+          "scenario": "delete/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.1,
+          "result": "pass",
+          "scenario": "dump/analytics-dashboards/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.11,
+          "result": "pass",
+          "scenario": "errors/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.82,
+          "result": "pass",
+          "scenario": "event-gateway/consume-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.57,
+          "result": "pass",
+          "scenario": "event-gateway/dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.29,
+          "result": "pass",
+          "scenario": "event-gateway/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.67,
+          "result": "pass",
+          "scenario": "event-gateway/tls-trust-bundle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.79,
+          "result": "pass",
+          "scenario": "external/api-impl/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.9,
+          "result": "pass",
+          "scenario": "namespace/defaults-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.49,
+          "result": "pass",
+          "scenario": "org/teams/external-role/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.66,
+          "result": "pass",
+          "scenario": "org/teams/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.21,
+          "result": "pass",
+          "scenario": "plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.6,
+          "result": "pass",
+          "scenario": "portal/assets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.78,
+          "result": "pass",
+          "scenario": "portal/custom-domain/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.4,
+          "result": "pass",
+          "scenario": "portal/email-domains/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.19,
+          "result": "pass",
+          "scenario": "portal/identity_providers_duplicate_type/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.09,
+          "result": "pass",
+          "scenario": "portal/page-frontmatter-conflict/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.51,
+          "result": "pass",
+          "scenario": "portal/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.66,
+          "result": "pass",
+          "scenario": "protected-resources/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.43,
+          "result": "pass",
+          "scenario": "require-namespace/portal/scenario.yaml"
+        }
+      ],
+      "shard_admission_delay_seconds": {
+        "kongctl-acceptance": 4.0,
+        "kongctl-acceptance-2": 4.0,
+        "kongctl-acceptance-3": 3.0,
+        "kongctl-acceptance-4": 3.0,
+        "kongctl-acceptance-5": 3.0
+      },
+      "shard_spread_seconds": 374.0,
+      "shards": [
+        {
+          "execution_duration_seconds": 578,
+          "org_name": "kongctl-acceptance",
+          "selected_scenario_count": 43
+        },
+        {
+          "execution_duration_seconds": 253,
+          "org_name": "kongctl-acceptance-2",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 204,
+          "org_name": "kongctl-acceptance-3",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 271,
+          "org_name": "kongctl-acceptance-4",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 206,
+          "org_name": "kongctl-acceptance-5",
+          "selected_scenario_count": 30
+        }
+      ],
+      "url": "https://github.com/Kong/kongctl/actions/runs/34046810193",
+      "workflow_admission_delay_seconds": 1292.0
+    },
+    {
+      "build_job_seconds": 62.0,
+      "build_kongctl_seconds": 10.0,
+      "build_scenario_binary_seconds": 7.0,
+      "build_setup_seconds": 26.0,
+      "cohort": "cache-enabled",
+      "created_at": "2026-09-06T16:51:52Z",
+      "harness_job_seconds": 76.0,
+      "harness_setup_seconds": 10.0,
+      "harness_test_seconds": 53.0,
+      "head_sha": "6e7107545dee4e23e988850e20a8a5db113da5f0",
+      "longest_shard_seconds": 493.0,
+      "original_created_at": "2026-09-06T16:51:52Z",
+      "queue_to_required_status_seconds": 1300.0,
+      "reset": {
+        "count": 164,
+        "delete_calls": 103,
+        "delete_duration_ms": 9352,
+        "duration_ms": 459201,
+        "list_calls": 2459,
+        "list_duration_ms": 448359,
+        "resources_deleted": 84,
+        "resources_found": 1614
+      },
+      "run_attempt": 1,
+      "run_id": 34046799058,
+      "scenario_durations": [
+        {
+          "duration_seconds": 8.76,
+          "result": "pass",
+          "scenario": "adopt/auth-strategy-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.73,
+          "result": "pass",
+          "scenario": "ai-gateway/agent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.56,
+          "result": "pass",
+          "scenario": "ai-gateway/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.56,
+          "result": "pass",
+          "scenario": "ai-gateway/model/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.02,
+          "result": "pass",
+          "scenario": "ai-gateway/vault/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.03,
+          "result": "pass",
+          "scenario": "apis/comprehensive-fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.9,
+          "result": "pass",
+          "scenario": "apis/root-level-publication-visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.6,
+          "result": "pass",
+          "scenario": "control-plane/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.16,
+          "result": "pass",
+          "scenario": "control-plane/serverless/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.66,
+          "result": "pass",
+          "scenario": "deck/env-vars/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.13,
+          "result": "pass",
+          "scenario": "declarative/rename-sync-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.61,
+          "result": "pass",
+          "scenario": "delete/plan-based/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.98,
+          "result": "pass",
+          "scenario": "dump/dcr-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.41,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.97,
+          "result": "pass",
+          "scenario": "event-gateway/dataplane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.27,
+          "result": "pass",
+          "scenario": "event-gateway/listener-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 26.61,
+          "result": "pass",
+          "scenario": "event-gateway/produce-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.41,
+          "result": "pass",
+          "scenario": "event-gateway/virtual-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.15,
+          "result": "pass",
+          "scenario": "external/portal-publication/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.59,
+          "result": "pass",
+          "scenario": "org/get-org/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.39,
+          "result": "pass",
+          "scenario": "org/teams/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.62,
+          "result": "pass",
+          "scenario": "plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.81,
+          "result": "pass",
+          "scenario": "portal/api_with_attributes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.75,
+          "result": "pass",
+          "scenario": "portal/auth-strategy-link/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.28,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.06,
+          "result": "pass",
+          "scenario": "portal/email/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.26,
+          "result": "pass",
+          "scenario": "portal/integrations/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.9,
+          "result": "pass",
+          "scenario": "portal/publication-auth-omitted-noop/scenario.yaml"
+        },
+        {
+          "duration_seconds": 26.14,
+          "result": "pass",
+          "scenario": "portal/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.92,
+          "result": "pass",
+          "scenario": "protected-resources/org/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.04,
+          "result": "pass",
+          "scenario": "smoke/version/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.81,
+          "result": "pass",
+          "scenario": "apis/eventual-consistency-polp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.98,
+          "result": "pass",
+          "scenario": "dump/organization-teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.21,
+          "result": "pass",
+          "scenario": "org/system-accounts/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.22,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.06,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.13,
+          "result": "pass",
+          "scenario": "org/system-accounts/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.21,
+          "result": "pass",
+          "scenario": "org/token/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.18,
+          "result": "pass",
+          "scenario": "org/users/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.74,
+          "result": "pass",
+          "scenario": "org/users/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.42,
+          "result": "pass",
+          "scenario": "org/users/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.56,
+          "result": "pass",
+          "scenario": "org/users/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.57,
+          "result": "pass",
+          "scenario": "org/users/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.49,
+          "result": "pass",
+          "scenario": "adopt/create-portal-adopt-dump-plan/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.66,
+          "result": "pass",
+          "scenario": "ai-gateway/auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.44,
+          "result": "pass",
+          "scenario": "ai-gateway/maturity/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.09,
+          "result": "pass",
+          "scenario": "ai-gateway/policy-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 33.81,
+          "result": "pass",
+          "scenario": "all/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.75,
+          "result": "pass",
+          "scenario": "apis/control-plane-implementation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.02,
+          "result": "pass",
+          "scenario": "apis/versions-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.44,
+          "result": "pass",
+          "scenario": "control-plane/delete-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.13,
+          "result": "pass",
+          "scenario": "control-plane/sync-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.71,
+          "result": "pass",
+          "scenario": "deck/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.41,
+          "result": "pass",
+          "scenario": "delete/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.88,
+          "result": "pass",
+          "scenario": "diff/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.15,
+          "result": "pass",
+          "scenario": "dump/filtered/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.75,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.96,
+          "result": "pass",
+          "scenario": "event-gateway/dependency-order/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.82,
+          "result": "pass",
+          "scenario": "event-gateway/listener/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.07,
+          "result": "pass",
+          "scenario": "event-gateway/schema-registry/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.47,
+          "result": "pass",
+          "scenario": "explain/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.91,
+          "result": "pass",
+          "scenario": "external/portal-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.27,
+          "result": "pass",
+          "scenario": "org/system-accounts/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.26,
+          "result": "pass",
+          "scenario": "org/teams/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.51,
+          "result": "pass",
+          "scenario": "plan/remote-url-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.71,
+          "result": "pass",
+          "scenario": "portal/app-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.56,
+          "result": "pass",
+          "scenario": "portal/auth_settings/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.41,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy_ref_selection/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.13,
+          "result": "pass",
+          "scenario": "portal/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.5,
+          "result": "pass",
+          "scenario": "portal/ip-allow-list/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.16,
+          "result": "pass",
+          "scenario": "portal/snippets-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 52.21,
+          "result": "pass",
+          "scenario": "portal/visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.45,
+          "result": "pass",
+          "scenario": "protected-resources/portals/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.58,
+          "result": "pass",
+          "scenario": "yaml-tags/env/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.61,
+          "result": "pass",
+          "scenario": "adopt/event-gateway-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.6,
+          "result": "pass",
+          "scenario": "ai-gateway/config-store/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.74,
+          "result": "pass",
+          "scenario": "ai-gateway/mcp-server/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.46,
+          "result": "pass",
+          "scenario": "ai-gateway/policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.0,
+          "result": "pass",
+          "scenario": "analytics/dashboard-repro/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.7,
+          "result": "pass",
+          "scenario": "apis/get-api-by-name-and-id/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "auth/get-me/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.03,
+          "result": "pass",
+          "scenario": "control-plane/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.5,
+          "result": "pass",
+          "scenario": "control-plane/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.52,
+          "result": "pass",
+          "scenario": "deck/multi-file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.67,
+          "result": "pass",
+          "scenario": "delete/dry-run/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.96,
+          "result": "pass",
+          "scenario": "dump/ai-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 24.16,
+          "result": "pass",
+          "scenario": "dump/portal-owned/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.57,
+          "result": "pass",
+          "scenario": "event-gateway/cluster-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.64,
+          "result": "pass",
+          "scenario": "event-gateway/diff/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.45,
+          "result": "pass",
+          "scenario": "event-gateway/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.7,
+          "result": "pass",
+          "scenario": "event-gateway/static-key/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.41,
+          "result": "pass",
+          "scenario": "external/ai-gateway-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.35,
+          "result": "pass",
+          "scenario": "lint/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.56,
+          "result": "pass",
+          "scenario": "org/teams/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.18,
+          "result": "pass",
+          "scenario": "org/teams/roles/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.05,
+          "result": "pass",
+          "scenario": "plan/sync-partial-scope/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "portal/applications/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.19,
+          "result": "pass",
+          "scenario": "portal/auth_settings_deprecated_fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.25,
+          "result": "pass",
+          "scenario": "portal/edit/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.83,
+          "result": "pass",
+          "scenario": "portal/identity_providers/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.75,
+          "result": "pass",
+          "scenario": "portal/oidc-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.41,
+          "result": "pass",
+          "scenario": "portal/snippets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.97,
+          "result": "pass",
+          "scenario": "protected-resources/apis/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.71,
+          "result": "pass",
+          "scenario": "require-namespace/external/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.78,
+          "result": "pass",
+          "scenario": "yaml-tags/file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.66,
+          "result": "pass",
+          "scenario": "adopt/full/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.69,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer-group/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.52,
+          "result": "pass",
+          "scenario": "ai-gateway/model-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.38,
+          "result": "pass",
+          "scenario": "ai-gateway/root/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.0,
+          "result": "pass",
+          "scenario": "analytics/dashboard/scenario.yaml"
+        },
+        {
+          "duration_seconds": 29.6,
+          "result": "pass",
+          "scenario": "apis/nested-child-lifecycle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.87,
+          "result": "pass",
+          "scenario": "catalog/service/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.96,
+          "result": "pass",
+          "scenario": "control-plane/groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 21.11,
+          "result": "pass",
+          "scenario": "dcr-providers/workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.64,
+          "result": "pass",
+          "scenario": "deck/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.56,
+          "result": "pass",
+          "scenario": "delete/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.02,
+          "result": "pass",
+          "scenario": "dump/analytics-dashboards/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.36,
+          "result": "pass",
+          "scenario": "errors/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 27.88,
+          "result": "pass",
+          "scenario": "event-gateway/consume-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.32,
+          "result": "pass",
+          "scenario": "event-gateway/dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 43.05,
+          "result": "pass",
+          "scenario": "event-gateway/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.36,
+          "result": "pass",
+          "scenario": "event-gateway/tls-trust-bundle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.8,
+          "result": "pass",
+          "scenario": "external/api-impl/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.45,
+          "result": "pass",
+          "scenario": "namespace/defaults-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.05,
+          "result": "pass",
+          "scenario": "org/teams/external-role/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.12,
+          "result": "pass",
+          "scenario": "org/teams/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.63,
+          "result": "pass",
+          "scenario": "plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.29,
+          "result": "pass",
+          "scenario": "portal/assets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 27.28,
+          "result": "pass",
+          "scenario": "portal/custom-domain/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.85,
+          "result": "pass",
+          "scenario": "portal/email-domains/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.2,
+          "result": "pass",
+          "scenario": "portal/identity_providers_duplicate_type/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.73,
+          "result": "pass",
+          "scenario": "portal/page-frontmatter-conflict/scenario.yaml"
+        },
+        {
+          "duration_seconds": 36.83,
+          "result": "pass",
+          "scenario": "portal/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.17,
+          "result": "pass",
+          "scenario": "protected-resources/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.65,
+          "result": "pass",
+          "scenario": "require-namespace/portal/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.87,
+          "result": "pass",
+          "scenario": "adopt/team-create-adopt-dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.36,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.17,
+          "result": "pass",
+          "scenario": "ai-gateway/model-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.12,
+          "result": "pass",
+          "scenario": "ai-gateway/runtime-tls/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.4,
+          "result": "pass",
+          "scenario": "apis/child-delete-namespace/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.98,
+          "result": "pass",
+          "scenario": "apis/region/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.42,
+          "result": "pass",
+          "scenario": "control-plane/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.73,
+          "result": "pass",
+          "scenario": "control-plane/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.21,
+          "result": "pass",
+          "scenario": "deck/basic/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.55,
+          "result": "pass",
+          "scenario": "declarative/plan-mode-validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.74,
+          "result": "pass",
+          "scenario": "delete/partial-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.04,
+          "result": "pass",
+          "scenario": "dump/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.02,
+          "result": "pass",
+          "scenario": "event-gateway/adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.29,
+          "result": "pass",
+          "scenario": "event-gateway/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.45,
+          "result": "pass",
+          "scenario": "event-gateway/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "event-gateway/principal-metadata/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.2,
+          "result": "pass",
+          "scenario": "event-gateway/topic-aliases/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.71,
+          "result": "pass",
+          "scenario": "external/api-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.81,
+          "result": "pass",
+          "scenario": "namespace/validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.05,
+          "result": "pass",
+          "scenario": "org/teams/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.45,
+          "result": "pass",
+          "scenario": "patch/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 19.57,
+          "result": "pass",
+          "scenario": "portal/api_docs_with_children/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.91,
+          "result": "pass",
+          "scenario": "portal/audit-log-webhook/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.26,
+          "result": "pass",
+          "scenario": "portal/customization/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.19,
+          "result": "pass",
+          "scenario": "portal/email-templates/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.51,
+          "result": "pass",
+          "scenario": "portal/idp_team_group_mappings_readback/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.65,
+          "result": "pass",
+          "scenario": "portal/pages/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.68,
+          "result": "pass",
+          "scenario": "portal/team_group_mappings_no_idp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.65,
+          "result": "pass",
+          "scenario": "protected-resources/event-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.95,
+          "result": "pass",
+          "scenario": "scaffold/command-coverage/scenario.yaml"
+        }
+      ],
+      "shard_admission_delay_seconds": {
+        "kongctl-acceptance": 3.0,
+        "kongctl-acceptance-2": 4.0,
+        "kongctl-acceptance-3": 3.0,
+        "kongctl-acceptance-4": 4.0,
+        "kongctl-acceptance-5": 3.0
+      },
+      "shard_spread_seconds": 331.0,
+      "shards": [
+        {
+          "execution_duration_seconds": 493,
+          "org_name": "kongctl-acceptance",
+          "selected_scenario_count": 43
+        },
+        {
+          "execution_duration_seconds": 397,
+          "org_name": "kongctl-acceptance-2",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 162,
+          "org_name": "kongctl-acceptance-3",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 412,
+          "org_name": "kongctl-acceptance-4",
+          "selected_scenario_count": 30
+        },
+        {
+          "execution_duration_seconds": 178,
+          "org_name": "kongctl-acceptance-5",
+          "selected_scenario_count": 30
+        }
+      ],
+      "url": "https://github.com/Kong/kongctl/actions/runs/34046799058",
+      "workflow_admission_delay_seconds": 640.0
+    },
+    {
+      "build_job_seconds": 63.0,
+      "build_kongctl_seconds": 11.0,
+      "build_scenario_binary_seconds": 7.0,
+      "build_setup_seconds": 26.0,
+      "cohort": "cache-enabled",
+      "created_at": "2026-09-06T16:51:26Z",
+      "harness_job_seconds": 66.0,
+      "harness_setup_seconds": 10.0,
+      "harness_test_seconds": 44.0,
+      "head_sha": "deaf1ef95a6bfa6f6bd1fda5c906296792449ad4",
+      "longest_shard_seconds": 414.0,
+      "original_created_at": "2026-09-06T16:51:26Z",
+      "queue_to_required_status_seconds": 663.0,
+      "reset": {
+        "count": 164,
+        "delete_calls": 103,
+        "delete_duration_ms": 9366,
+        "duration_ms": 415450,
+        "list_calls": 2459,
+        "list_duration_ms": 404558,
+        "resources_deleted": 84,
+        "resources_found": 1614
+      },
+      "run_attempt": 1,
+      "run_id": 34046778067,
+      "scenario_durations": [
+        {
+          "duration_seconds": 4.61,
+          "result": "pass",
+          "scenario": "adopt/auth-strategy-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.21,
+          "result": "pass",
+          "scenario": "ai-gateway/agent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.74,
+          "result": "pass",
+          "scenario": "ai-gateway/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.42,
+          "result": "pass",
+          "scenario": "ai-gateway/model/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.36,
+          "result": "pass",
+          "scenario": "ai-gateway/vault/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.06,
+          "result": "pass",
+          "scenario": "apis/comprehensive-fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.9,
+          "result": "pass",
+          "scenario": "apis/root-level-publication-visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.21,
+          "result": "pass",
+          "scenario": "control-plane/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.36,
+          "result": "pass",
+          "scenario": "control-plane/serverless/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.75,
+          "result": "pass",
+          "scenario": "deck/env-vars/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.04,
+          "result": "pass",
+          "scenario": "declarative/rename-sync-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.73,
+          "result": "pass",
+          "scenario": "delete/plan-based/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.46,
+          "result": "pass",
+          "scenario": "dump/dcr-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.76,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.61,
+          "result": "pass",
+          "scenario": "event-gateway/dataplane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.03,
+          "result": "pass",
+          "scenario": "event-gateway/listener-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.79,
+          "result": "pass",
+          "scenario": "event-gateway/produce-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.03,
+          "result": "pass",
+          "scenario": "event-gateway/virtual-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.38,
+          "result": "pass",
+          "scenario": "external/portal-publication/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.05,
+          "result": "pass",
+          "scenario": "org/get-org/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.35,
+          "result": "pass",
+          "scenario": "org/teams/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.28,
+          "result": "pass",
+          "scenario": "plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.8,
+          "result": "pass",
+          "scenario": "portal/api_with_attributes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.17,
+          "result": "pass",
+          "scenario": "portal/auth-strategy-link/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.57,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.47,
+          "result": "pass",
+          "scenario": "portal/email/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.97,
+          "result": "pass",
+          "scenario": "portal/integrations/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.59,
+          "result": "pass",
+          "scenario": "portal/publication-auth-omitted-noop/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.73,
+          "result": "pass",
+          "scenario": "portal/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.78,
+          "result": "pass",
+          "scenario": "protected-resources/org/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.06,
+          "result": "pass",
+          "scenario": "smoke/version/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.56,
+          "result": "pass",
+          "scenario": "apis/eventual-consistency-polp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.31,
+          "result": "pass",
+          "scenario": "dump/organization-teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.84,
+          "result": "pass",
+          "scenario": "org/system-accounts/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.39,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.92,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.38,
+          "result": "pass",
+          "scenario": "org/system-accounts/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.16,
+          "result": "pass",
+          "scenario": "org/token/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.2,
+          "result": "pass",
+          "scenario": "org/users/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.71,
+          "result": "pass",
+          "scenario": "org/users/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.52,
+          "result": "pass",
+          "scenario": "org/users/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.45,
+          "result": "pass",
+          "scenario": "org/users/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.08,
+          "result": "pass",
+          "scenario": "org/users/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.26,
+          "result": "pass",
+          "scenario": "adopt/create-portal-adopt-dump-plan/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.73,
+          "result": "pass",
+          "scenario": "ai-gateway/auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.44,
+          "result": "pass",
+          "scenario": "ai-gateway/maturity/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.12,
+          "result": "pass",
+          "scenario": "ai-gateway/policy-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.31,
+          "result": "pass",
+          "scenario": "all/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.36,
+          "result": "pass",
+          "scenario": "apis/control-plane-implementation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.66,
+          "result": "pass",
+          "scenario": "apis/versions-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.06,
+          "result": "pass",
+          "scenario": "control-plane/delete-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.52,
+          "result": "pass",
+          "scenario": "control-plane/sync-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.55,
+          "result": "pass",
+          "scenario": "deck/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.53,
+          "result": "pass",
+          "scenario": "delete/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.09,
+          "result": "pass",
+          "scenario": "diff/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.36,
+          "result": "pass",
+          "scenario": "dump/filtered/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.65,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.5,
+          "result": "pass",
+          "scenario": "event-gateway/dependency-order/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.44,
+          "result": "pass",
+          "scenario": "event-gateway/listener/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.54,
+          "result": "pass",
+          "scenario": "event-gateway/schema-registry/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.45,
+          "result": "pass",
+          "scenario": "explain/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.63,
+          "result": "pass",
+          "scenario": "external/portal-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.46,
+          "result": "pass",
+          "scenario": "org/system-accounts/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.34,
+          "result": "pass",
+          "scenario": "org/teams/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.78,
+          "result": "pass",
+          "scenario": "plan/remote-url-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.66,
+          "result": "pass",
+          "scenario": "portal/app-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.35,
+          "result": "pass",
+          "scenario": "portal/auth_settings/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.13,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy_ref_selection/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.45,
+          "result": "pass",
+          "scenario": "portal/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.59,
+          "result": "pass",
+          "scenario": "portal/ip-allow-list/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.31,
+          "result": "pass",
+          "scenario": "portal/snippets-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 25.85,
+          "result": "pass",
+          "scenario": "portal/visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.44,
+          "result": "pass",
+          "scenario": "protected-resources/portals/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.58,
+          "result": "pass",
+          "scenario": "yaml-tags/env/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.45,
+          "result": "pass",
+          "scenario": "adopt/event-gateway-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.86,
+          "result": "pass",
+          "scenario": "ai-gateway/config-store/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.62,
+          "result": "pass",
+          "scenario": "ai-gateway/mcp-server/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.67,
+          "result": "pass",
+          "scenario": "ai-gateway/policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.32,
+          "result": "pass",
+          "scenario": "analytics/dashboard-repro/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.02,
+          "result": "pass",
+          "scenario": "apis/get-api-by-name-and-id/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "auth/get-me/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.09,
+          "result": "pass",
+          "scenario": "control-plane/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.9,
+          "result": "pass",
+          "scenario": "control-plane/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.86,
+          "result": "pass",
+          "scenario": "deck/multi-file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.14,
+          "result": "pass",
+          "scenario": "delete/dry-run/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.85,
+          "result": "pass",
+          "scenario": "dump/ai-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 49.68,
+          "result": "pass",
+          "scenario": "dump/portal-owned/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.26,
+          "result": "pass",
+          "scenario": "event-gateway/cluster-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.67,
+          "result": "pass",
+          "scenario": "event-gateway/diff/scenario.yaml"
+        },
+        {
+          "duration_seconds": 32.02,
+          "result": "pass",
+          "scenario": "event-gateway/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.51,
+          "result": "pass",
+          "scenario": "event-gateway/static-key/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.11,
+          "result": "pass",
+          "scenario": "external/ai-gateway-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.35,
+          "result": "pass",
+          "scenario": "lint/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.18,
+          "result": "pass",
+          "scenario": "org/teams/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.45,
+          "result": "pass",
+          "scenario": "org/teams/roles/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.66,
+          "result": "pass",
+          "scenario": "plan/sync-partial-scope/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "portal/applications/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.19,
+          "result": "pass",
+          "scenario": "portal/auth_settings_deprecated_fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.42,
+          "result": "pass",
+          "scenario": "portal/edit/scenario.yaml"
+        },
+        {
+          "duration_seconds": 29.07,
+          "result": "pass",
+          "scenario": "portal/identity_providers/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.75,
+          "result": "pass",
+          "scenario": "portal/oidc-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.64,
+          "result": "pass",
+          "scenario": "portal/snippets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.1,
+          "result": "pass",
+          "scenario": "protected-resources/apis/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.91,
+          "result": "pass",
+          "scenario": "require-namespace/external/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.38,
+          "result": "pass",
+          "scenario": "yaml-tags/file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.85,
+          "result": "pass",
+          "scenario": "adopt/full/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.54,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer-group/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.3,
+          "result": "pass",
+          "scenario": "ai-gateway/model-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.46,
+          "result": "pass",
+          "scenario": "ai-gateway/root/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.94,
+          "result": "pass",
+          "scenario": "analytics/dashboard/scenario.yaml"
+        },
+        {
+          "duration_seconds": 29.95,
+          "result": "pass",
+          "scenario": "apis/nested-child-lifecycle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.74,
+          "result": "pass",
+          "scenario": "catalog/service/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.97,
+          "result": "pass",
+          "scenario": "control-plane/groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 21.13,
+          "result": "pass",
+          "scenario": "dcr-providers/workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.8,
+          "result": "pass",
+          "scenario": "deck/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.54,
+          "result": "pass",
+          "scenario": "delete/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.92,
+          "result": "pass",
+          "scenario": "dump/analytics-dashboards/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.33,
+          "result": "pass",
+          "scenario": "errors/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 27.45,
+          "result": "pass",
+          "scenario": "event-gateway/consume-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.4,
+          "result": "pass",
+          "scenario": "event-gateway/dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 42.94,
+          "result": "pass",
+          "scenario": "event-gateway/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.45,
+          "result": "pass",
+          "scenario": "event-gateway/tls-trust-bundle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.83,
+          "result": "pass",
+          "scenario": "external/api-impl/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.41,
+          "result": "pass",
+          "scenario": "namespace/defaults-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.26,
+          "result": "pass",
+          "scenario": "org/teams/external-role/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.38,
+          "result": "pass",
+          "scenario": "org/teams/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.85,
+          "result": "pass",
+          "scenario": "plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.67,
+          "result": "pass",
+          "scenario": "portal/assets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 28.42,
+          "result": "pass",
+          "scenario": "portal/custom-domain/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.87,
+          "result": "pass",
+          "scenario": "portal/email-domains/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.2,
+          "result": "pass",
+          "scenario": "portal/identity_providers_duplicate_type/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.69,
+          "result": "pass",
+          "scenario": "portal/page-frontmatter-conflict/scenario.yaml"
+        },
+        {
+          "duration_seconds": 37.03,
+          "result": "pass",
+          "scenario": "portal/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.23,
+          "result": "pass",
+          "scenario": "protected-resources/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.7,
+          "result": "pass",
+          "scenario": "require-namespace/portal/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.61,
+          "result": "pass",
+          "scenario": "adopt/team-create-adopt-dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 20.82,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.64,
+          "result": "pass",
+          "scenario": "ai-gateway/model-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.97,
+          "result": "pass",
+          "scenario": "ai-gateway/runtime-tls/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.17,
+          "result": "pass",
+          "scenario": "apis/child-delete-namespace/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.99,
+          "result": "pass",
+          "scenario": "apis/region/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.69,
+          "result": "pass",
+          "scenario": "control-plane/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.94,
+          "result": "pass",
+          "scenario": "control-plane/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 17.5,
+          "result": "pass",
+          "scenario": "deck/basic/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.57,
+          "result": "pass",
+          "scenario": "declarative/plan-mode-validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.13,
+          "result": "pass",
+          "scenario": "delete/partial-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.19,
+          "result": "pass",
+          "scenario": "dump/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.46,
+          "result": "pass",
+          "scenario": "event-gateway/adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.45,
+          "result": "pass",
+          "scenario": "event-gateway/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.71,
+          "result": "pass",
+          "scenario": "event-gateway/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "event-gateway/principal-metadata/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.71,
+          "result": "pass",
+          "scenario": "event-gateway/topic-aliases/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.78,
+          "result": "pass",
+          "scenario": "external/api-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.01,
+          "result": "pass",
+          "scenario": "namespace/validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.63,
+          "result": "pass",
+          "scenario": "org/teams/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.45,
+          "result": "pass",
+          "scenario": "patch/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 34.71,
+          "result": "pass",
+          "scenario": "portal/api_docs_with_children/scenario.yaml"
+        },
+        {
+          "duration_seconds": 22.0,
+          "result": "pass",
+          "scenario": "portal/audit-log-webhook/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.81,
+          "result": "pass",
+          "scenario": "portal/customization/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.35,
+          "result": "pass",
+          "scenario": "portal/email-templates/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.61,
+          "result": "pass",
+          "scenario": "portal/idp_team_group_mappings_readback/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.66,
+          "result": "pass",
+          "scenario": "portal/pages/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.1,
+          "result": "pass",
+          "scenario": "portal/team_group_mappings_no_idp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.47,
+          "result": "pass",
+          "scenario": "protected-resources/event-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.0,
+          "result": "pass",
+          "scenario": "scaffold/command-coverage/scenario.yaml"
+        }
+      ],
+      "shard_admission_delay_seconds": {
+        "kongctl-acceptance": 2.0,
+        "kongctl-acceptance-2": 2.0,
+        "kongctl-acceptance-3": 4.0,
+        "kongctl-acceptance-4": 3.0,
+        "kongctl-acceptance-5": 3.0
+      },
+      "shard_spread_seconds": 217.0,
+      "shards": [
+        {
+          "execution_duration_seconds": 288,
+          "org_name": "kongctl-acceptance",
+          "selected_scenario_count": 43
+        },
+        {
+          "execution_duration_seconds": 197,
+          "org_name": "kongctl-acceptance-2",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 346,
+          "org_name": "kongctl-acceptance-3",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 414,
+          "org_name": "kongctl-acceptance-4",
+          "selected_scenario_count": 30
+        },
+        {
+          "execution_duration_seconds": 343,
+          "org_name": "kongctl-acceptance-5",
+          "selected_scenario_count": 30
+        }
+      ],
+      "url": "https://github.com/Kong/kongctl/actions/runs/34046778067",
+      "workflow_admission_delay_seconds": 73.0
+    },
+    {
+      "build_job_seconds": 58.0,
+      "build_kongctl_seconds": 12.0,
+      "build_scenario_binary_seconds": 6.0,
+      "build_setup_seconds": 22.0,
+      "cohort": "cache-enabled",
+      "created_at": "2026-09-06T16:40:27Z",
+      "harness_job_seconds": 57.0,
+      "harness_setup_seconds": 7.0,
+      "harness_test_seconds": 38.0,
+      "head_sha": "fa8c3e19df8e4c93a3aaf545e9e90066f16546c9",
+      "longest_shard_seconds": 343.0,
+      "original_created_at": "2026-09-06T16:40:27Z",
+      "queue_to_required_status_seconds": 701.0,
+      "reset": {
+        "count": 164,
+        "delete_calls": 103,
+        "delete_duration_ms": 7670,
+        "duration_ms": 296362,
+        "list_calls": 2459,
+        "list_duration_ms": 287183,
+        "resources_deleted": 84,
+        "resources_found": 1614
+      },
+      "run_attempt": 1,
+      "run_id": 34046202376,
+      "scenario_durations": [
+        {
+          "duration_seconds": 5.64,
+          "result": "pass",
+          "scenario": "adopt/auth-strategy-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.07,
+          "result": "pass",
+          "scenario": "ai-gateway/agent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.78,
+          "result": "pass",
+          "scenario": "ai-gateway/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.59,
+          "result": "pass",
+          "scenario": "ai-gateway/model/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.62,
+          "result": "pass",
+          "scenario": "ai-gateway/vault/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.8,
+          "result": "pass",
+          "scenario": "apis/comprehensive-fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.75,
+          "result": "pass",
+          "scenario": "apis/root-level-publication-visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.07,
+          "result": "pass",
+          "scenario": "control-plane/data-plane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.51,
+          "result": "pass",
+          "scenario": "control-plane/serverless/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.8,
+          "result": "pass",
+          "scenario": "deck/env-vars/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.85,
+          "result": "pass",
+          "scenario": "declarative/rename-sync-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.76,
+          "result": "pass",
+          "scenario": "delete/plan-based/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.45,
+          "result": "pass",
+          "scenario": "dump/dcr-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.79,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.77,
+          "result": "pass",
+          "scenario": "event-gateway/dataplane-certificate/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.21,
+          "result": "pass",
+          "scenario": "event-gateway/listener-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.22,
+          "result": "pass",
+          "scenario": "event-gateway/produce-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.05,
+          "result": "pass",
+          "scenario": "event-gateway/virtual-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.11,
+          "result": "pass",
+          "scenario": "external/portal-publication/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.1,
+          "result": "pass",
+          "scenario": "org/get-org/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.41,
+          "result": "pass",
+          "scenario": "org/teams/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.37,
+          "result": "pass",
+          "scenario": "plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.98,
+          "result": "pass",
+          "scenario": "portal/api_with_attributes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.27,
+          "result": "pass",
+          "scenario": "portal/auth-strategy-link/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.5,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.7,
+          "result": "pass",
+          "scenario": "portal/email/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.24,
+          "result": "pass",
+          "scenario": "portal/integrations/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.51,
+          "result": "pass",
+          "scenario": "portal/publication-auth-omitted-noop/scenario.yaml"
+        },
+        {
+          "duration_seconds": 16.11,
+          "result": "pass",
+          "scenario": "portal/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.76,
+          "result": "pass",
+          "scenario": "protected-resources/org/teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.07,
+          "result": "pass",
+          "scenario": "smoke/version/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.54,
+          "result": "pass",
+          "scenario": "apis/eventual-consistency-polp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.16,
+          "result": "pass",
+          "scenario": "dump/organization-teams/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.94,
+          "result": "pass",
+          "scenario": "org/system-accounts/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.39,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.08,
+          "result": "pass",
+          "scenario": "org/system-accounts/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.45,
+          "result": "pass",
+          "scenario": "org/system-accounts/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.15,
+          "result": "pass",
+          "scenario": "org/token/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.09,
+          "result": "pass",
+          "scenario": "org/users/assignments/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.69,
+          "result": "pass",
+          "scenario": "org/users/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.5,
+          "result": "pass",
+          "scenario": "org/users/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.5,
+          "result": "pass",
+          "scenario": "org/users/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.55,
+          "result": "pass",
+          "scenario": "org/users/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.01,
+          "result": "pass",
+          "scenario": "adopt/create-portal-adopt-dump-plan/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.63,
+          "result": "pass",
+          "scenario": "ai-gateway/auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.43,
+          "result": "pass",
+          "scenario": "ai-gateway/maturity/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.3,
+          "result": "pass",
+          "scenario": "ai-gateway/policy-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 19.47,
+          "result": "pass",
+          "scenario": "all/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.0,
+          "result": "pass",
+          "scenario": "apis/control-plane-implementation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.81,
+          "result": "pass",
+          "scenario": "apis/versions-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.2,
+          "result": "pass",
+          "scenario": "control-plane/delete-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.92,
+          "result": "pass",
+          "scenario": "control-plane/sync-groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.8,
+          "result": "pass",
+          "scenario": "deck/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.51,
+          "result": "pass",
+          "scenario": "delete/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.41,
+          "result": "pass",
+          "scenario": "diff/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.64,
+          "result": "pass",
+          "scenario": "dump/filtered/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.83,
+          "result": "pass",
+          "scenario": "event-gateway/backend-cluster/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.73,
+          "result": "pass",
+          "scenario": "event-gateway/dependency-order/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.76,
+          "result": "pass",
+          "scenario": "event-gateway/listener/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.5,
+          "result": "pass",
+          "scenario": "event-gateway/schema-registry/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.37,
+          "result": "pass",
+          "scenario": "explain/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.27,
+          "result": "pass",
+          "scenario": "external/portal-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.77,
+          "result": "pass",
+          "scenario": "org/system-accounts/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.79,
+          "result": "pass",
+          "scenario": "org/teams/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.96,
+          "result": "pass",
+          "scenario": "plan/remote-url-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.71,
+          "result": "pass",
+          "scenario": "portal/app-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.74,
+          "result": "pass",
+          "scenario": "portal/auth_settings/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.75,
+          "result": "pass",
+          "scenario": "portal/default_application_auth_strategy_ref_selection/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.84,
+          "result": "pass",
+          "scenario": "portal/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.22,
+          "result": "pass",
+          "scenario": "portal/ip-allow-list/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.43,
+          "result": "pass",
+          "scenario": "portal/snippets-pagination/scenario.yaml"
+        },
+        {
+          "duration_seconds": 27.65,
+          "result": "pass",
+          "scenario": "portal/visibility/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.47,
+          "result": "pass",
+          "scenario": "protected-resources/portals/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.88,
+          "result": "pass",
+          "scenario": "yaml-tags/env/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.2,
+          "result": "pass",
+          "scenario": "adopt/event-gateway-adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.49,
+          "result": "pass",
+          "scenario": "ai-gateway/config-store/scenario.yaml"
+        },
+        {
+          "duration_seconds": 23.5,
+          "result": "pass",
+          "scenario": "ai-gateway/mcp-server/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.71,
+          "result": "pass",
+          "scenario": "ai-gateway/policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.29,
+          "result": "pass",
+          "scenario": "analytics/dashboard-repro/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.92,
+          "result": "pass",
+          "scenario": "apis/get-api-by-name-and-id/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "auth/get-me/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.64,
+          "result": "pass",
+          "scenario": "control-plane/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.69,
+          "result": "pass",
+          "scenario": "control-plane/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.96,
+          "result": "pass",
+          "scenario": "deck/multi-file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.0,
+          "result": "pass",
+          "scenario": "delete/dry-run/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.72,
+          "result": "pass",
+          "scenario": "dump/ai-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 49.36,
+          "result": "pass",
+          "scenario": "dump/portal-owned/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.13,
+          "result": "pass",
+          "scenario": "event-gateway/cluster-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.49,
+          "result": "pass",
+          "scenario": "event-gateway/diff/scenario.yaml"
+        },
+        {
+          "duration_seconds": 32.51,
+          "result": "pass",
+          "scenario": "event-gateway/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 14.41,
+          "result": "pass",
+          "scenario": "event-gateway/static-key/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.85,
+          "result": "pass",
+          "scenario": "external/ai-gateway-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.35,
+          "result": "pass",
+          "scenario": "lint/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.08,
+          "result": "pass",
+          "scenario": "org/teams/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.57,
+          "result": "pass",
+          "scenario": "org/teams/roles/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.52,
+          "result": "pass",
+          "scenario": "plan/sync-partial-scope/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "portal/applications/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.19,
+          "result": "pass",
+          "scenario": "portal/auth_settings_deprecated_fields/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.37,
+          "result": "pass",
+          "scenario": "portal/edit/scenario.yaml"
+        },
+        {
+          "duration_seconds": 29.27,
+          "result": "pass",
+          "scenario": "portal/identity_providers/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.88,
+          "result": "pass",
+          "scenario": "portal/oidc-auth-strategy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.55,
+          "result": "pass",
+          "scenario": "portal/snippets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 13.93,
+          "result": "pass",
+          "scenario": "protected-resources/apis/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.74,
+          "result": "pass",
+          "scenario": "require-namespace/external/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.32,
+          "result": "pass",
+          "scenario": "yaml-tags/file/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.12,
+          "result": "pass",
+          "scenario": "adopt/full/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.47,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer-group/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.27,
+          "result": "pass",
+          "scenario": "ai-gateway/model-matrix/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.67,
+          "result": "pass",
+          "scenario": "ai-gateway/root/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.18,
+          "result": "pass",
+          "scenario": "analytics/dashboard/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.32,
+          "result": "pass",
+          "scenario": "apis/nested-child-lifecycle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.63,
+          "result": "pass",
+          "scenario": "catalog/service/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.17,
+          "result": "pass",
+          "scenario": "control-plane/groups/scenario.yaml"
+        },
+        {
+          "duration_seconds": 12.79,
+          "result": "pass",
+          "scenario": "dcr-providers/workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.79,
+          "result": "pass",
+          "scenario": "deck/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.99,
+          "result": "pass",
+          "scenario": "delete/idempotent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.71,
+          "result": "pass",
+          "scenario": "dump/analytics-dashboards/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.4,
+          "result": "pass",
+          "scenario": "errors/declarative/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.23,
+          "result": "pass",
+          "scenario": "event-gateway/consume-policy/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.02,
+          "result": "pass",
+          "scenario": "event-gateway/dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 22.68,
+          "result": "pass",
+          "scenario": "event-gateway/plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.37,
+          "result": "pass",
+          "scenario": "event-gateway/tls-trust-bundle/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.07,
+          "result": "pass",
+          "scenario": "external/api-impl/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.38,
+          "result": "pass",
+          "scenario": "namespace/defaults-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.11,
+          "result": "pass",
+          "scenario": "org/teams/external-role/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.18,
+          "result": "pass",
+          "scenario": "org/teams/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.6,
+          "result": "pass",
+          "scenario": "plan/sync-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.4,
+          "result": "pass",
+          "scenario": "portal/assets/scenario.yaml"
+        },
+        {
+          "duration_seconds": 15.33,
+          "result": "pass",
+          "scenario": "portal/custom-domain/scenario.yaml"
+        },
+        {
+          "duration_seconds": 1.59,
+          "result": "pass",
+          "scenario": "portal/email-domains/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.2,
+          "result": "pass",
+          "scenario": "portal/identity_providers_duplicate_type/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.75,
+          "result": "pass",
+          "scenario": "portal/page-frontmatter-conflict/scenario.yaml"
+        },
+        {
+          "duration_seconds": 19.67,
+          "result": "pass",
+          "scenario": "portal/sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.68,
+          "result": "pass",
+          "scenario": "protected-resources/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.86,
+          "result": "pass",
+          "scenario": "require-namespace/portal/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.52,
+          "result": "pass",
+          "scenario": "adopt/team-create-adopt-dump/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.41,
+          "result": "pass",
+          "scenario": "ai-gateway/consumer/scenario.yaml"
+        },
+        {
+          "duration_seconds": 9.0,
+          "result": "pass",
+          "scenario": "ai-gateway/model-provider/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.11,
+          "result": "pass",
+          "scenario": "ai-gateway/runtime-tls/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.25,
+          "result": "pass",
+          "scenario": "apis/child-delete-namespace/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.28,
+          "result": "pass",
+          "scenario": "apis/region/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.29,
+          "result": "pass",
+          "scenario": "control-plane/apply/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.52,
+          "result": "pass",
+          "scenario": "control-plane/plan/apply-workflow/scenario.yaml"
+        },
+        {
+          "duration_seconds": 8.61,
+          "result": "pass",
+          "scenario": "deck/basic/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.55,
+          "result": "pass",
+          "scenario": "declarative/plan-mode-validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.22,
+          "result": "pass",
+          "scenario": "delete/partial-delete/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.57,
+          "result": "pass",
+          "scenario": "dump/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.83,
+          "result": "pass",
+          "scenario": "event-gateway/adopt/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.06,
+          "result": "pass",
+          "scenario": "event-gateway/control-planes/scenario.yaml"
+        },
+        {
+          "duration_seconds": 11.95,
+          "result": "pass",
+          "scenario": "event-gateway/external-sync/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.0,
+          "result": "skip",
+          "scenario": "event-gateway/principal-metadata/scenario.yaml"
+        },
+        {
+          "duration_seconds": 4.98,
+          "result": "pass",
+          "scenario": "event-gateway/topic-aliases/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.37,
+          "result": "pass",
+          "scenario": "external/api-parent/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.81,
+          "result": "pass",
+          "scenario": "namespace/validation/scenario.yaml"
+        },
+        {
+          "duration_seconds": 2.84,
+          "result": "pass",
+          "scenario": "org/teams/get/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.44,
+          "result": "pass",
+          "scenario": "patch/command-coverage/scenario.yaml"
+        },
+        {
+          "duration_seconds": 18.7,
+          "result": "pass",
+          "scenario": "portal/api_docs_with_children/scenario.yaml"
+        },
+        {
+          "duration_seconds": 10.42,
+          "result": "pass",
+          "scenario": "portal/audit-log-webhook/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.24,
+          "result": "pass",
+          "scenario": "portal/customization/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.86,
+          "result": "pass",
+          "scenario": "portal/email-templates/scenario.yaml"
+        },
+        {
+          "duration_seconds": 6.35,
+          "result": "pass",
+          "scenario": "portal/idp_team_group_mappings_readback/scenario.yaml"
+        },
+        {
+          "duration_seconds": 7.38,
+          "result": "pass",
+          "scenario": "portal/pages/scenario.yaml"
+        },
+        {
+          "duration_seconds": 3.46,
+          "result": "pass",
+          "scenario": "portal/team_group_mappings_no_idp/scenario.yaml"
+        },
+        {
+          "duration_seconds": 5.51,
+          "result": "pass",
+          "scenario": "protected-resources/event-gateways/scenario.yaml"
+        },
+        {
+          "duration_seconds": 0.96,
+          "result": "pass",
+          "scenario": "scaffold/command-coverage/scenario.yaml"
+        }
+      ],
+      "shard_admission_delay_seconds": {
+        "kongctl-acceptance": 3.0,
+        "kongctl-acceptance-2": 2.0,
+        "kongctl-acceptance-3": 3.0,
+        "kongctl-acceptance-4": 4.0,
+        "kongctl-acceptance-5": 2.0
+      },
+      "shard_spread_seconds": 173.0,
+      "shards": [
+        {
+          "execution_duration_seconds": 291,
+          "org_name": "kongctl-acceptance",
+          "selected_scenario_count": 43
+        },
+        {
+          "execution_duration_seconds": 208,
+          "org_name": "kongctl-acceptance-2",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 343,
+          "org_name": "kongctl-acceptance-3",
+          "selected_scenario_count": 31
+        },
+        {
+          "execution_duration_seconds": 220,
+          "org_name": "kongctl-acceptance-4",
+          "selected_scenario_count": 30
+        },
+        {
+          "execution_duration_seconds": 170,
+          "org_name": "kongctl-acceptance-5",
+          "selected_scenario_count": 30
+        }
+      ],
+      "url": "https://github.com/Kong/kongctl/actions/runs/34046202376",
+      "workflow_admission_delay_seconds": 200.0
+    },
+    {
       "build_job_seconds": 55.0,
       "build_kongctl_seconds": 10.0,
       "build_scenario_binary_seconds": 6.0,

--- a/test/e2e/baselines/post-cache-2026-09.md
+++ b/test/e2e/baselines/post-cache-2026-09.md
@@ -3,8 +3,8 @@
 Repository: `kong/kongctl`
 Cohort: `cache-enabled`
 
-Full successful runs: 14 of 20
-Status: **collecting**
+Full successful runs: 20 of 20
+Status: **complete**
 
 The report scans successful `e2e.yaml` runs newest-first and retains only
 runs with a complete latest-attempt metrics manifest for every `.com` shard.
@@ -21,35 +21,41 @@ attempt; reruns are not independent samples.
 
 | Metric | p50 | p75 | p90 |
 | --- | ---: | ---: | ---: |
-| workflow_admission_delay_seconds | 4.0s | 30.0s | 546.0s |
-| queue_to_required_status_seconds | 657.0s | 912.0s | 1102.0s |
-| build_job_seconds | 49.0s | 55.0s | 64.0s |
-| build_kongctl_seconds | 4.0s | 8.0s | 11.0s |
-| build_scenario_binary_seconds | 1.0s | 5.0s | 6.0s |
-| build_setup_seconds | 22.0s | 25.0s | 29.0s |
-| harness_job_seconds | 72.0s | 75.0s | 78.0s |
+| workflow_admission_delay_seconds | 8.0s | 546.0s | 1292.0s |
+| queue_to_required_status_seconds | 701.0s | 1102.0s | 2031.0s |
+| build_job_seconds | 51.0s | 60.0s | 63.0s |
+| build_kongctl_seconds | 5.0s | 10.0s | 12.0s |
+| build_scenario_binary_seconds | 1.0s | 6.0s | 7.0s |
+| build_setup_seconds | 22.0s | 25.0s | 26.0s |
+| harness_job_seconds | 72.0s | 75.0s | 76.0s |
 | harness_setup_seconds | 10.0s | 10.0s | 11.0s |
 | harness_test_seconds | 51.0s | 53.0s | 53.0s |
-| longest_shard_seconds | 480.0s | 505.0s | 513.0s |
-| shard_spread_seconds | 267.0s | 332.0s | 346.0s |
+| longest_shard_seconds | 480.0s | 496.0s | 513.0s |
+| shard_spread_seconds | 256.0s | 331.0s | 346.0s |
 
 ## Reset cost per workflow run
 
 | Metric | p50 | p75 | p90 |
 | --- | ---: | ---: | ---: |
 | count | 164.0 | 164.0 | 164.0 |
-| duration_ms | 415210.0ms | 462432.0ms | 486068.0ms |
+| duration_ms | 418556.0ms | 450436.0ms | 475189.0ms |
 | list_calls | 2459.0 | 2459.0 | 2459.0 |
-| list_duration_ms | 404252.0ms | 450914.0ms | 474589.0ms |
+| list_duration_ms | 407132.0ms | 439797.0ms | 463423.0ms |
 | resources_found | 1614.0 | 1614.0 | 1614.0 |
 | delete_calls | 103.0 | 103.0 | 103.0 |
-| delete_duration_ms | 8984.0ms | 9985.0ms | 10082.0ms |
+| delete_duration_ms | 9186.0ms | 9552.0ms | 10082.0ms |
 | resources_deleted | 84.0 | 84.0 | 84.0 |
 
 ## Included runs
 
 | Run / Attempt | Attempt created | Queue-to-status | Build | Longest shard | Spread | Resets |
 | --- | --- | ---: | ---: | ---: | ---: | ---: |
+| [34047830584 / 1](https://github.com/Kong/kongctl/actions/runs/34047830584/attempts/1) | 2026-09-06T17:11:44Z | 2102s | 53s | 492s | 256s | 164 |
+| [34047278188 / 1](https://github.com/Kong/kongctl/actions/runs/34047278188/attempts/1) | 2026-09-06T17:01:21Z | 2058s | 52s | 414s | 254s | 164 |
+| [34046810193 / 1](https://github.com/Kong/kongctl/actions/runs/34046810193/attempts/1) | 2026-09-06T16:52:03Z | 2031s | 62s | 578s | 374s | 165 |
+| [34046799058 / 1](https://github.com/Kong/kongctl/actions/runs/34046799058/attempts/1) | 2026-09-06T16:51:52Z | 1300s | 62s | 493s | 331s | 164 |
+| [34046778067 / 1](https://github.com/Kong/kongctl/actions/runs/34046778067/attempts/1) | 2026-09-06T16:51:26Z | 663s | 63s | 414s | 217s | 164 |
+| [34046202376 / 1](https://github.com/Kong/kongctl/actions/runs/34046202376/attempts/1) | 2026-09-06T16:40:27Z | 701s | 58s | 343s | 173s | 164 |
 | [34026314755 / 1](https://github.com/Kong/kongctl/actions/runs/34026314755/attempts/1) | 2026-09-06T10:02:36Z | 535s | 55s | 359s | 180s | 164 |
 | [34007840146 / 1](https://github.com/Kong/kongctl/actions/runs/34007840146/attempts/1) | 2026-09-06T02:59:07Z | 539s | 64s | 357s | 65s | 164 |
 | [34006266279 / 1](https://github.com/Kong/kongctl/actions/runs/34006266279/attempts/1) | 2026-09-06T02:21:19Z | 1139s | 60s | 396s | 236s | 164 |
@@ -69,6 +75,36 @@ attempt; reruns are not independent samples.
 
 | Run | Organization | Admission delay | Selected | Execution |
 | --- | --- | ---: | ---: | ---: |
+| 34047830584 | `kongctl-acceptance` | 3s | 43 | 492s |
+| 34047830584 | `kongctl-acceptance-2` | 3s | 31 | 274s |
+| 34047830584 | `kongctl-acceptance-3` | 4s | 31 | 291s |
+| 34047830584 | `kongctl-acceptance-4` | 3s | 30 | 278s |
+| 34047830584 | `kongctl-acceptance-5` | 3s | 30 | 236s |
+| 34047278188 | `kongctl-acceptance` | 3s | 43 | 272s |
+| 34047278188 | `kongctl-acceptance-2` | 3s | 31 | 395s |
+| 34047278188 | `kongctl-acceptance-3` | 3s | 31 | 160s |
+| 34047278188 | `kongctl-acceptance-4` | 4s | 30 | 414s |
+| 34047278188 | `kongctl-acceptance-5` | 4s | 30 | 344s |
+| 34046810193 | `kongctl-acceptance` | 4s | 43 | 578s |
+| 34046810193 | `kongctl-acceptance-2` | 4s | 31 | 253s |
+| 34046810193 | `kongctl-acceptance-3` | 3s | 31 | 204s |
+| 34046810193 | `kongctl-acceptance-4` | 3s | 31 | 271s |
+| 34046810193 | `kongctl-acceptance-5` | 3s | 30 | 206s |
+| 34046799058 | `kongctl-acceptance` | 3s | 43 | 493s |
+| 34046799058 | `kongctl-acceptance-2` | 4s | 31 | 397s |
+| 34046799058 | `kongctl-acceptance-3` | 3s | 31 | 162s |
+| 34046799058 | `kongctl-acceptance-4` | 4s | 30 | 412s |
+| 34046799058 | `kongctl-acceptance-5` | 3s | 30 | 178s |
+| 34046778067 | `kongctl-acceptance` | 2s | 43 | 288s |
+| 34046778067 | `kongctl-acceptance-2` | 2s | 31 | 197s |
+| 34046778067 | `kongctl-acceptance-3` | 4s | 31 | 346s |
+| 34046778067 | `kongctl-acceptance-4` | 3s | 30 | 414s |
+| 34046778067 | `kongctl-acceptance-5` | 3s | 30 | 343s |
+| 34046202376 | `kongctl-acceptance` | 3s | 43 | 291s |
+| 34046202376 | `kongctl-acceptance-2` | 2s | 31 | 208s |
+| 34046202376 | `kongctl-acceptance-3` | 3s | 31 | 343s |
+| 34046202376 | `kongctl-acceptance-4` | 4s | 30 | 220s |
+| 34046202376 | `kongctl-acceptance-5` | 2s | 30 | 170s |
 | 34026314755 | `kongctl-acceptance` | 3s | 43 | 320s |
 | 34026314755 | `kongctl-acceptance-2` | 4s | 31 | 359s |
 | 34026314755 | `kongctl-acceptance-3` | 3s | 31 | 179s |
@@ -144,168 +180,169 @@ attempt; reruns are not independent samples.
 
 | Scenario | Samples | Median | p90 |
 | --- | ---: | ---: | ---: |
-| `portal/visibility/scenario.yaml` | 14 | 42.11s | 51.68s |
-| `dump/portal-owned/scenario.yaml` | 14 | 32.45s | 50.87s |
-| `portal/api_docs_with_children/scenario.yaml` | 14 | 30.21s | 35.43s |
-| `all/scenario.yaml` | 14 | 28.77s | 33.86s |
-| `event-gateway/produce-policy/scenario.yaml` | 14 | 26.12s | 28.33s |
-| `portal/teams/scenario.yaml` | 14 | 25.48s | 26.86s |
-| `event-gateway/plan/apply-workflow/scenario.yaml` | 14 | 21.15s | 32.47s |
-| `event-gateway/plan/sync-workflow/scenario.yaml` | 14 | 20.65s | 37.16s |
-| `portal/auth-strategy-link/scenario.yaml` | 14 | 20.07s | 21.23s |
-| `event-gateway/external-sync/scenario.yaml` | 14 | 20.01s | 24.07s |
-| `portal/identity_providers/scenario.yaml` | 14 | 20.00s | 29.18s |
-| `portal/audit-log-webhook/scenario.yaml` | 14 | 18.61s | 21.82s |
-| `portal/sync/scenario.yaml` | 14 | 17.82s | 32.14s |
-| `ai-gateway/consumer/scenario.yaml` | 14 | 16.84s | 20.31s |
-| `apis/root-level-publication-visibility/scenario.yaml` | 14 | 16.61s | 17.63s |
-| `dump/organization-teams/scenario.yaml` | 14 | 16.37s | 17.34s |
-| `portal/ip-allow-list/scenario.yaml` | 14 | 16.18s | 20.61s |
-| `org/users/assignments/scenario.yaml` | 14 | 15.73s | 17.12s |
-| `portal/custom-domain/scenario.yaml` | 14 | 15.55s | 23.25s |
-| `event-gateway/virtual-cluster/scenario.yaml` | 14 | 15.39s | 16.56s |
-| `ai-gateway/model-provider/scenario.yaml` | 14 | 15.38s | 18.46s |
-| `ai-gateway/mcp-server/scenario.yaml` | 14 | 15.22s | 23.76s |
-| `deck/basic/scenario.yaml` | 14 | 15.08s | 17.80s |
-| `apis/control-plane-implementation/scenario.yaml` | 14 | 14.96s | 18.38s |
-| `diff/command-coverage/scenario.yaml` | 14 | 14.70s | 17.95s |
-| `apis/nested-child-lifecycle/scenario.yaml` | 14 | 14.38s | 25.23s |
-| `event-gateway/backend-cluster/scenario.yaml` | 14 | 14.38s | 17.70s |
-| `ai-gateway/agent/scenario.yaml` | 14 | 14.19s | 15.50s |
-| `portal/email-templates/scenario.yaml` | 14 | 14.10s | 16.65s |
-| `org/system-accounts/assignments/scenario.yaml` | 14 | 13.93s | 14.96s |
-| `portal/email/scenario.yaml` | 14 | 13.64s | 14.52s |
-| `portal/external-sync/scenario.yaml` | 14 | 13.41s | 17.22s |
-| `dump/filtered/scenario.yaml` | 14 | 13.30s | 16.29s |
-| `portal/default_application_auth_strategy/scenario.yaml` | 14 | 12.97s | 13.79s |
-| `plan/apply-workflow/scenario.yaml` | 14 | 12.96s | 13.86s |
-| `yaml-tags/env/scenario.yaml` | 14 | 12.84s | 15.82s |
-| `control-plane/data-plane-certificate/scenario.yaml` | 14 | 12.74s | 13.83s |
-| `ai-gateway/data-plane-certificate/scenario.yaml` | 14 | 12.72s | 13.57s |
-| `event-gateway/consume-policy/scenario.yaml` | 14 | 12.72s | 23.82s |
-| `portal/pages/scenario.yaml` | 14 | 12.62s | 14.97s |
-| `control-plane/serverless/scenario.yaml` | 14 | 12.59s | 13.47s |
-| `declarative/rename-sync-delete/scenario.yaml` | 14 | 12.54s | 14.74s |
-| `ai-gateway/vault/scenario.yaml` | 14 | 12.49s | 13.35s |
-| `portal/customization/scenario.yaml` | 14 | 12.36s | 14.86s |
-| `event-gateway/listener-policy/scenario.yaml` | 14 | 12.22s | 13.14s |
-| `ai-gateway/auth-strategy/scenario.yaml` | 14 | 11.95s | 15.19s |
-| `external/api-parent/scenario.yaml` | 14 | 11.94s | 14.37s |
-| `dcr-providers/workflow/scenario.yaml` | 14 | 11.79s | 18.90s |
-| `apis/region/scenario.yaml` | 14 | 11.50s | 12.67s |
-| `org/users/sync/scenario.yaml` | 14 | 11.32s | 11.94s |
-| `org/users/plan/sync-workflow/scenario.yaml` | 14 | 11.22s | 12.05s |
-| `portal/idp_team_group_mappings_readback/scenario.yaml` | 14 | 11.10s | 12.85s |
-| `event-gateway/schema-registry/scenario.yaml` | 14 | 11.08s | 13.96s |
-| `portal/auth_settings/scenario.yaml` | 14 | 10.98s | 13.92s |
-| `apis/comprehensive-fields/scenario.yaml` | 14 | 10.75s | 11.62s |
-| `ai-gateway/config-store/scenario.yaml` | 14 | 10.71s | 15.92s |
-| `org/system-accounts/plan/sync-workflow/scenario.yaml` | 14 | 10.50s | 11.67s |
-| `ai-gateway/runtime-tls/scenario.yaml` | 14 | 10.49s | 12.10s |
-| `ai-gateway/model/scenario.yaml` | 14 | 10.47s | 11.37s |
-| `ai-gateway/policy-matrix/scenario.yaml` | 14 | 10.34s | 13.21s |
-| `portal/publication-auth-omitted-noop/scenario.yaml` | 14 | 10.29s | 11.85s |
-| `portal/integrations/scenario.yaml` | 14 | 10.17s | 11.01s |
-| `delete/declarative/scenario.yaml` | 14 | 10.04s | 12.61s |
-| `org/teams/roles/scenario.yaml` | 14 | 9.98s | 15.66s |
-| `org/system-accounts/sync/scenario.yaml` | 14 | 9.82s | 10.55s |
-| `apis/child-delete-namespace/scenario.yaml` | 14 | 9.78s | 11.43s |
-| `protected-resources/event-gateways/scenario.yaml` | 14 | 9.78s | 11.52s |
-| `dump/control-planes/scenario.yaml` | 14 | 9.68s | 11.30s |
-| `protected-resources/apis/scenario.yaml` | 14 | 9.56s | 14.45s |
-| `event-gateway/dataplane-certificate/scenario.yaml` | 14 | 9.51s | 10.67s |
-| `event-gateway/static-key/scenario.yaml` | 14 | 9.41s | 14.60s |
-| `portal/api_with_attributes/scenario.yaml` | 14 | 9.35s | 10.05s |
-| `event-gateway/diff/scenario.yaml` | 14 | 9.33s | 14.69s |
-| `event-gateway/listener/scenario.yaml` | 14 | 9.22s | 11.84s |
-| `event-gateway/topic-aliases/scenario.yaml` | 14 | 9.09s | 10.84s |
-| `protected-resources/portals/scenario.yaml` | 14 | 9.03s | 12.11s |
-| `ai-gateway/consumer-group/scenario.yaml` | 14 | 8.82s | 16.29s |
-| `external/portal-publication/scenario.yaml` | 14 | 8.73s | 9.73s |
-| `delete/partial-delete/scenario.yaml` | 14 | 8.68s | 10.22s |
-| `ai-gateway/root/scenario.yaml` | 14 | 8.63s | 13.69s |
-| `portal/app-auth-strategy/scenario.yaml` | 14 | 8.60s | 10.73s |
-| `event-gateway/cluster-policy/scenario.yaml` | 14 | 8.41s | 13.40s |
-| `org/token/scenario.yaml` | 14 | 8.33s | 8.68s |
-| `deck/env-vars/scenario.yaml` | 14 | 8.24s | 8.98s |
-| `event-gateway/control-planes/scenario.yaml` | 14 | 8.20s | 8.52s |
-| `org/users/plan/apply-workflow/scenario.yaml` | 14 | 7.97s | 9.08s |
-| `adopt/full/scenario.yaml` | 14 | 7.93s | 12.66s |
-| `org/system-accounts/plan/apply-workflow/scenario.yaml` | 14 | 7.92s | 8.54s |
-| `adopt/auth-strategy-adopt/scenario.yaml` | 14 | 7.55s | 8.50s |
-| `control-plane/sync-groups/scenario.yaml` | 14 | 7.52s | 9.15s |
-| `portal/team_group_mappings_no_idp/scenario.yaml` | 14 | 7.02s | 8.30s |
-| `external/ai-gateway-parent/scenario.yaml` | 14 | 6.66s | 11.06s |
-| `protected-resources/org/teams/scenario.yaml` | 14 | 6.66s | 7.37s |
-| `delete/plan-based/scenario.yaml` | 14 | 6.45s | 6.89s |
-| `plan/remote-url-workflow/scenario.yaml` | 14 | 6.43s | 7.73s |
-| `apis/eventual-consistency-polp/scenario.yaml` | 14 | 6.40s | 6.84s |
-| `event-gateway/dependency-order/scenario.yaml` | 14 | 6.35s | 7.98s |
-| `deck/idempotent/scenario.yaml` | 14 | 6.30s | 8.42s |
-| `portal/page-frontmatter-conflict/scenario.yaml` | 14 | 6.29s | 11.14s |
-| `adopt/create-portal-adopt-dump-plan/scenario.yaml` | 14 | 6.28s | 8.51s |
-| `portal/snippets/scenario.yaml` | 14 | 6.17s | 9.57s |
-| `control-plane/plan/apply-workflow/scenario.yaml` | 14 | 6.15s | 7.08s |
-| `catalog/service/scenario.yaml` | 14 | 5.99s | 10.64s |
-| `portal/edit/scenario.yaml` | 14 | 5.96s | 9.34s |
-| `org/teams/plan/apply-workflow/scenario.yaml` | 14 | 5.95s | 6.65s |
-| `org/teams/plan/sync-workflow/scenario.yaml` | 14 | 5.93s | 7.46s |
-| `adopt/team-create-adopt-dump/scenario.yaml` | 14 | 5.89s | 7.34s |
-| `portal/assets/scenario.yaml` | 14 | 5.89s | 10.74s |
-| `control-plane/apply/scenario.yaml` | 14 | 5.88s | 6.82s |
-| `adopt/event-gateway-adopt/scenario.yaml` | 14 | 5.82s | 8.24s |
-| `dump/dcr-provider/scenario.yaml` | 14 | 5.74s | 6.42s |
-| `org/teams/get/scenario.yaml` | 14 | 5.61s | 6.85s |
-| `event-gateway/adopt/scenario.yaml` | 14 | 5.57s | 6.58s |
-| `dump/ai-gateways/scenario.yaml` | 14 | 5.48s | 8.91s |
-| `plan/sync-partial-scope/scenario.yaml` | 14 | 5.37s | 8.57s |
-| `deck/sync/scenario.yaml` | 14 | 5.29s | 10.13s |
-| `org/teams/external-role/scenario.yaml` | 14 | 5.28s | 9.57s |
-| `org/users/get/scenario.yaml` | 14 | 5.27s | 6.04s |
-| `deck/multi-file/scenario.yaml` | 14 | 5.25s | 8.30s |
-| `analytics/dashboard/scenario.yaml` | 14 | 5.24s | 8.65s |
-| `require-namespace/portal/scenario.yaml` | 14 | 5.21s | 8.51s |
-| `control-plane/delete-groups/scenario.yaml` | 14 | 5.19s | 6.65s |
-| `portal/oidc-auth-strategy/scenario.yaml` | 14 | 5.18s | 7.96s |
-| `event-gateway/backend-cluster-pagination/scenario.yaml` | 14 | 5.15s | 5.79s |
-| `portal/default_application_auth_strategy_ref_selection/scenario.yaml` | 14 | 5.10s | 6.42s |
-| `apis/versions-pagination/scenario.yaml` | 14 | 4.97s | 5.91s |
-| `org/system-accounts/scenario.yaml` | 14 | 4.92s | 6.42s |
-| `ai-gateway/model-matrix/scenario.yaml` | 14 | 4.77s | 8.88s |
-| `external/portal-sync/scenario.yaml` | 14 | 4.71s | 6.08s |
-| `event-gateway/tls-trust-bundle/scenario.yaml` | 14 | 4.70s | 9.27s |
-| `external/api-impl/scenario.yaml` | 14 | 4.68s | 8.77s |
-| `control-plane/get/scenario.yaml` | 14 | 4.34s | 6.86s |
-| `ai-gateway/policy/scenario.yaml` | 14 | 4.33s | 5.76s |
-| `plan/sync-workflow/scenario.yaml` | 14 | 4.20s | 7.48s |
-| `org/get-org/scenario.yaml` | 14 | 4.15s | 4.81s |
-| `yaml-tags/file/scenario.yaml` | 14 | 4.12s | 6.48s |
-| `dump/analytics-dashboards/scenario.yaml` | 14 | 4.10s | 8.68s |
-| `apis/get-api-by-name-and-id/scenario.yaml` | 14 | 4.05s | 6.09s |
-| `portal/snippets-pagination/scenario.yaml` | 14 | 4.01s | 5.30s |
-| `delete/dry-run/scenario.yaml` | 14 | 3.81s | 6.15s |
-| `control-plane/groups/scenario.yaml` | 14 | 3.77s | 6.90s |
-| `org/teams/apply/scenario.yaml` | 14 | 3.72s | 6.19s |
-| `require-namespace/external/scenario.yaml` | 14 | 3.71s | 6.04s |
-| `event-gateway/dump/scenario.yaml` | 14 | 3.66s | 7.09s |
-| `control-plane/sync/scenario.yaml` | 14 | 3.61s | 5.80s |
-| `protected-resources/control-planes/scenario.yaml` | 14 | 3.34s | 6.41s |
-| `namespace/defaults-sync/scenario.yaml` | 14 | 3.15s | 5.89s |
-| `errors/declarative/scenario.yaml` | 14 | 3.08s | 4.78s |
-| `org/teams/sync/scenario.yaml` | 14 | 2.88s | 5.37s |
-| `delete/idempotent/scenario.yaml` | 14 | 1.85s | 4.12s |
-| `portal/email-domains/scenario.yaml` | 14 | 1.50s | 3.34s |
-| `explain/command-coverage/scenario.yaml` | 14 | 1.34s | 1.43s |
-| `analytics/dashboard-repro/scenario.yaml` | 14 | 1.03s | 1.31s |
-| `scaffold/command-coverage/scenario.yaml` | 14 | 0.98s | 1.00s |
-| `namespace/validation/scenario.yaml` | 14 | 0.91s | 1.06s |
-| `declarative/plan-mode-validation/scenario.yaml` | 14 | 0.57s | 0.59s |
-| `patch/command-coverage/scenario.yaml` | 14 | 0.46s | 0.47s |
-| `ai-gateway/maturity/scenario.yaml` | 14 | 0.42s | 0.45s |
-| `lint/command-coverage/scenario.yaml` | 14 | 0.34s | 0.35s |
-| `portal/auth_settings_deprecated_fields/scenario.yaml` | 14 | 0.19s | 0.19s |
-| `portal/identity_providers_duplicate_type/scenario.yaml` | 14 | 0.19s | 0.20s |
-| `smoke/version/scenario.yaml` | 14 | 0.06s | 0.07s |
-| `auth/get-me/scenario.yaml` | 14 | 0.00s | 0.00s |
-| `event-gateway/principal-metadata/scenario.yaml` | 14 | 0.00s | 0.00s |
-| `portal/applications/scenario.yaml` | 14 | 0.00s | 0.00s |
+| `dump/portal-owned/scenario.yaml` | 20 | 38.19s | 49.91s |
+| `portal/visibility/scenario.yaml` | 20 | 36.85s | 51.68s |
+| `portal/api_docs_with_children/scenario.yaml` | 20 | 30.21s | 35.43s |
+| `all/scenario.yaml` | 20 | 25.56s | 33.81s |
+| `event-gateway/plan/apply-workflow/scenario.yaml` | 20 | 24.17s | 32.47s |
+| `event-gateway/plan/sync-workflow/scenario.yaml` | 20 | 22.76s | 43.05s |
+| `event-gateway/produce-policy/scenario.yaml` | 20 | 22.56s | 28.05s |
+| `portal/identity_providers/scenario.yaml` | 20 | 22.29s | 29.18s |
+| `portal/teams/scenario.yaml` | 20 | 21.51s | 26.70s |
+| `ai-gateway/consumer-pagination/scenario.yaml` | 1 | 20.62s | 20.62s |
+| `event-gateway/external-sync/scenario.yaml` | 20 | 20.01s | 24.07s |
+| `portal/sync/scenario.yaml` | 20 | 19.67s | 36.91s |
+| `portal/audit-log-webhook/scenario.yaml` | 20 | 18.61s | 22.00s |
+| `ai-gateway/mcp-server/scenario.yaml` | 20 | 17.77s | 23.64s |
+| `portal/auth-strategy-link/scenario.yaml` | 20 | 17.09s | 21.19s |
+| `ai-gateway/consumer/scenario.yaml` | 20 | 16.84s | 20.37s |
+| `dump/organization-teams/scenario.yaml` | 20 | 16.18s | 17.34s |
+| `portal/custom-domain/scenario.yaml` | 20 | 16.18s | 26.61s |
+| `org/users/assignments/scenario.yaml` | 20 | 15.73s | 17.12s |
+| `ai-gateway/model-provider/scenario.yaml` | 20 | 15.38s | 18.64s |
+| `apis/nested-child-lifecycle/scenario.yaml` | 20 | 15.34s | 29.60s |
+| `deck/basic/scenario.yaml` | 20 | 15.34s | 17.83s |
+| `event-gateway/consume-policy/scenario.yaml` | 20 | 15.23s | 27.67s |
+| `apis/control-plane-implementation/scenario.yaml` | 20 | 14.78s | 18.38s |
+| `apis/root-level-publication-visibility/scenario.yaml` | 20 | 14.38s | 17.63s |
+| `ai-gateway/agent/scenario.yaml` | 20 | 14.19s | 15.50s |
+| `portal/email-templates/scenario.yaml` | 20 | 14.10s | 16.65s |
+| `portal/ip-allow-list/scenario.yaml` | 20 | 14.08s | 20.50s |
+| `org/system-accounts/assignments/scenario.yaml` | 20 | 13.93s | 14.96s |
+| `dcr-providers/workflow/scenario.yaml` | 20 | 12.80s | 21.12s |
+| `event-gateway/virtual-cluster/scenario.yaml` | 20 | 12.65s | 16.09s |
+| `portal/pages/scenario.yaml` | 20 | 12.62s | 14.97s |
+| `portal/customization/scenario.yaml` | 20 | 12.36s | 14.86s |
+| `diff/command-coverage/scenario.yaml` | 20 | 12.27s | 17.88s |
+| `org/teams/roles/scenario.yaml` | 20 | 11.97s | 15.63s |
+| `ai-gateway/consumer-group/scenario.yaml` | 20 | 11.95s | 18.65s |
+| `external/api-parent/scenario.yaml` | 20 | 11.94s | 14.37s |
+| `portal/external-sync/scenario.yaml` | 20 | 11.92s | 17.13s |
+| `event-gateway/backend-cluster/scenario.yaml` | 20 | 11.59s | 17.70s |
+| `portal/email/scenario.yaml` | 20 | 11.57s | 14.25s |
+| `apis/region/scenario.yaml` | 20 | 11.50s | 12.67s |
+| `org/users/sync/scenario.yaml` | 20 | 11.32s | 11.94s |
+| `dump/filtered/scenario.yaml` | 20 | 11.26s | 16.29s |
+| `event-gateway/diff/scenario.yaml` | 20 | 11.26s | 14.67s |
+| `org/users/plan/sync-workflow/scenario.yaml` | 20 | 11.22s | 12.05s |
+| `portal/default_application_auth_strategy/scenario.yaml` | 20 | 11.21s | 13.73s |
+| `portal/idp_team_group_mappings_readback/scenario.yaml` | 20 | 11.10s | 13.05s |
+| `plan/apply-workflow/scenario.yaml` | 20 | 11.02s | 13.86s |
+| `event-gateway/static-key/scenario.yaml` | 20 | 10.94s | 14.55s |
+| `control-plane/data-plane-certificate/scenario.yaml` | 20 | 10.80s | 13.52s |
+| `ai-gateway/vault/scenario.yaml` | 20 | 10.77s | 13.14s |
+| `yaml-tags/env/scenario.yaml` | 20 | 10.75s | 15.69s |
+| `protected-resources/apis/scenario.yaml` | 20 | 10.72s | 14.24s |
+| `ai-gateway/config-store/scenario.yaml` | 20 | 10.71s | 15.86s |
+| `control-plane/serverless/scenario.yaml` | 20 | 10.67s | 13.31s |
+| `event-gateway/listener-policy/scenario.yaml` | 20 | 10.64s | 12.88s |
+| `declarative/rename-sync-delete/scenario.yaml` | 20 | 10.55s | 13.56s |
+| `ai-gateway/data-plane-certificate/scenario.yaml` | 20 | 10.54s | 13.57s |
+| `org/system-accounts/plan/sync-workflow/scenario.yaml` | 20 | 10.50s | 11.67s |
+| `ai-gateway/runtime-tls/scenario.yaml` | 20 | 10.49s | 12.32s |
+| `ai-gateway/policy-matrix/scenario.yaml` | 20 | 10.34s | 13.09s |
+| `ai-gateway/auth-strategy/scenario.yaml` | 20 | 10.27s | 14.96s |
+| `adopt/full/scenario.yaml` | 20 | 10.15s | 13.85s |
+| `event-gateway/cluster-policy/scenario.yaml` | 20 | 9.89s | 13.26s |
+| `org/system-accounts/sync/scenario.yaml` | 20 | 9.82s | 10.55s |
+| `apis/child-delete-namespace/scenario.yaml` | 20 | 9.78s | 11.48s |
+| `protected-resources/event-gateways/scenario.yaml` | 20 | 9.78s | 11.52s |
+| `portal/auth_settings/scenario.yaml` | 20 | 9.74s | 13.64s |
+| `dump/control-planes/scenario.yaml` | 20 | 9.68s | 11.40s |
+| `apis/comprehensive-fields/scenario.yaml` | 20 | 9.18s | 11.41s |
+| `delete/declarative/scenario.yaml` | 20 | 9.09s | 12.61s |
+| `event-gateway/schema-registry/scenario.yaml` | 20 | 9.09s | 13.96s |
+| `event-gateway/topic-aliases/scenario.yaml` | 20 | 9.09s | 10.84s |
+| `portal/publication-auth-omitted-noop/scenario.yaml` | 20 | 9.01s | 11.19s |
+| `ai-gateway/root/scenario.yaml` | 20 | 8.97s | 15.38s |
+| `ai-gateway/model/scenario.yaml` | 20 | 8.74s | 11.14s |
+| `delete/partial-delete/scenario.yaml` | 20 | 8.68s | 10.26s |
+| `event-gateway/dataplane-certificate/scenario.yaml` | 20 | 8.63s | 10.28s |
+| `portal/integrations/scenario.yaml` | 20 | 8.56s | 10.65s |
+| `event-gateway/control-planes/scenario.yaml` | 20 | 8.20s | 8.52s |
+| `external/ai-gateway-parent/scenario.yaml` | 20 | 8.18s | 11.06s |
+| `org/token/scenario.yaml` | 20 | 8.10s | 8.68s |
+| `org/users/plan/apply-workflow/scenario.yaml` | 20 | 7.97s | 9.08s |
+| `org/system-accounts/plan/apply-workflow/scenario.yaml` | 20 | 7.92s | 8.54s |
+| `portal/api_with_attributes/scenario.yaml` | 20 | 7.92s | 9.99s |
+| `protected-resources/portals/scenario.yaml` | 20 | 7.88s | 11.68s |
+| `external/portal-publication/scenario.yaml` | 20 | 7.67s | 9.46s |
+| `event-gateway/listener/scenario.yaml` | 20 | 7.58s | 11.82s |
+| `adopt/auth-strategy-adopt/scenario.yaml` | 20 | 7.55s | 8.71s |
+| `control-plane/sync-groups/scenario.yaml` | 20 | 7.52s | 9.15s |
+| `portal/app-auth-strategy/scenario.yaml` | 20 | 7.28s | 10.71s |
+| `portal/edit/scenario.yaml` | 20 | 7.17s | 9.36s |
+| `portal/snippets/scenario.yaml` | 20 | 7.15s | 9.57s |
+| `portal/team_group_mappings_no_idp/scenario.yaml` | 20 | 7.02s | 8.30s |
+| `portal/page-frontmatter-conflict/scenario.yaml` | 20 | 6.82s | 12.69s |
+| `deck/env-vars/scenario.yaml` | 20 | 6.74s | 8.85s |
+| `catalog/service/scenario.yaml` | 20 | 6.63s | 11.74s |
+| `dump/ai-gateways/scenario.yaml` | 20 | 6.62s | 8.85s |
+| `deck/multi-file/scenario.yaml` | 20 | 6.54s | 8.30s |
+| `portal/assets/scenario.yaml` | 20 | 6.49s | 12.40s |
+| `plan/sync-partial-scope/scenario.yaml` | 20 | 6.46s | 8.57s |
+| `apis/eventual-consistency-polp/scenario.yaml` | 20 | 6.38s | 6.84s |
+| `control-plane/plan/apply-workflow/scenario.yaml` | 20 | 6.25s | 7.08s |
+| `adopt/create-portal-adopt-dump-plan/scenario.yaml` | 20 | 6.07s | 8.35s |
+| `portal/oidc-auth-strategy/scenario.yaml` | 20 | 6.07s | 7.89s |
+| `deck/sync/scenario.yaml` | 20 | 5.92s | 11.76s |
+| `control-plane/apply/scenario.yaml` | 20 | 5.88s | 6.82s |
+| `require-namespace/portal/scenario.yaml` | 20 | 5.86s | 9.65s |
+| `adopt/event-gateway-adopt/scenario.yaml` | 20 | 5.82s | 8.20s |
+| `org/teams/get/scenario.yaml` | 20 | 5.61s | 6.85s |
+| `adopt/team-create-adopt-dump/scenario.yaml` | 20 | 5.57s | 6.94s |
+| `event-gateway/adopt/scenario.yaml` | 20 | 5.57s | 6.60s |
+| `protected-resources/org/teams/scenario.yaml` | 20 | 5.44s | 7.31s |
+| `org/teams/external-role/scenario.yaml` | 20 | 5.42s | 11.09s |
+| `analytics/dashboard/scenario.yaml` | 20 | 5.37s | 9.72s |
+| `event-gateway/tls-trust-bundle/scenario.yaml` | 20 | 5.37s | 10.43s |
+| `event-gateway/dependency-order/scenario.yaml` | 20 | 5.36s | 7.98s |
+| `delete/plan-based/scenario.yaml` | 20 | 5.34s | 6.85s |
+| `plan/remote-url-workflow/scenario.yaml` | 20 | 5.33s | 7.73s |
+| `ai-gateway/model-matrix/scenario.yaml` | 20 | 5.27s | 10.45s |
+| `org/users/get/scenario.yaml` | 20 | 5.27s | 6.04s |
+| `external/api-impl/scenario.yaml` | 20 | 5.14s | 9.83s |
+| `deck/idempotent/scenario.yaml` | 20 | 5.09s | 7.82s |
+| `control-plane/get/scenario.yaml` | 20 | 5.08s | 6.86s |
+| `dump/dcr-provider/scenario.yaml` | 20 | 4.96s | 6.26s |
+| `org/teams/plan/apply-workflow/scenario.yaml` | 20 | 4.94s | 6.42s |
+| `portal/default_application_auth_strategy_ref_selection/scenario.yaml` | 20 | 4.93s | 6.41s |
+| `yaml-tags/file/scenario.yaml` | 20 | 4.77s | 6.41s |
+| `org/teams/apply/scenario.yaml` | 20 | 4.75s | 6.18s |
+| `org/teams/plan/sync-workflow/scenario.yaml` | 20 | 4.75s | 7.32s |
+| `dump/analytics-dashboards/scenario.yaml` | 20 | 4.71s | 9.93s |
+| `delete/dry-run/scenario.yaml` | 20 | 4.67s | 6.15s |
+| `apis/get-api-by-name-and-id/scenario.yaml` | 20 | 4.64s | 6.09s |
+| `plan/sync-workflow/scenario.yaml` | 20 | 4.60s | 8.63s |
+| `ai-gateway/policy/scenario.yaml` | 20 | 4.46s | 5.72s |
+| `control-plane/delete-groups/scenario.yaml` | 20 | 4.33s | 6.46s |
+| `require-namespace/external/scenario.yaml` | 20 | 4.33s | 5.91s |
+| `control-plane/sync/scenario.yaml` | 20 | 4.32s | 5.80s |
+| `event-gateway/backend-cluster-pagination/scenario.yaml` | 20 | 4.32s | 5.63s |
+| `control-plane/groups/scenario.yaml` | 20 | 4.17s | 7.96s |
+| `org/get-org/scenario.yaml` | 20 | 4.10s | 4.59s |
+| `event-gateway/dump/scenario.yaml` | 20 | 4.05s | 8.39s |
+| `org/system-accounts/scenario.yaml` | 20 | 3.99s | 6.42s |
+| `apis/versions-pagination/scenario.yaml` | 20 | 3.95s | 5.91s |
+| `external/portal-sync/scenario.yaml` | 20 | 3.86s | 5.95s |
+| `protected-resources/control-planes/scenario.yaml` | 20 | 3.85s | 7.17s |
+| `portal/snippets-pagination/scenario.yaml` | 20 | 3.69s | 5.24s |
+| `errors/declarative/scenario.yaml` | 20 | 3.40s | 5.33s |
+| `namespace/defaults-sync/scenario.yaml` | 20 | 3.38s | 6.41s |
+| `org/teams/sync/scenario.yaml` | 20 | 3.18s | 6.12s |
+| `delete/idempotent/scenario.yaml` | 20 | 2.03s | 4.53s |
+| `portal/email-domains/scenario.yaml` | 20 | 1.59s | 3.85s |
+| `explain/command-coverage/scenario.yaml` | 20 | 1.37s | 1.43s |
+| `analytics/dashboard-repro/scenario.yaml` | 20 | 1.03s | 1.32s |
+| `scaffold/command-coverage/scenario.yaml` | 20 | 0.98s | 1.00s |
+| `namespace/validation/scenario.yaml` | 20 | 0.91s | 1.04s |
+| `declarative/plan-mode-validation/scenario.yaml` | 20 | 0.57s | 0.58s |
+| `patch/command-coverage/scenario.yaml` | 20 | 0.45s | 0.47s |
+| `ai-gateway/maturity/scenario.yaml` | 20 | 0.43s | 0.44s |
+| `lint/command-coverage/scenario.yaml` | 20 | 0.34s | 0.35s |
+| `portal/auth_settings_deprecated_fields/scenario.yaml` | 20 | 0.19s | 0.19s |
+| `portal/identity_providers_duplicate_type/scenario.yaml` | 20 | 0.19s | 0.20s |
+| `smoke/version/scenario.yaml` | 20 | 0.06s | 0.07s |
+| `auth/get-me/scenario.yaml` | 20 | 0.00s | 0.00s |
+| `event-gateway/principal-metadata/scenario.yaml` | 20 | 0.00s | 0.00s |
+| `portal/applications/scenario.yaml` | 20 | 0.00s | 0.00s |

--- a/test/e2e/baselines/scenario-weights.json
+++ b/test/e2e/baselines/scenario-weights.json
@@ -1,662 +1,660 @@
 {
-  "default_duration_ms": 8840,
+  "default_duration_ms": 8402,
   "scenarios": {
     "adopt/auth-strategy-adopt/scenario.yaml": {
-      "duration_ms": 8310,
-      "samples": 21
+      "duration_ms": 7725,
+      "samples": 20
     },
     "adopt/create-portal-adopt-dump-plan/scenario.yaml": {
-      "duration_ms": 6280,
-      "samples": 21
+      "duration_ms": 6175,
+      "samples": 20
     },
     "adopt/event-gateway-adopt/scenario.yaml": {
-      "duration_ms": 6100,
-      "samples": 21
+      "duration_ms": 5930,
+      "samples": 20
     },
     "adopt/full/scenario.yaml": {
-      "duration_ms": 10490,
-      "samples": 21
+      "duration_ms": 10205,
+      "samples": 20
     },
     "adopt/team-create-adopt-dump/scenario.yaml": {
-      "duration_ms": 5570,
-      "samples": 21
+      "duration_ms": 5730,
+      "samples": 20
     },
     "ai-gateway/agent/scenario.yaml": {
-      "duration_ms": 15000,
-      "samples": 21
+      "duration_ms": 14420,
+      "samples": 20
     },
     "ai-gateway/auth-strategy/scenario.yaml": {
-      "duration_ms": 11950,
-      "samples": 21
+      "duration_ms": 11110,
+      "samples": 20
     },
     "ai-gateway/config-store/scenario.yaml": {
-      "duration_ms": 10710,
-      "samples": 21
+      "duration_ms": 11645,
+      "samples": 20
     },
     "ai-gateway/consumer-group/scenario.yaml": {
-      "duration_ms": 12240,
-      "samples": 21
+      "duration_ms": 12095,
+      "samples": 20
     },
     "ai-gateway/consumer/scenario.yaml": {
-      "duration_ms": 16840,
-      "samples": 21
+      "duration_ms": 17085,
+      "samples": 20
     },
     "ai-gateway/data-plane-certificate/scenario.yaml": {
-      "duration_ms": 12970,
-      "samples": 21
+      "duration_ms": 11550,
+      "samples": 20
     },
     "ai-gateway/maturity/scenario.yaml": {
       "duration_ms": 430,
-      "samples": 21
+      "samples": 20
     },
     "ai-gateway/mcp-server/scenario.yaml": {
-      "duration_ms": 15220,
-      "samples": 21
+      "duration_ms": 18620,
+      "samples": 20
     },
     "ai-gateway/model-matrix/scenario.yaml": {
-      "duration_ms": 6870,
-      "samples": 21
+      "duration_ms": 5740,
+      "samples": 20
     },
     "ai-gateway/model-provider/scenario.yaml": {
-      "duration_ms": 15360,
-      "samples": 21
+      "duration_ms": 15550,
+      "samples": 20
     },
     "ai-gateway/model/scenario.yaml": {
-      "duration_ms": 10700,
-      "samples": 21
+      "duration_ms": 9605,
+      "samples": 20
     },
     "ai-gateway/policy-matrix/scenario.yaml": {
-      "duration_ms": 10340,
-      "samples": 21
+      "duration_ms": 10510,
+      "samples": 20
     },
     "ai-gateway/policy/scenario.yaml": {
-      "duration_ms": 3760,
-      "samples": 21
+      "duration_ms": 4600,
+      "samples": 20
     },
     "ai-gateway/root/scenario.yaml": {
-      "duration_ms": 10320,
-      "samples": 21
+      "duration_ms": 9480,
+      "samples": 20
     },
     "ai-gateway/runtime-tls/scenario.yaml": {
-      "duration_ms": 10250,
-      "samples": 21
+      "duration_ms": 10615,
+      "samples": 20
     },
     "ai-gateway/vault/scenario.yaml": {
-      "duration_ms": 13040,
-      "samples": 21
+      "duration_ms": 11630,
+      "samples": 20
     },
     "all/scenario.yaml": {
-      "duration_ms": 28770,
-      "samples": 21
+      "duration_ms": 27165,
+      "samples": 20
     },
     "analytics/dashboard-repro/scenario.yaml": {
-      "duration_ms": 1040,
-      "samples": 21
+      "duration_ms": 1035,
+      "samples": 20
     },
     "analytics/dashboard/scenario.yaml": {
-      "duration_ms": 6450,
-      "samples": 21
+      "duration_ms": 5745,
+      "samples": 20
     },
     "apis/child-delete-namespace/scenario.yaml": {
-      "duration_ms": 9700,
-      "samples": 21
+      "duration_ms": 9790,
+      "samples": 20
     },
     "apis/comprehensive-fields/scenario.yaml": {
-      "duration_ms": 11110,
-      "samples": 21
+      "duration_ms": 9965,
+      "samples": 20
     },
     "apis/control-plane-implementation/scenario.yaml": {
-      "duration_ms": 14960,
-      "samples": 21
+      "duration_ms": 14870,
+      "samples": 20
     },
     "apis/eventual-consistency-polp/scenario.yaml": {
-      "duration_ms": 6660,
-      "samples": 21
+      "duration_ms": 6390,
+      "samples": 20
     },
     "apis/get-api-by-name-and-id/scenario.yaml": {
-      "duration_ms": 3960,
-      "samples": 21
+      "duration_ms": 4690,
+      "samples": 20
     },
     "apis/nested-child-lifecycle/scenario.yaml": {
-      "duration_ms": 19010,
-      "samples": 21
+      "duration_ms": 17100,
+      "samples": 20
     },
     "apis/region/scenario.yaml": {
-      "duration_ms": 11370,
-      "samples": 21
+      "duration_ms": 11595,
+      "samples": 20
     },
     "apis/root-level-publication-visibility/scenario.yaml": {
-      "duration_ms": 17420,
-      "samples": 21
+      "duration_ms": 15495,
+      "samples": 20
     },
     "apis/versions-pagination/scenario.yaml": {
-      "duration_ms": 4970,
-      "samples": 21
+      "duration_ms": 4460,
+      "samples": 20
     },
     "catalog/service/scenario.yaml": {
-      "duration_ms": 7850,
-      "samples": 21
+      "duration_ms": 7175,
+      "samples": 20
     },
     "control-plane/apply/scenario.yaml": {
-      "duration_ms": 5840,
-      "samples": 21
+      "duration_ms": 5945,
+      "samples": 20
     },
     "control-plane/data-plane-certificate/scenario.yaml": {
-      "duration_ms": 13160,
-      "samples": 21
+      "duration_ms": 11700,
+      "samples": 20
     },
     "control-plane/delete-groups/scenario.yaml": {
-      "duration_ms": 5190,
-      "samples": 21
+      "duration_ms": 4760,
+      "samples": 20
     },
     "control-plane/get/scenario.yaml": {
-      "duration_ms": 4390,
-      "samples": 21
+      "duration_ms": 5325,
+      "samples": 20
     },
     "control-plane/groups/scenario.yaml": {
-      "duration_ms": 5270,
-      "samples": 21
+      "duration_ms": 4520,
+      "samples": 20
     },
     "control-plane/plan/apply-workflow/scenario.yaml": {
-      "duration_ms": 6050,
-      "samples": 21
+      "duration_ms": 6555,
+      "samples": 20
     },
     "control-plane/serverless/scenario.yaml": {
-      "duration_ms": 12830,
-      "samples": 21
+      "duration_ms": 11415,
+      "samples": 20
     },
     "control-plane/sync-groups/scenario.yaml": {
       "duration_ms": 7520,
-      "samples": 21
+      "samples": 20
     },
     "control-plane/sync/scenario.yaml": {
-      "duration_ms": 3680,
-      "samples": 21
+      "duration_ms": 4435,
+      "samples": 20
     },
     "dcr-providers/workflow/scenario.yaml": {
-      "duration_ms": 16020,
-      "samples": 21
+      "duration_ms": 13500,
+      "samples": 20
     },
     "deck/basic/scenario.yaml": {
-      "duration_ms": 15000,
-      "samples": 21
+      "duration_ms": 15470,
+      "samples": 20
     },
     "deck/env-vars/scenario.yaml": {
-      "duration_ms": 8710,
-      "samples": 21
+      "duration_ms": 7490,
+      "samples": 20
     },
     "deck/idempotent/scenario.yaml": {
-      "duration_ms": 6300,
-      "samples": 21
+      "duration_ms": 5695,
+      "samples": 20
     },
     "deck/multi-file/scenario.yaml": {
-      "duration_ms": 5070,
-      "samples": 21
+      "duration_ms": 6715,
+      "samples": 20
     },
     "deck/sync/scenario.yaml": {
-      "duration_ms": 7670,
-      "samples": 21
+      "duration_ms": 6625,
+      "samples": 20
     },
     "declarative/plan-mode-validation/scenario.yaml": {
       "duration_ms": 570,
-      "samples": 21
+      "samples": 20
     },
     "declarative/rename-sync-delete/scenario.yaml": {
-      "duration_ms": 13310,
-      "samples": 21
+      "duration_ms": 11545,
+      "samples": 20
     },
     "delete/declarative/scenario.yaml": {
-      "duration_ms": 10040,
-      "samples": 21
+      "duration_ms": 9565,
+      "samples": 20
     },
     "delete/dry-run/scenario.yaml": {
-      "duration_ms": 3870,
-      "samples": 21
+      "duration_ms": 4865,
+      "samples": 20
     },
     "delete/idempotent/scenario.yaml": {
-      "duration_ms": 2790,
-      "samples": 21
+      "duration_ms": 2360,
+      "samples": 20
     },
     "delete/partial-delete/scenario.yaml": {
-      "duration_ms": 8580,
-      "samples": 21
+      "duration_ms": 8845,
+      "samples": 20
     },
     "delete/plan-based/scenario.yaml": {
-      "duration_ms": 6630,
-      "samples": 21
+      "duration_ms": 5895,
+      "samples": 20
     },
     "diff/command-coverage/scenario.yaml": {
-      "duration_ms": 14700,
-      "samples": 21
+      "duration_ms": 13485,
+      "samples": 20
     },
     "dump/ai-gateways/scenario.yaml": {
-      "duration_ms": 5540,
-      "samples": 21
+      "duration_ms": 6870,
+      "samples": 20
     },
     "dump/analytics-dashboards/scenario.yaml": {
-      "duration_ms": 6270,
-      "samples": 21
+      "duration_ms": 5380,
+      "samples": 20
     },
     "dump/control-planes/scenario.yaml": {
-      "duration_ms": 9560,
-      "samples": 21
+      "duration_ms": 9710,
+      "samples": 20
     },
     "dump/dcr-provider/scenario.yaml": {
-      "duration_ms": 6020,
-      "samples": 21
+      "duration_ms": 5350,
+      "samples": 20
     },
     "dump/filtered/scenario.yaml": {
-      "duration_ms": 13300,
-      "samples": 21
+      "duration_ms": 12280,
+      "samples": 20
     },
     "dump/organization-teams/scenario.yaml": {
-      "duration_ms": 16880,
-      "samples": 21
+      "duration_ms": 16275,
+      "samples": 20
     },
     "dump/portal-owned/scenario.yaml": {
-      "duration_ms": 33460,
-      "samples": 21
+      "duration_ms": 38735,
+      "samples": 20
     },
     "errors/declarative/scenario.yaml": {
-      "duration_ms": 3930,
-      "samples": 21
+      "duration_ms": 3425,
+      "samples": 20
     },
     "event-gateway/adopt/scenario.yaml": {
-      "duration_ms": 5520,
-      "samples": 21
+      "duration_ms": 5600,
+      "samples": 20
     },
     "event-gateway/backend-cluster-pagination/scenario.yaml": {
-      "duration_ms": 5430,
-      "samples": 21
+      "duration_ms": 4700,
+      "samples": 20
     },
     "event-gateway/backend-cluster/scenario.yaml": {
-      "duration_ms": 14380,
-      "samples": 21
+      "duration_ms": 12985,
+      "samples": 20
     },
     "event-gateway/cluster-policy/scenario.yaml": {
-      "duration_ms": 8560,
-      "samples": 21
+      "duration_ms": 10190,
+      "samples": 20
     },
     "event-gateway/consume-policy/scenario.yaml": {
-      "duration_ms": 18060,
-      "samples": 21
+      "duration_ms": 16230,
+      "samples": 20
     },
     "event-gateway/control-planes/scenario.yaml": {
-      "duration_ms": 7220,
-      "samples": 21
+      "duration_ms": 8295,
+      "samples": 20
     },
     "event-gateway/dataplane-certificate/scenario.yaml": {
-      "duration_ms": 10100,
-      "samples": 21
+      "duration_ms": 9070,
+      "samples": 20
     },
     "event-gateway/dependency-order/scenario.yaml": {
-      "duration_ms": 6350,
-      "samples": 21
+      "duration_ms": 5855,
+      "samples": 20
     },
     "event-gateway/diff/scenario.yaml": {
-      "duration_ms": 9330,
-      "samples": 21
+      "duration_ms": 11490,
+      "samples": 20
     },
     "event-gateway/dump/scenario.yaml": {
-      "duration_ms": 5330,
-      "samples": 21
+      "duration_ms": 4590,
+      "samples": 20
     },
     "event-gateway/external-sync/scenario.yaml": {
-      "duration_ms": 19820,
-      "samples": 21
+      "duration_ms": 20300,
+      "samples": 20
     },
     "event-gateway/listener-policy/scenario.yaml": {
-      "duration_ms": 12640,
-      "samples": 21
+      "duration_ms": 11430,
+      "samples": 20
     },
     "event-gateway/listener/scenario.yaml": {
-      "duration_ms": 9220,
-      "samples": 21
+      "duration_ms": 8400,
+      "samples": 20
     },
     "event-gateway/plan/apply-workflow/scenario.yaml": {
-      "duration_ms": 21250,
-      "samples": 21
+      "duration_ms": 24855,
+      "samples": 20
     },
     "event-gateway/plan/sync-workflow/scenario.yaml": {
-      "duration_ms": 28680,
-      "samples": 21
+      "duration_ms": 25090,
+      "samples": 20
     },
     "event-gateway/produce-policy/scenario.yaml": {
-      "duration_ms": 26860,
-      "samples": 21
+      "duration_ms": 24340,
+      "samples": 20
     },
     "event-gateway/schema-registry/scenario.yaml": {
-      "duration_ms": 11080,
-      "samples": 21
+      "duration_ms": 10085,
+      "samples": 20
     },
     "event-gateway/static-key/scenario.yaml": {
-      "duration_ms": 9410,
-      "samples": 21
+      "duration_ms": 11315,
+      "samples": 20
     },
     "event-gateway/tls-trust-bundle/scenario.yaml": {
-      "duration_ms": 6730,
-      "samples": 21
+      "duration_ms": 5895,
+      "samples": 20
     },
     "event-gateway/topic-aliases/scenario.yaml": {
-      "duration_ms": 8970,
-      "samples": 21
+      "duration_ms": 9160,
+      "samples": 20
     },
     "event-gateway/virtual-cluster/scenario.yaml": {
-      "duration_ms": 15560,
-      "samples": 21
+      "duration_ms": 13865,
+      "samples": 20
     },
     "explain/command-coverage/scenario.yaml": {
-      "duration_ms": 1360,
-      "samples": 21
+      "duration_ms": 1375,
+      "samples": 20
     },
     "external/ai-gateway-parent/scenario.yaml": {
-      "duration_ms": 6640,
-      "samples": 21
+      "duration_ms": 8405,
+      "samples": 20
     },
     "external/api-impl/scenario.yaml": {
-      "duration_ms": 6390,
-      "samples": 21
+      "duration_ms": 5765,
+      "samples": 20
     },
     "external/api-parent/scenario.yaml": {
-      "duration_ms": 11830,
-      "samples": 21
+      "duration_ms": 11945,
+      "samples": 20
     },
     "external/portal-publication/scenario.yaml": {
-      "duration_ms": 9180,
-      "samples": 21
+      "duration_ms": 8200,
+      "samples": 20
     },
     "external/portal-sync/scenario.yaml": {
-      "duration_ms": 4710,
-      "samples": 21
+      "duration_ms": 4285,
+      "samples": 20
     },
     "lint/command-coverage/scenario.yaml": {
-      "duration_ms": 350,
-      "samples": 21
+      "duration_ms": 340,
+      "samples": 20
     },
     "namespace/defaults-sync/scenario.yaml": {
-      "duration_ms": 4230,
-      "samples": 21
+      "duration_ms": 3740,
+      "samples": 20
     },
     "namespace/validation/scenario.yaml": {
-      "duration_ms": 890,
-      "samples": 21
+      "duration_ms": 940,
+      "samples": 20
     },
     "org/get-org/scenario.yaml": {
-      "duration_ms": 4410,
-      "samples": 21
+      "duration_ms": 4125,
+      "samples": 20
     },
     "org/system-accounts/assignments/scenario.yaml": {
-      "duration_ms": 14350,
-      "samples": 21
+      "duration_ms": 13985,
+      "samples": 20
     },
     "org/system-accounts/plan/apply-workflow/scenario.yaml": {
-      "duration_ms": 8350,
-      "samples": 21
+      "duration_ms": 7920,
+      "samples": 20
     },
     "org/system-accounts/plan/sync-workflow/scenario.yaml": {
-      "duration_ms": 11110,
-      "samples": 21
+      "duration_ms": 10610,
+      "samples": 20
     },
     "org/system-accounts/scenario.yaml": {
-      "duration_ms": 4920,
-      "samples": 21
+      "duration_ms": 4455,
+      "samples": 20
     },
     "org/system-accounts/sync/scenario.yaml": {
-      "duration_ms": 10170,
-      "samples": 21
+      "duration_ms": 9870,
+      "samples": 20
     },
     "org/teams/apply/scenario.yaml": {
-      "duration_ms": 3880,
-      "samples": 21
+      "duration_ms": 4835,
+      "samples": 20
     },
     "org/teams/external-role/scenario.yaml": {
-      "duration_ms": 6740,
-      "samples": 21
+      "duration_ms": 6015,
+      "samples": 20
     },
     "org/teams/get/scenario.yaml": {
-      "duration_ms": 5520,
-      "samples": 21
+      "duration_ms": 5670,
+      "samples": 20
     },
     "org/teams/plan/apply-workflow/scenario.yaml": {
-      "duration_ms": 6110,
-      "samples": 21
+      "duration_ms": 5445,
+      "samples": 20
     },
     "org/teams/plan/sync-workflow/scenario.yaml": {
-      "duration_ms": 5930,
-      "samples": 21
+      "duration_ms": 5340,
+      "samples": 20
     },
     "org/teams/roles/scenario.yaml": {
-      "duration_ms": 10230,
-      "samples": 21
+      "duration_ms": 12185,
+      "samples": 20
     },
     "org/teams/sync/scenario.yaml": {
-      "duration_ms": 4020,
-      "samples": 21
+      "duration_ms": 3500,
+      "samples": 20
     },
     "org/token/scenario.yaml": {
-      "duration_ms": 8380,
-      "samples": 21
+      "duration_ms": 8155,
+      "samples": 20
     },
     "org/users/assignments/scenario.yaml": {
-      "duration_ms": 16500,
-      "samples": 21
+      "duration_ms": 15875,
+      "samples": 20
     },
     "org/users/get/scenario.yaml": {
-      "duration_ms": 5560,
-      "samples": 21
+      "duration_ms": 5325,
+      "samples": 20
     },
     "org/users/plan/apply-workflow/scenario.yaml": {
-      "duration_ms": 8470,
-      "samples": 21
+      "duration_ms": 8005,
+      "samples": 20
     },
     "org/users/plan/sync-workflow/scenario.yaml": {
-      "duration_ms": 11770,
-      "samples": 21
+      "duration_ms": 11245,
+      "samples": 20
     },
     "org/users/sync/scenario.yaml": {
-      "duration_ms": 11640,
-      "samples": 21
+      "duration_ms": 11355,
+      "samples": 20
     },
     "patch/command-coverage/scenario.yaml": {
-      "duration_ms": 460,
-      "samples": 21
+      "duration_ms": 455,
+      "samples": 20
     },
     "plan/apply-workflow/scenario.yaml": {
-      "duration_ms": 13420,
-      "samples": 21
+      "duration_ms": 11990,
+      "samples": 20
     },
     "plan/remote-url-workflow/scenario.yaml": {
-      "duration_ms": 6430,
-      "samples": 21
+      "duration_ms": 5880,
+      "samples": 20
     },
     "plan/sync-partial-scope/scenario.yaml": {
-      "duration_ms": 5640,
-      "samples": 21
+      "duration_ms": 6650,
+      "samples": 20
     },
     "plan/sync-workflow/scenario.yaml": {
-      "duration_ms": 5700,
-      "samples": 21
+      "duration_ms": 5025,
+      "samples": 20
     },
     "portal/api_docs_with_children/scenario.yaml": {
-      "duration_ms": 30140,
-      "samples": 21
+      "duration_ms": 30495,
+      "samples": 20
     },
     "portal/api_with_attributes/scenario.yaml": {
-      "duration_ms": 9550,
-      "samples": 21
+      "duration_ms": 8605,
+      "samples": 20
     },
     "portal/app-auth-strategy/scenario.yaml": {
-      "duration_ms": 8600,
-      "samples": 21
+      "duration_ms": 7940,
+      "samples": 20
     },
     "portal/assets/scenario.yaml": {
-      "duration_ms": 8460,
-      "samples": 21
+      "duration_ms": 7060,
+      "samples": 20
     },
     "portal/audit-log-webhook/scenario.yaml": {
-      "duration_ms": 18570,
-      "samples": 21
+      "duration_ms": 18715,
+      "samples": 20
     },
     "portal/auth-strategy-link/scenario.yaml": {
-      "duration_ms": 20900,
-      "samples": 21
+      "duration_ms": 18580,
+      "samples": 20
     },
     "portal/auth_settings/scenario.yaml": {
-      "duration_ms": 10980,
-      "samples": 21
+      "duration_ms": 10360,
+      "samples": 20
     },
     "portal/auth_settings_deprecated_fields/scenario.yaml": {
       "duration_ms": 190,
-      "samples": 21
+      "samples": 20
     },
     "portal/custom-domain/scenario.yaml": {
-      "duration_ms": 18390,
-      "samples": 21
+      "duration_ms": 17055,
+      "samples": 20
     },
     "portal/customization/scenario.yaml": {
-      "duration_ms": 12250,
-      "samples": 21
+      "duration_ms": 12775,
+      "samples": 20
     },
     "portal/default_application_auth_strategy/scenario.yaml": {
-      "duration_ms": 13450,
-      "samples": 21
+      "duration_ms": 12090,
+      "samples": 20
     },
     "portal/default_application_auth_strategy_ref_selection/scenario.yaml": {
-      "duration_ms": 5100,
-      "samples": 21
+      "duration_ms": 5015,
+      "samples": 20
     },
     "portal/edit/scenario.yaml": {
-      "duration_ms": 6080,
-      "samples": 21
+      "duration_ms": 7340,
+      "samples": 20
     },
     "portal/email-domains/scenario.yaml": {
-      "duration_ms": 3080,
-      "samples": 21
+      "duration_ms": 1955,
+      "samples": 20
     },
     "portal/email-templates/scenario.yaml": {
-      "duration_ms": 13900,
-      "samples": 21
+      "duration_ms": 14120,
+      "samples": 20
     },
     "portal/email/scenario.yaml": {
-      "duration_ms": 14050,
-      "samples": 21
+      "duration_ms": 12545,
+      "samples": 20
     },
     "portal/external-sync/scenario.yaml": {
-      "duration_ms": 13410,
-      "samples": 21
+      "duration_ms": 12665,
+      "samples": 20
     },
     "portal/identity_providers/scenario.yaml": {
-      "duration_ms": 20000,
-      "samples": 21
+      "duration_ms": 22840,
+      "samples": 20
     },
     "portal/identity_providers_duplicate_type/scenario.yaml": {
       "duration_ms": 190,
-      "samples": 21
+      "samples": 20
     },
     "portal/idp_team_group_mappings_readback/scenario.yaml": {
-      "duration_ms": 10910,
-      "samples": 21
+      "duration_ms": 11195,
+      "samples": 20
     },
     "portal/integrations/scenario.yaml": {
-      "duration_ms": 10380,
-      "samples": 21
+      "duration_ms": 9255,
+      "samples": 20
     },
     "portal/ip-allow-list/scenario.yaml": {
-      "duration_ms": 16180,
-      "samples": 21
+      "duration_ms": 15130,
+      "samples": 20
     },
     "portal/oidc-auth-strategy/scenario.yaml": {
-      "duration_ms": 5390,
-      "samples": 21
+      "duration_ms": 6205,
+      "samples": 20
     },
     "portal/page-frontmatter-conflict/scenario.yaml": {
-      "duration_ms": 9040,
-      "samples": 21
+      "duration_ms": 7460,
+      "samples": 20
     },
     "portal/pages/scenario.yaml": {
-      "duration_ms": 12610,
-      "samples": 21
+      "duration_ms": 12750,
+      "samples": 20
     },
     "portal/publication-auth-omitted-noop/scenario.yaml": {
-      "duration_ms": 10900,
-      "samples": 21
+      "duration_ms": 9650,
+      "samples": 20
     },
     "portal/snippets-pagination/scenario.yaml": {
-      "duration_ms": 4010,
-      "samples": 21
+      "duration_ms": 3850,
+      "samples": 20
     },
     "portal/snippets/scenario.yaml": {
-      "duration_ms": 6170,
-      "samples": 21
+      "duration_ms": 7485,
+      "samples": 20
     },
     "portal/sync/scenario.yaml": {
-      "duration_ms": 24460,
-      "samples": 21
+      "duration_ms": 21875,
+      "samples": 20
     },
     "portal/team_group_mappings_no_idp/scenario.yaml": {
-      "duration_ms": 6900,
-      "samples": 21
+      "duration_ms": 7035,
+      "samples": 20
     },
     "portal/teams/scenario.yaml": {
-      "duration_ms": 26050,
-      "samples": 21
+      "duration_ms": 23465,
+      "samples": 20
     },
     "portal/visibility/scenario.yaml": {
-      "duration_ms": 42110,
-      "samples": 21
+      "duration_ms": 39480,
+      "samples": 20
     },
     "protected-resources/apis/scenario.yaml": {
-      "duration_ms": 9560,
-      "samples": 21
+      "duration_ms": 11050,
+      "samples": 20
     },
     "protected-resources/control-planes/scenario.yaml": {
-      "duration_ms": 4760,
-      "samples": 21
+      "duration_ms": 4140,
+      "samples": 20
     },
     "protected-resources/event-gateways/scenario.yaml": {
-      "duration_ms": 9440,
-      "samples": 21
+      "duration_ms": 9790,
+      "samples": 20
     },
     "protected-resources/org/teams/scenario.yaml": {
-      "duration_ms": 7010,
-      "samples": 21
+      "duration_ms": 6050,
+      "samples": 20
     },
     "protected-resources/portals/scenario.yaml": {
-      "duration_ms": 9030,
-      "samples": 21
+      "duration_ms": 8455,
+      "samples": 20
     },
     "require-namespace/external/scenario.yaml": {
-      "duration_ms": 3900,
-      "samples": 21
+      "duration_ms": 4505,
+      "samples": 20
     },
     "require-namespace/portal/scenario.yaml": {
-      "duration_ms": 7080,
-      "samples": 21
+      "duration_ms": 6180,
+      "samples": 20
     },
     "scaffold/command-coverage/scenario.yaml": {
       "duration_ms": 980,
-      "samples": 21
+      "samples": 20
     },
     "smoke/version/scenario.yaml": {
       "duration_ms": 60,
-      "samples": 21
+      "samples": 20
     },
     "yaml-tags/env/scenario.yaml": {
-      "duration_ms": 12840,
-      "samples": 21
+      "duration_ms": 11795,
+      "samples": 20
     },
     "yaml-tags/file/scenario.yaml": {
-      "duration_ms": 4120,
-      "samples": 21
+      "duration_ms": 4890,
+      "samples": 20
     }
   },
   "schema_version": 1,
   "source_sha256": {
-    "test/e2e/baselines/post-cache-2026-09-observations.json": "522713d68c11ee949a4b3418b0703c4831b2449a446a413247b57bac1ae7e6f7",
-    "test/e2e/baselines/stage0-2026-09-observations.json": "d8fbb43c85bc02479536fb30b51e7af2b2e1f72f85b6b54517991c49e685bdf5"
+    "test/e2e/baselines/post-cache-2026-09-observations.json": "d47f9ec80f2d100f74dd0af2f403f9eea30e750b4f0d63f6e63e3acbba88b519"
   },
   "sources": [
-    "test/e2e/baselines/post-cache-2026-09-observations.json",
-    "test/e2e/baselines/stage0-2026-09-observations.json"
+    "test/e2e/baselines/post-cache-2026-09-observations.json"
   ]
 }

--- a/test/e2e/baselines/weighted-v1-activation.md
+++ b/test/e2e/baselines/weighted-v1-activation.md
@@ -1,0 +1,78 @@
+# Weighted sharding activation
+
+Related: #2053 and the report-only foundation in #2094.
+
+## Frozen reference
+
+The completed `post-cache-2026-09-observations.json` contains 20 successful
+full `.com` runs from September 4–6, 2026. The companion report is preserved
+as collected, without pooling subsequent weighted execution into it.
+
+Measured pre-activation p50 values:
+
+| Metric | Seconds |
+| --- | ---: |
+| Build job | 51 |
+| Longest shard | 480 |
+| Shard spread | 256 |
+| Queue to required status | 701 |
+| Workflow admission delay | 8 |
+
+Workflow admission delay p90 is 1,292 seconds. Queueing remains a substantial
+confounder for overall latency; concurrency is unchanged in this experiment.
+Successful-run percentiles do not measure failure rate, and multiple revisions
+from the same PR are correlated samples.
+
+## Activation snapshot
+
+Weights use only this completed cache-enabled baseline, not the older uncached
+cohort. There are 162 qualified scenarios with 20 passing observations each.
+The other three scenarios use the 8,402ms fallback weight. All 165 scenarios
+remain assigned, and all 12 organization pins remain enforced.
+
+The snapshot SHA-256 is:
+
+```text
+a30975c68af38565631cb7379995b28ad40edfeee6a58344ae1dc52aa0c323af
+```
+
+The measurement identity is `weighted-v1:` followed by that hash. Regeneration
+from the frozen input is deterministic. Do not refresh weights during the
+initial 20-run experiment; any changed snapshot requires a separate observation
+file and measurement identity.
+
+Offline validation against the repository corpus predicts longest-shard load
+of 452.26s under modulo versus 318.21s under weighted allocation. These are
+sums of scenario median weights, not measured job durations or promised savings.
+They must not be compared directly with the measured 480s baseline median.
+
+## Rollout and evaluation
+
+The activation PR exercises weighted allocation in its own full `.com` CI run;
+after merge, normal full `.com` runs use it too. Filtered, unsharded, and `.tech`
+runs continue using the original selector. Reset policy and concurrency remain
+unchanged. Weighted execution order is deterministic normalized-path order.
+
+After passing CI and human review, collect normal runs with:
+
+```sh
+make collect-e2e-baseline E2E_BASELINE_COUNT=20 E2E_BASELINE_SCAN=150
+```
+
+This now updates the separate `weighted-v1-2026-09-*` files. The collector
+requires the exact algorithm and snapshot identity, rejects mixed allocations,
+and refuses to overwrite an observation file from another experiment.
+Keep committing partial observations before artifact expiry.
+
+Evaluate the first 20 successful weighted runs against the frozen reference:
+longest-shard p50/p90, spread, and overall completion time, with build/harness
+cost and admission delays shown separately. Independently inspect all failed
+and cancelled workflows and beta failures. Success requires measured runtime
+improvement without worse reliability; better predictions alone do not count.
+
+For coverage/pinning defects or reproducible ordering-related failures, set the
+repository variable `KONGCTL_E2E_SHARD_STRATEGY` to `modulo`. New target-selection
+jobs capture that value once for their entire matrix. In-flight matrices keep
+their selected strategy. Rollback does not depend on valid weights. Collect any
+rollback runs separately as documented in the E2E README. Never weaken scenario
+assertions or reset safety to keep a speed improvement.

--- a/test/e2e/scenarios_allocation.go
+++ b/test/e2e/scenarios_allocation.go
@@ -1,0 +1,94 @@
+package e2e
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	allocationModulo   = "modulo"
+	allocationWeighted = "weighted"
+	allocationModuloID = "modulo-v1"
+)
+
+type scenarioAllocation struct {
+	SchemaVersion int    `json:"schema_version"`
+	Strategy      string `json:"strategy"`
+	ID            string `json:"allocation_id"`
+}
+
+func scenarioAllocationForConfig(cfg scenarioSelectionConfig) (scenarioAllocation, error) {
+	allocation := scenarioAllocation{SchemaVersion: 1, Strategy: allocationModulo, ID: allocationModuloID}
+	if cfg.Filter != "" || !cfg.Shard.Enabled || !cfg.ValidateEnvs {
+		return allocation, nil
+	}
+	switch strings.TrimSpace(cfg.Strategy) {
+	case allocationModulo:
+		return allocation, nil
+	case "", allocationWeighted:
+		allocation.Strategy = allocationWeighted
+		allocation.ID = fmt.Sprintf("weighted-v1:%x", sha256.Sum256(scenarioWeightsJSON))
+		return allocation, nil
+	default:
+		return allocation, fmt.Errorf("invalid KONGCTL_E2E_SHARD_STRATEGY %q: use weighted or modulo", cfg.Strategy)
+	}
+}
+
+func validateWeightedMatrix(cfg scenarioSelectionConfig) error {
+	if cfg.Shard.Total != len(cfg.AllowedEnvs) || cfg.Shard.Index < 0 || cfg.Shard.Index >= cfg.Shard.Total ||
+		cfg.AllowedEnvs[cfg.Shard.Index] != cfg.CurrentEnv {
+		return fmt.Errorf("weighted allocation requires shard indices matching configured organization order")
+	}
+	return nil
+}
+
+func selectScenariosForExecution(
+	scenarios []string, cfg scenarioSelectionConfig,
+) ([]string, scenarioAllocation, error) {
+	allocation, err := scenarioAllocationForConfig(cfg)
+	if err != nil {
+		return nil, allocation, err
+	}
+	if allocation.Strategy == allocationModulo {
+		selected, err := selectScenariosWithConfig(scenarios, cfg)
+		return selected, allocation, err
+	}
+	if err := validateWeightedMatrix(cfg); err != nil {
+		return nil, allocation, err
+	}
+	var weights scenarioWeights
+	if err := json.Unmarshal(scenarioWeightsJSON, &weights); err != nil {
+		return nil, allocation, fmt.Errorf("parse activation weights: %w", err)
+	}
+	plan, err := planWeightedScenarios(scenarios, cfg.AllowedEnvs, cfg.Assignments, weights)
+	if err != nil {
+		return nil, allocation, err
+	}
+	paths := make(map[string]string, len(scenarios))
+	for _, path := range scenarios {
+		paths[normalizeScenarioPath(path)] = path
+	}
+	selected := make([]string, 0, len(plan.Organizations[cfg.Shard.Index].Weighted))
+	for _, item := range plan.Organizations[cfg.Shard.Index].Weighted {
+		selected = append(selected, paths[item.Scenario])
+	}
+	return selected, allocation, nil
+}
+
+func writeScenarioAllocation(dir string, shard scenarioShard, allocation scenarioAllocation) error {
+	if !shard.Enabled || strings.TrimSpace(dir) == "" {
+		return nil
+	}
+	data, err := json.MarshalIndent(allocation, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "scenario-allocation.json"), append(data, '\n'), 0o600)
+}

--- a/test/e2e/scenarios_allocation_test.go
+++ b/test/e2e/scenarios_allocation_test.go
@@ -1,0 +1,115 @@
+package e2e
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestWeightedExecutionAndRollback(t *testing.T) {
+	paths := []string{"scenarios/a", "scenarios/b", "scenarios/c", "scenarios/d", "scenarios/e", "scenarios/f"}
+	cfg := scenarioSelectionConfig{
+		Shard: scenarioShard{Enabled: true, Total: 2}, CurrentEnv: "one", AllowedEnvs: []string{"one", "two"},
+		Assignments: map[string]scenarioAssignment{"a": {Environment: "one"}}, ValidateEnvs: true, EnforceEnv: true,
+	}
+	selected, allocation, err := selectScenariosForExecution(paths, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(selected, []string{"scenarios/a", "scenarios/c", "scenarios/e"}) {
+		t.Fatalf("unexpected weighted execution order: %v", selected)
+	}
+	if allocation.Strategy != allocationWeighted || !strings.HasPrefix(allocation.ID, "weighted-v1:") {
+		t.Fatalf("missing activation identity: %+v", allocation)
+	}
+	weightedID := allocation.ID
+	dir := t.TempDir()
+	if err := writeScenarioAllocation(dir, cfg.Shard, allocation); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeScenarioShardManifest(dir, cfg.Shard, selected, nil); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "scenario-allocation.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var recorded scenarioAllocation
+	if err := json.Unmarshal(data, &recorded); err != nil || recorded != allocation {
+		t.Fatalf("allocation identity did not round trip: %s, %v", data, err)
+	}
+	data, err = os.ReadFile(filepath.Join(dir, "assigned-scenarios.txt"))
+	if err != nil || string(data) != "shard_index=0\nshard_total=2\n\na\nc\ne\n" {
+		t.Fatalf("manifest does not describe actual execution: %s, %v", data, err)
+	}
+	cfg.Strategy = allocationModulo
+	selected, allocation, err = selectScenariosForExecution(paths, cfg)
+	legacy, legacyErr := selectScenariosWithConfig(paths, cfg)
+	if err != nil || legacyErr != nil || !reflect.DeepEqual(selected, legacy) {
+		t.Fatalf("rollback differs from legacy allocation: %v, %v", err, legacyErr)
+	}
+	if allocation.ID != allocationModuloID || allocation.ID == weightedID {
+		t.Fatal("rollback must be identifiable separately from weighted execution")
+	}
+}
+
+func TestWeightedScopeAndInvalidConfiguration(t *testing.T) {
+	base := scenarioSelectionConfig{
+		Shard: scenarioShard{Enabled: true, Total: 1}, CurrentEnv: "one", AllowedEnvs: []string{"one"},
+		ValidateEnvs: true, EnforceEnv: true,
+	}
+	paths := []string{"scenarios/a/scenario.yaml"}
+	for _, mode := range []string{"filtered", "tech", "unsharded"} {
+		t.Run(mode, func(t *testing.T) {
+			cfg := base
+			switch mode {
+			case "filtered":
+				cfg.Filter = "a"
+			case "tech":
+				cfg.ValidateEnvs = false
+			case "unsharded":
+				cfg.Shard.Enabled = false
+			}
+			selected, allocation, err := selectScenariosForExecution(paths, cfg)
+			legacy, legacyErr := selectScenariosWithConfig(paths, cfg)
+			if err != nil || legacyErr != nil || !slices.Equal(selected, legacy) || allocation.ID != allocationModuloID {
+				t.Fatalf("out-of-scope selection changed: %+v, %v", allocation, err)
+			}
+		})
+	}
+	invalid := base
+	invalid.Strategy = "weightd"
+	if _, _, err := selectScenariosForExecution(paths, invalid); err == nil {
+		t.Fatal("invalid strategy must not silently change allocation")
+	}
+	invalid = base
+	invalid.CurrentEnv = "different"
+	if _, _, err := selectScenariosForExecution(paths, invalid); err == nil {
+		t.Fatal("invalid matrix must fail before execution")
+	}
+}
+
+func TestWeightedMalformedSnapshotFailsClosed(t *testing.T) {
+	original := scenarioWeightsJSON
+	t.Cleanup(func() { scenarioWeightsJSON = original })
+	cfg := scenarioSelectionConfig{
+		Shard: scenarioShard{Enabled: true, Total: 1}, CurrentEnv: "one", AllowedEnvs: []string{"one"},
+		ValidateEnvs: true,
+	}
+	for _, data := range []string{"{", `{"schema_version":1,"default_duration_ms":0}`} {
+		scenarioWeightsJSON = []byte(data)
+		if _, _, err := selectScenariosForExecution([]string{"a"}, cfg); err == nil {
+			t.Fatal("invalid weights must fail weighted execution")
+		}
+		rollback := cfg
+		rollback.Strategy = allocationModulo
+		if _, allocation, err := selectScenariosForExecution([]string{"a"}, rollback); err != nil ||
+			allocation.ID != allocationModuloID {
+			t.Fatal("rollback must work independently of broken weights")
+		}
+	}
+}

--- a/test/e2e/scenarios_shard.go
+++ b/test/e2e/scenarios_shard.go
@@ -20,6 +20,7 @@ type scenarioAssignment struct {
 }
 
 type scenarioSelectionConfig struct {
+	Strategy     string
 	Filter       string
 	Shard        scenarioShard
 	CurrentEnv   string

--- a/test/e2e/scenarios_test.go
+++ b/test/e2e/scenarios_test.go
@@ -69,6 +69,7 @@ func Test_Scenarios(t *testing.T) {
 	)
 
 	selectionConfig := scenarioSelectionConfig{
+		Strategy:     os.Getenv("KONGCTL_E2E_SHARD_STRATEGY"),
 		Filter:       filt,
 		Shard:        shard,
 		CurrentEnv:   os.Getenv("KONGCTL_E2E_MATRIX_ORG"),
@@ -77,16 +78,19 @@ func Test_Scenarios(t *testing.T) {
 		ValidateEnvs: validateEnvs,
 		EnforceEnv:   shard.Enabled,
 	}
-	selected, err := selectScenariosWithConfig(scenarios, selectionConfig)
+	selected, allocation, err := selectScenariosForExecution(scenarios, selectionConfig)
 	if err != nil {
 		t.Fatalf("select scenarios: %v", err)
 	}
 	excluded := missingAssignedEnvironmentScenarios(scenarios, assignments, allowedEnvs, validateEnvs)
+	if err := writeScenarioAllocation(os.Getenv("KONGCTL_E2E_ARTIFACTS_DIR"), shard, allocation); err != nil {
+		t.Fatalf("write scenario allocation: %v", err)
+	}
 	if err := writeScenarioShardManifest(os.Getenv("KONGCTL_E2E_ARTIFACTS_DIR"), shard, selected, excluded); err != nil {
 		t.Fatalf("write shard manifest: %v", err)
 	}
 	if err := writeWeightedScenarioReport(os.Getenv("KONGCTL_E2E_ARTIFACTS_DIR"), scenarios, selectionConfig); err != nil {
-		t.Logf("WARNING: weighted sharding report unavailable (live assignments unchanged): %v", err)
+		t.Logf("WARNING: sharding comparison unavailable (allocation %s): %v", allocation.ID, err)
 	}
 
 	if len(selected) == 0 {

--- a/test/e2e/scenarios_weighted.go
+++ b/test/e2e/scenarios_weighted.go
@@ -39,15 +39,15 @@ type weightedScenario struct {
 
 type weightedOrganization struct {
 	Environment string             `json:"environment"`
-	Current     []weightedScenario `json:"current"`
-	Proposed    []weightedScenario `json:"proposed"`
-	CurrentMS   int64              `json:"current_estimated_ms"`
-	ProposedMS  int64              `json:"proposed_estimated_ms"`
+	Legacy      []weightedScenario `json:"legacy"`
+	Weighted    []weightedScenario `json:"weighted"`
+	LegacyMS    int64              `json:"legacy_estimated_ms"`
+	WeightedMS  int64              `json:"weighted_estimated_ms"`
 }
 
 type weightedScenarioReport struct {
 	SchemaVersion int                    `json:"schema_version"`
-	Mode          string                 `json:"mode"`
+	Allocation    scenarioAllocation     `json:"allocation"`
 	Uniform       bool                   `json:"uniform_weights"`
 	Sources       []string               `json:"weight_sources"`
 	SourceSHA256  map[string]string      `json:"weight_source_sha256"`
@@ -66,15 +66,15 @@ func (w scenarioWeights) validate() error {
 	return nil
 }
 
-// planWeightedScenarios never selects scenarios for execution. Current retains
-// the existing selector's ordering; Proposed is a deterministic shadow plan.
+// Legacy retains the modulo selector's ordering. Weighted is the deterministic,
+// pin-aware plan consumed by the live allocator and the comparison report.
 func planWeightedScenarios(
 	scenarios []string,
 	environments []string,
 	assignments map[string]scenarioAssignment,
 	weights scenarioWeights,
 ) (weightedScenarioReport, error) {
-	report := weightedScenarioReport{SchemaVersion: 1, Mode: "report-only"}
+	report := weightedScenarioReport{SchemaVersion: 2}
 	if err := weights.validate(); err != nil {
 		return report, err
 	}
@@ -91,7 +91,7 @@ func planWeightedScenarios(
 		}
 		indices[env] = i
 		report.Organizations = append(report.Organizations, weightedOrganization{
-			Environment: env, Current: []weightedScenario{}, Proposed: []weightedScenario{},
+			Environment: env, Legacy: []weightedScenario{}, Weighted: []weightedScenario{},
 		})
 	}
 	items := make(map[string]weightedScenario, len(scenarios))
@@ -118,8 +118,8 @@ func planWeightedScenarios(
 				return report, fmt.Errorf("scenario %s pinned to unavailable environment %q", path, env)
 			}
 			org := &report.Organizations[index]
-			org.Proposed = append(org.Proposed, item)
-			org.ProposedMS += item.DurationMS
+			org.Weighted = append(org.Weighted, item)
+			org.WeightedMS += item.DurationMS
 		} else {
 			unpinned = append(unpinned, item)
 		}
@@ -136,17 +136,17 @@ func planWeightedScenarios(
 	for _, item := range unpinned {
 		index := 0
 		for i := range report.Organizations {
-			if report.Organizations[i].ProposedMS < report.Organizations[index].ProposedMS {
+			if report.Organizations[i].WeightedMS < report.Organizations[index].WeightedMS {
 				index = i
 			}
 		}
 		org := &report.Organizations[index]
-		org.Proposed = append(org.Proposed, item)
-		org.ProposedMS += item.DurationMS
+		org.Weighted = append(org.Weighted, item)
+		org.WeightedMS += item.DurationMS
 	}
 	for i := range report.Organizations {
 		org := &report.Organizations[i]
-		slices.SortFunc(org.Proposed, func(a, b weightedScenario) int { return strings.Compare(a.Scenario, b.Scenario) })
+		slices.SortFunc(org.Weighted, func(a, b weightedScenario) int { return strings.Compare(a.Scenario, b.Scenario) })
 		current, err := selectScenariosWithConfig(scenarios, scenarioSelectionConfig{
 			Shard:      scenarioShard{Enabled: true, Index: i, Total: len(environments)},
 			CurrentEnv: org.Environment, AllowedEnvs: environments, Assignments: assignments,
@@ -157,8 +157,8 @@ func planWeightedScenarios(
 		}
 		for _, path := range current {
 			item := items[normalizeScenarioPath(path)]
-			org.Current = append(org.Current, item)
-			org.CurrentMS += item.DurationMS
+			org.Legacy = append(org.Legacy, item)
+			org.LegacyMS += item.DurationMS
 		}
 	}
 	return report, nil
@@ -168,15 +168,18 @@ func writeWeightedScenarioReport(artifactsDir string, scenarios []string, cfg sc
 	if cfg.Filter != "" || !cfg.Shard.Enabled || !cfg.ValidateEnvs || artifactsDir == "" {
 		return nil
 	}
-	if cfg.Shard.Total != len(cfg.AllowedEnvs) || cfg.Shard.Index < 0 || cfg.Shard.Index >= cfg.Shard.Total ||
-		cfg.AllowedEnvs[cfg.Shard.Index] != cfg.CurrentEnv {
-		return fmt.Errorf("weighted report requires shard indices matching configured organization order")
+	if err := validateWeightedMatrix(cfg); err != nil {
+		return err
 	}
 	var weights scenarioWeights
 	if err := json.Unmarshal(scenarioWeightsJSON, &weights); err != nil {
 		return fmt.Errorf("parse scenario weights: %w", err)
 	}
 	report, err := planWeightedScenarios(scenarios, cfg.AllowedEnvs, cfg.Assignments, weights)
+	if err != nil {
+		return err
+	}
+	report.Allocation, err = scenarioAllocationForConfig(cfg)
 	if err != nil {
 		return err
 	}
@@ -191,19 +194,20 @@ func writeWeightedScenarioReport(artifactsDir string, scenarios []string, cfg sc
 		return err
 	}
 	var summary strings.Builder
-	summary.WriteString("### Weighted sharding predictions (report only)\n\n")
-	summary.WriteString("Live assignments are unchanged. Estimates exclude job overhead and are not measured savings.\n\n")
+	summary.WriteString("### Sharding comparison\n\n")
+	fmt.Fprintf(&summary, "Actual allocation: `%s`.\n\n", report.Allocation.ID)
+	summary.WriteString("Estimates exclude job overhead and are not measured savings.\n\n")
 	fmt.Fprintf(&summary, "Uniform fallback weights: %t.\n\n", report.Uniform)
-	summary.WriteString("| Organization | Current estimate (s) | Proposed estimate (s) |\n| --- | ---: | ---: |\n")
+	summary.WriteString("| Organization | Modulo estimate (s) | Weighted estimate (s) |\n| --- | ---: | ---: |\n")
 	currentMin, proposedMin := int64(math.MaxInt64), int64(math.MaxInt64)
 	var currentMax, proposedMax int64
 	for _, org := range report.Organizations {
 		fmt.Fprintf(&summary, "| %s | %.2f | %.2f |\n", org.Environment,
-			float64(org.CurrentMS)/1000, float64(org.ProposedMS)/1000)
-		currentMin, proposedMin = min(currentMin, org.CurrentMS), min(proposedMin, org.ProposedMS)
-		currentMax, proposedMax = max(currentMax, org.CurrentMS), max(proposedMax, org.ProposedMS)
+			float64(org.LegacyMS)/1000, float64(org.WeightedMS)/1000)
+		currentMin, proposedMin = min(currentMin, org.LegacyMS), min(proposedMin, org.WeightedMS)
+		currentMax, proposedMax = max(currentMax, org.LegacyMS), max(proposedMax, org.WeightedMS)
 	}
-	fmt.Fprintf(&summary, "\nEstimated longest shard: %.2fs → %.2fs; spread: %.2fs → %.2fs.\n",
+	fmt.Fprintf(&summary, "\nEstimated modulo → weighted longest shard: %.2fs → %.2fs; spread: %.2fs → %.2fs.\n",
 		float64(currentMax)/1000, float64(proposedMax)/1000,
 		float64(currentMax-currentMin)/1000, float64(proposedMax-proposedMin)/1000)
 	return os.WriteFile(filepath.Join(artifactsDir, "weighted-sharding-summary.md"), []byte(summary.String()), 0o600)

--- a/test/e2e/scenarios_weighted_repository_test.go
+++ b/test/e2e/scenarios_weighted_repository_test.go
@@ -80,7 +80,7 @@ func TestWeightedRepositoryPlan(t *testing.T) {
 			t.Fatal(err)
 		}
 		var current []string
-		for _, item := range report.Organizations[i].Current {
+		for _, item := range report.Organizations[i].Legacy {
 			current = append(current, item.Scenario)
 		}
 		for j := range selected {
@@ -89,12 +89,31 @@ func TestWeightedRepositoryPlan(t *testing.T) {
 		if !slices.Equal(current, selected) {
 			t.Fatalf("report for %s does not match actual selector", env)
 		}
+		active, allocation, err := selectScenariosForExecution(paths, cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var weighted []string
+		for _, item := range report.Organizations[i].Weighted {
+			weighted = append(weighted, item.Scenario)
+		}
+		for j := range active {
+			active[j] = normalizeScenarioPath(active[j])
+		}
+		if !slices.Equal(active, weighted) || allocation != report.Allocation {
+			t.Fatal("active weighted selection does not match comparison report")
+		}
 		seen := map[string]bool{}
 		var currentTotal, proposedTotal int64
 		for _, org := range report.Organizations {
-			currentTotal += org.CurrentMS
-			proposedTotal += org.ProposedMS
-			for _, item := range org.Proposed {
+			if i == 0 {
+				t.Logf("%s: modulo=%d scenarios/%.2fs, weighted=%d scenarios/%.2fs",
+					org.Environment, len(org.Legacy), float64(org.LegacyMS)/1000,
+					len(org.Weighted), float64(org.WeightedMS)/1000)
+			}
+			currentTotal += org.LegacyMS
+			proposedTotal += org.WeightedMS
+			for _, item := range org.Weighted {
 				if seen[item.Scenario] {
 					t.Fatalf("duplicate proposed scenario %s", item.Scenario)
 				}

--- a/test/e2e/scenarios_weighted_test.go
+++ b/test/e2e/scenarios_weighted_test.go
@@ -23,22 +23,22 @@ func TestWeightedScenarioPlan(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.Organizations[0].ProposedMS != 100 || plan.Organizations[1].ProposedMS != 70 {
+	if plan.Organizations[0].WeightedMS != 100 || plan.Organizations[1].WeightedMS != 70 {
 		t.Fatalf("pinned load not reserved first: %+v", plan)
 	}
 	seen := map[string]bool{}
 	for _, org := range plan.Organizations {
-		for _, item := range org.Proposed {
+		for _, item := range org.Weighted {
 			if seen[item.Scenario] {
 				t.Fatalf("duplicate assignment: %s", item.Scenario)
 			}
 			seen[item.Scenario] = true
 		}
 	}
-	if len(seen) != len(paths) || !plan.Organizations[1].Proposed[1].Fallback {
+	if len(seen) != len(paths) || !plan.Organizations[1].Weighted[1].Fallback {
 		t.Fatalf("coverage or new-scenario fallback incorrect: %+v", plan)
 	}
-	if plan.Organizations[0].CurrentMS != 160 || plan.Organizations[1].CurrentMS != 10 {
+	if plan.Organizations[0].LegacyMS != 160 || plan.Organizations[1].LegacyMS != 10 {
 		t.Fatalf("current selector comparison incorrect: %+v", plan)
 	}
 	reversed := slices.Clone(paths)
@@ -48,7 +48,7 @@ func TestWeightedScenarioPlan(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i, org := range plan.Organizations {
-		if !reflect.DeepEqual(org.Proposed, other.Organizations[i].Proposed) {
+		if !reflect.DeepEqual(org.Weighted, other.Organizations[i].Weighted) {
 			t.Fatal("proposed assignment depends on input order")
 		}
 	}
@@ -67,7 +67,7 @@ func TestWeightedUniformTiesAndEmptyShards(t *testing.T) {
 		if !plan.Uniform || len(plan.Organizations) != 3 {
 			t.Fatal("uniform fallback or empty shard missing")
 		}
-		if len(paths) > 0 && plan.Organizations[0].Proposed[0].Scenario != "a" {
+		if len(paths) > 0 && plan.Organizations[0].Weighted[0].Scenario != "a" {
 			t.Fatal("ties must use path and configured org order")
 		}
 	}


### PR DESCRIPTION
## Summary

Related to #2053; follows merged report-only PR #2094. This PR actually changes allocation for full .com scenario runs, including its own CI run. It does not close the optimization issue: measured validation remains to be collected.

- Preserve the completed 20-run cache-enabled modulo baseline from the administrator collection in a separate commit.
- Freeze activation weights using only those 20 runs: 162 qualified scenarios with 20 passing samples each; all 165 scenarios and 12 pins remain assigned.
- Use deterministic pin-aware weighted allocation for full .com execution. Filtered, unsharded, and .tech behavior stays on the original selector. Concurrency and reset policy do not change.
- Capture the strategy once per workflow matrix. Set repository variable KONGCTL_E2E_SHARD_STRATEGY=modulo to restore the original allocator for subsequently selected runs. In-flight matrices keep their captured strategy. No repository variable has been changed by this PR.
- Write actual assigned-scenarios.txt plus scenario-allocation.json; metrics schema 2 records the exact algorithm/snapshot allocation_id. Historical schema 1 metrics remain modulo-v1.
- Isolate collector outputs by allocation identity, rejecting mixed strategies, snapshots, and mismatched saved files. The collection target now defaults to separate weighted-v1-2026-09 files, not the completed pre-activation files.
- Upgrade the comparison artifact to schema 2 with explicit legacy/weighted fields and actual allocation identity.

## Evidence and rollout

Measured pre-activation p50: longest shard 480s, spread 256s, build 51s, queue-to-required-status 701s. Admission delay p90 is 1292s, so queueing must be considered independently.

The frozen snapshot predicts 452.26s longest modulo load versus 318.21s weighted load. These are estimated sums, not measured savings and not directly comparable to the measured 480s baseline median.

Allocation ID:
`weighted-v1:a30975c68af38565631cb7379995b28ad40edfeee6a58344ae1dc52aa0c323af`

Keep this snapshot fixed for the initial 20 successful weighted runs. Collect with:

```sh
make collect-e2e-baseline E2E_BASELINE_COUNT=20 E2E_BASELINE_SCAN=150
```

Compare actual longest-shard and total latency plus failed/cancelled workflows and beta failures. The successful-run collector alone does not establish reliability. Roll back for coverage/pinning defects or reproducible ordering-dependent failures; do not weaken assertions or reset safety to retain speedups. Details are in test/e2e/baselines/weighted-v1-activation.md and test/e2e/README.md.

## Validation

- CGO_ENABLED=0 go fix ./...
- make format: no changes
- make build
- make test-all: lint, installer tests, race-enabled unit/integration tests, all 30 Python tests
- Compiled E2E binary offline weighted tests: all 165 scenarios and 12 pins, actual selection/report agreement, rollback, unchanged out-of-scope behavior, fail-closed malformed weights
- Collector tests: legacy compatibility, exact allocation filtering, mixed-shard/saved-data rejection, authoritative sidecar identity, duplicate-shard rejection
- actionlint -shellcheck= .github/workflows/e2e.yaml
- git diff --check

No live Konnect scenarios were run locally. The PR workflow will supply the first live weighted validation. No merge to main will be performed automatically.
