### PR TITLE
refactor(declarative): register namespace and collection scope capabilities

### DIFF
--- a/docs/contributor/declarative-resource-implementation-guide.md
+++ b/docs/contributor/declarative-resource-implementation-guide.md
@@ -168,6 +168,8 @@ Co-locate [scope capabilities][scope-capabilities] with registration:
 The shared [declaration structure][declaration-structure] supplies root and
 nested YAML keys for scope and explain. Relationship descriptors supply the
 parent selector. Do not duplicate these facts in loader or planner inventories.
+Scope descriptors are derived and checked once, on first use after resource
+initialization. `SyncCollections` returns copies, including nested keys.
 The loader captures key presence; planner fallback infers scope only from
 populated slices and retains any explicit `SyncScope`.
 

--- a/docs/contributor/declarative-resource-implementation-guide.md
+++ b/docs/contributor/declarative-resource-implementation-guide.md
@@ -37,12 +37,13 @@ are different representations. Do not use resource serialization as an API
 request: it can contain `ref`, `kongctl`, children, and parent selectors.
 
 The [resource registry][registry] drives iteration, aggregation,
-explain/scaffold, load-schema discovery, and dump-default metadata. The
+explain/scaffold, load-schema discovery, namespace participation,
+ordinary collection scope, and dump-default metadata. The
 [root planner inventory][roots] drives root construction and dispatch.
 [Runtime executor registration][runtime-executors] supplies action routing and
-payload validation for SDK resource operations. Loader scope/extraction,
-namespace participation, relationships, pre-execution validation, state-client
-wiring, and dump collection still have separate integration points.
+payload validation for SDK resource operations. Nested extraction, specialized
+scope, namespace inheritance/filtering, relationships, pre-execution
+validation, state-client wiring, and dump collection remain separate steps.
 Registering a declaration does not complete those steps automatically.
 
 ## 1. Define and register the resource
@@ -64,14 +65,34 @@ Registering a declaration does not complete those steps automatically.
 - Implement validation, dependencies, and supported label access. Prefer
   shared matching/normalization helpers over new reflection or type switches.
   Registry-driven aggregation must not acquire another resource inventory.
