### PR TITLE
fix(declarative): distinguish auth variants in extended explain

### DIFF
--- a/internal/declarative/loader/ai_gateway_bedrock_auth_test.go
+++ b/internal/declarative/loader/ai_gateway_bedrock_auth_test.go
@@ -1,0 +1,75 @@
+package loader
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func bedrockAuthConfig(auth string) string {
+	return `
+_defaults:
+  kongctl:
+    namespace: bedrock-repro
+ai_gateways:
+  - ref: repro-gw
+    name: repro-bedrock-gw
+    display_name: Bedrock Repro GW
+    deployment_type: hybrid
+    model_providers:
+      - ref: repro-bedrock
+        name: repro-bedrock
+        type: bedrock
+        display_name: AWS Bedrock Provider
+        config:
+          auth:
+            type: aws
+` + auth
+}
+
+func TestLoaderBedrockAuthRejectsNestedAWS(t *testing.T) {
+	_, err := New().LoadFile(writeLoaderTestFile(t, bedrockAuthConfig(`
+            aws:
+              access_key_id: AKIAEXAMPLE
+              secret_access_key: examplesecret
+`)))
+	require.ErrorContains(t, err, "unknown field 'aws'")
+	assert.Contains(t, err.Error(), "ai_gateways[0].model_providers[0].config.auth.aws")
+}
+
+func TestLoaderBedrockAuthLiteralErrorNamesAcceptedForms(t *testing.T) {
+	_, err := New().LoadFile(writeLoaderTestFile(t, bedrockAuthConfig(`
+            access_key_id: AKIAEXAMPLE
+            secret_access_key: examplesecret
+`)))
+	require.ErrorContains(t, err, "field /config/auth/secret_access_key")
+	assert.Contains(t, err.Error(), "!secret with a deferred source")
+	assert.Contains(t, err.Error(), "{vault://<store>/<key>}")
+	assert.NotContains(t, err.Error(), "examplesecret")
+}
+
+func TestLoaderBedrockAuthPreservesVaultReferences(t *testing.T) {
+	rs, err := New().LoadFile(writeLoaderTestFile(t, bedrockAuthConfig(`
+            access_key_id: '{vault://poc-aigw-secrets/aws-access-key-id}'
+            secret_access_key: '{vault://poc-aigw-secrets/aws-secret-access-key}'
+`)))
+	require.NoError(t, err)
+	require.Len(t, rs.AIGatewayProviders, 1)
+	auth := rs.AIGatewayProviders[0].Config["auth"].(map[string]any)
+	assert.Equal(t, "{vault://poc-aigw-secrets/aws-access-key-id}", auth["access_key_id"])
+	assert.Equal(t, "{vault://poc-aigw-secrets/aws-secret-access-key}", auth["secret_access_key"])
+	assert.Empty(t, rs.GetSecretSources("repro-bedrock"))
+}
+
+func TestLoaderBedrockAuthPreservesDeferredSecret(t *testing.T) {
+	rs, err := New().LoadFile(writeLoaderTestFile(t, bedrockAuthConfig(`
+            access_key_id: AKIAEXAMPLE
+            secret_access_key: !secret {source: !env BEDROCK_TEST_SECRET}
+`)))
+	require.NoError(t, err)
+	declaration := rs.GetSecretSources("repro-bedrock")["/config/auth/secret_access_key"]
+	require.Len(t, declaration.Expression.Parts, 1)
+	assert.Equal(t, "BEDROCK_TEST_SECRET", declaration.Expression.Parts[0].Source.Reference)
+	assert.False(t, declaration.DeprecatedBareEnv)
+}

--- a/internal/declarative/loader/secret_sources.go
+++ b/internal/declarative/loader/secret_sources.go
@@ -57,7 +57,8 @@ func (l *Loader) collectSecretSources(actual, placeholder *resources.ResourceSet
 			}
 
 			return false, fmt.Errorf(
-				"resource %s %q field %s is write-only and requires !secret with a deferred source",
+				"resource %s %q field %s is write-only and requires !secret with a deferred source"+
+					" or a vault reference such as {vault://<store>/<key>}",
 				resource.GetType(), resourceRef, path,
 			)
 		})

