### PR TITLE
refactor(declarative): register desired namespace selection

### DIFF
--- a/docs/contributor/declarative-resource-implementation-guide.md
+++ b/docs/contributor/declarative-resource-implementation-guide.md
@@ -107,6 +107,9 @@ Supply a typed owner lookup, as in [API versions][api-version]. The child
 inherits the owner's registered selection policy. Preserve exact reference
 matching and first-match behavior; missing owners exclude the child. Namespace
 ownership need not match structural parenthood or sync ownership.
+The registry contract checks that every namespace-owner chain reaches a
+registered namespace root without cycles. Call the generic selector only for
+kinds with selection; using an unsupported kind is a programming error.
 
 Organization assignment selection retains its specialized rules. Resources
 already selected within a parent collection do not need an additional

--- a/docs/contributor/declarative-resource-implementation-guide.md
+++ b/docs/contributor/declarative-resource-implementation-guide.md
@@ -42,9 +42,9 @@ collection scope, AI Gateway child loading, and dump-default metadata. The
 [root planner inventory][roots] drives root construction and dispatch.
 [Runtime executor registration][runtime-executors] supplies action routing and
 payload validation for SDK resource operations. Other families' nested
-extraction and load validation, namespace inheritance/filtering,
-relationships, pre-execution
-validation, state-client wiring, and dump collection remain separate steps.
+extraction and load validation, specialized namespace selection, relationships,
+pre-execution validation, state-client wiring, and dump collection remain
+separate steps.
 Registering a declaration does not complete those steps automatically.
 
 ## 1. Define and register the resource
@@ -92,8 +92,25 @@ revisiting those groups. Organization users/system accounts use
 not enter the ordinary resource registry.
 
 Defaulting, namespace enforcement, and planner discovery share participation
-but retain their different external-resource policies. Namespace accessors and
-parent filtering in `ResourceSet` still require explicit integration.
+but retain their different external-resource policies. `WithNamespace` also
+supplies [desired-resource namespace selection][selection] for
+managed roots, using their registered flattened collection.
+
+Use `GetResourcesByNamespace[APIResource](rs, namespace)` to select typed
+resources. It returns shallow copies in source order, with nil for no matches;
+supplemental grouping locations are excluded. External roots belong to
+`NamespaceExternal`; other roots use their declared or default namespace.
+Existing root namespace getters delegate to this shared policy.
+
+API children and Portal pages use `WithNamespaceFrom` beside registration.
+Supply a typed owner lookup, as in [API versions][api-version]. The child
+inherits the owner's registered selection policy. Preserve exact reference
+matching and first-match behavior; missing owners exclude the child. Namespace
+ownership need not match structural parenthood or sync ownership.
+
+Organization assignment selection retains its specialized rules. Resources
+already selected within a parent collection do not need an additional
+namespace getter; avoid adding unused accessors or planner wrappers.
 
 ### Defaults and SDK shape
 
@@ -574,6 +591,8 @@ engine contract. Each refactoring migration should:
 [interfaces]: ../../internal/declarative/resources/interfaces.go
 [registry]: ../../internal/declarative/resources/registry.go
 [namespaces]: ../../internal/declarative/resources/namespace_participants.go
+[selection]: ../../internal/declarative/resources/namespace_selection.go
+[api-version]: ../../internal/declarative/resources/api_version.go
 [scope-capabilities]: ../../internal/declarative/resources/sync_capabilities.go
 [scope-capture]: ../../internal/declarative/resources/sync_capture.go
 [portal-scope]: ../../internal/declarative/resources/portal_sync_scope.go

--- a/internal/declarative/planner/base_planner.go
+++ b/internal/declarative/planner/base_planner.go
@@ -115,56 +115,6 @@ func (b *BasePlanner) GetDesiredAPIDocuments(namespace string) []resources.APIDo
 	return b.planner.resources.GetAPIDocumentsByNamespace(namespace)
 }
 
-// GetDesiredPortalCustomizations returns desired portal customization resources from the specified namespace
-func (b *BasePlanner) GetDesiredPortalCustomizations(namespace string) []resources.PortalCustomizationResource {
-	return b.planner.resources.GetPortalCustomizationsByNamespace(namespace)
-}
-
-// GetDesiredPortalAuthSettings returns desired portal auth settings resources from the specified namespace
-func (b *BasePlanner) GetDesiredPortalAuthSettings(namespace string) []resources.PortalAuthSettingsResource {
-	return b.planner.resources.GetPortalAuthSettingsByNamespace(namespace)
-}
-
-// GetDesiredPortalIPAllowLists returns desired portal IP allow list resources from the specified namespace
-func (b *BasePlanner) GetDesiredPortalIPAllowLists(namespace string) []resources.PortalIPAllowListResource {
-	return b.planner.resources.GetPortalIPAllowListsByNamespace(namespace)
-}
-
-// GetDesiredPortalIntegrations returns desired portal integration resources from the specified namespace
-func (b *BasePlanner) GetDesiredPortalIntegrations(namespace string) []resources.PortalIntegrationResource {
-	return b.planner.resources.GetPortalIntegrationsByNamespace(namespace)
-}
-
-// GetDesiredPortalIdentityProviders returns desired portal identity provider resources from the specified namespace
-func (b *BasePlanner) GetDesiredPortalIdentityProviders(namespace string) []resources.PortalIdentityProviderResource {
-	return b.planner.resources.GetPortalIdentityProvidersByNamespace(namespace)
-}
-
-// GetDesiredPortalCustomDomains returns desired portal custom domain resources from the specified namespace
-func (b *BasePlanner) GetDesiredPortalCustomDomains(namespace string) []resources.PortalCustomDomainResource {
-	return b.planner.resources.GetPortalCustomDomainsByNamespace(namespace)
-}
-
-// GetDesiredPortalEmailConfigs returns desired portal email config resources from the specified namespace
-func (b *BasePlanner) GetDesiredPortalEmailConfigs(namespace string) []resources.PortalEmailConfigResource {
-	return b.planner.resources.GetPortalEmailConfigsByNamespace(namespace)
-}
-
-// GetDesiredPortalAuditLogWebhooks returns desired portal audit-log webhook resources from the specified namespace
-func (b *BasePlanner) GetDesiredPortalAuditLogWebhooks(namespace string) []resources.PortalAuditLogWebhookResource {
-	return b.planner.resources.GetPortalAuditLogWebhooksByNamespace(namespace)
-}
-
-// GetDesiredPortalPages returns desired portal page resources from the specified namespace
-func (b *BasePlanner) GetDesiredPortalPages(namespace string) []resources.PortalPageResource {
-	return b.planner.resources.GetPortalPagesByNamespace(namespace)
-}
-
-// GetDesiredPortalSnippets returns desired portal snippet resources from the specified namespace
-func (b *BasePlanner) GetDesiredPortalSnippets(namespace string) []resources.PortalSnippetResource {
-	return b.planner.resources.GetPortalSnippetsByNamespace(namespace)
-}
-
 // GetDesiredEventGatewayControlPlanes returns desired EGW CP resources from the specified namespace
 func (b *BasePlanner) GetDesiredEventGatewayControlPlanes(
 	namespace string,

--- a/internal/declarative/resources/api_document.go
+++ b/internal/declarative/resources/api_document.go
@@ -25,6 +25,9 @@ func init() {
 			}),
 		),
 		WithExternalUnsupportedReason("scoped API document lookup is planned for API domain enablement"),