-- For namespace-bearing declarations, inspect
-  [namespace participants][namespaces] and namespace accessors in
-  `ResourceSet`. Ordinary managed children inherit namespace and protection
-  from their parent; do not give them independent `kongctl` configuration.
+- Namespace-bearing declarations add `WithNamespace` beside registration;
+  see [namespace capabilities](#namespace-capabilities). Ordinary managed
+  children inherit namespace and protection from their parent; do not give
+  them independent `kongctl` configuration.
 - Follow the [maturity policy](maturity.md). Resources default to GA.
   Co-locate `WithMaturity` and narrower `WithOperationMaturity` overrides
   with registration. Maturity is discovery metadata, not runtime gating or
   plan, result, or telemetry data.
+
+### Namespace capabilities
+
+[`WithNamespace`][namespaces] supplies a typed `NamespaceParticipant` accessor
+using the resource's registered slice. Return the actual `Kongctl` field's
+address, `ref`, diagnostic label, external state, and protected support.
+Keep traversal order stable: defaulting and validation use it for diagnostics.
+Each order must be unique; leave gaps when adding participants.
+
+Supply supplemental grouped locations when values exist there before nested
+extraction; dashboard and organization team registrations demonstrate this.
+`ForEachNamespaceParticipant` visits flattened then grouped values per kind.
+`NamespaceValues` reads post-extraction values for loader validation without
+revisiting those groups. Organization users/system accounts use
+`registerNamespaceSelector`: they carry namespace without protection and do
+not enter the ordinary resource registry.
+
+Defaulting, namespace enforcement, and planner discovery share participation
+but retain their different external-resource policies. Namespace accessors and
+parent filtering in `ResourceSet` still require explicit integration.
 
 ### Defaults and SDK shape
 
@@ -138,10 +159,29 @@ Sync deletion follows explicit manifest scope:
 | Singleton `null` | Reject; no implicit reset/delete |
 | Optional, delete-capable singleton `{}` | Zero for that parent |
 
-Update [loader scope tables][load-scope] for root collections, root-level
-child selectors, and nested child keys. For delete-capable singletons,
-preserve scope while dropping the empty desired value during decoding.
-Do not apply that deletion meaning to update-only singletons.
+Co-locate [scope capabilities][scope-capabilities] with registration:
+
+- `WithRootSyncScope()` handles ordinary root collections.
+- `WithChildSyncScope(ownerType)` handles ordinary child collections whose
+  sync owner matches `GetParentRef()` and a root-only parent relationship.
+
+The shared [declaration structure][declaration-structure] supplies root and
+nested YAML keys for scope and explain. Relationship descriptors supply the
+parent selector. Do not duplicate these facts in loader or planner inventories.
+The loader captures key presence; planner fallback infers scope only from
+populated slices and retains any explicit `SyncScope`.
+
+All eight ordinary roots use the capability. API versions, publications,
+implementations, documents, and control-plane data-plane certificates are
+the migrated child examples. Grouped dashboard/organization roots and other
+child families retain [loader scope handling][load-scope] and
+[planner scope handling][plan-scope]. Structural containment alone does not
+define ownership: portal team roles, for example, are scoped to the portal.
+Review parent-scope validation and external-parent support for new owners.
+
+Keep specialized empty-input diagnostics at their existing phase. For
+delete-capable singletons, preserve scope while dropping the empty desired
+value during decoding. Do not apply that meaning to update-only singletons.
 
 Root dispatch applies `shouldPlanRoot`. Parent planners must apply
 `shouldPlanChild` before child observation and pruning. An external parent
@@ -460,12 +500,16 @@ engine contract. Each refactoring migration should:
 [interfaces]: ../../internal/declarative/resources/interfaces.go
 [registry]: ../../internal/declarative/resources/registry.go
 [namespaces]: ../../internal/declarative/resources/namespace_participants.go
+[scope-capabilities]: ../../internal/declarative/resources/sync_capabilities.go
+[declaration-structure]:
+  ../../internal/declarative/resources/declaration_structure.go
 [relationships]: ../../internal/declarative/resources/relationships.go
 [explain]: ../../internal/declarative/resources/explain.go
 [load-schema]: ../../internal/declarative/resources/load_schema.go
 [loader]: ../../internal/declarative/loader/loader.go
 [load-validation]: ../../internal/declarative/loader/validator.go
 [load-scope]: ../../internal/declarative/loader/sync_scope.go
+[plan-scope]: ../../internal/declarative/planner/sync_scope.go
 [planner]: ../../internal/declarative/planner/planner.go
 [roots]: ../../internal/declarative/planner/root_planners.go
 [constants]: ../../internal/declarative/planner/constants.go

--- a/internal/declarative/loader/sync_scope.go
+++ b/internal/declarative/loader/sync_scope.go
@@ -7,27 +7,11 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-type rootCollectionScope struct {
-	key          string
-	resourceType resources.ResourceType
-}
-
 type childCollectionScope struct {
 	key          string
 	resourceType resources.ResourceType
 	parentKey    string
 	parentType   resources.ResourceType
-}
-
-var rootCollectionScopes = []rootCollectionScope{
-	{key: "portals", resourceType: resources.ResourceTypePortal},
-	{key: "application_auth_strategies", resourceType: resources.ResourceTypeApplicationAuthStrategy},
-	{key: "dcr_providers", resourceType: resources.ResourceTypeDCRProvider},
-	{key: "control_planes", resourceType: resources.ResourceTypeControlPlane},
-	{key: "catalog_services", resourceType: resources.ResourceTypeCatalogService},
-	{key: "ai_gateways", resourceType: resources.ResourceTypeAIGateway},
-	{key: "apis", resourceType: resources.ResourceTypeAPI},
-	{key: "event_gateways", resourceType: resources.ResourceTypeEventGatewayControlPlane},
 }
 
 var rootChildCollectionScopes = []childCollectionScope{
@@ -126,36 +110,6 @@ var rootChildCollectionScopes = []childCollectionScope{
 		resourceType: resources.ResourceTypeAIGatewaySNI,
 		parentKey:    resources.SchemaFieldAIGateway,
 		parentType:   resources.ResourceTypeAIGateway,
-	},
-	{
-		key:          "control_plane_data_plane_certificates",
-		resourceType: resources.ResourceTypeControlPlaneDataPlaneCertificate,
-		parentKey:    "control_plane",
-		parentType:   resources.ResourceTypeControlPlane,
-	},
-	{
-		key:          "api_versions",
-		resourceType: resources.ResourceTypeAPIVersion,
-		parentKey:    "api",
-		parentType:   resources.ResourceTypeAPI,
-	},
-	{
-		key:          "api_publications",
-		resourceType: resources.ResourceTypeAPIPublication,
-		parentKey:    "api",
-		parentType:   resources.ResourceTypeAPI,
-	},
-	{
-		key:          "api_implementations",
-		resourceType: resources.ResourceTypeAPIImplementation,
-		parentKey:    "api",
-		parentType:   resources.ResourceTypeAPI,
-	},
-	{
-		key:          "api_documents",
-		resourceType: resources.ResourceTypeAPIDocument,
-		parentKey:    "api",
-		parentType:   resources.ResourceTypeAPI,
 	},
 	{
 		key:          "portal_customizations",
@@ -370,17 +324,6 @@ var rootChildParentDescriptions = map[resources.ResourceType]string{
 	resources.ResourceTypeAIGatewaySNI:                  "each resource must declare an ai_gateway parent",
 }
 
-var apiChildCollectionScopes = []childCollectionScope{
-	{key: "versions", resourceType: resources.ResourceTypeAPIVersion, parentType: resources.ResourceTypeAPI},
-	{key: "publications", resourceType: resources.ResourceTypeAPIPublication, parentType: resources.ResourceTypeAPI},
-	{
-		key:          "implementations",
-		resourceType: resources.ResourceTypeAPIImplementation,
-		parentType:   resources.ResourceTypeAPI,
-	},
-	{key: "documents", resourceType: resources.ResourceTypeAPIDocument, parentType: resources.ResourceTypeAPI},
-}
-
 var portalChildCollectionScopes = []childCollectionScope{
 	{
 		key:          "customization",
@@ -570,9 +513,12 @@ func captureSyncScope(content []byte, rs *resources.ResourceSet) error {
 	}
 
 	scope := rs.EnsureSyncScope()
-	for _, entry := range rootCollectionScopes {
-		if _, ok := raw[entry.key]; ok {
-			scope.AddRoot(entry.resourceType)
+	collections := resources.SyncCollections()
+	for _, collection := range collections {
+		if collection.ParentType == "" {
+			if _, ok := raw[collection.RootKey]; ok {
+				scope.AddRoot(collection.ResourceType)
+			}
 		}
 	}
 
@@ -582,7 +528,9 @@ func captureSyncScope(content []byte, rs *resources.ResourceSet) error {
 		}
 	}
 
-	captureNestedCollectionScopes(scope, raw, "apis", resources.ResourceTypeAPI, apiChildCollectionScopes)
+	if err := captureRegisteredChildScopes(scope, raw, collections); err != nil {
+		return err
+	}
 	captureNestedCollectionScopes(
 		scope,
 		raw,
@@ -592,19 +540,6 @@ func captureSyncScope(content []byte, rs *resources.ResourceSet) error {
 	)
 	captureNestedAIGatewayConsumerCredentialScopes(scope, raw)
 	captureNestedAIGatewayConfigStoreSecretScopes(scope, raw)
-	captureNestedCollectionScopes(
-		scope,
-		raw,
-		"control_planes",
-		resources.ResourceTypeControlPlane,
-		[]childCollectionScope{
-			{
-				key:          "data_plane_certificates",
-				resourceType: resources.ResourceTypeControlPlaneDataPlaneCertificate,
-				parentType:   resources.ResourceTypeControlPlane,
-			},
-		},
-	)
 	captureNestedCollectionScopes(
 		scope,
 		raw,
@@ -619,6 +554,35 @@ func captureSyncScope(content []byte, rs *resources.ResourceSet) error {
 	captureOrganizationScope(scope, raw)
 	captureAnalyticsScope(scope, raw)
 
+	return nil
+}
+
+func captureRegisteredChildScopes(
+	scope *resources.SyncScope,
+	raw map[string]any,
+	collections []resources.SyncCollection,
+) error {
+	for _, collection := range collections {
+		if collection.ParentType == "" {
+			continue
+		}
+		entry := childCollectionScope{
+			key:          collection.RootKey,
+			resourceType: collection.ResourceType,
+			parentKey:    collection.ParentKey,
+			parentType:   collection.ParentType,
+		}
+		if err := captureRootChildScope(scope, raw, entry); err != nil {
+			return err
+		}
+		var nested []childCollectionScope
+		for _, key := range collection.NestedKeys {
+			child := entry
+			child.key = key
+			nested = append(nested, child)
+		}
+		captureNestedCollectionScopes(scope, raw, collection.ParentRootKey, collection.ParentType, nested)
+	}
 	return nil
 }
 

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -1950,80 +1950,9 @@ func (l *Loader) toPascalCase(s string) string {
 // validateNamespaces validates all namespace values in the resource set
 func (l *Loader) validateNamespaces(rs *resources.ResourceSet) error {
 	nsValidator := validator.NewNamespaceValidator()
-	namespaces := make(map[string]bool)
-	addNamespace := func(meta *resources.KongctlMeta) {
-		if meta != nil && meta.Namespace != nil {
-			namespaces[*meta.Namespace] = true
-		}
-	}
-
-	// Collect all unique namespaces from parent resources
-	// Portals
-	for _, portal := range rs.Portals {
-		addNamespace(portal.Kongctl)
-	}
-
-	// APIs
-	for _, api := range rs.APIs {
-		addNamespace(api.Kongctl)
-	}
-
-	// Application Auth Strategies
-	for _, strategy := range rs.ApplicationAuthStrategies {
-		addNamespace(strategy.Kongctl)
-	}
-
-	// DCR Providers
-	for _, provider := range rs.DCRProviders {
-		addNamespace(provider.Kongctl)
-	}
-
-	// Control Planes
-	for _, cp := range rs.ControlPlanes {
-		addNamespace(cp.Kongctl)
-	}
-
-	// Catalog Services
-	for _, service := range rs.CatalogServices {
-		addNamespace(service.Kongctl)
-	}
-
-	// AI Gateways
-	for _, gateway := range rs.AIGateways {
-		addNamespace(gateway.Kongctl)
-	}
-
-	// Dashboards
-	for _, dashboard := range rs.Dashboards {
-		addNamespace(dashboard.Kongctl)
-	}
-
-	// Event Gateway Control Planes
-	for _, cp := range rs.EventGatewayControlPlanes {
-		addNamespace(cp.Kongctl)
-	}
-
-	// Organization resources
-	for _, team := range rs.OrganizationTeams {
-		addNamespace(team.Kongctl)
-	}
-	if rs.Organization != nil {
-		for _, user := range rs.Organization.Users {
-			addNamespace(user.Kongctl)
-		}
-		for _, systemAccount := range rs.Organization.SystemAccounts {
-			addNamespace(systemAccount.Kongctl)
-		}
-	}
-
-	// Convert to slice for validation
-	namespaceList := make([]string, 0, len(namespaces))
-	for ns := range namespaces {
-		namespaceList = append(namespaceList, ns)
-	}
 
 	// Validate all namespaces
-	if err := nsValidator.ValidateNamespaces(namespaceList); err != nil {
+	if err := nsValidator.ValidateNamespaces(rs.NamespaceValues()); err != nil {
 		return fmt.Errorf("namespace validation failed: %w", err)
 	}
 

--- a/internal/declarative/planner/sync_scope.go
+++ b/internal/declarative/planner/sync_scope.go
@@ -49,36 +49,10 @@ func ensurePlanningSyncScope(rs *resources.ResourceSet) {
 	}
 
 	scope := rs.EnsureSyncScope()
-	addRootIfPresent(scope, resources.ResourceTypePortal, len(rs.Portals))
-	addRootIfPresent(scope, resources.ResourceTypeApplicationAuthStrategy, len(rs.ApplicationAuthStrategies))
-	addRootIfPresent(scope, resources.ResourceTypeDCRProvider, len(rs.DCRProviders))
-	addRootIfPresent(scope, resources.ResourceTypeControlPlane, len(rs.ControlPlanes))
-	addRootIfPresent(scope, resources.ResourceTypeCatalogService, len(rs.CatalogServices))
-	addRootIfPresent(scope, resources.ResourceTypeAIGateway, len(rs.AIGateways))
+	rs.InferRegisteredSyncScope(scope)
 	addRootIfPresent(scope, resources.ResourceTypeDashboard, len(rs.Dashboards))
-	addRootIfPresent(scope, resources.ResourceTypeAPI, len(rs.APIs))
-	addRootIfPresent(scope, resources.ResourceTypeEventGatewayControlPlane, len(rs.EventGatewayControlPlanes))
 	addRootIfPresent(scope, resources.ResourceTypeOrganizationTeam, len(rs.OrganizationTeams))
 
-	for _, cert := range rs.ControlPlaneDataPlaneCertificates {
-		scope.AddChild(
-			resources.ResourceTypeControlPlane,
-			cert.ControlPlane,
-			resources.ResourceTypeControlPlaneDataPlaneCertificate,
-		)
-	}
-	for _, version := range rs.APIVersions {
-		scope.AddChild(resources.ResourceTypeAPI, version.API, resources.ResourceTypeAPIVersion)
-	}
-	for _, publication := range rs.APIPublications {
-		scope.AddChild(resources.ResourceTypeAPI, publication.API, resources.ResourceTypeAPIPublication)
-	}
-	for _, implementation := range rs.APIImplementations {
-		scope.AddChild(resources.ResourceTypeAPI, implementation.API, resources.ResourceTypeAPIImplementation)
-	}
-	for _, document := range rs.APIDocuments {
-		scope.AddChild(resources.ResourceTypeAPI, document.API, resources.ResourceTypeAPIDocument)
-	}
 	addPortalChildScopes(scope, rs)
 	addAIGatewayChildScopes(scope, rs)
 	addEventGatewayChildScopes(scope, rs)

--- a/internal/declarative/resources/ai_gateway.go
+++ b/internal/declarative/resources/ai_gateway.go
@@ -23,6 +23,16 @@ func init() {
 			WithExplainSchemaBuilder(aiGatewayExplainNode),
 		),
 		ExternalResolutionRegistration{Selectors: []string{SchemaFieldName, "display_name"}},
+		WithNamespace(40, func(r *AIGatewayResource) NamespaceParticipant {
+			return NamespaceParticipant{
+				Ref:               r.Ref,
+				Label:             "ai_gateway",
+				SupportsProtected: true,
+				Meta:              &r.Kongctl,
+				External:          r.IsExternal(),
+			}
+		}),
+		WithRootSyncScope(),
 	)
 }
 

--- a/internal/declarative/resources/api.go
+++ b/internal/declarative/resources/api.go
@@ -16,6 +16,16 @@ func init() {
 			WithExplainSchemaBuilder(apiExplainNode),
 		),
 		ExternalResolutionRegistration{Selectors: []string{SchemaFieldName}},
+		WithNamespace(20, func(r *APIResource) NamespaceParticipant {
+			return NamespaceParticipant{
+				Ref:               r.Ref,
+				Label:             "api",
+				SupportsProtected: true,
+				Meta:              &r.Kongctl,
+				External:          r.IsExternal(),
+			}
+		}),
+		WithRootSyncScope(),
 	)
 }
 

--- a/internal/declarative/resources/api_document.go
+++ b/internal/declarative/resources/api_document.go
@@ -25,6 +25,7 @@ func init() {
 			}),
 		),
 		WithExternalUnsupportedReason("scoped API document lookup is planned for API domain enablement"),
+		WithChildSyncScope(ResourceTypeAPI),
 	)
 }
 

--- a/internal/declarative/resources/api_implementation.go
+++ b/internal/declarative/resources/api_implementation.go
@@ -23,6 +23,7 @@ func init() {
 		AutoExplain[APIImplementationResource](
 			WithExplainSchemaBuilder(apiImplementationExplainNode),
 		),
+		WithChildSyncScope(ResourceTypeAPI),
 	)
 }
 

--- a/internal/declarative/resources/api_publication.go
+++ b/internal/declarative/resources/api_publication.go
@@ -13,6 +13,7 @@ func init() {
 		ResourceTypeAPIPublication,
 		func(rs *ResourceSet) *[]APIPublicationResource { return &rs.APIPublications },
 		AutoExplain[APIPublicationResource](),
+		WithChildSyncScope(ResourceTypeAPI),
 	)
 }
 

--- a/internal/declarative/resources/api_version.go
+++ b/internal/declarative/resources/api_version.go
@@ -28,6 +28,7 @@ func init() {
 				Notes: []string{"Set the whole spec with `spec: !file ...` instead of populating content directly."},
 			}),
 		),
