### PR TITLE
refactor(simplify): reuse publication records and simplify credential payloads

### DIFF
--- a/internal/cmd/root/products/konnect/api/publications.go
+++ b/internal/cmd/root/products/konnect/api/publications.go
@@ -307,21 +307,12 @@ func publicationDetailView(publication *kkComps.APIPublicationListItem) string {
 		return ""
 	}
 
-	visibility := valueNA
-	if publication.GetVisibility() != "" {
-		visibility = string(publication.GetVisibility())
-	}
-
-	authStrategies := valueNA
-	if ids := publication.GetAuthStrategyIds(); len(ids) > 0 {
-		authStrategies = strings.Join(ids, ", ")
-	}
-
+	record := publicationToRecord(*publication)
 	fields := map[string]string{
-		"auth_strategy_ids": authStrategies,
-		"created_at":        publication.GetCreatedAt().In(time.Local).Format("2006-01-02 15:04:05"),
-		"visibility":        visibility,
-		"updated_at":        publication.GetUpdatedAt().In(time.Local).Format("2006-01-02 15:04:05"),
+		"auth_strategy_ids": record.AuthStrategyIDs,
+		"created_at":        record.LocalCreatedTime,
+		"visibility":        record.Visibility,
+		"updated_at":        record.LocalUpdatedTime,
 	}
 
 	keys := slices.Sorted(maps.Keys(fields))

--- a/internal/declarative/resources/ai_gateway_consumer_credential.go
+++ b/internal/declarative/resources/ai_gateway_consumer_credential.go
@@ -168,11 +168,7 @@ func (a AIGatewayConsumerCredentialResource) CreateRequest() kkComps.CreateAIGat
 }
 
 func (a AIGatewayConsumerCredentialResource) PayloadMap() (map[string]any, error) {
-	payload, err := marshalObjectToMap(a.CreateRequest(), "AI Gateway Consumer Credential payload")
-	if err != nil {
-		return nil, err
-	}
-	return payload, nil
+	return marshalObjectToMap(a.CreateRequest(), "AI Gateway Consumer Credential payload")
 }
 
 func (a AIGatewayConsumerCredentialResource) MutablePayloadMap() (map[string]any, error) {


### PR DESCRIPTION
Reuse `publicationToRecord` in publication details and return the AI Gateway
consumer credential payload helper result directly. This removes duplicated
field derivation and redundant error handling while preserving behavior.
Existing tests are unchanged.

Closes #2070
Closes #2124

Validation passed:
- `CGO_ENABLED=0 go fix ./...` and `make format` (no extra changes)
- `make build`
- `mise exec shellcheck@0.11.0 -- make test-all` (lint, installer checks,
  unit tests with race detection, E2E metrics tests, and integration tests)

The explicit shellcheck selection uses the installed version because the
local mise shim has no default version configured.
