### PR TITLE
test(e2e): cover DCR provider adopt namespace rejection

### DIFF
--- a/test/e2e/scenarios/dcr-providers/workflow/scenario.yaml
+++ b/test/e2e/scenarios/dcr-providers/workflow/scenario.yaml
@@ -439,7 +439,7 @@ steps:
         run:
           - adopt
           - dcr-provider
-          - "{{ .vars.overwriteAdoptName }}"
+          - "{{ .vars.overwriteAdoptID }}"
           - --namespace
           - "{{ .vars.namespace }}"
         assertions:
@@ -448,11 +448,27 @@ steps:
                 resource_type: dcr_provider
                 name: "{{ .vars.overwriteAdoptName }}"
                 namespace: "{{ .vars.namespace }}"
+      - name: 001a-reject-dcr-provider-namespace-overwrite
+        run:
+          - adopt
+          - dcr-provider
+          - "{{ .vars.overwriteAdoptID }}"
+          - --namespace
+          - "{{ .vars.overwrite_namespace }}"
+        expectFailure:
+          exitCode: 1
+          contains: "already has namespace label"
+      - name: 001b-verify-dcr-provider-namespace-unchanged
+        run: ["get", "dcr-provider", "{{ .vars.overwriteAdoptID }}", "-o", "json"]
+        assertions:
+          - expect:
+              fields:
+                labels."KONGCTL-namespace": "{{ .vars.namespace }}"
       - name: 002-overwrite-dcr-provider-namespace
         run:
           - adopt
           - dcr-provider
-          - "{{ .vars.overwriteAdoptName }}"
+          - "{{ .vars.overwriteAdoptID }}"
           - --namespace
           - "{{ .vars.overwrite_namespace }}"
           - --overwrite-namespace


### PR DESCRIPTION
The DCR provider workflow already covers adoption by name, namespace
overwrite, dump fidelity, and zero-change planning. Extend that scenario to
cover adoption and overwrite by ID, plus rejection when changing an existing
namespace without `--overwrite-namespace`. Read the provider after rejection
to verify that its namespace remains unchanged.

Closes #2064.

Validation: `go fix ./...`, `make format`, `make build`, `make lint`,
`make test`, `make test-integration`, installer tests, and E2E metrics tests
passed. The full live `dcr-providers/workflow` scenario passed, including
round-trip planning and cleanup. An earlier run failed before adoption with
`dcr_provider no longer exists`; the complete rerun passed.

Local E2E artifacts:
`/home/rspurgeon/.local/share/worktrees/kong/kongctl/gh-2064-e2e-dcr-adopt/.e2e-artifacts/20260907-093948`