+		WithChildSyncScope(ResourceTypeAPI),
 	)
 }
 

--- a/internal/declarative/resources/auth_strategy.go
+++ b/internal/declarative/resources/auth_strategy.go
@@ -18,6 +18,16 @@ func init() {
 			WithExplainSchemaBuilder(applicationAuthStrategyExplainNode),
 		),
 		ExternalResolutionRegistration{Selectors: []string{SchemaFieldName, "display_name"}},
+		WithNamespace(70, func(r *ApplicationAuthStrategyResource) NamespaceParticipant {
+			return NamespaceParticipant{
+				Ref:               r.Ref,
+				Label:             "application_auth_strategy",
+				SupportsProtected: true,
+				Meta:              &r.Kongctl,
+				External:          r.IsExternal(),
+			}
+		}),
+		WithRootSyncScope(),
 	)
 }
 

--- a/internal/declarative/resources/catalog_service.go
+++ b/internal/declarative/resources/catalog_service.go
@@ -12,6 +12,10 @@ func init() {
 		ResourceTypeCatalogService,
 		func(rs *ResourceSet) *[]CatalogServiceResource { return &rs.CatalogServices },
 		AutoExplain[CatalogServiceResource](),
+		WithNamespace(30, func(r *CatalogServiceResource) NamespaceParticipant {
+			return NamespaceParticipant{Ref: r.Ref, Label: "catalog_service", SupportsProtected: true, Meta: &r.Kongctl}
+		}),
+		WithRootSyncScope(),
 	)
 }
 

--- a/internal/declarative/resources/control_plane.go
+++ b/internal/declarative/resources/control_plane.go
@@ -13,6 +13,16 @@ func init() {
 		func(rs *ResourceSet) *[]ControlPlaneResource { return &rs.ControlPlanes },
 		AutoExplain[ControlPlaneResource](),
 		ExternalResolutionRegistration{Selectors: []string{SchemaFieldName}},
+		WithNamespace(90, func(r *ControlPlaneResource) NamespaceParticipant {
+			return NamespaceParticipant{
+				Ref:               r.Ref,
+				Label:             "control_plane",
+				SupportsProtected: true,
+				Meta:              &r.Kongctl,
+				External:          r.IsExternal(),
+			}
+		}),
+		WithRootSyncScope(),
 	)
 }
 

--- a/internal/declarative/resources/control_plane_data_plane_certificate.go
+++ b/internal/declarative/resources/control_plane_data_plane_certificate.go
@@ -25,6 +25,7 @@ func init() {
 			}),
 			WithExplainRecommendedFields("ref", "control_plane", "cert"),
 		),
+		WithChildSyncScope(ResourceTypeControlPlane),
 	)
 }
 

--- a/internal/declarative/resources/dashboard.go
+++ b/internal/declarative/resources/dashboard.go
@@ -17,6 +17,14 @@ func init() {
 			WithExplainRecommendedFields("ref", "name", "definition"),
 			WithExplainSchemaBuilder(dashboardExplainNode),
 		),