+		WithNamespaceFrom(func(rs *ResourceSet, r *APIDocumentResource) *APIResource {
+			return rs.GetAPIByRef(r.API)
+		}),
 		WithChildSyncScope(ResourceTypeAPI),
 	)
 }

--- a/internal/declarative/resources/api_implementation.go
+++ b/internal/declarative/resources/api_implementation.go
@@ -23,6 +23,9 @@ func init() {
 		AutoExplain[APIImplementationResource](
 			WithExplainSchemaBuilder(apiImplementationExplainNode),
 		),
+		WithNamespaceFrom(func(rs *ResourceSet, r *APIImplementationResource) *APIResource {
+			return rs.GetAPIByRef(r.API)
+		}),
 		WithChildSyncScope(ResourceTypeAPI),
 	)
 }

--- a/internal/declarative/resources/api_publication.go
+++ b/internal/declarative/resources/api_publication.go
@@ -13,6 +13,9 @@ func init() {
 		ResourceTypeAPIPublication,
 		func(rs *ResourceSet) *[]APIPublicationResource { return &rs.APIPublications },
 		AutoExplain[APIPublicationResource](),
+		WithNamespaceFrom(func(rs *ResourceSet, r *APIPublicationResource) *APIResource {
+			return rs.GetAPIByRef(r.API)
+		}),
 		WithChildSyncScope(ResourceTypeAPI),
 	)
 }

--- a/internal/declarative/resources/api_version.go
+++ b/internal/declarative/resources/api_version.go
@@ -28,6 +28,9 @@ func init() {
 				Notes: []string{"Set the whole spec with `spec: !file ...` instead of populating content directly."},
 			}),
 		),
+		WithNamespaceFrom(func(rs *ResourceSet, r *APIVersionResource) *APIResource {
+			return rs.GetAPIByRef(r.API)
+		}),
 		WithChildSyncScope(ResourceTypeAPI),
 	)
 }

