### PR TITLE
refactor(declarative): share Portal and API observation caching

### DIFF
--- a/docs/contributor/declarative-resource-implementation-guide.md
+++ b/docs/contributor/declarative-resource-implementation-guide.md
@@ -260,9 +260,21 @@ operations. Check `ClientConfig`, `NewClient`, SDK helper interfaces, and the
 
 Managed listing must filter by the intended namespace and normalize managed
 and user labels. External lookup uses unrestricted observation instead.
-Inspect [planning caches][cache] before adding reads: namespace fanout can
-share observations across a run. Preserve missing-client and error behavior
-during refactoring; a failed read must not become an empty successful result.
+Inspect [planning caches][cache] before adding reads. Portals and APIs use
+[`observationCache[T]`][observation-cache]: a typed fetch function and namespace
+accessor supply resource-specific behavior; the cache owns namespace queries,
+reuse, and filtering. Compatible managed-root observations should use this
+boundary. Initialize their typed cache in `newPlanningResourceCache` and keep
+planner listing methods as thin adapters. The other eight root families and
+Portal child caches still use their existing implementations.
+
+Namespace planners share observations within a run; `GeneratePlan` resets the
+cache on every invocation. Preserve request counts and order, wildcard reuse,
+fanout behavior, result order, and nil/empty slices. An empty namespace query
+returns an empty result without fetching. Successful empty observations are
+cached; failed reads are not. A nil cache preserves uncached reads, including
+returning the full wildcard result during fanout. Keep missing-client behavior
+and error propagation unchanged. Observation does not choose lifecycle actions.
 
 Return errors with operation/resource context. Let callers report errors.
 Use existing structured HTTP logging context and useful debug metadata;
@@ -593,6 +605,7 @@ engine contract. Each refactoring migration should:
 [execute-protection]:
   ../../internal/declarative/executor/protection_inheritance.go
 [cache]: ../../internal/declarative/planner/resource_cache.go
+[observation-cache]: ../../internal/declarative/planner/observation_cache.go
 [resolver]: ../../internal/declarative/planner/resolver.go
 [external]: ../../internal/declarative/planner/external_lookup.go
 [state]: ../../internal/declarative/state/client.go

--- a/internal/declarative/planner/observation_cache.go
+++ b/internal/declarative/planner/observation_cache.go
@@ -1,0 +1,89 @@
+package planner
+
+import "context"
+
+// observationCache holds one managed resource kind's observations for a plan run.
+// Namespace planners share it; a new run creates a fresh cache.
+type observationCache[T any] struct {
+	byNamespaces map[string][]T
+	all          []T
+	// A successful empty observation must be distinguishable from a cache miss.
+	allLoaded bool
+}
+
+func newObservationCache[T any]() observationCache[T] {
+	return observationCache[T]{byNamespaces: make(map[string][]T)}
+}
+
+// list preserves uncached reads when the receiver is nil. In that case, fanout
+// still requests all namespaces and returns the fetched result without filtering.
+func (c *observationCache[T]) list(
+	ctx context.Context,
+	namespaces []string,
+	fanout bool,
+	fetch func(context.Context, []string) ([]T, error),
+	namespaceOf func(T) string,
+) ([]T, error) {
+	normalizedNamespaces := normalizeNamespaces(namespaces)
+	if len(normalizedNamespaces) == 0 {
+		return []T{}, nil
+	}
+
+	cacheKey := namespaceCacheKey(normalizedNamespaces)
+	if c != nil {
+		if cached, ok := c.byNamespaces[cacheKey]; ok {
+			return cached, nil
+		}
+
+		if cacheKey != "*" && c.allLoaded {
+			filtered := filterObservedNamespaces(c.all, normalizedNamespaces, namespaceOf)
+			c.byNamespaces[cacheKey] = filtered
+			return filtered, nil
+		}
+	}
+
+	requestNamespaces := normalizedNamespaces
+	useAllNamespaces := fanout && cacheKey != "*"
+	if useAllNamespaces {
+		requestNamespaces = []string{"*"}
+	}
+
+	observed, err := fetch(ctx, requestNamespaces)
+	if err != nil {
+		return nil, err
+	}
+
+	if c != nil {
+		if useAllNamespaces {
+			c.all = observed
+			c.allLoaded = true
+			filtered := filterObservedNamespaces(observed, normalizedNamespaces, namespaceOf)
+			c.byNamespaces[cacheKey] = filtered
+			return filtered, nil
+		}
+
+		c.byNamespaces[cacheKey] = observed
+		if cacheKey == "*" {
+			c.all = observed
+			c.allLoaded = true
+		}
+	}
+
+	return observed, nil
+}
+
+// filterObservedNamespaces receives normalized, non-empty, non-wildcard namespaces.
+func filterObservedNamespaces[T any](observed []T, namespaces []string, namespaceOf func(T) string) []T {
+	allowed := make(map[string]struct{}, len(namespaces))
+	for _, ns := range namespaces {
+		allowed[ns] = struct{}{}
+	}
+
+	filtered := make([]T, 0, len(observed))
+	for _, resource := range observed {
+		if _, ok := allowed[namespaceOf(resource)]; ok {
+			filtered = append(filtered, resource)
+		}
+	}
+	return filtered
+}

