### PR TITLE
feat(cmd): add no-trunc for full-width text tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,20 +259,21 @@ characters of an ID. Missing and `null` values render as blank cells; arrays and
 objects render as compact JSON. Custom columns are available only with
 `--output text` and cannot be combined with `--jq`.
 
-Text cells are limited to 40 display characters and shrink further to fit the
-terminal. JSON and YAML output remain complete and are not affected by text
-column selection.
+By default, text cells are limited to 40 display characters and shrink further
+to fit the terminal. Use `--no-trunc` to preserve full cell widths. JSON and YAML
+output remain complete and are not affected by text column selection.
 
 ### Text table layout and IDs
 
-Static text tables use a compact layout and abbreviated UUIDs by default. Both
-behaviors can be configured for each profile:
+Static text tables use a compact layout, abbreviated UUIDs, and truncated cells
+by default. These behaviors can be configured for each profile:
 
 ```yaml
 default:
   text:
     layout: auto
     id-format: full
+    no-trunc: true
 ```
 
 `text.layout` accepts the following values:
@@ -291,8 +292,26 @@ in semantic ID columns, such as `ID`, `OWNER UUID`, and `RESOURCE IDENTIFIER`.
 Other columns shrink first, so a table may exceed the terminal width rather
 than truncate a UUID.
 
-Override profile settings for one command with `--text-layout` and
-`--text-id-format`:
+`text.no-trunc: true` (or `--no-trunc`) sizes each selected column to its longest
+rendered value, including its header. It disables both the 40-character cap and
+shrinking to terminal width, including for piped or redirected output. The
+terminal may wrap wide tables. Column selection remains unchanged for compact,
+auto, and wide layouts.
+
+For example, retain complete Mesh dataplane names in a normal text table:
+
+```shell
+kongctl get mesh dataplanes --no-trunc
+kongctl get mesh dataplanes --no-trunc --columns 'MESH=.mesh,NAME=.name'
+```
+
+UUID abbreviation is independent: use `--text-id-format full --no-trunc` to
+preserve both UUIDs and long names in built-in columns. Explicit `--columns`
+already bypasses UUID formatting; slices such as `.name[:8]` still apply with
+`--no-trunc`.
+
+Override profile settings for one command with `--text-layout`,
+`--text-id-format`, and `--no-trunc` (or `--no-trunc=false`):
 
 ```shell
 kongctl get apis --output text --text-layout wide --text-id-format full
@@ -303,11 +322,13 @@ The equivalent environment variables follow the normal profile convention:
 ```shell
 KONGCTL_DEFAULT_TEXT_LAYOUT=auto \
 KONGCTL_DEFAULT_TEXT_ID_FORMAT=full \
