### PR TITLE
refactor(declarative): register API child loading capabilities

### DIFF
--- a/docs/contributor/declarative-resource-implementation-guide.md
+++ b/docs/contributor/declarative-resource-implementation-guide.md
@@ -38,7 +38,8 @@ request: it can contain `ref`, `kongctl`, children, and parent selectors.
 
 The [resource registry][registry] drives iteration, aggregation,
 explain/scaffold, load-schema discovery, namespace participation,
-collection scope, AI Gateway/Portal child loading, and dump-default metadata.
+collection scope, AI Gateway/API/Portal child loading, and dump-default
+metadata.
 The [root planner inventory][roots] drives root construction and dispatch.
 [Runtime executor registration][runtime-executors] supplies action routing and
 payload validation for SDK resource operations. Other families' nested
@@ -144,15 +145,22 @@ input cannot disclose a secret in an error.
 
 ### Child loading capabilities
 
-AI Gateway and Portal children register loading beside their declarations,
+AI Gateway, API, and Portal children register loading beside their declarations,
 reusing root storage through [`registerChildResourceType`][child-load]. Supply
 one extraction form: `nested`/`setParent` with an optional `beforeAppend`, or a
 typed `extract` handler for exceptional sources. Custom extraction receives
-the registered destination and must preserve copying and source clearing.
+the registered destination; preserve each source's copying and storage rules.
 
 All 16 AI Gateway child kinds pair extraction with validation. Direct children
 use [`registerAIGatewayChildResource`][ai-child-load] for gateway-local moniker
 uniqueness; data-plane certificates retain `title` diagnostics.
+
+API versions, publications, implementations, and documents register in that
+order. [`apiChildLoad`][api-child-load] shares ordinary extraction and both
+validation phases. [Documents][api-document] use custom preorder flattening:
+nested documents remain under their API; `FlattenRootAPIDocuments` separately
+normalizes root documents. Preserve parent-document selectors, explicit child
+API overrides, and allocated empty document slices in both locations.
 
 Portal registers fourteen extraction paths and its twelve existing child
 validators. [Singleton extraction][portal-child-load] copies a present value,
@@ -174,18 +182,22 @@ within their group, independently of scope-capture order. Registration rejects
 conflicting extraction forms, missing validation dispositions, and order
 clashes.
 
-The loader still owns phase sequencing. `ExtractRegisteredChildren` copies
-children, overwrites their parent selector, appends after existing root values,
-and clears nested fields. Recursion is explicit: Config Stores extract secrets
-before appending the store, ahead of secrets from root-declared stores. Secret
-defaults still run before source indexing; consumer credentials are extracted
-later. Preserve these phases in both loader representations.
+The loader still owns phase sequencing. Ordinary `ExtractRegisteredChildren`
+handlers copy children, overwrite their parent selector, append after existing
+root values, and clear nested fields. Recursion is explicit: Config Stores
+extract secrets before appending the store, ahead of secrets from root-declared
+stores. Secret defaults still run before source indexing; consumer credentials
+are extracted later. Preserve these phases in both loader representations.
 
-`ValidateRegisteredChildren` stops at the family's first error. Portal child
-validation follows separate API-child validation, preserving error precedence.
-Other families, root validation, cross-references, and namespaces retain their
-existing loader paths. Migrating another family requires its own compatibility
-assessment.
+`ValidateRegisteredNestedChildren` runs optional per-parent callbacks in
+extraction order. API root validation invokes it after each API's identity
+checks, preserving parent-context errors and cross-kind ref checks, including
+documents retained after extraction. `ValidateRegisteredChildren` then checks
+root child collections in family order, stopping at the first error. API and
+ordinary Portal ref validation both validate each resource before checking
+later siblings for duplicate refs.
+Portal child validation follows API-child validation. Other families, root
+validation, cross-references, and namespaces retain their existing loader paths.
 
 ### Explain, scaffold, and load schema
 
@@ -626,6 +638,8 @@ engine contract. Each refactoring migration should:
 [loader]: ../../internal/declarative/loader/loader.go
 [load-validation]: ../../internal/declarative/loader/validator.go
 [child-load]: ../../internal/declarative/resources/child_load.go
