### PR TITLE
refactor(declarative): register Event Gateway child loading capabilities

### DIFF
--- a/docs/contributor/declarative-resource-implementation-guide.md
+++ b/docs/contributor/declarative-resource-implementation-guide.md
@@ -38,8 +38,7 @@ request: it can contain `ref`, `kongctl`, children, and parent selectors.
 
 The [resource registry][registry] drives iteration, aggregation,
 explain/scaffold, load-schema discovery, namespace participation,
-collection scope, AI Gateway/API/Portal child loading, and dump-default
-metadata.
+collection scope, registered child loading, and dump-default metadata.
 The [root planner inventory][roots] drives root construction and dispatch.
 [Runtime executor registration][runtime-executors] supplies action routing and
 payload validation for SDK resource operations. Other families' nested
@@ -145,9 +144,9 @@ input cannot disclose a secret in an error.
 
 ### Child loading capabilities
 
-AI Gateway, API, and Portal children register loading beside their declarations,
-reusing root storage through [`registerChildResourceType`][child-load]. Supply
-one extraction form: `nested`/`setParent` with an optional `beforeAppend`, or a
+AI Gateway, API, Portal, and Event Gateway children register loading beside
+their declarations through [`registerChildResourceType`][child-load], reusing
+root storage. Supply `nested`/`setParent` with an optional `beforeAppend`, or a
 typed `extract` handler for exceptional sources. Custom extraction receives
 the registered destination; preserve each source's copying and storage rules.
 
@@ -170,11 +169,17 @@ map-key defaults. [Teams][portal-team] extract roles and group mappings before
 appending the team, carrying both team and portal selectors. Only teams nested
 under portals enter that extraction phase; root-declared teams do not.
 
-Portal teams and team roles explicitly set `validationOmittedReason` and leave
-`validateOrder` zero to preserve their existing lack of loader validation.
-Other registrations require a validator and a positive order. This exception
-does not authorize skipping validation for a new resource. Portal assets keep
-their separate handling and are outside these loading registrations.
+Event Gateway's [`eventGatewayChildLoad`][eg-child-load] registers extraction
+for static keys, TLS trust bundles, schema registries, backend clusters,
+listeners, and data-plane certificates, in that order. Extraction stays before
+deferred-value indexing, preserving attribution to each child ref. Virtual
+clusters and policy placement retain their existing storage and traversal.
+
+Portal teams, team roles, and these Event Gateway children record
+`validationOmittedReason` with zero `validateOrder` to preserve their lack of
+family-level loader validation. Other registrations require a validator and a
+positive order; these exceptions do not authorize skipping new-resource
+validation. Portal assets retain separate handling outside these registrations.
 
 Extraction order is per immediate parent; validation order is per family,
 including grandchildren. Participating orders must be positive and unique
@@ -197,8 +202,9 @@ only documents nested. `ValidateRegisteredChildren` then checks
 root child collections in family order, stopping at the first error. API and
 ordinary Portal ref validation both validate each resource before checking
 later siblings for duplicate refs.
-Portal child validation follows API-child validation. Other families, root
-validation, cross-references, and namespaces retain their existing loader paths.
+Portal child validation follows API-child validation. Control-plane and
+organization/grouped loading, root validation, cross-references, and namespaces
+retain their existing loader paths.
 
 ### Explain, scaffold, and load schema
 
@@ -646,6 +652,7 @@ engine contract. Each refactoring migration should:
 [portal-template]: ../../internal/declarative/resources/portal_email_template.go
 [portal-team]: ../../internal/declarative/resources/portal_team.go
 [ai-child-load]: ../../internal/declarative/resources/ai_gateway_child_load.go
+[eg-child-load]: ../../internal/declarative/resources/event_gateway_child_load.go
 [plan-scope]: ../../internal/declarative/planner/sync_scope.go
 [planner]: ../../internal/declarative/planner/planner.go
 [roots]: ../../internal/declarative/planner/root_planners.go