--- a/internal/declarative/planner/observation_cache_test.go
+++ b/internal/declarative/planner/observation_cache_test.go
@@ -1,0 +1,193 @@
+package planner
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestObservationCacheList(t *testing.T) {
+	t.Parallel()
+
+	type observation struct {
+		namespace string
+		id        string
+	}
+	type response struct {
+		values []observation
+		err    error
+	}
+	type step struct {
+		query []string
+		want  []observation
+		err   error
+		calls int
+	}
+
+	all := []observation{{"b", "b-1"}, {"a", "a-1"}, {"a", "a-2"}}
+	aOnly := all[1:]
+	bOnly := all[:1]
+	empty := []observation{}
+	fetchErr := errors.New("observation failed")
+
+	testCases := []struct {
+		name         string
+		uncached     bool
+		fanout       bool
+		responses    []response
+		steps        []step
+		wantRequests [][]string
+	}{
+		{
+			name: "empty queries skip fetching",
+			steps: []step{
+				{query: nil, want: empty},
+				{query: []string{}, want: empty},
+				{query: []string{" ", ""}, want: empty},
+			},
+		},
+		{
+			name:      "equivalent queries reuse observations",
+			responses: []response{{values: all}},
+			steps: []step{
+				{query: []string{"b", " a ", "b", ""}, want: all, calls: 1},
+				{query: []string{"a", "b"}, want: all, calls: 1},
+			},
+			wantRequests: [][]string{{"a", "b"}},
+		},
+		{
+			name:      "different namespaces fetch separately",
+			responses: []response{{values: aOnly}, {values: bOnly}},
+			steps: []step{
+				{query: []string{"a"}, want: aOnly, calls: 1},
+				{query: []string{"b"}, want: bOnly, calls: 2},
+				{query: []string{"a"}, want: aOnly, calls: 2},
+			},
+			wantRequests: [][]string{{"a"}, {"b"}},
+		},
+		{
+			name:      "nil success is cached",
+			responses: []response{{values: nil}},
+			steps: []step{
+				{query: []string{"a"}, want: nil, calls: 1},
+				{query: []string{"a"}, want: nil, calls: 1},
+			},
+			wantRequests: [][]string{{"a"}},
+		},
+		{
+			name:      "empty success is cached",
+			responses: []response{{values: empty}},
+			steps: []step{
+				{query: []string{"a"}, want: empty, calls: 1},
+				{query: []string{"a"}, want: empty, calls: 1},
+			},
+			wantRequests: [][]string{{"a"}},
+		},
+		{
+			name:      "failed observation is discarded and retried",
+			responses: []response{{values: aOnly, err: fetchErr}, {values: aOnly}},
+			steps: []step{
+				{query: []string{"a"}, want: nil, err: fetchErr, calls: 1},
+				{query: []string{"a"}, want: aOnly, calls: 2},
+				{query: []string{"a"}, want: aOnly, calls: 2},
+			},
+			wantRequests: [][]string{{"a"}, {"a"}},
+		},
+		{
+			name:      "wildcard observations are reused and filtered in order",
+			responses: []response{{values: all}},
+			steps: []step{
+				{query: []string{"b", " * ", "a"}, want: all, calls: 1},
+				{query: []string{"a"}, want: aOnly, calls: 1},
+				{query: []string{"missing"}, want: empty, calls: 1},
+				{query: []string{"b"}, want: bOnly, calls: 1},
+				{query: []string{"*"}, want: all, calls: 1},
+			},
+			wantRequests: [][]string{{"*"}},
+		},
+		{
+			name:      "empty wildcard observation is loaded",
+			responses: []response{{values: empty}},
+			steps: []step{
+				{query: []string{"*"}, want: empty, calls: 1},
+				{query: []string{"a"}, want: empty, calls: 1},
+			},
+			wantRequests: [][]string{{"*"}},
+		},
+		{
+			name:      "nil wildcard observation filters to an empty slice",
+			responses: []response{{values: nil}},
+			steps: []step{
+				{query: []string{"*"}, want: nil, calls: 1},
+				{query: []string{"a"}, want: empty, calls: 1},
+			},
+			wantRequests: [][]string{{"*"}},
+		},
+		{
+			name:      "fanout filters and reuses the wildcard fetch",
+			fanout:    true,
+			responses: []response{{values: all}, {values: all}},
+			steps: []step{
+				{query: []string{"a"}, want: aOnly, calls: 1},
+				{query: []string{"b"}, want: bOnly, calls: 1},
+				{query: []string{"a"}, want: aOnly, calls: 1},
+				{query: []string{"*"}, want: all, calls: 2},
+				{query: []string{"*"}, want: all, calls: 2},
+			},
+			wantRequests: [][]string{{"*"}, {"*"}},
+		},
+		{
+			name:      "nil cache fetches each time",
+			uncached:  true,
+			responses: []response{{values: aOnly}, {values: aOnly}},
+			steps: []step{
+				{query: []string{"a"}, want: aOnly, calls: 1},
+				{query: []string{"a"}, want: aOnly, calls: 2},
+			},
+			wantRequests: [][]string{{"a"}, {"a"}},
+		},
+		{
+			name:      "nil cache fanout returns unfiltered observations",
+			uncached:  true,
+			fanout:    true,
+			responses: []response{{values: all}, {values: all}},
+			steps: []step{
+				{query: []string{"a"}, want: all, calls: 1},
+				{query: []string{"b"}, want: all, calls: 2},
+				{query: []string{" "}, want: empty, calls: 2},
+			},
+			wantRequests: [][]string{{"*"}, {"*"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cache := newObservationCache[observation]()
+			activeCache := &cache
+			if tc.uncached {
+				activeCache = nil
+			}
+
+			var requests [][]string
+			fetch := func(_ context.Context, namespaces []string) ([]observation, error) {
+				require.Less(t, len(requests), len(tc.responses), "unexpected fetch for %v", namespaces)
+				result := tc.responses[len(requests)]
+				requests = append(requests, namespaces)
+				return result.values, result.err
+			}
+
+			for i, step := range tc.steps {
+				got, err := activeCache.list(t.Context(), step.query, tc.fanout, fetch,
+					func(value observation) string { return value.namespace })
+				require.ErrorIs(t, err, step.err, "step %d", i)
+				require.Equal(t, step.want, got, "step %d", i)
+				require.Len(t, requests, step.calls, "step %d", i)
+			}
+			require.Equal(t, tc.wantRequests, requests)
+		})
+	}
+}

--- a/internal/declarative/planner/resource_cache.go
+++ b/internal/declarative/planner/resource_cache.go
@@ -18,9 +18,7 @@ type planningResourceCache struct {
 	managedEventGatewayControlPlanesAll    []state.EventGatewayControlPlane
 	managedEventGatewayControlPlanesLoaded bool
 
-	managedPortalsByKey  map[string][]state.Portal
-	managedPortalsAll    []state.Portal
-	managedPortalsLoaded bool
+	managedPortals observationCache[state.Portal]
 
 	managedAuthStrategiesByKey  map[string][]state.ApplicationAuthStrategy
 	managedAuthStrategiesAll    []state.ApplicationAuthStrategy
@@ -29,9 +27,7 @@ type planningResourceCache struct {
 	managedDCRProvidersAll      []state.DCRProvider
 	managedDCRProvidersLoaded   bool
 
-	managedAPIsByKey  map[string][]state.API
-	managedAPIsAll    []state.API
-	managedAPIsLoaded bool
+	managedAPIs observationCache[state.API]
 
 	managedCatalogServicesByKey  map[string][]state.CatalogService
 	managedCatalogServicesAll    []state.CatalogService
@@ -58,10 +54,10 @@ func newPlanningResourceCache() *planningResourceCache {
 	return &planningResourceCache{
 		managedControlPlanesByKey:             make(map[string][]state.ControlPlane),
 		managedEventGatewayControlPlanesByKey: make(map[string][]state.EventGatewayControlPlane),
-		managedPortalsByKey:                   make(map[string][]state.Portal),
+		managedPortals:                        newObservationCache[state.Portal](),
 		managedAuthStrategiesByKey:            make(map[string][]state.ApplicationAuthStrategy),
 		managedDCRProvidersByKey:              make(map[string][]state.DCRProvider),
-		managedAPIsByKey:                      make(map[string][]state.API),
+		managedAPIs:                           newObservationCache[state.API](),
 		managedCatalogServicesByKey:           make(map[string][]state.CatalogService),
 		managedAIGatewaysByKey:                make(map[string][]state.AIGateway),
 		managedDashboardsByKey:                make(map[string][]state.Dashboard),
@@ -123,53 +119,12 @@ func (p *Planner) listManagedControlPlanes(ctx context.Context, namespaces []str
 }
 
 func (p *Planner) listManagedPortals(ctx context.Context, namespaces []string) ([]state.Portal, error) {
-	normalizedNamespaces := normalizeNamespaces(namespaces)
-	if len(normalizedNamespaces) == 0 {
-		return []state.Portal{}, nil
+	var cache *observationCache[state.Portal]
+	if p.resourceCache != nil {
+		cache = &p.resourceCache.managedPortals
 	}
-
-	cache := p.resourceCache
-	cacheKey := namespaceCacheKey(normalizedNamespaces)
-	if cache != nil {
-		if cached, ok := cache.managedPortalsByKey[cacheKey]; ok {
-			return cached, nil
-		}
-
-		if cacheKey != "*" && cache.managedPortalsLoaded {
-			filtered := filterPortalsByNamespaces(cache.managedPortalsAll, normalizedNamespaces)
-			cache.managedPortalsByKey[cacheKey] = filtered
-			return filtered, nil
-		}
-	}
-
-	requestNamespaces := normalizedNamespaces
-	useAllNamespaces := p.namespaceFanout && cacheKey != "*"
-	if useAllNamespaces {
-		requestNamespaces = []string{"*"}
-	}
-
-	portals, err := p.client.ListManagedPortals(ctx, requestNamespaces)
-	if err != nil {
-		return nil, err
-	}
-
-	if cache != nil {
-		if useAllNamespaces {
-			cache.managedPortalsAll = portals
-			cache.managedPortalsLoaded = true
-			filtered := filterPortalsByNamespaces(portals, normalizedNamespaces)
-			cache.managedPortalsByKey[cacheKey] = filtered
-			return filtered, nil
-		}
-
-		cache.managedPortalsByKey[cacheKey] = portals
-		if cacheKey == "*" {
-			cache.managedPortalsAll = portals
-			cache.managedPortalsLoaded = true
-		}
-	}
-
-	return portals, nil
+	return cache.list(ctx, namespaces, p.namespaceFanout, p.client.ListManagedPortals,
+		func(portal state.Portal) string { return portal.NormalizedLabels[labels.NamespaceKey] })
 }
 
 func (p *Planner) listManagedAuthStrategies(
@@ -279,53 +234,12 @@ func (p *Planner) listManagedDCRProviders(ctx context.Context, namespaces []stri
 }
 
 func (p *Planner) listManagedAPIs(ctx context.Context, namespaces []string) ([]state.API, error) {
-	normalizedNamespaces := normalizeNamespaces(namespaces)
-	if len(normalizedNamespaces) == 0 {
-		return []state.API{}, nil
+	var cache *observationCache[state.API]
+	if p.resourceCache != nil {
+		cache = &p.resourceCache.managedAPIs
 	}
-
-	cache := p.resourceCache
-	cacheKey := namespaceCacheKey(normalizedNamespaces)
-	if cache != nil {
-		if cached, ok := cache.managedAPIsByKey[cacheKey]; ok {
-			return cached, nil
-		}
-
-		if cacheKey != "*" && cache.managedAPIsLoaded {
-			filtered := filterAPIsByNamespaces(cache.managedAPIsAll, normalizedNamespaces)
-			cache.managedAPIsByKey[cacheKey] = filtered
-			return filtered, nil
-		}
-	}
-
-	requestNamespaces := normalizedNamespaces
-	useAllNamespaces := p.namespaceFanout && cacheKey != "*"
-	if useAllNamespaces {
-		requestNamespaces = []string{"*"}
-	}
-
-	apis, err := p.client.ListManagedAPIs(ctx, requestNamespaces)
-	if err != nil {
-		return nil, err
-	}
-
-	if cache != nil {
-		if useAllNamespaces {
-			cache.managedAPIsAll = apis
-			cache.managedAPIsLoaded = true
-			filtered := filterAPIsByNamespaces(apis, normalizedNamespaces)
-			cache.managedAPIsByKey[cacheKey] = filtered
-			return filtered, nil
-		}
-
-		cache.managedAPIsByKey[cacheKey] = apis
-		if cacheKey == "*" {
-			cache.managedAPIsAll = apis
-			cache.managedAPIsLoaded = true
-		}
-	}
-
-	return apis, nil
+	return cache.list(ctx, namespaces, p.namespaceFanout, p.client.ListManagedAPIs,
+		func(api state.API) string { return api.NormalizedLabels[labels.NamespaceKey] })
 }
 
 func (p *Planner) listManagedCatalogServices(
@@ -734,29 +648,6 @@ func filterControlPlanesByNamespaces(controlPlanes []state.ControlPlane, namespa
 	return filtered
 }
 
-func filterPortalsByNamespaces(portals []state.Portal, namespaces []string) []state.Portal {
-	if len(namespaces) == 0 {
-		return []state.Portal{}
-	}
-	if len(namespaces) == 1 && namespaces[0] == "*" {
-		return portals
-	}
-
-	allowed := make(map[string]struct{}, len(namespaces))
-	for _, ns := range namespaces {
-		allowed[ns] = struct{}{}
-	}
-
-	filtered := make([]state.Portal, 0, len(portals))
-	for _, portal := range portals {
-		namespace := portal.NormalizedLabels[labels.NamespaceKey]
-		if _, ok := allowed[namespace]; ok {
-			filtered = append(filtered, portal)
-		}
-	}
-	return filtered
-}
-
 func filterAuthStrategiesByNamespaces(
 	strategies []state.ApplicationAuthStrategy,
 	namespaces []string,
@@ -805,29 +696,6 @@ func filterDCRProvidersByNamespaces(providers []state.DCRProvider, namespaces []
 		}
 	}
 
-	return filtered
-}
-
-func filterAPIsByNamespaces(apis []state.API, namespaces []string) []state.API {
-	if len(namespaces) == 0 {
-		return []state.API{}
-	}
-	if len(namespaces) == 1 && namespaces[0] == "*" {
-		return apis
-	}
-
-	allowed := make(map[string]struct{}, len(namespaces))
-	for _, ns := range namespaces {
-		allowed[ns] = struct{}{}
-	}
-
-	filtered := make([]state.API, 0, len(apis))
-	for _, api := range apis {
-		namespace := api.NormalizedLabels[labels.NamespaceKey]
-		if _, ok := allowed[namespace]; ok {
-			filtered = append(filtered, api)
-		}
-	}
 	return filtered
 }
 


### PR DESCRIPTION
Portals and APIs duplicated the planner's namespace-query and observation-cache policy. Introduce a typed `observationCache[T]` and route both listing methods through it, with resource-specific fetch and namespace access supplied by thin adapters. Their duplicate cache state and filtering implementations are removed.

Preserve per-run cache lifetime, sharing across namespace planners, request order/counts, wildcard and fanout behavior, error propagation, successful empty observations, result order, and nil/empty slices. The guide documents the new integration path and the eight root families still using their existing implementations. Child caches and lifecycle decisions remain separate.

A focused, 12-case unit test asserts cache results and fetch traces across normalized queries, cache hits, errors/retries, nil/empty observations, wildcard reuse, and cached/uncached fanout.

Part of #2080; this two-family milestone leaves the broader issue open.

Validation:

- Read-only `CGO_ENABLED=0 go fix -diff ./...` produces no changes; formatting and `git diff --check` pass.
- CGO-disabled `make build-ci` and `make test-all` pass using the repository-pinned golangci-lint 2.13.2.
- Existing planner, loader, and resources suites pass.
- Temporary Go build overlays compare 3,240 baseline/candidate observation sequences (19,440 results), including cache hits, fanout, errors/retry, empty results, shared caches, resets, and normalized queries. Requests, context, results, and error identity match. This is bounded comparison evidence, not exhaustive coverage.
- The maintainer-authorized test follow-up adds only `observation_cache_test.go`; all 2,749 preexisting files retain their hashes from the refactor head, including all existing tests, fixtures, and helpers.
- The new test fails under three temporary production overlays: incorrectly filtering uncached fanout results, caching failed observations, and treating empty wildcard observations as cache misses.
- Guide reference targets, local anchors, and 80-column wrapping pass.