--- a/internal/declarative/resources/ai_gateway_auth_explain_test.go
+++ b/internal/declarative/resources/ai_gateway_auth_explain_test.go
@@ -1,0 +1,46 @@
+package resources
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAIGatewayProviderAuthShapesDistinguishBedrockAndSagemaker(t *testing.T) {
+	node, err := aiGatewayProviderExplainNode(ExplainBuildContext{})
+	require.NoError(t, err)
+	bedrock := explainUnionBranchByType(t, node, "bedrock")
+	auth, ok := bedrock.lookup([]string{"config", "auth"})
+	require.True(t, ok)
+	aws := explainUnionBranchByType(t, auth, "aws")
+	assert.False(t, aws.propertyExists("aws"))
+	for _, field := range []string{"access_key_id", "secret_access_key", "session_token"} {
+		assert.True(t, aws.propertyExists(field), field)
+	}
+	sagemaker := explainUnionBranchByType(t, node, "sagemaker")
+	auth, ok = sagemaker.lookup([]string{"config", "auth"})
+	require.True(t, ok)
+	assert.True(t, explainUnionBranchByType(t, auth, "sagemaker").propertyExists("aws"))
+}
+
+func TestRenderExplainText_AIGatewayProviderAuthVariantContext(t *testing.T) {
+	subject, err := ResolveExplainSubject("ai_gateway.model_providers")
+	require.NoError(t, err)
+	text := RenderExplainText(subject, true)
+
+	// Use the existing scaffold convention to identify each provider's fields.
+	_, bedrock, found := strings.Cut(text, "oneOf option: type=bedrock\n")
+	require.True(t, found, "extended explain must identify the Bedrock variant")
+	bedrock, _, _ = strings.Cut(bedrock, "\noneOf option:")
+	assert.Contains(t, bedrock, "oneOf option: type=aws\n")
+	assert.Contains(t, bedrock, "- access_key_id:")
+	assert.Contains(t, bedrock, "- secret_access_key:")
+	assert.NotContains(t, bedrock, "- aws:")
+
+	_, sagemaker, found := strings.Cut(text, "oneOf option: type=sagemaker\n")
+	require.True(t, found, "extended explain must identify the SageMaker variant")
+	sagemaker, _, _ = strings.Cut(sagemaker, "\noneOf option:")
+	assert.Contains(t, sagemaker, "- aws:")
+}

--- a/internal/declarative/resources/explain.go
+++ b/internal/declarative/resources/explain.go
@@ -1531,6 +1531,13 @@ func renderExplainFields(b *strings.Builder, node *ExplainNode, path string, dep
 		renderExplainFields(b, node.Items, path+"[]", depth)
 		return
 	}
+	if node.Kind == explainKindObject && len(node.OneOf) > 0 {
+		for _, branch := range node.OneOf {
+			fmt.Fprintf(b, "%soneOf option: %s\n", strings.Repeat("  ", depth), scaffoldOneOfOptionLabel(branch))
+			renderExplainFields(b, branch, path, depth+1)
+		}
+		return
+	}
 	if node.Kind == explainKindObject && node.Additional != nil {
 		renderExplainFields(b, node.Additional, path+"{}", depth)
 	}

--- a/internal/declarative/resources/explain_test.go
+++ b/internal/declarative/resources/explain_test.go
@@ -425,11 +425,10 @@ func TestRenderExplainText_AIGatewayProviderAuthAllowedValues(t *testing.T) {
 
 	resource, err := ResolveExplainSubject("ai_gateway.model_providers")
 	require.NoError(t, err)
-	assert.Contains(
-		t,
-		RenderExplainText(resource, true),
-		"- type: string required allowed: basic|azure|aws|gcp|sagemaker",
-	)
+	text := RenderExplainText(resource, true)
+	for _, authType := range []string{"basic", "azure", "aws", "gcp", "sagemaker"} {
+		assert.Contains(t, text, "- type: string required allowed: "+authType+"\n")
+	}
 
 	field, err := ResolveExplainSubject("ai_gateway.model_providers.config.auth.type")
 	require.NoError(t, err)


### PR DESCRIPTION
Extended explain merges model-provider fields into a single list, making
SageMaker's nested `config.auth.aws` object appear valid for Bedrock. Render
object union branches with separate labels so Bedrock's flat AWS credentials
and SageMaker's nested credentials appear in their respective contexts.

Also name `{vault://<store>/<key>}` as an accepted alternative in write-only
field errors. Preserve loader validation and secret handling.

Regression coverage checks variant rendering, Bedrock's rejection of nested
AWS fields, accepted vault references and deferred secrets, and error guidance.

Validation: `go fix ./...` with CGO disabled, `make format`, `make build`,
`make lint`, `make test`, `make test-integration`, `make test-installer` with
the installed shellcheck version selected, and `make test-e2e-metrics` passed.
Also inspected the built CLI's extended Bedrock output.

`pre-commit run -a` could not run because pre-commit is not installed.

Fixes #2132