+[api-child-load]: ../../internal/declarative/resources/api_child_load.go
+[api-document]: ../../internal/declarative/resources/api_document.go
 [portal-child-load]: ../../internal/declarative/resources/portal_child_load.go
 [portal-page]: ../../internal/declarative/resources/portal_page.go
 [portal-template]: ../../internal/declarative/resources/portal_email_template.go

--- a/docs/contributor/declarative-resource-implementation-guide.md
+++ b/docs/contributor/declarative-resource-implementation-guide.md
@@ -191,8 +191,9 @@ are extracted later. Preserve these phases in both loader representations.
 
 `ValidateRegisteredNestedChildren` runs optional per-parent callbacks in
 extraction order. API root validation invokes it after each API's identity
-checks, preserving parent-context errors and cross-kind ref checks, including
-documents retained after extraction. `ValidateRegisteredChildren` then checks
+checks, preserving parent-context errors and cross-kind ref checks. Ordinary
+API child callbacks retain validation before extraction; normal loading leaves
+only documents nested. `ValidateRegisteredChildren` then checks
 root child collections in family order, stopping at the first error. API and
 ordinary Portal ref validation both validate each resource before checking
 later siblings for duplicate refs.

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -748,49 +748,9 @@ func (l *Loader) extractNestedResources(rs *resources.ResourceSet) {
 	}
 
 	for i := range rs.APIs {
-		api := &rs.APIs[i]
-
-		// Extract versions
-		for j := range api.Versions {
-			version := api.Versions[j]
-			version.API = api.Ref // Set parent reference
-			rs.APIVersions = append(rs.APIVersions, version)
-		}
-
-		// Extract publications
-		for j := range api.Publications {
-			publication := api.Publications[j]
-			publication.API = api.Ref // Set parent reference
-			rs.APIPublications = append(rs.APIPublications, publication)
-		}
-
-		// Extract implementations
-		for j := range api.Implementations {
-			implementation := api.Implementations[j]
-			implementation.API = api.Ref // Set parent reference
-			rs.APIImplementations = append(rs.APIImplementations, implementation)
-		}
-
-		// Extract documents (with recursive flattening) and reassign to API
-		docs := make([]resources.APIDocumentResource, 0)
-		for j := range api.Documents {
-			document := api.Documents[j]
-			l.extractAPIDocuments(&docs, document, api.Ref, "")
-		}
-		api.Documents = docs
-
-		// Clear other nested resources from API
-		api.Versions = nil
-		api.Publications = nil
-		api.Implementations = nil
+		rs.ExtractRegisteredChildren(&rs.APIs[i])
 	}