--- a/internal/declarative/resources/namespace_participants.go
+++ b/internal/declarative/resources/namespace_participants.go
@@ -34,7 +34,8 @@ type namespaceRegistration struct {
 var namespaceRegistrations []namespaceRegistration
 
 // WithNamespace registers typed metadata access alongside the resource's
-// existing slice accessor. Order preserves namespace diagnostic traversal.
+// existing slice accessor and supplies its desired namespace selection policy.
+// Order preserves namespace diagnostic traversal.
 // Additional sources are grouping locations visited before nested extraction.
 func WithNamespace[R any](
 	order int,
@@ -42,11 +43,15 @@ func WithNamespace[R any](
 	nested ...func(*ResourceSet) []R,
 ) ResourceRegistrationOption {
 	return func(ops *resourceOps) error {
-		if ops.namespace != nil {
+		if ops.namespace != nil || ops.matchesNamespace != nil {
 			return fmt.Errorf("namespace capability is already registered")
 		}
 		if participant == nil || ops.explain.typ != reflect.TypeFor[R]() {
 			return fmt.Errorf("namespace accessor must match the registered resource type")
+		}
+		ops.matchesNamespace = func(_ *ResourceSet, resource Resource, namespace string) bool {
+			value := participant(any(resource).(*R))
+			return resourceNamespaceMatches(value.External, *value.Meta, namespace)
 		}
 		ops.namespace = &namespaceRegistration{
 			order: order,

--- a/internal/declarative/resources/namespace_selection.go
+++ b/internal/declarative/resources/namespace_selection.go
@@ -1,0 +1,67 @@
+package resources
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// GetResourcesByNamespace returns shallow copies from the registered collection,
+// in source order. Grouping locations used only before extraction are excluded.
+// A resource must register namespace selection through WithNamespace or
+// WithNamespaceFrom; asking for an unsupported kind is a programming error.
+func GetResourcesByNamespace[R any, RPtr interface {
+	*R
+	Resource
+}](rs *ResourceSet, namespace string) []R {
+	kind := RPtr(new(R)).GetType()
+	matches := namespaceMatcher(kind)
+	var filtered []R
+	registry[kind].forEach(rs, func(resource Resource) bool {
+		if matches(rs, resource, namespace) {
+			filtered = append(filtered, *any(resource).(*R))
+		}
+		return true
+	})
+	return filtered
+}
+
+// WithNamespaceFrom selects a child using its owner's registered namespace
+// policy. The typed lookup preserves each family's reference-matching behavior;
+// a missing owner excludes the child.
+func WithNamespaceFrom[R, P any, PPtr interface {
+	*P
+	Resource
+}](owner func(*ResourceSet, *R) *P) ResourceRegistrationOption {
+	return func(ops *resourceOps) error {
+		if ops.matchesNamespace != nil {
+			return fmt.Errorf("namespace capability is already registered")
+		}
+		if owner == nil || ops.explain.typ != reflect.TypeFor[R]() {
+			return fmt.Errorf("namespace owner accessor must match the registered resource type")
+		}
+		ops.matchesNamespace = func(rs *ResourceSet, resource Resource, namespace string) bool {
+			parent := owner(rs, any(resource).(*R))
+			if parent == nil {
+				return false
+			}
+			parentResource := PPtr(parent)
+			return namespaceMatcher(parentResource.GetType())(rs, parentResource, namespace)
+		}
+		return nil
+	}
+}
+
+func namespaceMatcher(kind ResourceType) func(*ResourceSet, Resource, string) bool {
+	matches := registry[kind].matchesNamespace
+	if matches == nil {
+		panic("resource type " + string(kind) + " has no namespace selection")
+	}
+	return matches
+}
+
+func resourceNamespaceMatches(external bool, meta *KongctlMeta, namespace string) bool {
+	if external {
+		return namespace == NamespaceExternal
+	}
+	return GetNamespace(meta) == namespace
+}

--- a/internal/declarative/resources/namespace_selection.go
+++ b/internal/declarative/resources/namespace_selection.go
@@ -39,13 +39,15 @@ func WithNamespaceFrom[R, P any, PPtr interface {
 		if owner == nil || ops.explain.typ != reflect.TypeFor[R]() {
 			return fmt.Errorf("namespace owner accessor must match the registered resource type")
 		}
+		// Record the dependency without requiring the owner to register first.
+		ownerKind := PPtr(new(P)).GetType()
+		ops.namespaceOwner = ownerKind
 		ops.matchesNamespace = func(rs *ResourceSet, resource Resource, namespace string) bool {
 			parent := owner(rs, any(resource).(*R))
 			if parent == nil {
 				return false
 			}
-			parentResource := PPtr(parent)
-			return namespaceMatcher(parentResource.GetType())(rs, parentResource, namespace)
+			return namespaceMatcher(ownerKind)(rs, PPtr(parent), namespace)
 		}
 		return nil
 	}

--- a/internal/declarative/resources/portal_page.go
+++ b/internal/declarative/resources/portal_page.go
@@ -14,6 +14,9 @@ func init() {
 		func(rs *ResourceSet) *[]PortalPageResource { return &rs.PortalPages },
 		AutoExplain[PortalPageResource](),
 		WithExternalUnsupportedReason("scoped portal page lookup is planned for Portal domain enablement"),
+		WithNamespaceFrom(func(rs *ResourceSet, r *PortalPageResource) *PortalResource {
+			return rs.GetPortalByRef(r.Portal)
+		}),
 		WithChildSyncScopeFrom(ResourceTypePortal, func(r *PortalPageResource) string { return r.Portal }),
 	)
 	registerResourceType(

--- a/internal/declarative/resources/registry.go
+++ b/internal/declarative/resources/registry.go
@@ -26,6 +26,7 @@ type resourceOps struct {
 	count                     func(rs *ResourceSet) int
 	explain                   ExplainRegistration
 	namespace                 *namespaceRegistration
+	matchesNamespace          func(*ResourceSet, Resource, string) bool
 	syncScope                 *syncScopeRegistration
 	load                      *childLoadRegistration
 	dumpDefaultRules          map[string]dumpDefaultRule

--- a/internal/declarative/resources/registry.go
+++ b/internal/declarative/resources/registry.go
@@ -27,6 +27,7 @@ type resourceOps struct {
 	explain                   ExplainRegistration
 	namespace                 *namespaceRegistration
 	matchesNamespace          func(*ResourceSet, Resource, string) bool
+	namespaceOwner            ResourceType
 	syncScope                 *syncScopeRegistration
 	load                      *childLoadRegistration
 	dumpDefaultRules          map[string]dumpDefaultRule

--- a/internal/declarative/resources/registry_test.go
+++ b/internal/declarative/resources/registry_test.go
@@ -288,6 +288,36 @@ func TestRegisteredTypesContainsKnownTypes(t *testing.T) {
 	assert.False(t, typeSet[ResourceType("unknown_type")])
 }
 
+func TestNamespaceSelectionRegistrationContract(t *testing.T) {
+	for _, kind := range RegisteredTypes() {
+		t.Run(string(kind), func(t *testing.T) {
+			ops := registry[kind]
+			if ops.namespace != nil {
+				require.NotNil(t, ops.matchesNamespace, "namespace roots must supply selection")
+			}
+			if ops.matchesNamespace == nil {
+				require.Empty(t, ops.namespaceOwner, "namespace ownership requires selection")
+				return
+			}
+
+			seen := make(map[ResourceType]bool)
+			for current := kind; ; {
+				require.NotContains(t, seen, current, "namespace ownership must not contain cycles")
+				seen[current] = true
+				require.Contains(t, registry, current, "namespace owners must be registered")
+				currentOps := registry[current]
+				require.NotNil(t, currentOps.matchesNamespace, "namespace owners must supply selection: %s", current)
+				if currentOps.namespaceOwner == "" {
+					require.NotNil(t, currentOps.namespace, "namespace ownership must terminate at a namespace root")
+					break
+				}
+				require.Nil(t, currentOps.namespace, "namespace roots must not also inherit selection")
+				current = currentOps.namespaceOwner
+			}
+		})
+	}
+}
+
 // extractRefs is a test helper that collects refs from a slice of Resources.
 func extractRefs(resources []Resource) []string {
 	refs := make([]string, len(resources))

--- a/internal/declarative/resources/types.go
+++ b/internal/declarative/resources/types.go
@@ -604,696 +604,72 @@ func (rs *ResourceSet) GetDCRProviderByRef(ref string) *DCRProviderResource {
 
 // GetPortalsByNamespace returns all portal resources from the specified namespace
 func (rs *ResourceSet) GetPortalsByNamespace(namespace string) []PortalResource {
-	var filtered []PortalResource
-	for _, portal := range rs.Portals {
-		if portal.IsExternal() {
-			if namespace == NamespaceExternal {
-				filtered = append(filtered, portal)
-			}
-			continue
-		}
-		if GetNamespace(portal.Kongctl) == namespace {
-			filtered = append(filtered, portal)
-		}
-	}
-	return filtered
+	return GetResourcesByNamespace[PortalResource](rs, namespace)
 }
 
 // GetControlPlanesByNamespace returns all control plane resources from the specified namespace
 func (rs *ResourceSet) GetControlPlanesByNamespace(namespace string) []ControlPlaneResource {
-	var filtered []ControlPlaneResource
-	for _, cp := range rs.ControlPlanes {
-		if cp.IsExternal() {
-			if namespace == NamespaceExternal {
-				filtered = append(filtered, cp)
-			}
-			continue
-		}
-		if GetNamespace(cp.Kongctl) == namespace {
-			filtered = append(filtered, cp)
-		}
-	}
-	return filtered
+	return GetResourcesByNamespace[ControlPlaneResource](rs, namespace)
 }
 
 // GetCatalogServicesByNamespace returns all catalog service resources from the specified namespace
 func (rs *ResourceSet) GetCatalogServicesByNamespace(namespace string) []CatalogServiceResource {
-	var filtered []CatalogServiceResource
-	for _, svc := range rs.CatalogServices {
-		if GetNamespace(svc.Kongctl) == namespace {
-			filtered = append(filtered, svc)
-		}
-	}
-	return filtered
+	return GetResourcesByNamespace[CatalogServiceResource](rs, namespace)
 }
 
 // GetAIGatewaysByNamespace returns all AI Gateway resources from the specified namespace.
 func (rs *ResourceSet) GetAIGatewaysByNamespace(namespace string) []AIGatewayResource {
-	var filtered []AIGatewayResource
-	for _, gateway := range rs.AIGateways {
-		if gateway.IsExternal() {
-			if namespace == NamespaceExternal {
-				filtered = append(filtered, gateway)
-			}
-			continue
-		}
-		if GetNamespace(gateway.Kongctl) == namespace {
-			filtered = append(filtered, gateway)
-		}
-	}
-	return filtered
-}
-
-// GetAIGatewayProvidersByNamespace returns all AI Gateway Model Provider resources from the specified namespace.
-func (rs *ResourceSet) GetAIGatewayProvidersByNamespace(namespace string) []AIGatewayProviderResource {
-	gatewayByRef := make(map[string]AIGatewayResource)
-	for _, gateway := range rs.GetAIGatewaysByNamespace(namespace) {
-		gatewayByRef[gateway.Ref] = gateway
-	}
-
-	var filtered []AIGatewayProviderResource
-	for _, provider := range rs.AIGatewayProviders {
-		if _, ok := gatewayByRef[NormalizeResourceRef(provider.AIGateway)]; ok {
-			filtered = append(filtered, provider)
-		}
-	}
-	return filtered
-}
-
-// GetAIGatewayAuthStrategiesByNamespace returns AI Gateway Auth Strategy resources from the specified namespace.
-func (rs *ResourceSet) GetAIGatewayAuthStrategiesByNamespace(
-	namespace string,
-) []AIGatewayAuthStrategyResource {
-	gatewayByRef := make(map[string]AIGatewayResource)
-	for _, gateway := range rs.GetAIGatewaysByNamespace(namespace) {
-		gatewayByRef[gateway.Ref] = gateway
-	}
-
-	var filtered []AIGatewayAuthStrategyResource
-	for _, provider := range rs.AIGatewayAuthStrategies {
-		if _, ok := gatewayByRef[NormalizeResourceRef(provider.AIGateway)]; ok {
-			filtered = append(filtered, provider)
-		}
-	}
-	return filtered
-}
-
-// GetAIGatewayPoliciesByNamespace returns AI Gateway policy resources from the specified namespace.
-func (rs *ResourceSet) GetAIGatewayPoliciesByNamespace(namespace string) []AIGatewayPolicyResource {
-	var filtered []AIGatewayPolicyResource
-	for _, policy := range rs.AIGatewayPolicies {
-		if gateway := rs.GetAIGatewayByRef(policy.AIGateway); gateway != nil {
-			if gateway.IsExternal() {
-				if namespace == NamespaceExternal {
-					filtered = append(filtered, policy)
-				}
-				continue
-			}
-			if GetNamespace(gateway.Kongctl) == namespace {
-				filtered = append(filtered, policy)
-			}
-		}
-	}
-	return filtered
-}
-
-// GetAIGatewayAgentsByNamespace returns AI Gateway Agent resources from the specified namespace.
-func (rs *ResourceSet) GetAIGatewayAgentsByNamespace(namespace string) []AIGatewayAgentResource {
-	var filtered []AIGatewayAgentResource
-	for _, agent := range rs.AIGatewayAgents {
-		if gateway := rs.GetAIGatewayByRef(agent.AIGateway); gateway != nil {
-			if gateway.IsExternal() {
-				if namespace == NamespaceExternal {
-					filtered = append(filtered, agent)
-				}
-				continue
-			}
-			if GetNamespace(gateway.Kongctl) == namespace {
-				filtered = append(filtered, agent)
-			}
-		}
-	}
-	return filtered
-}
-
-// GetAIGatewayConsumersByNamespace returns AI Gateway Consumer resources from the specified namespace.
-func (rs *ResourceSet) GetAIGatewayConsumersByNamespace(namespace string) []AIGatewayConsumerResource {
-	var filtered []AIGatewayConsumerResource
-	for _, consumer := range rs.AIGatewayConsumers {
-		if gateway := rs.GetAIGatewayByRef(consumer.AIGateway); gateway != nil {
-			if gateway.IsExternal() {
-				if namespace == NamespaceExternal {
-					filtered = append(filtered, consumer)
-				}
-				continue
-			}
-			if GetNamespace(gateway.Kongctl) == namespace {
-				filtered = append(filtered, consumer)
-			}
-		}
-	}
-	return filtered
-}
-
-// GetAIGatewayConsumerGroupsByNamespace returns AI Gateway Consumer Group resources from the specified namespace.
-func (rs *ResourceSet) GetAIGatewayConsumerGroupsByNamespace(namespace string) []AIGatewayConsumerGroupResource {
-	var filtered []AIGatewayConsumerGroupResource
-	for _, group := range rs.AIGatewayConsumerGroups {
-		if gateway := rs.GetAIGatewayByRef(group.AIGateway); gateway != nil {
-			if gateway.IsExternal() {
-				if namespace == NamespaceExternal {
-					filtered = append(filtered, group)
-				}
-				continue
-			}
-			if GetNamespace(gateway.Kongctl) == namespace {
-				filtered = append(filtered, group)
-			}
-		}
-	}
-	return filtered
-}
-
-// GetAIGatewayConsumerCredentialsByNamespace returns AI Gateway Consumer Credential
-// resources from the specified namespace.
-func (rs *ResourceSet) GetAIGatewayConsumerCredentialsByNamespace(
-	namespace string,
-) []AIGatewayConsumerCredentialResource {
-	var filtered []AIGatewayConsumerCredentialResource
-	for _, credential := range rs.AIGatewayConsumerCredentials {
-		if consumer := rs.GetAIGatewayConsumerByRef(credential.AIGatewayConsumer); consumer != nil {
-			if gateway := rs.GetAIGatewayByRef(consumer.AIGateway); gateway != nil {
-				if gateway.IsExternal() {
-					if namespace == NamespaceExternal {
-						filtered = append(filtered, credential)
-					}
-					continue
-				}
-				if GetNamespace(gateway.Kongctl) == namespace {
-					filtered = append(filtered, credential)
-				}
-			}
-		}
-	}
-	return filtered
-}
-
-// GetAIGatewayModelsByNamespace returns AI Gateway model resources from the specified namespace.
-func (rs *ResourceSet) GetAIGatewayModelsByNamespace(namespace string) []AIGatewayModelResource {
-	var filtered []AIGatewayModelResource
-	for _, model := range rs.AIGatewayModels {
-		if gateway := rs.GetAIGatewayByRef(model.AIGateway); gateway != nil {
-			if gateway.IsExternal() {
-				if namespace == NamespaceExternal {
-					filtered = append(filtered, model)
-				}
-				continue
-			}
-			if GetNamespace(gateway.Kongctl) == namespace {
-				filtered = append(filtered, model)
-			}
-		}
-	}
-	return filtered
-}
-
-// GetAIGatewayMCPServersByNamespace returns AI Gateway MCP Server resources from the specified namespace.
-func (rs *ResourceSet) GetAIGatewayMCPServersByNamespace(namespace string) []AIGatewayMCPServerResource {
-	var filtered []AIGatewayMCPServerResource
-	for _, server := range rs.AIGatewayMCPServers {
-		if gateway := rs.GetAIGatewayByRef(server.AIGateway); gateway != nil {
-			if gateway.IsExternal() {
-				if namespace == NamespaceExternal {
-					filtered = append(filtered, server)
-				}
-				continue
-			}
-			if GetNamespace(gateway.Kongctl) == namespace {
-				filtered = append(filtered, server)
-			}
-		}
-	}
-	return filtered
-}
-
-// GetAIGatewayVaultsByNamespace returns AI Gateway Vault resources from the specified namespace.
-func (rs *ResourceSet) GetAIGatewayVaultsByNamespace(namespace string) []AIGatewayVaultResource {
-	var filtered []AIGatewayVaultResource
-	for _, vault := range rs.AIGatewayVaults {
-		if gateway := rs.GetAIGatewayByRef(vault.AIGateway); gateway != nil {
-			if gateway.IsExternal() {
-				if namespace == NamespaceExternal {
-					filtered = append(filtered, vault)
-				}
-				continue
-			}
-			if GetNamespace(gateway.Kongctl) == namespace {
-				filtered = append(filtered, vault)
-			}
-		}
-	}
-	return filtered
-}
-
-// GetAIGatewayConfigStoresByNamespace returns AI Gateway Config Stores from the specified namespace.
-func (rs *ResourceSet) GetAIGatewayConfigStoresByNamespace(namespace string) []AIGatewayConfigStoreResource {
-	var filtered []AIGatewayConfigStoreResource
-	for _, store := range rs.AIGatewayConfigStores {
-		if gateway := rs.GetAIGatewayByRef(store.AIGateway); gateway != nil {
-			if gateway.IsExternal() {
-				if namespace == NamespaceExternal {
-					filtered = append(filtered, store)
-				}
-				continue
-			}
-			if GetNamespace(gateway.Kongctl) == namespace {
-				filtered = append(filtered, store)
-			}
-		}
-	}
-	return filtered
-}
-
-// GetAIGatewayDataPlaneCertificatesByNamespace returns AI Gateway data plane certificate
-// resources from the specified namespace.
-func (rs *ResourceSet) GetAIGatewayDataPlaneCertificatesByNamespace(
-	namespace string,
-) []AIGatewayDataPlaneCertificateResource {
-	var filtered []AIGatewayDataPlaneCertificateResource
-	for _, cert := range rs.AIGatewayDataPlaneCertificates {
-		if gateway := rs.GetAIGatewayByRef(cert.AIGateway); gateway != nil {
-			if gateway.IsExternal() {
-				if namespace == NamespaceExternal {
-					filtered = append(filtered, cert)
-				}
-				continue
-			}
-			if GetNamespace(gateway.Kongctl) == namespace {
-				filtered = append(filtered, cert)
-			}
-		}
-	}
-	return filtered
+	return GetResourcesByNamespace[AIGatewayResource](rs, namespace)
 }
 
 // GetAPIsByNamespace returns all API resources from the specified namespace
 func (rs *ResourceSet) GetAPIsByNamespace(namespace string) []APIResource {
-	var filtered []APIResource
-	for _, api := range rs.APIs {
-		if api.IsExternal() {
-			if namespace == NamespaceExternal {
-				filtered = append(filtered, api)
-			}
-			continue
-		}
-		if GetNamespace(api.Kongctl) == namespace {
-			filtered = append(filtered, api)
-		}
-	}
-	return filtered
+	return GetResourcesByNamespace[APIResource](rs, namespace)
 }
 
 // GetDashboardsByNamespace returns all dashboard resources from the specified namespace.
 func (rs *ResourceSet) GetDashboardsByNamespace(namespace string) []DashboardResource {
-	var filtered []DashboardResource
-	for _, dashboard := range rs.Dashboards {
-		if GetNamespace(dashboard.Kongctl) == namespace {
-			filtered = append(filtered, dashboard)
-		}
-	}
-	return filtered
+	return GetResourcesByNamespace[DashboardResource](rs, namespace)
 }
 
 // GetAuthStrategiesByNamespace returns all auth strategy resources from the specified namespace
 func (rs *ResourceSet) GetAuthStrategiesByNamespace(namespace string) []ApplicationAuthStrategyResource {
-	var filtered []ApplicationAuthStrategyResource
-	for _, strategy := range rs.ApplicationAuthStrategies {
-		if strategy.IsExternal() {
-			if namespace == NamespaceExternal {
-				filtered = append(filtered, strategy)
-			}
-			continue
-		}
-		if GetNamespace(strategy.Kongctl) == namespace {
-			filtered = append(filtered, strategy)
-		}
-	}
-	return filtered
+	return GetResourcesByNamespace[ApplicationAuthStrategyResource](rs, namespace)
 }
 
 // GetDCRProvidersByNamespace returns all DCR provider resources from the specified namespace
 func (rs *ResourceSet) GetDCRProvidersByNamespace(namespace string) []DCRProviderResource {
-	var filtered []DCRProviderResource
-	for _, provider := range rs.DCRProviders {
-		if GetNamespace(provider.Kongctl) == namespace {
-			filtered = append(filtered, provider)
-		}
-	}
-	return filtered
+	return GetResourcesByNamespace[DCRProviderResource](rs, namespace)
 }
 
 // GetAPIVersionsByNamespace returns all API version resources from the specified namespace
 func (rs *ResourceSet) GetAPIVersionsByNamespace(namespace string) []APIVersionResource {
-	var filtered []APIVersionResource
-	for _, version := range rs.APIVersions {
-		// Check if parent API is in the namespace
-		api := rs.GetAPIByRef(version.API)
-		if api != nil && resourceNamespaceMatches(api.IsExternal(), api.Kongctl, namespace) {
-			filtered = append(filtered, version)
-		}
-	}
-	return filtered
+	return GetResourcesByNamespace[APIVersionResource](rs, namespace)
 }
 
 // GetAPIPublicationsByNamespace returns all API publication resources from the specified namespace
 func (rs *ResourceSet) GetAPIPublicationsByNamespace(namespace string) []APIPublicationResource {
-	var filtered []APIPublicationResource
-	for _, pub := range rs.APIPublications {
-		// Check if parent API is in the namespace
-		if api := rs.GetAPIByRef(pub.API); api != nil && resourceNamespaceMatches(api.IsExternal(), api.Kongctl, namespace) {
-			filtered = append(filtered, pub)
-		}
-	}
-	return filtered
+	return GetResourcesByNamespace[APIPublicationResource](rs, namespace)
 }
 
 // GetAPIImplementationsByNamespace returns all API implementation resources from the specified namespace
 func (rs *ResourceSet) GetAPIImplementationsByNamespace(namespace string) []APIImplementationResource {
-	var filtered []APIImplementationResource
-	for _, impl := range rs.APIImplementations {
-		// Check if parent API is in the namespace
-		if api := rs.GetAPIByRef(impl.API); api != nil && resourceNamespaceMatches(api.IsExternal(), api.Kongctl, namespace) {
-			filtered = append(filtered, impl)
-		}
-	}
-	return filtered
+	return GetResourcesByNamespace[APIImplementationResource](rs, namespace)
 }
 
 // GetAPIDocumentsByNamespace returns all API document resources from the specified namespace
 func (rs *ResourceSet) GetAPIDocumentsByNamespace(namespace string) []APIDocumentResource {
-	var filtered []APIDocumentResource
-	for _, doc := range rs.APIDocuments {
-		// Check if parent API is in the namespace
-		if api := rs.GetAPIByRef(doc.API); api != nil && resourceNamespaceMatches(api.IsExternal(), api.Kongctl, namespace) {
-			filtered = append(filtered, doc)
-		}
-	}
-	return filtered
-}
-
-func resourceNamespaceMatches(external bool, meta *KongctlMeta, namespace string) bool {
-	if external {
-		return namespace == NamespaceExternal
-	}
-	return GetNamespace(meta) == namespace
-}
-
-// GetPortalCustomizationsByNamespace returns all portal customization resources from the specified namespace
-func (rs *ResourceSet) GetPortalCustomizationsByNamespace(namespace string) []PortalCustomizationResource {
-	var filtered []PortalCustomizationResource
-	for _, custom := range rs.PortalCustomizations {
-		// Check if parent portal is in the namespace
-		if portal := rs.GetPortalByRef(custom.Portal); portal != nil {
-			if portal.IsExternal() {
-				if namespace == NamespaceExternal {
-					filtered = append(filtered, custom)
-				}
-				continue
-			}
-			if GetNamespace(portal.Kongctl) == namespace {
-				filtered = append(filtered, custom)
-			}
-		}
-	}
-	return filtered
-}
-
-// GetPortalAuthSettingsByNamespace returns all portal auth settings resources from the specified namespace
-func (rs *ResourceSet) GetPortalAuthSettingsByNamespace(namespace string) []PortalAuthSettingsResource {
-	var filtered []PortalAuthSettingsResource
-	for _, settings := range rs.PortalAuthSettings {
-		if portal := rs.GetPortalByRef(settings.Portal); portal != nil {
-			if portal.IsExternal() {
-				if namespace == NamespaceExternal {
-					filtered = append(filtered, settings)
-				}
-				continue
-			}
-			if GetNamespace(portal.Kongctl) == namespace {
-				filtered = append(filtered, settings)
-			}
-		}
-	}
-	return filtered
-}
-
-// GetPortalIPAllowListsByNamespace returns all portal IP allow-list resources from the specified namespace.
-func (rs *ResourceSet) GetPortalIPAllowListsByNamespace(namespace string) []PortalIPAllowListResource {
-	var filtered []PortalIPAllowListResource
-	for _, allowList := range rs.PortalIPAllowLists {
-		if portal := rs.GetPortalByRef(allowList.Portal); portal != nil {
-			if portal.IsExternal() {
-				if namespace == NamespaceExternal {
-					filtered = append(filtered, allowList)
-				}
-				continue
-			}
-			if GetNamespace(portal.Kongctl) == namespace {
-				filtered = append(filtered, allowList)
-			}
-		}
-	}
-	return filtered
-}
-
-// GetPortalIntegrationsByNamespace returns all portal integration resources from the specified namespace
-func (rs *ResourceSet) GetPortalIntegrationsByNamespace(namespace string) []PortalIntegrationResource {
-	var filtered []PortalIntegrationResource
-	for _, integration := range rs.PortalIntegrations {
-		if portal := rs.GetPortalByRef(integration.Portal); portal != nil {
-			if portal.IsExternal() {
-				if namespace == NamespaceExternal {
-					filtered = append(filtered, integration)
-				}
-				continue
-			}
-			if GetNamespace(portal.Kongctl) == namespace {
-				filtered = append(filtered, integration)
-			}
-		}
-	}
-	return filtered
-}
-
-// GetPortalIdentityProvidersByNamespace returns all portal identity provider resources from the specified namespace
-func (rs *ResourceSet) GetPortalIdentityProvidersByNamespace(namespace string) []PortalIdentityProviderResource {
-	var filtered []PortalIdentityProviderResource
-	for _, provider := range rs.PortalIdentityProviders {
-		if portal := rs.GetPortalByRef(provider.Portal); portal != nil {
-			if portal.IsExternal() {
-				if namespace == NamespaceExternal {
-					filtered = append(filtered, provider)
-				}
-				continue
-			}
-			if GetNamespace(portal.Kongctl) == namespace {
-				filtered = append(filtered, provider)
-			}
-		}
-	}
-	return filtered
-}
-
-// GetPortalTeamGroupMappingsByNamespace returns portal team group mappings from the specified namespace.
-func (rs *ResourceSet) GetPortalTeamGroupMappingsByNamespace(namespace string) []PortalTeamGroupMappingResource {
-	var filtered []PortalTeamGroupMappingResource
-	for _, mapping := range rs.PortalTeamGroupMappings {
-		if portal := rs.GetPortalByRef(mapping.Portal); portal != nil {
-			if portal.IsExternal() {
-				if namespace == NamespaceExternal {
-					filtered = append(filtered, mapping)
-				}
-				continue
-			}
-			if GetNamespace(portal.Kongctl) == namespace {
-				filtered = append(filtered, mapping)
-			}
-		}
-	}
-	return filtered
-}
-
-// GetPortalCustomDomainsByNamespace returns all portal custom domain resources from the specified namespace
-func (rs *ResourceSet) GetPortalCustomDomainsByNamespace(namespace string) []PortalCustomDomainResource {
-	var filtered []PortalCustomDomainResource
-	for _, domain := range rs.PortalCustomDomains {
-		// Check if parent portal is in the namespace
-		if portal := rs.GetPortalByRef(domain.Portal); portal != nil {
-			if portal.IsExternal() {
-				if namespace == NamespaceExternal {
-					filtered = append(filtered, domain)
-				}
-				continue
-			}
-			if GetNamespace(portal.Kongctl) == namespace {
-				filtered = append(filtered, domain)
-			}
-		}
-	}
-	return filtered
+	return GetResourcesByNamespace[APIDocumentResource](rs, namespace)
 }
 
 // GetPortalPagesByNamespace returns all portal page resources from the specified namespace
 func (rs *ResourceSet) GetPortalPagesByNamespace(namespace string) []PortalPageResource {
-	var filtered []PortalPageResource
-	for _, page := range rs.PortalPages {
-		// Check if parent portal is in the namespace
-		if portal := rs.GetPortalByRef(page.Portal); portal != nil {
-			if portal.IsExternal() {
-				if namespace == NamespaceExternal {
-					filtered = append(filtered, page)
-				}
-				continue
-			}
-			if GetNamespace(portal.Kongctl) == namespace {
-				filtered = append(filtered, page)
-			}
-		}
-	}
-	return filtered
-}
-
-// GetPortalSnippetsByNamespace returns all portal snippet resources from the specified namespace
-func (rs *ResourceSet) GetPortalSnippetsByNamespace(namespace string) []PortalSnippetResource {
-	var filtered []PortalSnippetResource
-	for _, snippet := range rs.PortalSnippets {
-		// Check if parent portal is in the namespace
-		if portal := rs.GetPortalByRef(snippet.Portal); portal != nil {
-			if portal.IsExternal() {
-				if namespace == NamespaceExternal {
-					filtered = append(filtered, snippet)
-				}
-				continue
-			}
-			if GetNamespace(portal.Kongctl) == namespace {
-				filtered = append(filtered, snippet)
-			}
-		}
-	}
-	return filtered
-}
-
-// GetPortalEmailConfigsByNamespace returns all portal email config resources from the specified namespace
-func (rs *ResourceSet) GetPortalEmailConfigsByNamespace(namespace string) []PortalEmailConfigResource {
-	var filtered []PortalEmailConfigResource
-	for _, cfg := range rs.PortalEmailConfigs {
-		if portal := rs.GetPortalByRef(cfg.Portal); portal != nil {
-			if portal.IsExternal() {
-				if namespace == NamespaceExternal {
-					filtered = append(filtered, cfg)
-				}
-				continue
-			}
-			if GetNamespace(portal.Kongctl) == namespace {
-				filtered = append(filtered, cfg)
-			}
-		}
-	}
-	return filtered
-}
-
-// GetPortalAuditLogWebhooksByNamespace returns all portal audit-log webhook resources from the specified namespace
-func (rs *ResourceSet) GetPortalAuditLogWebhooksByNamespace(namespace string) []PortalAuditLogWebhookResource {
-	var filtered []PortalAuditLogWebhookResource
-	for _, webhook := range rs.PortalAuditLogWebhooks {
-		if portal := rs.GetPortalByRef(webhook.Portal); portal != nil {
-			if portal.IsExternal() {
-				if namespace == NamespaceExternal {
-					filtered = append(filtered, webhook)
-				}
-				continue
-			}
-			if GetNamespace(portal.Kongctl) == namespace {
-				filtered = append(filtered, webhook)
-			}
-		}
-	}
-	return filtered
-}
-
-// GetPortalEmailTemplatesByNamespace returns all portal email template resources from the specified namespace
-func (rs *ResourceSet) GetPortalEmailTemplatesByNamespace(namespace string) []PortalEmailTemplateResource {
-	var filtered []PortalEmailTemplateResource
-	for _, tpl := range rs.PortalEmailTemplates {
-		if portal := rs.GetPortalByRef(tpl.Portal); portal != nil {
-			if portal.IsExternal() {
-				if namespace == NamespaceExternal {
-					filtered = append(filtered, tpl)
-				}
-				continue
-			}
-			if GetNamespace(portal.Kongctl) == namespace {
-				filtered = append(filtered, tpl)
-			}
-		}
-	}
-	return filtered
-}
-
-// GetPortalTeamsByNamespace returns all portal team resources from the specified namespace
-func (rs *ResourceSet) GetPortalTeamsByNamespace(namespace string) []PortalTeamResource {
-	var filtered []PortalTeamResource
-	for _, team := range rs.PortalTeams {
-		// Check if parent portal is in the namespace
-		if portal := rs.GetPortalByRef(team.Portal); portal != nil {
-			if portal.IsExternal() {
-				if namespace == NamespaceExternal {
-					filtered = append(filtered, team)
-				}
-				continue
-			}
-			if GetNamespace(portal.Kongctl) == namespace {
-				filtered = append(filtered, team)
-			}
-		}
-	}
-	return filtered
-}
-
-// GetPortalTeamRolesByNamespace returns all portal team role resources from the specified namespace
-func (rs *ResourceSet) GetPortalTeamRolesByNamespace(namespace string) []PortalTeamRoleResource {
-	var filtered []PortalTeamRoleResource
-	for _, role := range rs.PortalTeamRoles {
-		if portal := rs.GetPortalByRef(role.Portal); portal != nil {
-			if portal.IsExternal() {
-				if namespace == NamespaceExternal {
-					filtered = append(filtered, role)
-				}
-				continue
-			}
-			if GetNamespace(portal.Kongctl) == namespace {
-				filtered = append(filtered, role)
-			}
-		}
-	}
-	return filtered
+	return GetResourcesByNamespace[PortalPageResource](rs, namespace)
 }
 
 // GetEventGatewayControlPlanesByNamespace returns all EGW CP resources from the specified namespace
 func (rs *ResourceSet) GetEventGatewayControlPlanesByNamespace(namespace string) []EventGatewayControlPlaneResource {
-	var filtered []EventGatewayControlPlaneResource
-	for _, cp := range rs.EventGatewayControlPlanes {
-		if cp.IsExternal() {
-			if namespace == NamespaceExternal {
-				filtered = append(filtered, cp)
-			}
-			continue
-		}
-		if GetNamespace(cp.Kongctl) == namespace {
-			filtered = append(filtered, cp)
-		}
-	}
-	return filtered
+	return GetResourcesByNamespace[EventGatewayControlPlaneResource](rs, namespace)
 }
 
 // GetBackendClusterByRef returns a backend cluster resource by its ref from any namespace
@@ -1335,19 +711,7 @@ func (rs *ResourceSet) GetVirtualClusterByRef(ref string) *EventGatewayVirtualCl
 
 // GetOrganizationTeamsByNamespace returns all organization_team resources from the specified namespace
 func (rs *ResourceSet) GetOrganizationTeamsByNamespace(namespace string) []OrganizationTeamResource {
-	var filtered []OrganizationTeamResource
-	for _, team := range rs.OrganizationTeams {
-		if team.IsExternal() {
-			if namespace == NamespaceExternal {
-				filtered = append(filtered, team)
-			}
-			continue
-		}
-		if GetNamespace(team.Kongctl) == namespace {
-			filtered = append(filtered, team)
-		}
-	}
-	return filtered
+	return GetResourcesByNamespace[OrganizationTeamResource](rs, namespace)
 }
 
 // GetOrganizationTeamRolesByNamespace returns all organization_team_role resources from the specified namespace.


### PR DESCRIPTION
Desired-resource namespace selection was repeated in per-kind `ResourceSet`
getters, alongside unused child getters and planner wrappers. New managed
roots now reuse their registered storage and namespace metadata; child
selection supplies only the typed namespace-owner lookup.

- Extend `WithNamespace` so all ten managed roots supply selection through
  their existing registrations.
- Add `GetResourcesByNamespace[R]` and `WithNamespaceFrom`. Register typed
  owner lookups for API versions, publications, implementations, documents,
  and Portal pages beside their declarations.
- Keep the 15 retained getters as thin adapters, including the existing
  test-facing Portal-pages entry point. Remove 25 unused namespace getters
  and ten unused planner wrappers.
- Record the owner kind from the typed registration. A registry contract
  verifies that every selected kind's ownership chain reaches a registered
  namespace root, with no missing selection policy or cycle. Owners may
  register later, so this check runs after package initialization.
- Update the authoritative declarative implementation guide with the new
  entry points and remaining specialized integration rules.

Selection preserves default/external namespaces, exact and first-match parent
lookup, missing-owner exclusion, nil results, source order, and shallow-copy
behavior. API documents select through their API and Portal pages through
their Portal, regardless of recursive structural parents. Supplemental
grouping collections remain excluded. Organization assignments retain their
specialized selection logic.

The contract validates declared namespace ownership. A direct generic call
for a kind without selection remains a programming error; this change does
not make every registered resource support namespace selection.

Refs #2079. This completes another capability migration; it does not close the
broader program.

## Validation

- The production refactor passed unchanged local suites and GitHub
  unit/integration, CodeQL, and E2E checks before the contract follow-up.
- Final-head read-only modernization, formatting, CGO-disabled
  `make build-ci`, and `make test-all` pass: lint 2.13.2, installer checks,
  race-enabled unit/integration suites, and 57 E2E tooling tests.
- The only test change is a 30-line registration contract added to
  `registry_test.go`, as proposed in the maintainer's review. All
  preexisting test bodies, fixtures, and helpers remain unchanged.
  Temporary production build overlays confirm that it fails for an
  unregistered owner, an owner without selection, and an ownership cycle.
- An external Go build-overlay comparison of the final implementation
  matches 123,000 selection results and 26,112 namespace-participant
  observations against the original implementation. Cases include
  duplicate/missing/empty/whitespace parent refs, external/default/explicit
  namespaces, grouped declarations, organization selectors, returned-copy
  isolation, and metadata sharing. This is bounded compatibility evidence.
- SHA-256 comparison against the reviewed production commit confirms only
  the four intended follow-up files changed. Removing the new contract
  function leaves `registry_test.go` byte-for-byte identical to its
  previous contents. Guide wrapping and its 72 local links/anchors pass.