+		WithNamespace(50, func(r *DashboardResource) NamespaceParticipant {
+			return NamespaceParticipant{Ref: r.Ref, Label: "dashboard", SupportsProtected: true, Meta: &r.Kongctl}
+		}, func(rs *ResourceSet) []DashboardResource {
+			if rs.Analytics == nil {
+				return nil
+			}
+			return rs.Analytics.Dashboards
+		}),
 	)
 }
 

--- a/internal/declarative/resources/dcr_provider.go
+++ b/internal/declarative/resources/dcr_provider.go
@@ -13,13 +13,20 @@ func init() {
 		ResourceTypeDCRProvider,
 		func(rs *ResourceSet) *[]DCRProviderResource { return &rs.DCRProviders },
 		AutoExplain[DCRProviderResource](
-			WithExplainFieldHint("dcr_config.initial_client_secret", secretExplainFieldHint("DCR_INITIAL_CLIENT_SECRET")),
+			WithExplainFieldHint(
+				"dcr_config.initial_client_secret",
+				secretExplainFieldHint("DCR_INITIAL_CLIENT_SECRET"),
+			),
 			WithExplainFieldHint("dcr_config.dcr_token", secretExplainFieldHint("DCR_TOKEN")),
 			WithExplainFieldHint("dcr_config.api_key", secretExplainFieldHint("DCR_API_KEY")),
 		),
 		WithExternalUnsupportedReason(
 			"DCR provider lookup is deferred until write-only configuration can be separated from identity",
 		),
+		WithNamespace(80, func(r *DCRProviderResource) NamespaceParticipant {
+			return NamespaceParticipant{Ref: r.Ref, Label: "dcr_provider", SupportsProtected: true, Meta: &r.Kongctl}
+		}),
+		WithRootSyncScope(),
 	)
 }
 

--- a/internal/declarative/resources/declaration_structure.go
+++ b/internal/declarative/resources/declaration_structure.go
@@ -1,0 +1,74 @@
+package resources
+
+import (
+	"reflect"
+	"strings"
+)
+
+type nestedResourceField struct {
+	name         string
+	resourceType ResourceType
+	array        bool
+}
+
+// nestedResourceFields discovers declaration containment without assigning
+// lifecycle or sync ownership semantics.
+func nestedResourceFields(parent reflect.Type) []nestedResourceField {
+	var fields []nestedResourceField
+	for field := range derefExplainType(parent).Fields() {
+		if !field.IsExported() {
+			continue
+		}
+		name, _, _, skip := explainFieldName(field, "yaml")
+		if skip || name == "" {
+			continue
+		}
+		kind, ok := registeredResourceType(field.Type)
+		if !ok {
+			continue
+		}
+		fields = append(fields, nestedResourceField{
+			name:         name,
+			resourceType: kind,
+			array:        derefExplainType(field.Type).Kind() == reflect.Slice,
+		})
+	}
+	return fields
+}
+
+func registeredResourceType(typ reflect.Type) (ResourceType, bool) {
+	typ = derefExplainType(typ)
+	if typ.Kind() == reflect.Slice {
+		typ = derefExplainType(typ.Elem())
+	}
+	for rt, ops := range registry {
+		if ops.explain.typ == typ {
+			return rt, true
+		}
+	}
+	return "", false
+}
+
+func resourceSetRootKey(resourceType reflect.Type) string {
+	resourceType = derefExplainType(resourceType)
+	rsType := reflect.TypeFor[ResourceSet]()
+	for field := range rsType.Fields() {
+		fieldType := derefExplainType(field.Type)
+		if fieldType.Kind() != reflect.Slice {
+			continue
+		}
+		if derefExplainType(fieldType.Elem()) != resourceType {
+			continue
+		}
+		tag := field.Tag.Get("yaml")
+		if tag == "" || tag == "-" {
+			return ""
+		}
+		name := strings.Split(tag, ",")[0]
+		if name == "-" {
+			return ""
+		}
+		return name
+	}
+	return ""
+}

--- a/internal/declarative/resources/event_gateway_control_plane.go
+++ b/internal/declarative/resources/event_gateway_control_plane.go
@@ -14,6 +14,16 @@ func init() {
 			WithExplainAliases("egw"),
 		),
 		ExternalResolutionRegistration{AllowAnyStringSelector: true},
+		WithNamespace(60, func(r *EventGatewayControlPlaneResource) NamespaceParticipant {
+			return NamespaceParticipant{
+				Ref:               r.Ref,
+				Label:             SchemaFieldEventGateway,
+				SupportsProtected: true,
+				Meta:              &r.Kongctl,
+				External:          r.IsExternal(),
+			}
+		}),
+		WithRootSyncScope(),
 	)
 }
 