--- a/internal/declarative/loader/loader.go
+++ b/internal/declarative/loader/loader.go
@@ -756,48 +756,9 @@ func (l *Loader) extractNestedResources(rs *resources.ResourceSet) {
 		rs.ExtractRegisteredChildren(&rs.Portals[i])
 	}
 
-	// Extract nested Event Gateway child resources so that deferred !env
-	// placeholders on their fields are tracked per child resource ref (not
-	// per gateway ref).  Each nested type already has a root-level slice in
-	// ResourceSet and a GetXxxForGateway helper that reads from both.
+	// Extract Event Gateway children before indexing deferred values by child ref.
 	for i := range rs.EventGatewayControlPlanes {
-		egw := &rs.EventGatewayControlPlanes[i]
-
-		for _, sk := range egw.StaticKeys {
-			sk.EventGateway = egw.Ref
-			rs.EventGatewayStaticKeys = append(rs.EventGatewayStaticKeys, sk)
-		}
-		egw.StaticKeys = nil
-
-		for _, tb := range egw.TrustBundles {
-			tb.EventGateway = egw.Ref
-			rs.EventGatewayTLSTrustBundles = append(rs.EventGatewayTLSTrustBundles, tb)
-		}
-		egw.TrustBundles = nil
-
-		for _, sr := range egw.SchemaRegistries {
-			sr.EventGateway = egw.Ref
-			rs.EventGatewaySchemaRegistries = append(rs.EventGatewaySchemaRegistries, sr)
-		}
-		egw.SchemaRegistries = nil
-
-		for _, bc := range egw.BackendClusters {
-			bc.EventGateway = egw.Ref
-			rs.EventGatewayBackendClusters = append(rs.EventGatewayBackendClusters, bc)
-		}
-		egw.BackendClusters = nil
-
-		for _, l := range egw.Listeners {
-			l.EventGateway = egw.Ref
-			rs.EventGatewayListeners = append(rs.EventGatewayListeners, l)
-		}
-		egw.Listeners = nil
-
-		for _, dp := range egw.DataPlaneCertificates {
-			dp.EventGateway = egw.Ref
-			rs.EventGatewayDataPlaneCertificates = append(rs.EventGatewayDataPlaneCertificates, dp)
-		}
-		egw.DataPlaneCertificates = nil
+		rs.ExtractRegisteredChildren(&rs.EventGatewayControlPlanes[i])
 	}
 
 	for i := range rs.AIGatewayConsumers {

--- a/internal/declarative/resources/event_gateway_backend_cluster.go
+++ b/internal/declarative/resources/event_gateway_backend_cluster.go
@@ -8,11 +8,18 @@ import (
 )
 
 func init() {
-	registerResourceType(
+	registerChildResourceType(
 		ResourceTypeEventGatewayBackendCluster,
 		func(rs *ResourceSet) *[]EventGatewayBackendClusterResource { return &rs.EventGatewayBackendClusters },
 		AutoExplain[EventGatewayBackendClusterResource](
 			WithExplainSchemaBuilder(eventGatewayBackendClusterExplainNode),
+		),
+		eventGatewayChildLoad(
+			40,
+			func(gateway *EventGatewayControlPlaneResource) *[]EventGatewayBackendClusterResource {
+				return &gateway.BackendClusters
+			},
+			func(child *EventGatewayBackendClusterResource, ref string) { child.EventGateway = ref },
 		),
 		WithChildSyncScope(ResourceTypeEventGatewayControlPlane),
 	)

--- a/internal/declarative/resources/event_gateway_child_load.go
+++ b/internal/declarative/resources/event_gateway_child_load.go
@@ -1,0 +1,17 @@
+package resources
+
+// Event Gateway extraction retains its existing phase without introducing
+// family-level loader validation.
+func eventGatewayChildLoad[R any](
+	order int,
+	nested func(*EventGatewayControlPlaneResource) *[]R,
+	setParent func(*R, string),
+) childLoad[R, EventGatewayControlPlaneResource] {
+	return childLoad[R, EventGatewayControlPlaneResource]{
+		family:                  ResourceTypeEventGatewayControlPlane,
+		extractOrder:            order,
+		nested:                  nested,
+		setParent:               setParent,
+		validationOmittedReason: "Event Gateway children retain loading without family-level resource validation",
+	}
+}

--- a/internal/declarative/resources/event_gateway_child_load_test.go
+++ b/internal/declarative/resources/event_gateway_child_load_test.go
@@ -1,0 +1,25 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventGatewayChildLoadRegistrations(t *testing.T) {
+	want := []ResourceType{
+		ResourceTypeEventGatewayStaticKey,
+		ResourceTypeEventGatewayTLSTrustBundle,
+		ResourceTypeEventGatewaySchemaRegistry,
+		ResourceTypeEventGatewayBackendCluster,
+		ResourceTypeEventGatewayListener,
+		ResourceTypeEventGatewayDataPlaneCertificate,
+	}
+
+	got := make([]ResourceType, 0, len(childExtractors[ResourceTypeEventGatewayControlPlane]))
+	for _, registration := range childExtractors[ResourceTypeEventGatewayControlPlane] {
+		got = append(got, registration.kind)
+	}
+
+	require.Equal(t, want, got)
+}

--- a/internal/declarative/resources/event_gateway_data_plane_certificate.go
+++ b/internal/declarative/resources/event_gateway_data_plane_certificate.go
@@ -9,12 +9,19 @@ import (
 )
 
 func init() {
-	registerResourceType(
+	registerChildResourceType(
 		ResourceTypeEventGatewayDataPlaneCertificate,
 		func(rs *ResourceSet) *[]EventGatewayDataPlaneCertificateResource {
 			return &rs.EventGatewayDataPlaneCertificates
 		},
 		AutoExplain[EventGatewayDataPlaneCertificateResource](),
+		eventGatewayChildLoad(
+			60,
+			func(gateway *EventGatewayControlPlaneResource) *[]EventGatewayDataPlaneCertificateResource {
+				return &gateway.DataPlaneCertificates
+			},
+			func(child *EventGatewayDataPlaneCertificateResource, ref string) { child.EventGateway = ref },
+		),
 		WithChildSyncScope(ResourceTypeEventGatewayControlPlane),
 	)
 }

--- a/internal/declarative/resources/event_gateway_listener.go
+++ b/internal/declarative/resources/event_gateway_listener.go
@@ -9,10 +9,17 @@ import (
 )
 
 func init() {
-	registerResourceType(
+	registerChildResourceType(
 		ResourceTypeEventGatewayListener,
 		func(rs *ResourceSet) *[]EventGatewayListenerResource { return &rs.EventGatewayListeners },
 		AutoExplain[EventGatewayListenerResource](),
+		eventGatewayChildLoad(
+			50,
+			func(gateway *EventGatewayControlPlaneResource) *[]EventGatewayListenerResource {
+				return &gateway.Listeners
+			},
+			func(child *EventGatewayListenerResource, ref string) { child.EventGateway = ref },
+		),
 		WithExternalUnsupportedReason("listener lookup requires an Event Gateway-scoped list adapter"),
 		WithChildSyncScope(ResourceTypeEventGatewayControlPlane),
 	)

--- a/internal/declarative/resources/event_gateway_schema_registry.go
+++ b/internal/declarative/resources/event_gateway_schema_registry.go
@@ -8,13 +8,20 @@ import (
 )
 
 func init() {
-	registerResourceType(
+	registerChildResourceType(
 		ResourceTypeEventGatewaySchemaRegistry,
 		func(rs *ResourceSet) *[]EventGatewaySchemaRegistryResource {
 			return &rs.EventGatewaySchemaRegistries
 		},
 		AutoExplain[EventGatewaySchemaRegistryResource](
 			WithExplainSchemaBuilder(eventGatewaySchemaRegistryExplainNode),
+		),
+		eventGatewayChildLoad(
+			30,
+			func(gateway *EventGatewayControlPlaneResource) *[]EventGatewaySchemaRegistryResource {
+				return &gateway.SchemaRegistries
+			},
+			func(child *EventGatewaySchemaRegistryResource, ref string) { child.EventGateway = ref },
 		),
 		WithChildSyncScope(ResourceTypeEventGatewayControlPlane),
 	)

--- a/internal/declarative/resources/event_gateway_static_key.go
+++ b/internal/declarative/resources/event_gateway_static_key.go
@@ -8,10 +8,17 @@ import (
 )
 
 func init() {
-	registerResourceType(
+	registerChildResourceType(
 		ResourceTypeEventGatewayStaticKey,
 		func(rs *ResourceSet) *[]EventGatewayStaticKeyResource { return &rs.EventGatewayStaticKeys },
 		AutoExplain[EventGatewayStaticKeyResource](),
+		eventGatewayChildLoad(
+			10,
+			func(gateway *EventGatewayControlPlaneResource) *[]EventGatewayStaticKeyResource {
+				return &gateway.StaticKeys
+			},
+			func(child *EventGatewayStaticKeyResource, ref string) { child.EventGateway = ref },
+		),
 		WithChildSyncScope(ResourceTypeEventGatewayControlPlane),
 	)
 }

--- a/internal/declarative/resources/event_gateway_tls_trust_bundle.go
+++ b/internal/declarative/resources/event_gateway_tls_trust_bundle.go
@@ -8,12 +8,19 @@ import (
 )
 
 func init() {
-	registerResourceType(
+	registerChildResourceType(
 		ResourceTypeEventGatewayTLSTrustBundle,
 		func(rs *ResourceSet) *[]EventGatewayTLSTrustBundleResource {
 			return &rs.EventGatewayTLSTrustBundles
 		},
 		AutoExplain[EventGatewayTLSTrustBundleResource](),
+		eventGatewayChildLoad(
+			20,
+			func(gateway *EventGatewayControlPlaneResource) *[]EventGatewayTLSTrustBundleResource {
+				return &gateway.TrustBundles
+			},
+			func(child *EventGatewayTLSTrustBundleResource, ref string) { child.EventGateway = ref },
+		),
 		WithChildSyncScope(ResourceTypeEventGatewayControlPlane),
 	)
 }


### PR DESCRIPTION
Event Gateway children previously required separate extraction loops in the
loader. Six existing collections now register their nested source, parent
setter, and extraction order beside their resource declarations. The loader
uses the shared child-loading dispatch, removing its Event Gateway inventory.

A small family helper records the existing absence of family-level loader
validation. Extraction order, parent overrides, append/copy behavior,
nil/empty slices, repeated extraction, and deferred-value attribution remain
unchanged. Virtual clusters and policy placement retain their current behavior.
The contributor guide documents the registration path and remaining exceptions.

Validation: read-only Go modernization, scoped formatting, CGO-disabled
`make build-ci`, and baseline/candidate `make test-all` pass, including lint,
race-enabled unit/integration tests, installer checks, and 76 E2E tooling tests.
Rebased onto main at `892b1ddc` and repeated the gates.
An external build-overlay audit matches 601 baseline/candidate cases:
361 extraction cases and 240 parsing cases, including 120 existing Event
Gateway manifests. It also verifies registration order and validation
dispositions. This is bounded compatibility evidence, not exhaustive coverage.

A focused registration test pins the six Event Gateway extraction kinds and
their order. Production-only mutations confirm it fails when the static-key
registration is omitted or the order is reversed. Full local gates pass with
the new test.

No preexisting tests, fixtures, or helpers changed. The test addition preserves
all 2,800 files from the reviewed production head. Guide links, anchors, and
wrapping pass.

Part of #2079; the broader capability migration remains open.