+KONGCTL_DEFAULT_TEXT_NO_TRUNC=true \
 kongctl get apis
 ```
 
-Explicit `--columns` definitions take precedence over both text settings, then
-command-line text flags take precedence over profile or environment values.
+Explicit `--columns` definitions override layout and ID formatting, while
+`--no-trunc` still controls cell widths. Command-line text flags take precedence
+over environment values, which take precedence over profile settings.
 JSON and YAML ignore profile text settings. Explicit text-formatting flags
 cannot be combined with JSON or YAML output.
 

--- a/internal/cmd/output/columns/columns.go
+++ b/internal/cmd/output/columns/columns.go
@@ -37,6 +37,9 @@ type RenderOptions struct {
 	// MinimumWidths prevents selected columns from shrinking below the
 	// corresponding display width. Missing entries use the legacy minimum.
 	MinimumWidths []int
+
+	// NoTrunc preserves natural cell widths regardless of terminal width.
+	NoTrunc bool
 }
 
 type pathStep struct {
@@ -470,7 +473,7 @@ func RenderWithOptions(
 	if availableWidth <= 0 {
 		availableWidth = 120
 	}
-	widths := calculateWidths(headers, rows, availableWidth, options.MinimumWidths)
+	widths := calculateWidths(headers, rows, availableWidth, options)
 	if err := writeRow(out, headers, widths); err != nil {
 		return err
 	}
@@ -482,18 +485,25 @@ func RenderWithOptions(
 	return nil
 }
 
-func calculateWidths(headers []string, rows [][]string, available int, configuredMinimums []int) []int {
+func calculateWidths(headers []string, rows [][]string, available int, options RenderOptions) []int {
 	widths := make([]int, len(headers))
 	minimums := make([]int, len(headers))
 	for i, header := range headers {
-		widths[i] = min(MaxColumnWidth, max(1, runewidth.StringWidth(singleLine(header))))
+		widths[i] = max(1, runewidth.StringWidth(singleLine(header)))
 		minimums[i] = min(widths[i], 3)
 	}
 	for _, row := range rows {
 		for i := 0; i < len(headers) && i < len(row); i++ {
-			widths[i] = min(MaxColumnWidth, max(widths[i], runewidth.StringWidth(singleLine(row[i]))))
+			widths[i] = max(widths[i], runewidth.StringWidth(singleLine(row[i])))
 		}
 	}
+	if options.NoTrunc {
+		return widths
+	}
+	for i := range widths {
+		widths[i] = min(MaxColumnWidth, widths[i])
+	}
+	configuredMinimums := options.MinimumWidths
 	for i := range minimums {
 		if i >= len(configuredMinimums) || configuredMinimums[i] <= 0 {
 			continue

--- a/internal/cmd/output/columns/columns_test.go
+++ b/internal/cmd/output/columns/columns_test.go
@@ -113,7 +113,24 @@ func TestCalculateWidthsConfiguredMinimumCannotLowerLegacyFloor(t *testing.T) {
 		[]string{"NAME", "DESCRIPTION"},
 		[][]string{{"payments", "Payment service"}},
 		1,
-		[]int{1, 1},
+		RenderOptions{MinimumWidths: []int{1, 1}},
 	)
 	require.Equal(t, []int{3, 3}, widths)
+}
+
+func TestRenderNoTrunc(t *testing.T) {
+	for _, value := range []string{strings.Repeat("name", 40), strings.Repeat("界e\u0301", 50)} {
+		for _, width := range []int{1, 30, 120, 300} {
+			var out bytes.Buffer
+			headers := []string{"NAME", "END"}
+			rows := [][]string{{value, "last"}, {"short", "next"}}
+			require.NoError(t, RenderWithOptions(&out, headers, rows, width, RenderOptions{NoTrunc: true}))
+			lines := strings.Split(strings.TrimSuffix(out.String(), "\n"), "\n")
+			require.Equal(t, value+"  last", lines[1])
+			require.Equal(t, "short"+strings.Repeat(" ", runewidth.StringWidth(value)-5+2)+"next", lines[2])
+			var redirected bytes.Buffer
+			require.NoError(t, RenderAutoWidthWithOptions(&redirected, headers, rows, RenderOptions{NoTrunc: true}))
+			require.Equal(t, out.String(), redirected.String())
+		}
+	}
 }

--- a/internal/cmd/output/tableview/tableview.go
+++ b/internal/cmd/output/tableview/tableview.go
@@ -2404,7 +2404,7 @@ func RenderForFormat(
 			streams.Out,
 			headers,
 			matrix,
-			columnoutput.RenderOptions{MinimumWidths: minimumWidths},
+			columnoutput.RenderOptions{MinimumWidths: minimumWidths, NoTrunc: textSettings.NoTrunc},
 		)
 	case cmdCommon.JSON, cmdCommon.YAML:
 		if printer != nil {

--- a/internal/cmd/output/tableview/tableview_test.go
+++ b/internal/cmd/output/tableview/tableview_test.go
@@ -587,6 +587,21 @@ func TestSelectLayoutColumns(t *testing.T) {
 		require.Equal(t, compactRows, rows)
 	})
 
+	t.Run("no trunc preserves column selection", func(t *testing.T) {
+		for _, layout := range []textoutput.Layout{textoutput.LayoutCompact, textoutput.LayoutAuto, textoutput.LayoutWide} {
+			for _, width := range []int{10, 27, 39, 200} {
+				for _, tty := range []bool{false, true} {
+					settings := textoutput.Settings{Layout: layout, IDFormat: textoutput.IDFormatCompact}
+					headers, rows := selectLayoutColumns(compactHeaders, compactRows, sources, settings, width, tty)
+					settings.NoTrunc = true
+					fullHeaders, fullRows := selectLayoutColumns(compactHeaders, compactRows, sources, settings, width, tty)
+					require.Equal(t, headers, fullHeaders)
+					require.Equal(t, rows, fullRows)
+				}
+			}
+		}
+	})
+
 	t.Run("non tty auto falls back to compact", func(t *testing.T) {
 		headers, _ := selectLayoutColumns(
 			compactHeaders,
@@ -726,6 +741,67 @@ func TestRenderForFormatStructuredOutputRemainsRaw(t *testing.T) {
 	err := RenderForFormat(nil, false, cmdCommon.JSON, printer, streams, raw, raw, "")
 	require.NoError(t, err)
 	require.Equal(t, []any{raw}, printer.printed)
+}
+
+func TestRenderForFormatNoTrunc(t *testing.T) {
+	name := "kong-mesh-default-egress-84bc8497c7-q6z-" + strings.Repeat("suffix", 20)
+	uuid := "12345678-1234-1234-1234-123456789012"
+	record := struct {
+		Name        string `json:"name"`
+		ID          string `json:"id"`
+		Description string `json:"description"`
+	}{name, uuid, "Mesh dataplane"}
+	for _, layout := range []string{"compact", "auto", "wide"} {
+		for _, idFormat := range []string{"compact", "full"} {
+			for _, custom := range []string{"", "NAME=.name,ID=.id", "NAME=.name[:8],ID=.id[:8]"} {
+				t.Run(layout+"/"+idFormat+"/"+custom, func(t *testing.T) {
+					mainConfig := viper.New()
+					mainConfig.Set("default", map[string]any{
+						"text": map[string]any{"layout": layout, "id-format": idFormat},
+					})
+					cfg := configpkg.BuildProfiledConfig("default", "config.yaml", mainConfig)
+					command := &cobra.Command{Use: "get"}
+					textoutput.AddFlags(command.Flags())
+					require.NoError(t, textoutput.BindFlags(cfg, command.Flags()))
+					require.NoError(t, command.ParseFlags([]string{"--no-trunc"}))
+					columnoutput.AddFlags(command.Flags())
+					if custom != "" {
+						require.NoError(t, command.Flags().Set(columnoutput.FlagName, custom))
+					}
+					command.SetContext(context.WithValue(t.Context(), configpkg.ConfigKey, cfg))
+					helper := cmd.BuildHelper(command, nil)
+					streams, _, output, _ := iostreams.NewTestIOStreams()
+					require.NoError(t, RenderForFormat(helper, false, cmdCommon.TEXT, nil, streams, record, record, ""))
+					if strings.Contains(custom, "[:8]") {
+						require.Equal(t, "NAME      ID\nkong-mes  12345678\n", output.String())
+					} else {
+						require.Contains(t, output.String(), name)
+						if custom != "" || idFormat == "full" {
+							require.NotContains(t, output.String(), "…")
+							require.Contains(t, output.String(), uuid)
+						} else {
+							require.Contains(t, output.String(), "1234…")
+							require.NotContains(t, output.String(), uuid)
+						}
+					}
+					if custom == "" {
+						require.Equal(t, layout == "wide", strings.Contains(output.String(), "DESCRIPTION"))
+					}
+					for _, format := range []cmdCommon.OutputFormat{cmdCommon.JSON, cmdCommon.YAML} {
+						// Profile settings are ignored by structured output.
+						structuredCmd := &cobra.Command{Use: "get"}
+						mainConfig.Set("default.text.no-trunc", true)
+						structuredCfg := configpkg.BuildProfiledConfig("default", "config.yaml", mainConfig)
+						structuredCmd.SetContext(context.WithValue(t.Context(), configpkg.ConfigKey, structuredCfg))
+						printer := &stubPrinter{}
+						require.NoError(t, RenderForFormat(cmd.BuildHelper(structuredCmd, nil), false,
+							format, printer, streams, record, record, ""))
+						require.Equal(t, []any{record}, printer.printed)
+					}
+				})
+			}
+		}
+	}
 }
 
 func TestRenderForFormat_ExplicitDefaultDescriptionIsTruncated(t *testing.T) {

--- a/internal/cmd/output/text/settings.go
+++ b/internal/cmd/output/text/settings.go
@@ -15,6 +15,8 @@ const (
 	LayoutConfigPath   = "text.layout"
 	IDFormatFlagName   = "text-id-format"
 	IDFormatConfigPath = "text.id-format"
+	NoTruncFlagName    = "no-trunc"
+	NoTruncConfigPath  = "text.no-trunc"
 	DefaultLayout      = LayoutCompact
 	DefaultIDFormat    = IDFormatCompact
 )
@@ -37,11 +39,18 @@ const (
 type Settings struct {
 	Layout   Layout
 	IDFormat IDFormat
+	NoTrunc  bool
 }
 
 func AddFlags(flags *pflag.FlagSet) {
 	if flags == nil {
 		return
+	}
+	if flags.Lookup(NoTruncFlagName) == nil {
+		flags.Bool(NoTruncFlagName, false, fmt.Sprintf(`Preserve full cell widths in static text tables beyond terminal width.
+Does not change column selection, UUID formatting, or explicit string slices.
+- Config path: [ %s ]
+- Default    : [ false ]`, NoTruncConfigPath))
 	}
 	if flags.Lookup(LayoutFlagName) == nil {
 		flags.String(LayoutFlagName, "", fmt.Sprintf(`Configure static text-table column selection.