--- a/internal/declarative/resources/explain.go
+++ b/internal/declarative/resources/explain.go
@@ -69,7 +69,7 @@ type ExplainDoc struct {
 	ResourceType              ResourceType      `json:"resource_type"               yaml:"resource_type"`
 	CanonicalAlias            string            `json:"canonical_alias"             yaml:"canonical_alias"`
 	Aliases                   []string          `json:"aliases,omitempty"           yaml:"aliases,omitempty"`
-	ResourceClass             string            `json:"resource_class"              yaml:"resource_class"`
+	ResourceClass             string            `json:"resource_class" yaml:"resource_class"`
 	RootKey                   string            `json:"root_key,omitempty"          yaml:"root_key,omitempty"`
 	SupportsRoot              bool              `json:"supports_root"               yaml:"supports_root"`
 	SupportsNestedDeclaration bool              `json:"supports_nested_declaration" yaml:"supports_nested_declaration"`
@@ -147,7 +147,7 @@ type JSONSchema struct {
 	Description   string                  `json:"description,omitempty" yaml:"description,omitempty"`
 	Type          any                     `json:"type,omitempty" yaml:"type,omitempty"`
 	Properties    map[string]*JSONSchema  `json:"properties,omitempty" yaml:"properties,omitempty"`
-	Required      []string                `json:"required,omitempty" yaml:"required,omitempty"`
+	Required      []string                `json:"required,omitempty"    yaml:"required,omitempty"`
 	Items         *JSONSchema             `json:"items,omitempty" yaml:"items,omitempty"`
 	Additional    any                     `json:"additionalProperties,omitempty" yaml:"additionalProperties,omitempty"`
 	OneOf         []*JSONSchema           `json:"oneOf,omitempty" yaml:"oneOf,omitempty"`
@@ -185,7 +185,7 @@ type ExplainRelationship struct {
 	Target              ResourceType            `json:"target,omitempty" yaml:"target,omitempty"`
 	Targets             []ResourceType          `json:"targets,omitempty" yaml:"targets,omitempty"`
 	TargetDiscriminator string                  `json:"target_discriminator,omitempty" yaml:"target_discriminator,omitempty"` //nolint:lll
-	Kind                RelationshipKind        `json:"kind" yaml:"kind"`
+	Kind                RelationshipKind        `json:"kind"                  yaml:"kind"`
 	Cardinality         RelationshipCardinality `json:"cardinality" yaml:"cardinality"`
 	ResultField         RelationshipResultField `json:"result_field" yaml:"result_field"`
 	AcceptedTags        []string                `json:"accepted_tags,omitempty" yaml:"accepted_tags,omitempty"`
@@ -1296,7 +1296,7 @@ func autoExplainValueNode(
 			child := recursiveExplainNode(typ)
 			child.Nullable = child.Nullable || nullable
 			node = child
-		} else if resourceType, ok := explainRegisteredResourceType(typ); ok {
+		} else if resourceType, ok := registeredResourceType(typ); ok {
 			if doc, ok := explainDocByType(resourceType); ok {
 				child := doc.Schema.clone()
 				child.Nullable = child.Nullable || nullable
@@ -2380,67 +2380,18 @@ func organizationAssignmentParentRelations(target ResourceType) []ExplainRelatio
 }
 
 func explainNestedRelations(parentType ResourceType, parent reflect.Type) []ExplainRelation {
-	parent = derefExplainType(parent)
 	var relations []ExplainRelation
-	for field := range parent.Fields() {
-		if !field.IsExported() {
-			continue
-		}
-		name, _, _, skip := explainFieldName(field, "yaml")
-		if skip || name == "" {
-			continue
-		}
-		childType, ok := explainRegisteredResourceType(field.Type)
-		if !ok {
-			continue
-		}
+	for _, field := range nestedResourceFields(parent) {
 		relations = append(relations, ExplainRelation{
 			ParentAlias:   string(parentType),
 			ParentType:    string(parentType),
-			FieldName:     name,
-			FieldArray:    derefExplainType(field.Type).Kind() == reflect.Slice,
-			ChildAlias:    string(childType),
+			FieldName:     field.name,
+			FieldArray:    field.array,
+			ChildAlias:    string(field.resourceType),
 			ParentRootKey: resourceSetRootKey(parent),
 		})
 	}
 	return relations
-}
-
-func explainRegisteredResourceType(typ reflect.Type) (ResourceType, bool) {
-	typ = derefExplainType(typ)
-	if typ.Kind() == reflect.Slice {
-		typ = derefExplainType(typ.Elem())
-	}
-	for rt, ops := range registry {
-		if ops.explain.typ == typ {
-			return rt, true
-		}
-	}
-	return "", false
-}
-
-func resourceSetRootKey(resourceType reflect.Type) string {
-	resourceType = derefExplainType(resourceType)
-	rsType := reflect.TypeFor[ResourceSet]()
-	for field := range rsType.Fields() {
-		fieldType := derefExplainType(field.Type)
-		if fieldType.Kind() != reflect.Slice {
-			continue
-		}
-		if derefExplainType(fieldType.Elem()) != resourceType {
-			continue
-		}
-		tag := field.Tag.Get("yaml")
-		if tag == "" || tag == "-" {
-			return ""
-		}
-		name := strings.Split(tag, ",")[0]
-		if name == "-" {
-			return ""
-		}
-		return name
-	}
-	return ""
 }
 
 func explainFieldName(field reflect.StructField, tagName string) (name string, inline bool, omitempty bool, skip bool) {

--- a/internal/declarative/resources/load_schema.go
+++ b/internal/declarative/resources/load_schema.go
@@ -194,7 +194,7 @@ func reflectLoadSchema(typ reflect.Type, stack []reflect.Type) *JSONSchema {
 	typ = derefExplainType(typ)
 
 	if typ.Kind() == reflect.Struct {
-		if resourceType, ok := explainRegisteredResourceType(typ); ok {
+		if resourceType, ok := registeredResourceType(typ); ok {
 			return loadSchemaResourceRef(resourceType, false)
 		}
 	}

--- a/internal/declarative/resources/namespace_participants.go
+++ b/internal/declarative/resources/namespace_participants.go
@@ -1,128 +1,138 @@
 package resources
 
-// NamespaceParticipant is a namespace-bearing declarative parent resource. It is
-// the single source of truth for which resources carry kongctl namespace
-// metadata, shared by loader defaulting, namespace validation, and planner
-// namespace discovery. Callers keep their own handling of external resources,
-// which is intentionally not uniform across those paths.
+import (
+	"cmp"
+	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+)
+
+// NamespaceParticipant is a namespace-bearing declarative parent resource.
+// Resource registrations supply these values; callers retain their own
+// defaulting, validation, and external-resource policies.
 type NamespaceParticipant struct {
 	Type ResourceType
 	Ref  string
 	// External reports whether the resource is declared as an external reference.
-	// Callers decide what that means: the loader rejects kongctl metadata on
-	// external resources, the validator skips them, and the planner maps them to
-	// the external namespace.
 	External bool
-	// SupportsProtected reports whether kongctl.protected defaulting applies.
-	// Organization users and system accounts only carry a namespace.
+	// SupportsProtected excludes namespace-only organization selectors.
 	SupportsProtected bool
-	// Label is the human-facing name used in loader defaulting error messages.
+	// Label is the human-facing name used in loader defaulting errors.
 	Label string
-	// Meta addresses the resource's Kongctl field so callers can read the current
-	// metadata and assign defaults in place.
+	// Meta addresses the resource's Kongctl field for in-place defaulting.
 	Meta **KongctlMeta
 }
 
-// ForEachNamespaceParticipant visits every namespace-bearing resource in rs and
-// returns early if fn returns an error. Both the nested (Analytics.Dashboards,
-// Organization.Teams) and the flattened (Dashboards, OrganizationTeams)
-// locations are visited so the iterator is correct both before and after
-// extractNestedResources runs; only one side is populated at a given stage.
-//
-// The visit order matches the namespace validator's violation order so error
-// messages are unchanged.
+type namespaceRegistration struct {
+	kind        ResourceType
+	order       int
+	visit       func(*ResourceSet, func(NamespaceParticipant) error) error
+	visitNested func(*ResourceSet, func(NamespaceParticipant) error) error
+}
+
+var namespaceRegistrations []namespaceRegistration
+
+// WithNamespace registers typed metadata access alongside the resource's
+// existing slice accessor. Order preserves namespace diagnostic traversal.
+// Additional sources are grouping locations visited before nested extraction.
+func WithNamespace[R any](
+	order int,
+	participant func(*R) NamespaceParticipant,
+	nested ...func(*ResourceSet) []R,
+) ResourceRegistrationOption {
+	return func(ops *resourceOps) error {
+		if ops.namespace != nil {
+			return fmt.Errorf("namespace capability is already registered")
+		}
+		if participant == nil || ops.explain.typ != reflect.TypeFor[R]() {
+			return fmt.Errorf("namespace accessor must match the registered resource type")
+		}
+		ops.namespace = &namespaceRegistration{
+			order: order,
+			visit: func(rs *ResourceSet, fn func(NamespaceParticipant) error) error {
+				var err error
+				ops.forEach(rs, func(resource Resource) bool {
+					err = fn(participant(any(resource).(*R)))
+					return err == nil
+				})
+				return err
+			},
+			visitNested: func(rs *ResourceSet, fn func(NamespaceParticipant) error) error {
+				for _, source := range nested {
+					if err := visitNamespaceSlice(source(rs), participant, fn); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+		}
+		return nil
+	}
+}
+
+// Organization selectors do not implement Resource and must not enter the
+// declaration registry merely to participate in namespace processing.
+func registerNamespaceSelector[R any](
+	kind ResourceType,
+	order int,
+	source func(*ResourceSet) []R,
+	participant func(*R) NamespaceParticipant,
+) {
+	registerNamespaceParticipant(kind, namespaceRegistration{
+		order: order,
+		visit: func(rs *ResourceSet, fn func(NamespaceParticipant) error) error {
+			return visitNamespaceSlice(source(rs), participant, fn)
+		},
+	})
+}
+
+func visitNamespaceSlice[R any](
+	values []R,
+	participant func(*R) NamespaceParticipant,
+	fn func(NamespaceParticipant) error,
+) error {
+	for i := range values {
+		if err := fn(participant(&values[i])); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func registerNamespaceParticipant(kind ResourceType, registration namespaceRegistration) {
+	if kind == "" || registration.order <= 0 || registration.visit == nil {
+		panic("namespace registration requires a resource type, positive order, and visitor")
+	}
+	for _, existing := range namespaceRegistrations {
+		if existing.kind == kind || existing.order == registration.order {
+			panic("duplicate namespace resource type or traversal order: " + string(kind))
+		}
+	}
+	registration.kind = kind
+	namespaceRegistrations = append(namespaceRegistrations, registration)
+	slices.SortFunc(namespaceRegistrations, func(a, b namespaceRegistration) int {
+		return cmp.Compare(a.order, b.order)
+	})
+}
+
+// ForEachNamespaceParticipant visits namespace-bearing resources in diagnostic
+// order and stops on error. Both flattened and nested grouping locations are
+// visited, preserving behavior before and after nested extraction.
 func (rs *ResourceSet) ForEachNamespaceParticipant(fn func(NamespaceParticipant) error) error {
 	if rs == nil {
 		return nil
 	}
-
-	for i := range rs.Portals {
-		if err := fn(NamespaceParticipant{
-			Type: ResourceTypePortal, Ref: rs.Portals[i].Ref, External: rs.Portals[i].IsExternal(),
-			SupportsProtected: true, Label: "portal", Meta: &rs.Portals[i].Kongctl,
-		}); err != nil {
+	for _, registration := range namespaceRegistrations {
+		visit := func(participant NamespaceParticipant) error {
+			participant.Type = registration.kind
+			return fn(participant)
+		}
+		if err := registration.visit(rs, visit); err != nil {
 			return err
 		}
-	}
-	for i := range rs.APIs {
-		if err := fn(NamespaceParticipant{
-			Type: ResourceTypeAPI, Ref: rs.APIs[i].Ref, External: rs.APIs[i].IsExternal(),
-			SupportsProtected: true, Label: "api", Meta: &rs.APIs[i].Kongctl,
-		}); err != nil {
-			return err
-		}
-	}
-	for i := range rs.CatalogServices {
-		if err := fn(NamespaceParticipant{
-			Type: ResourceTypeCatalogService, Ref: rs.CatalogServices[i].Ref,
-			SupportsProtected: true, Label: "catalog_service", Meta: &rs.CatalogServices[i].Kongctl,
-		}); err != nil {
-			return err
-		}
-	}
-	for i := range rs.AIGateways {
-		if err := fn(NamespaceParticipant{
-			Type: ResourceTypeAIGateway, Ref: rs.AIGateways[i].Ref, External: rs.AIGateways[i].IsExternal(),
-			SupportsProtected: true, Label: "ai_gateway", Meta: &rs.AIGateways[i].Kongctl,
-		}); err != nil {
-			return err
-		}
-	}
-	if err := rs.forEachDashboardParticipant(fn); err != nil {
-		return err
-	}
-	for i := range rs.EventGatewayControlPlanes {
-		if err := fn(NamespaceParticipant{
-			Type: ResourceTypeEventGatewayControlPlane, Ref: rs.EventGatewayControlPlanes[i].Ref,
-			External: rs.EventGatewayControlPlanes[i].IsExternal(), SupportsProtected: true,
-			Label: SchemaFieldEventGateway, Meta: &rs.EventGatewayControlPlanes[i].Kongctl,
-		}); err != nil {
-			return err
-		}
-	}
-	for i := range rs.ApplicationAuthStrategies {
-		if err := fn(NamespaceParticipant{
-			Type: ResourceTypeApplicationAuthStrategy, Ref: rs.ApplicationAuthStrategies[i].Ref,
-			External:          rs.ApplicationAuthStrategies[i].IsExternal(),
-			SupportsProtected: true, Label: "application_auth_strategy",
-			Meta: &rs.ApplicationAuthStrategies[i].Kongctl,
-		}); err != nil {
-			return err
-		}
-	}
-	for i := range rs.DCRProviders {
-		if err := fn(NamespaceParticipant{
-			Type: ResourceTypeDCRProvider, Ref: rs.DCRProviders[i].Ref,
-			SupportsProtected: true, Label: "dcr_provider", Meta: &rs.DCRProviders[i].Kongctl,
-		}); err != nil {
-			return err
-		}
-	}
-	for i := range rs.ControlPlanes {
-		if err := fn(NamespaceParticipant{
-			Type: ResourceTypeControlPlane, Ref: rs.ControlPlanes[i].Ref, External: rs.ControlPlanes[i].IsExternal(),
-			SupportsProtected: true, Label: "control_plane", Meta: &rs.ControlPlanes[i].Kongctl,
-		}); err != nil {
-			return err
-		}
-	}
-	if err := rs.forEachOrganizationTeamParticipant(fn); err != nil {
-		return err
-	}
-	if rs.Organization != nil {
-		for i := range rs.Organization.Users {
-			if err := fn(NamespaceParticipant{
-				Type: ResourceTypeOrganizationUser, Ref: rs.Organization.Users[i].Ref,
-				Label: "organization user", Meta: &rs.Organization.Users[i].Kongctl,
-			}); err != nil {
-				return err
-			}
-		}
-		for i := range rs.Organization.SystemAccounts {
-			if err := fn(NamespaceParticipant{
-				Type: ResourceTypeOrganizationSystemAccount, Ref: rs.Organization.SystemAccounts[i].Ref,
-				Label: "organization system account", Meta: &rs.Organization.SystemAccounts[i].Kongctl,
-			}); err != nil {
+		if registration.visitNested != nil {
+			if err := registration.visitNested(rs, visit); err != nil {
 				return err
 			}
 		}
@@ -130,46 +140,21 @@ func (rs *ResourceSet) ForEachNamespaceParticipant(fn func(NamespaceParticipant)
 	return nil
 }
 
-func (rs *ResourceSet) forEachDashboardParticipant(fn func(NamespaceParticipant) error) error {
-	dashboard := func(d *DashboardResource) error {
-		return fn(NamespaceParticipant{
-			Type: ResourceTypeDashboard, Ref: d.Ref,
-			SupportsProtected: true, Label: "dashboard", Meta: &d.Kongctl,
+// NamespaceValues returns present kongctl.namespace values after extraction.
+// It reads flattened resources and organization selectors, without revisiting
+// grouping locations or applying the planner's external-namespace policy.
+func (rs *ResourceSet) NamespaceValues() []string {
+	if rs == nil {
+		return nil
+	}
+	namespaces := make(map[string]struct{})
+	for _, registration := range namespaceRegistrations {
+		_ = registration.visit(rs, func(participant NamespaceParticipant) error {
+			if meta := *participant.Meta; meta != nil && meta.Namespace != nil {
+				namespaces[*meta.Namespace] = struct{}{}
+			}
+			return nil
 		})
 	}
-	for i := range rs.Dashboards {
-		if err := dashboard(&rs.Dashboards[i]); err != nil {
-			return err
-		}
-	}
-	if rs.Analytics != nil {
-		for i := range rs.Analytics.Dashboards {
-			if err := dashboard(&rs.Analytics.Dashboards[i]); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-func (rs *ResourceSet) forEachOrganizationTeamParticipant(fn func(NamespaceParticipant) error) error {
-	team := func(t *OrganizationTeamResource) error {
-		return fn(NamespaceParticipant{
-			Type: ResourceTypeOrganizationTeam, Ref: t.Ref, External: t.IsExternal(),
-			SupportsProtected: true, Label: string(ResourceTypeTeam), Meta: &t.Kongctl,
-		})
-	}
-	for i := range rs.OrganizationTeams {
-		if err := team(&rs.OrganizationTeams[i]); err != nil {
-			return err
-		}
-	}
-	if rs.Organization != nil {
-		for i := range rs.Organization.Teams {
-			if err := team(&rs.Organization.Teams[i]); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
+	return slices.Collect(maps.Keys(namespaces))
 }

--- a/internal/declarative/resources/organization_system_account.go
+++ b/internal/declarative/resources/organization_system_account.go
@@ -5,6 +5,18 @@ import (
 )
 
 func init() {
+	registerNamespaceSelector(
+		ResourceTypeOrganizationSystemAccount, 120,
+		func(rs *ResourceSet) []OrganizationSystemAccountResource {
+			if rs.Organization == nil {
+				return nil
+			}
+			return rs.Organization.SystemAccounts
+		},
+		func(r *OrganizationSystemAccountResource) NamespaceParticipant {
+			return NamespaceParticipant{Ref: r.Ref, Label: "organization system account", Meta: &r.Kongctl}
+		},
+	)
 	registerResourceType(
 		ResourceTypeOrganizationSystemAccountTeamMembership,
 		func(rs *ResourceSet) *[]OrganizationSystemAccountTeamMembershipResource {
@@ -27,7 +39,7 @@ func init() {
 
 // OrganizationSystemAccountResource selects an existing Konnect system account and declares assignments.
 type OrganizationSystemAccountResource struct {
-	Ref     string                                            `yaml:"ref"               json:"ref"`
+	Ref     string                                            `yaml:"ref" json:"ref"`
 	Name    string                                            `yaml:"name,omitempty"    json:"name,omitempty"`
 	ID      string                                            `yaml:"id,omitempty"      json:"id,omitempty"`
 	Kongctl *KongctlMeta                                      `yaml:"kongctl,omitempty" json:"kongctl,omitempty"`
@@ -71,7 +83,7 @@ func (s *OrganizationSystemAccountResource) SetKonnectID(id string) {
 
 // OrganizationSystemAccountTeamMembershipResource represents a system account's team assignment.
 type OrganizationSystemAccountTeamMembershipResource struct {
-	Ref           string `yaml:"ref"  json:"ref"`
+	Ref           string `yaml:"ref" json:"ref"`
 	SystemAccount string `yaml:"system_account,omitempty" json:"system_account,omitempty"`
 	Team          string `yaml:"team" json:"team"`
 }

--- a/internal/declarative/resources/organization_team.go
+++ b/internal/declarative/resources/organization_team.go
@@ -13,6 +13,20 @@ func init() {
 		func(rs *ResourceSet) *[]OrganizationTeamResource { return &rs.OrganizationTeams },
 		AutoExplain[OrganizationTeamResource](),
 		ExternalResolutionRegistration{Selectors: []string{SchemaFieldName}},
+		WithNamespace(100, func(r *OrganizationTeamResource) NamespaceParticipant {
+			return NamespaceParticipant{
+				Ref:               r.Ref,
+				Label:             string(ResourceTypeTeam),
+				SupportsProtected: true,
+				Meta:              &r.Kongctl,
+				External:          r.IsExternal(),
+			}
+		}, func(rs *ResourceSet) []OrganizationTeamResource {
+			if rs.Organization == nil {
+				return nil
+			}
+			return rs.Organization.Teams
+		}),
 	)
 }
 

--- a/internal/declarative/resources/organization_user.go
+++ b/internal/declarative/resources/organization_user.go
@@ -5,6 +5,18 @@ import (
 )
 
 func init() {
+	registerNamespaceSelector(
+		ResourceTypeOrganizationUser, 110,
+		func(rs *ResourceSet) []OrganizationUserResource {
+			if rs.Organization == nil {
+				return nil
+			}
+			return rs.Organization.Users
+		},
+		func(r *OrganizationUserResource) NamespaceParticipant {
+			return NamespaceParticipant{Ref: r.Ref, Label: "organization user", Meta: &r.Kongctl}
+		},
+	)
 	registerResourceType(
 		ResourceTypeOrganizationUserTeamMembership,
 		func(rs *ResourceSet) *[]OrganizationUserTeamMembershipResource {
@@ -25,7 +37,7 @@ func init() {
 
 // OrganizationUserResource selects an existing Konnect user and declares user-bound assignments.
 type OrganizationUserResource struct {
-	Ref     string                                   `yaml:"ref"               json:"ref"`
+	Ref     string                                   `yaml:"ref" json:"ref"`
 	Email   string                                   `yaml:"email,omitempty"   json:"email,omitempty"`
 	ID      string                                   `yaml:"id,omitempty"      json:"id,omitempty"`
 	Kongctl *KongctlMeta                             `yaml:"kongctl,omitempty" json:"kongctl,omitempty"`
@@ -69,7 +81,7 @@ func (u *OrganizationUserResource) SetKonnectID(id string) {
 
 // OrganizationUserTeamMembershipResource represents an organization user's team assignment.
 type OrganizationUserTeamMembershipResource struct {
-	Ref  string `yaml:"ref"  json:"ref"`
+	Ref  string `yaml:"ref" json:"ref"`
 	User string `yaml:"user,omitempty" json:"user,omitempty"`
 	Team string `yaml:"team" json:"team"`
 }

--- a/internal/declarative/resources/portal.go
+++ b/internal/declarative/resources/portal.go
@@ -15,6 +15,16 @@ func init() {
 		func(rs *ResourceSet) *[]PortalResource { return &rs.Portals },
 		AutoExplain[PortalResource](),
 		ExternalResolutionRegistration{Selectors: []string{SchemaFieldName}},
+		WithNamespace(10, func(r *PortalResource) NamespaceParticipant {
+			return NamespaceParticipant{
+				Ref:               r.Ref,
+				Label:             "portal",
+				SupportsProtected: true,
+				Meta:              &r.Kongctl,
+				External:          r.IsExternal(),
+			}
+		}),
+		WithRootSyncScope(),
 	)
 }
 

--- a/internal/declarative/resources/registry.go
+++ b/internal/declarative/resources/registry.go
@@ -25,6 +25,8 @@ type resourceOps struct {
 	forEach                   func(rs *ResourceSet, fn func(Resource) bool) bool
 	count                     func(rs *ResourceSet) int
 	explain                   ExplainRegistration
+	namespace                 *namespaceRegistration
+	syncScope                 *syncScopeRegistration
 	dumpDefaultRules          map[string]dumpDefaultRule
 	maturity                  *maturity.Metadata
 	operationMaturity         map[Operation]maturity.Metadata
@@ -100,7 +102,11 @@ func registerExternalResourceType[R any, RPtr interface {
 	registerResourceTypeWithSliceAccessors[R, RPtr](rt, getSlicePtr, getSlicePtr, explain, options...)
 	ops := registry[rt]
 	if ops.externalUnsupportedReason != "" {
-		panic("register resource type " + string(rt) + ": external capability and unsupported reason are mutually exclusive")
+		panic(
+			"register resource type " + string(
+				rt,
+			) + ": external capability and unsupported reason are mutually exclusive",
+		)
 	}
 	ops.external = &external
 	ops.materializeExternal = externalMaterializer[R, RPtr](rt, getSlicePtr, external)
@@ -120,7 +126,11 @@ func registerExternalResourceTypeWithSliceAccessors[R any, RPtr interface {
 	registerResourceTypeWithSliceAccessors[R, RPtr](rt, getSlicePtr, ensureSlicePtr, explain, options...)
 	ops := registry[rt]
 	if ops.externalUnsupportedReason != "" {
-		panic("register resource type " + string(rt) + ": external capability and unsupported reason are mutually exclusive")
+		panic(
+			"register resource type " + string(
+				rt,
+			) + ": external capability and unsupported reason are mutually exclusive",
+		)
 	}
 	ops.external = &external
 	ops.materializeExternal = externalMaterializer[R, RPtr](rt, ensureSlicePtr, external)
@@ -144,7 +154,12 @@ func externalMaterializer[R any, RPtr interface {
 		}
 		if existing, ok := rs.GetResourceByRef(ref); ok {
 			if existing.GetType() != rt {
-				return nil, fmt.Errorf("external ref %q is already used by %s, expected %s", ref, existing.GetType(), rt)
+				return nil, fmt.Errorf(
+					"external ref %q is already used by %s, expected %s",
+					ref,
+					existing.GetType(),
+					rt,
+				)
 			}
 			if existing.GetKonnectID() != "" && existing.GetKonnectID() != id {
 				return nil, fmt.Errorf(
@@ -168,7 +183,11 @@ func externalMaterializer[R any, RPtr interface {
 		}
 		if external.ParentType != "" {
 			if external.ParentFieldPath == "" {
-				return nil, fmt.Errorf("external %s registration has parent type %s without parent field", rt, external.ParentType)
+				return nil, fmt.Errorf(
+					"external %s registration has parent type %s without parent field",
+					rt,
+					external.ParentType,
+				)
 			}
 			if strings.TrimSpace(parentRef) == "" {
 				return nil, fmt.Errorf("cannot materialize external %s without %s parent ref", rt, external.ParentType)
@@ -315,6 +334,9 @@ func registerResourceTypeWithSliceAccessors[R any, RPtr interface {
 		if err := option(&ops); err != nil {
 			panic("register resource type " + string(rt) + ": " + err.Error())
 		}
+	}
+	if ops.namespace != nil {
+		registerNamespaceParticipant(rt, *ops.namespace)
 	}
 	registry[rt] = ops
 }

--- a/internal/declarative/resources/sync_capabilities.go
+++ b/internal/declarative/resources/sync_capabilities.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"sync"
 )
 
 type syncScopeRegistration struct {
@@ -53,10 +54,22 @@ func withSyncScope(parentType ResourceType) ResourceRegistrationOption {
 	}
 }
 
-// SyncCollections derives locations from the same struct metadata as explain
-// and parent selectors from relationship descriptors. Scope semantics remain
-// opt-in: structural containment alone does not imply sync ownership.
+// Defer derivation until every resource's init function has registered its
+// metadata. Cross-resource validation must not depend on registration order.
+var cachedSyncCollections = sync.OnceValue(computeSyncCollections)
+
+// SyncCollections returns a copy of the collection metadata, including nested
+// keys. Locations and parent selectors are derived once from the declaration
+// structure and relationships; callers cannot mutate the cached descriptors.
 func SyncCollections() []SyncCollection {
+	collections := slices.Clone(cachedSyncCollections())
+	for i := range collections {
+		collections[i].NestedKeys = slices.Clone(collections[i].NestedKeys)
+	}
+	return collections
+}
+
+func computeSyncCollections() []SyncCollection {
 	var collections []SyncCollection
 	kinds := RegisteredTypes()
 	slices.Sort(kinds)

--- a/internal/declarative/resources/sync_capabilities.go
+++ b/internal/declarative/resources/sync_capabilities.go
@@ -1,0 +1,126 @@
+package resources
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+)
+
+type syncScopeRegistration struct {
+	parentType ResourceType
+}
+
+// SyncCollection describes an opted-in collection's sync ownership and YAML
+// locations. An empty ParentType identifies a managed root collection.
+type SyncCollection struct {
+	ResourceType  ResourceType
+	RootKey       string
+	ParentType    ResourceType
+	ParentKey     string
+	ParentRootKey string
+	NestedKeys    []string
+}
+
+// WithRootSyncScope opts a root collection into shared loader scope capture
+// and planner inference. Grouped roots retain their dedicated scope handling.
+func WithRootSyncScope() ResourceRegistrationOption {
+	return withSyncScope("")
+}
+
+// WithChildSyncScope opts an ordinary child collection into shared scope
+// handling. Its sync owner must match GetParentRef and a root-only parent
+// relationship. Singleton, grouping, and indirect ownership need dedicated
+// handling rather than this capability.
+func WithChildSyncScope(parentType ResourceType) ResourceRegistrationOption {
+	return func(ops *resourceOps) error {
+		if parentType == "" || !reflect.PointerTo(ops.explain.typ).Implements(reflect.TypeFor[ResourceWithParent]()) {
+			return fmt.Errorf("child sync scope requires an owner and ResourceWithParent")
+		}
+		return withSyncScope(parentType)(ops)
+	}
+}
+
+func withSyncScope(parentType ResourceType) ResourceRegistrationOption {
+	return func(ops *resourceOps) error {
+		if ops.syncScope != nil {
+			return fmt.Errorf("sync scope capability is already registered")
+		}
+		if resourceSetRootKey(ops.explain.typ) == "" {
+			return fmt.Errorf("sync scope capability requires a root-level YAML collection")
+		}
+		ops.syncScope = &syncScopeRegistration{parentType: parentType}
+		return nil
+	}
+}
+
+// SyncCollections derives locations from the same struct metadata as explain
+// and parent selectors from relationship descriptors. Scope semantics remain
+// opt-in: structural containment alone does not imply sync ownership.
+func SyncCollections() []SyncCollection {
+	var collections []SyncCollection
+	kinds := RegisteredTypes()
+	slices.Sort(kinds)
+	for _, kind := range kinds {
+		ops := registry[kind]
+		if ops.syncScope == nil {
+			continue
+		}
+		collection := SyncCollection{
+			ResourceType: kind,
+			RootKey:      resourceSetRootKey(ops.explain.typ),
+			ParentType:   ops.syncScope.parentType,
+		}
+		if collection.ParentType != "" {
+			parent, ok := registry[collection.ParentType]
+			if !ok || parent.syncScope == nil || parent.syncScope.parentType != "" {
+				panic("sync collection requires a registered root owner: " + string(kind))
+			}
+			collection.ParentRootKey = resourceSetRootKey(parent.explain.typ)
+			for _, relationship := range RelationshipDescriptorsForType(kind) {
+				if relationship.Kind == RelationshipKindKongctlParentSelector && relationship.RootOnly &&
+					relationship.TargetType == collection.ParentType {
+					if collection.ParentKey != "" {
+						panic("ambiguous sync parent selector: " + string(kind))
+					}
+					collection.ParentKey = relationship.FieldPath
+				}
+			}
+			if collection.ParentKey == "" {
+				panic("sync collection requires a root-only parent selector: " + string(kind))
+			}
+			for _, field := range nestedResourceFields(parent.explain.typ) {
+				if field.resourceType == kind && field.array {
+					collection.NestedKeys = append(collection.NestedKeys, field.name)
+				}
+			}
+		}
+		collections = append(collections, collection)
+	}
+	return collections
+}
+
+// InferRegisteredSyncScope adds scopes supported by populated resource slices.
+// Callers must retain an existing explicit SyncScope: slices cannot represent
+// the loader's distinction between omitted and explicitly empty collections.
+func (rs *ResourceSet) InferRegisteredSyncScope(scope *SyncScope) {
+	if rs == nil || scope == nil {
+		return
+	}
+	for kind, ops := range registry {
+		if ops.syncScope == nil {
+			continue
+		}
+		if ops.syncScope.parentType == "" {
+			if ops.count(rs) > 0 {
+				scope.AddRoot(kind)
+			}
+			continue
+		}
+		ops.forEach(rs, func(resource Resource) bool {
+			if parent := resource.(ResourceWithParent).GetParentRef(); parent != nil {
+				scope.AddChild(ops.syncScope.parentType, parent.Ref, kind)
+			}
+			return true
+		})
+	}
+}


### PR DESCRIPTION
Namespace participation and collection scope required separate inventories in resource, loader, and planner code. Resource registration now supplies those capabilities to the existing consumers.

- Co-locate all 12 namespace participants with their declarations: ten resource options and two namespace-only organization selectors. Reuse registered slice accessors, preserve diagnostic order and grouped/flattened traversal, and remove the loader's independent namespace inventory.
- Register all eight ordinary root collections and the API/control-plane child families: API versions, publications, implementations, documents, and control-plane data-plane certificates. Both loader presence capture and planner fallback inference consume this metadata.
- Share structural YAML-location discovery with explain/load schema; derive parent selectors from existing relationship descriptors. Remove the corresponding root/child scope tables and planner loops.
- Update the authoritative contributor guide with registration entry points, compatibility requirements, and remaining manual integration work.

For an ordinary API child, its existing declaration storage, YAML tags, and parent relationship plus `WithChildSyncScope(ResourceTypeAPI)` now supply both scope paths. No additional loader scope-table entry or planner inference loop is needed.

Compatibility remains explicit: omitted versus empty input, early versus late empty-child errors, external namespace policies, protected defaults, and organization selector identity are preserved. Portal singleton/indirect ownership, grouped roots, other child families, namespace inheritance/filtering, and extraction retain their dedicated paths.

Validation:
- Read-only `CGO_ENABLED=0 go fix -diff ./...`: no changes.
- Changed production files pass gofumpt and golines (existing struct-tag spacing preserved to avoid formatter-induced line-length failures).
- `make build-ci`: passes with CGO disabled and readonly modules.
- `make test-all`: passes with golangci-lint 2.13.1, installer checks, all race-enabled unit/integration tests, and 30 metrics tests.
- Existing focused resources/loader/planner/validator suites pass.
- All 1,590 test, fixture, and helper files match their pre-refactor SHA-256 values. No test files or packages were added or changed.
- Static inventory audit matches all 12 namespace kinds and all 8 root/5 child scope registrations to the baseline. Guide links and 80-column wrapping checked.

Refs #2079. This is a bounded milestone; the broader issue remains In Progress.

