### PR TITLE
task(release): schedule Homebrew cask disablement

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -82,8 +82,12 @@ homebrew_casks:
       email: rspurgeon@users.noreply.github.com
     homepage: "https://github.com/kong/kongctl"
     description: Developer CLI for Kong
+    custom_block: |
+      disable! date: "2027-02-08",
+               because: "has been replaced by the Homebrew formula",
+               replacement_formula: "kong/kongctl/kongctl"
     caveats: |
-      The kongctl Homebrew cask installation will be deprecated on February 8, 2027.
+      The kongctl Homebrew cask is deprecated and will be disabled on February 8, 2027.
       Switch to the Homebrew formula by running:
 
         brew uninstall --cask kong/kongctl/kongctl

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -82,4 +82,13 @@ homebrew_casks:
       email: rspurgeon@users.noreply.github.com
     homepage: "https://github.com/kong/kongctl"
     description: Developer CLI for Kong
+    caveats: |
+      The kongctl Homebrew cask installation will be deprecated on February 8, 2027.
+      Switch to the Homebrew formula by running:
+
+        brew uninstall --cask kong/kongctl/kongctl
+        brew install --formula kong/kongctl/kongctl
+
+      For more information, see:
+        https://developer.konghq.com/kongctl/troubleshooting/
     skip_upload: true


### PR DESCRIPTION
Schedule Homebrew cask disablement for February 8, 2027 in GoReleaser so each
generated cask retains the deadline and replacement formula. Homebrew warns
during the transition and blocks installation from that date. Keep the
migration caveats with separate uninstall/install commands and the
troubleshooting link.

The published v1.15.1 cask currently lacks the disable declaration. This change
reaches the tap through the next release after merge. Cask generation and
validation continue during the transition; #2040 tracks their retirement before
the deadline and is not closed by this PR.

Validation: `goreleaser check`, Ruby syntax validation of the configured custom
block, `git diff --check`, and `make test` passed for the updated configuration.
Build, modernization, formatting, lint, installer tests, E2E metrics tests,
and integration tests passed earlier in this PR; Go source is unchanged.
Integration tests used the mock Konnect SDK. The pre-commit runner and native
Homebrew are not installed locally; native Homebrew validation remains in the
release/tap workflows.