@@ -67,6 +76,7 @@ func BindFlags(cfg config.Hook, flags *pflag.FlagSet) error {
 	}{
 		{LayoutFlagName, LayoutConfigPath},
 		{IDFormatFlagName, IDFormatConfigPath},
+		{NoTruncFlagName, NoTruncConfigPath},
 	}
 	for _, binding := range bindings {
 		if flag := flags.Lookup(binding.flag); flag != nil {
@@ -83,9 +93,10 @@ func Resolve(cmd *cobra.Command, cfg config.Hook, outputFormat string) (Settings
 	if outputFormat != cmdcommon.TEXT.String() {
 		if explicitlyConfigured(cmd) {
 			return settings, fmt.Errorf(
-				"--%s and --%s are only supported with --%s text",
+				"--%s, --%s, and --%s are only supported with --%s text",
 				LayoutFlagName,
 				IDFormatFlagName,
+				NoTruncFlagName,
 				cmdcommon.OutputFlagName,
 			)
 		}
@@ -96,6 +107,7 @@ func Resolve(cmd *cobra.Command, cfg config.Hook, outputFormat string) (Settings
 		return settings, nil
 	}
 
+	settings.NoTrunc = cfg.GetBool(NoTruncConfigPath)
 	layout := strings.ToLower(strings.TrimSpace(cfg.GetString(LayoutConfigPath)))
 	if layout != "" {
 		settings.Layout = Layout(layout)
@@ -130,5 +142,6 @@ func explicitlyConfigured(cmd *cobra.Command) bool {
 	}
 	root := cmd.Root()
 	return cmdcommon.CommandTreeFlagChanged(root, LayoutFlagName) ||
-		cmdcommon.CommandTreeFlagChanged(root, IDFormatFlagName)
+		cmdcommon.CommandTreeFlagChanged(root, IDFormatFlagName) ||
+		cmdcommon.CommandTreeFlagChanged(root, NoTruncFlagName)
 }

--- a/internal/cmd/output/text/settings_test.go
+++ b/internal/cmd/output/text/settings_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/kong/kongctl/internal/config"
+	utilviper "github.com/kong/kongctl/internal/util/viper"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
@@ -93,7 +94,7 @@ func TestResolveNonTextOutput(t *testing.T) {
 		require.EqualError(
 			t,
 			err,
-			"--text-layout and --text-id-format are only supported with --output text",
+			"--text-layout, --text-id-format, and --no-trunc are only supported with --output text",
 		)
 	})
 }
@@ -101,10 +102,48 @@ func TestResolveNonTextOutput(t *testing.T) {
 func configuredCommand(t *testing.T, profile map[string]any) (*cobra.Command, config.Hook) {
 	t.Helper()
 	mainConfig := viper.New()
+	utilviper.ConfigureEnvVars(mainConfig, "KONGCTL")
 	mainConfig.Set("default", profile)
 	cfg := config.BuildProfiledConfig("default", "config.yaml", mainConfig)
 	cmd := &cobra.Command{Use: "kongctl"}
 	AddFlags(cmd.PersistentFlags())
 	require.NoError(t, BindFlags(cfg, cmd.PersistentFlags()))
 	return cmd, cfg
+}
+
+func TestNoTruncPrecedence(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		profile bool
+		env     string
+		flag    string
+		want    bool
+	}{
+		{name: "default"},
+		{name: "profile", profile: true, want: true},
+		{name: "environment enables", env: "true", want: true},
+		{name: "environment overrides profile", profile: true, env: "false"},
+		{name: "flag disables", profile: true, env: "true", flag: "false"},
+		{name: "flag enables", env: "false", flag: "true", want: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("KONGCTL_DEFAULT_TEXT_NO_TRUNC", tt.env)
+			command, cfg := configuredCommand(t, map[string]any{"text": map[string]any{"no-trunc": tt.profile}})
+			if tt.flag != "" {
+				require.NoError(t, command.ParseFlags([]string{"--no-trunc=" + tt.flag}))
+			}
+			settings, err := Resolve(command, cfg, "text")
+			require.NoError(t, err)
+			require.Equal(t, tt.want, settings.NoTrunc)
+			for _, format := range []string{"json", "yaml"} {
+				settings, err := Resolve(command, cfg, format)
+				if tt.flag != "" {
+					require.ErrorContains(t, err, "only supported with --output text")
+				} else {
+					require.NoError(t, err)
+					require.False(t, settings.NoTrunc)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
Static text tables truncate long resource names, including Mesh dataplane names.
Add `--no-trunc` to preserve each selected column's full rendered width, even in
narrow terminals and redirected output. Support `text.no-trunc` and
`KONGCTL_<PROFILE>_TEXT_NO_TRUNC` with normal flag/environment/profile precedence.

Column selection, UUID formatting, and explicit string slices remain independent.
The README documents the Mesh use case and combining this option with
`--text-id-format full`.

Closes #2121

Validation: `go fix ./...`, `make format`, `make build`, `make lint`, `make test`
(race enabled), `make test-integration` (mock SDK), and installer/E2E-metrics
checks passed. Regression tests cover long and Unicode values, narrow widths,
redirected output, layouts, custom columns, UUIDs, configuration precedence, and
unchanged structured output. `pre-commit run -a` could not run because
`pre-commit` is not installed.