-
-	// Extract root-level API documents (with recursive flattening)
-	flattenedDocs := make([]resources.APIDocumentResource, 0)
-	for _, document := range rs.APIDocuments {
-		l.extractAPIDocuments(&flattenedDocs, document, document.API, "")
-	}
-	rs.APIDocuments = flattenedDocs
+	rs.FlattenRootAPIDocuments()
 
 	for i := range rs.Portals {
 		rs.ExtractRegisteredChildren(&rs.Portals[i])
@@ -842,34 +802,6 @@ func (l *Loader) extractNestedResources(rs *resources.ResourceSet) {
 
 	for i := range rs.AIGatewayConsumers {
 		rs.ExtractRegisteredChildren(&rs.AIGatewayConsumers[i])
-	}
-}
-
-// extractAPIDocuments recursively extracts and flattens nested API documents
-func (l *Loader) extractAPIDocuments(
-	allDocs *[]resources.APIDocumentResource,
-	doc resources.APIDocumentResource,
-	apiRef string,
-	parentDocRef string,
-) {
-	if apiRef != "" {
-		doc.API = apiRef
-	}
-	if parentDocRef != "" {
-		doc.ParentDocumentRef = parentDocRef
-	}
-
-	children := doc.Children
-	doc.Children = nil
-
-	*allDocs = append(*allDocs, doc)
-
-	for _, child := range children {
-		childAPIRef := apiRef
-		if child.API != "" {
-			childAPIRef = child.API
-		}
-		l.extractAPIDocuments(allDocs, child, childAPIRef, doc.Ref)
 	}
 }
 

--- a/internal/declarative/loader/validator.go
+++ b/internal/declarative/loader/validator.go
@@ -76,8 +76,8 @@ func (l *Loader) validateResourceSet(rs *resources.ResourceSet) error {
 		return err
 	}
 
-	// Validate separate API child resources (extracted from nested resources)
-	if err := l.validateSeparateAPIChildResources(rs); err != nil {
+	// Validate API child resources in root storage.
+	if err := rs.ValidateRegisteredChildren(resources.ResourceTypeAPI); err != nil {
 		return err
 	}
 
@@ -875,71 +875,8 @@ func (l *Loader) validateAPIs(apis []resources.APIResource, rs *resources.Resour
 
 		apiNames[api.Name] = api.GetRef()
 
-		// Validate nested versions (these should be empty after extraction)
-		for j := range api.Versions {
-			version := &api.Versions[j]
-			if err := version.Validate(); err != nil {
-				return fmt.Errorf("invalid api_version %q in api %q: %w", version.GetRef(), api.GetRef(), err)
-			}
-			// Check global ref uniqueness for nested version
-			if existing, found := rs.GetResourceByRef(version.GetRef()); found {
-				if existing.GetType() != resources.ResourceTypeAPIVersion {
-					return fmt.Errorf("duplicate ref '%s' (already defined as %s)",
-						version.GetRef(), existing.GetType())
-				}
-			}
-		}
-
-		// Validate nested publications (these should be empty after extraction)
-		for j := range api.Publications {
-			publication := &api.Publications[j]
-			if err := publication.Validate(); err != nil {
-				return fmt.Errorf("invalid api_publication %q in api %q: %w", publication.GetRef(), api.GetRef(), err)
-			}
-			// Check global ref uniqueness for nested publication
-			if existing, found := rs.GetResourceByRef(publication.GetRef()); found {
-				if existing.GetType() != resources.ResourceTypeAPIPublication {
-					return fmt.Errorf("duplicate ref '%s' (already defined as %s)",
-						publication.GetRef(), existing.GetType())
-				}
-			}
-		}
-
-		// Validate nested implementations (these should be empty after extraction)
-		for j := range api.Implementations {
-			implementation := &api.Implementations[j]
-			if err := implementation.Validate(); err != nil {
-				return fmt.Errorf(
-					"invalid api_implementation %q in api %q: %w",
-					implementation.GetRef(),
-					api.GetRef(),
-					err,
-				)
-			}
-			// Check global ref uniqueness for nested implementation
-			if existing, found := rs.GetResourceByRef(implementation.GetRef()); found {
-				if existing.GetType() != resources.ResourceTypeAPIImplementation {
-					return fmt.Errorf("duplicate ref '%s' (already defined as %s)",
-						implementation.GetRef(), existing.GetType())
-				}
-			}
-		}
-
-		// Validate documents retained under their parent API after flattening.
-		for j := range api.Documents {
-			document := &api.Documents[j]
-			if err := document.Validate(); err != nil {
-				return fmt.Errorf("invalid api_document %q in api %q: %w", document.GetRef(), api.GetRef(), err)
-			}
-			if existing, found := rs.GetResourceByRef(document.GetRef()); found {
-				if existing.GetType() != resources.ResourceTypeAPIDocument {
-					return fmt.Errorf(
-						"duplicate ref '%s' (already defined as %s)",
-						document.GetRef(),
-						existing.GetType(),
-					)
-				}
-			}
+		if err := rs.ValidateRegisteredNestedChildren(api); err != nil {
+			return err
 		}
 	}
 
@@ -1005,78 +942,6 @@ func (l *Loader) validateCrossReferences(rs *resources.ResourceSet) error {
 	}
 
 	// Note: API versions don't have outbound references, so no validation needed
-
-	return nil
-}
-
-// validateSeparateAPIChildResources validates individual API child resources that were extracted
-func (l *Loader) validateSeparateAPIChildResources(rs *resources.ResourceSet) error {
-	// Count versions per API to enforce single-version constraint
-	// This is a safety check in case the early validation was bypassed
-	versionCountByAPI := make(map[string]int)
-	for i := range rs.APIVersions {
-		version := &rs.APIVersions[i]
-		if version.API != "" {
-			versionCountByAPI[version.API]++
-		}
-	}
-
-	// Validate separate API versions
-	for i := range rs.APIVersions {
-		version := &rs.APIVersions[i]
-		if err := version.Validate(); err != nil {
-			return fmt.Errorf("invalid api_version %q: %w", version.GetRef(), err)
-		}
-		// Check global ref uniqueness using RefReader (duplicates were extracted from nested)
-		// We need to check against self since these are already in the ResourceSet
-		for j := i + 1; j < len(rs.APIVersions); j++ {
-			if rs.APIVersions[j].GetRef() == version.GetRef() {
-				return fmt.Errorf("duplicate ref '%s' (already defined as api_version)", version.GetRef())
-			}
-		}
-	}
-
-	// Validate separate API publications
-	for i := range rs.APIPublications {
-		publication := &rs.APIPublications[i]
-		if err := publication.Validate(); err != nil {
-			return fmt.Errorf("invalid api_publication %q: %w", publication.GetRef(), err)
-		}
-		// Check for duplicates within extracted publications
-		for j := i + 1; j < len(rs.APIPublications); j++ {
-			if rs.APIPublications[j].GetRef() == publication.GetRef() {
-				return fmt.Errorf("duplicate ref '%s' (already defined as api_publication)", publication.GetRef())
-			}
-		}
-	}
-
-	// Validate separate API implementations
-	for i := range rs.APIImplementations {
-		implementation := &rs.APIImplementations[i]
-		if err := implementation.Validate(); err != nil {
-			return fmt.Errorf("invalid api_implementation %q: %w", implementation.GetRef(), err)
-		}
-		// Check for duplicates within extracted implementations
-		for j := i + 1; j < len(rs.APIImplementations); j++ {
-			if rs.APIImplementations[j].GetRef() == implementation.GetRef() {
-				return fmt.Errorf("duplicate ref '%s' (already defined as api_implementation)", implementation.GetRef())
-			}
-		}
-	}
-
-	// Validate separate API documents
-	for i := range rs.APIDocuments {
-		document := &rs.APIDocuments[i]
-		if err := document.Validate(); err != nil {
-			return fmt.Errorf("invalid api_document %q: %w", document.GetRef(), err)
-		}
-		// Check for duplicates within extracted documents
-		for j := i + 1; j < len(rs.APIDocuments); j++ {
-			if rs.APIDocuments[j].GetRef() == document.GetRef() {
-				return fmt.Errorf("duplicate ref '%s' (already defined as api_document)", document.GetRef())
-			}
-		}
-	}
 
 	return nil
 }

--- a/internal/declarative/resources/api_child_load.go
+++ b/internal/declarative/resources/api_child_load.go
@@ -2,6 +2,8 @@ package resources
 
 import "fmt"
 
+// Retain the legacy per-API checks for validation before extraction. Normal
+// loading clears these nested slices and validates their children in root storage.
 func apiChildLoad[R any, RPtr interface {
 	*R
 	Resource

--- a/internal/declarative/resources/api_child_load.go
+++ b/internal/declarative/resources/api_child_load.go
@@ -1,0 +1,43 @@
+package resources
+
+import "fmt"
+
+func apiChildLoad[R any, RPtr interface {
+	*R
+	Resource
+}](
+	order int,
+	nested func(*APIResource) *[]R,
+	setParent func(*R, string),
+) childLoad[R, APIResource] {
+	return childLoad[R, APIResource]{
+		family:         ResourceTypeAPI,
+		extractOrder:   order,
+		validateOrder:  order,
+		nested:         nested,
+		setParent:      setParent,
+		validate:       validateChildRefs[R, RPtr],
+		validateNested: validateNestedAPIChildren[R, RPtr](nested),
+	}
+}
+
+func validateNestedAPIChildren[R any, RPtr interface {
+	*R
+	Resource
+}](nested func(*APIResource) *[]R) func(*ResourceSet, *APIResource) error {
+	return func(rs *ResourceSet, api *APIResource) error {
+		children := *nested(api)
+		for i := range children {
+			child := RPtr(&children[i])
+			if err := child.Validate(); err != nil {
+				return fmt.Errorf("invalid %s %q in api %q: %w", child.GetType(), child.GetRef(), api.GetRef(), err)
+			}
+			if existing, found := rs.GetResourceByRef(child.GetRef()); found {
+				if existing.GetType() != child.GetType() {
+					return fmt.Errorf("duplicate ref '%s' (already defined as %s)", child.GetRef(), existing.GetType())
+				}
+			}
+		}
+		return nil
+	}
+}

--- a/internal/declarative/resources/api_child_load_test.go
+++ b/internal/declarative/resources/api_child_load_test.go
@@ -1,0 +1,36 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIChildLoadRegistrations(t *testing.T) {
+	want := []ResourceType{
+		ResourceTypeAPIVersion,
+		ResourceTypeAPIPublication,
+		ResourceTypeAPIImplementation,
+		ResourceTypeAPIDocument,
+	}
+
+	tests := []struct {
+		name          string
+		registrations []childLoadRegistration
+	}{
+		// Extraction order also determines per-parent validation order.
+		{"extraction", childExtractors[ResourceTypeAPI]},
+		{"validation", childValidators[ResourceTypeAPI]},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := make([]ResourceType, 0, len(tt.registrations))
+			for _, registration := range tt.registrations {
+				got = append(got, registration.kind)
+			}
+
+			require.Equal(t, want, got)
+		})
+	}
+}

--- a/internal/declarative/resources/api_document.go
+++ b/internal/declarative/resources/api_document.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() {
-	registerResourceType(
+	registerChildResourceType(
 		ResourceTypeAPIDocument,
 		func(rs *ResourceSet) *[]APIDocumentResource { return &rs.APIDocuments },
 		AutoExplain[APIDocumentResource](
@@ -24,6 +24,16 @@ func init() {
 				},
 			}),
 		),
+		childLoad[APIDocumentResource, APIResource]{
+			family:        ResourceTypeAPI,
+			extractOrder:  40,
+			validateOrder: 40,
+			validate:      validateChildRefs[APIDocumentResource],
+			validateNested: validateNestedAPIChildren(
+				func(api *APIResource) *[]APIDocumentResource { return &api.Documents },
+			),
+			extract: extractNestedAPIDocuments,
+		},
 		WithExternalUnsupportedReason("scoped API document lookup is planned for API domain enablement"),
 		WithNamespaceFrom(func(rs *ResourceSet, r *APIDocumentResource) *APIResource {
 			return rs.GetAPIByRef(r.API)
@@ -260,4 +270,51 @@ func (d *APIDocumentResource) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
+}
+
+// Nested documents retain their API-owned storage after flattening.
+func extractNestedAPIDocuments(_ *ResourceSet, api *APIResource, _ *[]APIDocumentResource) {
+	docs := make([]APIDocumentResource, 0)
+	for _, document := range api.Documents {
+		extractAPIDocuments(&docs, document, api.Ref, "")
+	}
+	api.Documents = docs
+}
+
+// FlattenRootAPIDocuments normalizes root declarations separately from documents
+// retained under their API. Each root document supplies its own API selector.
+func (rs *ResourceSet) FlattenRootAPIDocuments() {
+	docs := make([]APIDocumentResource, 0)
+	for _, document := range rs.APIDocuments {
+		extractAPIDocuments(&docs, document, document.API, "")
+	}
+	rs.APIDocuments = docs
+}
+
+// extractAPIDocuments recursively extracts and flattens nested API documents
+func extractAPIDocuments(
+	allDocs *[]APIDocumentResource,
+	doc APIDocumentResource,
+	apiRef string,
+	parentDocRef string,
+) {
+	if apiRef != "" {
+		doc.API = apiRef
+	}
+	if parentDocRef != "" {
+		doc.ParentDocumentRef = parentDocRef
+	}
+
+	children := doc.Children
+	doc.Children = nil
+
+	*allDocs = append(*allDocs, doc)
+
+	for _, child := range children {
+		childAPIRef := apiRef
+		if child.API != "" {
+			childAPIRef = child.API
+		}
+		extractAPIDocuments(allDocs, child, childAPIRef, doc.Ref)
+	}
 }

--- a/internal/declarative/resources/api_implementation.go
+++ b/internal/declarative/resources/api_implementation.go
@@ -17,11 +17,16 @@ const (
 )
 
 func init() {
-	registerResourceType(
+	registerChildResourceType(
 		ResourceTypeAPIImplementation,
 		func(rs *ResourceSet) *[]APIImplementationResource { return &rs.APIImplementations },
 		AutoExplain[APIImplementationResource](
 			WithExplainSchemaBuilder(apiImplementationExplainNode),
+		),
+		apiChildLoad(
+			30,
+			func(api *APIResource) *[]APIImplementationResource { return &api.Implementations },
+			func(child *APIImplementationResource, ref string) { child.API = ref },
 		),
 		WithNamespaceFrom(func(rs *ResourceSet, r *APIImplementationResource) *APIResource {
 			return rs.GetAPIByRef(r.API)

--- a/internal/declarative/resources/api_publication.go
+++ b/internal/declarative/resources/api_publication.go
@@ -9,10 +9,15 @@ import (
 )
 
 func init() {
-	registerResourceType(
+	registerChildResourceType(
 		ResourceTypeAPIPublication,
 		func(rs *ResourceSet) *[]APIPublicationResource { return &rs.APIPublications },
 		AutoExplain[APIPublicationResource](),
+		apiChildLoad(
+			20,
+			func(api *APIResource) *[]APIPublicationResource { return &api.Publications },
+			func(child *APIPublicationResource, ref string) { child.API = ref },
+		),
 		WithNamespaceFrom(func(rs *ResourceSet, r *APIPublicationResource) *APIResource {
 			return rs.GetAPIByRef(r.API)
 		}),

--- a/internal/declarative/resources/api_version.go
+++ b/internal/declarative/resources/api_version.go
@@ -10,7 +10,7 @@ import (
 )
 
 func init() {
-	registerResourceType(
+	registerChildResourceType(
 		ResourceTypeAPIVersion,
 		func(rs *ResourceSet) *[]APIVersionResource { return &rs.APIVersions },
 		AutoExplain[APIVersionResource](
@@ -27,6 +27,11 @@ func init() {
 			WithExplainFieldHint("spec.content", ExplainFieldHint{
 				Notes: []string{"Set the whole spec with `spec: !file ...` instead of populating content directly."},
 			}),
+		),
+		apiChildLoad(
+			10,
+			func(api *APIResource) *[]APIVersionResource { return &api.Versions },
+			func(child *APIVersionResource, ref string) { child.API = ref },
 		),
 		WithNamespaceFrom(func(rs *ResourceSet, r *APIVersionResource) *APIResource {
 			return rs.GetAPIByRef(r.API)

--- a/internal/declarative/resources/child_load.go
+++ b/internal/declarative/resources/child_load.go
@@ -17,6 +17,7 @@ type childLoad[R, P any] struct {
 	setParent               func(*R, string)
 	beforeAppend            func(*ResourceSet, *R)
 	validate                func(*ResourceSet, []R) error
+	validateNested          func(*ResourceSet, *P) error
 	extract                 func(*ResourceSet, *P, *[]R)
 	validationOmittedReason string
 }
@@ -29,6 +30,7 @@ type childLoadRegistration struct {
 	validateOrder           int
 	extract                 func(*ResourceSet, Resource)
 	validate                func(*ResourceSet) error
+	validateNested          func(*ResourceSet, Resource) error
 	validationOmittedReason string
 }
 
@@ -91,6 +93,11 @@ func registerChildResourceType[R, P any, RPtr interface {
 				return load.validate(rs, *storage(rs))
 			}
 		}
+		if load.validateNested != nil {
+			registration.validateNested = func(rs *ResourceSet, parent Resource) error {
+				return load.validateNested(rs, any(parent).(*P))
+			}
+		}
 		ops.load = registration
 		return nil
 	})
@@ -136,13 +143,26 @@ func registerChildLoader(kind ResourceType, registration childLoadRegistration) 
 	}
 }
 
-// ExtractRegisteredChildren appends a parent's registered nested collections
-// to their existing root storage and clears the nested fields. Callers own the
-// phase order; extraction does not recursively visit children automatically.
+// ExtractRegisteredChildren applies a parent's registered child loaders.
+// Ordinary collections append to root storage and clear their nested fields;
+// custom handlers may retain normalized children. Callers own phase ordering.
 func (rs *ResourceSet) ExtractRegisteredChildren(parent Resource) {
 	for _, registration := range childExtractors[parent.GetType()] {
 		registration.extract(rs, parent)
 	}
+}
+
+// ValidateRegisteredNestedChildren runs optional per-parent validation in
+// extraction order. Callers choose its phase independently of root validation.
+func (rs *ResourceSet) ValidateRegisteredNestedChildren(parent Resource) error {
+	for _, registration := range childExtractors[parent.GetType()] {
+		if registration.validateNested != nil {
+			if err := registration.validateNested(rs, parent); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // ValidateRegisteredChildren validates a family's flattened child collections

--- a/internal/declarative/resources/child_validation.go
+++ b/internal/declarative/resources/child_validation.go
@@ -1,0 +1,23 @@
+package resources
+
+import "fmt"
+
+// Validate each resource before checking its later siblings, preserving the
+// loader's precedence between invalid resources and duplicate references.
+func validateChildRefs[R any, RPtr interface {
+	*R
+	Resource
+}](_ *ResourceSet, children []R) error {
+	for i := range children {
+		child := RPtr(&children[i])
+		if err := child.Validate(); err != nil {
+			return fmt.Errorf("invalid %s %q: %w", child.GetType(), child.GetRef(), err)
+		}
+		for j := i + 1; j < len(children); j++ {
+			if RPtr(&children[j]).GetRef() == child.GetRef() {
+				return fmt.Errorf("duplicate ref '%s' (already defined as %s)", child.GetRef(), child.GetType())
+			}
+		}
+	}
+	return nil
+}

--- a/internal/declarative/resources/portal_child_load.go
+++ b/internal/declarative/resources/portal_child_load.go
@@ -1,7 +1,5 @@
 package resources
 
-import "fmt"
-
 func extractPortalSingleton[R any](
 	nested func(*PortalResource) **R,
 	setParent func(*R, string),
@@ -21,22 +19,9 @@ func extractPortalSingleton[R any](
 	}
 }
 
-// Validate each resource before checking its later siblings, preserving the
-// loader's precedence between invalid resources and duplicate references.
 func validatePortalChildRefs[R any, RPtr interface {
 	*R
 	Resource
-}](_ *ResourceSet, children []R) error {
-	for i := range children {
-		child := RPtr(&children[i])
-		if err := child.Validate(); err != nil {
-			return fmt.Errorf("invalid %s %q: %w", child.GetType(), child.GetRef(), err)
-		}
-		for j := i + 1; j < len(children); j++ {
-			if RPtr(&children[j]).GetRef() == child.GetRef() {
-				return fmt.Errorf("duplicate ref '%s' (already defined as %s)", child.GetRef(), child.GetType())
-			}
-		}
-	}
-	return nil
+}](rs *ResourceSet, children []R) error {
+	return validateChildRefs[R, RPtr](rs, children)
 }


### PR DESCRIPTION
API child loading previously required separate inventories for nested
extraction, per-API validation, and root-child validation in the loader.
Versions, publications, implementations, and documents now register these
capabilities beside their declarations, using the existing child-loading
infrastructure and registered storage.

- Share ordinary API extraction and both validation callbacks through
  `apiChildLoad`; reuse duplicate-ref validation with Portal.
- Preserve per-API validation before root-child validation, exact diagnostic
  context and order, parent assignment, copying, and source clearing.
- Keep document preorder flattening resource-owned, retaining nested
  documents under their API and separately normalizing root documents.
  Explicit child API overrides and nil/empty distinctions retain existing
  behavior; planner storage and lookup semantics are unchanged.
- Update the authoritative implementation guide with both validation phases,
  document exceptions, and remaining manual loader paths.
- Pin API extraction and validation registration membership/order with a
  focused contract test, including the order used by per-parent validation.

Refs #2079. This completes a bounded API migration; other loader families and
cross-pipeline capability completeness remain follow-up work.

Validation: baseline and candidate `make test-all` pass, including lint
2.13.2, installer checks, race-enabled unit/integration suites, and 72 E2E
tooling tests. Read-only Go modernization proposes no changes;
formatting is idempotent on changed files; `make build-ci` passes.

An external Go build-overlay comparison matches all 199 baseline cases:
validation and error order, cross-kind refs, extraction/source copying,
recursive document inheritance in both storage locations, repeated
extraction, and parsing/environment-source metadata. This is bounded
compatibility evidence, not exhaustive coverage.

The authorized test addition is one 36-line `api_child_load_test.go`. Three
production-only mutation overlays verify that it detects independent
extraction/validation reordering and an omitted API document registration.
All 2,785 files present before this test addition retain their hashes, including
all preexisting tests, fixtures, helpers, production code, and documentation.
The work is isolated in a worktree based on main at `11c67aa8`.
