### PR TITLE
test(e2e): cover AI Gateway model name-only changes

### DIFF
--- a/test/e2e/scenarios/declarative/rename-sync-delete/overlays/002-renamed/config.yaml
+++ b/test/e2e/scenarios/declarative/rename-sync-delete/overlays/002-renamed/config.yaml
@@ -34,7 +34,7 @@ ai_gateway_models:
     ai_gateway: rename-sync-gateway
     type: model
     name: rename-sync-model-renamed
-    display_name: Rename Sync Model Renamed
+    display_name: Rename Sync Model Original
     config:
       route: {}
       model: {}

--- a/test/e2e/scenarios/declarative/rename-sync-delete/scenario.yaml
+++ b/test/e2e/scenarios/declarative/rename-sync-delete/scenario.yaml
@@ -41,6 +41,26 @@ steps:
     inputOverlayDirs:
       - overlays/002-renamed
     commands:
+      - name: plan-model-name-only-change
+        outputFormat: disable
+        run:
+          - plan
+          - -f
+          - "{{ .workdir }}/config.yaml"
+          - --mode
+          - apply
+        assertions:
+          - select: "changes[?resource_type=='ai_gateway_model']"
+            expect:
+              fields:
+                "length(@)": 1
+          - select: "changes[?resource_type=='ai_gateway_model'] | [0]"
+            expect:
+              fields:
+                action: CREATE
+                resource_ref: rename-sync-model
+                fields.name: rename-sync-model-renamed
+                fields.display_name: Rename Sync Model Original
       - name: 000-apply
         outputFormat: json
         run:
@@ -55,6 +75,30 @@ steps:
                 applied: 3
                 failed: 0
                 status: success
+      - name: get-models-after-name-only-change
+        run:
+          - get
+          - ai-gateway
+          - models
+          - --gateway-name
+          - rename-sync-gateway
+          - -o
+          - json
+        assertions:
+          - select: "length(@)"
+            expect:
+              fields:
+                "@": 2
+          - select: "[?name=='rename-sync-model-original'] | [0]"
+            expect:
+              fields:
+                name: rename-sync-model-original
+                display_name: Rename Sync Model Original
+          - select: "[?name=='rename-sync-model-renamed'] | [0]"
+            expect:
+              fields:
+                name: rename-sync-model-renamed
+                display_name: Rename Sync Model Original
 
   - name: 003-plan-sync-deletes-stale-entities
     inputOverlayDirs:
@@ -130,7 +174,7 @@ steps:
             expect:
               fields:
                 name: rename-sync-model-renamed
-                display_name: Rename Sync Model Renamed
+                display_name: Rename Sync Model Original
 
   - name: 004-reset-org
     skipInputs: true


### PR DESCRIPTION
The model rename scenario previously changed both `name` and `display_name`,
leaving name-only changes untested. Keep the display name unchanged and assert
that apply plans a CREATE and leaves both models with the same display name;
the existing sync step then removes the original model.

This covers ordinary, non-UUID refs. It does not cover ID-matched renames or
change product behavior.

Validation:
- `go fix ./...`, `make format` (no additional changes), `make build`, and
  `make lint` passed.
- `make test`, `make test-integration`, `make test-installer`, and
  `make test-e2e-metrics` passed.
- Live `declarative/rename-sync-delete` E2E scenario passed against Konnect
  `.com`, with organization resets disabled and targeted cleanup afterward.
- Local E2E artifacts: `/home/rspurgeon/go/e2e-artifacts/20260909-095617/`.
